### PR TITLE
Disable webview_cef and Linux builds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -103,44 +103,44 @@ jobs:
           name: ios-ipa
           path: webspace.ipa
 
-  # DISABLED: Linux builds are currently disabled due to webview_cef removal
-  # build-linux:
-  #   name: Build Linux
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
-  #
-  #     - name: Install Linux dependencies
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
-  #
-  #     - name: Setup Flutter
-  #       uses: subosito/flutter-action@v2
-  #       with:
-  #         channel: 'stable'
-  #         cache: true
-  #         cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
-  #
-  #     - name: Cache pub dependencies
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: |
-  #           ~/.pub-cache
-  #           .dart_tool
-  #         key: pub-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
-  #         restore-keys: |
-  #           pub-${{ runner.os }}-
-  #
-  #     - name: Get dependencies
-  #       run: flutter pub get
-  #
-  #     - name: Run tests
-  #       run: flutter test
-  #
-  #     - name: Build Linux
-  #       run: flutter build linux --release
+  build-linux:
+    name: Build Linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+          cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
+
+      - name: Cache pub dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            .dart_tool
+          key: pub-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            pub-${{ runner.os }}-
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      - name: Run tests
+        run: flutter test
+
+      # DISABLED: Linux builds are currently disabled due to webview_cef removal
+      # - name: Build Linux
+      #   run: flutter build linux --release
 
   build-macos:
     name: Build macOS
@@ -189,7 +189,7 @@ jobs:
 
   release-summary:
     name: Release Summary
-    needs: [build-android, build-ios, build-macos]
+    needs: [build-android, build-ios, build-linux, build-macos]
     runs-on: ubuntu-latest
     if: success()
     steps:
@@ -208,6 +208,6 @@ jobs:
           echo "❌ Linux x64 build (disabled)" >> $GITHUB_STEP_SUMMARY
           echo "✅ macOS app bundle" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Note: Linux builds are currently disabled due to webview_cef removal" >> $GITHUB_STEP_SUMMARY
+          echo "Note: Linux tests run but builds are disabled due to webview_cef removal" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "All enabled platform builds completed successfully!" >> $GITHUB_STEP_SUMMARY
+          echo "All platform tests and enabled builds completed successfully!" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -103,43 +103,44 @@ jobs:
           name: ios-ipa
           path: webspace.ipa
 
-  build-linux:
-    name: Build Linux
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install Linux dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
-
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: 'stable'
-          cache: true
-          cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
-
-      - name: Cache pub dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.pub-cache
-            .dart_tool
-          key: pub-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            pub-${{ runner.os }}-
-
-      - name: Get dependencies
-        run: flutter pub get
-
-      - name: Run tests
-        run: flutter test
-
-      - name: Build Linux
-        run: flutter build linux --release
+  # DISABLED: Linux builds are currently disabled due to webview_cef removal
+  # build-linux:
+  #   name: Build Linux
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #
+  #     - name: Install Linux dependencies
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
+  #
+  #     - name: Setup Flutter
+  #       uses: subosito/flutter-action@v2
+  #       with:
+  #         channel: 'stable'
+  #         cache: true
+  #         cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
+  #
+  #     - name: Cache pub dependencies
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: |
+  #           ~/.pub-cache
+  #           .dart_tool
+  #         key: pub-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
+  #         restore-keys: |
+  #           pub-${{ runner.os }}-
+  #
+  #     - name: Get dependencies
+  #       run: flutter pub get
+  #
+  #     - name: Run tests
+  #       run: flutter test
+  #
+  #     - name: Build Linux
+  #       run: flutter build linux --release
 
   build-macos:
     name: Build macOS
@@ -188,7 +189,7 @@ jobs:
 
   release-summary:
     name: Release Summary
-    needs: [build-android, build-ios, build-linux, build-macos]
+    needs: [build-android, build-ios, build-macos]
     runs-on: ubuntu-latest
     if: success()
     steps:
@@ -204,7 +205,9 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "✅ Android APKs (fdroid flavor, split by ABI)" >> $GITHUB_STEP_SUMMARY
           echo "✅ iOS IPA (unsigned)" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Linux x64 build" >> $GITHUB_STEP_SUMMARY
+          echo "❌ Linux x64 build (disabled)" >> $GITHUB_STEP_SUMMARY
           echo "✅ macOS app bundle" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "All platform builds completed successfully!" >> $GITHUB_STEP_SUMMARY
+          echo "Note: Linux builds are currently disabled due to webview_cef removal" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "All enabled platform builds completed successfully!" >> $GITHUB_STEP_SUMMARY

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -140,7 +140,7 @@ Future<String?> getFaviconUrl(String url) async {
   return null;
 }
 
-// Get page title by parsing HTML (fallback for webview_cef on Linux)
+// Get page title by parsing HTML (fallback for platforms without native title support)
 Future<String?> getPageTitle(String url) async {
   // Check cache first
   if (_pageTitleCache.containsKey(url)) {
@@ -450,7 +450,7 @@ class _WebSpacePageState extends State<WebSpacePage> {
       MaterialPageRoute(builder: (context) => AddSiteScreen()),
     );
     if (url != null) {
-      // Try to fetch page title for Linux (webview_cef doesn't expose getTitle)
+      // Try to fetch page title for platforms without native title support
       final pageTitle = await getPageTitle(url);
       
       setState(() {

--- a/lib/platform/platform_info.dart
+++ b/lib/platform/platform_info.dart
@@ -17,8 +17,7 @@ class PlatformInfo {
   /// Returns true if flutter_inappwebview should be used
   static bool get useInAppWebView => !isLinux;
 
-  /// Returns true if webview_cef should be used (DISABLED)
-  /// webview_cef support has been removed from the application
+  /// Returns true if webview_cef should be used
   static bool get useWebViewCef => false;
 
   static bool get isProxySupported {

--- a/lib/platform/platform_info.dart
+++ b/lib/platform/platform_info.dart
@@ -17,7 +17,7 @@ class PlatformInfo {
   /// Returns true if flutter_inappwebview should be used
   static bool get useInAppWebView => !isLinux;
 
-  /// Returns true if webview_cef should be used
+  /// Returns true if CEF-based webview should be used (currently disabled)
   static bool get useWebViewCef => false;
 
   static bool get isProxySupported {

--- a/lib/platform/platform_info.dart
+++ b/lib/platform/platform_info.dart
@@ -16,9 +16,10 @@ class PlatformInfo {
   
   /// Returns true if flutter_inappwebview should be used
   static bool get useInAppWebView => !isLinux;
-  
-  /// Returns true if webview_cef should be used (Linux/Windows/macOS desktop)
-  static bool get useWebViewCef => isLinux;
+
+  /// Returns true if webview_cef should be used (DISABLED)
+  /// webview_cef support has been removed from the application
+  static bool get useWebViewCef => false;
 
   static bool get isProxySupported {
     if (!useInAppWebView) {

--- a/lib/platform/unified_webview.dart
+++ b/lib/platform/unified_webview.dart
@@ -110,7 +110,6 @@ class UnifiedCookieManager {
       final cookies = await _inApp.getCookies(url: _toWebUri(url));
       return cookies.map((c) => UnifiedCookie.fromInAppCookie(c)).toList();
     }
-    // webview_cef doesn't provide cookie reading API
     return [];
   }
 
@@ -137,7 +136,6 @@ class UnifiedCookieManager {
         isHttpOnly: isHttpOnly,
       );
     }
-    // webview_cef doesn't have cookie API
   }
 
   /// Delete a cookie
@@ -155,7 +153,6 @@ class UnifiedCookieManager {
         path: path ?? '/',
       );
     }
-    // webview_cef doesn't have cookie API
   }
 
   /// Delete all cookies for a URL
@@ -163,7 +160,6 @@ class UnifiedCookieManager {
     if (PlatformInfo.useInAppWebView) {
       await _inApp.deleteCookies(url: _toWebUri(url));
     }
-    // webview_cef doesn't have cookie API
   }
 }
 

--- a/lib/platform/webview_factory.dart
+++ b/lib/platform/webview_factory.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
-import 'package:webview_cef/webview_cef.dart' as cef;
+// webview_cef support has been removed
+// import 'package:webview_cef/webview_cef.dart' as cef;
 import 'platform_info.dart';
 import 'unified_webview.dart';
 
@@ -132,114 +133,11 @@ class _InAppWebViewController implements UnifiedWebViewController {
   }
 }
 
-/// WebviewCef controller wrapper
-class _WebViewCefController implements UnifiedWebViewController {
-  final cef.WebViewController controller;
-  String _currentUrl = '';
-
-  _WebViewCefController(this.controller);
-
-  @override
-  Future<void> loadUrl(String url) async {
-    _currentUrl = url;
-    await controller.loadUrl(url); // loadUrl for subsequent loads
-  }
-
-  @override
-  Future<void> reload() async {
-    await controller.reload();
-  }
-
-  @override
-  Future<Uri?> getUrl() async {
-    return _currentUrl.isNotEmpty ? Uri.tryParse(_currentUrl) : null;
-  }
-
-  @override
-  Future<String?> getTitle() async {
-    // webview_cef doesn't expose getTitle API, but we can inject a callback
-    // Use a workaround: inject JavaScript that sets the title in the URL hash temporarily
-    try {
-      // Create a unique callback ID
-      final callbackId = 'getTitleCallback_${DateTime.now().millisecondsSinceEpoch}';
-      
-      // Inject JavaScript to get the title
-      // We'll store it in a global variable that can be accessed
-      await controller.executeJavaScript('''
-        (function() {
-          window._webspace_page_title = document.title;
-        })();
-      ''');
-      
-      // Wait a bit for JS to execute
-      await Future.delayed(Duration(milliseconds: 50));
-      
-      // Unfortunately, webview_cef's executeJavaScript doesn't return values
-      // So we can't retrieve the title this way
-      // Return null and let the name default to domain
-      return null;
-    } catch (e) {
-      return null;
-    }
-  }
-
-  @override
-  Future<void> evaluateJavascript(String source) async {
-    await controller.executeJavaScript(source);
-  }
-
-  @override
-  Future<void> findAllAsync({required String find}) async {
-    // webview_cef doesn't support find in page yet
-  }
-
-  @override
-  Future<void> findNext({required bool forward}) async {
-    // webview_cef doesn't support find in page yet
-  }
-
-  @override
-  Future<void> clearMatches() async {
-    // webview_cef doesn't support find in page yet
-  }
-
-  @override
-  Future<String?> getDefaultUserAgent() async {
-    return 'Mozilla/5.0'; // webview_cef doesn't expose default UA
-  }
-
-  @override
-  Future<void> setOptions({required bool javascriptEnabled, String? userAgent}) async {
-    // webview_cef doesn't have runtime options API
-    // Settings are applied during initialization
-  }
-
-  @override
-  Future<void> setThemePreference(WebViewTheme theme) async {
-    String themeValue = theme == WebViewTheme.dark ? 'dark' : 'light';
-    
-    await evaluateJavascript('''
-      (function() {
-        // Set color-scheme meta tag if it doesn't exist
-        let metaTag = document.querySelector('meta[name="color-scheme"]');
-        if (!metaTag) {
-          metaTag = document.createElement('meta');
-          metaTag.name = 'color-scheme';
-          document.head.appendChild(metaTag);
-        }
-        metaTag.content = '$themeValue';
-        
-        // Also set it on the root element for maximum compatibility
-        document.documentElement.style.colorScheme = '$themeValue';
-      })();
-    ''');
-  }
-}
+// WebviewCef controller has been removed
+// webview_cef support is no longer included in this application
 
 /// Factory for creating platform-specific webviews
 class WebViewFactory {
-  static bool _cefInitialized = false;
-
   /// Create a webview widget based on the current platform
   static Widget createWebView({
     required WebViewConfig config,
@@ -247,11 +145,10 @@ class WebViewFactory {
   }) {
     if (PlatformInfo.useInAppWebView) {
       return _createInAppWebView(config, onControllerCreated);
-    } else if (PlatformInfo.useWebViewCef) {
-      return _createWebViewCef(config, onControllerCreated);
     } else {
+      // webview_cef has been disabled
       return Center(
-        child: Text('WebView not supported on this platform'),
+        child: Text('WebView not supported on this platform.\nLinux builds are currently disabled.'),
       );
     }
   }
@@ -304,66 +201,3 @@ class WebViewFactory {
     );
   }
 
-  static Widget _createWebViewCef(
-    WebViewConfig config,
-    Function(UnifiedWebViewController) onControllerCreated,
-  ) {
-    // Initialize webview_cef manager once
-    if (!_cefInitialized) {
-      // Note: The threading warning is a known issue in webview_cef plugin
-      // It doesn't affect functionality but should be fixed upstream
-      cef.WebviewManager().initialize(
-        userAgent: config.userAgent ?? 'Mozilla/5.0',
-      );
-      _cefInitialized = true;
-    }
-
-    final controller = cef.WebviewManager().createWebView(
-      loading: const Center(child: CircularProgressIndicator()),
-    );
-
-    controller.setWebviewListener(cef.WebviewEventsListener(
-      onUrlChanged: (url) {
-        if (config.onUrlChanged != null) {
-          config.onUrlChanged!(url);
-        }
-      },
-      onLoadStart: (ctrl, url) {
-        // Load started
-      },
-      onLoadEnd: (ctrl, url) {
-        // Load finished - trigger URL change callback to fetch title
-        if (url != null && config.onUrlChanged != null) {
-          config.onUrlChanged!(url);
-        }
-      },
-    ));
-
-    // Initialize the webview with the URL
-    Future.microtask(() async {
-      await controller.initialize(config.initialUrl);
-      final unifiedController = _WebViewCefController(controller);
-      onControllerCreated(unifiedController);
-    });
-
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return ValueListenableBuilder(
-          valueListenable: controller,
-          builder: (context, value, child) {
-            final widget = controller.value
-                ? controller.webviewWidget
-                : controller.loadingWidget;
-            
-            // Force the webview to fill available space and respond to resizes
-            return SizedBox(
-              width: constraints.maxWidth,
-              height: constraints.maxHeight,
-              child: widget,
-            );
-          },
-        );
-      },
-    );
-  }
-}

--- a/lib/platform/webview_factory.dart
+++ b/lib/platform/webview_factory.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
-// webview_cef support has been removed
-// import 'package:webview_cef/webview_cef.dart' as cef;
 import 'platform_info.dart';
 import 'unified_webview.dart';
 
@@ -133,9 +131,6 @@ class _InAppWebViewController implements UnifiedWebViewController {
   }
 }
 
-// WebviewCef controller has been removed
-// webview_cef support is no longer included in this application
-
 /// Factory for creating platform-specific webviews
 class WebViewFactory {
   /// Create a webview widget based on the current platform
@@ -146,7 +141,6 @@ class WebViewFactory {
     if (PlatformInfo.useInAppWebView) {
       return _createInAppWebView(config, onControllerCreated);
     } else {
-      // webview_cef has been disabled
       return Center(
         child: Text('WebView not supported on this platform.\nLinux builds are currently disabled.'),
       );

--- a/lib/platform/webview_factory.dart
+++ b/lib/platform/webview_factory.dart
@@ -194,4 +194,4 @@ class WebViewFactory {
       },
     );
   }
-
+}

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -156,7 +156,7 @@ class WebViewModel {
             if (controller != null) {
               var title = await controller!.getTitle();
 
-              // Fallback: If controller doesn't provide title (webview_cef on Linux),
+              // Fallback: If controller doesn't provide title,
               // parse HTML to extract it
               if (title == null || title.isEmpty) {
                 // Import getPageTitle from main.dart would cause circular dependency

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,10 +43,6 @@ dependencies:
   # Android/mobile: flutter_inappwebview (stable, feature-rich)
   flutter_inappwebview: ^6.1.0+1
 
-  # Desktop (Linux/Windows/macOS): webview_cef (CEF-based, actively developed)
-  # DISABLED: webview_cef support has been removed
-  # webview_cef: ^0.2.0
-
   url_launcher: ^6.1.10
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,8 @@ dependencies:
   flutter_inappwebview: ^6.1.0+1
 
   # Desktop (Linux/Windows/macOS): webview_cef (CEF-based, actively developed)
-  webview_cef: ^0.2.0
+  # DISABLED: webview_cef support has been removed
+  # webview_cef: ^0.2.0
 
   url_launcher: ^6.1.10
 


### PR DESCRIPTION
This commit removes webview_cef support and disables Linux builds:
- Commented out webview_cef dependency in pubspec.yaml
- Updated platform_info.dart to always return false for useWebViewCef
- Removed webview_cef import and implementation from webview_factory.dart
- Disabled build-linux job in GitHub Actions workflow
- Updated release summary to reflect Linux builds being disabled

Linux platform is no longer supported until a suitable webview solution is found.