### PR TITLE
Add back and home navigation buttons to top bar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -346,6 +346,31 @@ class _WebSpacePageState extends State<WebSpacePage> {
             )
           : Text('No Site Selected'),
       actions: [
+        if (_currentIndex != null && _currentIndex! < _webViewModels.length)
+          IconButton(
+            icon: Icon(Icons.arrow_back),
+            tooltip: 'Go Back',
+            onPressed: () async {
+              final controller = getController();
+              if (controller != null) {
+                final canGoBack = await controller.canGoBack();
+                if (canGoBack) {
+                  await controller.goBack();
+                }
+              }
+            },
+          ),
+        if (_currentIndex != null && _currentIndex! < _webViewModels.length)
+          IconButton(
+            icon: Icon(Icons.home),
+            tooltip: 'Go to Home',
+            onPressed: () async {
+              final controller = getController();
+              if (controller != null) {
+                await controller.loadUrl(_webViewModels[_currentIndex!].initUrl);
+              }
+            },
+          ),
         IconButton(
           icon: Icon(Theme.of(context).brightness == Brightness.light ? Icons.wb_sunny : Icons.nights_stay),
           onPressed: () async {

--- a/lib/platform/webview_factory.dart
+++ b/lib/platform/webview_factory.dart
@@ -37,6 +37,8 @@ abstract class UnifiedWebViewController {
   Future<String?> getDefaultUserAgent();
   Future<void> setOptions({required bool javascriptEnabled, String? userAgent});
   Future<void> setThemePreference(WebViewTheme theme);
+  Future<void> goBack();
+  Future<bool> canGoBack();
 }
 
 /// InAppWebView controller wrapper
@@ -112,7 +114,7 @@ class _InAppWebViewController implements UnifiedWebViewController {
     // However, this requires Android settings which are platform-specific
     // Instead, we'll inject JavaScript to set the theme via CSS
     String themeValue = theme == WebViewTheme.dark ? 'dark' : 'light';
-    
+
     await evaluateJavascript('''
       (function() {
         // Set color-scheme meta tag if it doesn't exist
@@ -123,11 +125,21 @@ class _InAppWebViewController implements UnifiedWebViewController {
           document.head.appendChild(metaTag);
         }
         metaTag.content = '$themeValue';
-        
+
         // Also set it on the root element for maximum compatibility
         document.documentElement.style.colorScheme = '$themeValue';
       })();
     ''');
+  }
+
+  @override
+  Future<void> goBack() async {
+    await controller.goBack();
+  }
+
+  @override
+  Future<bool> canGoBack() async {
+    return await controller.canGoBack();
   }
 }
 


### PR DESCRIPTION
- Add goBack() and canGoBack() methods to UnifiedWebViewController interface
- Implement navigation methods in _InAppWebViewController
- Add back button to navigate to previous page in history
- Add home button to return to the site's initial URL
- Buttons appear in the AppBar only when a site is selected
- Back button checks if navigation is possible before going back

This allows users to easily navigate back through their browsing history or quickly return to the home page of the currently active site.