### PR TITLE
Enforce lockfile in GitHub Actions for reproducible builds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,7 +43,7 @@ jobs:
             pub-${{ runner.os }}-
 
       - name: Get dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Build APK
         run: flutter build apk --release --flavor fdroid --split-per-abi
@@ -79,7 +79,7 @@ jobs:
             pub-${{ runner.os }}-
 
       - name: Get dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Create iOS platform if not exists
         run: |
@@ -133,7 +133,7 @@ jobs:
             pub-${{ runner.os }}-
 
       - name: Get dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Run tests
         run: flutter test
@@ -167,7 +167,7 @@ jobs:
             pub-${{ runner.os }}-
 
       - name: Get dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Run tests
         run: flutter test


### PR DESCRIPTION
Update all Flutter pub get commands to use --enforce-lockfile flag. This ensures that dependency versions match pubspec.lock exactly, preventing unexpected version updates during CI builds.

Changes:
- Android build job: flutter pub get --enforce-lockfile
- iOS build job: flutter pub get --enforce-lockfile
- Linux build job: flutter pub get --enforce-lockfile
- macOS build job: flutter pub get --enforce-lockfile