### PR TITLE
Fix openspec validation for all specs

### DIFF
--- a/openspec/specs/cookie-secure-storage/spec.md
+++ b/openspec/specs/cookie-secure-storage/spec.md
@@ -1,6 +1,6 @@
 # Cookie Secure Storage Specification
 
-## Overview
+## Purpose
 
 This feature migrates cookie storage from SharedPreferences to Flutter Secure Storage for improved security. Cookies contain sensitive session data and authentication tokens that should be stored securely.
 

--- a/openspec/specs/icon-fetching/spec.md
+++ b/openspec/specs/icon-fetching/spec.md
@@ -1,6 +1,6 @@
 # Icon Fetching Specification
 
-## Overview
+## Purpose
 
 Comprehensive icon fetching system for the Webspace app that provides high-quality favicons through multiple sources, progressive loading, and intelligent selection.
 

--- a/openspec/specs/nested-url-blocking/spec.md
+++ b/openspec/specs/nested-url-blocking/spec.md
@@ -1,6 +1,6 @@
 # Nested Webview URL Blocking Specification
 
-## Overview
+## Purpose
 
 Prevents nested webviews from being created for tracking URLs, analytics, service workers, and popups while maintaining functionality for legitimate use cases like Cloudflare challenges.
 

--- a/openspec/specs/platform-support/spec.md
+++ b/openspec/specs/platform-support/spec.md
@@ -1,6 +1,6 @@
 # Platform Support Specification
 
-## Overview
+## Purpose
 
 Platform abstraction layer and support status for WebSpace app across different operating systems.
 

--- a/openspec/specs/proxy/spec.md
+++ b/openspec/specs/proxy/spec.md
@@ -1,6 +1,6 @@
 # Proxy Feature Specification
 
-## Overview
+## Purpose
 
 The proxy feature allows users to configure HTTP, HTTPS, and SOCKS5 proxies for their web views on supported platforms using Flutter InAppWebView's ProxyController.
 

--- a/openspec/specs/screenshots/spec.md
+++ b/openspec/specs/screenshots/spec.md
@@ -1,6 +1,6 @@
 # Screenshot Generation Specification
 
-## Overview
+## Purpose
 
 Automated screenshot generation for app store submissions using Flutter integration tests and Fastlane.
 
@@ -29,6 +29,12 @@ Screenshots SHALL be generated using Flutter integration tests that work on both
 
 Screenshots SHALL use realistic demo data seeded automatically.
 
+#### Scenario: Seed demo data before screenshots
+
+- **WHEN** the screenshot test starts
+- **THEN** demo sites are seeded (Blog, Tasks, Notes, Dashboard, Wiki, Media Server)
+- **AND** demo webspaces are created (All, Work, Home Server)
+
 Demo sites:
 - My Blog (https://example.com/blog)
 - Tasks (https://tasks.example.com)
@@ -46,8 +52,14 @@ Demo webspaces:
 
 ### Requirement: SCREENSHOT-003 - Screenshot Coverage
 
-The test SHALL capture 10 screenshots covering all major app features:
+The test SHALL capture 10 screenshots covering all major app features.
 
+#### Scenario: Capture all required screenshots
+
+- **WHEN** the screenshot test completes
+- **THEN** 10 screenshots are saved covering main screen, drawer, webview, and workspace features
+
+Screenshots:
 1. `01-all-sites` - Main screen with all sites
 2. `02-sites-drawer` - Navigation drawer with site list
 3. `03-site-webview` - DuckDuckGo site loaded
@@ -63,15 +75,28 @@ The test SHALL capture 10 screenshots covering all major app features:
 
 ### Requirement: SCREENSHOT-004 - Output Locations
 
-Screenshots SHALL be saved to platform-specific directories:
-- **Android**: `fastlane/metadata/android/en-US/images/phoneScreenshots/`
-- **iOS**: `fastlane/screenshots/en-US/`
+Screenshots SHALL be saved to platform-specific directories.
+
+#### Scenario: Save screenshots to correct directories
+
+- **WHEN** screenshots are generated on Android
+- **THEN** files are saved to `fastlane/metadata/android/en-US/images/phoneScreenshots/`
+
+#### Scenario: Save iOS screenshots to correct directories
+
+- **WHEN** screenshots are generated on iOS
+- **THEN** files are saved to `fastlane/screenshots/en-US/`
 
 ---
 
 ### Requirement: SCREENSHOT-005 - Fastlane Integration
 
 Screenshots SHALL be triggerable via Fastlane commands.
+
+#### Scenario: Run screenshots via Fastlane
+
+- **WHEN** the user runs `fastlane screenshots` in the android or ios directory
+- **THEN** screenshots are captured and saved to the appropriate location
 
 ```bash
 # Android

--- a/openspec/specs/settings-backup/spec.md
+++ b/openspec/specs/settings-backup/spec.md
@@ -1,6 +1,6 @@
 # Settings Import/Export Specification
 
-## Overview
+## Purpose
 
 This feature allows users to backup and restore their app configuration including sites, webspaces, and preferences.
 
@@ -54,7 +54,13 @@ Cookies SHALL NEVER be included in backups for security reasons.
 
 ### Requirement: BACKUP-004 - Backup Contents
 
-Backups SHALL include:
+Backups SHALL include all settings except cookies.
+
+#### Scenario: Export all settings except cookies
+
+- **WHEN** settings are exported
+- **THEN** sites, webspaces, theme, and preferences are included
+- **AND** cookies are excluded for security
 
 | Setting | Exported | Notes |
 |---------|----------|-------|

--- a/openspec/specs/site-editing/spec.md
+++ b/openspec/specs/site-editing/spec.md
@@ -1,6 +1,6 @@
 # Site Editing & Page Title Display Specification
 
-## Overview
+## Purpose
 
 Users can edit site details and see automatic page title extraction instead of just URLs/domains.
 

--- a/openspec/specs/theme-preference/spec.md
+++ b/openspec/specs/theme-preference/spec.md
@@ -1,6 +1,6 @@
 # Webview Theme Preference Specification
 
-## Overview
+## Purpose
 
 The app supports suggesting/applying the app's theme (light/dark mode) to webviews. When you toggle the app's theme, all webviews will be instructed to use that theme preference.
 

--- a/openspec/specs/webspaces/spec.md
+++ b/openspec/specs/webspaces/spec.md
@@ -1,6 +1,6 @@
 # Webspaces Feature Specification
 
-## Overview
+## Purpose
 
 The Webspaces feature allows users to organize their saved sites into separate workspaces, enabling better organization and context switching between different browsing contexts (e.g., Work, Personal, Research).
 


### PR DESCRIPTION
- Rename "## Overview" to "## Purpose" in all spec files (required section)
- Add missing scenarios to SCREENSHOT-002/003/004/005 requirements
- Add missing scenario to BACKUP-004 requirement

All 10 specs now pass `openspec validate --specs`.