### PR TITLE
Enable Linux build in CI workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libsecret-1-dev
 
       - name: Setup Flutter (for Dart SDK)
         uses: subosito/flutter-action@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -189,9 +189,8 @@ jobs:
       - name: Run tests
         run: fvm flutter test
 
-      # DISABLED: Linux builds are currently disabled due to webview_cef removal
-      # - name: Build Linux
-      #   run: flutter build linux --release
+      - name: Build Linux
+        run: fvm flutter build linux --release
 
   build-macos:
     name: Build macOS
@@ -273,9 +272,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "✅ Android APKs (fdroid flavor, split by ABI)" >> $GITHUB_STEP_SUMMARY
           echo "✅ iOS IPA (unsigned)" >> $GITHUB_STEP_SUMMARY
-          echo "❌ Linux x64 build (disabled)" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Linux x64 build" >> $GITHUB_STEP_SUMMARY
           echo "✅ macOS app bundle" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Note: Linux tests run but builds are disabled due to webview_cef removal" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "All platform tests and enabled builds completed successfully!" >> $GITHUB_STEP_SUMMARY
+          echo "All platform builds completed successfully!" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Get dependencies
         run: fvm flutter pub get --enforce-lockfile
 
+      - name: Generate launcher icons
+        run: fvm dart run flutter_launcher_icons
+
       - name: Build APK
         run: fvm flutter build apk --release --flavor fdroid --split-per-abi
 
@@ -120,6 +123,9 @@ jobs:
           if [ ! -d "ios" ]; then
             fvm flutter create --platforms=ios .
           fi
+
+      - name: Generate launcher icons
+        run: fvm dart run flutter_launcher_icons
 
       - name: Build iOS (no codesign)
         run: fvm flutter build ios --release --no-codesign
@@ -189,6 +195,9 @@ jobs:
       - name: Run tests
         run: fvm flutter test
 
+      - name: Generate launcher icons
+        run: fvm dart run flutter_launcher_icons
+
       - name: Build Linux
         run: fvm flutter build linux --release
 
@@ -238,6 +247,9 @@ jobs:
 
       - name: Run tests
         run: fvm flutter test
+
+      - name: Generate launcher icons
+        run: fvm dart run flutter_launcher_icons
 
       - name: Build macOS
         run: fvm flutter build macos --release

--- a/linux/main.cc
+++ b/linux/main.cc
@@ -1,8 +1,6 @@
-#include <webview_cef/webview_cef_plugin.h>
 #include "my_application.h"
 
 int main(int argc, char** argv) {
-  initCEFProcesses(argc, argv);
   g_autoptr(MyApplication) app = my_application_new();
   return g_application_run(G_APPLICATION(app), argc, argv);
 }

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -6,7 +6,6 @@
 #endif
 
 #include "flutter/generated_plugin_registrant.h"
-#include <webview_cef/webview_cef_plugin.h>
 
 struct _MyApplication {
   GtkApplication parent_instance;
@@ -55,8 +54,6 @@ static void my_application_activate(GApplication* application) {
   fl_dart_project_set_dart_entrypoint_arguments(project, self->dart_entrypoint_arguments);
 
   FlView* view = fl_view_new(project);
-  g_signal_connect(view, "key_press_event", G_CALLBACK(processKeyEventForCEF), nullptr);
-  g_signal_connect(view, "key_release_event", G_CALLBACK(processKeyEventForCEF), nullptr);
   gtk_widget_show(GTK_WIDGET(view));
   gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
 


### PR DESCRIPTION
Re-enable the Linux build step that was previously disabled. The build now uses fvm flutter for consistency with other jobs.