### PR TITLE
Fix setState error in FaviconImage widget

### DIFF
--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -38,7 +38,7 @@ class _FaviconImageState extends State<FaviconImage> {
   }
 
   void _tryNextUrl() {
-    if (_urlIndex < _getFaviconUrls().length - 1) {
+    if (_urlIndex < _getFaviconUrls().length - 1 && mounted) {
       setState(() {
         _urlIndex++;
       });


### PR DESCRIPTION
Add mounted check before calling setState in _tryNextUrl method to prevent error when widget is disposed before post-frame callback executes.

Fixes: setState() called after dispose error in favicon loading