### PR TITLE
Add username and password fields for proxy authentication

### DIFF
--- a/lib/platform/unified_webview.dart
+++ b/lib/platform/unified_webview.dart
@@ -236,12 +236,23 @@ class UnifiedProxyManager {
             scheme = 'http';
         }
 
+        // Build proxy URL with optional credentials
+        String proxyUrl;
+        if (proxySettings.hasCredentials) {
+          // URL-encode username and password to handle special characters
+          final encodedUsername = Uri.encodeComponent(proxySettings.username!);
+          final encodedPassword = Uri.encodeComponent(proxySettings.password!);
+          proxyUrl = '$scheme://$encodedUsername:$encodedPassword@$host:$port';
+        } else {
+          proxyUrl = '$scheme://$host:$port';
+        }
+
         // Set proxy override
         await proxyController.setProxyOverride(
           settings: inapp.ProxySettings(
             proxyRules: [
               inapp.ProxyRule(
-                url: '$scheme://$host:$port',
+                url: proxyUrl,
               ),
             ],
             bypassRules: ['<local>'], // Bypass localhost

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -43,8 +43,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late UserProxySettings _proxySettings;
   late TextEditingController _userAgentController;
   late TextEditingController _proxyAddressController;
+  late TextEditingController _proxyUsernameController;
+  late TextEditingController _proxyPasswordController;
   late bool _javascriptEnabled;
   late bool _thirdPartyCookiesEnabled;
+  bool _obscureProxyPassword = true;
 
   String getResetUserAgent() {
     return (widget.webViewModel.userAgent == '') ? (widget.webViewModel.defaultUserAgent ?? '') : widget.webViewModel.userAgent;
@@ -61,12 +64,24 @@ class _SettingsScreenState extends State<SettingsScreen> {
       address: PlatformInfo.isProxySupported
           ? widget.webViewModel.proxySettings.address
           : null,
+      username: PlatformInfo.isProxySupported
+          ? widget.webViewModel.proxySettings.username
+          : null,
+      password: PlatformInfo.isProxySupported
+          ? widget.webViewModel.proxySettings.password
+          : null,
     );
     _userAgentController = TextEditingController(
       text: getResetUserAgent(),
     );
     _proxyAddressController = TextEditingController(
       text: _proxySettings.address ?? '',
+    );
+    _proxyUsernameController = TextEditingController(
+      text: _proxySettings.username ?? '',
+    );
+    _proxyPasswordController = TextEditingController(
+      text: _proxySettings.password ?? '',
     );
     _javascriptEnabled = widget.webViewModel.javascriptEnabled;
     _thirdPartyCookiesEnabled = widget.webViewModel.thirdPartyCookiesEnabled;
@@ -76,6 +91,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
   void dispose() {
     _userAgentController.dispose();
     _proxyAddressController.dispose();
+    _proxyUsernameController.dispose();
+    _proxyPasswordController.dispose();
     super.dispose();
   }
 
@@ -120,6 +137,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
         _proxySettings.address = _proxyAddressController.text.isEmpty
             ? null
             : _proxyAddressController.text;
+        _proxySettings.username = _proxyUsernameController.text.isEmpty
+            ? null
+            : _proxyUsernameController.text;
+        _proxySettings.password = _proxyPasswordController.text.isEmpty
+            ? null
+            : _proxyPasswordController.text;
 
         widget.webViewModel.proxySettings = _proxySettings;
 
@@ -194,7 +217,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 ).toList(),
               ),
             ),
-            if (_proxySettings.type != ProxyType.DEFAULT)
+            if (_proxySettings.type != ProxyType.DEFAULT) ...[
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
                 child: TextFormField(
@@ -208,6 +231,47 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   validator: _validateProxyAddress,
                 ),
               ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                child: Text(
+                  'Credentials (optional - only if proxy requires authentication)',
+                  style: TextStyle(fontSize: 12, color: Colors.grey),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                child: TextFormField(
+                  controller: _proxyUsernameController,
+                  decoration: InputDecoration(
+                    labelText: 'Proxy Username',
+                    hintText: 'Leave empty if not required',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                child: TextFormField(
+                  controller: _proxyPasswordController,
+                  obscureText: _obscureProxyPassword,
+                  decoration: InputDecoration(
+                    labelText: 'Proxy Password',
+                    hintText: 'Leave empty if not required',
+                    border: OutlineInputBorder(),
+                    suffixIcon: IconButton(
+                      icon: Icon(
+                        _obscureProxyPassword ? Icons.visibility : Icons.visibility_off,
+                      ),
+                      onPressed: () {
+                        setState(() {
+                          _obscureProxyPassword = !_obscureProxyPassword;
+                        });
+                      },
+                    ),
+                  ),
+                ),
+              ),
+            ],
           ],
           SwitchListTile(
             title: Text('JavaScript Enabled'),

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -48,6 +48,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late bool _javascriptEnabled;
   late bool _thirdPartyCookiesEnabled;
   bool _obscureProxyPassword = true;
+  bool _showProxyCredentials = false;
 
   String getResetUserAgent() {
     return (widget.webViewModel.userAgent == '') ? (widget.webViewModel.defaultUserAgent ?? '') : widget.webViewModel.userAgent;
@@ -85,6 +86,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
     _javascriptEnabled = widget.webViewModel.javascriptEnabled;
     _thirdPartyCookiesEnabled = widget.webViewModel.thirdPartyCookiesEnabled;
+    // Show credentials section if credentials already exist
+    _showProxyCredentials = _proxySettings.hasCredentials;
   }
 
   @override
@@ -137,12 +140,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
         _proxySettings.address = _proxyAddressController.text.isEmpty
             ? null
             : _proxyAddressController.text;
-        _proxySettings.username = _proxyUsernameController.text.isEmpty
-            ? null
-            : _proxyUsernameController.text;
-        _proxySettings.password = _proxyPasswordController.text.isEmpty
-            ? null
-            : _proxyPasswordController.text;
+        // Only save credentials if the checkbox is enabled
+        if (_showProxyCredentials) {
+          _proxySettings.username = _proxyUsernameController.text.isEmpty
+              ? null
+              : _proxyUsernameController.text;
+          _proxySettings.password = _proxyPasswordController.text.isEmpty
+              ? null
+              : _proxyPasswordController.text;
+        } else {
+          _proxySettings.username = null;
+          _proxySettings.password = null;
+        }
 
         widget.webViewModel.proxySettings = _proxySettings;
 
@@ -231,46 +240,49 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   validator: _validateProxyAddress,
                 ),
               ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-                child: Text(
-                  'Credentials (optional - only if proxy requires authentication)',
-                  style: TextStyle(fontSize: 12, color: Colors.grey),
-                ),
+              CheckboxListTile(
+                title: Text('Proxy requires authentication'),
+                value: _showProxyCredentials,
+                onChanged: (bool? value) {
+                  setState(() {
+                    _showProxyCredentials = value ?? false;
+                  });
+                },
+                controlAffinity: ListTileControlAffinity.leading,
               ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-                child: TextFormField(
-                  controller: _proxyUsernameController,
-                  decoration: InputDecoration(
-                    labelText: 'Proxy Username',
-                    hintText: 'Leave empty if not required',
-                    border: OutlineInputBorder(),
-                  ),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-                child: TextFormField(
-                  controller: _proxyPasswordController,
-                  obscureText: _obscureProxyPassword,
-                  decoration: InputDecoration(
-                    labelText: 'Proxy Password',
-                    hintText: 'Leave empty if not required',
-                    border: OutlineInputBorder(),
-                    suffixIcon: IconButton(
-                      icon: Icon(
-                        _obscureProxyPassword ? Icons.visibility : Icons.visibility_off,
-                      ),
-                      onPressed: () {
-                        setState(() {
-                          _obscureProxyPassword = !_obscureProxyPassword;
-                        });
-                      },
+              if (_showProxyCredentials) ...[
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                  child: TextFormField(
+                    controller: _proxyUsernameController,
+                    decoration: InputDecoration(
+                      labelText: 'Proxy Username',
+                      border: OutlineInputBorder(),
                     ),
                   ),
                 ),
-              ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                  child: TextFormField(
+                    controller: _proxyPasswordController,
+                    obscureText: _obscureProxyPassword,
+                    decoration: InputDecoration(
+                      labelText: 'Proxy Password',
+                      border: OutlineInputBorder(),
+                      suffixIcon: IconButton(
+                        icon: Icon(
+                          _obscureProxyPassword ? Icons.visibility : Icons.visibility_off,
+                        ),
+                        onPressed: () {
+                          setState(() {
+                            _obscureProxyPassword = !_obscureProxyPassword;
+                          });
+                        },
+                      ),
+                    ),
+                  ),
+                ),
+              ],
             ],
           ],
           SwitchListTile(

--- a/lib/settings/proxy.dart
+++ b/lib/settings/proxy.dart
@@ -3,16 +3,25 @@ enum ProxyType { DEFAULT, HTTP, HTTPS, SOCKS5 }
 class UserProxySettings {
   ProxyType type;
   String? address;
+  String? username;
+  String? password;
 
-  UserProxySettings({required this.type, this.address});
+  UserProxySettings({required this.type, this.address, this.username, this.password});
 
   Map<String, dynamic> toJson() => {
         'type': type.index,
         'address': address,
+        'username': username,
+        'password': password,
       };
 
   factory UserProxySettings.fromJson(Map<String, dynamic> json) => UserProxySettings(
         type: ProxyType.values[json['type']],
         address: json['address'],
+        username: json['username'],
+        password: json['password'],
       );
+
+  /// Returns true if credentials are provided
+  bool get hasCredentials => username != null && username!.isNotEmpty && password != null && password!.isNotEmpty;
 }


### PR DESCRIPTION
When proxy is enabled, users can now optionally provide credentials for authenticated proxies. The credentials are:
- Stored in UserProxySettings model with JSON serialization
- Displayed in settings UI with password visibility toggle
- URL-encoded when applied to proxy URL to handle special characters
- Tested with 15 new credential-specific unit tests