### PR TITLE
Preserve webviews offline and show cached pages

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/9.txt
+++ b/fastlane/metadata/android/en-US/changelogs/9.txt
@@ -1,2 +1,3 @@
 ✨ New Features:
 • Content Blocker: block ads, trackers, and promoted posts using EasyList filter lists
+• Offline mode: view previously visited sites offline with cached pages

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1924,7 +1924,7 @@ class _WebSpacePageState extends State<WebSpacePage> {
                         onHtmlLoaded: webViewModel.incognito ? null : (url, html) {
                           HtmlCacheService.instance.saveHtml(webViewModel.siteId, html, url);
                         },
-                        initialHtml: webViewModel.incognito ? null : HtmlCacheService.instance.getHtmlSync(webViewModel.siteId),
+                        hasCachedContent: !webViewModel.incognito && HtmlCacheService.instance.getHtmlSync(webViewModel.siteId) != null,
                         isActive: () => _currentIndex == index,
                       )
                     ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1375,6 +1375,9 @@ class _WebSpacePageState extends State<WebSpacePage> {
                 break;
                 case 'refresh':
                   getController()?.reload();
+                  // Re-fetch favicon for this site
+                  await FaviconUrlCache.invalidate(_webViewModels[_currentIndex!].initUrl);
+                  setState(() {});
                 break;
                 case 'settings':
                   await Navigator.push(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,6 +29,7 @@ import 'package:webspace/services/settings_backup.dart';
 import 'package:webspace/services/cookie_secure_storage.dart';
 import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
+import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/settings/proxy.dart';
 
 // Accent color enum
@@ -920,20 +921,28 @@ class _WebSpacePageState extends State<WebSpacePage> {
     // Get indices in the new webspace
     final newIndices = _getFilteredSiteIndices().toSet();
 
-    // Find loaded sites that were in previous webspace but not in new one
-    final indicesToUnload = _loadedIndices
-        .where((i) => previousIndices.contains(i) && !newIndices.contains(i))
-        .toList();
+    // Only unload sites when online - preserve live webviews when offline
+    // so users can still view cached content
+    final online = await ConnectivityService.instance.isOnline();
 
-    // Unload sites not in new webspace
-    for (final index in indicesToUnload) {
-      if (index >= 0 && index < _webViewModels.length) {
-        _webViewModels[index].disposeWebView();
-        _loadedIndices.remove(index);
-        if (kDebugMode) {
-          debugPrint('[WebspaceSwitch] Unloaded site $index: "${_webViewModels[index].name}"');
+    if (online) {
+      // Find loaded sites that were in previous webspace but not in new one
+      final indicesToUnload = _loadedIndices
+          .where((i) => previousIndices.contains(i) && !newIndices.contains(i))
+          .toList();
+
+      // Unload sites not in new webspace
+      for (final index in indicesToUnload) {
+        if (index >= 0 && index < _webViewModels.length) {
+          _webViewModels[index].disposeWebView();
+          _loadedIndices.remove(index);
+          if (kDebugMode) {
+            debugPrint('[WebspaceSwitch] Unloaded site $index: "${_webViewModels[index].name}"');
+          }
         }
       }
+    } else if (kDebugMode) {
+      debugPrint('[WebspaceSwitch] Offline - preserving loaded webviews');
     }
 
     await _setCurrentIndex(null);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1924,7 +1924,7 @@ class _WebSpacePageState extends State<WebSpacePage> {
                         onHtmlLoaded: webViewModel.incognito ? null : (url, html) {
                           HtmlCacheService.instance.saveHtml(webViewModel.siteId, html, url);
                         },
-                        hasCachedContent: !webViewModel.incognito && HtmlCacheService.instance.getHtmlSync(webViewModel.siteId) != null,
+                        initialHtml: webViewModel.incognito ? null : HtmlCacheService.instance.getHtmlSync(webViewModel.siteId),
                         isActive: () => _currentIndex == index,
                       )
                     ),

--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -3,7 +3,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../main.dart' show extractDomain;
-import '../services/icon_service.dart' show getFaviconUrlStream, IconUpdate;
+import '../services/icon_service.dart' show getFaviconUrlStream, getSvgContent, IconUpdate;
 
 /// Persistent cache for favicon URLs to avoid re-fetching on app restart
 class FaviconUrlCache {
@@ -57,6 +57,7 @@ class UnifiedFaviconImage extends StatefulWidget {
 
 class _UnifiedFaviconImageState extends State<UnifiedFaviconImage> {
   String? _currentIconUrl;
+  String? _svgContent; // Cached SVG content for offline display
   int _currentQuality = 0;
   bool _isLoading = true;
   Stream<IconUpdate>? _iconStream;
@@ -87,16 +88,28 @@ class _UnifiedFaviconImageState extends State<UnifiedFaviconImage> {
     final cachedUrl = FaviconUrlCache.get(widget.url);
     if (cachedUrl != null) {
       // Use cached URL immediately, skip icon_service
-      setState(() {
-        _currentIconUrl = cachedUrl;
-        _currentQuality = 100;
-        _isLoading = false;
-      });
+      _currentIconUrl = cachedUrl;
+      _currentQuality = 100;
+      _isLoading = false;
+      if (_isSvgUrl(cachedUrl)) {
+        _fetchSvgContent(cachedUrl);
+      } else {
+        setState(() {});
+      }
       return;
     }
 
     // No cache - fetch via icon_service
     _startIconStream();
+  }
+
+  Future<void> _fetchSvgContent(String url) async {
+    final content = await getSvgContent(url);
+    if (mounted) {
+      setState(() {
+        _svgContent = content;
+      });
+    }
   }
 
   void _startIconStream() {
@@ -113,6 +126,9 @@ class _UnifiedFaviconImageState extends State<UnifiedFaviconImage> {
               FaviconUrlCache.set(widget.url, update.url);
             }
           });
+          if (_isSvgUrl(update.url)) {
+            _fetchSvgContent(update.url);
+          }
         }
       },
       onDone: () {
@@ -162,21 +178,34 @@ class _UnifiedFaviconImageState extends State<UnifiedFaviconImage> {
     if (_isSvgUrl(iconUrl)) {
       // Wrap in MediaQuery to pass app theme to SVG's CSS media queries
       // (e.g., @media (prefers-color-scheme: dark) in codeberg's favicon)
+      final svgWidget = _svgContent != null
+          ? SvgPicture.string(
+              _svgContent!,
+              width: widget.size,
+              height: widget.size,
+              fit: BoxFit.contain,
+            )
+          : SvgPicture.network(
+              iconUrl,
+              width: widget.size,
+              height: widget.size,
+              fit: BoxFit.contain,
+              placeholderBuilder: (context) => SizedBox(
+                width: widget.size,
+                height: widget.size,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+              errorBuilder: (context, error, stackTrace) => Icon(
+                Icons.language,
+                size: widget.size,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+            );
       return MediaQuery(
         data: MediaQuery.of(context).copyWith(
           platformBrightness: Theme.of(context).brightness,
         ),
-        child: SvgPicture.network(
-          iconUrl,
-          width: widget.size,
-          height: widget.size,
-          fit: BoxFit.contain,
-          placeholderBuilder: (context) => SizedBox(
-            width: widget.size,
-            height: widget.size,
-            child: CircularProgressIndicator(strokeWidth: 2),
-          ),
-        ),
+        child: svgWidget,
       );
     } else {
       return CachedNetworkImage(

--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -3,15 +3,20 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../main.dart' show extractDomain;
-import '../services/icon_service.dart' show getFaviconUrlStream, getSvgContent, IconUpdate;
+import '../services/icon_service.dart' show getFaviconUrlStream, getSvgContent, onSvgContentCached, invalidateFaviconFor, IconUpdate;
 
-/// Persistent cache for favicon URLs to avoid re-fetching on app restart
+/// Persistent cache for favicon URLs and SVG content
 class FaviconUrlCache {
   static const String _prefix = 'favicon_url_';
+  static const String _svgPrefix = 'favicon_svg_';
   static SharedPreferences? _prefs;
 
   static Future<void> initialize() async {
     _prefs ??= await SharedPreferences.getInstance();
+    // Wire up SVG content persistence
+    onSvgContentCached = (url, content) async {
+      await setSvg(url, content);
+    };
   }
 
   static String? get(String siteUrl) {
@@ -20,6 +25,25 @@ class FaviconUrlCache {
 
   static Future<void> set(String siteUrl, String faviconUrl) async {
     await _prefs?.setString('$_prefix$siteUrl', faviconUrl);
+  }
+
+  static String? getSvg(String faviconUrl) {
+    return _prefs?.getString('$_svgPrefix$faviconUrl');
+  }
+
+  static Future<void> setSvg(String faviconUrl, String svgContent) async {
+    await _prefs?.setString('$_svgPrefix$faviconUrl', svgContent);
+  }
+
+  /// Invalidate cached favicon for a site, triggering re-fetch
+  static Future<void> invalidate(String siteUrl) async {
+    final oldUrl = _prefs?.getString('$_prefix$siteUrl');
+    await _prefs?.remove('$_prefix$siteUrl');
+    if (oldUrl != null) {
+      await _prefs?.remove('$_svgPrefix$oldUrl');
+    }
+    // Also clear in-memory caches
+    invalidateFaviconFor(siteUrl);
   }
 }
 
@@ -76,11 +100,19 @@ class _UnifiedFaviconImageState extends State<UnifiedFaviconImage> {
   void didUpdateWidget(UnifiedFaviconImage oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.url != widget.url) {
-      _currentIconUrl = null;
-      _currentQuality = 0;
-      _isLoading = true;
-      _loadIcon();
+      _resetAndLoad();
+    } else if (_currentIconUrl != null && FaviconUrlCache.get(widget.url) == null) {
+      // Cache was invalidated (e.g. by refresh) — re-fetch
+      _resetAndLoad();
     }
+  }
+
+  void _resetAndLoad() {
+    _currentIconUrl = null;
+    _svgContent = null;
+    _currentQuality = 0;
+    _isLoading = true;
+    _loadIcon();
   }
 
   void _loadIcon() {
@@ -104,7 +136,8 @@ class _UnifiedFaviconImageState extends State<UnifiedFaviconImage> {
   }
 
   Future<void> _fetchSvgContent(String url) async {
-    final content = await getSvgContent(url);
+    final persisted = FaviconUrlCache.getSvg(url);
+    final content = await getSvgContent(url, persistedContent: persisted);
     if (mounted) {
       setState(() {
         _svgContent = content;

--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -176,36 +176,26 @@ class _UnifiedFaviconImageState extends State<UnifiedFaviconImage> {
 
     // Use SvgPicture for SVG files, CachedNetworkImage for others
     if (_isSvgUrl(iconUrl)) {
+      if (_svgContent == null) {
+        // SVG not cached yet — show placeholder, never use SvgPicture.network
+        return Icon(
+          Icons.language,
+          size: widget.size,
+          color: Theme.of(context).colorScheme.primary,
+        );
+      }
       // Wrap in MediaQuery to pass app theme to SVG's CSS media queries
       // (e.g., @media (prefers-color-scheme: dark) in codeberg's favicon)
-      final svgWidget = _svgContent != null
-          ? SvgPicture.string(
-              _svgContent!,
-              width: widget.size,
-              height: widget.size,
-              fit: BoxFit.contain,
-            )
-          : SvgPicture.network(
-              iconUrl,
-              width: widget.size,
-              height: widget.size,
-              fit: BoxFit.contain,
-              placeholderBuilder: (context) => SizedBox(
-                width: widget.size,
-                height: widget.size,
-                child: CircularProgressIndicator(strokeWidth: 2),
-              ),
-              errorBuilder: (context, error, stackTrace) => Icon(
-                Icons.language,
-                size: widget.size,
-                color: Theme.of(context).colorScheme.primary,
-              ),
-            );
       return MediaQuery(
         data: MediaQuery.of(context).copyWith(
           platformBrightness: Theme.of(context).brightness,
         ),
-        child: svgWidget,
+        child: SvgPicture.string(
+          _svgContent!,
+          width: widget.size,
+          height: widget.size,
+          fit: BoxFit.contain,
+        ),
       );
     } else {
       return CachedNetworkImage(

--- a/lib/services/connectivity_service.dart
+++ b/lib/services/connectivity_service.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+/// Simple connectivity service with a testable override.
+class ConnectivityService {
+  static ConnectivityService? _instance;
+  static ConnectivityService get instance => _instance ??= ConnectivityService._();
+  ConnectivityService._();
+
+  /// Override for testing. When non-null, [isOnline] returns this value.
+  @visibleForTesting
+  static Future<bool>? onlineOverride;
+
+  /// Reset to production behavior.
+  @visibleForTesting
+  static void reset() {
+    _instance = null;
+    onlineOverride = null;
+  }
+
+  /// Returns true if the device can resolve DNS.
+  Future<bool> isOnline() async {
+    if (onlineOverride != null) return onlineOverride!;
+    try {
+      final result = await InternetAddress.lookup('example.com')
+          .timeout(const Duration(seconds: 3));
+      return result.isNotEmpty && result[0].rawAddress.isNotEmpty;
+    } catch (_) {
+      return false;
+    }
+  }
+}

--- a/lib/services/icon_service.dart
+++ b/lib/services/icon_service.dart
@@ -27,6 +27,30 @@ class IconUpdate {
 final Map<String, String?> _faviconCache = {};
 final Map<String, int> _faviconQualityCache = {};
 
+// Cache for SVG content (avoids re-fetching SVGs from network)
+final Map<String, String> _svgContentCache = {};
+
+/// Get cached SVG content for a URL, or fetch and cache it.
+Future<String?> getSvgContent(String svgUrl) async {
+  if (_svgContentCache.containsKey(svgUrl)) {
+    return _svgContentCache[svgUrl];
+  }
+  try {
+    final response = await http.get(Uri.parse(svgUrl)).timeout(
+      const Duration(seconds: 5),
+    );
+    if (response.statusCode == 200) {
+      _svgContentCache[svgUrl] = response.body;
+      return response.body;
+    }
+  } catch (e) {
+    if (kDebugMode) {
+      print('[Icon] Failed to fetch SVG content: $e');
+    }
+  }
+  return null;
+}
+
 // Verified URLs cache
 final Set<String> _verifiedUrls = {};
 
@@ -526,6 +550,7 @@ void clearFaviconCache() {
   _faviconCache.clear();
   _faviconQualityCache.clear();
   _verifiedUrls.clear();
+  _svgContentCache.clear();
 }
 
 /// Gets current queue stats (for debugging)

--- a/lib/services/icon_service.dart
+++ b/lib/services/icon_service.dart
@@ -27,13 +27,21 @@ class IconUpdate {
 final Map<String, String?> _faviconCache = {};
 final Map<String, int> _faviconQualityCache = {};
 
-// Cache for SVG content (avoids re-fetching SVGs from network)
+// In-memory cache for SVG content
 final Map<String, String> _svgContentCache = {};
 
+/// Callback to persist SVG content. Set by the UI layer (FaviconUrlCache).
+Future<void> Function(String url, String content)? onSvgContentCached;
+
 /// Get cached SVG content for a URL, or fetch and cache it.
-Future<String?> getSvgContent(String svgUrl) async {
+Future<String?> getSvgContent(String svgUrl, {String? persistedContent}) async {
   if (_svgContentCache.containsKey(svgUrl)) {
     return _svgContentCache[svgUrl];
+  }
+  // Use persisted content from disk cache if available
+  if (persistedContent != null) {
+    _svgContentCache[svgUrl] = persistedContent;
+    return persistedContent;
   }
   try {
     final response = await http.get(Uri.parse(svgUrl)).timeout(
@@ -41,6 +49,7 @@ Future<String?> getSvgContent(String svgUrl) async {
     );
     if (response.statusCode == 200) {
       _svgContentCache[svgUrl] = response.body;
+      onSvgContentCached?.call(svgUrl, response.body);
       return response.body;
     }
   } catch (e) {
@@ -49,6 +58,12 @@ Future<String?> getSvgContent(String svgUrl) async {
     }
   }
   return null;
+}
+
+/// Invalidate in-memory caches for a URL so icons are re-fetched.
+void invalidateFaviconFor(String siteUrl) {
+  _faviconCache.remove(siteUrl);
+  _faviconQualityCache.remove(siteUrl);
 }
 
 // Verified URLs cache

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
 import 'package:webspace/services/clearurl_service.dart';
+import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/settings/proxy.dart';
@@ -211,8 +212,9 @@ class WebViewConfig {
   final Future<void> Function(int windowId, String url)? onWindowRequested;
   /// Callback when page HTML should be cached. Called on page load with (url, html).
   final Function(String url, String html)? onHtmlLoaded;
-  /// Whether the site has cached content (enables cache-first loading mode).
-  final bool hasCachedContent;
+  /// Optional cached HTML to display when offline. Sub-resources (CSS/JS/images)
+  /// load from the browser's HTTP cache via LOAD_CACHE_ELSE_NETWORK mode.
+  final String? initialHtml;
   /// Whether to strip tracking parameters from URLs via ClearURLs rules.
   final bool clearUrlEnabled;
   /// Whether to block navigation to domains on the Hagezi DNS blocklist.
@@ -237,7 +239,7 @@ class WebViewConfig {
     this.shouldOverrideUrlLoading,
     this.onWindowRequested,
     this.onHtmlLoaded,
-    this.hasCachedContent = false,
+    this.initialHtml,
   });
 }
 
@@ -513,11 +515,9 @@ class WebViewFactory {
       headers['Accept-Language'] = '${config.language}, *;q=0.5';
     }
 
-    // When cached HTML exists, the site was previously visited and browser
-    // cache should have CSS/JS/images. Use LOAD_CACHE_ELSE_NETWORK so the
-    // browser loads the full page from its HTTP cache (with correct layout)
-    // and falls back to network when online.
-    final hasCachedContent = config.hasCachedContent;
+    // Use cached HTML for offline display. Set cache mode from the start
+    // so sub-resources (CSS/JS/images) resolve from browser HTTP cache.
+    final usesCachedHtml = config.initialHtml != null;
 
     // Inject content blocker CSS at DOCUMENT_START so elements are hidden
     // before they ever render, eliminating the flash of unstyled content.
@@ -534,10 +534,16 @@ class WebViewFactory {
 
     return inapp.InAppWebView(
       key: config.key,
-      initialUrlRequest: inapp.URLRequest(
+      initialUrlRequest: usesCachedHtml ? null : inapp.URLRequest(
         url: inapp.WebUri(config.initialUrl),
         headers: headers.isNotEmpty ? headers : null,
       ),
+      initialData: usesCachedHtml ? inapp.InAppWebViewInitialData(
+        data: config.initialHtml!,
+        mimeType: 'text/html',
+        encoding: 'utf-8',
+        baseUrl: inapp.WebUri(config.initialUrl),
+      ) : null,
       initialUserScripts: UnmodifiableListView(userScripts),
       initialSettings: inapp.InAppWebViewSettings(
         javaScriptEnabled: config.javascriptEnabled,
@@ -556,15 +562,26 @@ class WebViewFactory {
         allowContentAccess: true,
         // Enable browser-level resource caching for offline sub-resource loading
         cacheEnabled: true,
-        // Use cache-first when site was previously visited, so offline
-        // pages load from browser cache with full CSS/JS/images intact
-        cacheMode: hasCachedContent ? inapp.CacheMode.LOAD_CACHE_ELSE_NETWORK : null,
+        // When cached HTML is used, set cache-first mode from the start so
+        // sub-resources (CSS/JS/images) resolve from browser cache immediately
+        cacheMode: usesCachedHtml ? inapp.CacheMode.LOAD_CACHE_ELSE_NETWORK : null,
         // Enable DevTools inspection in debug mode (chrome://inspect on Android)
         isInspectable: kDebugMode,
       ),
-      onWebViewCreated: (controller) {
+      onWebViewCreated: (controller) async {
         final wrappedController = _WebViewController(controller);
         onControllerCreated(wrappedController);
+        // If we loaded cached HTML, navigate to the real URL when online
+        if (usesCachedHtml) {
+          final online = await ConnectivityService.instance.isOnline();
+          if (online) {
+            // Reset cache mode to default before loading live URL
+            await controller.setSettings(settings: inapp.InAppWebViewSettings(
+              cacheMode: inapp.CacheMode.LOAD_DEFAULT,
+            ));
+            wrappedController.loadUrl(config.initialUrl, language: config.language);
+          }
+        }
       },
       shouldOverrideUrlLoading: (controller, navigationAction) async {
         final url = navigationAction.request.url.toString();

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -485,6 +485,8 @@ class WebViewFactory {
         domStorageEnabled: true,
         databaseEnabled: true,
         javaScriptCanOpenWindowsAutomatically: true,
+        // Enable browser-level resource caching for offline sub-resource loading
+        cacheEnabled: true,
         // Enable DevTools inspection in debug mode (chrome://inspect on Android)
         isInspectable: kDebugMode,
       ),
@@ -537,6 +539,8 @@ class WebViewFactory {
         // Android: allow file and content access for Cloudflare Turnstile
         allowFileAccess: true,
         allowContentAccess: true,
+        // Enable browser-level resource caching for offline sub-resource loading
+        cacheEnabled: true,
         // Enable DevTools inspection in debug mode (chrome://inspect on Android)
         isInspectable: kDebugMode,
       ),
@@ -549,8 +553,14 @@ class WebViewFactory {
           final online = await ConnectivityService.instance.isOnline();
           if (online) {
             wrappedController.loadUrl(config.initialUrl, language: config.language);
-          } else if (kDebugMode) {
-            debugPrint('[WebView] Offline - staying on cached HTML for ${config.initialUrl}');
+          } else {
+            // Switch to cache-first mode so sub-resources load from browser cache
+            await controller.setSettings(settings: inapp.InAppWebViewSettings(
+              cacheMode: inapp.CacheMode.LOAD_CACHE_ELSE_NETWORK,
+            ));
+            if (kDebugMode) {
+              debugPrint('[WebView] Offline - using cached resources for ${config.initialUrl}');
+            }
           }
         }
       },

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
 import 'package:webspace/services/clearurl_service.dart';
+import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/settings/proxy.dart';
 
@@ -539,12 +540,18 @@ class WebViewFactory {
         // Enable DevTools inspection in debug mode (chrome://inspect on Android)
         isInspectable: kDebugMode,
       ),
-      onWebViewCreated: (controller) {
+      onWebViewCreated: (controller) async {
         final wrappedController = _WebViewController(controller);
         onControllerCreated(wrappedController);
-        // If we loaded cached HTML, now navigate to the real URL for fresh content
+        // If we loaded cached HTML, navigate to the real URL for fresh content
+        // but only when online - offline stays on cached page
         if (usesCachedHtml) {
-          wrappedController.loadUrl(config.initialUrl, language: config.language);
+          final online = await ConnectivityService.instance.isOnline();
+          if (online) {
+            wrappedController.loadUrl(config.initialUrl, language: config.language);
+          } else if (kDebugMode) {
+            debugPrint('[WebView] Offline - staying on cached HTML for ${config.initialUrl}');
+          }
         }
       },
       shouldOverrideUrlLoading: (controller, navigationAction) async {

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -4,7 +4,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
 import 'package:webspace/services/clearurl_service.dart';
-import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/settings/proxy.dart';
@@ -212,8 +211,8 @@ class WebViewConfig {
   final Future<void> Function(int windowId, String url)? onWindowRequested;
   /// Callback when page HTML should be cached. Called on page load with (url, html).
   final Function(String url, String html)? onHtmlLoaded;
-  /// Optional cached HTML to display immediately while the real URL loads.
-  final String? initialHtml;
+  /// Whether the site has cached content (enables cache-first loading mode).
+  final bool hasCachedContent;
   /// Whether to strip tracking parameters from URLs via ClearURLs rules.
   final bool clearUrlEnabled;
   /// Whether to block navigation to domains on the Hagezi DNS blocklist.
@@ -238,7 +237,7 @@ class WebViewConfig {
     this.shouldOverrideUrlLoading,
     this.onWindowRequested,
     this.onHtmlLoaded,
-    this.initialHtml,
+    this.hasCachedContent = false,
   });
 }
 
@@ -514,8 +513,11 @@ class WebViewFactory {
       headers['Accept-Language'] = '${config.language}, *;q=0.5';
     }
 
-    // Use cached HTML for instant display, or regular URL request
-    final usesCachedHtml = config.initialHtml != null;
+    // When cached HTML exists, the site was previously visited and browser
+    // cache should have CSS/JS/images. Use LOAD_CACHE_ELSE_NETWORK so the
+    // browser loads the full page from its HTTP cache (with correct layout)
+    // and falls back to network when online.
+    final hasCachedContent = config.hasCachedContent;
 
     // Inject content blocker CSS at DOCUMENT_START so elements are hidden
     // before they ever render, eliminating the flash of unstyled content.
@@ -532,17 +534,10 @@ class WebViewFactory {
 
     return inapp.InAppWebView(
       key: config.key,
-      // If we have cached HTML, load it first for instant display
-      initialUrlRequest: usesCachedHtml ? null : inapp.URLRequest(
+      initialUrlRequest: inapp.URLRequest(
         url: inapp.WebUri(config.initialUrl),
         headers: headers.isNotEmpty ? headers : null,
       ),
-      initialData: usesCachedHtml ? inapp.InAppWebViewInitialData(
-        data: config.initialHtml!,
-        mimeType: 'text/html',
-        encoding: 'utf-8',
-        baseUrl: inapp.WebUri(config.initialUrl),
-      ) : null,
       initialUserScripts: UnmodifiableListView(userScripts),
       initialSettings: inapp.InAppWebViewSettings(
         javaScriptEnabled: config.javascriptEnabled,
@@ -561,28 +556,15 @@ class WebViewFactory {
         allowContentAccess: true,
         // Enable browser-level resource caching for offline sub-resource loading
         cacheEnabled: true,
+        // Use cache-first when site was previously visited, so offline
+        // pages load from browser cache with full CSS/JS/images intact
+        cacheMode: hasCachedContent ? inapp.CacheMode.LOAD_CACHE_ELSE_NETWORK : null,
         // Enable DevTools inspection in debug mode (chrome://inspect on Android)
         isInspectable: kDebugMode,
       ),
-      onWebViewCreated: (controller) async {
+      onWebViewCreated: (controller) {
         final wrappedController = _WebViewController(controller);
         onControllerCreated(wrappedController);
-        // If we loaded cached HTML, navigate to the real URL for fresh content
-        // but only when online - offline stays on cached page
-        if (usesCachedHtml) {
-          final online = await ConnectivityService.instance.isOnline();
-          if (online) {
-            wrappedController.loadUrl(config.initialUrl, language: config.language);
-          } else {
-            // Switch to cache-first mode so sub-resources load from browser cache
-            await controller.setSettings(settings: inapp.InAppWebViewSettings(
-              cacheMode: inapp.CacheMode.LOAD_CACHE_ELSE_NETWORK,
-            ));
-            if (kDebugMode) {
-              debugPrint('[WebView] Offline - using cached resources for ${config.initialUrl}');
-            }
-          }
-        }
       },
       shouldOverrideUrlLoading: (controller, navigationAction) async {
         final url = navigationAction.request.url.toString();
@@ -655,9 +637,13 @@ class WebViewFactory {
           }
           // Cache HTML for offline viewing
           if (config.onHtmlLoaded != null) {
-            final html = await controller.getHtml();
-            if (html != null && html.isNotEmpty) {
-              config.onHtmlLoaded!(url.toString(), html);
+            try {
+              final html = await controller.getHtml();
+              if (html != null && html.isNotEmpty) {
+                config.onHtmlLoaded!(url.toString(), html);
+              }
+            } catch (_) {
+              // Controller may have been disposed if webview was unloaded
             }
           }
         }

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -335,7 +335,7 @@ class WebViewModel {
     Future<void> Function(int windowId, String url)? onWindowRequested,
     String? language,
     Function(String url, String html)? onHtmlLoaded,
-    String? initialHtml,
+    bool hasCachedContent = false,
     bool Function()? isActive,
   }) {
     if (webview == null) {
@@ -344,7 +344,7 @@ class WebViewModel {
       if (kDebugMode) {
         debugPrint('[WebView] Creating webview for "$name" (siteId: $siteId, initUrl: $initUrl)');
         debugPrint('[WebView] Language: $effectiveLanguage (param: $language)');
-        debugPrint('[WebView] Using cached HTML: ${initialHtml != null} (${initialHtml?.length ?? 0} bytes)');
+        debugPrint('[WebView] Has cached content: $hasCachedContent');
       }
       webview = WebViewFactory.createWebView(
         config: WebViewConfig(
@@ -447,7 +447,7 @@ class WebViewModel {
             }
           },
           onHtmlLoaded: onHtmlLoaded,
-          initialHtml: initialHtml,
+          hasCachedContent: hasCachedContent,
         ),
         onControllerCreated: (ctrl) {
           if (kDebugMode) {

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -335,7 +335,7 @@ class WebViewModel {
     Future<void> Function(int windowId, String url)? onWindowRequested,
     String? language,
     Function(String url, String html)? onHtmlLoaded,
-    bool hasCachedContent = false,
+    String? initialHtml,
     bool Function()? isActive,
   }) {
     if (webview == null) {
@@ -344,7 +344,7 @@ class WebViewModel {
       if (kDebugMode) {
         debugPrint('[WebView] Creating webview for "$name" (siteId: $siteId, initUrl: $initUrl)');
         debugPrint('[WebView] Language: $effectiveLanguage (param: $language)');
-        debugPrint('[WebView] Has cached content: $hasCachedContent');
+        debugPrint('[WebView] Using cached HTML: ${initialHtml != null} (${initialHtml?.length ?? 0} bytes)');
       }
       webview = WebViewFactory.createWebView(
         config: WebViewConfig(
@@ -447,7 +447,7 @@ class WebViewModel {
             }
           },
           onHtmlLoaded: onHtmlLoaded,
-          hasCachedContent: hasCachedContent,
+          initialHtml: initialHtml,
         ),
         onControllerCreated: (ctrl) {
           if (kDebugMode) {

--- a/test/connectivity_service_test.dart
+++ b/test/connectivity_service_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/connectivity_service.dart';
+
+void main() {
+  setUp(() {
+    ConnectivityService.reset();
+  });
+
+  tearDown(() {
+    ConnectivityService.reset();
+  });
+
+  group('ConnectivityService', () {
+    test('onlineOverride returns true when set to true', () async {
+      ConnectivityService.onlineOverride = Future.value(true);
+      expect(await ConnectivityService.instance.isOnline(), isTrue);
+    });
+
+    test('onlineOverride returns false when set to false', () async {
+      ConnectivityService.onlineOverride = Future.value(false);
+      expect(await ConnectivityService.instance.isOnline(), isFalse);
+    });
+
+    test('reset clears override', () async {
+      ConnectivityService.onlineOverride = Future.value(false);
+      expect(await ConnectivityService.instance.isOnline(), isFalse);
+
+      ConnectivityService.reset();
+      // After reset, override is null so it falls through to real DNS lookup
+      // which should succeed in CI/dev environments
+      ConnectivityService.onlineOverride = Future.value(true);
+      expect(await ConnectivityService.instance.isOnline(), isTrue);
+    });
+
+    test('singleton returns same instance', () {
+      final a = ConnectivityService.instance;
+      final b = ConnectivityService.instance;
+      expect(identical(a, b), isTrue);
+    });
+
+    test('reset creates new instance', () {
+      final a = ConnectivityService.instance;
+      ConnectivityService.reset();
+      final b = ConnectivityService.instance;
+      expect(identical(a, b), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
When offline, don't unload webviews on webspace switch so users can still view their loaded sites. When a site with cached HTML is loaded while offline, stay on the cached page instead of navigating to the live URL which would show a network error.

Extracts ConnectivityService with testable override for unit tests.