### PR TITLE
Add site suggestions with favicon tiles

### DIFF
--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -250,6 +250,7 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
                                       imageUrl: _getFaviconUrl(suggestion.domain),
                                       width: iconSize,
                                       height: iconSize,
+                                      fit: BoxFit.contain,
                                       placeholder: (context, url) => SizedBox(
                                         width: iconSize,
                                         height: iconSize,

--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -216,7 +216,7 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
               child: LayoutBuilder(
                 builder: (context, constraints) {
                   final tileSize = (constraints.maxWidth - 36) / 4; // 4 columns with 12px spacing
-                  final iconSize = tileSize * 0.5; // Icon takes 50% of tile size
+                  final iconSize = tileSize * 0.7; // Icon takes 70% of tile size
 
                   return GridView.builder(
                     gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
@@ -240,38 +240,36 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
                             ),
                           ),
                           child: Padding(
-                            padding: const EdgeInsets.all(8.0),
+                            padding: const EdgeInsets.all(4.0),
                             child: Column(
                               mainAxisAlignment: MainAxisAlignment.center,
                               children: [
-                                Flexible(
-                                  flex: 3,
-                                  child: CachedNetworkImage(
-                                    imageUrl: _getFaviconUrl(suggestion.domain),
-                                    width: iconSize,
-                                    height: iconSize,
-                                    placeholder: (context, url) => SizedBox(
+                                Expanded(
+                                  child: Center(
+                                    child: CachedNetworkImage(
+                                      imageUrl: _getFaviconUrl(suggestion.domain),
                                       width: iconSize,
                                       height: iconSize,
-                                      child: CircularProgressIndicator(strokeWidth: 2),
-                                    ),
-                                    errorWidget: (context, url, error) => Icon(
-                                      Icons.language,
-                                      size: iconSize,
-                                      color: Theme.of(context).colorScheme.primary,
+                                      placeholder: (context, url) => SizedBox(
+                                        width: iconSize,
+                                        height: iconSize,
+                                        child: CircularProgressIndicator(strokeWidth: 2),
+                                      ),
+                                      errorWidget: (context, url, error) => Icon(
+                                        Icons.language,
+                                        size: iconSize,
+                                        color: Theme.of(context).colorScheme.primary,
+                                      ),
                                     ),
                                   ),
                                 ),
-                                SizedBox(height: 4),
-                                Flexible(
-                                  flex: 2,
-                                  child: Text(
-                                    suggestion.name,
-                                    style: TextStyle(fontSize: 11),
-                                    textAlign: TextAlign.center,
-                                    maxLines: 2,
-                                    overflow: TextOverflow.ellipsis,
-                                  ),
+                                SizedBox(height: 2),
+                                Text(
+                                  suggestion.name,
+                                  style: TextStyle(fontSize: 10),
+                                  textAlign: TextAlign.center,
+                                  maxLines: 2,
+                                  overflow: TextOverflow.ellipsis,
                                 ),
                               ],
                             ),

--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -112,8 +112,9 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
   }
 
   String _getFaviconUrl(String domain) {
-    // Use Google's favicon service with high resolution (256px)
-    return 'https://www.google.com/s2/favicons?domain=$domain&sz=256';
+    // Use Google's favicon service - sz=128 is more widely available than 256
+    // Falls back to smaller sizes automatically if not available
+    return 'https://www.google.com/s2/favicons?domain=$domain&sz=128';
   }
 
   IconData _getThemeIcon() {
@@ -254,6 +255,7 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
                                       width: iconSize,
                                       height: iconSize,
                                       fit: BoxFit.contain,
+                                      filterQuality: FilterQuality.high,
                                       placeholder: (context, url) => SizedBox(
                                         width: iconSize,
                                         height: iconSize,

--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -1,4 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+
+class SiteSuggestion {
+  final String name;
+  final String url;
+  final String domain;
+
+  const SiteSuggestion({
+    required this.name,
+    required this.url,
+    required this.domain,
+  });
+}
 
 class AddSiteScreen extends StatefulWidget {
   @override
@@ -7,6 +20,86 @@ class AddSiteScreen extends StatefulWidget {
 
 class _AddSiteScreenState extends State<AddSiteScreen> {
   final TextEditingController _controller = TextEditingController();
+
+  static const List<SiteSuggestion> _suggestions = [
+    SiteSuggestion(name: 'DuckDuckGo', url: 'https://duckduckgo.com', domain: 'duckduckgo.com'),
+    SiteSuggestion(name: 'Claude', url: 'https://claude.ai', domain: 'claude.ai'),
+    SiteSuggestion(name: 'ChatGPT', url: 'https://chatgpt.com', domain: 'chatgpt.com'),
+    SiteSuggestion(name: 'Perplexity', url: 'https://perplexity.ai', domain: 'perplexity.ai'),
+    SiteSuggestion(name: 'Instagram', url: 'https://instagram.com', domain: 'instagram.com'),
+    SiteSuggestion(name: 'Facebook', url: 'https://facebook.com', domain: 'facebook.com'),
+    SiteSuggestion(name: 'Piped', url: 'https://piped.video', domain: 'piped.video'),
+    SiteSuggestion(name: 'X (Twitter)', url: 'https://x.com', domain: 'x.com'),
+    SiteSuggestion(name: 'Google Chat', url: 'https://chat.google.com', domain: 'chat.google.com'),
+    SiteSuggestion(name: 'GitLab', url: 'https://gitlab.com', domain: 'gitlab.com'),
+    SiteSuggestion(name: 'Gitea', url: 'https://gitea.io', domain: 'gitea.io'),
+    SiteSuggestion(name: 'Slack', url: 'https://slack.com', domain: 'slack.com'),
+    SiteSuggestion(name: 'Gmail', url: 'https://gmail.com', domain: 'gmail.com'),
+    SiteSuggestion(name: 'Reddit', url: 'https://reddit.com', domain: 'reddit.com'),
+  ];
+
+  void _showSuggestionDialog(SiteSuggestion suggestion) {
+    final TextEditingController nameController = TextEditingController(text: suggestion.name);
+    final TextEditingController urlController = TextEditingController(text: suggestion.url);
+
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text('Add Site'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: nameController,
+                autocorrect: false,
+                enableSuggestions: false,
+                decoration: InputDecoration(
+                  labelText: 'Site Name',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              SizedBox(height: 16),
+              TextField(
+                controller: urlController,
+                autocorrect: false,
+                enableSuggestions: false,
+                keyboardType: TextInputType.url,
+                decoration: InputDecoration(
+                  labelText: 'Site URL',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: Text('Cancel'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                String url = urlController.text.trim();
+                // If no protocol specified, default to https
+                if (!url.startsWith('http://') && !url.startsWith('https://')) {
+                  url = 'https://$url';
+                }
+                Navigator.of(context).pop();
+                Navigator.of(context).pop(url);
+              },
+              child: Text('Add'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  String _getFaviconUrl(String domain) {
+    return 'https://icons.duckduckgo.com/ip3/$domain.ico';
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -17,6 +110,7 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             TextField(
               controller: _controller,
@@ -43,6 +137,67 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
               'Tip: Type http:// for HTTP sites, or just the domain for HTTPS',
               style: TextStyle(fontSize: 12, color: Colors.grey),
               textAlign: TextAlign.center,
+            ),
+            SizedBox(height: 24),
+            Text(
+              'Suggested Sites',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+            SizedBox(height: 12),
+            Expanded(
+              child: GridView.builder(
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 4,
+                  crossAxisSpacing: 12,
+                  mainAxisSpacing: 12,
+                  childAspectRatio: 1,
+                ),
+                itemCount: _suggestions.length,
+                itemBuilder: (context, index) {
+                  final suggestion = _suggestions[index];
+                  return InkWell(
+                    onTap: () => _showSuggestionDialog(suggestion),
+                    borderRadius: BorderRadius.circular(12),
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.5),
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(
+                          color: Theme.of(context).colorScheme.outline.withOpacity(0.2),
+                        ),
+                      ),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          CachedNetworkImage(
+                            imageUrl: _getFaviconUrl(suggestion.domain),
+                            width: 40,
+                            height: 40,
+                            placeholder: (context, url) => SizedBox(
+                              width: 40,
+                              height: 40,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            ),
+                            errorWidget: (context, url, error) => Icon(
+                              Icons.language,
+                              size: 40,
+                              color: Theme.of(context).colorScheme.primary,
+                            ),
+                          ),
+                          SizedBox(height: 8),
+                          Text(
+                            suggestion.name,
+                            style: TextStyle(fontSize: 12),
+                            textAlign: TextAlign.center,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              ),
             ),
           ],
         ),

--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -41,8 +41,10 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
     SiteSuggestion(name: 'X (Twitter)', url: 'https://x.com', domain: 'x.com'),
     SiteSuggestion(name: 'Google Chat', url: 'https://chat.google.com', domain: 'chat.google.com'),
     SiteSuggestion(name: 'GitLab', url: 'https://gitlab.com', domain: 'gitlab.com'),
-    SiteSuggestion(name: 'Gitea', url: 'https://gitea.io', domain: 'gitea.io'),
+    SiteSuggestion(name: 'Gitea', url: 'https://gitea.com', domain: 'gitea.com'),
+    SiteSuggestion(name: 'Codeberg', url: 'https://codeberg.org', domain: 'codeberg.org'),
     SiteSuggestion(name: 'Slack', url: 'https://slack.com', domain: 'slack.com'),
+    SiteSuggestion(name: 'Mattermost', url: 'https://mattermost.com', domain: 'mattermost.com'),
     SiteSuggestion(name: 'Gmail', url: 'https://gmail.com', domain: 'gmail.com'),
     SiteSuggestion(name: 'Reddit', url: 'https://reddit.com', domain: 'reddit.com'),
     SiteSuggestion(name: 'Mastodon', url: 'https://mastodon.social', domain: 'mastodon.social'),
@@ -110,7 +112,8 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
   }
 
   String _getFaviconUrl(String domain) {
-    return 'https://icons.duckduckgo.com/ip3/$domain.ico';
+    // Use Google's favicon service with high resolution (128px)
+    return 'https://www.google.com/s2/favicons?domain=$domain&sz=128';
   }
 
   IconData _getThemeIcon() {

--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -112,8 +112,8 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
   }
 
   String _getFaviconUrl(String domain) {
-    // Use Google's favicon service with high resolution (128px)
-    return 'https://www.google.com/s2/favicons?domain=$domain&sz=128';
+    // Use Google's favicon service with high resolution (256px)
+    return 'https://www.google.com/s2/favicons?domain=$domain&sz=256';
   }
 
   IconData _getThemeIcon() {

--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -14,12 +14,21 @@ class SiteSuggestion {
 }
 
 class AddSiteScreen extends StatefulWidget {
+  final ThemeMode themeMode;
+  final Function(ThemeMode) onThemeModeChanged;
+
+  AddSiteScreen({
+    required this.themeMode,
+    required this.onThemeModeChanged,
+  });
+
   @override
   _AddSiteScreenState createState() => _AddSiteScreenState();
 }
 
 class _AddSiteScreenState extends State<AddSiteScreen> {
-  final TextEditingController _controller = TextEditingController();
+  final TextEditingController _urlController = TextEditingController();
+  final TextEditingController _nameController = TextEditingController();
 
   static const List<SiteSuggestion> _suggestions = [
     SiteSuggestion(name: 'DuckDuckGo', url: 'https://duckduckgo.com', domain: 'duckduckgo.com'),
@@ -36,6 +45,8 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
     SiteSuggestion(name: 'Slack', url: 'https://slack.com', domain: 'slack.com'),
     SiteSuggestion(name: 'Gmail', url: 'https://gmail.com', domain: 'gmail.com'),
     SiteSuggestion(name: 'Reddit', url: 'https://reddit.com', domain: 'reddit.com'),
+    SiteSuggestion(name: 'Mastodon', url: 'https://mastodon.social', domain: 'mastodon.social'),
+    SiteSuggestion(name: 'Bluesky', url: 'https://bsky.app', domain: 'bsky.app'),
   ];
 
   void _showSuggestionDialog(SiteSuggestion suggestion) {
@@ -82,12 +93,13 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
             ElevatedButton(
               onPressed: () {
                 String url = urlController.text.trim();
+                String name = nameController.text.trim();
                 // If no protocol specified, default to https
                 if (!url.startsWith('http://') && !url.startsWith('https://')) {
                   url = 'https://$url';
                 }
                 Navigator.of(context).pop();
-                Navigator.of(context).pop(url);
+                Navigator.of(context).pop({'url': url, 'name': name});
               },
               child: Text('Add'),
             ),
@@ -101,11 +113,56 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
     return 'https://icons.duckduckgo.com/ip3/$domain.ico';
   }
 
+  IconData _getThemeIcon() {
+    switch (widget.themeMode) {
+      case ThemeMode.light:
+        return Icons.wb_sunny;
+      case ThemeMode.dark:
+        return Icons.nights_stay;
+      case ThemeMode.system:
+        return Icons.brightness_auto;
+    }
+  }
+
+  String _getThemeTooltip() {
+    switch (widget.themeMode) {
+      case ThemeMode.light:
+        return 'Light theme';
+      case ThemeMode.dark:
+        return 'Dark theme';
+      case ThemeMode.system:
+        return 'System theme';
+    }
+  }
+
+  void _toggleTheme() {
+    ThemeMode newMode;
+    switch (widget.themeMode) {
+      case ThemeMode.light:
+        newMode = ThemeMode.dark;
+        break;
+      case ThemeMode.dark:
+        newMode = ThemeMode.system;
+        break;
+      case ThemeMode.system:
+        newMode = ThemeMode.light;
+        break;
+    }
+    widget.onThemeModeChanged(newMode);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: Text('Add new site'),
+        actions: [
+          IconButton(
+            icon: Icon(_getThemeIcon()),
+            tooltip: _getThemeTooltip(),
+            onPressed: _toggleTheme,
+          ),
+        ],
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
@@ -113,7 +170,17 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             TextField(
-              controller: _controller,
+              controller: _nameController,
+              autocorrect: false,
+              enableSuggestions: false,
+              decoration: InputDecoration(
+                labelText: 'Site Name (optional)',
+                helperText: 'Leave empty to fetch from website',
+              ),
+            ),
+            SizedBox(height: 16),
+            TextField(
+              controller: _urlController,
               autofocus: true,
               autocorrect: false,
               enableSuggestions: false,
@@ -123,12 +190,13 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
             SizedBox(height: 16),
             ElevatedButton(
               onPressed: () {
-                String url = _controller.text.trim();
+                String url = _urlController.text.trim();
+                String name = _nameController.text.trim();
                 // If no protocol specified, default to https
                 if (!url.startsWith('http://') && !url.startsWith('https://')) {
                   url = 'https://$url';
                 }
-                Navigator.pop(context, url);
+                Navigator.pop(context, {'url': url, 'name': name});
               },
               child: Text('Add Site'),
             ),
@@ -145,56 +213,72 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
             ),
             SizedBox(height: 12),
             Expanded(
-              child: GridView.builder(
-                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: 4,
-                  crossAxisSpacing: 12,
-                  mainAxisSpacing: 12,
-                  childAspectRatio: 1,
-                ),
-                itemCount: _suggestions.length,
-                itemBuilder: (context, index) {
-                  final suggestion = _suggestions[index];
-                  return InkWell(
-                    onTap: () => _showSuggestionDialog(suggestion),
-                    borderRadius: BorderRadius.circular(12),
-                    child: Container(
-                      decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.5),
-                        borderRadius: BorderRadius.circular(12),
-                        border: Border.all(
-                          color: Theme.of(context).colorScheme.outline.withOpacity(0.2),
-                        ),
-                      ),
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          CachedNetworkImage(
-                            imageUrl: _getFaviconUrl(suggestion.domain),
-                            width: 40,
-                            height: 40,
-                            placeholder: (context, url) => SizedBox(
-                              width: 40,
-                              height: 40,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            ),
-                            errorWidget: (context, url, error) => Icon(
-                              Icons.language,
-                              size: 40,
-                              color: Theme.of(context).colorScheme.primary,
-                            ),
-                          ),
-                          SizedBox(height: 8),
-                          Text(
-                            suggestion.name,
-                            style: TextStyle(fontSize: 12),
-                            textAlign: TextAlign.center,
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ],
-                      ),
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final tileSize = (constraints.maxWidth - 36) / 4; // 4 columns with 12px spacing
+                  final iconSize = tileSize * 0.5; // Icon takes 50% of tile size
+
+                  return GridView.builder(
+                    gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 4,
+                      crossAxisSpacing: 12,
+                      mainAxisSpacing: 12,
+                      childAspectRatio: 1,
                     ),
+                    itemCount: _suggestions.length,
+                    itemBuilder: (context, index) {
+                      final suggestion = _suggestions[index];
+                      return InkWell(
+                        onTap: () => _showSuggestionDialog(suggestion),
+                        borderRadius: BorderRadius.circular(12),
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.5),
+                            borderRadius: BorderRadius.circular(12),
+                            border: Border.all(
+                              color: Theme.of(context).colorScheme.outline.withOpacity(0.2),
+                            ),
+                          ),
+                          child: Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Flexible(
+                                  flex: 3,
+                                  child: CachedNetworkImage(
+                                    imageUrl: _getFaviconUrl(suggestion.domain),
+                                    width: iconSize,
+                                    height: iconSize,
+                                    placeholder: (context, url) => SizedBox(
+                                      width: iconSize,
+                                      height: iconSize,
+                                      child: CircularProgressIndicator(strokeWidth: 2),
+                                    ),
+                                    errorWidget: (context, url, error) => Icon(
+                                      Icons.language,
+                                      size: iconSize,
+                                      color: Theme.of(context).colorScheme.primary,
+                                    ),
+                                  ),
+                                ),
+                                SizedBox(height: 4),
+                                Flexible(
+                                  flex: 2,
+                                  child: Text(
+                                    suggestion.name,
+                                    style: TextStyle(fontSize: 11),
+                                    textAlign: TextAlign.center,
+                                    maxLines: 2,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      );
+                    },
                   );
                 },
               ),


### PR DESCRIPTION
- Added 14 popular site suggestions (DuckDuckGo, Claude, ChatGPT, Perplexity, Instagram, Facebook, Piped, X, Google Chat, GitLab, Gitea, Slack, Gmail, Reddit)
- Display suggestions as a scrollable grid of tiles with cached favicons
- Clicking a tile opens a dialog with pre-filled site name and URL
- Dialog includes Cancel and Add buttons for confirmation
- Uses DuckDuckGo's icon service for favicon fetching