### PR TITLE
Fix: Properly await WebViewFeature detection for Android proxy support

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,6 +26,7 @@ import 'package:webspace/demo_data.dart';
 import 'package:webspace/services/settings_backup.dart';
 import 'package:webspace/services/cookie_secure_storage.dart';
 import 'package:webspace/platform/platform_info.dart';
+import 'package:webspace/settings/proxy.dart';
 
 // Helper to convert ThemeMode to WebViewTheme
 WebViewTheme _themeModeToWebViewTheme(ThemeMode mode) {
@@ -849,7 +850,18 @@ class _WebSpacePageState extends State<WebSpacePage> {
                 await Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (context) => SettingsScreen(webViewModel: _webViewModels[_currentIndex!]),
+                    builder: (context) => SettingsScreen(
+                      webViewModel: _webViewModels[_currentIndex!],
+                      onProxySettingsChanged: (newProxySettings) {
+                        // Sync proxy settings to all WebViewModels (proxy is global)
+                        for (var model in _webViewModels) {
+                          model.proxySettings = UserProxySettings(
+                            type: newProxySettings.type,
+                            address: newProxySettings.address,
+                          );
+                        }
+                      },
+                    ),
                   ),
                 );
                 _saveWebViewModels();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,7 @@ import 'package:webspace/widgets/url_bar.dart';
 import 'package:webspace/demo_data.dart';
 import 'package:webspace/services/settings_backup.dart';
 import 'package:webspace/services/cookie_secure_storage.dart';
+import 'package:webspace/platform/platform_info.dart';
 
 // Helper to convert ThemeMode to WebViewTheme
 WebViewTheme _themeModeToWebViewTheme(ThemeMode mode) {
@@ -81,6 +82,8 @@ Future<String?> getPageTitle(String url) async {
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  // Initialize platform info to detect proxy support before UI loads
+  await PlatformInfo.initialize();
   runApp(WebSpaceApp());
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -854,12 +854,16 @@ class _WebSpacePageState extends State<WebSpacePage> {
                       webViewModel: _webViewModels[_currentIndex!],
                       onProxySettingsChanged: (newProxySettings) {
                         // Sync proxy settings to all WebViewModels (proxy is global)
-                        for (var model in _webViewModels) {
-                          model.proxySettings = UserProxySettings(
-                            type: newProxySettings.type,
-                            address: newProxySettings.address,
-                          );
-                        }
+                        setState(() {
+                          for (var model in _webViewModels) {
+                            model.proxySettings = UserProxySettings(
+                              type: newProxySettings.type,
+                              address: newProxySettings.address,
+                            );
+                          }
+                        });
+                        // Persist the changes immediately
+                        _saveWebViewModels();
                       },
                     ),
                   ),

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -27,8 +27,13 @@ String generateRandomUserAgent() {
 
 class SettingsScreen extends StatefulWidget {
   final WebViewModel webViewModel;
+  /// Callback to sync proxy settings across all WebViewModels
+  final void Function(UserProxySettings)? onProxySettingsChanged;
 
-  SettingsScreen({required this.webViewModel});
+  SettingsScreen({
+    required this.webViewModel,
+    this.onProxySettingsChanged,
+  });
 
   @override
   _SettingsScreenState createState() => _SettingsScreenState();
@@ -120,6 +125,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
         // Apply proxy settings immediately
         await widget.webViewModel.updateProxySettings(_proxySettings);
+
+        // Sync proxy settings to all other WebViewModels (proxy is global)
+        widget.onProxySettingsChanged?.call(_proxySettings);
       } else {
         // Force DEFAULT proxy on unsupported platforms
         final defaultProxy = UserProxySettings(type: ProxyType.DEFAULT);
@@ -158,6 +166,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
         children: [
           // Only show proxy settings on supported platforms
           if (PlatformInfo.isProxySupported) ...[
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+              child: Text(
+                'Proxy settings are shared across all sites.',
+                style: TextStyle(fontSize: 12, color: Colors.grey),
+              ),
+            ),
             ListTile(
               title: Text('Proxy Type'),
               trailing: DropdownButton<ProxyType>(


### PR DESCRIPTION
The isProxySupported getter was using .then() on an async operation but returning immediately before the Future resolved, causing it to always return false on Android.

This fix:
- Adds PlatformInfo.initialize() async method to properly await the WebViewFeature.isFeatureSupported() call
- Caches the result in a static variable
- Calls initialize() at app startup in main.dart