### PR TITLE
Add demo mode no-save feature for screenshot tests

### DIFF
--- a/lib/demo_data.dart
+++ b/lib/demo_data.dart
@@ -3,6 +3,12 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:webspace/web_view_model.dart';
 import 'package:webspace/webspace_model.dart';
 
+/// Global flag to indicate demo mode is active.
+/// When true, the app will not persist any changes to storage.
+/// This is used during screenshot tests to ensure the demo data
+/// is not overwritten and normal app usage restores user settings.
+bool isDemoMode = false;
+
 /// Seeds demo/test data for screenshots and testing
 Future<void> seedDemoData() async {
   print('========================================');
@@ -118,4 +124,8 @@ Future<void> seedDemoData() async {
   print('DEMO DATA SEEDING COMPLETE');
   print('========================================');
   print('The app will load with ${sites.length} sites in ${webspaces.length} webspaces.');
+
+  // Enable demo mode to prevent any further saves during the session
+  isDemoMode = true;
+  print('Demo mode enabled - changes will NOT be persisted to storage');
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,7 +22,7 @@ import 'package:webspace/screens/webspaces_list.dart';
 import 'package:webspace/screens/webspace_detail.dart';
 import 'package:webspace/widgets/find_toolbar.dart';
 import 'package:webspace/widgets/url_bar.dart';
-import 'package:webspace/demo_data.dart';
+import 'package:webspace/demo_data.dart' show seedDemoData, isDemoMode;
 import 'package:webspace/services/settings_backup.dart';
 import 'package:webspace/services/cookie_secure_storage.dart';
 import 'package:webspace/platform/platform_info.dart';
@@ -159,6 +159,7 @@ class _WebSpacePageState extends State<WebSpacePage> {
   }
 
   Future<void> _saveWebViewModels() async {
+    if (isDemoMode) return; // Don't persist in demo mode
     SharedPreferences prefs = await SharedPreferences.getInstance();
 
     // Save cookies to secure storage, keyed by domain (not URL)
@@ -195,27 +196,32 @@ class _WebSpacePageState extends State<WebSpacePage> {
   }
 
   Future<void> _saveCurrentIndex() async {
+    if (isDemoMode) return; // Don't persist in demo mode
     SharedPreferences prefs = await SharedPreferences.getInstance();
     await prefs.setInt('currentIndex', _currentIndex == null ? 10000 : _currentIndex!);
   }
 
   Future<void> _saveThemeMode() async {
+    if (isDemoMode) return; // Don't persist in demo mode
     SharedPreferences prefs = await SharedPreferences.getInstance();
     await prefs.setInt('themeMode', _themeMode.index);
   }
 
   Future<void> _saveShowUrlBar() async {
+    if (isDemoMode) return; // Don't persist in demo mode
     SharedPreferences prefs = await SharedPreferences.getInstance();
     await prefs.setBool('showUrlBar', _showUrlBar);
   }
 
   Future<void> _saveWebspaces() async {
+    if (isDemoMode) return; // Don't persist in demo mode
     SharedPreferences prefs = await SharedPreferences.getInstance();
     List<String> webspacesJson = _webspaces.map((webspace) => jsonEncode(webspace.toJson())).toList();
     prefs.setStringList('webspaces', webspacesJson);
   }
 
   Future<void> _saveSelectedWebspaceId() async {
+    if (isDemoMode) return; // Don't persist in demo mode
     SharedPreferences prefs = await SharedPreferences.getInstance();
     if (_selectedWebspaceId != null) {
       await prefs.setString('selectedWebspaceId', _selectedWebspaceId!);

--- a/lib/services/cookie_secure_storage.dart
+++ b/lib/services/cookie_secure_storage.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:webspace/platform/unified_webview.dart';
+import 'package:webspace/demo_data.dart' show isDemoMode;
 
 /// Extracts the domain from a URL string.
 /// Returns the host portion of the URL (e.g., "github.com" from "https://github.com/user/repo").
@@ -67,6 +68,7 @@ class CookieSecureStorage {
   /// Saves cookies to secure storage.
   /// Falls back to SharedPreferences if secure storage is unavailable.
   Future<void> saveCookies(Map<String, List<UnifiedCookie>> cookiesByUrl) async {
+    if (isDemoMode) return; // Don't persist in demo mode
     final Map<String, List<Map<String, dynamic>>> jsonMap = {};
     cookiesByUrl.forEach((url, cookies) {
       jsonMap[url] = cookies.map((c) => c.toJson()).toList();
@@ -93,6 +95,7 @@ class CookieSecureStorage {
   /// Saves cookies for a single site URL.
   /// The URL is converted to a domain key before storing.
   Future<void> saveCookiesForUrl(String url, List<UnifiedCookie> cookies) async {
+    if (isDemoMode) return; // Don't persist in demo mode
     final domain = extractDomainFromUrl(url);
     final existingCookies = await loadCookies();
     existingCookies[domain] = cookies;
@@ -102,6 +105,7 @@ class CookieSecureStorage {
   /// Removes cookies for domains not in the provided set of active domains.
   /// This cleans up orphaned cookies after sites are deleted or settings are imported.
   Future<void> removeOrphanedCookies(Set<String> activeDomains) async {
+    if (isDemoMode) return; // Don't persist in demo mode
     final allCookies = await loadCookies();
     final domainsToRemove = allCookies.keys
         .where((domain) => !activeDomains.contains(domain))
@@ -121,6 +125,7 @@ class CookieSecureStorage {
 
   /// Clears all stored cookies from both secure storage and fallback.
   Future<void> clearCookies() async {
+    if (isDemoMode) return; // Don't persist in demo mode
     try {
       await _secureStorage.delete(key: _secureStorageKey);
     } catch (e) {
@@ -138,6 +143,7 @@ class CookieSecureStorage {
   /// Clears cookies from SharedPreferences after migration.
   /// This should be called after confirming cookies are safely in secure storage.
   Future<void> clearSharedPreferencesCookies() async {
+    if (isDemoMode) return; // Don't persist in demo mode
     final prefs = await SharedPreferences.getInstance();
     final webViewModelsJson = prefs.getStringList('webViewModels');
 

--- a/test/demo_mode_test.dart
+++ b/test/demo_mode_test.dart
@@ -1,0 +1,318 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webspace/demo_data.dart';
+import 'package:webspace/services/cookie_secure_storage.dart';
+import 'package:webspace/platform/unified_webview.dart';
+
+/// Mock implementation of FlutterSecureStorage for testing
+class MockFlutterSecureStorage implements FlutterSecureStorage {
+  final Map<String, String> _storage = {};
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (value == null) {
+      _storage.remove(key);
+    } else {
+      _storage[key] = value;
+    }
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    return _storage[key];
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    _storage.remove(key);
+  }
+
+  @override
+  Future<bool> containsKey({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    return _storage.containsKey(key);
+  }
+
+  @override
+  Future<Map<String, String>> readAll({
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    return Map<String, String>.from(_storage);
+  }
+
+  @override
+  Future<void> deleteAll({
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    _storage.clear();
+  }
+
+  // Helper methods for testing
+  void clear() => _storage.clear();
+  Map<String, String> get storage => Map.unmodifiable(_storage);
+
+  @override
+  IOSOptions get iOptions => throw UnimplementedError();
+
+  @override
+  AndroidOptions get aOptions => throw UnimplementedError();
+
+  @override
+  LinuxOptions get lOptions => throw UnimplementedError();
+
+  @override
+  WebOptions get webOptions => throw UnimplementedError();
+
+  @override
+  MacOsOptions get mOptions => throw UnimplementedError();
+
+  @override
+  WindowsOptions get wOptions => throw UnimplementedError();
+
+  @override
+  void registerListener({
+    required String key,
+    required ValueChanged<String?> listener,
+  }) {}
+
+  @override
+  void unregisterListener({
+    required String key,
+    required ValueChanged<String?> listener,
+  }) {}
+
+  @override
+  void unregisterAllListeners() {}
+
+  @override
+  void unregisterAllListenersForKey({required String key}) {}
+
+  @override
+  Future<bool?> isCupertinoProtectedDataAvailable() async => true;
+
+  @override
+  Stream<bool>? get onCupertinoProtectedDataAvailabilityChanged => null;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    // Reset demo mode before each test
+    isDemoMode = false;
+  });
+
+  tearDown(() {
+    // Ensure demo mode is reset after each test
+    isDemoMode = false;
+  });
+
+  group('Demo Mode Flag', () {
+    test('isDemoMode is false by default', () {
+      // Reset to ensure fresh state
+      isDemoMode = false;
+      expect(isDemoMode, isFalse);
+    });
+
+    test('seedDemoData sets isDemoMode to true', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      // Initially false
+      isDemoMode = false;
+      expect(isDemoMode, isFalse);
+
+      // Call seedDemoData
+      await seedDemoData();
+
+      // Should now be true
+      expect(isDemoMode, isTrue);
+    });
+
+    test('seedDemoData creates demo data in SharedPreferences', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      await seedDemoData();
+
+      final prefs = await SharedPreferences.getInstance();
+
+      // Verify demo data was seeded
+      final sites = prefs.getStringList('webViewModels');
+      final webspaces = prefs.getStringList('webspaces');
+
+      expect(sites, isNotNull);
+      expect(sites!.length, equals(8)); // 8 demo sites
+
+      expect(webspaces, isNotNull);
+      expect(webspaces!.length, equals(4)); // 4 demo webspaces
+    });
+  });
+
+  group('Demo Mode - CookieSecureStorage No Save', () {
+    late MockFlutterSecureStorage mockSecureStorage;
+    late CookieSecureStorage cookieSecureStorage;
+
+    setUp(() {
+      mockSecureStorage = MockFlutterSecureStorage();
+      cookieSecureStorage = CookieSecureStorage(secureStorage: mockSecureStorage);
+      SharedPreferences.setMockInitialValues({});
+      isDemoMode = false;
+    });
+
+    tearDown(() {
+      mockSecureStorage.clear();
+      isDemoMode = false;
+    });
+
+    test('saveCookies does nothing when isDemoMode is true', () async {
+      // Enable demo mode
+      isDemoMode = true;
+
+      final cookies = {
+        'example.com': [
+          UnifiedCookie(name: 'session', value: 'abc123', domain: 'example.com'),
+        ],
+      };
+
+      await cookieSecureStorage.saveCookies(cookies);
+
+      // Storage should be empty because demo mode is enabled
+      expect(mockSecureStorage.storage, isEmpty);
+    });
+
+    test('saveCookies works normally when isDemoMode is false', () async {
+      // Demo mode disabled
+      isDemoMode = false;
+
+      final cookies = {
+        'example.com': [
+          UnifiedCookie(name: 'session', value: 'abc123', domain: 'example.com'),
+        ],
+      };
+
+      await cookieSecureStorage.saveCookies(cookies);
+
+      // Storage should contain the cookies
+      expect(mockSecureStorage.storage, isNotEmpty);
+      expect(mockSecureStorage.storage['secure_cookies'], isNotNull);
+    });
+
+    test('saveCookiesForUrl does nothing when isDemoMode is true', () async {
+      isDemoMode = true;
+
+      await cookieSecureStorage.saveCookiesForUrl(
+        'https://example.com',
+        [UnifiedCookie(name: 'test', value: 'value', domain: 'example.com')],
+      );
+
+      expect(mockSecureStorage.storage, isEmpty);
+    });
+
+    test('clearCookies does nothing when isDemoMode is true', () async {
+      // First, save some cookies with demo mode disabled
+      isDemoMode = false;
+      await cookieSecureStorage.saveCookies({
+        'example.com': [
+          UnifiedCookie(name: 'session', value: 'abc123', domain: 'example.com'),
+        ],
+      });
+
+      // Verify cookies were saved
+      expect(mockSecureStorage.storage, isNotEmpty);
+
+      // Now enable demo mode and try to clear
+      isDemoMode = true;
+      await cookieSecureStorage.clearCookies();
+
+      // Cookies should still be there because demo mode prevented clearing
+      expect(mockSecureStorage.storage, isNotEmpty);
+    });
+
+    test('removeOrphanedCookies does nothing when isDemoMode is true', () async {
+      // First, save some cookies with demo mode disabled
+      isDemoMode = false;
+      await cookieSecureStorage.saveCookies({
+        'example.com': [
+          UnifiedCookie(name: 'session', value: 'abc123', domain: 'example.com'),
+        ],
+        'other.com': [
+          UnifiedCookie(name: 'token', value: 'xyz', domain: 'other.com'),
+        ],
+      });
+
+      // Now enable demo mode and try to remove orphaned cookies
+      isDemoMode = true;
+      await cookieSecureStorage.removeOrphanedCookies({'example.com'});
+
+      // Both cookies should still be there
+      final loaded = await cookieSecureStorage.loadCookies();
+      expect(loaded.keys, contains('other.com'));
+    });
+  });
+
+  group('Demo Mode - Full Workflow', () {
+    test('after seedDemoData, no further saves are persisted', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      // Seed demo data (this enables demo mode)
+      await seedDemoData();
+      expect(isDemoMode, isTrue);
+
+      // Try to save something new to SharedPreferences
+      final prefs = await SharedPreferences.getInstance();
+
+      // Verify initial demo data
+      final initialSites = prefs.getStringList('webViewModels');
+      expect(initialSites!.length, equals(8));
+
+      // The demo mode flag prevents saves at the application level,
+      // not at the SharedPreferences level directly.
+      // This test verifies the flag is set correctly after seeding.
+      expect(isDemoMode, isTrue);
+    });
+  });
+}

--- a/test/demo_mode_test.dart
+++ b/test/demo_mode_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';


### PR DESCRIPTION
When seedDemoData() is called, it now sets a global isDemoMode flag that prevents all subsequent save operations from persisting to storage. This ensures screenshot tests can run with demo data without affecting user settings when the app is opened normally.

- Add isDemoMode flag to demo_data.dart
- Modify all _save* methods in main.dart to check isDemoMode
- Update CookieSecureStorage methods to respect isDemoMode
- Add demo_mode_test.dart to verify the behavior