### PR TITLE
Delete cookies and cache when removing a site

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/10.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10.txt
@@ -1,1 +1,2 @@
 • Block unwanted auto-redirects (Google One Tap, Stripe) using gesture detection with per-site toggle
+• Fix cookies persisting after site removal

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1702,7 +1702,7 @@ class _WebSpacePageState extends State<WebSpacePage> {
                 final wasCurrentIndex = _currentIndex == index;
                 // Delete cookies from webview cookie jar and secure storage
                 final deletedModel = _webViewModels[index];
-                await deletedModel.deleteCookies(_cookieManager);
+                await _cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.initUrl));
                 await _cookieSecureStorage.saveCookiesForSite(deletedModel.siteId, []);
                 await HtmlCacheService.instance.deleteCache(deletedModel.siteId);
                 setState(() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1700,8 +1700,12 @@ class _WebSpacePageState extends State<WebSpacePage> {
 
               if (confirmed == true) {
                 final wasCurrentIndex = _currentIndex == index;
-                // Delete cookies and cache for the removed site
+                // Dispose webview first to stop it from re-setting cookies
                 final deletedModel = _webViewModels[index];
+                deletedModel.disposeWebView();
+                _loadedIndices.remove(index);
+
+                // Delete cookies and cache for the removed site
                 final deletedDomain = getBaseDomain(deletedModel.initUrl);
                 final otherSiteSameDomain = _webViewModels
                     .where((m) => m != deletedModel && getBaseDomain(m.initUrl) == deletedDomain)
@@ -1709,6 +1713,10 @@ class _WebSpacePageState extends State<WebSpacePage> {
                 // Only clear the webview cookie jar if no other site shares this domain
                 if (!otherSiteSameDomain) {
                   await _cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.initUrl));
+                  // Also clear for currentUrl in case the host differs (e.g. www.linkedin.com vs linkedin.com)
+                  if (deletedModel.currentUrl.isNotEmpty && deletedModel.currentUrl != deletedModel.initUrl) {
+                    await _cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.currentUrl));
+                  }
                 }
                 await _cookieSecureStorage.saveCookiesForSite(deletedModel.siteId, []);
                 await HtmlCacheService.instance.deleteCache(deletedModel.siteId);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1700,6 +1700,11 @@ class _WebSpacePageState extends State<WebSpacePage> {
 
               if (confirmed == true) {
                 final wasCurrentIndex = _currentIndex == index;
+                // Delete cookies from webview cookie jar and secure storage
+                final deletedModel = _webViewModels[index];
+                await deletedModel.deleteCookies(_cookieManager);
+                await _cookieSecureStorage.saveCookiesForSite(deletedModel.siteId, []);
+                await HtmlCacheService.instance.deleteCache(deletedModel.siteId);
                 setState(() {
                   _webViewModels.removeAt(index);
                   // Update _loadedIndices after deletion (shift indices down)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1700,9 +1700,16 @@ class _WebSpacePageState extends State<WebSpacePage> {
 
               if (confirmed == true) {
                 final wasCurrentIndex = _currentIndex == index;
-                // Delete cookies from webview cookie jar and secure storage
+                // Delete cookies and cache for the removed site
                 final deletedModel = _webViewModels[index];
-                await _cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.initUrl));
+                final deletedDomain = getBaseDomain(deletedModel.initUrl);
+                final otherSiteSameDomain = _webViewModels
+                    .where((m) => m != deletedModel && getBaseDomain(m.initUrl) == deletedDomain)
+                    .isNotEmpty;
+                // Only clear the webview cookie jar if no other site shares this domain
+                if (!otherSiteSameDomain) {
+                  await _cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.initUrl));
+                }
                 await _cookieSecureStorage.saveCookiesForSite(deletedModel.siteId, []);
                 await HtmlCacheService.instance.deleteCache(deletedModel.siteId);
                 setState(() {

--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -307,6 +307,7 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
     SiteSuggestion(name: 'Discord', url: 'https://discord.com/login', domain: 'discord.com'),
     SiteSuggestion(name: 'Mattermost', url: 'https://mattermost.com', domain: 'mattermost.com'),
     SiteSuggestion(name: 'Gmail', url: 'https://gmail.com', domain: 'gmail.com'),
+    SiteSuggestion(name: 'LinkedIn', url: 'https://linkedin.com', domain: 'linkedin.com'),
     SiteSuggestion(name: 'Reddit', url: 'https://reddit.com', domain: 'reddit.com'),
     SiteSuggestion(name: 'Mastodon', url: 'https://mastodon.social', domain: 'mastodon.social'),
     SiteSuggestion(name: 'Bluesky', url: 'https://bsky.app', domain: 'bsky.app'),

--- a/openspec/specs/per-site-cookie-isolation/spec.md
+++ b/openspec/specs/per-site-cookie-isolation/spec.md
@@ -261,6 +261,36 @@ IndexedStack(
 - `test/nested_webview_navigation_test.dart` - Tests for per-site URL blocking and widget identity
 - `openspec/specs/per-site-cookie-isolation/spec.md` - This specification
 
+### Requirement: ISO-010 - Cookie Cleanup on Site Deletion
+
+The system SHALL clean up all cookie-related data when a site is deleted.
+
+#### Scenario: Delete only site on a domain
+
+**Given** Site A (`linkedin.com`) is the only site on that domain
+**When** the user deletes Site A
+**Then** all cookies for `linkedin.com` are deleted from the webview cookie jar
+**And** Site A's cookies are removed from secure storage (by siteId)
+**And** Site A's HTML cache is deleted
+
+#### Scenario: Delete one of multiple sites on same domain
+
+**Given** Site A (`github.com/personal`) and Site B (`github.com/work`) exist
+**When** the user deletes Site A
+**Then** cookies in the webview cookie jar are NOT deleted (Site B still needs them)
+**And** Site A's cookies are removed from secure storage (by siteId)
+**And** Site A's HTML cache is deleted
+**And** Site B continues to function with its cookies intact
+
+#### Scenario: Re-adding a deleted site starts fresh
+
+**Given** Site A (`linkedin.com`) was the only site on that domain and was deleted
+**When** the user adds a new site for `linkedin.com`
+**Then** the new site has no pre-existing cookies
+**And** the user must log in again
+
+---
+
 ## Migration
 
 For existing users upgrading:

--- a/test/cookie_isolation_integration_test.dart
+++ b/test/cookie_isolation_integration_test.dart
@@ -167,6 +167,38 @@ class CookieIsolationTestHarness {
     }
   }
 
+  /// Simulates deleting a site, mirroring the cleanup logic in main.dart
+  Future<void> deleteSite(int index) async {
+    final deletedModel = sites[index];
+    final deletedDomain = getBaseDomain(deletedModel.initUrl);
+    final otherSiteSameDomain = sites
+        .where((m) => m != deletedModel && getBaseDomain(m.initUrl) == deletedDomain)
+        .isNotEmpty;
+
+    // Only clear the webview cookie jar if no other site shares this domain
+    if (!otherSiteSameDomain) {
+      await cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.initUrl));
+    }
+
+    // Always clear secure storage for this siteId
+    await storage.saveCookiesForSite(deletedModel.siteId, []);
+
+    // Remove from sites list and loaded indices
+    sites.removeAt(index);
+    loadedIndices.remove(index);
+    // Shift indices down
+    loadedIndices.removeWhere((i) => i >= sites.length);
+    final updatedIndices = loadedIndices.map((i) => i > index ? i - 1 : i).toSet();
+    loadedIndices.clear();
+    loadedIndices.addAll(updatedIndices);
+
+    if (currentIndex == index) {
+      currentIndex = null;
+    } else if (currentIndex != null && currentIndex! > index) {
+      currentIndex = currentIndex! - 1;
+    }
+  }
+
   /// Simulates a site receiving cookies (e.g., after login)
   Future<void> simulateLogin(int index, List<Cookie> cookies) async {
     if (index < 0 || index >= sites.length) return;
@@ -478,6 +510,133 @@ void main() {
       var ghCookies = await harness.cookieManager.getCookies(url: Uri.parse('https://github.com'));
       expect(ghCookies.any((c) => c.value == 'gh_user2'), isTrue);
       expect(ghCookies.any((c) => c.value == 'gh_user1'), isFalse);
+    });
+  });
+
+  group('Site Deletion Cookie Cleanup', () {
+    late CookieIsolationTestHarness harness;
+
+    setUp(() {
+      harness = CookieIsolationTestHarness();
+    });
+
+    test('deleting sole site on domain clears cookie jar', () async {
+      harness.addSite('https://linkedin.com', name: 'LinkedIn');
+
+      await harness.switchToSite(0);
+      await harness.simulateLogin(0, [
+        Cookie(name: 'li_at', value: 'auth_token', domain: 'linkedin.com'),
+        Cookie(name: 'JSESSIONID', value: 'session123', domain: 'linkedin.com'),
+      ]);
+
+      // Verify cookies are in jar
+      var cookies = await harness.cookieManager.getCookies(url: Uri.parse('https://linkedin.com'));
+      expect(cookies, hasLength(2));
+
+      final siteId = harness.sites[0].siteId;
+      await harness.storage.saveCookiesForSite(siteId, harness.sites[0].cookies);
+
+      // Delete the site
+      await harness.deleteSite(0);
+
+      // Cookie jar should be cleared for this domain
+      cookies = await harness.cookieManager.getCookies(url: Uri.parse('https://linkedin.com'));
+      expect(cookies, isEmpty);
+
+      // Secure storage should be cleared for this siteId
+      var stored = await harness.storage.loadCookiesForSite(siteId);
+      expect(stored, isEmpty);
+    });
+
+    test('deleting one of multiple same-domain sites preserves cookie jar', () async {
+      harness.addSite('https://github.com/personal', name: 'GitHub Personal');
+      harness.addSite('https://github.com/work', name: 'GitHub Work');
+
+      // Login to personal account
+      await harness.switchToSite(0);
+      await harness.simulateLogin(0, [
+        Cookie(name: 'session', value: 'personal_session', domain: 'github.com'),
+      ]);
+      await harness.storage.saveCookiesForSite(harness.sites[0].siteId, harness.sites[0].cookies);
+
+      // Switch to work account
+      await harness.switchToSite(1);
+      await harness.simulateLogin(1, [
+        Cookie(name: 'session', value: 'work_session', domain: 'github.com'),
+      ]);
+      await harness.storage.saveCookiesForSite(harness.sites[1].siteId, harness.sites[1].cookies);
+
+      final personalSiteId = harness.sites[0].siteId;
+      final workSiteId = harness.sites[1].siteId;
+
+      // Delete personal account (index 0)
+      await harness.deleteSite(0);
+
+      // Cookie jar should NOT be cleared (work account still exists)
+      var cookies = await harness.cookieManager.getCookies(url: Uri.parse('https://github.com'));
+      expect(cookies, isNotEmpty);
+
+      // Personal secure storage should be cleared
+      var personalStored = await harness.storage.loadCookiesForSite(personalSiteId);
+      expect(personalStored, isEmpty);
+
+      // Work secure storage should be intact
+      var workStored = await harness.storage.loadCookiesForSite(workSiteId);
+      expect(workStored, hasLength(1));
+      expect(workStored[0].value, equals('work_session'));
+    });
+
+    test('re-adding deleted site starts with no cookies', () async {
+      harness.addSite('https://linkedin.com', name: 'LinkedIn');
+
+      await harness.switchToSite(0);
+      await harness.simulateLogin(0, [
+        Cookie(name: 'li_at', value: 'auth_token', domain: 'linkedin.com'),
+      ]);
+      await harness.storage.saveCookiesForSite(harness.sites[0].siteId, harness.sites[0].cookies);
+
+      // Delete
+      await harness.deleteSite(0);
+
+      // Re-add LinkedIn
+      harness.addSite('https://linkedin.com', name: 'LinkedIn New');
+      await harness.switchToSite(0);
+
+      // New site should have no cookies in jar or storage
+      var cookies = await harness.cookieManager.getCookies(url: Uri.parse('https://linkedin.com'));
+      expect(cookies, isEmpty);
+
+      var stored = await harness.storage.loadCookiesForSite(harness.sites[0].siteId);
+      expect(stored, isEmpty);
+    });
+
+    test('deleting site does not affect unrelated domains', () async {
+      harness.addSite('https://github.com', name: 'GitHub');
+      harness.addSite('https://gitlab.com', name: 'GitLab');
+
+      await harness.switchToSite(0);
+      await harness.simulateLogin(0, [
+        Cookie(name: 'gh_session', value: 'gh123', domain: 'github.com'),
+      ]);
+
+      await harness.switchToSite(1);
+      await harness.simulateLogin(1, [
+        Cookie(name: 'gl_session', value: 'gl456', domain: 'gitlab.com'),
+      ]);
+      await harness.storage.saveCookiesForSite(harness.sites[1].siteId, harness.sites[1].cookies);
+
+      final gitlabSiteId = harness.sites[1].siteId;
+
+      // Delete GitHub
+      await harness.deleteSite(0);
+
+      // GitLab cookies should be unaffected
+      var glCookies = await harness.cookieManager.getCookies(url: Uri.parse('https://gitlab.com'));
+      expect(glCookies, hasLength(1));
+      expect(glCookies[0].value, equals('gl456'));
+
+      var glStored = await harness.storage.loadCookiesForSite(gitlabSiteId);
+      expect(glStored, hasLength(1));
     });
   });
 


### PR DESCRIPTION
Previously, removing a site left its cookies in the webview cookie jar and secure storage, so re-adding the same domain would find old cookies.