### PR TITLE
Update app display name from 'webspace_app' to 'Webspace'

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <application
-        android:label="webspace_app"
+        android:label="Webspace"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -41,11 +41,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "webspace_app");
+    gtk_header_bar_set_title(header_bar, "Webspace");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "webspace_app");
+    gtk_window_set_title(window, "Webspace");
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,7 +5,7 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = webspace
+PRODUCT_NAME = Webspace
 
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = org.codeberg.theoden8.webspace


### PR DESCRIPTION
- Changed Android app label to 'Webspace' in AndroidManifest.xml
- Updated Linux window title to 'Webspace' in my_application.cc
- iOS already had correct display name 'Webspace' in Info.plist