### PR TITLE
Add URL bar with display and editing functionality

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -467,23 +467,23 @@ class _WebSpacePageState extends State<WebSpacePage> {
               ),
               if (_currentIndex != null && _currentIndex! < _webViewModels.length)
               PopupMenuItem<String>(
-                value: "settings",
-                child: Row(
-                  children: [
-                    Icon(Icons.settings),
-                    SizedBox(width: 8),
-                    Text("Settings"),
-                  ],
-                ),
-              ),
-              if (_currentIndex != null && _currentIndex! < _webViewModels.length)
-              PopupMenuItem<String>(
                 value: "toggleUrlBar",
                 child: Row(
                   children: [
                     Icon(_showUrlBar ? Icons.visibility_off : Icons.visibility),
                     SizedBox(width: 8),
                     Text(_showUrlBar ? "Hide URL Bar" : "Show URL Bar"),
+                  ],
+                ),
+              ),
+              if (_currentIndex != null && _currentIndex! < _webViewModels.length)
+              PopupMenuItem<String>(
+                value: "settings",
+                child: Row(
+                  children: [
+                    Icon(Icons.settings),
+                    SizedBox(width: 8),
+                    Text("Settings"),
                   ],
                 ),
               ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ import 'package:webspace/screens/add_site.dart';
 import 'package:webspace/screens/settings.dart';
 import 'package:webspace/screens/inappbrowser.dart';
 import 'package:webspace/widgets/find_toolbar.dart';
+import 'package:webspace/widgets/url_bar.dart';
 
 // Helper to convert ThemeMode to WebViewTheme
 WebViewTheme _themeModeToWebViewTheme(ThemeMode mode) {
@@ -761,6 +762,19 @@ class _WebSpacePageState extends State<WebSpacePage> {
                         _toggleFind();
                       },
                     ),
+                  UrlBar(
+                    currentUrl: webViewModel.currentUrl,
+                    onUrlSubmitted: (url) async {
+                      final controller = webViewModel.getController(launchUrl, _cookieManager, _saveWebViewModels);
+                      if (controller != null) {
+                        await controller.loadUrl(url);
+                        setState(() {
+                          webViewModel.currentUrl = url;
+                        });
+                        await _saveWebViewModels();
+                      }
+                    },
+                  ),
                   Expanded(
                     child: webViewModel.getWebView(launchUrl, _cookieManager, _saveWebViewModels)
                   ),

--- a/lib/widgets/url_bar.dart
+++ b/lib/widgets/url_bar.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+
+class UrlBar extends StatefulWidget {
+  final String currentUrl;
+  final Function(String) onUrlSubmitted;
+
+  const UrlBar({
+    Key? key,
+    required this.currentUrl,
+    required this.onUrlSubmitted,
+  }) : super(key: key);
+
+  @override
+  _UrlBarState createState() => _UrlBarState();
+}
+
+class _UrlBarState extends State<UrlBar> {
+  late TextEditingController _urlController;
+  late FocusNode _focusNode;
+  bool _isEditing = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _urlController = TextEditingController(text: widget.currentUrl);
+    _focusNode = FocusNode();
+
+    _focusNode.addListener(() {
+      if (!_focusNode.hasFocus && _isEditing) {
+        setState(() {
+          _isEditing = false;
+          _urlController.text = widget.currentUrl;
+        });
+      }
+    });
+  }
+
+  @override
+  void didUpdateWidget(UrlBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Update the displayed URL when navigating (but not while editing)
+    if (!_isEditing && widget.currentUrl != oldWidget.currentUrl) {
+      _urlController.text = widget.currentUrl;
+    }
+  }
+
+  @override
+  void dispose() {
+    _urlController.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _handleSubmit() {
+    String url = _urlController.text.trim();
+
+    // Infer protocol if not specified
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      url = 'https://$url';
+    }
+
+    widget.onUrlSubmitted(url);
+    _focusNode.unfocus();
+    setState(() {
+      _isEditing = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: isDark ? Color(0xFF1E1E1E) : Color(0xFFF5F5F5),
+        border: Border(
+          bottom: BorderSide(
+            color: isDark ? Color(0xFF3E3E3E) : Color(0xFFE0E0E0),
+            width: 1,
+          ),
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            Icons.lock,
+            size: 16,
+            color: widget.currentUrl.startsWith('https://')
+                ? Colors.green
+                : Colors.grey,
+          ),
+          SizedBox(width: 8),
+          Expanded(
+            child: TextField(
+              controller: _urlController,
+              focusNode: _focusNode,
+              onTap: () {
+                setState(() {
+                  _isEditing = true;
+                });
+                _urlController.selection = TextSelection(
+                  baseOffset: 0,
+                  extentOffset: _urlController.text.length,
+                );
+              },
+              onSubmitted: (_) => _handleSubmit(),
+              decoration: InputDecoration(
+                hintText: 'Enter URL',
+                border: InputBorder.none,
+                isDense: true,
+                contentPadding: EdgeInsets.symmetric(vertical: 8, horizontal: 8),
+              ),
+              style: TextStyle(
+                fontSize: 14,
+                color: _isEditing
+                    ? theme.colorScheme.onSurface
+                    : theme.colorScheme.onSurface.withOpacity(0.7),
+              ),
+              keyboardType: TextInputType.url,
+              textInputAction: TextInputAction.go,
+            ),
+          ),
+          if (_isEditing)
+            IconButton(
+              icon: Icon(Icons.check, size: 20),
+              onPressed: _handleSubmit,
+              padding: EdgeInsets.all(4),
+              constraints: BoxConstraints(),
+              tooltip: 'Go',
+            ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Implemented a URL bar that displays the current webview URL and allows users to edit and navigate to new URLs. The URL bar features:
- Live URL display that updates as the user navigates
- Click-to-edit functionality with automatic text selection
- Protocol inference (defaults to https:// if not specified)
- Visual lock icon indicating secure (HTTPS) connections
- Seamless integration with existing webview navigation

Created new UrlBar widget in lib/widgets/url_bar.dart and integrated it into the main webview UI above the webview content.