### PR TITLE
Save cookies to secure storage on every page load

### DIFF
--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -409,6 +409,7 @@ class WebViewModel {
             if (!thirdPartyCookiesEnabled && controller != null) {
               removeThirdPartyCookies(controller!);
             }
+            await saveFunc();
           },
           onFindResult: (activeMatch, totalMatches) {
             findMatches.activeMatchOrdinal = activeMatch;


### PR DESCRIPTION
Previously cookies were only persisted during domain conflict switches. Now cookies are saved via onCookiesChanged callback whenever a page finishes loading, ensuring session data is preserved if the app closes.