### PR TITLE
Fix iOS webview assertion error by migrating to InAppWebViewSettings API

### DIFF
--- a/lib/platform/webview_factory.dart
+++ b/lib/platform/webview_factory.dart
@@ -96,14 +96,12 @@ class _InAppWebViewController implements UnifiedWebViewController {
 
   @override
   Future<void> setOptions({required bool javascriptEnabled, String? userAgent}) async {
-    await controller.setOptions(
-      options: inapp.InAppWebViewGroupOptions(
-        crossPlatform: inapp.InAppWebViewOptions(
-          javaScriptEnabled: javascriptEnabled,
-          userAgent: userAgent ?? '',
-          supportZoom: true,
-          useShouldOverrideUrlLoading: true,
-        ),
+    await controller.setSettings(
+      settings: inapp.InAppWebViewSettings(
+        javaScriptEnabled: javascriptEnabled,
+        userAgent: userAgent ?? '',
+        supportZoom: true,
+        useShouldOverrideUrlLoading: true,
       ),
     );
   }
@@ -278,13 +276,11 @@ class WebViewFactory {
 
     return inapp.InAppWebView(
       initialUrlRequest: inapp.URLRequest(url: inapp.WebUri(config.initialUrl)),
-      initialOptions: inapp.InAppWebViewGroupOptions(
-        crossPlatform: inapp.InAppWebViewOptions(
-          javaScriptEnabled: config.javascriptEnabled,
-          userAgent: config.userAgent ?? '',
-          supportZoom: true,
-          useShouldOverrideUrlLoading: true,
-        ),
+      initialSettings: inapp.InAppWebViewSettings(
+        javaScriptEnabled: config.javascriptEnabled,
+        userAgent: config.userAgent ?? '',
+        supportZoom: true,
+        useShouldOverrideUrlLoading: true,
       ),
       onWebViewCreated: (controller) {
         onControllerCreated(_InAppWebViewController(controller));


### PR DESCRIPTION
The app was crashing on iOS with an assertion error: 'allowingReadAccessTo == null || allowingReadAccessTo!.isScheme("file")': is not true

This was caused by using the deprecated InAppWebViewGroupOptions API, which triggered validation errors during internal conversion to InAppWebViewSettings.

Changes:
- Updated setOptions() to use setSettings() with InAppWebViewSettings
- Updated initialOptions to initialSettings with InAppWebViewSettings
- Removed nested crossPlatform/InAppWebViewOptions structure
- Now uses flat InAppWebViewSettings structure directly

This ensures iOS-specific parameters are properly handled and prevents the assertion failure.