### PR TITLE
Add content blocker with ABP filter list support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ WebSpace is a mobile app that brings all your favorite websites and web apps tog
 - 🔄 Proxy support with authentication (Android)
 - 🧹 ClearURLs tracking parameter removal
 - 🛡️ Hagezi DNS blocklist domain blocking (5 severity levels)
+- 🚫 Content blocker with EasyList/EasyPrivacy ad & tracker filtering
 - 🎨 Light/dark mode with accent colors
 
 ## Development
@@ -81,6 +82,8 @@ This project is made possible by [flutter_inappwebview](https://github.com/pichi
 URL cleaning is powered by rules from [ClearURLs](https://github.com/ClearURLs/Rules) (LGPL-3.0).
 
 DNS domain blocking uses blocklists from [Hagezi](https://github.com/hagezi/dns-blocklists) (GPL-3.0).
+
+Content blocking uses filter lists from [EasyList](https://easylist.to/) (GPL-3.0 / CC BY-SA 3.0), including EasyList, EasyPrivacy, Fanboy's Social Blocking List, and Fanboy's Annoyance List.
 
 ## License
 

--- a/fastlane/metadata/android/en-US/changelogs/9.txt
+++ b/fastlane/metadata/android/en-US/changelogs/9.txt
@@ -1,0 +1,9 @@
+✨ New Features:
+• Content Blocker: block ads and trackers using EasyList filter lists
+• Cosmetic filtering: hide ad banners, promoted posts, and sponsored content
+• Text-based hiding: detect and hide promoted/sponsored posts on LinkedIn and similar sites
+• Manage multiple filter lists with per-site toggle
+
+🔧 Improvements:
+• Propagate all per-site settings to nested webviews
+• Fix captcha detection to check parsed host

--- a/fastlane/metadata/android/en-US/changelogs/9.txt
+++ b/fastlane/metadata/android/en-US/changelogs/9.txt
@@ -1,6 +1,2 @@
 ✨ New Features:
 • Content Blocker: block ads, trackers, and promoted posts using EasyList filter lists
-
-🔧 Improvements:
-• Propagate all per-site settings to nested webviews
-• Fix captcha detection to check parsed host

--- a/fastlane/metadata/android/en-US/changelogs/9.txt
+++ b/fastlane/metadata/android/en-US/changelogs/9.txt
@@ -1,8 +1,5 @@
 ✨ New Features:
-• Content Blocker: block ads and trackers using EasyList filter lists
-• Cosmetic filtering: hide ad banners, promoted posts, and sponsored content
-• Text-based hiding: detect and hide promoted/sponsored posts on LinkedIn and similar sites
-• Manage multiple filter lists with per-site toggle
+• Content Blocker: block ads, trackers, and promoted posts using EasyList filter lists
 
 🔧 Improvements:
 • Propagate all per-site settings to nested webviews

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,7 @@ import 'package:webspace/services/html_cache_service.dart';
 import 'package:webspace/services/settings_backup.dart';
 import 'package:webspace/services/cookie_secure_storage.dart';
 import 'package:webspace/services/clearurl_service.dart';
+import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/settings/proxy.dart';
 
@@ -218,6 +219,9 @@ void main() async {
 
   // Initialize DNS block service (loads cached blocklist from disk)
   await DnsBlockService.instance.initialize();
+
+  // Initialize content blocker service (loads cached filter lists from disk)
+  await ContentBlockerService.instance.initialize();
 
   // Register custom licenses
   LicenseRegistry.addLicense(() async* {
@@ -784,6 +788,7 @@ class _WebSpacePageState extends State<WebSpacePage> {
     required bool thirdPartyCookiesEnabled,
     required bool clearUrlEnabled,
     required bool dnsBlockEnabled,
+    required bool contentBlockEnabled,
     required String? language,
   }) async {
     await Navigator.push(
@@ -796,6 +801,7 @@ class _WebSpacePageState extends State<WebSpacePage> {
           thirdPartyCookiesEnabled: thirdPartyCookiesEnabled,
           clearUrlEnabled: clearUrlEnabled,
           dnsBlockEnabled: dnsBlockEnabled,
+          contentBlockEnabled: contentBlockEnabled,
           language: language,
         ),
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -309,6 +309,29 @@ Source: https://github.com/hagezi/dns-blocklists''',
     );
   });
 
+  LicenseRegistry.addLicense(() async* {
+    yield const LicenseEntryWithLineBreaks(
+      ['EasyList filter lists (filter data)'],
+      '''Creative Commons Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0)
+
+Copyright (c) The EasyList authors
+
+EasyList, EasyPrivacy, Fanboy's Social Blocking List, and Fanboy's
+Annoyance List are dual-licensed under the GNU General Public License
+version 3 (or later) and Creative Commons Attribution-ShareAlike 3.0
+Unported (or later). Used here under CC BY-SA 3.0.
+
+You are free to share and adapt the material, provided you give
+appropriate credit, provide a link to the license, and indicate if
+changes were made. If you remix, transform, or build upon the material,
+you must distribute your contributions under the same license.
+
+Full license: https://creativecommons.org/licenses/by-sa/3.0/
+Licence page: https://easylist.to/pages/licence.html
+Source: https://easylist.to/''',
+    );
+  });
+
   // Initialize platform info to detect proxy support before UI loads
   await PlatformInfo.initialize();
   runApp(WebSpaceApp());

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:webspace/main.dart' show AppThemeSettings, AccentColor;
 import 'package:webspace/services/clearurl_service.dart';
+import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 
 // Accent color definitions for display
@@ -46,6 +47,9 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
   int _dnsBlockLevel = 0; // Downloaded level
   double _dnsBlockSliderValue = 0; // Ephemeral slider value
   late AnimationController _spinController;
+
+  // Content Blocker state
+  String? _downloadingListId;
 
   @override
   void initState() {
@@ -108,6 +112,116 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
         );
       }
     }
+  }
+
+  Future<void> _downloadContentList(String id) async {
+    setState(() {
+      _downloadingListId = id;
+    });
+
+    final success = await ContentBlockerService.instance.downloadList(id);
+
+    if (mounted) {
+      setState(() {
+        _downloadingListId = null;
+      });
+
+      if (success) {
+        final list = ContentBlockerService.instance.lists
+            .firstWhere((l) => l.id == id);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+              content:
+                  Text('${list.name}: ${_formatNumber(list.ruleCount)} rules')),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to download filter list')),
+        );
+      }
+    }
+  }
+
+  Future<void> _downloadAllContentLists() async {
+    setState(() {
+      _downloadingListId = '__all__';
+    });
+
+    final count = await ContentBlockerService.instance.downloadAllLists();
+
+    if (mounted) {
+      setState(() {
+        _downloadingListId = null;
+      });
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Updated $count filter lists')),
+      );
+    }
+  }
+
+  Future<void> _toggleContentList(String id, bool enabled) async {
+    await ContentBlockerService.instance.toggleList(id, enabled);
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _removeContentList(String id) async {
+    await ContentBlockerService.instance.removeList(id);
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _showAddCustomListDialog() async {
+    final nameController = TextEditingController();
+    final urlController = TextEditingController();
+
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Add Custom List'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: nameController,
+              decoration: const InputDecoration(
+                labelText: 'Name',
+                hintText: 'e.g., My Custom List',
+              ),
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: urlController,
+              decoration: const InputDecoration(
+                labelText: 'URL',
+                hintText: 'https://example.com/filters.txt',
+              ),
+              keyboardType: TextInputType.url,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Add'),
+          ),
+        ],
+      ),
+    );
+
+    if (result == true &&
+        nameController.text.isNotEmpty &&
+        urlController.text.isNotEmpty) {
+      final id = await ContentBlockerService.instance
+          .addCustomList(nameController.text, urlController.text);
+      await _downloadContentList(id);
+    }
+
+    nameController.dispose();
+    urlController.dispose();
   }
 
   String _formatNumber(int n) {
@@ -336,6 +450,103 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
                   ],
                 ),
               ],
+            ),
+          ),
+
+          // Content Blocker
+          const Divider(height: 32),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    'Content Blocker',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
+                ),
+                if (ContentBlockerService.instance.lists
+                    .any((l) => l.enabled))
+                  _downloadingListId == '__all__'
+                      ? const SizedBox(
+                          width: 24,
+                          height: 24,
+                          child:
+                              CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : IconButton(
+                          icon: const Icon(Icons.sync),
+                          tooltip: 'Update all lists',
+                          onPressed: _downloadingListId != null
+                              ? null
+                              : _downloadAllContentLists,
+                        ),
+              ],
+            ),
+          ),
+          ...ContentBlockerService.instance.lists.map((list) {
+            final isDownloading = _downloadingListId == list.id ||
+                _downloadingListId == '__all__';
+            final isDefault = !list.id.startsWith('custom_');
+
+            return ListTile(
+              leading: Switch(
+                value: list.enabled,
+                onChanged: list.lastUpdated != null && !isDownloading
+                    ? (value) => _toggleContentList(list.id, value)
+                    : null,
+              ),
+              title: Text(list.name),
+              subtitle: Text(
+                list.lastUpdated != null
+                    ? '${_formatNumber(list.ruleCount)} rules'
+                    : 'Not downloaded',
+              ),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (isDownloading)
+                    const SizedBox(
+                      width: 24,
+                      height: 24,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  else
+                    IconButton(
+                      icon: Icon(
+                        list.lastUpdated != null
+                            ? Icons.sync
+                            : Icons.download,
+                      ),
+                      tooltip: list.lastUpdated != null
+                          ? 'Refresh'
+                          : 'Download',
+                      onPressed: _downloadingListId != null
+                          ? null
+                          : () => _downloadContentList(list.id),
+                    ),
+                  if (!isDefault)
+                    IconButton(
+                      icon: const Icon(Icons.delete_outline),
+                      tooltip: 'Remove',
+                      onPressed: _downloadingListId != null
+                          ? null
+                          : () => _removeContentList(list.id),
+                    ),
+                ],
+              ),
+            );
+          }),
+          Padding(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+            child: OutlinedButton.icon(
+              onPressed:
+                  _downloadingListId != null ? null : _showAddCustomListDialog,
+              icon: const Icon(Icons.add),
+              label: const Text('Add Custom List'),
             ),
           ),
 

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -13,6 +13,7 @@ class InAppWebViewScreen extends StatefulWidget {
   final bool thirdPartyCookiesEnabled;
   final bool clearUrlEnabled;
   final bool dnsBlockEnabled;
+  final bool contentBlockEnabled;
   final String? language;
 
   InAppWebViewScreen({
@@ -22,6 +23,7 @@ class InAppWebViewScreen extends StatefulWidget {
     required this.thirdPartyCookiesEnabled,
     required this.clearUrlEnabled,
     required this.dnsBlockEnabled,
+    required this.contentBlockEnabled,
     required this.language,
   });
 
@@ -247,6 +249,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen> {
                 thirdPartyCookiesEnabled: widget.thirdPartyCookiesEnabled,
                 clearUrlEnabled: widget.clearUrlEnabled,
                 dnsBlockEnabled: widget.dnsBlockEnabled,
+                contentBlockEnabled: widget.contentBlockEnabled,
                 language: widget.language,
                 onUrlChanged: (url) {
                   // Keep home site title even when navigating within nested webview

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:webspace/web_view_model.dart';
 import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/services/webview.dart';
+import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 
 // Supported languages for webview
@@ -87,6 +88,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late bool _incognito;
   late bool _clearUrlEnabled;
   late bool _dnsBlockEnabled;
+  late bool _contentBlockEnabled;
   String? _selectedLanguage;
   bool _obscureProxyPassword = true;
   bool _showProxyCredentials = false;
@@ -130,6 +132,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _incognito = widget.webViewModel.incognito;
     _clearUrlEnabled = widget.webViewModel.clearUrlEnabled;
     _dnsBlockEnabled = widget.webViewModel.dnsBlockEnabled;
+    _contentBlockEnabled = widget.webViewModel.contentBlockEnabled;
     _selectedLanguage = widget.webViewModel.language;
     // Show credentials section if credentials already exist
     _showProxyCredentials = _proxySettings.hasCredentials;
@@ -221,6 +224,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       widget.webViewModel.incognito = _incognito;
       widget.webViewModel.clearUrlEnabled = _clearUrlEnabled;
       widget.webViewModel.dnsBlockEnabled = _dnsBlockEnabled;
+      widget.webViewModel.contentBlockEnabled = _contentBlockEnabled;
       widget.webViewModel.language = _selectedLanguage;
 
       if (!mounted) return;
@@ -451,6 +455,22 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 ? (bool value) {
                     setState(() {
                       _dnsBlockEnabled = value;
+                    });
+                  }
+                : null,
+          ),
+          SwitchListTile(
+            title: const Text('Content Blocker'),
+            subtitle: Text(
+              ContentBlockerService.instance.hasRules
+                  ? '${ContentBlockerService.instance.totalRuleCount} rules'
+                  : 'Not configured',
+            ),
+            value: _contentBlockEnabled,
+            onChanged: ContentBlockerService.instance.hasRules
+                ? (bool value) {
+                    setState(() {
+                      _contentBlockEnabled = value;
                     });
                   }
                 : null,

--- a/lib/services/abp_filter_parser.dart
+++ b/lib/services/abp_filter_parser.dart
@@ -1,30 +1,25 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
-/// Result of parsing ABP filter list text into ContentBlocker rules.
+/// Result of parsing ABP filter list text.
 class AbpParseResult {
-  final List<ContentBlocker> rules;
+  /// Domain-anchored network block rules for O(1) lookup.
+  /// From `||domain.com^` rules (simple domain blocks without path/options).
+  final Set<String> blockedDomains;
+
+  /// CSS selectors to hide elements, grouped by scope.
+  /// Key '' (empty) = global, key 'domain.com' = domain-specific.
+  final Map<String, List<String>> cosmeticSelectors;
+
   final int convertedCount;
   final int skippedCount;
 
   const AbpParseResult({
-    required this.rules,
+    required this.blockedDomains,
+    required this.cosmeticSelectors,
     required this.convertedCount,
     required this.skippedCount,
   });
 }
-
-/// ABP option-to-resource-type mapping.
-const Map<String, ContentBlockerTriggerResourceType> _resourceTypeMap = {
-  'script': ContentBlockerTriggerResourceType.SCRIPT,
-  'image': ContentBlockerTriggerResourceType.IMAGE,
-  'stylesheet': ContentBlockerTriggerResourceType.STYLE_SHEET,
-  'font': ContentBlockerTriggerResourceType.FONT,
-  'media': ContentBlockerTriggerResourceType.MEDIA,
-  'subdocument': ContentBlockerTriggerResourceType.DOCUMENT,
-  'xmlhttprequest': ContentBlockerTriggerResourceType.RAW,
-  'other': ContentBlockerTriggerResourceType.RAW,
-};
 
 /// Unsupported ABP options that cause a rule to be skipped.
 const Set<String> _unsupportedOptions = {
@@ -36,80 +31,18 @@ const Set<String> _unsupportedOptions = {
   'replace',
 };
 
-/// Convert ABP filter syntax to a URL filter regex pattern.
-/// `||` means "beginning of domain", `^` means separator, `*` means wildcard.
-String abpToRegex(String pattern) {
-  final buf = StringBuffer();
+/// Regex matching simple domain-only rules: `||domain.com^` with optional
+/// trailing options we can safely ignore for domain extraction.
+final _simpleDomainRule = RegExp(r'^\|\|([a-zA-Z0-9._-]+)\^?$');
 
-  int i = 0;
-
-  // Handle || prefix: match domain start
-  if (pattern.startsWith('||')) {
-    buf.write('^https?://([^/]+\\.)?');
-    i = 2;
-  } else if (pattern.startsWith('|')) {
-    buf.write('^');
-    i = 1;
-  }
-
-  // Handle | suffix
-  final hasEndAnchor = pattern.endsWith('|') && !pattern.endsWith('||');
-  final end = hasEndAnchor ? pattern.length - 1 : pattern.length;
-
-  for (; i < end; i++) {
-    final c = pattern[i];
-    switch (c) {
-      case '*':
-        buf.write('.*');
-        break;
-      case '^':
-        buf.write('[/:?&=]');
-        break;
-      case '.':
-        buf.write('\\.');
-        break;
-      case '?':
-        buf.write('\\?');
-        break;
-      case '+':
-        buf.write('\\+');
-        break;
-      case '(':
-        buf.write('\\(');
-        break;
-      case ')':
-        buf.write('\\)');
-        break;
-      case '[':
-        buf.write('\\[');
-        break;
-      case ']':
-        buf.write('\\]');
-        break;
-      case '{':
-        buf.write('\\{');
-        break;
-      case '}':
-        buf.write('\\}');
-        break;
-      default:
-        buf.write(c);
-    }
-  }
-
-  if (hasEndAnchor) {
-    buf.write('\$');
-  }
-
-  return buf.toString();
-}
-
-/// Parse a single ABP filter line into a ContentBlocker, or null if unsupported.
-/// Returns null and increments skip counting for unsupported rules.
-/// Set [skipExceptions] to filter out IGNORE_PREVIOUS_RULES
-/// (unsupported on Android and other non-iOS/macOS platforms).
-ContentBlocker? _parseLine(String line, {required bool skipExceptions}) {
-  // Cosmetic filter: ##selector or domain##selector
+/// Parse a single line, adding to blockedDomains / cosmeticSelectors.
+/// Returns true if converted, false if skipped.
+bool _parseLine(
+  String line,
+  Set<String> blockedDomains,
+  Map<String, List<String>> cosmeticSelectors,
+) {
+  // --- Cosmetic filter: ##selector or domain##selector ---
   final cosmeticIdx = line.indexOf('##');
   if (cosmeticIdx >= 0) {
     // Skip extended CSS selectors
@@ -119,159 +52,78 @@ ContentBlocker? _parseLine(String line, {required bool skipExceptions}) {
         afterHash.contains(':has(') ||
         afterHash.contains(':has-text(') ||
         afterHash.contains(':-abp-')) {
-      return null;
+      return false;
     }
 
     final selector = line.substring(cosmeticIdx + 2).trim();
-    if (selector.isEmpty) return null;
+    if (selector.isEmpty) return false;
 
     // HTML filter (##^)
-    if (selector.startsWith('^')) return null;
+    if (selector.startsWith('^')) return false;
 
-    final domains = cosmeticIdx > 0 ? line.substring(0, cosmeticIdx) : '';
+    final domainsStr = cosmeticIdx > 0 ? line.substring(0, cosmeticIdx) : '';
 
-    final List<String> ifDomain = [];
-    if (domains.isNotEmpty) {
-      for (final d in domains.split(',')) {
+    if (domainsStr.isEmpty) {
+      // Global cosmetic rule
+      cosmeticSelectors.putIfAbsent('', () => []).add(selector);
+    } else {
+      for (final d in domainsStr.split(',')) {
         final trimmed = d.trim();
-        if (trimmed.isEmpty) continue;
-        if (trimmed.startsWith('~')) continue; // Exclude domain, skip for simplicity
-        ifDomain.add('*$trimmed');
+        if (trimmed.isEmpty || trimmed.startsWith('~')) continue;
+        cosmeticSelectors.putIfAbsent(trimmed, () => []).add(selector);
       }
-      if (ifDomain.isEmpty) return null;
     }
-
-    return ContentBlocker(
-      trigger: ContentBlockerTrigger(
-        urlFilter: '.*',
-        ifDomain: ifDomain,
-      ),
-      action: ContentBlockerAction(
-        type: ContentBlockerActionType.CSS_DISPLAY_NONE,
-        selector: selector,
-      ),
-    );
+    return true;
   }
 
-  // Check for #?# / #$# extended selectors (if ## was not found above)
+  // Skip #?# / #$# extended selectors
   if (line.contains('#?#') || line.contains('#\$#')) {
-    return null;
+    return false;
   }
 
-  // Network rule
-  bool isException = false;
-  String rulePart = line;
+  // --- Network rule ---
+  // Skip exception rules (@@) — we only do domain blocking, no unblocking
+  if (line.startsWith('@@')) return false;
 
-  if (rulePart.startsWith('@@')) {
-    isException = true;
-    rulePart = rulePart.substring(2);
-    // IGNORE_PREVIOUS_RULES only supported on iOS/macOS
-    if (skipExceptions) return null;
-  }
-
-  // Split options
-  String pattern = rulePart;
-  String optionsPart = '';
-
-  // Find the last $ that's not inside a regex
-  final dollarIdx = rulePart.lastIndexOf('\$');
+  // Check for options
+  final dollarIdx = line.lastIndexOf('\$');
+  String pattern = line;
   if (dollarIdx > 0) {
-    final beforeDollar = rulePart.substring(0, dollarIdx);
-    final afterDollar = rulePart.substring(dollarIdx + 1);
-    // Only treat as options if the part after $ looks like options
-    // (contains known option keywords or comma-separated values)
+    final afterDollar = line.substring(dollarIdx + 1);
     if (!afterDollar.contains('//') && !afterDollar.startsWith('/')) {
-      pattern = beforeDollar;
-      optionsPart = afterDollar;
-    }
-  }
-
-  // Skip regex patterns (enclosed in /.../)
-  if (pattern.startsWith('/') && pattern.endsWith('/')) {
-    return null;
-  }
-
-  // Parse options
-  final List<ContentBlockerTriggerResourceType> resourceTypes = [];
-  final List<ContentBlockerTriggerLoadType> loadTypes = [];
-  final List<String> ifDomain = [];
-  final List<String> unlessDomain = [];
-
-  if (optionsPart.isNotEmpty) {
-    for (final opt in optionsPart.split(',')) {
-      final trimmed = opt.trim().toLowerCase();
-      if (trimmed.isEmpty) continue;
-
       // Check for unsupported options
-      if (_unsupportedOptions.any((u) => trimmed == u || trimmed.startsWith('$u='))) {
-        return null;
-      }
-
-      if (trimmed == 'third-party' || trimmed == '3p') {
-        loadTypes.add(ContentBlockerTriggerLoadType.THIRD_PARTY);
-      } else if (trimmed == '~third-party' || trimmed == '~3p' || trimmed == '1p') {
-        loadTypes.add(ContentBlockerTriggerLoadType.FIRST_PARTY);
-      } else if (trimmed.startsWith('domain=')) {
-        final domainList = trimmed.substring(7);
-        for (final d in domainList.split('|')) {
-          if (d.startsWith('~')) {
-            unlessDomain.add('*${d.substring(1)}');
-          } else {
-            ifDomain.add('*$d');
-          }
+      for (final opt in afterDollar.split(',')) {
+        final trimmed = opt.trim().toLowerCase();
+        if (_unsupportedOptions.any((u) => trimmed == u || trimmed.startsWith('$u='))) {
+          return false;
         }
-      } else if (_resourceTypeMap.containsKey(trimmed)) {
-        resourceTypes.add(_resourceTypeMap[trimmed]!);
-      } else if (trimmed.startsWith('~')) {
-        // Negated resource type, ignore
       }
-      // Other unknown options: ignore silently
+      pattern = line.substring(0, dollarIdx);
     }
   }
 
-  // Convert pattern to regex
-  final urlFilter = abpToRegex(pattern);
-  if (urlFilter.isEmpty) return null;
-
-  if (isException) {
-    try {
-      return ContentBlocker(
-        trigger: ContentBlockerTrigger(
-          urlFilter: urlFilter,
-          resourceType: resourceTypes,
-          loadType: loadTypes,
-          ifDomain: ifDomain,
-          unlessDomain: unlessDomain,
-        ),
-        action: ContentBlockerAction(
-          type: ContentBlockerActionType.IGNORE_PREVIOUS_RULES,
-        ),
-      );
-    } catch (_) {
-      // IGNORE_PREVIOUS_RULES not supported on this platform
-      return null;
-    }
+  // Skip regex patterns
+  if (pattern.startsWith('/') && pattern.endsWith('/') && pattern.length > 1) {
+    return false;
   }
 
-  return ContentBlocker(
-    trigger: ContentBlockerTrigger(
-      urlFilter: urlFilter,
-      resourceType: resourceTypes,
-      loadType: loadTypes,
-      ifDomain: ifDomain,
-      unlessDomain: unlessDomain,
-    ),
-    action: ContentBlockerAction(
-      type: ContentBlockerActionType.BLOCK,
-    ),
-  );
+  // Only convert simple domain-anchored rules: ||domain.com^
+  // These go into the hash set for O(1) lookup.
+  // Complex patterns (paths, wildcards, options) are skipped to keep it fast.
+  final match = _simpleDomainRule.firstMatch(pattern);
+  if (match != null) {
+    blockedDomains.add(match.group(1)!.toLowerCase());
+    return true;
+  }
+
+  // Skip complex patterns — not worth the per-request regex cost
+  return false;
 }
 
 /// Parse ABP filter text synchronously. Use [parseAbpFilterList] for isolate-based parsing.
-/// Set [skipExceptions] to true on platforms that don't support IGNORE_PREVIOUS_RULES
-/// (Android, Linux, Windows — only iOS/macOS support it).
-AbpParseResult parseAbpFilterListSync(String text, {bool skipExceptions = false}) {
-  final rules = <ContentBlocker>[];
+AbpParseResult parseAbpFilterListSync(String text) {
+  final blockedDomains = <String>{};
+  final cosmeticSelectors = <String, List<String>>{};
   int converted = 0;
   int skipped = 0;
 
@@ -284,9 +136,7 @@ AbpParseResult parseAbpFilterListSync(String text, {bool skipExceptions = false}
       continue;
     }
 
-    final rule = _parseLine(trimmed, skipExceptions: skipExceptions);
-    if (rule != null) {
-      rules.add(rule);
+    if (_parseLine(trimmed, blockedDomains, cosmeticSelectors)) {
       converted++;
     } else {
       skipped++;
@@ -294,26 +144,18 @@ AbpParseResult parseAbpFilterListSync(String text, {bool skipExceptions = false}
   }
 
   return AbpParseResult(
-    rules: rules,
+    blockedDomains: blockedDomains,
+    cosmeticSelectors: cosmeticSelectors,
     convertedCount: converted,
     skippedCount: skipped,
   );
 }
 
 /// Parse ABP filter text in an isolate to avoid blocking the UI thread.
-Future<AbpParseResult> parseAbpFilterList(String text, {bool skipExceptions = false}) {
-  return compute(
-    _parseInIsolate,
-    _ParseArgs(text: text, skipExceptions: skipExceptions),
-  );
+Future<AbpParseResult> parseAbpFilterList(String text) {
+  return compute(_parseInIsolate, text);
 }
 
-class _ParseArgs {
-  final String text;
-  final bool skipExceptions;
-  const _ParseArgs({required this.text, required this.skipExceptions});
-}
-
-AbpParseResult _parseInIsolate(_ParseArgs args) {
-  return parseAbpFilterListSync(args.text, skipExceptions: args.skipExceptions);
+AbpParseResult _parseInIsolate(String text) {
+  return parseAbpFilterListSync(text);
 }

--- a/lib/services/abp_filter_parser.dart
+++ b/lib/services/abp_filter_parser.dart
@@ -1,14 +1,25 @@
 import 'package:flutter/foundation.dart';
 
+/// A text-based hiding rule: hide elements matching [selector] that contain
+/// text matching any of [textPatterns].
+class TextHideRule {
+  final String selector;
+  final List<String> textPatterns;
+
+  const TextHideRule({required this.selector, required this.textPatterns});
+}
+
 /// Result of parsing ABP filter list text.
 class AbpParseResult {
   /// Domain-anchored network block rules for O(1) lookup.
-  /// From `||domain.com^` rules (simple domain blocks without path/options).
   final Set<String> blockedDomains;
 
   /// CSS selectors to hide elements, grouped by scope.
   /// Key '' (empty) = global, key 'domain.com' = domain-specific.
   final Map<String, List<String>> cosmeticSelectors;
+
+  /// Text-based hiding rules (from #?# rules with :-abp-contains), grouped by domain.
+  final Map<String, List<TextHideRule>> textHideRules;
 
   final int convertedCount;
   final int skippedCount;
@@ -16,6 +27,7 @@ class AbpParseResult {
   const AbpParseResult({
     required this.blockedDomains,
     required this.cosmeticSelectors,
+    required this.textHideRules,
     required this.convertedCount,
     required this.skippedCount,
   });
@@ -31,24 +43,93 @@ const Set<String> _unsupportedOptions = {
   'replace',
 };
 
-/// Regex matching simple domain-only rules: `||domain.com^` with optional
-/// trailing options we can safely ignore for domain extraction.
+/// Regex matching simple domain-only rules: `||domain.com^`
 final _simpleDomainRule = RegExp(r'^\|\|([a-zA-Z0-9._-]+)\^?$');
 
-/// Parse a single line, adding to blockedDomains / cosmeticSelectors.
+/// Parse :-abp-contains(/pattern1|pattern2/) or :-abp-contains(text) from a rule.
+/// Returns list of text patterns to match, or null if not parseable.
+List<String>? _extractAbpContainsPatterns(String rule) {
+  // Find :-abp-contains( or :has-text(
+  final containsRegex = RegExp(r':-abp-contains\(|:has-text\(');
+  final match = containsRegex.firstMatch(rule);
+  if (match == null) return null;
+
+  final start = match.end;
+  // Find matching closing paren, handling nested parens
+  int depth = 1;
+  int i = start;
+  while (i < rule.length && depth > 0) {
+    if (rule[i] == '(') depth++;
+    if (rule[i] == ')') depth--;
+    i++;
+  }
+  if (depth != 0) return null;
+
+  var content = rule.substring(start, i - 1);
+
+  // Handle regex syntax: /pattern/
+  if (content.startsWith('/') && content.endsWith('/')) {
+    content = content.substring(1, content.length - 1);
+    // Split on | for alternation
+    return content.split('|').where((s) => s.isNotEmpty).toList();
+  }
+
+  // Plain text match
+  return [content];
+}
+
+/// Extract the container selector from a #?# rule.
+/// e.g. "div.feed-shared-update-v2:-abp-has(...)" → "div.feed-shared-update-v2"
+String? _extractContainerSelector(String selectorPart) {
+  // Find the first :-abp- or :has-text( pseudo-class
+  final pseudoIdx = selectorPart.indexOf(RegExp(r':-abp-|:has-text\('));
+  if (pseudoIdx <= 0) return null;
+  return selectorPart.substring(0, pseudoIdx).trim();
+}
+
+/// Parse a single line, adding to the appropriate data structure.
 /// Returns true if converted, false if skipped.
 bool _parseLine(
   String line,
   Set<String> blockedDomains,
   Map<String, List<String>> cosmeticSelectors,
+  Map<String, List<TextHideRule>> textHideRules,
 ) {
+  // --- Extended CSS: #?# rules with text matching ---
+  final extIdx = line.indexOf('#?#');
+  if (extIdx >= 0) {
+    final domainsStr = extIdx > 0 ? line.substring(0, extIdx) : '';
+    final selectorPart = line.substring(extIdx + 3).trim();
+    if (selectorPart.isEmpty) return false;
+
+    // Extract text patterns from :-abp-contains or :has-text
+    final patterns = _extractAbpContainsPatterns(selectorPart);
+    if (patterns == null || patterns.isEmpty) return false;
+
+    // Extract the container CSS selector (before the pseudo-class)
+    final containerSelector = _extractContainerSelector(selectorPart);
+    if (containerSelector == null || containerSelector.isEmpty) return false;
+
+    final rule = TextHideRule(selector: containerSelector, textPatterns: patterns);
+
+    if (domainsStr.isEmpty) {
+      textHideRules.putIfAbsent('', () => []).add(rule);
+    } else {
+      for (final d in domainsStr.split(',')) {
+        final trimmed = d.trim();
+        if (trimmed.isEmpty || trimmed.startsWith('~')) continue;
+        textHideRules.putIfAbsent(trimmed, () => []).add(rule);
+      }
+    }
+    return true;
+  }
+
   // --- Cosmetic filter: ##selector or domain##selector ---
   final cosmeticIdx = line.indexOf('##');
   if (cosmeticIdx >= 0) {
     // Skip ABP extended CSS selectors (but NOT standard CSS :has() which browsers support)
     final afterHash = line.substring(cosmeticIdx);
-    if (afterHash.startsWith('#?#') ||
-        afterHash.startsWith('#\$#') ||
+    if (afterHash.startsWith('#\$#') ||
         afterHash.contains(':has-text(') ||
         afterHash.contains(':contains(') ||
         afterHash.contains(':-abp-') ||
@@ -68,7 +149,6 @@ bool _parseLine(
     final domainsStr = cosmeticIdx > 0 ? line.substring(0, cosmeticIdx) : '';
 
     if (domainsStr.isEmpty) {
-      // Global cosmetic rule
       cosmeticSelectors.putIfAbsent('', () => []).add(selector);
     } else {
       for (final d in domainsStr.split(',')) {
@@ -80,13 +160,12 @@ bool _parseLine(
     return true;
   }
 
-  // Skip #?# / #$# extended selectors
-  if (line.contains('#?#') || line.contains('#\$#')) {
+  // Skip #$# snippet rules
+  if (line.contains('#\$#')) {
     return false;
   }
 
   // --- Network rule ---
-  // Skip exception rules (@@) — we only do domain blocking, no unblocking
   if (line.startsWith('@@')) return false;
 
   // Check for options
@@ -95,7 +174,6 @@ bool _parseLine(
   if (dollarIdx > 0) {
     final afterDollar = line.substring(dollarIdx + 1);
     if (!afterDollar.contains('//') && !afterDollar.startsWith('/')) {
-      // Check for unsupported options
       for (final opt in afterDollar.split(',')) {
         final trimmed = opt.trim().toLowerCase();
         if (_unsupportedOptions.any((u) => trimmed == u || trimmed.startsWith('$u='))) {
@@ -112,35 +190,32 @@ bool _parseLine(
   }
 
   // Only convert simple domain-anchored rules: ||domain.com^
-  // These go into the hash set for O(1) lookup.
-  // Complex patterns (paths, wildcards, options) are skipped to keep it fast.
   final match = _simpleDomainRule.firstMatch(pattern);
   if (match != null) {
     blockedDomains.add(match.group(1)!.toLowerCase());
     return true;
   }
 
-  // Skip complex patterns — not worth the per-request regex cost
   return false;
 }
 
-/// Parse ABP filter text synchronously. Use [parseAbpFilterList] for isolate-based parsing.
+/// Parse ABP filter text synchronously.
 AbpParseResult parseAbpFilterListSync(String text) {
   final blockedDomains = <String>{};
   final cosmeticSelectors = <String, List<String>>{};
+  final textHideRules = <String, List<TextHideRule>>{};
   int converted = 0;
   int skipped = 0;
 
   for (final line in text.split('\n')) {
     final trimmed = line.trim();
-    // Skip empty lines, comments, and header lines
     if (trimmed.isEmpty ||
         trimmed.startsWith('!') ||
         trimmed.startsWith('[Adblock')) {
       continue;
     }
 
-    if (_parseLine(trimmed, blockedDomains, cosmeticSelectors)) {
+    if (_parseLine(trimmed, blockedDomains, cosmeticSelectors, textHideRules)) {
       converted++;
     } else {
       skipped++;
@@ -150,6 +225,7 @@ AbpParseResult parseAbpFilterListSync(String text) {
   return AbpParseResult(
     blockedDomains: blockedDomains,
     cosmeticSelectors: cosmeticSelectors,
+    textHideRules: textHideRules,
     convertedCount: converted,
     skippedCount: skipped,
   );

--- a/lib/services/abp_filter_parser.dart
+++ b/lib/services/abp_filter_parser.dart
@@ -45,13 +45,17 @@ bool _parseLine(
   // --- Cosmetic filter: ##selector or domain##selector ---
   final cosmeticIdx = line.indexOf('##');
   if (cosmeticIdx >= 0) {
-    // Skip extended CSS selectors
+    // Skip ABP extended CSS selectors (but NOT standard CSS :has() which browsers support)
     final afterHash = line.substring(cosmeticIdx);
     if (afterHash.startsWith('#?#') ||
         afterHash.startsWith('#\$#') ||
-        afterHash.contains(':has(') ||
         afterHash.contains(':has-text(') ||
-        afterHash.contains(':-abp-')) {
+        afterHash.contains(':contains(') ||
+        afterHash.contains(':-abp-') ||
+        afterHash.contains(':matches-path(') ||
+        afterHash.contains(':matches-attr(') ||
+        afterHash.contains(':min-text-length(') ||
+        afterHash.contains(':watch-attr(')) {
       return false;
     }
 

--- a/lib/services/abp_filter_parser.dart
+++ b/lib/services/abp_filter_parser.dart
@@ -1,0 +1,319 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+/// Result of parsing ABP filter list text into ContentBlocker rules.
+class AbpParseResult {
+  final List<ContentBlocker> rules;
+  final int convertedCount;
+  final int skippedCount;
+
+  const AbpParseResult({
+    required this.rules,
+    required this.convertedCount,
+    required this.skippedCount,
+  });
+}
+
+/// ABP option-to-resource-type mapping.
+const Map<String, ContentBlockerTriggerResourceType> _resourceTypeMap = {
+  'script': ContentBlockerTriggerResourceType.SCRIPT,
+  'image': ContentBlockerTriggerResourceType.IMAGE,
+  'stylesheet': ContentBlockerTriggerResourceType.STYLE_SHEET,
+  'font': ContentBlockerTriggerResourceType.FONT,
+  'media': ContentBlockerTriggerResourceType.MEDIA,
+  'subdocument': ContentBlockerTriggerResourceType.DOCUMENT,
+  'xmlhttprequest': ContentBlockerTriggerResourceType.RAW,
+  'other': ContentBlockerTriggerResourceType.RAW,
+};
+
+/// Unsupported ABP options that cause a rule to be skipped.
+const Set<String> _unsupportedOptions = {
+  'redirect',
+  'redirect-rule',
+  'csp',
+  'removeparam',
+  'rewrite',
+  'replace',
+};
+
+/// Convert ABP filter syntax to a URL filter regex pattern.
+/// `||` means "beginning of domain", `^` means separator, `*` means wildcard.
+String abpToRegex(String pattern) {
+  final buf = StringBuffer();
+
+  int i = 0;
+
+  // Handle || prefix: match domain start
+  if (pattern.startsWith('||')) {
+    buf.write('^https?://([^/]+\\.)?');
+    i = 2;
+  } else if (pattern.startsWith('|')) {
+    buf.write('^');
+    i = 1;
+  }
+
+  // Handle | suffix
+  final hasEndAnchor = pattern.endsWith('|') && !pattern.endsWith('||');
+  final end = hasEndAnchor ? pattern.length - 1 : pattern.length;
+
+  for (; i < end; i++) {
+    final c = pattern[i];
+    switch (c) {
+      case '*':
+        buf.write('.*');
+        break;
+      case '^':
+        buf.write('[/:?&=]');
+        break;
+      case '.':
+        buf.write('\\.');
+        break;
+      case '?':
+        buf.write('\\?');
+        break;
+      case '+':
+        buf.write('\\+');
+        break;
+      case '(':
+        buf.write('\\(');
+        break;
+      case ')':
+        buf.write('\\)');
+        break;
+      case '[':
+        buf.write('\\[');
+        break;
+      case ']':
+        buf.write('\\]');
+        break;
+      case '{':
+        buf.write('\\{');
+        break;
+      case '}':
+        buf.write('\\}');
+        break;
+      default:
+        buf.write(c);
+    }
+  }
+
+  if (hasEndAnchor) {
+    buf.write('\$');
+  }
+
+  return buf.toString();
+}
+
+/// Parse a single ABP filter line into a ContentBlocker, or null if unsupported.
+/// Returns null and increments skip counting for unsupported rules.
+/// Set [skipExceptions] to filter out IGNORE_PREVIOUS_RULES
+/// (unsupported on Android and other non-iOS/macOS platforms).
+ContentBlocker? _parseLine(String line, {required bool skipExceptions}) {
+  // Cosmetic filter: ##selector or domain##selector
+  final cosmeticIdx = line.indexOf('##');
+  if (cosmeticIdx >= 0) {
+    // Skip extended CSS selectors
+    final afterHash = line.substring(cosmeticIdx);
+    if (afterHash.startsWith('#?#') ||
+        afterHash.startsWith('#\$#') ||
+        afterHash.contains(':has(') ||
+        afterHash.contains(':has-text(') ||
+        afterHash.contains(':-abp-')) {
+      return null;
+    }
+
+    final selector = line.substring(cosmeticIdx + 2).trim();
+    if (selector.isEmpty) return null;
+
+    // HTML filter (##^)
+    if (selector.startsWith('^')) return null;
+
+    final domains = cosmeticIdx > 0 ? line.substring(0, cosmeticIdx) : '';
+
+    final List<String> ifDomain = [];
+    if (domains.isNotEmpty) {
+      for (final d in domains.split(',')) {
+        final trimmed = d.trim();
+        if (trimmed.isEmpty) continue;
+        if (trimmed.startsWith('~')) continue; // Exclude domain, skip for simplicity
+        ifDomain.add('*$trimmed');
+      }
+      if (ifDomain.isEmpty) return null;
+    }
+
+    return ContentBlocker(
+      trigger: ContentBlockerTrigger(
+        urlFilter: '.*',
+        ifDomain: ifDomain,
+      ),
+      action: ContentBlockerAction(
+        type: ContentBlockerActionType.CSS_DISPLAY_NONE,
+        selector: selector,
+      ),
+    );
+  }
+
+  // Check for #?# / #$# extended selectors (if ## was not found above)
+  if (line.contains('#?#') || line.contains('#\$#')) {
+    return null;
+  }
+
+  // Network rule
+  bool isException = false;
+  String rulePart = line;
+
+  if (rulePart.startsWith('@@')) {
+    isException = true;
+    rulePart = rulePart.substring(2);
+    // IGNORE_PREVIOUS_RULES only supported on iOS/macOS
+    if (skipExceptions) return null;
+  }
+
+  // Split options
+  String pattern = rulePart;
+  String optionsPart = '';
+
+  // Find the last $ that's not inside a regex
+  final dollarIdx = rulePart.lastIndexOf('\$');
+  if (dollarIdx > 0) {
+    final beforeDollar = rulePart.substring(0, dollarIdx);
+    final afterDollar = rulePart.substring(dollarIdx + 1);
+    // Only treat as options if the part after $ looks like options
+    // (contains known option keywords or comma-separated values)
+    if (!afterDollar.contains('//') && !afterDollar.startsWith('/')) {
+      pattern = beforeDollar;
+      optionsPart = afterDollar;
+    }
+  }
+
+  // Skip regex patterns (enclosed in /.../)
+  if (pattern.startsWith('/') && pattern.endsWith('/')) {
+    return null;
+  }
+
+  // Parse options
+  final List<ContentBlockerTriggerResourceType> resourceTypes = [];
+  final List<ContentBlockerTriggerLoadType> loadTypes = [];
+  final List<String> ifDomain = [];
+  final List<String> unlessDomain = [];
+
+  if (optionsPart.isNotEmpty) {
+    for (final opt in optionsPart.split(',')) {
+      final trimmed = opt.trim().toLowerCase();
+      if (trimmed.isEmpty) continue;
+
+      // Check for unsupported options
+      if (_unsupportedOptions.any((u) => trimmed == u || trimmed.startsWith('$u='))) {
+        return null;
+      }
+
+      if (trimmed == 'third-party' || trimmed == '3p') {
+        loadTypes.add(ContentBlockerTriggerLoadType.THIRD_PARTY);
+      } else if (trimmed == '~third-party' || trimmed == '~3p' || trimmed == '1p') {
+        loadTypes.add(ContentBlockerTriggerLoadType.FIRST_PARTY);
+      } else if (trimmed.startsWith('domain=')) {
+        final domainList = trimmed.substring(7);
+        for (final d in domainList.split('|')) {
+          if (d.startsWith('~')) {
+            unlessDomain.add('*${d.substring(1)}');
+          } else {
+            ifDomain.add('*$d');
+          }
+        }
+      } else if (_resourceTypeMap.containsKey(trimmed)) {
+        resourceTypes.add(_resourceTypeMap[trimmed]!);
+      } else if (trimmed.startsWith('~')) {
+        // Negated resource type, ignore
+      }
+      // Other unknown options: ignore silently
+    }
+  }
+
+  // Convert pattern to regex
+  final urlFilter = abpToRegex(pattern);
+  if (urlFilter.isEmpty) return null;
+
+  if (isException) {
+    try {
+      return ContentBlocker(
+        trigger: ContentBlockerTrigger(
+          urlFilter: urlFilter,
+          resourceType: resourceTypes,
+          loadType: loadTypes,
+          ifDomain: ifDomain,
+          unlessDomain: unlessDomain,
+        ),
+        action: ContentBlockerAction(
+          type: ContentBlockerActionType.IGNORE_PREVIOUS_RULES,
+        ),
+      );
+    } catch (_) {
+      // IGNORE_PREVIOUS_RULES not supported on this platform
+      return null;
+    }
+  }
+
+  return ContentBlocker(
+    trigger: ContentBlockerTrigger(
+      urlFilter: urlFilter,
+      resourceType: resourceTypes,
+      loadType: loadTypes,
+      ifDomain: ifDomain,
+      unlessDomain: unlessDomain,
+    ),
+    action: ContentBlockerAction(
+      type: ContentBlockerActionType.BLOCK,
+    ),
+  );
+}
+
+/// Parse ABP filter text synchronously. Use [parseAbpFilterList] for isolate-based parsing.
+/// Set [skipExceptions] to true on platforms that don't support IGNORE_PREVIOUS_RULES
+/// (Android, Linux, Windows — only iOS/macOS support it).
+AbpParseResult parseAbpFilterListSync(String text, {bool skipExceptions = false}) {
+  final rules = <ContentBlocker>[];
+  int converted = 0;
+  int skipped = 0;
+
+  for (final line in text.split('\n')) {
+    final trimmed = line.trim();
+    // Skip empty lines, comments, and header lines
+    if (trimmed.isEmpty ||
+        trimmed.startsWith('!') ||
+        trimmed.startsWith('[Adblock')) {
+      continue;
+    }
+
+    final rule = _parseLine(trimmed, skipExceptions: skipExceptions);
+    if (rule != null) {
+      rules.add(rule);
+      converted++;
+    } else {
+      skipped++;
+    }
+  }
+
+  return AbpParseResult(
+    rules: rules,
+    convertedCount: converted,
+    skippedCount: skipped,
+  );
+}
+
+/// Parse ABP filter text in an isolate to avoid blocking the UI thread.
+Future<AbpParseResult> parseAbpFilterList(String text, {bool skipExceptions = false}) {
+  return compute(
+    _parseInIsolate,
+    _ParseArgs(text: text, skipExceptions: skipExceptions),
+  );
+}
+
+class _ParseArgs {
+  final String text;
+  final bool skipExceptions;
+  const _ParseArgs({required this.text, required this.skipExceptions});
+}
+
+AbpParseResult _parseInIsolate(_ParseArgs args) {
+  return parseAbpFilterListSync(args.text, skipExceptions: args.skipExceptions);
+}

--- a/lib/services/content_blocker_service.dart
+++ b/lib/services/content_blocker_service.dart
@@ -100,8 +100,8 @@ class ContentBlockerService {
   /// Key '' = global selectors.
   Map<String, List<String>> _cosmeticSelectors = {};
 
-  /// Cached CSS injection script (rebuilt when rules change).
-  String? _cosmeticScript;
+  /// Aggregated text-based hiding rules: domain -> rules.
+  Map<String, List<TextHideRule>> _textHideRules = {};
 
   /// All configured filter lists.
   List<FilterList> get lists => List.unmodifiable(_lists);
@@ -111,7 +111,7 @@ class ContentBlockerService {
       _lists.where((l) => l.enabled).fold(0, (sum, l) => sum + l.ruleCount);
 
   /// Whether any rules are loaded.
-  bool get hasRules => _blockedDomains.isNotEmpty || _cosmeticSelectors.isNotEmpty;
+  bool get hasRules => _blockedDomains.isNotEmpty || _cosmeticSelectors.isNotEmpty || _textHideRules.isNotEmpty;
 
   /// Check if a URL's domain (or any parent domain) is blocked.
   bool isBlocked(String url) {
@@ -134,30 +134,32 @@ class ContentBlockerService {
   /// Get JavaScript to inject for cosmetic filtering on a given page URL.
   /// Returns null if no cosmetic rules apply.
   String? getCosmeticScript(String pageUrl) {
-    if (_cosmeticSelectors.isEmpty) return null;
-
     // Collect applicable selectors: global + domain-specific
     final selectors = <String>[];
+    final textRules = <TextHideRule>[];
 
-    final global = _cosmeticSelectors[''];
-    if (global != null) selectors.addAll(global);
+    final globalSel = _cosmeticSelectors[''];
+    if (globalSel != null) selectors.addAll(globalSel);
+    final globalText = _textHideRules[''];
+    if (globalText != null) textRules.addAll(globalText);
 
     try {
       final host = Uri.parse(pageUrl).host.toLowerCase();
-      // Check domain-specific selectors for this host and parent domains
       String domain = host;
       while (domain.isNotEmpty) {
-        final domainSelectors = _cosmeticSelectors[domain];
-        if (domainSelectors != null) selectors.addAll(domainSelectors);
+        final ds = _cosmeticSelectors[domain];
+        if (ds != null) selectors.addAll(ds);
+        final tr = _textHideRules[domain];
+        if (tr != null) textRules.addAll(tr);
         final dotIdx = domain.indexOf('.');
         if (dotIdx < 0) break;
         domain = domain.substring(dotIdx + 1);
       }
     } catch (_) {}
 
-    if (selectors.isEmpty) return null;
+    if (selectors.isEmpty && textRules.isEmpty) return null;
 
-    // Build CSS: one rule per selector so a bad selector doesn't break others.
+    // Build CSS: one rule per selector so a bad selector doesn't break others
     final cssRules = StringBuffer();
     for (final s in selectors) {
       final escaped = s.replaceAll('\\', '\\\\').replaceAll("'", "\\'");
@@ -165,14 +167,10 @@ class ContentBlockerService {
     }
     final cssText = cssRules.toString();
 
-    // Build JS that:
-    // 1. Injects a <style> with display:none rules
-    // 2. Uses MutationObserver to force-hide elements (in case site overrides with inline styles)
-    // querySelectorAll batches selectors in small groups to avoid one invalid selector breaking all
+    // Batch selectors for querySelectorAll resilience
     final escapedForJs = selectors
         .map((s) => s.replaceAll('\\', '\\\\').replaceAll("'", "\\'"))
         .toList();
-    // Batch selectors into groups of 20 for querySelectorAll resilience
     final batches = <String>[];
     for (var i = 0; i < escapedForJs.length; i += 20) {
       final end = (i + 20 < escapedForJs.length) ? i + 20 : escapedForJs.length;
@@ -180,12 +178,27 @@ class ContentBlockerService {
     }
     final batchArray = batches.map((b) => "'$b'").join(',');
 
+    // Build text-match rules array for JS
+    // Each rule: {sel: 'div.class', patterns: ['Promoted', 'Sponsored']}
+    final textRulesJs = StringBuffer('[');
+    for (var i = 0; i < textRules.length; i++) {
+      if (i > 0) textRulesJs.write(',');
+      final r = textRules[i];
+      final sel = r.selector.replaceAll('\\', '\\\\').replaceAll("'", "\\'");
+      final pats = r.textPatterns
+          .map((p) => "'${p.replaceAll('\\', '\\\\').replaceAll("'", "\\'")}'")
+          .join(',');
+      textRulesJs.write("{sel:'$sel',pats:[$pats]}");
+    }
+    textRulesJs.write(']');
+
     return '''
 (function() {
   var ID = '_webspace_content_blocker_style';
   if (document.getElementById(ID)) return;
   var CSS = '$cssText';
   var BATCHES = [$batchArray];
+  var TEXT_RULES = $textRulesJs;
   function inject() {
     if (!document.head && !document.documentElement) return;
     var s = document.createElement('style');
@@ -197,11 +210,28 @@ class ContentBlockerService {
   if (!document.getElementById(ID)) {
     document.addEventListener('DOMContentLoaded', function() { inject(); });
   }
-  function hide() {
+  function hideCSS() {
     for (var i = 0; i < BATCHES.length; i++) {
       try { document.querySelectorAll(BATCHES[i]).forEach(function(el) { el.style.display = 'none'; }); } catch(e) {}
     }
   }
+  function hideText() {
+    for (var i = 0; i < TEXT_RULES.length; i++) {
+      var r = TEXT_RULES[i];
+      try {
+        document.querySelectorAll(r.sel).forEach(function(el) {
+          var text = el.textContent || '';
+          for (var j = 0; j < r.pats.length; j++) {
+            if (text.indexOf(r.pats[j]) !== -1) {
+              el.style.display = 'none';
+              break;
+            }
+          }
+        });
+      } catch(e) {}
+    }
+  }
+  function hide() { hideCSS(); hideText(); }
   hide();
   var t = null;
   var obs = new MutationObserver(function() {
@@ -357,6 +387,7 @@ class ContentBlockerService {
   Future<void> _rebuildRules() async {
     final allDomains = <String>{};
     final allSelectors = <String, List<String>>{};
+    final allTextRules = <String, List<TextHideRule>>{};
 
     for (final list in _lists) {
       if (!list.enabled) continue;
@@ -369,12 +400,13 @@ class ContentBlockerService {
         final result = parseAbpFilterListSync(text);
         allDomains.addAll(result.blockedDomains);
 
-        // Merge cosmetic selectors
         for (final entry in result.cosmeticSelectors.entries) {
           allSelectors.putIfAbsent(entry.key, () => []).addAll(entry.value);
         }
+        for (final entry in result.textHideRules.entries) {
+          allTextRules.putIfAbsent(entry.key, () => []).addAll(entry.value);
+        }
 
-        // Update counts from re-parse
         list.ruleCount = result.convertedCount;
         list.skippedCount = result.skippedCount;
       } catch (e) {
@@ -387,7 +419,7 @@ class ContentBlockerService {
 
     _blockedDomains = allDomains;
     _cosmeticSelectors = allSelectors;
-    _cosmeticScript = null; // Invalidate cached script
+    _textHideRules = allTextRules;
   }
 
   Future<void> _saveLists() async {
@@ -407,7 +439,7 @@ class ContentBlockerService {
     _lists = [];
     _blockedDomains = {};
     _cosmeticSelectors = {};
-    _cosmeticScript = null;
+    _textHideRules = {};
   }
 
   /// Exposed for testing: set lists directly.

--- a/lib/services/content_blocker_service.dart
+++ b/lib/services/content_blocker_service.dart
@@ -2,15 +2,11 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'abp_filter_parser.dart';
-
-/// Maximum number of content blocker rules to avoid performance issues.
-const int maxContentBlockerRules = 50000;
 
 /// A filter list entry with metadata.
 class FilterList {
@@ -79,7 +75,12 @@ const List<Map<String, String>> _defaultLists = [
   },
 ];
 
-/// Singleton service for managing ABP filter lists and generating ContentBlocker rules.
+/// Singleton service for managing ABP filter lists.
+///
+/// Uses two mechanisms instead of InAppWebView's contentBlockers (which does
+/// O(n) regex per request on Android):
+/// 1. **Domain blocking** — O(1) hash set lookup in shouldOverrideUrlLoading
+/// 2. **Cosmetic filtering** — JavaScript injection with MutationObserver
 class ContentBlockerService {
   static const String _listsKey = 'content_blocker_lists';
   static const String _cacheDir = 'content_blocker_cache';
@@ -91,20 +92,107 @@ class ContentBlockerService {
   ContentBlockerService._();
 
   List<FilterList> _lists = [];
-  List<ContentBlocker> _contentBlockers = [];
+
+  /// Aggregated blocked domains from all enabled lists.
+  Set<String> _blockedDomains = {};
+
+  /// Aggregated cosmetic selectors: domain -> selectors.
+  /// Key '' = global selectors.
+  Map<String, List<String>> _cosmeticSelectors = {};
+
+  /// Cached CSS injection script (rebuilt when rules change).
+  String? _cosmeticScript;
 
   /// All configured filter lists.
   List<FilterList> get lists => List.unmodifiable(_lists);
-
-  /// Aggregated content blocker rules from all enabled lists.
-  List<ContentBlocker> get contentBlockers => _contentBlockers;
 
   /// Total rule count across all enabled lists.
   int get totalRuleCount =>
       _lists.where((l) => l.enabled).fold(0, (sum, l) => sum + l.ruleCount);
 
   /// Whether any rules are loaded.
-  bool get hasRules => _contentBlockers.isNotEmpty;
+  bool get hasRules => _blockedDomains.isNotEmpty || _cosmeticSelectors.isNotEmpty;
+
+  /// Check if a URL's domain (or any parent domain) is blocked.
+  bool isBlocked(String url) {
+    if (_blockedDomains.isEmpty) return false;
+    try {
+      final host = Uri.parse(url).host.toLowerCase();
+      if (host.isEmpty) return false;
+      // Check exact and parent domains: a.b.example.com -> b.example.com -> example.com
+      String domain = host;
+      while (domain.isNotEmpty) {
+        if (_blockedDomains.contains(domain)) return true;
+        final dotIdx = domain.indexOf('.');
+        if (dotIdx < 0) break;
+        domain = domain.substring(dotIdx + 1);
+      }
+    } catch (_) {}
+    return false;
+  }
+
+  /// Get JavaScript to inject for cosmetic filtering on a given page URL.
+  /// Returns null if no cosmetic rules apply.
+  String? getCosmeticScript(String pageUrl) {
+    if (_cosmeticSelectors.isEmpty) return null;
+
+    // Collect applicable selectors: global + domain-specific
+    final selectors = <String>[];
+
+    final global = _cosmeticSelectors[''];
+    if (global != null) selectors.addAll(global);
+
+    try {
+      final host = Uri.parse(pageUrl).host.toLowerCase();
+      // Check domain-specific selectors for this host and parent domains
+      String domain = host;
+      while (domain.isNotEmpty) {
+        final domainSelectors = _cosmeticSelectors[domain];
+        if (domainSelectors != null) selectors.addAll(domainSelectors);
+        final dotIdx = domain.indexOf('.');
+        if (dotIdx < 0) break;
+        domain = domain.substring(dotIdx + 1);
+      }
+    } catch (_) {}
+
+    if (selectors.isEmpty) return null;
+
+    // Build JS that:
+    // 1. Injects a <style> with display:none for all selectors
+    // 2. Uses MutationObserver to re-apply to dynamically added content
+    final escapedSelectors = selectors
+        .map((s) => s.replaceAll('\\', '\\\\').replaceAll("'", "\\'"))
+        .join(', ');
+
+    return '''
+(function() {
+  var SEL = '$escapedSelectors';
+  var ID = '_webspace_content_blocker_style';
+  if (document.getElementById(ID)) return;
+  function inject() {
+    if (!document.head) return;
+    var s = document.createElement('style');
+    s.id = ID;
+    s.textContent = SEL + ' { display: none !important; }';
+    document.head.appendChild(s);
+  }
+  inject();
+  function hide() {
+    try { document.querySelectorAll(SEL).forEach(function(el) { el.style.display = 'none'; }); } catch(e) {}
+  }
+  hide();
+  var obs = new MutationObserver(function() { hide(); });
+  if (document.body) {
+    obs.observe(document.body, { childList: true, subtree: true });
+  } else {
+    document.addEventListener('DOMContentLoaded', function() {
+      hide();
+      if (document.body) obs.observe(document.body, { childList: true, subtree: true });
+    });
+  }
+})();
+''';
+  }
 
   /// Initialize: load list metadata from prefs, parse cached files for enabled lists.
   Future<void> initialize() async {
@@ -130,11 +218,13 @@ class ContentBlockerService {
       }
 
       // Parse cached filter text for enabled lists
-      await _rebuildContentBlockers();
+      await _rebuildRules();
 
       if (kDebugMode) {
         debugPrint(
-            '[ContentBlocker] Initialized: ${_lists.length} lists, ${_contentBlockers.length} rules');
+            '[ContentBlocker] Initialized: ${_lists.length} lists, '
+            '${_blockedDomains.length} blocked domains, '
+            '${_cosmeticSelectors.values.fold<int>(0, (s, l) => s + l.length)} cosmetic selectors');
       }
     } catch (e) {
       if (kDebugMode) {
@@ -166,10 +256,8 @@ class ContentBlockerService {
       await cacheFile.parent.create(recursive: true);
       await cacheFile.writeAsString(response.body);
 
-      // Parse — skip exception rules on platforms that don't support IGNORE_PREVIOUS_RULES
-      final skipExceptions = !kIsWeb && (Platform.isAndroid || Platform.isLinux || Platform.isWindows);
-      final result =
-          await parseAbpFilterList(response.body, skipExceptions: skipExceptions);
+      // Parse
+      final result = await parseAbpFilterList(response.body);
 
       list.ruleCount = result.convertedCount;
       list.skippedCount = result.skippedCount;
@@ -177,7 +265,7 @@ class ContentBlockerService {
       list.enabled = true;
 
       await _saveLists();
-      await _rebuildContentBlockers();
+      await _rebuildRules();
 
       if (kDebugMode) {
         debugPrint(
@@ -228,7 +316,7 @@ class ContentBlockerService {
     } catch (_) {}
 
     await _saveLists();
-    await _rebuildContentBlockers();
+    await _rebuildRules();
   }
 
   /// Toggle a filter list enabled/disabled.
@@ -236,13 +324,13 @@ class ContentBlockerService {
     final list = _lists.firstWhere((l) => l.id == id);
     list.enabled = enabled;
     await _saveLists();
-    await _rebuildContentBlockers();
+    await _rebuildRules();
   }
 
-  /// Rebuild aggregated content blockers from all enabled lists' cached files.
-  Future<void> _rebuildContentBlockers() async {
-    final allRules = <ContentBlocker>[];
-    final skipExceptions = !kIsWeb && (Platform.isAndroid || Platform.isLinux || Platform.isWindows);
+  /// Rebuild aggregated rules from all enabled lists' cached files.
+  Future<void> _rebuildRules() async {
+    final allDomains = <String>{};
+    final allSelectors = <String, List<String>>{};
 
     for (final list in _lists) {
       if (!list.enabled) continue;
@@ -252,8 +340,13 @@ class ContentBlockerService {
         if (!await cacheFile.exists()) continue;
 
         final text = await cacheFile.readAsString();
-        final result = parseAbpFilterListSync(text, skipExceptions: skipExceptions);
-        allRules.addAll(result.rules);
+        final result = parseAbpFilterListSync(text);
+        allDomains.addAll(result.blockedDomains);
+
+        // Merge cosmetic selectors
+        for (final entry in result.cosmeticSelectors.entries) {
+          allSelectors.putIfAbsent(entry.key, () => []).addAll(entry.value);
+        }
 
         // Update counts from re-parse
         list.ruleCount = result.convertedCount;
@@ -266,16 +359,9 @@ class ContentBlockerService {
       }
     }
 
-    // Cap at max rules
-    if (allRules.length > maxContentBlockerRules) {
-      _contentBlockers = allRules.sublist(0, maxContentBlockerRules);
-      if (kDebugMode) {
-        debugPrint(
-            '[ContentBlocker] Capped rules from ${allRules.length} to $maxContentBlockerRules');
-      }
-    } else {
-      _contentBlockers = allRules;
-    }
+    _blockedDomains = allDomains;
+    _cosmeticSelectors = allSelectors;
+    _cosmeticScript = null; // Invalidate cached script
   }
 
   Future<void> _saveLists() async {
@@ -293,7 +379,9 @@ class ContentBlockerService {
   @visibleForTesting
   void reset() {
     _lists = [];
-    _contentBlockers = [];
+    _blockedDomains = {};
+    _cosmeticSelectors = {};
+    _cosmeticScript = null;
   }
 
   /// Exposed for testing: set lists directly.

--- a/lib/services/content_blocker_service.dart
+++ b/lib/services/content_blocker_service.dart
@@ -170,13 +170,17 @@ class ContentBlockerService {
   var ID = '_webspace_content_blocker_style';
   if (document.getElementById(ID)) return;
   function inject() {
-    if (!document.head) return;
+    if (!document.head && !document.documentElement) return;
     var s = document.createElement('style');
     s.id = ID;
     s.textContent = SEL + ' { display: none !important; }';
-    document.head.appendChild(s);
+    (document.head || document.documentElement).appendChild(s);
   }
   inject();
+  if (!document.getElementById(ID)) {
+    // head not ready yet — retry when DOM is available
+    document.addEventListener('DOMContentLoaded', function() { inject(); });
+  }
   function hide() {
     try { document.querySelectorAll(SEL).forEach(function(el) { el.style.display = 'none'; }); } catch(e) {}
   }

--- a/lib/services/content_blocker_service.dart
+++ b/lib/services/content_blocker_service.dart
@@ -157,35 +157,57 @@ class ContentBlockerService {
 
     if (selectors.isEmpty) return null;
 
+    // Build CSS: one rule per selector so a bad selector doesn't break others.
+    final cssRules = StringBuffer();
+    for (final s in selectors) {
+      final escaped = s.replaceAll('\\', '\\\\').replaceAll("'", "\\'");
+      cssRules.write('$escaped { display: none !important; } ');
+    }
+    final cssText = cssRules.toString();
+
     // Build JS that:
-    // 1. Injects a <style> with display:none for all selectors
-    // 2. Uses MutationObserver to re-apply to dynamically added content
-    final escapedSelectors = selectors
+    // 1. Injects a <style> with display:none rules
+    // 2. Uses MutationObserver to force-hide elements (in case site overrides with inline styles)
+    // querySelectorAll batches selectors in small groups to avoid one invalid selector breaking all
+    final escapedForJs = selectors
         .map((s) => s.replaceAll('\\', '\\\\').replaceAll("'", "\\'"))
-        .join(', ');
+        .toList();
+    // Batch selectors into groups of 20 for querySelectorAll resilience
+    final batches = <String>[];
+    for (var i = 0; i < escapedForJs.length; i += 20) {
+      final end = (i + 20 < escapedForJs.length) ? i + 20 : escapedForJs.length;
+      batches.add(escapedForJs.sublist(i, end).join(', '));
+    }
+    final batchArray = batches.map((b) => "'$b'").join(',');
 
     return '''
 (function() {
-  var SEL = '$escapedSelectors';
   var ID = '_webspace_content_blocker_style';
   if (document.getElementById(ID)) return;
+  var CSS = '$cssText';
+  var BATCHES = [$batchArray];
   function inject() {
     if (!document.head && !document.documentElement) return;
     var s = document.createElement('style');
     s.id = ID;
-    s.textContent = SEL + ' { display: none !important; }';
+    s.textContent = CSS;
     (document.head || document.documentElement).appendChild(s);
   }
   inject();
   if (!document.getElementById(ID)) {
-    // head not ready yet — retry when DOM is available
     document.addEventListener('DOMContentLoaded', function() { inject(); });
   }
   function hide() {
-    try { document.querySelectorAll(SEL).forEach(function(el) { el.style.display = 'none'; }); } catch(e) {}
+    for (var i = 0; i < BATCHES.length; i++) {
+      try { document.querySelectorAll(BATCHES[i]).forEach(function(el) { el.style.display = 'none'; }); } catch(e) {}
+    }
   }
   hide();
-  var obs = new MutationObserver(function() { hide(); });
+  var t = null;
+  var obs = new MutationObserver(function() {
+    if (t) clearTimeout(t);
+    t = setTimeout(hide, 50);
+  });
   if (document.body) {
     obs.observe(document.body, { childList: true, subtree: true });
   } else {

--- a/lib/services/content_blocker_service.dart
+++ b/lib/services/content_blocker_service.dart
@@ -131,10 +131,8 @@ class ContentBlockerService {
     return false;
   }
 
-  /// Get JavaScript to inject for cosmetic filtering on a given page URL.
-  /// Returns null if no cosmetic rules apply.
-  String? getCosmeticScript(String pageUrl) {
-    // Collect applicable selectors: global + domain-specific
+  /// Collect applicable selectors and text rules for a page URL.
+  ({List<String> selectors, List<TextHideRule> textRules}) _collectRules(String pageUrl) {
     final selectors = <String>[];
     final textRules = <TextHideRule>[];
 
@@ -157,18 +155,50 @@ class ContentBlockerService {
       }
     } catch (_) {}
 
-    if (selectors.isEmpty && textRules.isEmpty) return null;
+    return (selectors: selectors, textRules: textRules);
+  }
 
-    // Build CSS: one rule per selector so a bad selector doesn't break others
+  String _buildCssText(List<String> selectors) {
     final cssRules = StringBuffer();
     for (final s in selectors) {
       final escaped = s.replaceAll('\\', '\\\\').replaceAll("'", "\\'");
       cssRules.write('$escaped { display: none !important; } ');
     }
-    final cssText = cssRules.toString();
+    return cssRules.toString();
+  }
+
+  /// Get CSS-only JavaScript for early injection at DOCUMENT_START.
+  /// Injects a <style> tag with display:none rules before content renders.
+  /// Returns null if no CSS selectors apply.
+  String? getEarlyCssScript(String pageUrl) {
+    final rules = _collectRules(pageUrl);
+    if (rules.selectors.isEmpty) return null;
+
+    final cssText = _buildCssText(rules.selectors);
+
+    return '''
+(function() {
+  var ID = '_webspace_content_blocker_style';
+  if (document.getElementById(ID)) return;
+  var s = document.createElement('style');
+  s.id = ID;
+  s.textContent = '$cssText';
+  (document.head || document.documentElement || document).appendChild(s);
+})();
+''';
+  }
+
+  /// Get full JavaScript for injection after page load.
+  /// Sets up MutationObserver for dynamic content and text-based hiding.
+  /// Returns null if no cosmetic rules apply.
+  String? getCosmeticScript(String pageUrl) {
+    final rules = _collectRules(pageUrl);
+    if (rules.selectors.isEmpty && rules.textRules.isEmpty) return null;
+
+    final cssText = _buildCssText(rules.selectors);
 
     // Batch selectors for querySelectorAll resilience
-    final escapedForJs = selectors
+    final escapedForJs = rules.selectors
         .map((s) => s.replaceAll('\\', '\\\\').replaceAll("'", "\\'"))
         .toList();
     final batches = <String>[];
@@ -179,11 +209,10 @@ class ContentBlockerService {
     final batchArray = batches.map((b) => "'$b'").join(',');
 
     // Build text-match rules array for JS
-    // Each rule: {sel: 'div.class', patterns: ['Promoted', 'Sponsored']}
     final textRulesJs = StringBuffer('[');
-    for (var i = 0; i < textRules.length; i++) {
+    for (var i = 0; i < rules.textRules.length; i++) {
       if (i > 0) textRulesJs.write(',');
-      final r = textRules[i];
+      final r = rules.textRules[i];
       final sel = r.selector.replaceAll('\\', '\\\\').replaceAll("'", "\\'");
       final pats = r.textPatterns
           .map((p) => "'${p.replaceAll('\\', '\\\\').replaceAll("'", "\\'")}'")
@@ -195,21 +224,14 @@ class ContentBlockerService {
     return '''
 (function() {
   var ID = '_webspace_content_blocker_style';
-  if (document.getElementById(ID)) return;
-  var CSS = '$cssText';
-  var BATCHES = [$batchArray];
-  var TEXT_RULES = $textRulesJs;
-  function inject() {
-    if (!document.head && !document.documentElement) return;
+  if (!document.getElementById(ID)) {
     var s = document.createElement('style');
     s.id = ID;
-    s.textContent = CSS;
+    s.textContent = '$cssText';
     (document.head || document.documentElement).appendChild(s);
   }
-  inject();
-  if (!document.getElementById(ID)) {
-    document.addEventListener('DOMContentLoaded', function() { inject(); });
-  }
+  var BATCHES = [$batchArray];
+  var TEXT_RULES = $textRulesJs;
   function hideCSS() {
     for (var i = 0; i < BATCHES.length; i++) {
       try { document.querySelectorAll(BATCHES[i]).forEach(function(el) { el.style.display = 'none'; }); } catch(e) {}

--- a/lib/services/content_blocker_service.dart
+++ b/lib/services/content_blocker_service.dart
@@ -1,0 +1,304 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'abp_filter_parser.dart';
+
+/// Maximum number of content blocker rules to avoid performance issues.
+const int maxContentBlockerRules = 50000;
+
+/// A filter list entry with metadata.
+class FilterList {
+  final String id;
+  String name;
+  String url;
+  bool enabled;
+  DateTime? lastUpdated;
+  int ruleCount;
+  int skippedCount;
+
+  FilterList({
+    required this.id,
+    required this.name,
+    required this.url,
+    this.enabled = false,
+    this.lastUpdated,
+    this.ruleCount = 0,
+    this.skippedCount = 0,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'url': url,
+        'enabled': enabled,
+        'lastUpdated': lastUpdated?.toIso8601String(),
+        'ruleCount': ruleCount,
+        'skippedCount': skippedCount,
+      };
+
+  factory FilterList.fromJson(Map<String, dynamic> json) => FilterList(
+        id: json['id'],
+        name: json['name'],
+        url: json['url'],
+        enabled: json['enabled'] ?? false,
+        lastUpdated: json['lastUpdated'] != null
+            ? DateTime.tryParse(json['lastUpdated'])
+            : null,
+        ruleCount: json['ruleCount'] ?? 0,
+        skippedCount: json['skippedCount'] ?? 0,
+      );
+}
+
+/// Default filter lists added on first initialization.
+const List<Map<String, String>> _defaultLists = [
+  {
+    'id': 'easylist',
+    'name': 'EasyList',
+    'url': 'https://easylist.to/easylist/easylist.txt',
+  },
+  {
+    'id': 'easyprivacy',
+    'name': 'EasyPrivacy',
+    'url': 'https://easylist.to/easylist/easyprivacy.txt',
+  },
+  {
+    'id': 'fanboy-social',
+    'name': "Fanboy's Social",
+    'url': 'https://easylist.to/easylist/fanboy-social.txt',
+  },
+  {
+    'id': 'fanboy-annoyance',
+    'name': "Fanboy's Annoyance",
+    'url': 'https://easylist.to/easylist/fanboy-annoyance.txt',
+  },
+];
+
+/// Singleton service for managing ABP filter lists and generating ContentBlocker rules.
+class ContentBlockerService {
+  static const String _listsKey = 'content_blocker_lists';
+  static const String _cacheDir = 'content_blocker_cache';
+
+  static ContentBlockerService? _instance;
+  static ContentBlockerService get instance =>
+      _instance ??= ContentBlockerService._();
+
+  ContentBlockerService._();
+
+  List<FilterList> _lists = [];
+  List<ContentBlocker> _contentBlockers = [];
+
+  /// All configured filter lists.
+  List<FilterList> get lists => List.unmodifiable(_lists);
+
+  /// Aggregated content blocker rules from all enabled lists.
+  List<ContentBlocker> get contentBlockers => _contentBlockers;
+
+  /// Total rule count across all enabled lists.
+  int get totalRuleCount =>
+      _lists.where((l) => l.enabled).fold(0, (sum, l) => sum + l.ruleCount);
+
+  /// Whether any rules are loaded.
+  bool get hasRules => _contentBlockers.isNotEmpty;
+
+  /// Initialize: load list metadata from prefs, parse cached files for enabled lists.
+  Future<void> initialize() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final listsJson = prefs.getString(_listsKey);
+
+      if (listsJson != null) {
+        final List<dynamic> decoded = jsonDecode(listsJson);
+        _lists = decoded
+            .map((e) => FilterList.fromJson(Map<String, dynamic>.from(e)))
+            .toList();
+      } else {
+        // First run: add default lists (disabled until downloaded)
+        _lists = _defaultLists
+            .map((d) => FilterList(
+                  id: d['id']!,
+                  name: d['name']!,
+                  url: d['url']!,
+                ))
+            .toList();
+        await _saveLists();
+      }
+
+      // Parse cached filter text for enabled lists
+      await _rebuildContentBlockers();
+
+      if (kDebugMode) {
+        debugPrint(
+            '[ContentBlocker] Initialized: ${_lists.length} lists, ${_contentBlockers.length} rules');
+      }
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('[ContentBlocker] Error initializing: $e');
+      }
+    }
+  }
+
+  /// Download a filter list by ID. Returns true on success.
+  Future<bool> downloadList(String id) async {
+    final list = _lists.firstWhere((l) => l.id == id,
+        orElse: () => throw Exception('List not found: $id'));
+
+    try {
+      final response = await http
+          .get(Uri.parse(list.url))
+          .timeout(const Duration(seconds: 30));
+
+      if (response.statusCode != 200) {
+        if (kDebugMode) {
+          debugPrint(
+              '[ContentBlocker] Download failed for ${list.name}: HTTP ${response.statusCode}');
+        }
+        return false;
+      }
+
+      // Cache raw text to disk
+      final cacheFile = await _getCacheFile(id);
+      await cacheFile.parent.create(recursive: true);
+      await cacheFile.writeAsString(response.body);
+
+      // Parse — skip exception rules on platforms that don't support IGNORE_PREVIOUS_RULES
+      final skipExceptions = !kIsWeb && (Platform.isAndroid || Platform.isLinux || Platform.isWindows);
+      final result =
+          await parseAbpFilterList(response.body, skipExceptions: skipExceptions);
+
+      list.ruleCount = result.convertedCount;
+      list.skippedCount = result.skippedCount;
+      list.lastUpdated = DateTime.now();
+      list.enabled = true;
+
+      await _saveLists();
+      await _rebuildContentBlockers();
+
+      if (kDebugMode) {
+        debugPrint(
+            '[ContentBlocker] Downloaded ${list.name}: ${result.convertedCount} rules, ${result.skippedCount} skipped');
+      }
+
+      return true;
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('[ContentBlocker] Error downloading ${list.name}: $e');
+      }
+      return false;
+    }
+  }
+
+  /// Download all enabled lists. Returns number of successful downloads.
+  Future<int> downloadAllLists() async {
+    int success = 0;
+    for (final list in _lists) {
+      if (list.enabled) {
+        if (await downloadList(list.id)) {
+          success++;
+        }
+      }
+    }
+    return success;
+  }
+
+  /// Add a custom filter list. Returns the new list's ID.
+  Future<String> addCustomList(String name, String url) async {
+    final id =
+        'custom_${DateTime.now().millisecondsSinceEpoch.toRadixString(36)}';
+    _lists.add(FilterList(id: id, name: name, url: url));
+    await _saveLists();
+    return id;
+  }
+
+  /// Remove a filter list by ID.
+  Future<void> removeList(String id) async {
+    _lists.removeWhere((l) => l.id == id);
+
+    // Delete cached file
+    try {
+      final cacheFile = await _getCacheFile(id);
+      if (await cacheFile.exists()) {
+        await cacheFile.delete();
+      }
+    } catch (_) {}
+
+    await _saveLists();
+    await _rebuildContentBlockers();
+  }
+
+  /// Toggle a filter list enabled/disabled.
+  Future<void> toggleList(String id, bool enabled) async {
+    final list = _lists.firstWhere((l) => l.id == id);
+    list.enabled = enabled;
+    await _saveLists();
+    await _rebuildContentBlockers();
+  }
+
+  /// Rebuild aggregated content blockers from all enabled lists' cached files.
+  Future<void> _rebuildContentBlockers() async {
+    final allRules = <ContentBlocker>[];
+    final skipExceptions = !kIsWeb && (Platform.isAndroid || Platform.isLinux || Platform.isWindows);
+
+    for (final list in _lists) {
+      if (!list.enabled) continue;
+
+      try {
+        final cacheFile = await _getCacheFile(list.id);
+        if (!await cacheFile.exists()) continue;
+
+        final text = await cacheFile.readAsString();
+        final result = parseAbpFilterListSync(text, skipExceptions: skipExceptions);
+        allRules.addAll(result.rules);
+
+        // Update counts from re-parse
+        list.ruleCount = result.convertedCount;
+        list.skippedCount = result.skippedCount;
+      } catch (e) {
+        if (kDebugMode) {
+          debugPrint(
+              '[ContentBlocker] Error parsing cached list ${list.name}: $e');
+        }
+      }
+    }
+
+    // Cap at max rules
+    if (allRules.length > maxContentBlockerRules) {
+      _contentBlockers = allRules.sublist(0, maxContentBlockerRules);
+      if (kDebugMode) {
+        debugPrint(
+            '[ContentBlocker] Capped rules from ${allRules.length} to $maxContentBlockerRules');
+      }
+    } else {
+      _contentBlockers = allRules;
+    }
+  }
+
+  Future<void> _saveLists() async {
+    final prefs = await SharedPreferences.getInstance();
+    final json = jsonEncode(_lists.map((l) => l.toJson()).toList());
+    await prefs.setString(_listsKey, json);
+  }
+
+  Future<File> _getCacheFile(String id) async {
+    final appDir = await getApplicationDocumentsDirectory();
+    return File('${appDir.path}/$_cacheDir/$id.txt');
+  }
+
+  /// Exposed for testing: reset singleton state.
+  @visibleForTesting
+  void reset() {
+    _lists = [];
+    _contentBlockers = [];
+  }
+
+  /// Exposed for testing: set lists directly.
+  @visibleForTesting
+  void setLists(List<FilterList> lists) {
+    _lists = lists;
+  }
+}

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
@@ -512,6 +514,19 @@ class WebViewFactory {
     // Use cached HTML for instant display, or regular URL request
     final usesCachedHtml = config.initialHtml != null;
 
+    // Inject content blocker CSS at DOCUMENT_START so elements are hidden
+    // before they ever render, eliminating the flash of unstyled content.
+    final userScripts = <inapp.UserScript>[];
+    if (config.contentBlockEnabled) {
+      final earlyScript = ContentBlockerService.instance.getEarlyCssScript(config.initialUrl);
+      if (earlyScript != null) {
+        userScripts.add(inapp.UserScript(
+          source: earlyScript,
+          injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
+        ));
+      }
+    }
+
     return inapp.InAppWebView(
       key: config.key,
       // If we have cached HTML, load it first for instant display
@@ -525,6 +540,7 @@ class WebViewFactory {
         encoding: 'utf-8',
         baseUrl: inapp.WebUri(config.initialUrl),
       ) : null,
+      initialUserScripts: UnmodifiableListView(userScripts),
       initialSettings: inapp.InAppWebViewSettings(
         javaScriptEnabled: config.javascriptEnabled,
         userAgent: config.userAgent,
@@ -598,9 +614,9 @@ class WebViewFactory {
         return false;
       },
       onLoadStart: (controller, url) async {
-        // Inject cosmetic filters early so the style tag is in place before content renders
+        // Re-inject CSS for in-page navigations (initialUserScripts only runs on first load)
         if (config.contentBlockEnabled && url != null) {
-          final script = ContentBlockerService.instance.getCosmeticScript(url.toString());
+          final script = ContentBlockerService.instance.getEarlyCssScript(url.toString());
           if (script != null) {
             await controller.evaluateJavascript(source: script);
           }
@@ -613,7 +629,7 @@ class WebViewFactory {
             final cookies = await cookieManager.getCookies(url: inapp.WebUri(url.toString()));
             config.onCookiesChanged!(cookies);
           }
-          // Inject cosmetic filter CSS for content blocking
+          // Inject full cosmetic script: MutationObserver + text-based hiding
           if (config.contentBlockEnabled) {
             final script = ContentBlockerService.instance.getCosmeticScript(url.toString());
             if (script != null) {

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
 import 'package:webspace/services/clearurl_service.dart';
+import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/settings/proxy.dart';
 
@@ -214,6 +215,8 @@ class WebViewConfig {
   final bool clearUrlEnabled;
   /// Whether to block navigation to domains on the Hagezi DNS blocklist.
   final bool dnsBlockEnabled;
+  /// Whether to apply ABP content blocker rules (ads, trackers, cosmetic).
+  final bool contentBlockEnabled;
 
   WebViewConfig({
     this.key,
@@ -225,6 +228,7 @@ class WebViewConfig {
     this.language,
     this.clearUrlEnabled = true,
     this.dnsBlockEnabled = true,
+    this.contentBlockEnabled = true,
     this.onUrlChanged,
     this.onCookiesChanged,
     this.onFindResult,
@@ -538,6 +542,9 @@ class WebViewFactory {
         allowContentAccess: true,
         // Enable DevTools inspection in debug mode (chrome://inspect on Android)
         isInspectable: kDebugMode,
+        contentBlockers: config.contentBlockEnabled
+            ? ContentBlockerService.instance.contentBlockers
+            : [],
       ),
       onWebViewCreated: (controller) {
         final wrappedController = _WebViewController(controller);

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -542,9 +542,6 @@ class WebViewFactory {
         allowContentAccess: true,
         // Enable DevTools inspection in debug mode (chrome://inspect on Android)
         isInspectable: kDebugMode,
-        contentBlockers: config.contentBlockEnabled
-            ? ContentBlockerService.instance.contentBlockers
-            : [],
       ),
       onWebViewCreated: (controller) {
         final wrappedController = _WebViewController(controller);
@@ -560,6 +557,10 @@ class WebViewFactory {
         if (isCaptchaChallenge(url)) return inapp.NavigationActionPolicy.ALLOW;
         // DNS blocklist check
         if (config.dnsBlockEnabled && DnsBlockService.instance.isBlocked(url)) {
+          return inapp.NavigationActionPolicy.CANCEL;
+        }
+        // Content blocker domain check
+        if (config.contentBlockEnabled && ContentBlockerService.instance.isBlocked(url)) {
           return inapp.NavigationActionPolicy.CANCEL;
         }
         // ClearURLs: strip tracking parameters from URLs
@@ -602,6 +603,13 @@ class WebViewFactory {
           if (config.onCookiesChanged != null) {
             final cookies = await cookieManager.getCookies(url: inapp.WebUri(url.toString()));
             config.onCookiesChanged!(cookies);
+          }
+          // Inject cosmetic filter CSS for content blocking
+          if (config.contentBlockEnabled) {
+            final script = ContentBlockerService.instance.getCosmeticScript(url.toString());
+            if (script != null) {
+              await controller.evaluateJavascript(source: script);
+            }
           }
           // Cache HTML for offline viewing
           if (config.onHtmlLoaded != null) {

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -597,6 +597,15 @@ class WebViewFactory {
 
         return false;
       },
+      onLoadStart: (controller, url) async {
+        // Inject cosmetic filters early so the style tag is in place before content renders
+        if (config.contentBlockEnabled && url != null) {
+          final script = ContentBlockerService.instance.getCosmeticScript(url.toString());
+          if (script != null) {
+            await controller.evaluateJavascript(source: script);
+          }
+        }
+      },
       onLoadStop: (controller, url) async {
         if (url != null) {
           config.onUrlChanged?.call(url.toString());

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -218,6 +218,7 @@ class WebViewModel {
   String? language; // Language code (e.g., 'en', 'es'), null = system default
   bool clearUrlEnabled; // Strip tracking parameters from URLs via ClearURLs
   bool dnsBlockEnabled; // Block navigation to domains on Hagezi DNS blocklist
+  bool contentBlockEnabled; // Block ads/trackers via ABP filter list rules
 
   String? defaultUserAgent;
   Function? stateSetterF;
@@ -238,6 +239,7 @@ class WebViewModel {
     this.language,
     this.clearUrlEnabled = true,
     this.dnsBlockEnabled = true,
+    this.contentBlockEnabled = true,
     this.stateSetterF,
   })  : siteId = siteId ?? _generateSiteId(),
         currentUrl = currentUrl ?? initUrl,
@@ -327,7 +329,7 @@ class WebViewModel {
   }
 
   Widget getWebView(
-    Function(String url, {String? homeTitle, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required String? language}) launchUrlFunc,
+    Function(String url, {String? homeTitle, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required String? language}) launchUrlFunc,
     CookieManager cookieManager,
     Function saveFunc, {
     Future<void> Function(int windowId, String url)? onWindowRequested,
@@ -355,6 +357,7 @@ class WebViewModel {
           language: effectiveLanguage, // Use WebViewModel's language, not parameter
           clearUrlEnabled: clearUrlEnabled,
           dnsBlockEnabled: dnsBlockEnabled,
+          contentBlockEnabled: contentBlockEnabled,
           onWindowRequested: onWindowRequested,
           shouldOverrideUrlLoading: (url, shouldAllow) {
             // Allow about:blank and about:srcdoc - required for Cloudflare Turnstile iframes
@@ -398,7 +401,7 @@ class WebViewModel {
             if (kDebugMode) {
               debugPrint('  -> CANCEL (opening nested webview)');
             }
-            launchUrlFunc(url, homeTitle: name, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, language: this.language);
+            launchUrlFunc(url, homeTitle: name, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, language: this.language);
             return false; // Cancel
           },
           onUrlChanged: (url) async {
@@ -459,7 +462,7 @@ class WebViewModel {
   }
 
   WebViewController? getController(
-    Function(String url, {String? homeTitle, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required String? language}) launchUrlFunc,
+    Function(String url, {String? homeTitle, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required String? language}) launchUrlFunc,
     CookieManager cookieManager,
     Function saveFunc,
   ) {
@@ -524,6 +527,7 @@ class WebViewModel {
         'language': language,
         'clearUrlEnabled': clearUrlEnabled,
         'dnsBlockEnabled': dnsBlockEnabled,
+        'contentBlockEnabled': contentBlockEnabled,
       };
 
   factory WebViewModel.fromJson(Map<String, dynamic> json, Function? stateSetterF) {
@@ -543,6 +547,7 @@ class WebViewModel {
       language: json['language'],
       clearUrlEnabled: json['clearUrlEnabled'] ?? true,
       dnsBlockEnabled: json['dnsBlockEnabled'] ?? true,
+      contentBlockEnabled: json['contentBlockEnabled'] ?? true,
       stateSetterF: stateSetterF,
     )..pageTitle = json['pageTitle'];
   }

--- a/test/abp_filter_parser_test.dart
+++ b/test/abp_filter_parser_test.dart
@@ -58,8 +58,14 @@ void main() {
       expect(result.cosmeticSelectors['test.org'], contains('.sponsored'));
     });
 
-    test('skips extended CSS selectors (:has)', () {
+    test('converts standard CSS :has() selectors', () {
       final result = parseAbpFilterListSync('##.container:has(.ad)');
+      expect(result.convertedCount, equals(1));
+      expect(result.cosmeticSelectors[''], contains('.container:has(.ad)'));
+    });
+
+    test('skips ABP-only :has-text() selectors', () {
+      final result = parseAbpFilterListSync('##.container:has-text(Sponsored)');
       expect(result.convertedCount, equals(0));
       expect(result.skippedCount, equals(1));
     });
@@ -124,8 +130,8 @@ void main() {
 ||malware.com^
 ''';
       final result = parseAbpFilterListSync(input);
-      expect(result.convertedCount, equals(3)); // 2 domains + 1 cosmetic
-      expect(result.skippedCount, equals(2)); // redirect + extended CSS
+      expect(result.convertedCount, equals(4)); // 2 domains + 1 cosmetic + 1 :has() cosmetic
+      expect(result.skippedCount, equals(1)); // redirect
       expect(result.blockedDomains, contains('ads.example.com'));
       expect(result.blockedDomains, contains('malware.com'));
       expect(result.cosmeticSelectors[''], contains('.ad-banner'));

--- a/test/abp_filter_parser_test.dart
+++ b/test/abp_filter_parser_test.dart
@@ -1,103 +1,61 @@
-import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:webspace/services/abp_filter_parser.dart';
 
 void main() {
-  group('abpToRegex', () {
-    test('converts || domain anchor to regex', () {
-      final regex = abpToRegex('||example.com^');
-      expect(regex, equals(r'^https?://([^/]+\.)?example\.com[/:?&=]'));
-    });
-
-    test('converts * wildcard to .*', () {
-      final regex = abpToRegex('||example.com/*/ad');
-      expect(regex, contains('.*'));
-    });
-
-    test('escapes dots', () {
-      final regex = abpToRegex('example.com');
-      expect(regex, contains(r'\.'));
-    });
-
-    test('handles | start anchor', () {
-      final regex = abpToRegex('|https://example.com');
-      expect(regex, startsWith('^'));
-    });
-
-    test('handles | end anchor', () {
-      final regex = abpToRegex('example.com|');
-      expect(regex, endsWith(r'$'));
-    });
-
-    test('handles pattern with no special chars', () {
-      final regex = abpToRegex('ad');
-      expect(regex, equals('ad'));
-    });
-  });
-
   group('parseAbpFilterListSync', () {
     test('skips comment lines', () {
       final result = parseAbpFilterListSync('! This is a comment\n! Another comment');
-      expect(result.rules, isEmpty);
+      expect(result.blockedDomains, isEmpty);
+      expect(result.cosmeticSelectors, isEmpty);
       expect(result.convertedCount, equals(0));
       expect(result.skippedCount, equals(0));
     });
 
     test('skips header lines', () {
       final result = parseAbpFilterListSync('[Adblock Plus 2.0]');
-      expect(result.rules, isEmpty);
       expect(result.convertedCount, equals(0));
     });
 
     test('skips empty lines', () {
       final result = parseAbpFilterListSync('\n\n\n');
-      expect(result.rules, isEmpty);
+      expect(result.blockedDomains, isEmpty);
     });
 
-    test('converts basic network block rule', () {
+    test('converts simple domain block rule', () {
       final result = parseAbpFilterListSync('||ads.example.com^');
       expect(result.convertedCount, equals(1));
       expect(result.skippedCount, equals(0));
-      expect(result.rules.length, equals(1));
-      expect(result.rules[0].action.type, equals(ContentBlockerActionType.BLOCK));
-      expect(result.rules[0].trigger.urlFilter, contains('ads\\.example\\.com'));
+      expect(result.blockedDomains, contains('ads.example.com'));
     });
 
-    test('skips exception rules when skipExceptions is true', () {
-      final result = parseAbpFilterListSync('@@||example.com^', skipExceptions: true);
+    test('converts domain rule without trailing ^', () {
+      final result = parseAbpFilterListSync('||tracker.example.com');
+      expect(result.blockedDomains, contains('tracker.example.com'));
+    });
+
+    test('skips exception rules (@@)', () {
+      final result = parseAbpFilterListSync('@@||example.com^');
       expect(result.convertedCount, equals(0));
       expect(result.skippedCount, equals(1));
     });
 
-    test('converts exception rules when skipExceptions is false', () {
-      // On platforms that support IGNORE_PREVIOUS_RULES (iOS/macOS), exception rules are converted.
-      // On test platform (Linux), IGNORE_PREVIOUS_RULES throws, so we skip this assertion.
-      final result = parseAbpFilterListSync('@@||example.com^', skipExceptions: false);
-      // The rule either converts or is skipped depending on platform
-      expect(result.convertedCount + result.skippedCount, equals(1));
-    });
-
-    test('converts cosmetic filter with ## selector', () {
+    test('converts global cosmetic filter', () {
       final result = parseAbpFilterListSync('##.ad-banner');
       expect(result.convertedCount, equals(1));
-      expect(result.rules[0].action.type,
-          equals(ContentBlockerActionType.CSS_DISPLAY_NONE));
-      expect(result.rules[0].action.selector, equals('.ad-banner'));
-      expect(result.rules[0].trigger.urlFilter, equals('.*'));
+      expect(result.cosmeticSelectors[''], contains('.ad-banner'));
     });
 
     test('converts domain-specific cosmetic filter', () {
       final result = parseAbpFilterListSync('example.com##.ad-sidebar');
       expect(result.convertedCount, equals(1));
-      expect(result.rules[0].action.selector, equals('.ad-sidebar'));
-      expect(result.rules[0].trigger.ifDomain, contains('*example.com'));
+      expect(result.cosmeticSelectors['example.com'], contains('.ad-sidebar'));
     });
 
     test('converts multi-domain cosmetic filter', () {
       final result = parseAbpFilterListSync('example.com,test.org##.sponsored');
       expect(result.convertedCount, equals(1));
-      expect(result.rules[0].trigger.ifDomain, contains('*example.com'));
-      expect(result.rules[0].trigger.ifDomain, contains('*test.org'));
+      expect(result.cosmeticSelectors['example.com'], contains('.sponsored'));
+      expect(result.cosmeticSelectors['test.org'], contains('.sponsored'));
     });
 
     test('skips extended CSS selectors (:has)', () {
@@ -124,46 +82,11 @@ void main() {
       expect(result.skippedCount, equals(1));
     });
 
-    test('parses \$third-party option', () {
-      final result = parseAbpFilterListSync(r'||ads.example.com^$third-party');
-      expect(result.convertedCount, equals(1));
-      expect(result.rules[0].trigger.loadType,
-          contains(ContentBlockerTriggerLoadType.THIRD_PARTY));
-    });
-
-    test('parses \$script resource type', () {
-      final result = parseAbpFilterListSync(r'||ads.example.com^$script');
-      expect(result.convertedCount, equals(1));
-      expect(result.rules[0].trigger.resourceType,
-          contains(ContentBlockerTriggerResourceType.SCRIPT));
-    });
-
-    test('parses \$image resource type', () {
-      final result = parseAbpFilterListSync(r'||ads.example.com^$image');
-      expect(result.convertedCount, equals(1));
-      expect(result.rules[0].trigger.resourceType,
-          contains(ContentBlockerTriggerResourceType.IMAGE));
-    });
-
-    test('parses multiple resource types', () {
-      final result = parseAbpFilterListSync(r'||ads.example.com^$script,image');
-      expect(result.convertedCount, equals(1));
-      expect(result.rules[0].trigger.resourceType,
-          contains(ContentBlockerTriggerResourceType.SCRIPT));
-      expect(result.rules[0].trigger.resourceType,
-          contains(ContentBlockerTriggerResourceType.IMAGE));
-    });
-
-    test('parses \$domain= option with ifDomain', () {
-      final result = parseAbpFilterListSync(r'||ads.com^$domain=example.com');
-      expect(result.convertedCount, equals(1));
-      expect(result.rules[0].trigger.ifDomain, contains('*example.com'));
-    });
-
-    test('parses \$domain= option with unlessDomain', () {
-      final result = parseAbpFilterListSync(r'||ads.com^$domain=~safe.com');
-      expect(result.convertedCount, equals(1));
-      expect(result.rules[0].trigger.unlessDomain, contains('*safe.com'));
+    test('skips complex path rules (not domain-only)', () {
+      // Rules with paths/wildcards are skipped for performance
+      final result = parseAbpFilterListSync(r'||ads.example.com/path$script,third-party');
+      expect(result.convertedCount, equals(0));
+      expect(result.skippedCount, equals(1));
     });
 
     test('skips \$redirect rules', () {
@@ -201,41 +124,44 @@ void main() {
 ||malware.com^
 ''';
       final result = parseAbpFilterListSync(input);
-      expect(result.convertedCount, equals(3)); // 2 network + 1 cosmetic
+      expect(result.convertedCount, equals(3)); // 2 domains + 1 cosmetic
       expect(result.skippedCount, equals(2)); // redirect + extended CSS
+      expect(result.blockedDomains, contains('ads.example.com'));
+      expect(result.blockedDomains, contains('malware.com'));
+      expect(result.cosmeticSelectors[''], contains('.ad-banner'));
     });
 
     test('handles real EasyList-style rules', () {
       const input = '''
 [Adblock Plus 2.0]
 ! Title: EasyList
-! Last modified: 01 Jan 2024
 ||googleads.g.doubleclick.net^
 ||pagead2.googlesyndication.com^
-||securepubads.g.doubleclick.net/tag/js/gpt.js
--advertisement-icon.
--advertising-partner.
 ##.AdSense
 ##.ad-leaderboard
 ###ad-banner
 ''';
       final result = parseAbpFilterListSync(input);
-      // All lines should be convertible
-      expect(result.convertedCount, greaterThan(0));
-      expect(result.rules.length, equals(result.convertedCount));
+      expect(result.blockedDomains, contains('googleads.g.doubleclick.net'));
+      expect(result.blockedDomains, contains('pagead2.googlesyndication.com'));
+      expect(result.cosmeticSelectors[''], containsAll(['.AdSense', '.ad-leaderboard', '#ad-banner']));
     });
 
-    test('handles combined options: type + third-party + domain', () {
-      final result = parseAbpFilterListSync(
-          r'||cdn.ads.com/banner$image,third-party,domain=example.com|test.org');
-      expect(result.convertedCount, equals(1));
-      final rule = result.rules[0];
-      expect(rule.trigger.resourceType,
-          contains(ContentBlockerTriggerResourceType.IMAGE));
-      expect(rule.trigger.loadType,
-          contains(ContentBlockerTriggerLoadType.THIRD_PARTY));
-      expect(rule.trigger.ifDomain, contains('*example.com'));
-      expect(rule.trigger.ifDomain, contains('*test.org'));
+    test('domain blocking is case-insensitive', () {
+      final result = parseAbpFilterListSync('||ADS.Example.COM^');
+      expect(result.blockedDomains, contains('ads.example.com'));
+    });
+
+    test('aggregates selectors from multiple rules', () {
+      const input = '''
+##.ad-banner
+##.ad-sidebar
+example.com##.promoted
+example.com##.sponsored
+''';
+      final result = parseAbpFilterListSync(input);
+      expect(result.cosmeticSelectors['']!.length, equals(2));
+      expect(result.cosmeticSelectors['example.com']!.length, equals(2));
     });
   });
 }

--- a/test/abp_filter_parser_test.dart
+++ b/test/abp_filter_parser_test.dart
@@ -1,0 +1,241 @@
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/abp_filter_parser.dart';
+
+void main() {
+  group('abpToRegex', () {
+    test('converts || domain anchor to regex', () {
+      final regex = abpToRegex('||example.com^');
+      expect(regex, equals(r'^https?://([^/]+\.)?example\.com[/:?&=]'));
+    });
+
+    test('converts * wildcard to .*', () {
+      final regex = abpToRegex('||example.com/*/ad');
+      expect(regex, contains('.*'));
+    });
+
+    test('escapes dots', () {
+      final regex = abpToRegex('example.com');
+      expect(regex, contains(r'\.'));
+    });
+
+    test('handles | start anchor', () {
+      final regex = abpToRegex('|https://example.com');
+      expect(regex, startsWith('^'));
+    });
+
+    test('handles | end anchor', () {
+      final regex = abpToRegex('example.com|');
+      expect(regex, endsWith(r'$'));
+    });
+
+    test('handles pattern with no special chars', () {
+      final regex = abpToRegex('ad');
+      expect(regex, equals('ad'));
+    });
+  });
+
+  group('parseAbpFilterListSync', () {
+    test('skips comment lines', () {
+      final result = parseAbpFilterListSync('! This is a comment\n! Another comment');
+      expect(result.rules, isEmpty);
+      expect(result.convertedCount, equals(0));
+      expect(result.skippedCount, equals(0));
+    });
+
+    test('skips header lines', () {
+      final result = parseAbpFilterListSync('[Adblock Plus 2.0]');
+      expect(result.rules, isEmpty);
+      expect(result.convertedCount, equals(0));
+    });
+
+    test('skips empty lines', () {
+      final result = parseAbpFilterListSync('\n\n\n');
+      expect(result.rules, isEmpty);
+    });
+
+    test('converts basic network block rule', () {
+      final result = parseAbpFilterListSync('||ads.example.com^');
+      expect(result.convertedCount, equals(1));
+      expect(result.skippedCount, equals(0));
+      expect(result.rules.length, equals(1));
+      expect(result.rules[0].action.type, equals(ContentBlockerActionType.BLOCK));
+      expect(result.rules[0].trigger.urlFilter, contains('ads\\.example\\.com'));
+    });
+
+    test('skips exception rules when skipExceptions is true', () {
+      final result = parseAbpFilterListSync('@@||example.com^', skipExceptions: true);
+      expect(result.convertedCount, equals(0));
+      expect(result.skippedCount, equals(1));
+    });
+
+    test('converts exception rules when skipExceptions is false', () {
+      // On platforms that support IGNORE_PREVIOUS_RULES (iOS/macOS), exception rules are converted.
+      // On test platform (Linux), IGNORE_PREVIOUS_RULES throws, so we skip this assertion.
+      final result = parseAbpFilterListSync('@@||example.com^', skipExceptions: false);
+      // The rule either converts or is skipped depending on platform
+      expect(result.convertedCount + result.skippedCount, equals(1));
+    });
+
+    test('converts cosmetic filter with ## selector', () {
+      final result = parseAbpFilterListSync('##.ad-banner');
+      expect(result.convertedCount, equals(1));
+      expect(result.rules[0].action.type,
+          equals(ContentBlockerActionType.CSS_DISPLAY_NONE));
+      expect(result.rules[0].action.selector, equals('.ad-banner'));
+      expect(result.rules[0].trigger.urlFilter, equals('.*'));
+    });
+
+    test('converts domain-specific cosmetic filter', () {
+      final result = parseAbpFilterListSync('example.com##.ad-sidebar');
+      expect(result.convertedCount, equals(1));
+      expect(result.rules[0].action.selector, equals('.ad-sidebar'));
+      expect(result.rules[0].trigger.ifDomain, contains('*example.com'));
+    });
+
+    test('converts multi-domain cosmetic filter', () {
+      final result = parseAbpFilterListSync('example.com,test.org##.sponsored');
+      expect(result.convertedCount, equals(1));
+      expect(result.rules[0].trigger.ifDomain, contains('*example.com'));
+      expect(result.rules[0].trigger.ifDomain, contains('*test.org'));
+    });
+
+    test('skips extended CSS selectors (:has)', () {
+      final result = parseAbpFilterListSync('##.container:has(.ad)');
+      expect(result.convertedCount, equals(0));
+      expect(result.skippedCount, equals(1));
+    });
+
+    test('skips #?# extended selectors', () {
+      final result = parseAbpFilterListSync('example.com#?#.ad:has-text(Sponsored)');
+      expect(result.convertedCount, equals(0));
+      expect(result.skippedCount, equals(1));
+    });
+
+    test('skips #\$# snippet rules', () {
+      final result = parseAbpFilterListSync(r'example.com#$#abort-on-property-read');
+      expect(result.convertedCount, equals(0));
+      expect(result.skippedCount, equals(1));
+    });
+
+    test('skips HTML filter rules (##^)', () {
+      final result = parseAbpFilterListSync('##^script[data-ad]');
+      expect(result.convertedCount, equals(0));
+      expect(result.skippedCount, equals(1));
+    });
+
+    test('parses \$third-party option', () {
+      final result = parseAbpFilterListSync(r'||ads.example.com^$third-party');
+      expect(result.convertedCount, equals(1));
+      expect(result.rules[0].trigger.loadType,
+          contains(ContentBlockerTriggerLoadType.THIRD_PARTY));
+    });
+
+    test('parses \$script resource type', () {
+      final result = parseAbpFilterListSync(r'||ads.example.com^$script');
+      expect(result.convertedCount, equals(1));
+      expect(result.rules[0].trigger.resourceType,
+          contains(ContentBlockerTriggerResourceType.SCRIPT));
+    });
+
+    test('parses \$image resource type', () {
+      final result = parseAbpFilterListSync(r'||ads.example.com^$image');
+      expect(result.convertedCount, equals(1));
+      expect(result.rules[0].trigger.resourceType,
+          contains(ContentBlockerTriggerResourceType.IMAGE));
+    });
+
+    test('parses multiple resource types', () {
+      final result = parseAbpFilterListSync(r'||ads.example.com^$script,image');
+      expect(result.convertedCount, equals(1));
+      expect(result.rules[0].trigger.resourceType,
+          contains(ContentBlockerTriggerResourceType.SCRIPT));
+      expect(result.rules[0].trigger.resourceType,
+          contains(ContentBlockerTriggerResourceType.IMAGE));
+    });
+
+    test('parses \$domain= option with ifDomain', () {
+      final result = parseAbpFilterListSync(r'||ads.com^$domain=example.com');
+      expect(result.convertedCount, equals(1));
+      expect(result.rules[0].trigger.ifDomain, contains('*example.com'));
+    });
+
+    test('parses \$domain= option with unlessDomain', () {
+      final result = parseAbpFilterListSync(r'||ads.com^$domain=~safe.com');
+      expect(result.convertedCount, equals(1));
+      expect(result.rules[0].trigger.unlessDomain, contains('*safe.com'));
+    });
+
+    test('skips \$redirect rules', () {
+      final result = parseAbpFilterListSync(r'||ads.com^$redirect=noopjs');
+      expect(result.convertedCount, equals(0));
+      expect(result.skippedCount, equals(1));
+    });
+
+    test('skips \$csp rules', () {
+      final result = parseAbpFilterListSync(r'||example.com^$csp=script-src');
+      expect(result.convertedCount, equals(0));
+      expect(result.skippedCount, equals(1));
+    });
+
+    test('skips \$removeparam rules', () {
+      final result = parseAbpFilterListSync(r'||example.com^$removeparam=utm_source');
+      expect(result.convertedCount, equals(0));
+      expect(result.skippedCount, equals(1));
+    });
+
+    test('skips regex patterns', () {
+      final result = parseAbpFilterListSync(r'/^https?:\/\/ads\.example\.com\//');
+      expect(result.convertedCount, equals(0));
+      expect(result.skippedCount, equals(1));
+    });
+
+    test('parses a mix of supported and unsupported rules', () {
+      const input = '''
+[Adblock Plus 2.0]
+! Title: Test List
+||ads.example.com^
+##.ad-banner
+||tracker.com^\$redirect=noopjs
+##.container:has(.ad)
+||malware.com^
+''';
+      final result = parseAbpFilterListSync(input);
+      expect(result.convertedCount, equals(3)); // 2 network + 1 cosmetic
+      expect(result.skippedCount, equals(2)); // redirect + extended CSS
+    });
+
+    test('handles real EasyList-style rules', () {
+      const input = '''
+[Adblock Plus 2.0]
+! Title: EasyList
+! Last modified: 01 Jan 2024
+||googleads.g.doubleclick.net^
+||pagead2.googlesyndication.com^
+||securepubads.g.doubleclick.net/tag/js/gpt.js
+-advertisement-icon.
+-advertising-partner.
+##.AdSense
+##.ad-leaderboard
+###ad-banner
+''';
+      final result = parseAbpFilterListSync(input);
+      // All lines should be convertible
+      expect(result.convertedCount, greaterThan(0));
+      expect(result.rules.length, equals(result.convertedCount));
+    });
+
+    test('handles combined options: type + third-party + domain', () {
+      final result = parseAbpFilterListSync(
+          r'||cdn.ads.com/banner$image,third-party,domain=example.com|test.org');
+      expect(result.convertedCount, equals(1));
+      final rule = result.rules[0];
+      expect(rule.trigger.resourceType,
+          contains(ContentBlockerTriggerResourceType.IMAGE));
+      expect(rule.trigger.loadType,
+          contains(ContentBlockerTriggerLoadType.THIRD_PARTY));
+      expect(rule.trigger.ifDomain, contains('*example.com'));
+      expect(rule.trigger.ifDomain, contains('*test.org'));
+    });
+  });
+}

--- a/test/abp_filter_parser_test.dart
+++ b/test/abp_filter_parser_test.dart
@@ -70,8 +70,18 @@ void main() {
       expect(result.skippedCount, equals(1));
     });
 
-    test('skips #?# extended selectors', () {
-      final result = parseAbpFilterListSync('example.com#?#.ad:has-text(Sponsored)');
+    test('converts #?# rules with :-abp-contains to text hide rules', () {
+      final result = parseAbpFilterListSync(
+        r'linkedin.com#?#div.feed-shared-update-v2:-abp-has(span:-abp-contains(/Promoted|Sponsored/))'
+      );
+      expect(result.convertedCount, equals(1));
+      expect(result.textHideRules['linkedin.com'], isNotEmpty);
+      expect(result.textHideRules['linkedin.com']![0].selector, equals('div.feed-shared-update-v2'));
+      expect(result.textHideRules['linkedin.com']![0].textPatterns, containsAll(['Promoted', 'Sponsored']));
+    });
+
+    test('skips #?# rules without text matching', () {
+      final result = parseAbpFilterListSync('example.com#?#.ad:style(color: red)');
       expect(result.convertedCount, equals(0));
       expect(result.skippedCount, equals(1));
     });

--- a/test/content_blocker_service_test.dart
+++ b/test/content_blocker_service_test.dart
@@ -111,10 +111,6 @@ void main() {
   });
 
   group('ContentBlockerService', () {
-    test('maxContentBlockerRules constant is 50000', () {
-      expect(maxContentBlockerRules, equals(50000));
-    });
-
     test('instance is a singleton', () {
       final a = ContentBlockerService.instance;
       final b = ContentBlockerService.instance;
@@ -164,6 +160,20 @@ void main() {
       ]);
       expect(() => service.lists.add(FilterList(id: 'y', name: 'Y', url: 'https://y.com')),
           throwsUnsupportedError);
+    });
+
+    test('isBlocked checks domain and parent domains', () {
+      final service = ContentBlockerService.instance;
+      service.reset();
+      // Manually test isBlocked by checking service behavior
+      // (actual domain set is populated by _rebuildRules which needs file I/O)
+      expect(service.isBlocked('https://example.com'), isFalse);
+    });
+
+    test('getCosmeticScript returns null when no selectors', () {
+      final service = ContentBlockerService.instance;
+      service.reset();
+      expect(service.getCosmeticScript('https://example.com'), isNull);
     });
   });
 }

--- a/test/content_blocker_service_test.dart
+++ b/test/content_blocker_service_test.dart
@@ -1,0 +1,169 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/content_blocker_service.dart';
+
+void main() {
+  group('FilterList', () {
+    test('serializes to JSON correctly', () {
+      final list = FilterList(
+        id: 'test-list',
+        name: 'Test List',
+        url: 'https://example.com/list.txt',
+        enabled: true,
+        lastUpdated: DateTime(2024, 1, 15, 10, 30),
+        ruleCount: 1000,
+        skippedCount: 50,
+      );
+
+      final json = list.toJson();
+
+      expect(json['id'], equals('test-list'));
+      expect(json['name'], equals('Test List'));
+      expect(json['url'], equals('https://example.com/list.txt'));
+      expect(json['enabled'], isTrue);
+      expect(json['lastUpdated'], isNotNull);
+      expect(json['ruleCount'], equals(1000));
+      expect(json['skippedCount'], equals(50));
+    });
+
+    test('deserializes from JSON correctly', () {
+      final json = {
+        'id': 'test-list',
+        'name': 'Test List',
+        'url': 'https://example.com/list.txt',
+        'enabled': true,
+        'lastUpdated': '2024-01-15T10:30:00.000',
+        'ruleCount': 1000,
+        'skippedCount': 50,
+      };
+
+      final list = FilterList.fromJson(json);
+
+      expect(list.id, equals('test-list'));
+      expect(list.name, equals('Test List'));
+      expect(list.url, equals('https://example.com/list.txt'));
+      expect(list.enabled, isTrue);
+      expect(list.lastUpdated, isNotNull);
+      expect(list.ruleCount, equals(1000));
+      expect(list.skippedCount, equals(50));
+    });
+
+    test('handles missing optional fields in JSON', () {
+      final json = {
+        'id': 'test',
+        'name': 'Test',
+        'url': 'https://example.com/list.txt',
+      };
+
+      final list = FilterList.fromJson(json);
+
+      expect(list.enabled, isFalse);
+      expect(list.lastUpdated, isNull);
+      expect(list.ruleCount, equals(0));
+      expect(list.skippedCount, equals(0));
+    });
+
+    test('round-trips through JSON correctly', () {
+      final original = FilterList(
+        id: 'roundtrip',
+        name: 'Round Trip',
+        url: 'https://example.com/rules.txt',
+        enabled: true,
+        lastUpdated: DateTime(2024, 6, 1),
+        ruleCount: 5000,
+        skippedCount: 200,
+      );
+
+      final json = original.toJson();
+      final restored = FilterList.fromJson(json);
+
+      expect(restored.id, equals(original.id));
+      expect(restored.name, equals(original.name));
+      expect(restored.url, equals(original.url));
+      expect(restored.enabled, equals(original.enabled));
+      expect(restored.ruleCount, equals(original.ruleCount));
+      expect(restored.skippedCount, equals(original.skippedCount));
+    });
+
+    test('serializes list of FilterLists to JSON string', () {
+      final lists = [
+        FilterList(id: 'a', name: 'List A', url: 'https://a.com/list.txt'),
+        FilterList(
+            id: 'b',
+            name: 'List B',
+            url: 'https://b.com/list.txt',
+            enabled: true,
+            ruleCount: 100),
+      ];
+
+      final jsonStr = jsonEncode(lists.map((l) => l.toJson()).toList());
+      final decoded = jsonDecode(jsonStr) as List;
+
+      expect(decoded.length, equals(2));
+      final restored = decoded
+          .map((e) => FilterList.fromJson(Map<String, dynamic>.from(e)))
+          .toList();
+      expect(restored[0].id, equals('a'));
+      expect(restored[1].enabled, isTrue);
+      expect(restored[1].ruleCount, equals(100));
+    });
+  });
+
+  group('ContentBlockerService', () {
+    test('maxContentBlockerRules constant is 50000', () {
+      expect(maxContentBlockerRules, equals(50000));
+    });
+
+    test('instance is a singleton', () {
+      final a = ContentBlockerService.instance;
+      final b = ContentBlockerService.instance;
+      expect(identical(a, b), isTrue);
+    });
+
+    test('hasRules returns false when no rules loaded', () {
+      final service = ContentBlockerService.instance;
+      service.reset();
+      expect(service.hasRules, isFalse);
+    });
+
+    test('totalRuleCount sums enabled lists', () {
+      final service = ContentBlockerService.instance;
+      service.reset();
+      service.setLists([
+        FilterList(
+          id: 'a',
+          name: 'A',
+          url: 'https://a.com',
+          enabled: true,
+          ruleCount: 100,
+        ),
+        FilterList(
+          id: 'b',
+          name: 'B',
+          url: 'https://b.com',
+          enabled: false,
+          ruleCount: 200,
+        ),
+        FilterList(
+          id: 'c',
+          name: 'C',
+          url: 'https://c.com',
+          enabled: true,
+          ruleCount: 300,
+        ),
+      ]);
+      expect(service.totalRuleCount, equals(400));
+    });
+
+    test('lists getter returns unmodifiable list', () {
+      final service = ContentBlockerService.instance;
+      service.reset();
+      service.setLists([
+        FilterList(id: 'x', name: 'X', url: 'https://x.com'),
+      ]);
+      expect(() => service.lists.add(FilterList(id: 'y', name: 'Y', url: 'https://y.com')),
+          throwsUnsupportedError);
+    });
+  });
+}

--- a/test/web_view_model_test.dart
+++ b/test/web_view_model_test.dart
@@ -21,6 +21,7 @@ void main() {
       expect(model.incognito, isFalse);
       expect(model.clearUrlEnabled, isTrue);
       expect(model.dnsBlockEnabled, isTrue);
+      expect(model.contentBlockEnabled, isTrue);
     });
 
     test('should serialize to JSON correctly', () {
@@ -43,6 +44,7 @@ void main() {
       expect(json['incognito'], equals(false));
       expect(json['clearUrlEnabled'], equals(true));
       expect(json['dnsBlockEnabled'], equals(true));
+      expect(json['contentBlockEnabled'], equals(true));
       expect(json['cookies'], isList);
       expect(json['proxySettings'], isMap);
     });
@@ -95,6 +97,7 @@ void main() {
       expect(restored.incognito, equals(original.incognito));
       expect(restored.clearUrlEnabled, equals(original.clearUrlEnabled));
       expect(restored.dnsBlockEnabled, equals(original.dnsBlockEnabled));
+      expect(restored.contentBlockEnabled, equals(original.contentBlockEnabled));
     });
 
     test('clearUrlEnabled defaults to true when missing from JSON', () {
@@ -151,6 +154,34 @@ void main() {
 
       final restored = WebViewModel.fromJson(json, null);
       expect(restored.dnsBlockEnabled, isFalse);
+    });
+
+    test('contentBlockEnabled defaults to true when missing from JSON', () {
+      final json = {
+        'initUrl': 'https://example.com',
+        'currentUrl': 'https://example.com',
+        'cookies': [],
+        'proxySettings': {'type': 0, 'address': null},
+        'javascriptEnabled': true,
+        'userAgent': '',
+        'thirdPartyCookiesEnabled': false,
+      };
+
+      final model = WebViewModel.fromJson(json, null);
+      expect(model.contentBlockEnabled, isTrue);
+    });
+
+    test('contentBlockEnabled false is preserved through serialization', () {
+      final model = WebViewModel(
+        initUrl: 'https://example.com',
+        contentBlockEnabled: false,
+      );
+
+      final json = model.toJson();
+      expect(json['contentBlockEnabled'], equals(false));
+
+      final restored = WebViewModel.fromJson(json, null);
+      expect(restored.contentBlockEnabled, isFalse);
     });
   });
 


### PR DESCRIPTION
Parse ABP/EasyList-format filter lists into WebKit-style ContentBlocker rules for blocking ads, trackers, and hiding unwanted elements. Includes 4 default lists (EasyList, EasyPrivacy, Fanboy's Social/Annoyance), custom list support, per-site toggle, and list management UI in App Settings.