### PR TITLE
Fix auto-redirect blocking not working on iOS

### DIFF
--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -426,6 +427,20 @@ String _themeInjectionScript(String themeValue) => '''
 
 /// Factory for creating webviews
 class WebViewFactory {
+  /// Determine if a navigation was triggered by a user gesture.
+  /// Android: uses hasGesture property.
+  /// iOS/macOS: uses navigationType (LINK_ACTIVATED = user tap, FORM_SUBMITTED = user form).
+  static bool _hasUserGesture(inapp.NavigationAction action) {
+    if (Platform.isAndroid) {
+      return action.hasGesture ?? true;
+    }
+    if (Platform.isIOS || Platform.isMacOS) {
+      return action.navigationType == inapp.NavigationType.LINK_ACTIVATED ||
+             action.navigationType == inapp.NavigationType.FORM_SUBMITTED;
+    }
+    return true; // Default allow on unknown platforms
+  }
+
   static bool _shouldBlockUrl(String url) {
     // Allow about:blank and about:srcdoc - required for Cloudflare Turnstile
     if (url.startsWith('about:') && url != 'about:blank' && url != 'about:srcdoc') return true;
@@ -597,7 +612,7 @@ class WebViewFactory {
           }
         }
         if (config.shouldOverrideUrlLoading != null) {
-          final hasGesture = navigationAction.hasGesture ?? true;
+          final hasGesture = _hasUserGesture(navigationAction);
           return config.shouldOverrideUrlLoading!(url, hasGesture)
               ? inapp.NavigationActionPolicy.ALLOW
               : inapp.NavigationActionPolicy.CANCEL;

--- a/openspec/specs/nested-url-blocking/spec.md
+++ b/openspec/specs/nested-url-blocking/spec.md
@@ -172,9 +172,24 @@ URL received
 
 ### Gesture Detection
 
-`flutter_inappwebview`'s `NavigationAction` provides:
+`flutter_inappwebview`'s `NavigationAction` provides platform-specific gesture info. The `_hasUserGesture()` helper normalizes this:
+
 - **Android**: `hasGesture` (bool) — `true` when navigation triggered by user tap
-- **iOS**: `navigationType` — `LINK_ACTIVATED` for user-clicked links
+- **iOS/macOS**: `navigationType` — `LINK_ACTIVATED` or `FORM_SUBMITTED` for user-initiated navigations, `OTHER` for script-initiated
+- **Fallback**: defaults to `true` (allow) on unknown platforms
+
+```dart
+static bool _hasUserGesture(NavigationAction action) {
+  if (Platform.isAndroid) {
+    return action.hasGesture ?? true;
+  }
+  if (Platform.isIOS || Platform.isMacOS) {
+    return action.navigationType == NavigationType.LINK_ACTIVATED ||
+           action.navigationType == NavigationType.FORM_SUBMITTED;
+  }
+  return true;
+}
+```
 
 ### Files
 


### PR DESCRIPTION
hasGesture is Android-only (always null on iOS). Use navigationType on iOS/macOS to detect user-initiated navigations instead.