### PR TITLE
Fix icon background halo on non-white scaffolds

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -210,6 +210,11 @@ class _AccentLogoState extends State<AccentLogo> {
       return;
     }
 
+    // Clear stale image while processing so we don't flash the old color
+    if (_image != null) {
+      setState(() => _image = null);
+    }
+
     final asset = widget.brightness == Brightness.dark
         ? 'assets/webspace_icon_dark.png'
         : 'assets/webspace_icon.png';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -233,12 +233,25 @@ class _AccentLogoState extends State<AccentLogo> {
       final cMin = min(c0, min(c1, c2));
       final cMax = max(c0, max(c1, c2));
 
-      // Compute alpha: distance from background color
+      // Compute alpha: map background to transparent, content to opaque,
+      // with smooth falloff in between to anti-alias edges cleanly.
       int alpha;
       if (isLight) {
-        alpha = 255 - cMin; // white bg → transparent
+        if (cMin >= 200) {
+          alpha = 0;
+        } else if (cMin <= 100) {
+          alpha = 255;
+        } else {
+          alpha = 255 * (200 - cMin) ~/ 100;
+        }
       } else {
-        alpha = cMax; // black bg → transparent
+        if (cMax <= 55) {
+          alpha = 0;
+        } else if (cMax >= 155) {
+          alpha = 255;
+        } else {
+          alpha = 255 * (cMax - 55) ~/ 100;
+        }
       }
 
       // Determine final RGB

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -266,23 +266,10 @@ class _AccentLogoState extends State<AccentLogo> {
         b = accent.blue;
       }
 
-      // Premultiply alpha: decodeImageFromPixels expects premultiplied RGBA
-      if (alpha == 0) {
-        pixels[i] = 0;
-        pixels[i + 1] = 0;
-        pixels[i + 2] = 0;
-        pixels[i + 3] = 0;
-      } else if (alpha < 255) {
-        pixels[i] = (r * alpha) ~/ 255;
-        pixels[i + 1] = (g * alpha) ~/ 255;
-        pixels[i + 2] = (b * alpha) ~/ 255;
-        pixels[i + 3] = alpha;
-      } else {
-        pixels[i] = r;
-        pixels[i + 1] = g;
-        pixels[i + 2] = b;
-        pixels[i + 3] = 255;
-      }
+      pixels[i] = r;
+      pixels[i + 1] = g;
+      pixels[i + 2] = b;
+      pixels[i + 3] = alpha;
     }
 
     final completer = Completer<ui.Image>();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -233,14 +233,27 @@ class _AccentLogoState extends State<AccentLogo> {
       final cMin = min(c0, min(c1, c2));
       final cMax = max(c0, max(c1, c2));
 
-      // Compute alpha: distance from background color.
-      // Threshold near-background pixels to fully transparent to avoid
-      // faint smudges from JPEG compression noise.
+      // Compute alpha: map background to transparent, content to opaque,
+      // with smooth falloff in between to anti-alias edges cleanly.
+      // Light: content has cMin < ~100, bg has cMin > ~200.
+      // Dark: content has cMax > ~155, bg has cMax < ~55.
       int alpha;
       if (isLight) {
-        alpha = cMin > 240 ? 0 : 255 - cMin;
+        if (cMin >= 200) {
+          alpha = 0;
+        } else if (cMin <= 100) {
+          alpha = 255;
+        } else {
+          alpha = 255 * (200 - cMin) ~/ 100;
+        }
       } else {
-        alpha = cMax < 15 ? 0 : cMax;
+        if (cMax <= 55) {
+          alpha = 0;
+        } else if (cMax >= 155) {
+          alpha = 255;
+        } else {
+          alpha = 255 * (cMax - 55) ~/ 100;
+        }
       }
 
       // Determine final RGB

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -233,27 +233,12 @@ class _AccentLogoState extends State<AccentLogo> {
       final cMin = min(c0, min(c1, c2));
       final cMax = max(c0, max(c1, c2));
 
-      // Compute alpha: map background to transparent, content to opaque,
-      // with smooth falloff in between to anti-alias edges cleanly.
-      // Light: content has cMin < ~100, bg has cMin > ~200.
-      // Dark: content has cMax > ~155, bg has cMax < ~55.
+      // Compute alpha: distance from background color
       int alpha;
       if (isLight) {
-        if (cMin >= 200) {
-          alpha = 0;
-        } else if (cMin <= 100) {
-          alpha = 255;
-        } else {
-          alpha = 255 * (200 - cMin) ~/ 100;
-        }
+        alpha = 255 - cMin; // white bg → transparent
       } else {
-        if (cMax <= 55) {
-          alpha = 0;
-        } else if (cMax >= 155) {
-          alpha = 255;
-        } else {
-          alpha = 255 * (cMax - 55) ~/ 100;
-        }
+        alpha = cMax; // black bg → transparent
       }
 
       // Determine final RGB

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -264,10 +264,23 @@ class _AccentLogoState extends State<AccentLogo> {
         b = accent.blue;
       }
 
-      pixels[i] = r;
-      pixels[i + 1] = g;
-      pixels[i + 2] = b;
-      pixels[i + 3] = alpha;
+      // Premultiply: Skia/Impeller expect premultiplied RGBA
+      if (alpha == 0) {
+        pixels[i] = 0;
+        pixels[i + 1] = 0;
+        pixels[i + 2] = 0;
+        pixels[i + 3] = 0;
+      } else if (alpha < 255) {
+        pixels[i] = (r * alpha) ~/ 255;
+        pixels[i + 1] = (g * alpha) ~/ 255;
+        pixels[i + 2] = (b * alpha) ~/ 255;
+        pixels[i + 3] = alpha;
+      } else {
+        pixels[i] = r;
+        pixels[i + 1] = g;
+        pixels[i + 2] = b;
+        pixels[i + 3] = 255;
+      }
     }
 
     final completer = Completer<ui.Image>();


### PR DESCRIPTION
Material 3 scaffold background isn't pure white — it's a subtle grey tint. Semi-transparent white pixels (cMin 150-240) from anti-aliasing edges created a visible halo rectangle.

Replace hard threshold with smooth falloff: cMin >= 200 is fully transparent, cMin <= 100 is fully opaque, interpolated in between. Same approach for dark theme (cMax 55-155 range).