### PR TITLE
Fix Android 3-button nav bar overlapping app content

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1864,11 +1864,13 @@ class _WebSpacePageState extends State<WebSpacePage> {
                 ),
               ),
             ),
-            SizedBox(height: 8.0),
+            SizedBox(height: 8.0 + MediaQuery.of(context).padding.bottom),
           ],
         ),
       ),
-      body: _currentIndex == null || _currentIndex! >= _webViewModels.length
+      body: SafeArea(
+        top: false, // AppBar handles top inset
+        child: _currentIndex == null || _currentIndex! >= _webViewModels.length
           ? WebspacesListScreen(
               webspaces: _webspaces,
               selectedWebspaceId: _selectedWebspaceId,
@@ -1935,6 +1937,7 @@ class _WebSpacePageState extends State<WebSpacePage> {
                 );
               }).toList(),
             ),
+      ),
       floatingActionButton:
           !(_currentIndex == null || _currentIndex! >= _webViewModels.length) ? null
           : FloatingActionButton(

--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -565,6 +565,11 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
                     childCount: _suggestions.length,
                   ),
                 ),
+                SliverPadding(
+                  padding: EdgeInsets.only(
+                    bottom: MediaQuery.of(context).padding.bottom,
+                  ),
+                ),
               ],
             );
           },


### PR DESCRIPTION
Wrap Scaffold body in SafeArea (bottom only) so the system navigation bar doesn't overlap webview and webspace list content on Android devices using 3-button navigation.