### PR TITLE
Fix misleading CI build output naming

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -175,9 +175,9 @@ jobs:
       - name: Build macOS
         run: flutter build macos --release
 
-      - name: Create DMG (optional)
+      - name: Create ZIP archive
         run: |
-          # Simple approach: zip the .app bundle
+          # Package as zip for now (TODO: create proper DMG in the future)
           cd build/macos/Build/Products/Release
           zip -r ../../../../../webspace-macos.zip webspace.app
 


### PR DESCRIPTION
Update the macOS build step name from "Create DMG (optional)" to "Create ZIP archive" to accurately reflect that the build currently produces a zipped .app bundle, not a DMG file. Added TODO comment noting that proper DMG creation is planned for the future.