### PR TITLE
Fix cookie manager assertion failure on macOS

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -275,6 +275,10 @@ class _WebSpacePageState extends State<WebSpacePage> {
       });
       for (WebViewModel webViewModel in loadedWebViewModels) {
         for(final cookie in webViewModel.cookies) {
+          // Skip cookies with empty values to prevent assertion failures
+          if (cookie.value.isEmpty) {
+            continue;
+          }
           await _cookieManager.setCookie(
             url: Uri.parse(webViewModel.initUrl),
             name: cookie.name,

--- a/lib/platform/unified_webview.dart
+++ b/lib/platform/unified_webview.dart
@@ -124,6 +124,11 @@ class UnifiedCookieManager {
     bool? isSecure,
     bool? isHttpOnly,
   }) async {
+    // Skip cookies with empty values to prevent assertion failures on macOS
+    if (value.isEmpty) {
+      return;
+    }
+
     if (PlatformInfo.useInAppWebView) {
       await _inApp.setCookie(
         url: _toWebUri(url),


### PR DESCRIPTION
Prevents crash when restoring cookies with empty values by:
- Adding validation in _loadWebViewModels to skip empty-valued cookies
- Adding early return in UnifiedCookieManager.setCookie for empty values

This fixes the unhandled exception:
'value.isNotEmpty': is not true
in flutter_inappwebview_macos/src/cookie_manager.dart:83

Cookies with empty values are skipped since they are not meaningful and would cause assertion failures on macOS.