### PR TITLE
Fix iOS fastlane build by using Flutter commands

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -24,26 +24,12 @@ platform :ios do
 
   desc "Build debug version"
   lane :build_debug do
-    build_app(
-      workspace: File.join(ios_dir, "Runner.xcworkspace"),
-      scheme: "Runner",
-      configuration: "Debug",
-      export_method: "development",
-      output_directory: File.join(ios_dir, "build"),
-      output_name: "webspace-debug.ipa"
-    )
+    sh("cd '#{project_root}' && flutter build ios --debug --flavor fmain")
   end
 
   desc "Build release version"
   lane :build_release do
-    build_app(
-      workspace: File.join(ios_dir, "Runner.xcworkspace"),
-      scheme: "Runner",
-      configuration: "Release",
-      export_method: "app-store",
-      output_directory: File.join(ios_dir, "build"),
-      output_name: "webspace-release.ipa"
-    )
+    sh("cd '#{project_root}' && flutter build ipa --release --flavor fmain")
   end
 
   desc "Build iOS app (alias for build_release)"
@@ -53,14 +39,7 @@ platform :ios do
 
   desc "Build for Ad Hoc distribution"
   lane :build_adhoc do
-    build_app(
-      workspace: File.join(ios_dir, "Runner.xcworkspace"),
-      scheme: "Runner",
-      configuration: "Release",
-      export_method: "ad-hoc",
-      output_directory: File.join(ios_dir, "build"),
-      output_name: "webspace-adhoc.ipa"
-    )
+    sh("cd '#{project_root}' && flutter build ipa --release --flavor fmain --export-method ad-hoc")
   end
 
   desc "Update code signing and provisioning profiles"

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -24,12 +24,12 @@ platform :ios do
 
   desc "Build debug version"
   lane :build_debug do
-    sh("cd '#{project_root}' && flutter build ios --debug --flavor fmain")
+    sh("cd '#{project_root}' && flutter build ios --debug")
   end
 
   desc "Build release version"
   lane :build_release do
-    sh("cd '#{project_root}' && flutter build ipa --release --flavor fmain")
+    sh("cd '#{project_root}' && flutter build ipa --release")
   end
 
   desc "Build iOS app (alias for build_release)"
@@ -39,7 +39,7 @@ platform :ios do
 
   desc "Build for Ad Hoc distribution"
   lane :build_adhoc do
-    sh("cd '#{project_root}' && flutter build ipa --release --flavor fmain --export-method ad-hoc")
+    sh("cd '#{project_root}' && flutter build ipa --release --export-method ad-hoc")
   end
 
   desc "Update code signing and provisioning profiles"
@@ -132,7 +132,6 @@ platform :ios do
     sh("cd '#{project_root}' && flutter drive \
       --driver=test_driver/integration_test.dart \
       --target=integration_test/screenshot_test.dart \
-      --flavor fmain \
       -d #{device_id}")
 
     UI.success("Screenshots saved to: #{screenshots_dir}")


### PR DESCRIPTION
Replace build_app action with Flutter build commands to match the Android approach. This fixes the "Could not find action 'build_app'" error by removing the dependency on fastlane's gym plugin.