### PR TITLE
Add theming to changelog and fastlane metadata validation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,6 +11,14 @@ on:
   workflow_dispatch:
 
 jobs:
+  validate-metadata:
+    name: Validate Fastlane Metadata
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate metadata
+        run: ./scripts/validate_fastlane_metadata.sh
+
   check-screenshot-changes:
     name: Check Screenshot Changes
     runs-on: ubuntu-latest

--- a/fastlane/metadata/android/en-US/changelogs/6.txt
+++ b/fastlane/metadata/android/en-US/changelogs/6.txt
@@ -1,4 +1,5 @@
 ✨ New Features:
+• Theming: Separate theme mode and accent color selection
 • Language selection: Choose preferred language per site (30+ languages)
 • Accept-Language header support for localized content
 

--- a/scripts/validate_fastlane_metadata.sh
+++ b/scripts/validate_fastlane_metadata.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -e
+
+METADATA_DIR="fastlane/metadata/android/en-US"
+EXIT_CODE=0
+
+echo "Validating Fastlane metadata..."
+echo
+
+# Validate short_description.txt
+SHORT_DESC_FILE="$METADATA_DIR/short_description.txt"
+if [ -f "$SHORT_DESC_FILE" ]; then
+    SHORT_DESC=$(cat "$SHORT_DESC_FILE")
+    SHORT_DESC_LEN=$(echo -n "$SHORT_DESC" | wc -c)
+
+    echo "Checking short_description.txt..."
+    echo "  Length: $SHORT_DESC_LEN characters (max 80)"
+
+    if [ "$SHORT_DESC_LEN" -ge 80 ]; then
+        echo "  ERROR: short_description.txt is $SHORT_DESC_LEN characters (must be less than 80)"
+        EXIT_CODE=1
+    else
+        echo "  Length OK"
+    fi
+
+    # Check for trailing dot
+    if [[ "$SHORT_DESC" =~ \.$ ]]; then
+        echo "  ERROR: short_description.txt ends with a dot (trailing dot not allowed)"
+        EXIT_CODE=1
+    else
+        echo "  No trailing dot"
+    fi
+    echo
+else
+    echo "ERROR: $SHORT_DESC_FILE not found"
+    EXIT_CODE=1
+fi
+
+# Validate full_description.txt
+FULL_DESC_FILE="$METADATA_DIR/full_description.txt"
+if [ -f "$FULL_DESC_FILE" ]; then
+    FULL_DESC_LEN=$(wc -c < "$FULL_DESC_FILE")
+
+    echo "Checking full_description.txt..."
+    echo "  Length: $FULL_DESC_LEN characters (max 500)"
+
+    if [ "$FULL_DESC_LEN" -gt 500 ]; then
+        echo "  ERROR: full_description.txt is $FULL_DESC_LEN characters (must be 500 or less)"
+        EXIT_CODE=1
+    else
+        echo "  Length OK"
+    fi
+    echo
+else
+    echo "ERROR: $FULL_DESC_FILE not found"
+    EXIT_CODE=1
+fi
+
+# Validate changelog files
+CHANGELOGS_DIR="$METADATA_DIR/changelogs"
+if [ -d "$CHANGELOGS_DIR" ]; then
+    echo "Checking changelogs..."
+    CHANGELOG_ERROR=0
+
+    for changelog in "$CHANGELOGS_DIR"/*.txt; do
+        if [ -f "$changelog" ]; then
+            CHANGELOG_LEN=$(wc -c < "$changelog")
+            CHANGELOG_NAME=$(basename "$changelog")
+
+            if [ "$CHANGELOG_LEN" -gt 500 ]; then
+                echo "  ERROR: $CHANGELOG_NAME is $CHANGELOG_LEN characters (max 500)"
+                CHANGELOG_ERROR=1
+                EXIT_CODE=1
+            else
+                echo "  $CHANGELOG_NAME: $CHANGELOG_LEN characters"
+            fi
+        fi
+    done
+
+    if [ "$CHANGELOG_ERROR" -eq 0 ]; then
+        echo "  All changelogs OK"
+    fi
+    echo
+fi
+
+if [ "$EXIT_CODE" -eq 0 ]; then
+    echo "All fastlane metadata validation checks passed!"
+else
+    echo "Fastlane metadata validation failed!"
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
- Add theming feature to v6 changelog
- Add validate_fastlane_metadata.sh script to check:
  - short_description.txt length (< 80 chars) and no trailing dot
  - full_description.txt length (<= 500 chars)
  - changelog files length (<= 500 chars)
- Add validation job to CI workflow