### PR TITLE
Add settings import/export feature

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ import 'package:webspace/screens/webspace_detail.dart';
 import 'package:webspace/widgets/find_toolbar.dart';
 import 'package:webspace/widgets/url_bar.dart';
 import 'package:webspace/demo_data.dart';
+import 'package:webspace/services/settings_backup.dart';
 
 // Helper to convert ThemeMode to WebViewTheme
 WebViewTheme _themeModeToWebViewTheme(ThemeMode mode) {
@@ -470,6 +471,137 @@ class _WebSpacePageState extends State<WebSpacePage> {
     _saveWebspaces();
   }
 
+  // Export settings to a file
+  Future<void> _exportSettings() async {
+    await SettingsBackupService.exportAndShare(
+      context,
+      webViewModels: _webViewModels,
+      webspaces: _webspaces,
+      themeMode: _themeMode.index,
+      showUrlBar: _showUrlBar,
+      selectedWebspaceId: _selectedWebspaceId,
+      currentIndex: _currentIndex,
+    );
+  }
+
+  // Import settings from a file
+  Future<void> _importSettings() async {
+    final backup = await SettingsBackupService.pickAndImport(context);
+    if (backup == null) {
+      return;
+    }
+
+    // Show confirmation dialog with backup info
+    final sitesCount = backup.sites.length;
+    final webspacesCount = backup.webspaces.length;
+    final exportDate = backup.exportedAt.toLocal().toString().split('.')[0];
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('Import Settings'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('This will replace all your current settings with:'),
+            SizedBox(height: 12),
+            Text('  - $sitesCount site(s)'),
+            Text('  - $webspacesCount webspace(s)'),
+            SizedBox(height: 12),
+            Text(
+              'Exported: $exportDate',
+              style: TextStyle(fontSize: 12, color: Colors.grey),
+            ),
+            SizedBox(height: 16),
+            Text(
+              'Note: Cookies are not included in backups for security.',
+              style: TextStyle(fontSize: 12, color: Colors.orange),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: Text('Import'),
+            style: TextButton.styleFrom(
+              foregroundColor: Theme.of(context).colorScheme.primary,
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) {
+      return;
+    }
+
+    // Apply the imported settings
+    setState(() {
+      // Clear existing data
+      _webViewModels.clear();
+      _webspaces.clear();
+
+      // Restore sites
+      _webViewModels.addAll(
+        SettingsBackupService.restoreSites(backup, () {
+          setState(() {});
+        }),
+      );
+
+      // Restore webspaces
+      _webspaces.addAll(SettingsBackupService.restoreWebspaces(backup));
+
+      // Restore other settings
+      _themeMode = ThemeMode.values[backup.themeMode.clamp(0, ThemeMode.values.length - 1)];
+      _showUrlBar = backup.showUrlBar;
+
+      // Restore selection state
+      if (backup.selectedWebspaceId != null &&
+          _webspaces.any((ws) => ws.id == backup.selectedWebspaceId)) {
+        _selectedWebspaceId = backup.selectedWebspaceId;
+      } else {
+        _selectedWebspaceId = kAllWebspaceId;
+      }
+
+      // Restore current index if valid
+      if (backup.currentIndex != null &&
+          backup.currentIndex! >= 0 &&
+          backup.currentIndex! < _webViewModels.length) {
+        _currentIndex = backup.currentIndex;
+      } else {
+        _currentIndex = null;
+      }
+    });
+
+    // Apply theme to app
+    widget.onThemeModeChanged(_themeMode);
+
+    // Save all settings
+    await _saveWebViewModels();
+    await _saveWebspaces();
+    await _saveThemeMode();
+    await _saveShowUrlBar();
+    await _saveSelectedWebspaceId();
+    await _saveCurrentIndex();
+
+    // Apply theme to all webviews
+    final webViewTheme = _themeModeToWebViewTheme(_themeMode);
+    for (var webViewModel in _webViewModels) {
+      await webViewModel.setTheme(webViewTheme);
+    }
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Settings imported successfully')),
+      );
+    }
+  }
+
   UnifiedWebViewController? getController() {
     if(_currentIndex == null) {
       return null;
@@ -584,6 +716,7 @@ class _WebSpacePageState extends State<WebSpacePage> {
         ),
         PopupMenuButton<String>(
           itemBuilder: (BuildContext context) {
+            final bool onWebspacesList = _currentIndex == null || _currentIndex! >= _webViewModels.length;
             return [
               if (_currentIndex != null && _currentIndex! < _webViewModels.length)
               PopupMenuItem<String>(
@@ -640,6 +773,29 @@ class _WebSpacePageState extends State<WebSpacePage> {
                   ],
                 ),
               ),
+              // Import/Export options (only visible on webspaces list screen)
+              if (onWebspacesList)
+              PopupMenuItem<String>(
+                value: "export",
+                child: Row(
+                  children: [
+                    Icon(Icons.upload),
+                    SizedBox(width: 8),
+                    Text("Export Settings"),
+                  ],
+                ),
+              ),
+              if (onWebspacesList)
+              PopupMenuItem<String>(
+                value: "import",
+                child: Row(
+                  children: [
+                    Icon(Icons.download),
+                    SizedBox(width: 8),
+                    Text("Import Settings"),
+                  ],
+                ),
+              ),
             ];
           },
           onSelected: (String value) async {
@@ -669,6 +825,12 @@ class _WebSpacePageState extends State<WebSpacePage> {
                   _showUrlBar = !_showUrlBar;
                 });
                 _saveShowUrlBar();
+              break;
+              case 'export':
+                await _exportSettings();
+              break;
+              case 'import':
+                await _importSettings();
               break;
             }
           },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -473,7 +473,7 @@ class _WebSpacePageState extends State<WebSpacePage> {
 
   // Export settings to a file
   Future<void> _exportSettings() async {
-    await SettingsBackupService.exportAndShare(
+    await SettingsBackupService.exportAndSave(
       context,
       webViewModels: _webViewModels,
       webspaces: _webspaces,

--- a/lib/services/settings_backup.dart
+++ b/lib/services/settings_backup.dart
@@ -157,7 +157,7 @@ class SettingsBackupService {
 
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Settings exported to: $filePath')),
+          SnackBar(content: Text('Settings exported successfully')),
         );
       }
       return true;

--- a/lib/services/settings_backup.dart
+++ b/lib/services/settings_backup.dart
@@ -133,14 +133,14 @@ class SettingsBackupService {
       final defaultFileName = 'webspace_backup_$timestamp.json';
 
       // Use FilePicker save dialog
-      // On iOS/Android: bytes parameter is required
-      // On macOS: bytes parameter is not supported, write manually
-      final bool isMacOS = !kIsWeb && Platform.isMacOS;
+      // On mobile (iOS/Android): bytes parameter is required
+      // On desktop (macOS/Linux/Windows): bytes not supported, write manually
+      final bool isMobile = !kIsWeb && (Platform.isIOS || Platform.isAndroid);
 
       final outputPath = await FilePicker.platform.saveFile(
         dialogTitle: 'Save Settings Backup',
         fileName: defaultFileName,
-        bytes: isMacOS ? null : bytes,
+        bytes: isMobile ? bytes : null,
       );
 
       if (outputPath == null) {
@@ -148,8 +148,8 @@ class SettingsBackupService {
         return false;
       }
 
-      // On macOS, write file manually since bytes param not supported
-      if (isMacOS) {
+      // On desktop, write file manually since bytes param not supported
+      if (!isMobile) {
         final filePath = outputPath.endsWith('.json') ? outputPath : '$outputPath.json';
         final file = File(filePath);
         await file.writeAsString(jsonString);

--- a/lib/services/settings_backup.dart
+++ b/lib/services/settings_backup.dart
@@ -130,13 +130,10 @@ class SettingsBackupService {
       final timestamp = DateTime.now().toIso8601String().replaceAll(':', '-').split('.')[0];
       final defaultFileName = 'webspace_backup_$timestamp.json';
 
-      // Use FilePicker to let user choose save location
-      // Note: Don't pass bytes parameter as it's not supported on all platforms (e.g., macOS)
+      // Use FilePicker save dialog
       final outputPath = await FilePicker.platform.saveFile(
         dialogTitle: 'Save Settings Backup',
         fileName: defaultFileName,
-        type: FileType.custom,
-        allowedExtensions: ['json'],
       );
 
       if (outputPath == null) {
@@ -151,11 +148,12 @@ class SettingsBackupService {
 
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Settings exported successfully')),
+          SnackBar(content: Text('Settings exported to: $filePath')),
         );
       }
       return true;
-    } catch (e) {
+    } catch (e, stack) {
+      debugPrint('Export failed: $e\n$stack');
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Export failed: $e')),

--- a/lib/services/settings_backup.dart
+++ b/lib/services/settings_backup.dart
@@ -1,0 +1,249 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+
+import 'package:webspace/web_view_model.dart';
+import 'package:webspace/webspace_model.dart';
+
+/// Backup version for compatibility checking
+const int kBackupVersion = 1;
+
+/// Data class representing a backup of app settings
+class SettingsBackup {
+  final int version;
+  final List<Map<String, dynamic>> sites;
+  final List<Map<String, dynamic>> webspaces;
+  final int themeMode;
+  final bool showUrlBar;
+  final String? selectedWebspaceId;
+  final int? currentIndex;
+  final DateTime exportedAt;
+
+  SettingsBackup({
+    required this.version,
+    required this.sites,
+    required this.webspaces,
+    required this.themeMode,
+    required this.showUrlBar,
+    this.selectedWebspaceId,
+    this.currentIndex,
+    required this.exportedAt,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'version': version,
+        'sites': sites,
+        'webspaces': webspaces,
+        'themeMode': themeMode,
+        'showUrlBar': showUrlBar,
+        'selectedWebspaceId': selectedWebspaceId,
+        'currentIndex': currentIndex,
+        'exportedAt': exportedAt.toIso8601String(),
+      };
+
+  factory SettingsBackup.fromJson(Map<String, dynamic> json) {
+    return SettingsBackup(
+      version: json['version'] ?? 1,
+      sites: (json['sites'] as List<dynamic>)
+          .map((e) => e as Map<String, dynamic>)
+          .toList(),
+      webspaces: (json['webspaces'] as List<dynamic>)
+          .map((e) => e as Map<String, dynamic>)
+          .toList(),
+      themeMode: json['themeMode'] ?? 0,
+      showUrlBar: json['showUrlBar'] ?? false,
+      selectedWebspaceId: json['selectedWebspaceId'],
+      currentIndex: json['currentIndex'],
+      exportedAt: json['exportedAt'] != null
+          ? DateTime.parse(json['exportedAt'])
+          : DateTime.now(),
+    );
+  }
+}
+
+/// Service for exporting and importing app settings
+class SettingsBackupService {
+  /// Create a backup from current app state (excluding cookies)
+  static SettingsBackup createBackup({
+    required List<WebViewModel> webViewModels,
+    required List<Webspace> webspaces,
+    required int themeMode,
+    required bool showUrlBar,
+    String? selectedWebspaceId,
+    int? currentIndex,
+  }) {
+    // Convert sites to JSON, excluding cookies
+    final sitesJson = webViewModels.map((model) {
+      final json = model.toJson();
+      // Remove cookies from export
+      json['cookies'] = [];
+      return json;
+    }).toList();
+
+    // Convert webspaces to JSON, excluding the "All" webspace
+    final webspacesJson = webspaces
+        .where((ws) => ws.id != kAllWebspaceId)
+        .map((ws) => ws.toJson())
+        .toList();
+
+    return SettingsBackup(
+      version: kBackupVersion,
+      sites: sitesJson,
+      webspaces: webspacesJson,
+      themeMode: themeMode,
+      showUrlBar: showUrlBar,
+      selectedWebspaceId: selectedWebspaceId,
+      currentIndex: currentIndex,
+      exportedAt: DateTime.now(),
+    );
+  }
+
+  /// Export settings to a JSON string
+  static String exportToJson(SettingsBackup backup) {
+    return const JsonEncoder.withIndent('  ').convert(backup.toJson());
+  }
+
+  /// Export settings and share/save the file
+  static Future<bool> exportAndShare(
+    BuildContext context, {
+    required List<WebViewModel> webViewModels,
+    required List<Webspace> webspaces,
+    required int themeMode,
+    required bool showUrlBar,
+    String? selectedWebspaceId,
+    int? currentIndex,
+  }) async {
+    try {
+      final backup = createBackup(
+        webViewModels: webViewModels,
+        webspaces: webspaces,
+        themeMode: themeMode,
+        showUrlBar: showUrlBar,
+        selectedWebspaceId: selectedWebspaceId,
+        currentIndex: currentIndex,
+      );
+
+      final jsonString = exportToJson(backup);
+
+      // Get temp directory and create file
+      final tempDir = await getTemporaryDirectory();
+      final timestamp = DateTime.now().toIso8601String().replaceAll(':', '-').split('.')[0];
+      final fileName = 'webspace_backup_$timestamp.json';
+      final file = File('${tempDir.path}/$fileName');
+      await file.writeAsString(jsonString);
+
+      // Share the file
+      final result = await Share.shareXFiles(
+        [XFile(file.path)],
+        subject: 'WebSpace Settings Backup',
+      );
+
+      // Clean up temp file after a delay
+      Future.delayed(Duration(seconds: 30), () {
+        if (file.existsSync()) {
+          file.deleteSync();
+        }
+      });
+
+      return result.status == ShareResultStatus.success ||
+          result.status == ShareResultStatus.dismissed;
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Export failed: $e')),
+        );
+      }
+      return false;
+    }
+  }
+
+  /// Import settings from JSON string
+  static SettingsBackup? importFromJson(String jsonString) {
+    try {
+      final json = jsonDecode(jsonString) as Map<String, dynamic>;
+      return SettingsBackup.fromJson(json);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// Pick a file and import settings
+  static Future<SettingsBackup?> pickAndImport(BuildContext context) async {
+    try {
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: ['json'],
+        allowMultiple: false,
+      );
+
+      if (result == null || result.files.isEmpty) {
+        return null;
+      }
+
+      final file = result.files.first;
+      String jsonString;
+
+      if (file.bytes != null) {
+        // Web or platforms that provide bytes
+        jsonString = utf8.decode(file.bytes!);
+      } else if (file.path != null) {
+        // Platforms that provide file path
+        jsonString = await File(file.path!).readAsString();
+      } else {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Could not read the selected file')),
+          );
+        }
+        return null;
+      }
+
+      final backup = importFromJson(jsonString);
+      if (backup == null) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Invalid backup file format')),
+          );
+        }
+        return null;
+      }
+
+      return backup;
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Import failed: $e')),
+        );
+      }
+      return null;
+    }
+  }
+
+  /// Convert backup sites to WebViewModel list
+  static List<WebViewModel> restoreSites(
+    SettingsBackup backup,
+    Function? stateSetterF,
+  ) {
+    return backup.sites.map((json) {
+      // Ensure cookies is an empty list (we don't import cookies)
+      json['cookies'] = [];
+      return WebViewModel.fromJson(json, stateSetterF);
+    }).toList();
+  }
+
+  /// Convert backup webspaces to Webspace list
+  static List<Webspace> restoreWebspaces(SettingsBackup backup) {
+    final webspaces = <Webspace>[Webspace.all()];
+    for (final json in backup.webspaces) {
+      final ws = Webspace.fromJson(json);
+      if (ws.id != kAllWebspaceId) {
+        webspaces.add(ws);
+      }
+    }
+    return webspaces;
+  }
+}

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 </dict>
 </plist>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "701dcfc06da0882883a2657c445103380e53e647060ad8d9dfb710c100996608"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+1"
   crypto:
     dependency: transitive
     description:
@@ -145,6 +153,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: ab13ae8ef5580a411c458d6207b6774a6c237d77ac37011b13994879f68a8810
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.7"
   fixnum:
     dependency: transitive
     description:
@@ -251,6 +267,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: ee8068e0e1cd16c4a82714119918efdeed33b3ba7772c54b5d094ab53f9b7fd1
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.33"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -375,6 +399,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   octo_image:
     dependency: transitive
     description:
@@ -400,7 +432,7 @@ packages:
     source: hosted
     version: "1.1.0"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
@@ -495,6 +527,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.4"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -796,6 +844,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: "329edf97fdd893e0f1e3b9e88d6a0e627128cc17cc316a8d67fda8f1451178ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.13.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -399,14 +399,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
-  mime:
-    dependency: transitive
-    description:
-      name: mime
-      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.0"
   octo_image:
     dependency: transitive
     description:
@@ -432,7 +424,7 @@ packages:
     source: hosted
     version: "1.1.0"
   path_provider:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
@@ -527,22 +519,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
-  share_plus:
-    dependency: "direct main"
-    description:
-      name: share_plus
-      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.1.4"
-  share_plus_platform_interface:
-    dependency: transitive
-    description:
-      name: share_plus_platform_interface
-      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.0.2"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,9 @@ dependencies:
   url_launcher: ^6.1.10
   uuid: ^4.5.1
   image: ^4.3.0  # Required by third_party/favicon
+  file_picker: ^8.0.0
+  share_plus: ^10.0.0
+  path_provider: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,8 +49,6 @@ dependencies:
   uuid: ^4.5.1
   image: ^4.3.0  # Required by third_party/favicon
   file_picker: ^8.0.0
-  share_plus: ^10.0.0
-  path_provider: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/test/settings_backup_test.dart
+++ b/test/settings_backup_test.dart
@@ -1,0 +1,752 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/settings_backup.dart';
+import 'package:webspace/web_view_model.dart';
+import 'package:webspace/webspace_model.dart';
+import 'package:webspace/platform/unified_webview.dart';
+import 'package:webspace/settings/proxy.dart';
+
+void main() {
+  group('SettingsBackup Model', () {
+    test('should serialize to JSON correctly', () {
+      final backup = SettingsBackup(
+        version: 1,
+        sites: [
+          {'initUrl': 'https://example.com', 'name': 'Example'}
+        ],
+        webspaces: [
+          {'id': 'ws-1', 'name': 'Work', 'siteIndices': [0]}
+        ],
+        themeMode: 2,
+        showUrlBar: true,
+        selectedWebspaceId: 'ws-1',
+        currentIndex: 0,
+        exportedAt: DateTime(2024, 1, 15, 10, 30),
+      );
+
+      final json = backup.toJson();
+
+      expect(json['version'], equals(1));
+      expect(json['sites'], hasLength(1));
+      expect(json['webspaces'], hasLength(1));
+      expect(json['themeMode'], equals(2));
+      expect(json['showUrlBar'], equals(true));
+      expect(json['selectedWebspaceId'], equals('ws-1'));
+      expect(json['currentIndex'], equals(0));
+      expect(json['exportedAt'], equals('2024-01-15T10:30:00.000'));
+    });
+
+    test('should deserialize from JSON correctly', () {
+      final json = {
+        'version': 1,
+        'sites': [
+          {'initUrl': 'https://test.com', 'name': 'Test'}
+        ],
+        'webspaces': [
+          {'id': 'ws-2', 'name': 'Personal', 'siteIndices': [0, 1]}
+        ],
+        'themeMode': 1,
+        'showUrlBar': false,
+        'selectedWebspaceId': '__all_webspace__',
+        'currentIndex': null,
+        'exportedAt': '2024-02-20T15:45:00.000Z',
+      };
+
+      final backup = SettingsBackup.fromJson(json);
+
+      expect(backup.version, equals(1));
+      expect(backup.sites, hasLength(1));
+      expect(backup.webspaces, hasLength(1));
+      expect(backup.themeMode, equals(1));
+      expect(backup.showUrlBar, equals(false));
+      expect(backup.selectedWebspaceId, equals('__all_webspace__'));
+      expect(backup.currentIndex, isNull);
+    });
+
+    test('should handle missing optional fields', () {
+      final json = {
+        'sites': [],
+        'webspaces': [],
+      };
+
+      final backup = SettingsBackup.fromJson(json);
+
+      expect(backup.version, equals(1)); // Default
+      expect(backup.themeMode, equals(0)); // Default
+      expect(backup.showUrlBar, equals(false)); // Default
+      expect(backup.selectedWebspaceId, isNull);
+      expect(backup.currentIndex, isNull);
+    });
+
+    test('should round-trip through JSON correctly', () {
+      final original = SettingsBackup(
+        version: 1,
+        sites: [
+          {'url': 'https://a.com'},
+          {'url': 'https://b.com'},
+        ],
+        webspaces: [
+          {'id': 'w1', 'name': 'W1', 'siteIndices': [0]},
+        ],
+        themeMode: 2,
+        showUrlBar: true,
+        selectedWebspaceId: 'w1',
+        currentIndex: 1,
+        exportedAt: DateTime.now(),
+      );
+
+      final jsonString = jsonEncode(original.toJson());
+      final restored = SettingsBackup.fromJson(jsonDecode(jsonString));
+
+      expect(restored.version, equals(original.version));
+      expect(restored.sites.length, equals(original.sites.length));
+      expect(restored.webspaces.length, equals(original.webspaces.length));
+      expect(restored.themeMode, equals(original.themeMode));
+      expect(restored.showUrlBar, equals(original.showUrlBar));
+      expect(restored.selectedWebspaceId, equals(original.selectedWebspaceId));
+      expect(restored.currentIndex, equals(original.currentIndex));
+    });
+  });
+
+  group('SettingsBackupService.createBackup', () {
+    test('should create backup with all settings', () {
+      final webViewModels = [
+        WebViewModel(initUrl: 'https://example.com', name: 'Example'),
+        WebViewModel(initUrl: 'https://test.com', name: 'Test'),
+      ];
+      final webspaces = [
+        Webspace.all(),
+        Webspace(id: 'work', name: 'Work', siteIndices: [0]),
+      ];
+
+      final backup = SettingsBackupService.createBackup(
+        webViewModels: webViewModels,
+        webspaces: webspaces,
+        themeMode: 1,
+        showUrlBar: true,
+        selectedWebspaceId: 'work',
+        currentIndex: 0,
+      );
+
+      expect(backup.version, equals(kBackupVersion));
+      expect(backup.sites, hasLength(2));
+      expect(backup.webspaces, hasLength(1)); // "All" excluded
+      expect(backup.themeMode, equals(1));
+      expect(backup.showUrlBar, equals(true));
+      expect(backup.selectedWebspaceId, equals('work'));
+      expect(backup.currentIndex, equals(0));
+    });
+
+    test('should exclude cookies from export', () {
+      final modelWithCookies = WebViewModel(
+        initUrl: 'https://example.com',
+        cookies: [
+          UnifiedCookie(name: 'session', value: 'secret123'),
+          UnifiedCookie(name: 'auth', value: 'token456'),
+        ],
+      );
+
+      final backup = SettingsBackupService.createBackup(
+        webViewModels: [modelWithCookies],
+        webspaces: [Webspace.all()],
+        themeMode: 0,
+        showUrlBar: false,
+      );
+
+      // Cookies should be empty in the backup
+      expect(backup.sites[0]['cookies'], isEmpty);
+    });
+
+    test('should exclude "All" webspace from export', () {
+      final webspaces = [
+        Webspace.all(),
+        Webspace(name: 'Custom1'),
+        Webspace(name: 'Custom2'),
+      ];
+
+      final backup = SettingsBackupService.createBackup(
+        webViewModels: [],
+        webspaces: webspaces,
+        themeMode: 0,
+        showUrlBar: false,
+      );
+
+      // Only custom webspaces should be exported
+      expect(backup.webspaces, hasLength(2));
+      expect(backup.webspaces.every((ws) => ws['id'] != kAllWebspaceId), isTrue);
+    });
+
+    test('should preserve site settings except cookies', () {
+      final model = WebViewModel(
+        initUrl: 'https://example.com',
+        currentUrl: 'https://example.com/page',
+        name: 'My Site',
+        cookies: [UnifiedCookie(name: 'test', value: 'value')],
+        proxySettings: UserProxySettings(type: ProxyType.SOCKS5, address: 'localhost:9050'),
+        javascriptEnabled: false,
+        userAgent: 'Custom/1.0',
+        thirdPartyCookiesEnabled: true,
+      );
+
+      final backup = SettingsBackupService.createBackup(
+        webViewModels: [model],
+        webspaces: [Webspace.all()],
+        themeMode: 0,
+        showUrlBar: false,
+      );
+
+      final siteJson = backup.sites[0];
+      expect(siteJson['initUrl'], equals('https://example.com'));
+      expect(siteJson['currentUrl'], equals('https://example.com/page'));
+      expect(siteJson['name'], equals('My Site'));
+      expect(siteJson['cookies'], isEmpty); // Cookies stripped
+      expect(siteJson['javascriptEnabled'], equals(false));
+      expect(siteJson['userAgent'], equals('Custom/1.0'));
+      expect(siteJson['thirdPartyCookiesEnabled'], equals(true));
+      expect(siteJson['proxySettings']['type'], equals(ProxyType.SOCKS5.index));
+    });
+
+    test('should handle empty data', () {
+      final backup = SettingsBackupService.createBackup(
+        webViewModels: [],
+        webspaces: [],
+        themeMode: 0,
+        showUrlBar: false,
+      );
+
+      expect(backup.sites, isEmpty);
+      expect(backup.webspaces, isEmpty);
+    });
+  });
+
+  group('SettingsBackupService.exportToJson', () {
+    test('should produce valid JSON string', () {
+      final backup = SettingsBackup(
+        version: 1,
+        sites: [{'url': 'https://test.com'}],
+        webspaces: [],
+        themeMode: 0,
+        showUrlBar: false,
+        exportedAt: DateTime(2024, 1, 1),
+      );
+
+      final jsonString = SettingsBackupService.exportToJson(backup);
+
+      expect(() => jsonDecode(jsonString), returnsNormally);
+    });
+
+    test('should produce pretty-printed JSON', () {
+      final backup = SettingsBackup(
+        version: 1,
+        sites: [],
+        webspaces: [],
+        themeMode: 0,
+        showUrlBar: false,
+        exportedAt: DateTime(2024, 1, 1),
+      );
+
+      final jsonString = SettingsBackupService.exportToJson(backup);
+
+      expect(jsonString.contains('\n'), isTrue);
+      expect(jsonString.contains('  '), isTrue);
+    });
+  });
+
+  group('SettingsBackupService.importFromJson', () {
+    test('should parse valid JSON', () {
+      final jsonString = '''
+      {
+        "version": 1,
+        "sites": [{"initUrl": "https://example.com"}],
+        "webspaces": [],
+        "themeMode": 2,
+        "showUrlBar": true,
+        "exportedAt": "2024-01-01T00:00:00.000"
+      }
+      ''';
+
+      final backup = SettingsBackupService.importFromJson(jsonString);
+
+      expect(backup, isNotNull);
+      expect(backup!.version, equals(1));
+      expect(backup.sites, hasLength(1));
+      expect(backup.themeMode, equals(2));
+    });
+
+    test('should return null for invalid JSON', () {
+      final backup = SettingsBackupService.importFromJson('not valid json');
+
+      expect(backup, isNull);
+    });
+
+    test('should return null for empty string', () {
+      final backup = SettingsBackupService.importFromJson('');
+
+      expect(backup, isNull);
+    });
+
+    test('should return null for JSON missing required fields', () {
+      final backup = SettingsBackupService.importFromJson('{"foo": "bar"}');
+
+      // This should fail because 'sites' is required
+      expect(backup, isNull);
+    });
+  });
+
+  group('SettingsBackupService.restoreSites', () {
+    test('should restore WebViewModels from backup', () {
+      final backup = SettingsBackup(
+        version: 1,
+        sites: [
+          {
+            'initUrl': 'https://example.com',
+            'currentUrl': 'https://example.com',
+            'name': 'Example',
+            'pageTitle': 'Example Page',
+            'cookies': [],
+            'proxySettings': {'type': 0, 'address': null},
+            'javascriptEnabled': true,
+            'userAgent': '',
+            'thirdPartyCookiesEnabled': false,
+          }
+        ],
+        webspaces: [],
+        themeMode: 0,
+        showUrlBar: false,
+        exportedAt: DateTime.now(),
+      );
+
+      final sites = SettingsBackupService.restoreSites(backup, null);
+
+      expect(sites, hasLength(1));
+      expect(sites[0].initUrl, equals('https://example.com'));
+      expect(sites[0].name, equals('Example'));
+      expect(sites[0].cookies, isEmpty);
+    });
+
+    test('should strip any cookies that might be in backup', () {
+      final backup = SettingsBackup(
+        version: 1,
+        sites: [
+          {
+            'initUrl': 'https://example.com',
+            'currentUrl': 'https://example.com',
+            'name': 'Test',
+            'cookies': [
+              {'name': 'sneaky', 'value': 'cookie'}
+            ],
+            'proxySettings': {'type': 0, 'address': null},
+            'javascriptEnabled': true,
+            'userAgent': '',
+            'thirdPartyCookiesEnabled': false,
+          }
+        ],
+        webspaces: [],
+        themeMode: 0,
+        showUrlBar: false,
+        exportedAt: DateTime.now(),
+      );
+
+      final sites = SettingsBackupService.restoreSites(backup, null);
+
+      // Even if cookies were in the backup, they should be stripped
+      expect(sites[0].cookies, isEmpty);
+    });
+
+    test('should restore multiple sites', () {
+      final backup = SettingsBackup(
+        version: 1,
+        sites: [
+          {
+            'initUrl': 'https://a.com',
+            'currentUrl': 'https://a.com',
+            'name': 'A',
+            'cookies': [],
+            'proxySettings': {'type': 0, 'address': null},
+            'javascriptEnabled': true,
+            'userAgent': '',
+            'thirdPartyCookiesEnabled': false,
+          },
+          {
+            'initUrl': 'https://b.com',
+            'currentUrl': 'https://b.com',
+            'name': 'B',
+            'cookies': [],
+            'proxySettings': {'type': 0, 'address': null},
+            'javascriptEnabled': true,
+            'userAgent': '',
+            'thirdPartyCookiesEnabled': false,
+          },
+          {
+            'initUrl': 'https://c.com',
+            'currentUrl': 'https://c.com',
+            'name': 'C',
+            'cookies': [],
+            'proxySettings': {'type': 0, 'address': null},
+            'javascriptEnabled': true,
+            'userAgent': '',
+            'thirdPartyCookiesEnabled': false,
+          },
+        ],
+        webspaces: [],
+        themeMode: 0,
+        showUrlBar: false,
+        exportedAt: DateTime.now(),
+      );
+
+      final sites = SettingsBackupService.restoreSites(backup, null);
+
+      expect(sites, hasLength(3));
+      expect(sites[0].initUrl, equals('https://a.com'));
+      expect(sites[1].initUrl, equals('https://b.com'));
+      expect(sites[2].initUrl, equals('https://c.com'));
+    });
+  });
+
+  group('SettingsBackupService.restoreWebspaces', () {
+    test('should restore webspaces with "All" at the start', () {
+      final backup = SettingsBackup(
+        version: 1,
+        sites: [],
+        webspaces: [
+          {'id': 'ws-1', 'name': 'Work', 'siteIndices': [0, 1]},
+          {'id': 'ws-2', 'name': 'Personal', 'siteIndices': [2]},
+        ],
+        themeMode: 0,
+        showUrlBar: false,
+        exportedAt: DateTime.now(),
+      );
+
+      final webspaces = SettingsBackupService.restoreWebspaces(backup);
+
+      expect(webspaces, hasLength(3)); // "All" + 2 custom
+      expect(webspaces[0].id, equals(kAllWebspaceId));
+      expect(webspaces[0].name, equals('All'));
+      expect(webspaces[1].name, equals('Work'));
+      expect(webspaces[2].name, equals('Personal'));
+    });
+
+    test('should skip "All" webspace if somehow in backup', () {
+      final backup = SettingsBackup(
+        version: 1,
+        sites: [],
+        webspaces: [
+          {'id': kAllWebspaceId, 'name': 'All', 'siteIndices': []},
+          {'id': 'ws-1', 'name': 'Custom', 'siteIndices': [0]},
+        ],
+        themeMode: 0,
+        showUrlBar: false,
+        exportedAt: DateTime.now(),
+      );
+
+      final webspaces = SettingsBackupService.restoreWebspaces(backup);
+
+      // Should have exactly one "All" (auto-created) + one custom
+      expect(webspaces, hasLength(2));
+      expect(webspaces.where((ws) => ws.id == kAllWebspaceId).length, equals(1));
+    });
+
+    test('should handle empty webspaces list', () {
+      final backup = SettingsBackup(
+        version: 1,
+        sites: [],
+        webspaces: [],
+        themeMode: 0,
+        showUrlBar: false,
+        exportedAt: DateTime.now(),
+      );
+
+      final webspaces = SettingsBackupService.restoreWebspaces(backup);
+
+      // Should still have "All" webspace
+      expect(webspaces, hasLength(1));
+      expect(webspaces[0].id, equals(kAllWebspaceId));
+    });
+
+    test('should preserve webspace site indices', () {
+      final backup = SettingsBackup(
+        version: 1,
+        sites: [],
+        webspaces: [
+          {'id': 'ws-1', 'name': 'Mixed', 'siteIndices': [0, 2, 5, 10]},
+        ],
+        themeMode: 0,
+        showUrlBar: false,
+        exportedAt: DateTime.now(),
+      );
+
+      final webspaces = SettingsBackupService.restoreWebspaces(backup);
+
+      expect(webspaces[1].siteIndices, equals([0, 2, 5, 10]));
+    });
+  });
+
+  group('Export/Import Round-trip', () {
+    test('should preserve all data through export and import', () {
+      // Create original data
+      final originalSites = [
+        WebViewModel(
+          initUrl: 'https://example.com',
+          currentUrl: 'https://example.com/page',
+          name: 'Example',
+          javascriptEnabled: false,
+          userAgent: 'Custom/1.0',
+          thirdPartyCookiesEnabled: true,
+          proxySettings: UserProxySettings(type: ProxyType.HTTP, address: 'proxy:8080'),
+        ),
+      ];
+      final originalWebspaces = [
+        Webspace.all(),
+        Webspace(id: 'work', name: 'Work', siteIndices: [0]),
+      ];
+
+      // Export
+      final backup = SettingsBackupService.createBackup(
+        webViewModels: originalSites,
+        webspaces: originalWebspaces,
+        themeMode: 2,
+        showUrlBar: true,
+        selectedWebspaceId: 'work',
+        currentIndex: 0,
+      );
+      final jsonString = SettingsBackupService.exportToJson(backup);
+
+      // Import
+      final importedBackup = SettingsBackupService.importFromJson(jsonString);
+      expect(importedBackup, isNotNull);
+
+      final restoredSites = SettingsBackupService.restoreSites(importedBackup!, null);
+      final restoredWebspaces = SettingsBackupService.restoreWebspaces(importedBackup);
+
+      // Verify sites
+      expect(restoredSites, hasLength(1));
+      expect(restoredSites[0].initUrl, equals('https://example.com'));
+      expect(restoredSites[0].currentUrl, equals('https://example.com/page'));
+      expect(restoredSites[0].name, equals('Example'));
+      expect(restoredSites[0].javascriptEnabled, equals(false));
+      expect(restoredSites[0].userAgent, equals('Custom/1.0'));
+      expect(restoredSites[0].thirdPartyCookiesEnabled, equals(true));
+      expect(restoredSites[0].proxySettings.type, equals(ProxyType.HTTP));
+      expect(restoredSites[0].proxySettings.address, equals('proxy:8080'));
+      expect(restoredSites[0].cookies, isEmpty); // Cookies stripped
+
+      // Verify webspaces
+      expect(restoredWebspaces, hasLength(2));
+      expect(restoredWebspaces[0].id, equals(kAllWebspaceId));
+      expect(restoredWebspaces[1].id, equals('work'));
+      expect(restoredWebspaces[1].name, equals('Work'));
+
+      // Verify settings
+      expect(importedBackup.themeMode, equals(2));
+      expect(importedBackup.showUrlBar, equals(true));
+      expect(importedBackup.selectedWebspaceId, equals('work'));
+      expect(importedBackup.currentIndex, equals(0));
+    });
+
+    test('should handle multiple export/import cycles', () {
+      // First cycle
+      final sites1 = [WebViewModel(initUrl: 'https://first.com')];
+      final backup1 = SettingsBackupService.createBackup(
+        webViewModels: sites1,
+        webspaces: [Webspace.all()],
+        themeMode: 0,
+        showUrlBar: false,
+      );
+      final json1 = SettingsBackupService.exportToJson(backup1);
+
+      // Import first backup
+      final imported1 = SettingsBackupService.importFromJson(json1)!;
+      final restored1 = SettingsBackupService.restoreSites(imported1, null);
+
+      // Add more sites
+      restored1.add(WebViewModel(initUrl: 'https://second.com'));
+
+      // Second cycle with modified data
+      final backup2 = SettingsBackupService.createBackup(
+        webViewModels: restored1,
+        webspaces: [Webspace.all(), Webspace(name: 'New')],
+        themeMode: 1,
+        showUrlBar: true,
+      );
+      final json2 = SettingsBackupService.exportToJson(backup2);
+
+      // Import second backup
+      final imported2 = SettingsBackupService.importFromJson(json2)!;
+      final restored2 = SettingsBackupService.restoreSites(imported2, null);
+      final restoredWs2 = SettingsBackupService.restoreWebspaces(imported2);
+
+      // Verify final state
+      expect(restored2, hasLength(2));
+      expect(restored2[0].initUrl, equals('https://first.com'));
+      expect(restored2[1].initUrl, equals('https://second.com'));
+      expect(restoredWs2, hasLength(2)); // All + New
+      expect(imported2.themeMode, equals(1));
+      expect(imported2.showUrlBar, equals(true));
+    });
+
+    test('cookies should never appear in export even after import', () {
+      // Create site with cookies
+      final siteWithCookies = WebViewModel(
+        initUrl: 'https://example.com',
+        cookies: [
+          UnifiedCookie(name: 'session', value: 'abc123'),
+        ],
+      );
+
+      // First export (cookies stripped)
+      final backup1 = SettingsBackupService.createBackup(
+        webViewModels: [siteWithCookies],
+        webspaces: [Webspace.all()],
+        themeMode: 0,
+        showUrlBar: false,
+      );
+
+      expect(backup1.sites[0]['cookies'], isEmpty);
+
+      // Import
+      final json1 = SettingsBackupService.exportToJson(backup1);
+      final imported1 = SettingsBackupService.importFromJson(json1)!;
+      final restored1 = SettingsBackupService.restoreSites(imported1, null);
+
+      expect(restored1[0].cookies, isEmpty);
+
+      // Second export of restored data
+      final backup2 = SettingsBackupService.createBackup(
+        webViewModels: restored1,
+        webspaces: [Webspace.all()],
+        themeMode: 0,
+        showUrlBar: false,
+      );
+
+      expect(backup2.sites[0]['cookies'], isEmpty);
+    });
+  });
+
+  group('Edge Cases', () {
+    test('should handle sites with special characters in names', () {
+      final site = WebViewModel(
+        initUrl: 'https://example.com',
+        name: 'Test!@#\$%^&*()_+-=[]{}|;:\'",.<>?/`~',
+      );
+
+      final backup = SettingsBackupService.createBackup(
+        webViewModels: [site],
+        webspaces: [Webspace.all()],
+        themeMode: 0,
+        showUrlBar: false,
+      );
+
+      final jsonString = SettingsBackupService.exportToJson(backup);
+      final imported = SettingsBackupService.importFromJson(jsonString)!;
+      final restored = SettingsBackupService.restoreSites(imported, null);
+
+      expect(restored[0].name, equals(site.name));
+    });
+
+    test('should handle sites with unicode characters', () {
+      final site = WebViewModel(
+        initUrl: 'https://example.com',
+        name: '工作站 🚀 Espace de travail',
+      );
+
+      final backup = SettingsBackupService.createBackup(
+        webViewModels: [site],
+        webspaces: [Webspace.all()],
+        themeMode: 0,
+        showUrlBar: false,
+      );
+
+      final jsonString = SettingsBackupService.exportToJson(backup);
+      final imported = SettingsBackupService.importFromJson(jsonString)!;
+      final restored = SettingsBackupService.restoreSites(imported, null);
+
+      expect(restored[0].name, equals('工作站 🚀 Espace de travail'));
+    });
+
+    test('should handle large number of sites', () {
+      final sites = List.generate(
+        100,
+        (i) => WebViewModel(initUrl: 'https://site$i.com', name: 'Site $i'),
+      );
+
+      final backup = SettingsBackupService.createBackup(
+        webViewModels: sites,
+        webspaces: [Webspace.all()],
+        themeMode: 0,
+        showUrlBar: false,
+      );
+
+      expect(backup.sites, hasLength(100));
+
+      final jsonString = SettingsBackupService.exportToJson(backup);
+      final imported = SettingsBackupService.importFromJson(jsonString)!;
+      final restored = SettingsBackupService.restoreSites(imported, null);
+
+      expect(restored, hasLength(100));
+      expect(restored[99].initUrl, equals('https://site99.com'));
+    });
+
+    test('should handle large number of webspaces', () {
+      final webspaces = [
+        Webspace.all(),
+        ...List.generate(50, (i) => Webspace(name: 'Workspace $i')),
+      ];
+
+      final backup = SettingsBackupService.createBackup(
+        webViewModels: [],
+        webspaces: webspaces,
+        themeMode: 0,
+        showUrlBar: false,
+      );
+
+      // 50 custom webspaces (All excluded)
+      expect(backup.webspaces, hasLength(50));
+
+      final jsonString = SettingsBackupService.exportToJson(backup);
+      final imported = SettingsBackupService.importFromJson(jsonString)!;
+      final restored = SettingsBackupService.restoreWebspaces(imported);
+
+      // All + 50 custom
+      expect(restored, hasLength(51));
+    });
+
+    test('should handle sites with all proxy types', () {
+      final sites = [
+        WebViewModel(
+          initUrl: 'https://default.com',
+          proxySettings: UserProxySettings(type: ProxyType.DEFAULT),
+        ),
+        WebViewModel(
+          initUrl: 'https://http.com',
+          proxySettings: UserProxySettings(type: ProxyType.HTTP, address: 'http:8080'),
+        ),
+        WebViewModel(
+          initUrl: 'https://https.com',
+          proxySettings: UserProxySettings(type: ProxyType.HTTPS, address: 'https:443'),
+        ),
+        WebViewModel(
+          initUrl: 'https://socks.com',
+          proxySettings: UserProxySettings(type: ProxyType.SOCKS5, address: 'socks:1080'),
+        ),
+      ];
+
+      final backup = SettingsBackupService.createBackup(
+        webViewModels: sites,
+        webspaces: [Webspace.all()],
+        themeMode: 0,
+        showUrlBar: false,
+      );
+
+      final jsonString = SettingsBackupService.exportToJson(backup);
+      final imported = SettingsBackupService.importFromJson(jsonString)!;
+      final restored = SettingsBackupService.restoreSites(imported, null);
+
+      expect(restored[0].proxySettings.type, equals(ProxyType.DEFAULT));
+      expect(restored[1].proxySettings.type, equals(ProxyType.HTTP));
+      expect(restored[2].proxySettings.type, equals(ProxyType.HTTPS));
+      expect(restored[3].proxySettings.type, equals(ProxyType.SOCKS5));
+      expect(restored[3].proxySettings.address, equals('socks:1080'));
+    });
+  });
+}

--- a/transcript/SETTINGS_BACKUP.md
+++ b/transcript/SETTINGS_BACKUP.md
@@ -10,7 +10,7 @@ This document describes the settings import/export feature for the webspace_app,
 
 - Export all settings to a JSON file
 - Import settings from a backup file
-- Share backup files via system share sheet
+- Save backup files to user-chosen location
 - Cookies are **never** included in backups (security measure)
 - Version-tagged backups for future compatibility
 - Confirmation dialog before importing (shows backup details)
@@ -41,7 +41,7 @@ lib/services/settings_backup.dart
 ├── SettingsBackupService
 │   ├── createBackup() - creates backup excluding cookies
 │   ├── exportToJson() - serializes to JSON string
-│   ├── exportAndShare() - exports and opens share sheet
+│   ├── exportAndSave() - exports and saves to user-chosen location
 │   ├── importFromJson() - parses JSON to backup object
 │   ├── pickAndImport() - opens file picker and imports
 │   ├── restoreSites() - converts backup to WebViewModel list
@@ -61,17 +61,15 @@ User taps "Export Settings" in menu
     ↓
 _exportSettings() called
     ↓
-SettingsBackupService.exportAndShare()
+SettingsBackupService.exportAndSave()
     ↓
 createBackup() - collects all settings, strips cookies
     ↓
 exportToJson() - formats as pretty JSON
     ↓
-Write to temp file (webspace_backup_TIMESTAMP.json)
+FilePicker.platform.saveFile() - user chooses save location
     ↓
-Share.shareXFiles() - opens system share sheet
-    ↓
-Temp file cleaned up after 30 seconds
+Write file to chosen location
 ```
 
 #### Import Flow
@@ -195,7 +193,7 @@ PopupMenuButton<String>(
 1. Navigate to the webspaces list screen (tap webspace icon or "Back to Webspaces")
 2. Tap the triple-dot menu (⋮) in the top-right
 3. Select "Export Settings"
-4. Choose where to save/share the backup file
+4. Choose where to save the backup file
 
 ### Importing Settings
 
@@ -272,9 +270,7 @@ The feature requires these packages (added to `pubspec.yaml`):
 
 ```yaml
 dependencies:
-  file_picker: ^8.0.0      # For selecting import files
-  share_plus: ^10.0.0      # For sharing export files
-  path_provider: ^2.1.0    # For temp directory access
+  file_picker: ^8.0.0      # For selecting import files and saving export files
 ```
 
 ## Platform Support
@@ -338,7 +334,7 @@ fvm flutter test test/settings_backup_test.dart
 ### Key Methods
 
 - `SettingsBackupService.createBackup()` - Create backup excluding cookies
-- `SettingsBackupService.exportAndShare()` - Export and share file
+- `SettingsBackupService.exportAndSave()` - Export and save file
 - `SettingsBackupService.pickAndImport()` - Pick and parse backup file
 - `SettingsBackupService.restoreSites()` - Restore WebViewModel list
 - `SettingsBackupService.restoreWebspaces()` - Restore Webspace list

--- a/transcript/SETTINGS_BACKUP.md
+++ b/transcript/SETTINGS_BACKUP.md
@@ -1,0 +1,370 @@
+# Settings Import/Export Feature
+
+## Overview
+
+This document describes the settings import/export feature for the webspace_app, which allows users to backup and restore their app configuration including sites, webspaces, and preferences.
+
+## Features
+
+### Key Capabilities
+
+- Export all settings to a JSON file
+- Import settings from a backup file
+- Share backup files via system share sheet
+- Cookies are **never** included in backups (security measure)
+- Version-tagged backups for future compatibility
+- Confirmation dialog before importing (shows backup details)
+
+### What's Included in Backups
+
+| Setting | Exported | Notes |
+|---------|----------|-------|
+| Sites (URLs, names) | Yes | All site configurations |
+| Site proxy settings | Yes | Per-site proxy configuration |
+| Site user agents | Yes | Custom user agent strings |
+| Site JS enabled | Yes | JavaScript toggle state |
+| Site 3rd-party cookies | Yes | Third-party cookie setting |
+| Webspaces | Yes | Custom webspaces only ("All" is recreated) |
+| Theme mode | Yes | Light/dark/system preference |
+| URL bar visibility | Yes | Show/hide URL bar setting |
+| Selected webspace | Yes | Currently selected webspace ID |
+| Current site index | Yes | Last viewed site |
+| **Cookies** | **No** | Never exported for security |
+
+## Architecture
+
+### Component Overview
+
+```
+lib/services/settings_backup.dart
+├── SettingsBackup class (data model)
+├── SettingsBackupService
+│   ├── createBackup() - creates backup excluding cookies
+│   ├── exportToJson() - serializes to JSON string
+│   ├── exportAndShare() - exports and opens share sheet
+│   ├── importFromJson() - parses JSON to backup object
+│   ├── pickAndImport() - opens file picker and imports
+│   ├── restoreSites() - converts backup to WebViewModel list
+│   └── restoreWebspaces() - converts backup to Webspace list
+
+lib/main.dart
+├── _exportSettings() - handler for export menu item
+└── _importSettings() - handler for import menu item
+```
+
+### Data Flow
+
+#### Export Flow
+
+```
+User taps "Export Settings" in menu
+    ↓
+_exportSettings() called
+    ↓
+SettingsBackupService.exportAndShare()
+    ↓
+createBackup() - collects all settings, strips cookies
+    ↓
+exportToJson() - formats as pretty JSON
+    ↓
+Write to temp file (webspace_backup_TIMESTAMP.json)
+    ↓
+Share.shareXFiles() - opens system share sheet
+    ↓
+Temp file cleaned up after 30 seconds
+```
+
+#### Import Flow
+
+```
+User taps "Import Settings" in menu
+    ↓
+_importSettings() called
+    ↓
+SettingsBackupService.pickAndImport()
+    ↓
+FilePicker.platform.pickFiles() - user selects .json file
+    ↓
+importFromJson() - parse and validate
+    ↓
+Show confirmation dialog with backup details
+    ↓
+User confirms
+    ↓
+Clear existing data
+    ↓
+restoreSites() / restoreWebspaces() - rebuild models
+    ↓
+Apply theme, save all settings
+    ↓
+Show success message
+```
+
+## Implementation Details
+
+### 1. Backup Data Model (`SettingsBackup`)
+
+```dart
+class SettingsBackup {
+  final int version;                    // Backup format version
+  final List<Map<String, dynamic>> sites;      // Site configurations
+  final List<Map<String, dynamic>> webspaces;  // Custom webspaces
+  final int themeMode;                  // 0=light, 1=dark, 2=system
+  final bool showUrlBar;                // URL bar visibility
+  final String? selectedWebspaceId;     // Currently selected webspace
+  final int? currentIndex;              // Currently selected site
+  final DateTime exportedAt;            // Timestamp of export
+}
+```
+
+### 2. Cookie Exclusion
+
+Cookies are explicitly stripped during both export and import:
+
+```dart
+// In createBackup():
+final sitesJson = webViewModels.map((model) {
+  final json = model.toJson();
+  json['cookies'] = [];  // Remove cookies from export
+  return json;
+}).toList();
+
+// In restoreSites():
+return backup.sites.map((json) {
+  json['cookies'] = [];  // Ensure no cookies on import
+  return WebViewModel.fromJson(json, stateSetterF);
+}).toList();
+```
+
+### 3. "All" Webspace Handling
+
+The special "All" webspace is never exported and is always recreated on import:
+
+```dart
+// Export excludes "All":
+final webspacesJson = webspaces
+    .where((ws) => ws.id != kAllWebspaceId)
+    .map((ws) => ws.toJson())
+    .toList();
+
+// Import recreates "All":
+static List<Webspace> restoreWebspaces(SettingsBackup backup) {
+  final webspaces = <Webspace>[Webspace.all()];  // Always add "All" first
+  for (final json in backup.webspaces) {
+    final ws = Webspace.fromJson(json);
+    if (ws.id != kAllWebspaceId) {
+      webspaces.add(ws);
+    }
+  }
+  return webspaces;
+}
+```
+
+### 4. Menu Integration
+
+Import/Export options appear in the triple-dot menu only when on the webspaces list screen:
+
+```dart
+PopupMenuButton<String>(
+  itemBuilder: (BuildContext context) {
+    final bool onWebspacesList = _currentIndex == null ||
+                                  _currentIndex! >= _webViewModels.length;
+    return [
+      // ... site-specific menu items ...
+
+      // Import/Export (only on webspaces list screen)
+      if (onWebspacesList)
+        PopupMenuItem<String>(
+          value: "export",
+          child: Row(children: [Icon(Icons.upload), Text("Export Settings")]),
+        ),
+      if (onWebspacesList)
+        PopupMenuItem<String>(
+          value: "import",
+          child: Row(children: [Icon(Icons.download), Text("Import Settings")]),
+        ),
+    ];
+  },
+)
+```
+
+## Usage
+
+### Exporting Settings
+
+1. Navigate to the webspaces list screen (tap webspace icon or "Back to Webspaces")
+2. Tap the triple-dot menu (⋮) in the top-right
+3. Select "Export Settings"
+4. Choose where to save/share the backup file
+
+### Importing Settings
+
+1. Navigate to the webspaces list screen
+2. Tap the triple-dot menu (⋮)
+3. Select "Import Settings"
+4. Select a `.json` backup file
+5. Review the confirmation dialog showing:
+   - Number of sites in backup
+   - Number of webspaces in backup
+   - Export timestamp
+   - Note about cookies not being included
+6. Tap "Import" to confirm
+
+**Warning**: Importing will replace ALL current settings.
+
+## Backup File Format
+
+Example backup JSON structure:
+
+```json
+{
+  "version": 1,
+  "sites": [
+    {
+      "initUrl": "https://example.com",
+      "currentUrl": "https://example.com/page",
+      "name": "Example Site",
+      "pageTitle": "Example - Homepage",
+      "cookies": [],
+      "proxySettings": {
+        "type": 0,
+        "address": null
+      },
+      "javascriptEnabled": true,
+      "userAgent": "",
+      "thirdPartyCookiesEnabled": false
+    }
+  ],
+  "webspaces": [
+    {
+      "id": "abc123-uuid",
+      "name": "Work",
+      "siteIndices": [0, 1, 2]
+    }
+  ],
+  "themeMode": 2,
+  "showUrlBar": false,
+  "selectedWebspaceId": "__all_webspace__",
+  "currentIndex": null,
+  "exportedAt": "2024-01-15T10:30:00.000Z"
+}
+```
+
+## Security Considerations
+
+### Why Cookies Are Excluded
+
+1. **Authentication tokens**: Cookies often contain session tokens and auth credentials
+2. **Privacy**: Cookie data may contain tracking identifiers
+3. **Device-specific**: Cookies are tied to the device/browser context
+4. **Security risk**: Exported files could be shared, exposing sensitive data
+
+### Backup File Security
+
+- Backup files are plain JSON (not encrypted)
+- Users should treat backup files as potentially sensitive
+- Avoid sharing backups publicly if they contain sensitive site configurations
+- Proxy credentials (if any) would be included in backup
+
+## Dependencies
+
+The feature requires these packages (added to `pubspec.yaml`):
+
+```yaml
+dependencies:
+  file_picker: ^8.0.0      # For selecting import files
+  share_plus: ^10.0.0      # For sharing export files
+  path_provider: ^2.1.0    # For temp directory access
+```
+
+## Platform Support
+
+| Platform | Export | Import | Notes |
+|----------|--------|--------|-------|
+| Android  | Yes | Yes | Full support |
+| iOS      | Yes | Yes | Full support |
+| macOS    | Yes | Yes | Full support |
+| Linux    | Yes | Yes | Full support |
+| Windows  | Yes | Yes | Full support |
+| Web      | Yes | Yes | Uses bytes instead of file path |
+
+## Error Handling
+
+### Export Errors
+
+- Temp directory unavailable: Shows error snackbar
+- Share cancelled: Returns gracefully (not an error)
+- JSON encoding failure: Shows error snackbar
+
+### Import Errors
+
+- File picker cancelled: Returns null (no error shown)
+- Invalid JSON format: Shows "Invalid backup file format" snackbar
+- File read failure: Shows "Could not read the selected file" snackbar
+- Parse exception: Shows "Import failed: [error]" snackbar
+
+## Testing
+
+### Test Coverage
+
+The implementation includes tests for:
+
+- Backup creation with various configurations
+- Cookie exclusion verification
+- JSON serialization/deserialization round-trips
+- "All" webspace handling
+- Empty and large data sets
+- Import after export consistency
+
+### Running Tests
+
+```bash
+# Run settings backup tests
+fvm flutter test test/settings_backup_test.dart
+```
+
+## Code References
+
+### Modified Files
+
+1. `lib/main.dart` - Added menu items and handlers
+2. `pubspec.yaml` - Added dependencies
+
+### New Files
+
+1. `lib/services/settings_backup.dart` - Core backup service
+2. `test/settings_backup_test.dart` - Unit tests
+
+### Key Methods
+
+- `SettingsBackupService.createBackup()` - Create backup excluding cookies
+- `SettingsBackupService.exportAndShare()` - Export and share file
+- `SettingsBackupService.pickAndImport()` - Pick and parse backup file
+- `SettingsBackupService.restoreSites()` - Restore WebViewModel list
+- `SettingsBackupService.restoreWebspaces()` - Restore Webspace list
+- `_WebSpacePageState._exportSettings()` - Export menu handler
+- `_WebSpacePageState._importSettings()` - Import menu handler
+
+## Future Enhancements
+
+Potential improvements for future versions:
+
+1. **Selective Import**
+   - Choose which sites/webspaces to import
+   - Merge with existing data instead of replacing
+
+2. **Backup Encryption**
+   - Optional password protection
+   - Encrypted backup files
+
+3. **Cloud Backup**
+   - Sync to cloud storage providers
+   - Automatic periodic backups
+
+4. **Backup History**
+   - Keep multiple backup versions
+   - Compare and restore from history
+
+5. **Partial Export**
+   - Export specific webspaces only
+   - Export single site configuration


### PR DESCRIPTION
- Add import/export options to triple-dot menu on webspaces list screen
- Create settings_backup.dart service for backup/restore logic
- Export creates JSON file with sites, webspaces, theme, and UI settings
- Import allows selecting a backup file and restoring settings
- Cookies are never included in backups for security