### PR TITLE
Add Hugging Face support and whitelist popup windows to Cloudflare-only

### DIFF
--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -258,6 +258,7 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
     SiteSuggestion(name: 'Reddit', url: 'https://reddit.com', domain: 'reddit.com'),
     SiteSuggestion(name: 'Mastodon', url: 'https://mastodon.social', domain: 'mastodon.social'),
     SiteSuggestion(name: 'Bluesky', url: 'https://bsky.app', domain: 'bsky.app'),
+    SiteSuggestion(name: 'Hugging Face', url: 'https://huggingface.co', domain: 'huggingface.co'),
   ];
 
   void _showSuggestionDialog(SiteSuggestion suggestion) {

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -138,22 +138,22 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen> {
             itemBuilder: (BuildContext context) {
               return [
                 PopupMenuItem<String>(
-                  value: "copylink",
-                  child: Row(
-                    children: [
-                      Icon(Icons.copy),
-                      SizedBox(width: 8),
-                      Text("Copy Link"),
-                    ],
-                  ),
-                ),
-                PopupMenuItem<String>(
                   value: "openbrowser",
                   child: Row(
                     children: [
                       Icon(Icons.link),
                       SizedBox(width: 8),
                       Text("Open in Browser"),
+                    ],
+                  ),
+                ),
+                PopupMenuItem<String>(
+                  value: "copylink",
+                  child: Row(
+                    children: [
+                      Icon(Icons.copy),
+                      SizedBox(width: 8),
+                      Text("Copy Link"),
                     ],
                   ),
                 ),

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -148,16 +148,6 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen> {
                   ),
                 ),
                 PopupMenuItem<String>(
-                  value: "copylink",
-                  child: Row(
-                    children: [
-                      Icon(Icons.copy),
-                      SizedBox(width: 8),
-                      Text("Copy Link"),
-                    ],
-                  ),
-                ),
-                PopupMenuItem<String>(
                   value: "refresh",
                   child: Row(
                     children: [
@@ -174,6 +164,16 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen> {
                       Icon(Icons.search),
                       SizedBox(width: 8),
                       Text("Find"),
+                    ],
+                  ),
+                ),
+                PopupMenuItem<String>(
+                  value: "copylink",
+                  child: Row(
+                    children: [
+                      Icon(Icons.copy),
+                      SizedBox(width: 8),
+                      Text("Copy Link"),
                     ],
                   ),
                 ),

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:webspace/services/webview.dart';
@@ -137,6 +138,16 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen> {
             itemBuilder: (BuildContext context) {
               return [
                 PopupMenuItem<String>(
+                  value: "copylink",
+                  child: Row(
+                    children: [
+                      Icon(Icons.copy),
+                      SizedBox(width: 8),
+                      Text("Copy Link"),
+                    ],
+                  ),
+                ),
+                PopupMenuItem<String>(
                   value: "openbrowser",
                   child: Row(
                     children: [
@@ -170,6 +181,19 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen> {
             },
             onSelected: (String value) async {
               switch (value) {
+                case 'copylink':
+                  if (_controller != null) {
+                    final url = await _controller!.getUrl();
+                    if (url != null) {
+                      await Clipboard.setData(ClipboardData(text: url.toString()));
+                      if (mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(content: Text('Link copied to clipboard')),
+                        );
+                      }
+                    }
+                  }
+                  break;
                 case 'openbrowser':
                   if (_controller != null) {
                     final url = await _controller!.getUrl();

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -414,6 +414,8 @@ class WebViewFactory {
     'googletagmanager.com', 'google-analytics.com', 'googleadservices.com',
     'doubleclick.net', 'facebook.com/tr', 'connect.facebook.net',
     'analytics.twitter.com', 'static.ads-twitter.com',
+    'js.stripe.com', 'js.stripe.dev', 'm.stripe.network', 'm.stripe.com',
+    'b.stripecdn.com',
   ];
 
   static bool _shouldBlockUrl(String url) {

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -522,16 +522,18 @@ class WebViewFactory {
         final url = createWindowAction.request.url?.toString() ?? '';
         final windowId = createWindowAction.windowId;
 
-        // If we have a callback for handling popups, use it
+        // Only show popup dialog for Cloudflare challenges (captcha verification).
+        // All other window.open() calls (e.g. Stripe fraud detection, analytics)
+        // are silently dismissed to prevent unwanted popup windows.
+        if (!_isCloudflareChallenge(url)) {
+          return false;
+        }
+
         if (config.onWindowRequested != null && windowId != null) {
           await config.onWindowRequested!(windowId, url);
           return true;
         }
 
-        // For other popups without a handler, load in the same window instead
-        if (url.isNotEmpty) {
-          await controller.loadUrl(urlRequest: inapp.URLRequest(url: createWindowAction.request.url));
-        }
         return false;
       },
       onLoadStop: (controller, url) async {

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -116,6 +116,8 @@ String getBaseDomain(String url) {
 /// All Google properties (gmail.com, regional domains, etc.) are treated as google.com.
 const Map<String, String> _domainAliases = {
   'gmail.com': 'google.com',
+  // Hugging Face
+  'hf.co': 'huggingface.co',
   // Anthropic / Claude
   'claude.ai': 'anthropic.com',
   // OpenAI / ChatGPT


### PR DESCRIPTION
- Add Hugging Face to site suggestions
- Add hf.co as domain alias for huggingface.co
- Only show popup dialog for Cloudflare challenge windows; silently dismiss all other window.open() calls (e.g. Stripe fraud detection)