### PR TITLE
Fix: Add write permissions to update-lockfile workflow

### DIFF
--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -2,12 +2,6 @@ name: Update Lockfile
 
 on:
   workflow_dispatch:
-    inputs:
-      branch_name:
-        description: 'Branch name to commit the updated lockfile to'
-        required: false
-        default: 'update-pubspec-lock'
-        type: string
 
 permissions:
   contents: write
@@ -64,24 +58,16 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          BRANCH_NAME="${{ inputs.branch_name }}"
-
-          # Create or checkout the branch
-          git checkout -B "$BRANCH_NAME"
-
-          # Add and commit the lockfile
           git add pubspec.lock
           git commit -m "Update pubspec.lock"
-
-          # Push the branch
-          git push -u origin "$BRANCH_NAME" --force
+          git push
 
       - name: Summary
         run: |
           if [ "${{ steps.changes.outputs.changed }}" == "true" ]; then
             echo "## Lockfile Updated" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "pubspec.lock has been updated and pushed to branch \`${{ inputs.branch_name }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "pubspec.lock has been updated and pushed to branch \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
           else
             echo "## No Changes" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -9,6 +9,9 @@ on:
         default: 'update-pubspec-lock'
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   update-lockfile:
     name: Update pubspec.lock


### PR DESCRIPTION
The github-actions[bot] needs explicit contents:write permission to push commits to the repository.