### PR TITLE
Fix incognito mode not propagating to nested webviews

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/8.txt
+++ b/fastlane/metadata/android/en-US/changelogs/8.txt
@@ -5,3 +5,4 @@
 🔧 Improvements:
 • Improved favicon caching
 • Improved captcha loading
+• Fixed incognito mode not applying to nested webviews

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -778,11 +778,11 @@ class _WebSpacePageState extends State<WebSpacePage> {
     }
   }
 
-  Future<void> launchUrl(String url, {String? homeTitle}) async {
+  Future<void> launchUrl(String url, {String? homeTitle, bool? incognito}) async {
     await Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (context) => InAppWebViewScreen(url: url, homeTitle: homeTitle),
+        builder: (context) => InAppWebViewScreen(url: url, homeTitle: homeTitle, incognito: incognito ?? false),
       ),
     );
   }

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -9,8 +9,9 @@ import 'package:webspace/widgets/find_toolbar.dart';
 class InAppWebViewScreen extends StatefulWidget {
   final String url;
   final String? homeTitle;
+  final bool incognito;
 
-  InAppWebViewScreen({required this.url, this.homeTitle});
+  InAppWebViewScreen({required this.url, this.homeTitle, this.incognito = false});
 
   @override
   _InAppWebViewScreenState createState() => _InAppWebViewScreenState();
@@ -230,6 +231,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen> {
             child: WebViewFactory.createWebView(
               config: WebViewConfig(
                 initialUrl: widget.url,
+                incognito: widget.incognito,
                 onUrlChanged: (url) {
                   // Keep home site title even when navigating within nested webview
                 },

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -327,7 +327,7 @@ class WebViewModel {
   }
 
   Widget getWebView(
-    Function(String url, {String? homeTitle}) launchUrlFunc,
+    Function(String url, {String? homeTitle, bool? incognito}) launchUrlFunc,
     CookieManager cookieManager,
     Function saveFunc, {
     Future<void> Function(int windowId, String url)? onWindowRequested,
@@ -398,7 +398,7 @@ class WebViewModel {
             if (kDebugMode) {
               debugPrint('  -> CANCEL (opening nested webview)');
             }
-            launchUrlFunc(url, homeTitle: name);
+            launchUrlFunc(url, homeTitle: name, incognito: incognito);
             return false; // Cancel
           },
           onUrlChanged: (url) async {
@@ -459,7 +459,7 @@ class WebViewModel {
   }
 
   WebViewController? getController(
-    Function(String url, {String? homeTitle}) launchUrlFunc,
+    Function(String url, {String? homeTitle, bool? incognito}) launchUrlFunc,
     CookieManager cookieManager,
     Function saveFunc,
   ) {


### PR DESCRIPTION
When a parent site has incognito mode enabled and opens a cross-domain link in a nested webview, the nested webview was created without the incognito flag, causing cookies and cache to leak.