### PR TITLE
Disable autocorrect for text input fields

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -540,6 +540,8 @@ class _WebSpacePageState extends State<WebSpacePage> {
             TextField(
               controller: nameController,
               autofocus: true,
+              autocorrect: false,
+              enableSuggestions: false,
               decoration: InputDecoration(
                 labelText: 'Site Name',
                 hintText: 'Enter a custom name',
@@ -548,6 +550,9 @@ class _WebSpacePageState extends State<WebSpacePage> {
             SizedBox(height: 16),
             TextField(
               controller: urlController,
+              autocorrect: false,
+              enableSuggestions: false,
+              keyboardType: TextInputType.url,
               decoration: InputDecoration(
                 labelText: 'URL',
                 hintText: 'http://example.com:8080',

--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -21,6 +21,9 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
             TextField(
               controller: _controller,
               autofocus: true,
+              autocorrect: false,
+              enableSuggestions: false,
+              keyboardType: TextInputType.url,
               decoration: InputDecoration(labelText: 'Enter website URL'),
             ),
             SizedBox(height: 16),

--- a/lib/widgets/find_toolbar.dart
+++ b/lib/widgets/find_toolbar.dart
@@ -40,6 +40,8 @@ class _FindToolbarState extends State<FindToolbar> {
           Expanded(
             child: TextField(
               controller: _searchController,
+              autocorrect: false,
+              enableSuggestions: false,
               decoration: InputDecoration(
                 hintText: 'Search on page',
               ),


### PR DESCRIPTION
Fixed autocorrect triggering on user input like "new side" by:
- Disabling autocorrect and suggestions in Add Site screen
- Disabling autocorrect and suggestions in Edit Site dialog (both name and URL fields)
- Disabling autocorrect and suggestions in Find toolbar search
- Added TextInputType.url for URL input fields for better keyboard support