### PR TITLE
Propagate all per-site settings to nested webviews

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -778,11 +778,26 @@ class _WebSpacePageState extends State<WebSpacePage> {
     }
   }
 
-  Future<void> launchUrl(String url, {String? homeTitle, bool? incognito}) async {
+  Future<void> launchUrl(String url, {
+    String? homeTitle,
+    required bool incognito,
+    required bool thirdPartyCookiesEnabled,
+    required bool clearUrlEnabled,
+    required bool dnsBlockEnabled,
+    required String? language,
+  }) async {
     await Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (context) => InAppWebViewScreen(url: url, homeTitle: homeTitle, incognito: incognito ?? false),
+        builder: (context) => InAppWebViewScreen(
+          url: url,
+          homeTitle: homeTitle,
+          incognito: incognito,
+          thirdPartyCookiesEnabled: thirdPartyCookiesEnabled,
+          clearUrlEnabled: clearUrlEnabled,
+          dnsBlockEnabled: dnsBlockEnabled,
+          language: language,
+        ),
       ),
     );
   }

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -10,8 +10,20 @@ class InAppWebViewScreen extends StatefulWidget {
   final String url;
   final String? homeTitle;
   final bool incognito;
+  final bool thirdPartyCookiesEnabled;
+  final bool clearUrlEnabled;
+  final bool dnsBlockEnabled;
+  final String? language;
 
-  InAppWebViewScreen({required this.url, this.homeTitle, this.incognito = false});
+  InAppWebViewScreen({
+    required this.url,
+    this.homeTitle,
+    required this.incognito,
+    required this.thirdPartyCookiesEnabled,
+    required this.clearUrlEnabled,
+    required this.dnsBlockEnabled,
+    required this.language,
+  });
 
   @override
   _InAppWebViewScreenState createState() => _InAppWebViewScreenState();
@@ -232,6 +244,10 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen> {
               config: WebViewConfig(
                 initialUrl: widget.url,
                 incognito: widget.incognito,
+                thirdPartyCookiesEnabled: widget.thirdPartyCookiesEnabled,
+                clearUrlEnabled: widget.clearUrlEnabled,
+                dnsBlockEnabled: widget.dnsBlockEnabled,
+                language: widget.language,
                 onUrlChanged: (url) {
                   // Keep home site title even when navigating within nested webview
                 },

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -327,7 +327,7 @@ class WebViewModel {
   }
 
   Widget getWebView(
-    Function(String url, {String? homeTitle, bool? incognito}) launchUrlFunc,
+    Function(String url, {String? homeTitle, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required String? language}) launchUrlFunc,
     CookieManager cookieManager,
     Function saveFunc, {
     Future<void> Function(int windowId, String url)? onWindowRequested,
@@ -398,7 +398,7 @@ class WebViewModel {
             if (kDebugMode) {
               debugPrint('  -> CANCEL (opening nested webview)');
             }
-            launchUrlFunc(url, homeTitle: name, incognito: incognito);
+            launchUrlFunc(url, homeTitle: name, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, language: this.language);
             return false; // Cancel
           },
           onUrlChanged: (url) async {
@@ -459,7 +459,7 @@ class WebViewModel {
   }
 
   WebViewController? getController(
-    Function(String url, {String? homeTitle, bool? incognito}) launchUrlFunc,
+    Function(String url, {String? homeTitle, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required String? language}) launchUrlFunc,
     CookieManager cookieManager,
     Function saveFunc,
   ) {


### PR DESCRIPTION
Nested webviews now inherit thirdPartyCookiesEnabled, clearUrlEnabled, dnsBlockEnabled, and language from the parent site, in addition to the previously added incognito flag.