### PR TITLE
Fix screenshot directory detection for fastlane

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -68,15 +68,20 @@ platform :android do
     UI.success("Found device: #{device_id}")
     UI.message("Demo data will be seeded by Flutter integration test")
 
-    # Clear previous screenshots
+    # Set screenshot directory for Android
     screenshots_dir = File.join(project_root, "fastlane", "metadata", "android", "en-US", "images", "phoneScreenshots")
+
+    # Clear previous screenshots
     if Dir.exist?(screenshots_dir)
       UI.message("Clearing previous screenshots from #{screenshots_dir}")
       FileUtils.rm_rf(Dir.glob(File.join(screenshots_dir, "*.png")))
+    else
+      FileUtils.mkdir_p(screenshots_dir)
     end
 
     # Run Flutter integration test with screenshot capture
-    sh("cd '#{project_root}' && fvm flutter drive \
+    # SCREENSHOT_DIR is passed to the test driver to specify where to save screenshots
+    sh("cd '#{project_root}' && SCREENSHOT_DIR='#{screenshots_dir}' fvm flutter drive \
       --driver=test_driver/integration_test.dart \
       --target=integration_test/screenshot_test.dart \
       --flavor fmain \

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -77,56 +77,72 @@ flutter drive \
 - Useful for quick test validation
 
 ### When using `flutter drive` (recommended):
-Screenshots are automatically saved to platform-specific directories:
 
-**Android:**
-```
-fastlane/metadata/android/en-US/images/phoneScreenshots/01-all-sites.png
-fastlane/metadata/android/en-US/images/phoneScreenshots/02-sites-drawer.png
-fastlane/metadata/android/en-US/images/phoneScreenshots/03-site-webview.png
-... (all 10 screenshots)
-```
+**IMPORTANT**: The test driver runs on the **host machine**, not the target device.
+This means it cannot detect whether you're targeting Android or iOS at runtime.
+Use the `SCREENSHOT_DIR` environment variable to specify where screenshots should be saved.
 
-**iOS/Desktop:**
-```
-screenshots/01-all-sites.png
-screenshots/02-sites-drawer.png
-... (all 10 screenshots)
-```
-
-The `test_driver/integration_test.dart` file detects the platform and saves 
-screenshots to the appropriate directory for fastlane integration.
-
-### Custom directory:
+**Via fastlane (recommended):**
 ```bash
-# Override screenshot directory
-SCREENSHOT_DIR=my/custom/path flutter drive \
+# Android - uses fastlane/metadata/android/en-US/images/phoneScreenshots/
+cd android && bundle exec fastlane screenshots
+
+# iOS - uses fastlane/screenshots/en-US/
+cd ios && bundle exec fastlane screenshots
+```
+
+**Manual Android:**
+```bash
+SCREENSHOT_DIR=fastlane/metadata/android/en-US/images/phoneScreenshots flutter drive \
+  --driver=test_driver/integration_test.dart \
+  --target=integration_test/screenshot_test.dart \
+  --flavor fmain \
+  -d <device_id>
+```
+
+**Manual iOS:**
+```bash
+SCREENSHOT_DIR=fastlane/screenshots/en-US flutter drive \
+  --driver=test_driver/integration_test.dart \
+  --target=integration_test/screenshot_test.dart \
+  -d <simulator_id>
+```
+
+**Default (no SCREENSHOT_DIR):**
+```bash
+# Screenshots go to screenshots/ directory
+flutter drive \
   --driver=test_driver/integration_test.dart \
   --target=integration_test/screenshot_test.dart
 ```
 
 ### View screenshots:
 ```bash
-# Android
+# Android (after running fastlane screenshots)
 ls -la fastlane/metadata/android/en-US/images/phoneScreenshots/
 open fastlane/metadata/android/en-US/images/phoneScreenshots/01-all-sites.png
 
-# iOS/Desktop
+# iOS (after running fastlane screenshots)
+ls -la fastlane/screenshots/en-US/
+open fastlane/screenshots/en-US/01-all-sites.png
+
+# Default location (manual runs without SCREENSHOT_DIR)
 ls -la screenshots/
 open screenshots/01-all-sites.png
 ```
 
-**Note**: The old fastlane screenshots in `fastlane/metadata/android/en-US/images/phoneScreenshots/` 
-are from the Java/UiAutomator tests, not from the Flutter integration tests.
+## Fastlane Integration
 
-## Next Steps
+The screenshot generation is fully integrated with fastlane:
 
-To fully integrate with fastlane for automated Play Store/F-Droid screenshots:
+- **Android**: `cd android && bundle exec fastlane screenshots`
+- **iOS**: `cd ios && bundle exec fastlane screenshots`
 
-1. Create a test_driver file (if using flutter drive)
-2. Configure fastlane to run the Flutter integration test
-3. Set up screenshot locations in fastlane/Screengrabfile
-4. Add metadata for different locales
+The fastlane lanes handle:
+1. Finding connected devices/simulators
+2. Clearing previous screenshots
+3. Setting `SCREENSHOT_DIR` to the correct platform-specific path
+4. Running the Flutter integration test
 
 ## Test Flow
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -113,7 +113,7 @@ platform :ios do
 
     # Extract device ID from flutter devices output
     device_id = device_list.match(/• ([\w-]+) •/)[1] rescue ""
-    
+
     if device_id.empty?
       UI.user_error!("Could not parse device ID. Please ensure an iOS simulator or device is available.")
     end
@@ -121,8 +121,10 @@ platform :ios do
     UI.success("Found iOS device: #{device_id}")
     UI.message("Demo data will be seeded by Flutter integration test")
 
-    # Clear previous screenshots
+    # Set screenshot directory for iOS
     screenshots_dir = File.join(project_root, "fastlane", "screenshots", "en-US")
+
+    # Clear previous screenshots
     if Dir.exist?(screenshots_dir)
       UI.message("Clearing previous screenshots from #{screenshots_dir}")
       FileUtils.rm_rf(Dir.glob(File.join(screenshots_dir, "*.png")))
@@ -131,7 +133,8 @@ platform :ios do
     end
 
     # Run Flutter integration test with screenshot capture
-    sh("cd '#{project_root}' && fvm flutter drive \
+    # SCREENSHOT_DIR is passed to the test driver to specify where to save screenshots
+    sh("cd '#{project_root}' && SCREENSHOT_DIR='#{screenshots_dir}' fvm flutter drive \
       --driver=test_driver/integration_test.dart \
       --target=integration_test/screenshot_test.dart \
       -d #{device_id}")

--- a/scripts/make_screenshots.sh
+++ b/scripts/make_screenshots.sh
@@ -2,7 +2,10 @@
 
 set -ex
 
-fvm flutter drive \
+# Set SCREENSHOT_DIR to control where screenshots are saved.
+# The test_driver does NOT detect target platform - it runs on the host machine.
+# Fastlane lanes set this automatically; for manual runs, set it explicitly.
+SCREENSHOT_DIR="${SCREENSHOT_DIR:-screenshots}" fvm flutter drive \
   --driver=test_driver/integration_test.dart \
   --target=integration_test/screenshot_test.dart \
   --flavor fmain

--- a/test_driver/integration_test.dart
+++ b/test_driver/integration_test.dart
@@ -2,44 +2,25 @@ import 'dart:io';
 import 'package:integration_test/integration_test_driver_extended.dart';
 
 /// Test driver for integration tests with screenshot capture
-/// 
-/// This saves screenshots to platform-specific directories when using
-/// `flutter drive` command.
-/// 
+///
+/// IMPORTANT: The SCREENSHOT_DIR environment variable should be set by the
+/// calling script (e.g., fastlane) to specify where screenshots should be saved.
+/// This driver runs on the HOST machine, not the target device, so it cannot
+/// reliably detect the target platform at runtime.
+///
 /// Usage:
-///   flutter drive \
+///   SCREENSHOT_DIR=path/to/screenshots flutter drive \
 ///     --driver=test_driver/integration_test.dart \
 ///     --target=integration_test/screenshot_test.dart
-/// 
-/// Screenshots locations:
-///   - Android: fastlane/metadata/android/en-US/images/phoneScreenshots/
-///   - iOS: fastlane/metadata/ios/en-US/images/phoneScreenshots/ (if uncommented)
-///   - Desktop: screenshots/
-/// 
-/// Set SCREENSHOT_DIR environment variable to override:
-///   SCREENSHOT_DIR=my/custom/path flutter drive ...
+///
+/// Fastlane sets SCREENSHOT_DIR automatically based on the target platform.
+/// For manual runs without SCREENSHOT_DIR, screenshots go to 'screenshots/'.
 Future<void> main() async {
+  final screenshotDir = Platform.environment['SCREENSHOT_DIR'] ?? 'screenshots';
+
   await integrationDriver(
-    onScreenshot: (String screenshotName, List<int> screenshotBytes, [Map<String, Object?>? args]) async {
-      // Check for custom directory from environment variable
-      String? screenshotDir = Platform.environment['SCREENSHOT_DIR'];
-      
-      // If not set, use platform-specific defaults
-      if (screenshotDir == null) {
-        // Detect the actual runtime platform
-        if (Platform.isAndroid) {
-          // Save to fastlane directory for Android
-          screenshotDir = 'fastlane/metadata/android/en-US/images/phoneScreenshots';
-        } else if (Platform.isIOS) {
-          // For iOS, you can use fastlane directory too
-          // screenshotDir = 'fastlane/metadata/ios/en-US/images/phoneScreenshots';
-          screenshotDir = 'screenshots';
-        } else {
-          // Desktop or other platforms
-          screenshotDir = 'screenshots';
-        }
-      }
-      
+    onScreenshot: (String screenshotName, List<int> screenshotBytes,
+        [Map<String, Object?>? args]) async {
       final file = File('$screenshotDir/$screenshotName.png');
       await file.create(recursive: true);
       await file.writeAsBytes(screenshotBytes);


### PR DESCRIPTION
The test_driver runs on the host machine, not the target device, so Platform.isAndroid/isIOS checks were detecting the wrong platform.

This change:
- Removes platform detection from test_driver/integration_test.dart
- Has fastlane pass SCREENSHOT_DIR environment variable with the correct platform-specific path
- Updates scripts and documentation to reflect the new approach