### PR TITLE
Fix site link wrapping in drawer

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -635,8 +635,13 @@ class _WebSpacePageState extends State<WebSpacePage> {
                       overflow: TextOverflow.ellipsis,
                       softWrap: false,
                     ),
-                    subtitle: Text(extractDomain(_webViewModels[index].initUrl), 
-                      style: TextStyle(fontSize: 12, color: Colors.grey)),
+                    subtitle: Text(
+                      extractDomain(_webViewModels[index].initUrl),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      softWrap: false,
+                      style: TextStyle(fontSize: 12, color: Colors.grey),
+                    ),
                     onTap: () {
                       setState(() {
                         _currentIndex = index;


### PR DESCRIPTION
Apply same non-wrapping behavior to site links (domains) as site titles:
- Add maxLines: 1
- Add overflow: TextOverflow.ellipsis
- Add softWrap: false

This ensures both titles and links display on a single line with ellipsis for overflow, providing consistent UI behavior in the site drawer.