### PR TITLE
Fix screenshot path detection to use platform detection instead of di…

### DIFF
--- a/test_driver/integration_test.dart
+++ b/test_driver/integration_test.dart
@@ -26,14 +26,11 @@ Future<void> main() async {
       
       // If not set, use platform-specific defaults
       if (screenshotDir == null) {
-        // Check if android directory exists (indicates Android build)
-        final androidDir = Directory('android');
-        final iosDir = Directory('ios');
-        
-        if (androidDir.existsSync()) {
+        // Detect the actual runtime platform
+        if (Platform.isAndroid) {
           // Save to fastlane directory for Android
           screenshotDir = 'fastlane/metadata/android/en-US/images/phoneScreenshots';
-        } else if (iosDir.existsSync()) {
+        } else if (Platform.isIOS) {
           // For iOS, you can use fastlane directory too
           // screenshotDir = 'fastlane/metadata/ios/en-US/images/phoneScreenshots';
           screenshotDir = 'screenshots';


### PR DESCRIPTION
…rectory checks

Changed test driver to use Platform.isAndroid and Platform.isIOS instead of checking if android/ios directories exist. The previous approach was incorrect because both directories typically exist in Flutter projects regardless of the running platform.