### PR TITLE
Separate theme mode (light/dark/system) and accent color selection

### DIFF
--- a/integration_test/screenshot_test.dart
+++ b/integration_test/screenshot_test.dart
@@ -167,7 +167,7 @@ void main() {
         await tester.pump();
         await Future.delayed(const Duration(seconds: 2));
 
-        // Look for a site to select (SearXNG)
+        // Look for a site to select (SearXNG) to access settings
         print('Looking for SearXNG site...');
         final searxFinder = find.text('SearXNG');
 
@@ -192,16 +192,11 @@ void main() {
           await tester.pump();
           await tester.pump(const Duration(milliseconds: 500));
 
-          // Screenshot 1: SearXNG webview loaded
-          // Use native screenshot to capture the webview content (Flutter surface misses platform views)
-          await _takeThemedScreenshots(binding, tester, '01-site-webview', currentTheme, useNative: true);
-          print('Screenshot 1 captured successfully (site selected)');
-
           // Use pump() instead of pumpAndSettle() to avoid timeout with webviews
           await tester.pump(const Duration(seconds: 2));
           await Future.delayed(const Duration(seconds: 2));
 
-          // Screenshot 2: Open Settings from toolbar menu
+          // Screenshot 1: Open Settings from toolbar menu
           print('Opening toolbar menu to access Settings...');
           final popupMenuButton = find.byType(PopupMenuButton<String>);
           if (popupMenuButton.evaluate().isNotEmpty) {
@@ -218,9 +213,9 @@ void main() {
               await tester.pumpAndSettle();
               await Future.delayed(const Duration(seconds: 2));
 
-              // Screenshot 2: Settings screen
-              await _takeThemedScreenshots(binding, tester, '02-site-settings', currentTheme);
-              print('Screenshot 2 captured successfully (settings screen)');
+              // Screenshot 1: Settings screen
+              await _takeThemedScreenshots(binding, tester, '01-site-settings', currentTheme);
+              print('Screenshot 1 captured successfully (settings screen)');
 
               // Go back to webview
               print('Navigating back from Settings...');
@@ -296,9 +291,9 @@ void main() {
           await tester.pump();
           await Future.delayed(const Duration(seconds: 2));
 
-          // Screenshot 3: Work webspace drawer
-          await _takeThemedScreenshots(binding, tester, '03-work-sites-drawer', currentTheme);
-          print('Screenshot 3 captured successfully');
+          // Screenshot 2: Work webspace drawer
+          await _takeThemedScreenshots(binding, tester, '02-work-sites-drawer', currentTheme);
+          print('Screenshot 2 captured successfully');
           await tester.pump();
           await Future.delayed(const Duration(seconds: 2));
 
@@ -307,8 +302,8 @@ void main() {
           await tester.pump();
           await Future.delayed(const Duration(seconds: 2));
 
-          // Screenshot 4: Work webspace sites
-          await _takeThemedScreenshots(binding, tester, '04-work-webspace', currentTheme);
+          // Screenshot 3: Work webspace sites
+          await _takeThemedScreenshots(binding, tester, '03-work-webspace', currentTheme);
           await tester.pumpAndSettle(const Duration(seconds: 3));
         }
 
@@ -394,8 +389,8 @@ void main() {
               print('Wikipedia checkbox not found');
             }
 
-            // Screenshot 5: Sites selected
-            await _takeThemedScreenshots(binding, tester, '05-workspace-sites-selected', currentTheme);
+            // Screenshot 4: Sites selected
+            await _takeThemedScreenshots(binding, tester, '04-workspace-sites-selected', currentTheme);
             await Future.delayed(const Duration(seconds: 1));
 
             // Look for save button (check icon in AppBar)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,6 +31,12 @@ import 'package:webspace/settings/proxy.dart';
 enum AccentColor {
   blue,
   green,
+  purple,
+  orange,
+  red,
+  pink,
+  teal,
+  yellow,
 }
 
 // App theme settings - combines theme mode and accent color
@@ -113,6 +119,12 @@ AppThemeSettings _legacyAppThemeToSettings(AppTheme appTheme) {
 // Accent colors
 const Color _accentBlue = Color(0xFF6B8DD6);
 const Color _accentGreen = Color(0xFF7be592);
+const Color _accentPurple = Color(0xFF9B7BD6);
+const Color _accentOrange = Color(0xFFE59B5B);
+const Color _accentRed = Color(0xFFD66B6B);
+const Color _accentPink = Color(0xFFD66BA8);
+const Color _accentTeal = Color(0xFF5BC4C4);
+const Color _accentYellow = Color(0xFFD6C86B);
 
 // Get accent color from AccentColor enum
 Color _accentColorToColor(AccentColor accentColor) {
@@ -121,6 +133,18 @@ Color _accentColorToColor(AccentColor accentColor) {
       return _accentBlue;
     case AccentColor.green:
       return _accentGreen;
+    case AccentColor.purple:
+      return _accentPurple;
+    case AccentColor.orange:
+      return _accentOrange;
+    case AccentColor.red:
+      return _accentRed;
+    case AccentColor.pink:
+      return _accentPink;
+    case AccentColor.teal:
+      return _accentTeal;
+    case AccentColor.yellow:
+      return _accentYellow;
   }
 }
 

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -1,17 +1,17 @@
 import 'package:flutter/material.dart';
 
-import 'package:webspace/main.dart' show AppTheme;
+import 'package:webspace/main.dart' show AppThemeSettings, AccentColor;
 
 class AppSettingsScreen extends StatefulWidget {
-  final AppTheme currentTheme;
-  final Function(AppTheme) onThemeChanged;
+  final AppThemeSettings currentSettings;
+  final Function(AppThemeSettings) onSettingsChanged;
   final VoidCallback onExportSettings;
   final VoidCallback onImportSettings;
 
   const AppSettingsScreen({
     super.key,
-    required this.currentTheme,
-    required this.onThemeChanged,
+    required this.currentSettings,
+    required this.onSettingsChanged,
     required this.onExportSettings,
     required this.onImportSettings,
   });
@@ -21,12 +21,19 @@ class AppSettingsScreen extends StatefulWidget {
 }
 
 class _AppSettingsScreenState extends State<AppSettingsScreen> {
-  late AppTheme _selectedTheme;
+  late AppThemeSettings _settings;
 
   @override
   void initState() {
     super.initState();
-    _selectedTheme = widget.currentTheme;
+    _settings = widget.currentSettings;
+  }
+
+  void _updateSettings(AppThemeSettings newSettings) {
+    setState(() {
+      _settings = newSettings;
+    });
+    widget.onSettingsChanged(newSettings);
   }
 
   @override
@@ -37,7 +44,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
       ),
       body: ListView(
         children: [
-          // Theme Section
+          // Theme Mode Section
           Padding(
             padding: const EdgeInsets.all(16.0),
             child: Text(
@@ -47,36 +54,45 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
               ),
             ),
           ),
-          _buildThemeOption(
-            AppTheme.lightBlue,
-            'Light Blue',
+          _buildThemeModeOption(
+            ThemeMode.light,
+            'Light',
             Icons.wb_sunny,
-            Colors.blue,
           ),
-          _buildThemeOption(
-            AppTheme.darkBlue,
-            'Dark Blue',
+          _buildThemeModeOption(
+            ThemeMode.dark,
+            'Dark',
             Icons.nights_stay,
-            Colors.blue,
           ),
-          _buildThemeOption(
-            AppTheme.lightGreen,
-            'Light Green',
-            Icons.wb_sunny,
-            Colors.green,
-          ),
-          _buildThemeOption(
-            AppTheme.darkGreen,
-            'Dark Green',
-            Icons.nights_stay,
-            Colors.green,
-          ),
-          _buildThemeOption(
-            AppTheme.system,
+          _buildThemeModeOption(
+            ThemeMode.system,
             'System',
             Icons.brightness_auto,
-            null,
           ),
+          
+          const Divider(height: 32),
+          
+          // Accent Color Section
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Text(
+              'Accent Color',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          _buildAccentColorOption(
+            AccentColor.blue,
+            'Blue',
+            const Color(0xFF6B8DD6),
+          ),
+          _buildAccentColorOption(
+            AccentColor.green,
+            'Green',
+            const Color(0xFF7be592),
+          ),
+          
           const Divider(height: 32),
 
           // Data Section
@@ -112,39 +128,57 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
     );
   }
 
-  Widget _buildThemeOption(AppTheme theme, String label, IconData icon, Color? accentColor) {
-    final isSelected = _selectedTheme == theme;
-    return RadioListTile<AppTheme>(
-      value: theme,
-      groupValue: _selectedTheme,
+  Widget _buildThemeModeOption(ThemeMode mode, String label, IconData icon) {
+    final isSelected = _settings.themeMode == mode;
+    return RadioListTile<ThemeMode>(
+      value: mode,
+      groupValue: _settings.themeMode,
       onChanged: (value) {
         if (value != null) {
-          setState(() {
-            _selectedTheme = value;
-          });
-          widget.onThemeChanged(value);
+          _updateSettings(_settings.copyWith(themeMode: value));
         }
       },
       title: Row(
         children: [
           Icon(
             icon,
-            color: accentColor,
             size: 20,
           ),
           const SizedBox(width: 12),
           Text(label),
-          if (accentColor != null) ...[
-            const SizedBox(width: 8),
-            Container(
-              width: 16,
-              height: 16,
-              decoration: BoxDecoration(
-                color: accentColor,
-                shape: BoxShape.circle,
+        ],
+      ),
+      selected: isSelected,
+      activeColor: Theme.of(context).colorScheme.secondary,
+    );
+  }
+
+  Widget _buildAccentColorOption(AccentColor color, String label, Color displayColor) {
+    final isSelected = _settings.accentColor == color;
+    return RadioListTile<AccentColor>(
+      value: color,
+      groupValue: _settings.accentColor,
+      onChanged: (value) {
+        if (value != null) {
+          _updateSettings(_settings.copyWith(accentColor: value));
+        }
+      },
+      title: Row(
+        children: [
+          Container(
+            width: 20,
+            height: 20,
+            decoration: BoxDecoration(
+              color: displayColor,
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: isSelected ? displayColor : Colors.grey.shade400,
+                width: 2,
               ),
             ),
-          ],
+          ),
+          const SizedBox(width: 12),
+          Text(label),
         ],
       ),
       selected: isSelected,

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -92,6 +92,36 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
             'Green',
             const Color(0xFF7be592),
           ),
+          _buildAccentColorOption(
+            AccentColor.purple,
+            'Purple',
+            const Color(0xFF9B7BD6),
+          ),
+          _buildAccentColorOption(
+            AccentColor.orange,
+            'Orange',
+            const Color(0xFFE59B5B),
+          ),
+          _buildAccentColorOption(
+            AccentColor.red,
+            'Red',
+            const Color(0xFFD66B6B),
+          ),
+          _buildAccentColorOption(
+            AccentColor.pink,
+            'Pink',
+            const Color(0xFFD66BA8),
+          ),
+          _buildAccentColorOption(
+            AccentColor.teal,
+            'Teal',
+            const Color(0xFF5BC4C4),
+          ),
+          _buildAccentColorOption(
+            AccentColor.yellow,
+            'Yellow',
+            const Color(0xFFD6C86B),
+          ),
           
           const Divider(height: 32),
 

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -2,6 +2,18 @@ import 'package:flutter/material.dart';
 
 import 'package:webspace/main.dart' show AppThemeSettings, AccentColor;
 
+// Accent color definitions for display
+const Map<AccentColor, Color> _accentColors = {
+  AccentColor.blue: Color(0xFF6B8DD6),
+  AccentColor.green: Color(0xFF7be592),
+  AccentColor.purple: Color(0xFF9B7BD6),
+  AccentColor.orange: Color(0xFFE59B5B),
+  AccentColor.red: Color(0xFFD66B6B),
+  AccentColor.pink: Color(0xFFD66BA8),
+  AccentColor.teal: Color(0xFF5BC4C4),
+  AccentColor.yellow: Color(0xFFD6C86B),
+};
+
 class AppSettingsScreen extends StatefulWidget {
   final AppThemeSettings currentSettings;
   final Function(AppThemeSettings) onSettingsChanged;
@@ -54,23 +66,12 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
               ),
             ),
           ),
-          _buildThemeModeOption(
-            ThemeMode.light,
-            'Light',
-            Icons.wb_sunny,
-          ),
-          _buildThemeModeOption(
-            ThemeMode.dark,
-            'Dark',
-            Icons.nights_stay,
-          ),
-          _buildThemeModeOption(
-            ThemeMode.system,
-            'System',
-            Icons.brightness_auto,
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+            child: _buildThemeModeRow(),
           ),
           
-          const Divider(height: 32),
+          const SizedBox(height: 24),
           
           // Accent Color Section
           Padding(
@@ -82,47 +83,12 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
               ),
             ),
           ),
-          _buildAccentColorOption(
-            AccentColor.blue,
-            'Blue',
-            const Color(0xFF6B8DD6),
-          ),
-          _buildAccentColorOption(
-            AccentColor.green,
-            'Green',
-            const Color(0xFF7be592),
-          ),
-          _buildAccentColorOption(
-            AccentColor.purple,
-            'Purple',
-            const Color(0xFF9B7BD6),
-          ),
-          _buildAccentColorOption(
-            AccentColor.orange,
-            'Orange',
-            const Color(0xFFE59B5B),
-          ),
-          _buildAccentColorOption(
-            AccentColor.red,
-            'Red',
-            const Color(0xFFD66B6B),
-          ),
-          _buildAccentColorOption(
-            AccentColor.pink,
-            'Pink',
-            const Color(0xFFD66BA8),
-          ),
-          _buildAccentColorOption(
-            AccentColor.teal,
-            'Teal',
-            const Color(0xFF5BC4C4),
-          ),
-          _buildAccentColorOption(
-            AccentColor.yellow,
-            'Yellow',
-            const Color(0xFFD6C86B),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+            child: _buildAccentColorGrid(),
           ),
           
+          const SizedBox(height: 8),
           const Divider(height: 32),
 
           // Data Section
@@ -158,61 +124,137 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
     );
   }
 
-  Widget _buildThemeModeOption(ThemeMode mode, String label, IconData icon) {
-    final isSelected = _settings.themeMode == mode;
-    return RadioListTile<ThemeMode>(
-      value: mode,
-      groupValue: _settings.themeMode,
-      onChanged: (value) {
-        if (value != null) {
-          _updateSettings(_settings.copyWith(themeMode: value));
-        }
-      },
-      title: Row(
-        children: [
-          Icon(
-            icon,
-            size: 20,
+  Widget _buildThemeModeRow() {
+    return Row(
+      children: [
+        Expanded(
+          child: _buildThemeModeChip(
+            ThemeMode.light,
+            'Light',
+            Icons.wb_sunny,
           ),
-          const SizedBox(width: 12),
-          Text(label),
-        ],
-      ),
-      selected: isSelected,
-      activeColor: Theme.of(context).colorScheme.secondary,
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: _buildThemeModeChip(
+            ThemeMode.dark,
+            'Dark',
+            Icons.nights_stay,
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: _buildThemeModeChip(
+            ThemeMode.system,
+            'System',
+            Icons.brightness_auto,
+          ),
+        ),
+      ],
     );
   }
 
-  Widget _buildAccentColorOption(AccentColor color, String label, Color displayColor) {
-    final isSelected = _settings.accentColor == color;
-    return RadioListTile<AccentColor>(
-      value: color,
-      groupValue: _settings.accentColor,
-      onChanged: (value) {
-        if (value != null) {
-          _updateSettings(_settings.copyWith(accentColor: value));
-        }
+  Widget _buildThemeModeChip(ThemeMode mode, String label, IconData icon) {
+    final isSelected = _settings.themeMode == mode;
+    final accentColor = Theme.of(context).colorScheme.secondary;
+    
+    return GestureDetector(
+      onTap: () {
+        _updateSettings(_settings.copyWith(themeMode: mode));
       },
-      title: Row(
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
+        decoration: BoxDecoration(
+          color: isSelected ? accentColor.withOpacity(0.15) : Colors.transparent,
+          border: Border.all(
+            color: isSelected ? accentColor : Colors.grey.shade400,
+            width: isSelected ? 2 : 1,
+          ),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              icon,
+              size: 24,
+              color: isSelected ? accentColor : null,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                color: isSelected ? accentColor : null,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAccentColorGrid() {
+    return Wrap(
+      spacing: 16,
+      runSpacing: 16,
+      children: AccentColor.values.map((color) {
+        return _buildAccentColorSwatch(color);
+      }).toList(),
+    );
+  }
+
+  Widget _buildAccentColorSwatch(AccentColor color) {
+    final isSelected = _settings.accentColor == color;
+    final displayColor = _accentColors[color]!;
+    final label = color.name[0].toUpperCase() + color.name.substring(1);
+    
+    return GestureDetector(
+      onTap: () {
+        _updateSettings(_settings.copyWith(accentColor: color));
+      },
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
         children: [
           Container(
-            width: 20,
-            height: 20,
+            width: 48,
+            height: 48,
             decoration: BoxDecoration(
               color: displayColor,
               shape: BoxShape.circle,
               border: Border.all(
-                color: isSelected ? displayColor : Colors.grey.shade400,
-                width: 2,
+                color: isSelected ? Colors.white : Colors.transparent,
+                width: 3,
               ),
+              boxShadow: isSelected
+                  ? [
+                      BoxShadow(
+                        color: displayColor.withOpacity(0.6),
+                        blurRadius: 8,
+                        spreadRadius: 2,
+                      ),
+                    ]
+                  : null,
+            ),
+            child: isSelected
+                ? const Icon(
+                    Icons.check,
+                    color: Colors.white,
+                    size: 24,
+                  )
+                : null,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
             ),
           ),
-          const SizedBox(width: 12),
-          Text(label),
         ],
       ),
-      selected: isSelected,
-      activeColor: Theme.of(context).colorScheme.secondary,
     );
   }
 }

--- a/openspec/specs/screenshots/spec.md
+++ b/openspec/specs/screenshots/spec.md
@@ -22,13 +22,13 @@ Screenshots SHALL be generated using Flutter integration tests on both Android a
 
 - **GIVEN** an Android emulator is running
 - **WHEN** the user runs `bundle exec fastlane android screenshots`
-- **THEN** 10 screenshots are captured (5 per theme)
+- **THEN** 8 screenshots are captured (4 per theme)
 
 #### Scenario: Generate screenshots on iOS
 
 - **GIVEN** an iOS simulator is running
 - **WHEN** the user runs `fastlane ios screenshots`
-- **THEN** 10 screenshots are captured (5 per theme)
+- **THEN** 8 screenshots are captured (4 per theme)
 
 ---
 
@@ -46,18 +46,12 @@ Screenshots SHALL use demo data seeded automatically via `lib/demo_data.dart`.
 
 ### SCREENSHOT-003 - Screenshot Coverage
 
-The test SHALL capture 5 screenshots per theme (10 total): `01-site-webview`, `02-site-settings`, `03-work-sites-drawer`, `04-work-webspace`, `05-workspace-sites-selected`.
+The test SHALL capture 4 screenshots per theme (8 total): `01-site-settings`, `02-work-sites-drawer`, `03-work-webspace`, `04-workspace-sites-selected`.
 
 #### Scenario: Capture all screenshots
 
 - **WHEN** the screenshot test completes
-- **THEN** 10 screenshots are saved with `-light` and `-dark` variants
-
-#### Scenario: Capture webview content on Android
-
-- **GIVEN** screenshot 01 includes webview content
-- **WHEN** the test requests screenshot on Android
-- **THEN** ADB screencap is used via `@@NATIVE_SCREENSHOT:<name>@@` marker
+- **THEN** 8 screenshots are saved with `-light` and `-dark` variants
 
 ---
 

--- a/screenshots/android/title.strings
+++ b/screenshots/android/title.strings
@@ -1,6 +1,5 @@
 
-"01-site-webview" = "Browse with privacy"
-"02-site-settings" = "Per-site settings"
-"03-work-sites-drawer" = "Organize by workspace"
-"04-work-webspace" = "Focused browsing"
-"05-workspace-sites-selected" = "Custom workspaces"
+"01-site-settings" = "Per-site settings"
+"02-work-sites-drawer" = "Organize by workspace"
+"03-work-webspace" = "Focused browsing"
+"04-workspace-sites-selected" = "Custom workspaces"

--- a/screenshots/ios/title.strings
+++ b/screenshots/ios/title.strings
@@ -1,6 +1,5 @@
 
-"01-site-webview" = "Browse with privacy"
-"02-site-settings" = "Per-site settings"
-"03-work-sites-drawer" = "Organize by workspace"
-"04-work-webspace" = "Focused browsing"
-"05-workspace-sites-selected" = "Custom workspaces"
+"01-site-settings" = "Per-site settings"
+"02-work-sites-drawer" = "Organize by workspace"
+"03-work-webspace" = "Focused browsing"
+"04-workspace-sites-selected" = "Custom workspaces"


### PR DESCRIPTION
- Replace combined AppTheme enum with separate ThemeMode and AccentColor
- Add AppThemeSettings class to manage both settings independently
- Update App Settings UI with separate sections for theme and accent color
- Theme toggle button now cycles through light/dark/system
- System theme now works with any accent color
- Includes backward-compatible migration from old storage format