### PR TITLE
Add home screen shortcut for sites (Android)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,5 +95,6 @@ Detailed feature specs are in `openspec/specs/`. Each spec uses Given/When/Then 
 | clearurls | ClearURLs tracking parameter removal with per-site toggle |
 | content-blocker | ABP filter list content blocking (domain, CSS cosmetic, text-based hiding) |
 | dns-blocklist | Hagezi DNS blocklist domain blocking with severity levels and per-site toggle |
+| home-shortcut | Android home screen shortcut for sites via pinned shortcuts API |
 
 Read the relevant spec before modifying a feature. Specs include file paths, data models, and manual test procedures.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ WebSpace is a mobile app that brings all your favorite websites and web apps tog
 - 🧹 ClearURLs tracking parameter removal
 - 🛡️ Hagezi DNS blocklist domain blocking (5 severity levels)
 - 🚫 Content blocker with EasyList/EasyPrivacy ad & tracker filtering
+- 📌 Home screen shortcuts for quick site access (Android)
 - 🎨 Light/dark mode with accent colors
 
 ## Development

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -1,6 +1,96 @@
-package org.codeberg.theoden8.webspace;
+package org.codeberg.theoden8.webspace
 
+import android.content.Intent
+import android.graphics.BitmapFactory
+import android.os.Build
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+import java.net.URL
 
 class MainActivity: FlutterActivity() {
+    private val CHANNEL = "org.codeberg.theoden8.webspace/shortcuts"
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "pinShortcut" -> {
+                    val siteId = call.argument<String>("siteId")
+                    val label = call.argument<String>("label")
+                    val iconUrl = call.argument<String>("iconUrl")
+
+                    if (siteId == null || label == null) {
+                        result.error("INVALID_ARGS", "siteId and label are required", null)
+                        return@setMethodCallHandler
+                    }
+
+                    pinShortcut(siteId, label, iconUrl, result)
+                }
+                "getLaunchSiteId" -> {
+                    val siteId = intent?.getStringExtra("siteId")
+                    result.success(siteId)
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    private fun pinShortcut(siteId: String, label: String, iconUrl: String?, result: MethodChannel.Result) {
+        if (!ShortcutManagerCompat.isRequestPinShortcutSupported(this)) {
+            result.error("NOT_SUPPORTED", "Pinned shortcuts not supported on this device", null)
+            return
+        }
+
+        Thread {
+            try {
+                val intent = Intent(this, MainActivity::class.java).apply {
+                    action = Intent.ACTION_VIEW
+                    putExtra("siteId", siteId)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                }
+
+                val icon = if (iconUrl != null) {
+                    try {
+                        val stream = URL(iconUrl).openStream()
+                        val bitmap = BitmapFactory.decodeStream(stream)
+                        stream.close()
+                        if (bitmap != null) IconCompat.createWithBitmap(bitmap) else IconCompat.createWithResource(this, R.mipmap.ic_launcher)
+                    } catch (e: Exception) {
+                        IconCompat.createWithResource(this, R.mipmap.ic_launcher)
+                    }
+                } else {
+                    IconCompat.createWithResource(this, R.mipmap.ic_launcher)
+                }
+
+                val shortcut = ShortcutInfoCompat.Builder(this, "site_$siteId")
+                    .setShortLabel(label)
+                    .setLongLabel(label)
+                    .setIcon(icon)
+                    .setIntent(intent)
+                    .build()
+
+                val success = ShortcutManagerCompat.requestPinShortcut(this, shortcut, null)
+                runOnUiThread {
+                    if (success) {
+                        result.success(true)
+                    } else {
+                        result.error("FAILED", "Failed to request pinned shortcut", null)
+                    }
+                }
+            } catch (e: Exception) {
+                runOnUiThread {
+                    result.error("ERROR", e.message, null)
+                }
+            }
+        }.start()
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+    }
 }

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -30,6 +30,15 @@ class MainActivity: FlutterActivity() {
 
                     pinShortcut(siteId, label, iconUrl, result)
                 }
+                "removeShortcut" -> {
+                    val siteId = call.argument<String>("siteId")
+                    if (siteId != null) {
+                        ShortcutManagerCompat.removeDynamicShortcuts(this, listOf("site_$siteId"))
+                        // Also disable the pinned shortcut so it shows as unavailable
+                        ShortcutManagerCompat.disableShortcuts(this, listOf("site_$siteId"), "Site has been removed")
+                    }
+                    result.success(true)
+                }
                 "getLaunchSiteId" -> {
                     val siteId = intent?.getStringExtra("siteId")
                     result.success(siteId)

--- a/fastlane/metadata/android/en-US/changelogs/10.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10.txt
@@ -1,2 +1,3 @@
 • Block unwanted auto-redirects (Google One Tap, Stripe) using gesture detection with per-site toggle
 • Fix cookies persisting after site removal
+• Add home screen shortcuts for sites (Android)

--- a/fastlane/metadata/android/en-US/changelogs/10.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10.txt
@@ -1,3 +1,6 @@
-• Block unwanted auto-redirects (Google One Tap, Stripe) using gesture detection with per-site toggle
+✨ New Features:
+• Home screen shortcuts for quick site access (Android)
+• Block unwanted auto-redirects (Google One Tap, Stripe) with per-site toggle
+
+🐛 Bug Fixes:
 • Fix cookies persisting after site removal
-• Add home screen shortcuts for sites (Android)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1408,7 +1408,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                       children: [
                         Icon(Icons.add_to_home_screen),
                         SizedBox(width: 8),
-                        Text("Add to Home Screen"),
+                        Text("Home Shortcut"),
                       ],
                     ),
                   ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -31,6 +32,7 @@ import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/services/connectivity_service.dart';
+import 'package:webspace/services/shortcut_service.dart';
 import 'package:webspace/settings/proxy.dart';
 
 // Accent color enum
@@ -387,7 +389,7 @@ class WebSpacePage extends StatefulWidget {
   _WebSpacePageState createState() => _WebSpacePageState();
 }
 
-class _WebSpacePageState extends State<WebSpacePage> {
+class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver {
   int? _currentIndex;
   final List<WebViewModel> _webViewModels = [];
   AppThemeSettings _themeSettings = const AppThemeSettings();
@@ -409,7 +411,31 @@ class _WebSpacePageState extends State<WebSpacePage> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _restoreAppState();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _handleShortcutIntent();
+    }
+  }
+
+  Future<void> _handleShortcutIntent() async {
+    final siteId = await ShortcutService.getLaunchSiteId();
+    if (siteId == null) return;
+    final index = _webViewModels.indexWhere((m) => m.siteId == siteId);
+    if (index >= 0 && index != _currentIndex) {
+      await _setCurrentIndex(index);
+      setState(() {});
+    }
   }
 
   Future<void> _saveWebViewModels() async {
@@ -792,6 +818,15 @@ class _WebSpacePageState extends State<WebSpacePage> {
         if (filteredIndices.contains(savedIndex)) {
           indexToRestore = savedIndex;
         }
+      }
+    }
+
+    // Check if launched via home screen shortcut
+    final shortcutSiteId = await ShortcutService.getLaunchSiteId();
+    if (shortcutSiteId != null) {
+      final shortcutIndex = _webViewModels.indexWhere((m) => m.siteId == shortcutSiteId);
+      if (shortcutIndex >= 0) {
+        indexToRestore = shortcutIndex;
       }
     }
 
@@ -1366,6 +1401,17 @@ class _WebSpacePageState extends State<WebSpacePage> {
                     ],
                   ),
                 ),
+                if (Platform.isAndroid)
+                  PopupMenuItem<String>(
+                    value: "addToHome",
+                    child: Row(
+                      children: [
+                        Icon(Icons.add_to_home_screen),
+                        SizedBox(width: 8),
+                        Text("Add to Home Screen"),
+                      ],
+                    ),
+                  ),
               ];
             },
             onSelected: (String value) async {
@@ -1445,6 +1491,19 @@ class _WebSpacePageState extends State<WebSpacePage> {
                     _showUrlBar = !_showUrlBar;
                   });
                   _saveShowUrlBar();
+                break;
+                case 'addToHome':
+                  if (_currentIndex != null) {
+                    final model = _webViewModels[_currentIndex!];
+                    // Get favicon URL (non-SVG only, Android can't use SVG for shortcuts)
+                    final faviconUrl = FaviconUrlCache.get(model.initUrl);
+                    final isSvg = faviconUrl != null && faviconUrl.toLowerCase().endsWith('.svg');
+                    await ShortcutService.pinShortcut(
+                      siteId: model.siteId,
+                      label: model.name,
+                      iconUrl: isSvg ? null : faviconUrl,
+                    );
+                  }
                 break;
               }
             },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1764,6 +1764,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                 deletedModel.disposeWebView();
                 _loadedIndices.remove(index);
 
+                // Remove home screen shortcut if one exists
+                await ShortcutService.removeShortcut(deletedModel.siteId);
+
                 // Delete cookies and cache for the removed site
                 final deletedDomain = getBaseDomain(deletedModel.initUrl);
                 final otherSiteSameDomain = _webViewModels

--- a/lib/services/shortcut_service.dart
+++ b/lib/services/shortcut_service.dart
@@ -24,6 +24,16 @@ class ShortcutService {
     }
   }
 
+  /// Remove a pinned shortcut when a site is deleted (Android only).
+  static Future<void> removeShortcut(String siteId) async {
+    if (!Platform.isAndroid) return;
+    try {
+      await _channel.invokeMethod('removeShortcut', {'siteId': siteId});
+    } on PlatformException {
+      // Ignore — shortcut may not exist
+    }
+  }
+
   /// Get the siteId from the launch intent (if app was opened via shortcut).
   static Future<String?> getLaunchSiteId() async {
     if (!Platform.isAndroid) return null;

--- a/lib/services/shortcut_service.dart
+++ b/lib/services/shortcut_service.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+import 'package:flutter/services.dart';
+
+class ShortcutService {
+  static const _channel = MethodChannel('org.codeberg.theoden8.webspace/shortcuts');
+
+  /// Request a pinned home screen shortcut for a site (Android only).
+  /// Returns true if the request was made successfully.
+  static Future<bool> pinShortcut({
+    required String siteId,
+    required String label,
+    String? iconUrl,
+  }) async {
+    if (!Platform.isAndroid) return false;
+    try {
+      final result = await _channel.invokeMethod('pinShortcut', {
+        'siteId': siteId,
+        'label': label,
+        'iconUrl': iconUrl,
+      });
+      return result == true;
+    } on PlatformException {
+      return false;
+    }
+  }
+
+  /// Get the siteId from the launch intent (if app was opened via shortcut).
+  static Future<String?> getLaunchSiteId() async {
+    if (!Platform.isAndroid) return null;
+    try {
+      return await _channel.invokeMethod('getLaunchSiteId');
+    } on PlatformException {
+      return null;
+    }
+  }
+}

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -1,0 +1,136 @@
+# Home Screen Shortcut Specification
+
+## Purpose
+
+Allow users to add a site shortcut to the Android home screen. Tapping the shortcut launches WebSpace and navigates to that site.
+
+## Status
+
+- **Date**: 2026-03-08
+- **Status**: In Progress
+
+---
+
+## Problem Statement
+
+Users who frequently access a specific site (e.g., Gmail, Slack) want quick access from their home screen without opening WebSpace and navigating to the site manually.
+
+---
+
+## Requirements
+
+### Requirement: HS-001 - Pin Shortcut to Home Screen
+
+The system SHALL allow users to add a pinned shortcut for the current site to the Android home screen.
+
+#### Scenario: Add shortcut from menu
+
+**Given** the user has a site loaded (e.g., "Gmail")
+**When** the user opens the overflow menu and taps "Add to Home Screen"
+**Then** the system shows the Android pinned shortcut confirmation dialog
+**And** the shortcut appears on the home screen with the site's name and favicon
+
+---
+
+### Requirement: HS-002 - Launch Site via Shortcut
+
+The system SHALL navigate to the correct site when launched via a home screen shortcut.
+
+#### Scenario: Open app via shortcut
+
+**Given** the user has a "Gmail" shortcut on the home screen
+**When** the user taps the shortcut
+**Then** WebSpace opens
+**And** the Gmail site is selected and loaded
+
+#### Scenario: App already running
+
+**Given** WebSpace is already running in the background
+**When** the user taps a home screen shortcut
+**Then** the app is brought to the foreground
+**And** the correct site is selected
+
+---
+
+### Requirement: HS-003 - Shortcut Icon
+
+The system SHALL use the site's favicon as the shortcut icon when available, falling back to the app icon.
+
+#### Scenario: Site has favicon
+
+**Given** the site has a cached favicon URL (non-SVG)
+**When** a shortcut is created
+**Then** the shortcut icon is the site's favicon
+
+#### Scenario: Site has no favicon or SVG favicon
+
+**Given** the site has no cached favicon, or the favicon is SVG (not supported by Android shortcuts)
+**When** a shortcut is created
+**Then** the shortcut icon is the WebSpace app icon
+
+---
+
+### Requirement: HS-004 - Android Only
+
+The feature SHALL only be available on Android. On iOS/macOS, the menu item is not shown.
+
+---
+
+## Implementation
+
+### Platform Channel
+
+Flutter communicates with native Android code via `MethodChannel('org.codeberg.theoden8.webspace/shortcuts')`.
+
+Methods:
+- `pinShortcut({siteId, label, iconUrl})` — requests a pinned shortcut via `ShortcutManagerCompat.requestPinShortcut()`
+- `getLaunchSiteId()` — returns the `siteId` from the launch intent extra (if launched via shortcut)
+
+### Shortcut Intent
+
+The shortcut launches `MainActivity` with:
+- `action`: `ACTION_VIEW`
+- `extra`: `siteId` = the site's unique ID
+- `flags`: `FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TOP`
+
+### Launch Handling
+
+On app start and on `onNewIntent` (app already running), check for `siteId` in the intent:
+1. Find the site index matching the `siteId`
+2. Call `_setCurrentIndex(index)` to switch to that site
+
+### Files
+
+#### New
+- `lib/services/shortcut_service.dart` — Flutter wrapper around the platform channel
+- `openspec/specs/home-shortcut/spec.md` — this specification
+
+#### Modified
+- `android/app/src/main/kotlin/.../MainActivity.kt` — native shortcut creation and intent handling
+- `lib/main.dart` — menu item, shortcut action, launch intent handling
+
+---
+
+## Testing
+
+### Manual Test: Create Shortcut
+
+1. Open a site in WebSpace
+2. Tap overflow menu (three dots)
+3. Tap "Add to Home Screen"
+4. Confirm in the Android system dialog
+5. Verify shortcut appears on home screen with site name and icon
+
+### Manual Test: Launch via Shortcut
+
+1. Create a shortcut for a site
+2. Close WebSpace completely
+3. Tap the shortcut on the home screen
+4. Verify WebSpace opens and the correct site is loaded
+
+### Manual Test: Launch While Running
+
+1. Create a shortcut for Site A
+2. Open WebSpace and navigate to Site B
+3. Tap the home screen shortcut for Site A
+4. Verify the app switches to Site A

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -74,6 +74,12 @@ The system SHALL use the site's favicon as the shortcut icon when available, fal
 
 The feature SHALL only be available on Android. On iOS/macOS, the menu item is not shown.
 
+#### Scenario: Menu item hidden on non-Android platforms
+
+**Given** the app is running on iOS or macOS
+**When** the user opens the overflow menu
+**Then** the "Add to Home Screen" option is not shown
+
 ---
 
 ## Implementation


### PR DESCRIPTION
Uses ShortcutManagerCompat.requestPinShortcut() via platform channel. Shortcut launches the app and navigates to the pinned site. Uses site favicon as shortcut icon when available.