### PR TITLE
Add per-site user script loading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,5 +103,6 @@ Detailed feature specs are in `openspec/specs/`. Each spec uses Given/When/Then 
 | dns-blocklist | Hagezi DNS blocklist domain blocking with severity levels and per-site toggle |
 | home-shortcut | Android home screen shortcut for sites via pinned shortcuts API |
 | developer-tools | In-app dev tools: JS console, cookie inspector, HTML export, app logs |
+| user-scripts | Per-site custom JavaScript injection with injection timing control |
 
 Read the relevant spec before modifying a feature. Specs include file paths, data models, and manual test procedures.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ WebSpace is a mobile app that brings all your favorite websites and web apps tog
 - 🛡️ Hagezi DNS blocklist domain blocking (5 severity levels)
 - 🚫 Content blocker with EasyList/EasyPrivacy ad & tracker filtering
 - 📌 Home screen shortcuts for quick site access (Android)
+- 📜 Per-site user scripts (custom JavaScript injection)
 - 🎨 Light/dark mode with accent colors
 
 ## Development

--- a/fastlane/metadata/android/en-US/changelogs/12.txt
+++ b/fastlane/metadata/android/en-US/changelogs/12.txt
@@ -1,3 +1,3 @@
 ✨ New Features:
 • Accent-colored app logo in drawer and webspaces screen
-• Inspect user script source code in Developer Tools
+• Per-site user scripts with source inspection in Developer Tools

--- a/fastlane/metadata/android/en-US/changelogs/12.txt
+++ b/fastlane/metadata/android/en-US/changelogs/12.txt
@@ -1,2 +1,3 @@
 ✨ New Features:
 • Accent-colored app logo in drawer and webspaces screen
+• Inspect user script source code in Developer Tools

--- a/fastlane/metadata/android/en-US/changelogs/13.txt
+++ b/fastlane/metadata/android/en-US/changelogs/13.txt
@@ -1,2 +1,0 @@
-✨ New Features:
-• Per-site user scripts: inject custom JavaScript into any site with control over injection timing (document start or end)

--- a/fastlane/metadata/android/en-US/changelogs/13.txt
+++ b/fastlane/metadata/android/en-US/changelogs/13.txt
@@ -1,3 +1,2 @@
 ✨ New Features:
 • Per-site user scripts: inject custom JavaScript into any site with control over injection timing (document start or end)
-• Inspect user script source code in Developer Tools (Scripts tab)

--- a/fastlane/metadata/android/en-US/changelogs/13.txt
+++ b/fastlane/metadata/android/en-US/changelogs/13.txt
@@ -1,2 +1,3 @@
 ✨ New Features:
 • Per-site user scripts: inject custom JavaScript into any site with control over injection timing (document start or end)
+• Inspect user script source code in Developer Tools (Scripts tab)

--- a/fastlane/metadata/android/en-US/changelogs/13.txt
+++ b/fastlane/metadata/android/en-US/changelogs/13.txt
@@ -1,0 +1,2 @@
+✨ New Features:
+• Per-site user scripts: inject custom JavaScript into any site with control over injection timing (document start or end)

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -10,6 +10,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart' show ConsoleMess
 import 'package:webspace/web_view_model.dart';
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/services/log_service.dart';
+import 'package:webspace/settings/user_script.dart';
 
 class DevToolsScreen extends StatefulWidget {
   final WebViewModel? webViewModel;
@@ -33,11 +34,12 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
 
   bool get _hasSite => widget.webViewModel != null;
 
-  int get _tabCount => _hasSite ? 4 : 1;
+  int get _tabCount => _hasSite ? 5 : 1;
 
   List<Tab> get _tabs => [
         if (_hasSite) const Tab(text: 'Console'),
         if (_hasSite) const Tab(text: 'Cookies'),
+        if (_hasSite) const Tab(text: 'Scripts'),
         if (_hasSite) const Tab(text: 'Export'),
         const Tab(text: 'App Logs'),
       ];
@@ -55,6 +57,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
           children: [
             if (_hasSite) _buildConsoleTab(),
             if (_hasSite) _buildCookiesTab(),
+            if (_hasSite) _buildScriptsTab(),
             if (_hasSite) _buildExportTab(),
             _buildAppLogsTab(),
           ],
@@ -301,6 +304,70 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
       label = 'SameSite=None';
     }
     return _buildSecurityChip(label, color);
+  }
+
+  // ── Scripts Tab ──
+
+  Widget _buildScriptsTab() {
+    final scripts = widget.webViewModel!.userScripts;
+    if (scripts.isEmpty) {
+      return const Center(child: Text('No user scripts configured'));
+    }
+    return ListView.builder(
+      itemCount: scripts.length,
+      itemBuilder: (context, index) {
+        final script = scripts[index];
+        return ExpansionTile(
+          leading: Icon(
+            script.enabled ? Icons.code : Icons.code_off,
+            color: script.enabled ? Colors.green : Colors.grey,
+            size: 20,
+          ),
+          title: Text(script.name, style: const TextStyle(fontFamily: 'monospace', fontSize: 13)),
+          subtitle: Text(
+            script.injectionTime == UserScriptInjectionTime.atDocumentStart
+                ? 'document start'
+                : 'document end',
+            style: const TextStyle(fontSize: 11),
+          ),
+          children: [
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12.0),
+              margin: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Stack(
+                children: [
+                  SelectableText(
+                    script.source.isEmpty ? '// (empty script)' : script.source,
+                    style: const TextStyle(fontFamily: 'monospace', fontSize: 11),
+                  ),
+                  Positioned(
+                    top: 0,
+                    right: 0,
+                    child: IconButton(
+                      icon: const Icon(Icons.copy, size: 16),
+                      tooltip: 'Copy source',
+                      onPressed: () {
+                        Clipboard.setData(ClipboardData(text: script.source));
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(content: Text('Copied "${script.name}"')),
+                        );
+                      },
+                      visualDensity: VisualDensity.compact,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 8),
+          ],
+        );
+      },
+    );
   }
 
   // ── Export Tab ──

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -7,6 +7,7 @@ import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
+import 'package:webspace/screens/user_scripts.dart';
 
 // Supported languages for webview
 const List<MapEntry<String?, String>> _languages = [
@@ -477,6 +478,28 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     });
                   }
                 : null,
+          ),
+          ListTile(
+            title: const Text('User Scripts'),
+            subtitle: Text(
+              widget.webViewModel.userScripts.isEmpty
+                  ? 'None'
+                  : '${widget.webViewModel.userScripts.where((s) => s.enabled).length} active',
+            ),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => UserScriptsScreen(
+                    userScripts: widget.webViewModel.userScripts,
+                    onSave: (scripts) {
+                      widget.webViewModel.userScripts = scripts;
+                    },
+                  ),
+                ),
+              );
+            },
           ),
           SwitchListTile(
             title: const Text('Block auto-redirects'),

--- a/lib/screens/user_scripts.dart
+++ b/lib/screens/user_scripts.dart
@@ -1,0 +1,258 @@
+import 'package:flutter/material.dart';
+
+import 'package:webspace/settings/user_script.dart';
+
+/// Screen for managing per-site user scripts.
+class UserScriptsScreen extends StatefulWidget {
+  final List<UserScriptConfig> userScripts;
+  final void Function(List<UserScriptConfig>) onSave;
+
+  const UserScriptsScreen({
+    super.key,
+    required this.userScripts,
+    required this.onSave,
+  });
+
+  @override
+  State<UserScriptsScreen> createState() => _UserScriptsScreenState();
+}
+
+class _UserScriptsScreenState extends State<UserScriptsScreen> {
+  late List<UserScriptConfig> _scripts;
+
+  @override
+  void initState() {
+    super.initState();
+    // Deep copy so edits don't mutate the original until saved
+    _scripts = widget.userScripts
+        .map((s) => UserScriptConfig(
+              name: s.name,
+              source: s.source,
+              injectionTime: s.injectionTime,
+              enabled: s.enabled,
+            ))
+        .toList();
+  }
+
+  void _addScript() async {
+    final result = await Navigator.push<UserScriptConfig>(
+      context,
+      MaterialPageRoute(builder: (_) => const UserScriptEditScreen()),
+    );
+    if (result != null) {
+      setState(() => _scripts.add(result));
+    }
+  }
+
+  void _editScript(int index) async {
+    final result = await Navigator.push<UserScriptConfig>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => UserScriptEditScreen(script: _scripts[index]),
+      ),
+    );
+    if (result != null) {
+      setState(() => _scripts[index] = result);
+    }
+  }
+
+  void _deleteScript(int index) {
+    setState(() => _scripts.removeAt(index));
+  }
+
+  void _save() {
+    widget.onSave(_scripts);
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('User Scripts'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.save),
+            onPressed: _save,
+            tooltip: 'Save',
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _addScript,
+        child: const Icon(Icons.add),
+      ),
+      body: _scripts.isEmpty
+          ? const Center(
+              child: Padding(
+                padding: EdgeInsets.all(32.0),
+                child: Text(
+                  'No user scripts.\nTap + to add a script.',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(color: Colors.grey),
+                ),
+              ),
+            )
+          : ReorderableListView.builder(
+              itemCount: _scripts.length,
+              onReorder: (oldIndex, newIndex) {
+                setState(() {
+                  if (newIndex > oldIndex) newIndex--;
+                  final item = _scripts.removeAt(oldIndex);
+                  _scripts.insert(newIndex, item);
+                });
+              },
+              itemBuilder: (context, index) {
+                final script = _scripts[index];
+                return Dismissible(
+                  key: ValueKey('${script.name}_$index'),
+                  direction: DismissDirection.endToStart,
+                  background: Container(
+                    color: Colors.red,
+                    alignment: Alignment.centerRight,
+                    padding: const EdgeInsets.only(right: 16),
+                    child: const Icon(Icons.delete, color: Colors.white),
+                  ),
+                  onDismissed: (_) => _deleteScript(index),
+                  child: ListTile(
+                    title: Text(script.name),
+                    subtitle: Text(
+                      script.injectionTime == UserScriptInjectionTime.atDocumentStart
+                          ? 'Runs at document start'
+                          : 'Runs at document end',
+                    ),
+                    trailing: Switch(
+                      value: script.enabled,
+                      onChanged: (value) {
+                        setState(() => script.enabled = value);
+                      },
+                    ),
+                    onTap: () => _editScript(index),
+                  ),
+                );
+              },
+            ),
+    );
+  }
+}
+
+/// Screen for creating or editing a single user script.
+class UserScriptEditScreen extends StatefulWidget {
+  final UserScriptConfig? script;
+
+  const UserScriptEditScreen({super.key, this.script});
+
+  @override
+  State<UserScriptEditScreen> createState() => _UserScriptEditScreenState();
+}
+
+class _UserScriptEditScreenState extends State<UserScriptEditScreen> {
+  late TextEditingController _nameController;
+  late TextEditingController _sourceController;
+  late UserScriptInjectionTime _injectionTime;
+  late bool _enabled;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.script?.name ?? '');
+    _sourceController = TextEditingController(text: widget.script?.source ?? '');
+    _injectionTime = widget.script?.injectionTime ?? UserScriptInjectionTime.atDocumentEnd;
+    _enabled = widget.script?.enabled ?? true;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _sourceController.dispose();
+    super.dispose();
+  }
+
+  void _save() {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Script name is required')),
+      );
+      return;
+    }
+    Navigator.pop(
+      context,
+      UserScriptConfig(
+        name: name,
+        source: _sourceController.text,
+        injectionTime: _injectionTime,
+        enabled: _enabled,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isEditing = widget.script != null;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(isEditing ? 'Edit Script' : 'New Script'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.check),
+            onPressed: _save,
+            tooltip: 'Save',
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          TextField(
+            controller: _nameController,
+            decoration: const InputDecoration(
+              labelText: 'Name',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 16),
+          DropdownButtonFormField<UserScriptInjectionTime>(
+            value: _injectionTime,
+            decoration: const InputDecoration(
+              labelText: 'Injection Time',
+              border: OutlineInputBorder(),
+            ),
+            items: const [
+              DropdownMenuItem(
+                value: UserScriptInjectionTime.atDocumentStart,
+                child: Text('At document start'),
+              ),
+              DropdownMenuItem(
+                value: UserScriptInjectionTime.atDocumentEnd,
+                child: Text('At document end'),
+              ),
+            ],
+            onChanged: (value) {
+              if (value != null) setState(() => _injectionTime = value);
+            },
+          ),
+          const SizedBox(height: 16),
+          SwitchListTile(
+            title: const Text('Enabled'),
+            value: _enabled,
+            onChanged: (value) => setState(() => _enabled = value),
+            contentPadding: EdgeInsets.zero,
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _sourceController,
+            decoration: const InputDecoration(
+              labelText: 'JavaScript Source',
+              border: OutlineInputBorder(),
+              alignLabelWithHint: true,
+            ),
+            maxLines: 15,
+            minLines: 8,
+            style: const TextStyle(fontFamily: 'monospace', fontSize: 13),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -9,6 +9,7 @@ import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/settings/proxy.dart';
+import 'package:webspace/settings/user_script.dart';
 
 // Re-export inapp.Cookie as Cookie for convenience
 typedef Cookie = inapp.Cookie;
@@ -224,6 +225,8 @@ class WebViewConfig {
   final bool contentBlockEnabled;
   /// Callback for JS console messages.
   final Function(String message, inapp.ConsoleMessageLevel level)? onConsoleMessage;
+  /// Per-site user scripts to inject into the webview.
+  final List<UserScriptConfig> userScripts;
 
   WebViewConfig({
     this.key,
@@ -244,6 +247,7 @@ class WebViewConfig {
     this.onHtmlLoaded,
     this.initialHtml,
     this.onConsoleMessage,
+    this.userScripts = const [],
   });
 }
 
@@ -540,6 +544,18 @@ class WebViewFactory {
           injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
         ));
       }
+    }
+
+    // Inject per-site user scripts
+    for (final script in config.userScripts) {
+      if (!script.enabled || script.source.isEmpty) continue;
+      userScripts.add(inapp.UserScript(
+        groupName: 'user_scripts',
+        source: script.source,
+        injectionTime: script.injectionTime == UserScriptInjectionTime.atDocumentStart
+            ? inapp.UserScriptInjectionTime.AT_DOCUMENT_START
+            : inapp.UserScriptInjectionTime.AT_DOCUMENT_END,
+      ));
     }
 
     return inapp.InAppWebView(

--- a/lib/settings/user_script.dart
+++ b/lib/settings/user_script.dart
@@ -1,0 +1,40 @@
+/// Model for a user-defined script to inject into webviews.
+///
+/// Each script has a name, source code, injection time, and enabled toggle.
+/// Scripts are stored per-site in WebViewModel and serialized to JSON.
+enum UserScriptInjectionTime {
+  atDocumentStart,
+  atDocumentEnd,
+}
+
+class UserScriptConfig {
+  String name;
+  String source;
+  UserScriptInjectionTime injectionTime;
+  bool enabled;
+
+  UserScriptConfig({
+    required this.name,
+    required this.source,
+    this.injectionTime = UserScriptInjectionTime.atDocumentEnd,
+    this.enabled = true,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'source': source,
+        'injectionTime': injectionTime.index,
+        'enabled': enabled,
+      };
+
+  factory UserScriptConfig.fromJson(Map<String, dynamic> json) {
+    return UserScriptConfig(
+      name: json['name'] ?? 'Untitled',
+      source: json['source'] ?? '',
+      injectionTime: json['injectionTime'] == 0
+          ? UserScriptInjectionTime.atDocumentStart
+          : UserScriptInjectionTime.atDocumentEnd,
+      enabled: json['enabled'] ?? true,
+    );
+  }
+}

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -5,6 +5,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart' show ConsoleMess
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/settings/proxy.dart';
+import 'package:webspace/settings/user_script.dart';
 
 class ConsoleLogEntry {
   final DateTime timestamp;
@@ -232,6 +233,7 @@ class WebViewModel {
   bool dnsBlockEnabled; // Block navigation to domains on Hagezi DNS blocklist
   bool contentBlockEnabled; // Block ads/trackers via ABP filter list rules
   bool blockAutoRedirects; // Block script-initiated cross-domain navigations
+  List<UserScriptConfig> userScripts; // Per-site user scripts
 
   final List<ConsoleLogEntry> consoleLogs = [];
   static const _maxConsoleLogs = 500;
@@ -257,8 +259,10 @@ class WebViewModel {
     this.dnsBlockEnabled = true,
     this.contentBlockEnabled = true,
     this.blockAutoRedirects = true,
+    List<UserScriptConfig>? userScripts,
     this.stateSetterF,
-  })  : siteId = siteId ?? _generateSiteId(),
+  })  : userScripts = userScripts ?? [],
+        siteId = siteId ?? _generateSiteId(),
         currentUrl = currentUrl ?? initUrl,
         name = name ?? extractDomain(initUrl),
         proxySettings = proxySettings ?? UserProxySettings(type: ProxyType.DEFAULT);
@@ -377,6 +381,7 @@ class WebViewModel {
           clearUrlEnabled: clearUrlEnabled,
           dnsBlockEnabled: dnsBlockEnabled,
           contentBlockEnabled: contentBlockEnabled,
+          userScripts: userScripts,
           onWindowRequested: onWindowRequested,
           shouldOverrideUrlLoading: (url, hasGesture) {
             // Allow about:blank and about:srcdoc - required for Cloudflare Turnstile iframes
@@ -546,6 +551,7 @@ class WebViewModel {
         'dnsBlockEnabled': dnsBlockEnabled,
         'contentBlockEnabled': contentBlockEnabled,
         'blockAutoRedirects': blockAutoRedirects,
+        'userScripts': userScripts.map((s) => s.toJson()).toList(),
       };
 
   factory WebViewModel.fromJson(Map<String, dynamic> json, Function? stateSetterF) {
@@ -567,6 +573,9 @@ class WebViewModel {
       dnsBlockEnabled: json['dnsBlockEnabled'] ?? true,
       contentBlockEnabled: json['contentBlockEnabled'] ?? true,
       blockAutoRedirects: json['blockAutoRedirects'] ?? true,
+      userScripts: (json['userScripts'] as List<dynamic>?)
+          ?.map((e) => UserScriptConfig.fromJson(e as Map<String, dynamic>))
+          .toList(),
       stateSetterF: stateSetterF,
     )..pageTitle = json['pageTitle'];
   }

--- a/openspec/specs/user-scripts/spec.md
+++ b/openspec/specs/user-scripts/spec.md
@@ -1,0 +1,180 @@
+# User Scripts
+
+## Status
+**Implemented**
+
+## Purpose
+
+Allow users to inject custom JavaScript into webviews on a per-site basis, enabling personalization, automation, and enhanced browsing experiences.
+
+## Problem Statement
+
+Users often want to customize website behavior — hiding annoyances, injecting dark mode CSS, auto-filling forms, extracting data, or fixing broken layouts. Without user script support, these customizations require external tools or are impossible on mobile.
+
+## Solution
+
+Per-site user scripts stored in `WebViewModel`, injected via `flutter_inappwebview`'s `UserScript` API. Each script has a name, source code, injection timing (document start or end), and an enabled toggle. Scripts are managed through a dedicated UI accessible from per-site settings.
+
+---
+
+## Requirements
+
+### Requirement: US-001 - Per-Site Script Storage
+
+Each site SHALL support zero or more user scripts, each with a name, JavaScript source, injection time, and enabled flag.
+
+#### Scenario: Add a user script to a site
+
+**Given** a site with no user scripts
+**When** the user adds a script with name "Dark Mode" and source `document.body.style.background = 'black';`
+**Then** the script is stored in the site's `userScripts` list and persisted to SharedPreferences
+
+#### Scenario: Scripts survive app restart
+
+**Given** a site with user scripts configured
+**When** the app is restarted
+**Then** the user scripts are restored from SharedPreferences via `WebViewModel.fromJson()`
+
+### Requirement: US-002 - Script Injection
+
+Enabled user scripts SHALL be injected into the webview at the configured injection time.
+
+#### Scenario: Inject at document start
+
+**Given** a site with an enabled script set to inject at document start
+**When** the webview loads a page
+**Then** the script runs before the page's own scripts execute
+
+#### Scenario: Inject at document end
+
+**Given** a site with an enabled script set to inject at document end
+**When** the webview finishes loading a page
+**Then** the script runs after the DOM is fully loaded
+
+#### Scenario: Disabled scripts are not injected
+
+**Given** a site with a disabled user script
+**When** the webview loads a page
+**Then** the script is NOT injected
+
+### Requirement: US-003 - Script Management UI
+
+Users SHALL be able to add, edit, delete, reorder, and toggle scripts from per-site settings.
+
+#### Scenario: Add a new script
+
+**Given** the user opens User Scripts from site settings
+**When** they tap the + button
+**Then** a script editor is shown with name, source, injection time, and enabled fields
+
+#### Scenario: Edit an existing script
+
+**Given** a site with user scripts
+**When** the user taps a script in the list
+**Then** the script editor opens pre-filled with the script's current values
+
+#### Scenario: Delete a script
+
+**Given** a site with user scripts
+**When** the user swipes a script to dismiss
+**Then** the script is removed from the list
+
+#### Scenario: Toggle a script
+
+**Given** a site with user scripts
+**When** the user toggles the switch on a script
+**Then** the script's enabled state changes without opening the editor
+
+### Requirement: US-004 - Backward Compatibility
+
+Legacy data without `userScripts` field SHALL be handled gracefully.
+
+#### Scenario: Load legacy data
+
+**Given** a `WebViewModel` JSON without the `userScripts` field
+**When** `fromJson()` is called
+**Then** `userScripts` defaults to an empty list
+
+### Requirement: US-005 - Settings Backup Integration
+
+User scripts SHALL be included in settings export/import.
+
+#### Scenario: Export settings with user scripts
+
+**Given** sites with user scripts configured
+**When** settings are exported
+**Then** the JSON backup includes user scripts in each site's data
+
+#### Scenario: Import settings with user scripts
+
+**Given** a backup file containing user scripts
+**When** settings are imported
+**Then** user scripts are restored for each site
+
+---
+
+## Implementation Details
+
+### Data Model
+
+```dart
+enum UserScriptInjectionTime { atDocumentStart, atDocumentEnd }
+
+class UserScriptConfig {
+  String name;
+  String source;
+  UserScriptInjectionTime injectionTime;
+  bool enabled;
+}
+```
+
+### WebViewModel Integration
+
+- `userScripts` field: `List<UserScriptConfig>`, defaults to `[]`
+- Serialized in `toJson()`, deserialized in `fromJson()` with `?? []` fallback
+- Passed to `WebViewConfig` when creating the webview
+
+### Injection Mechanism
+
+Scripts are added to the `initialUserScripts` list in `WebViewFactory.createWebView()`:
+- Group name `'user_scripts'` for identification
+- Mapped to `inapp.UserScriptInjectionTime.AT_DOCUMENT_START` or `AT_DOCUMENT_END`
+- Empty or disabled scripts are skipped
+
+### UI
+
+- `UserScriptsScreen`: List of scripts with reorder, swipe-to-delete, enable/disable toggle
+- `UserScriptEditScreen`: Form with name, injection time dropdown, enabled switch, monospace source editor
+- Accessed from per-site settings via "User Scripts" list tile
+
+---
+
+## Files
+
+### Created
+- `lib/settings/user_script.dart` — UserScriptConfig model with JSON serialization
+- `lib/screens/user_scripts.dart` — Management and editor screens
+- `test/user_script_test.dart` — Unit tests for model and WebViewModel integration
+
+### Modified
+- `lib/web_view_model.dart` — Added `userScripts` field, serialization, passed to WebViewConfig
+- `lib/services/webview.dart` — Added `userScripts` to WebViewConfig, injection in createWebView
+- `lib/screens/settings.dart` — Added "User Scripts" navigation tile
+
+---
+
+## Testing
+
+### Unit Tests
+```bash
+fvm flutter test test/user_script_test.dart
+```
+
+### Manual Testing
+1. Open a site's settings
+2. Tap "User Scripts"
+3. Add a script: name "Test", source `document.title = "Modified";`, injection time "At document end"
+4. Save and reload the site
+5. Verify the page title shows "Modified"
+6. Disable the script and reload — title should revert to normal
+7. Force-close and reopen the app — verify scripts persist

--- a/test/user_script_test.dart
+++ b/test/user_script_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/settings/user_script.dart';
+import 'package:webspace/web_view_model.dart';
+
+void main() {
+  group('UserScriptConfig', () {
+    test('should initialize with default values', () {
+      final script = UserScriptConfig(
+        name: 'Test Script',
+        source: 'console.log("hello");',
+      );
+
+      expect(script.name, equals('Test Script'));
+      expect(script.source, equals('console.log("hello");'));
+      expect(script.injectionTime, equals(UserScriptInjectionTime.atDocumentEnd));
+      expect(script.enabled, isTrue);
+    });
+
+    test('should serialize to JSON', () {
+      final script = UserScriptConfig(
+        name: 'Dark Mode',
+        source: 'document.body.style.background = "black";',
+        injectionTime: UserScriptInjectionTime.atDocumentStart,
+        enabled: false,
+      );
+
+      final json = script.toJson();
+
+      expect(json['name'], equals('Dark Mode'));
+      expect(json['source'], equals('document.body.style.background = "black";'));
+      expect(json['injectionTime'], equals(0)); // atDocumentStart
+      expect(json['enabled'], isFalse);
+    });
+
+    test('should deserialize from JSON', () {
+      final json = {
+        'name': 'Auto Login',
+        'source': 'document.querySelector("#login").click();',
+        'injectionTime': 1,
+        'enabled': true,
+      };
+
+      final script = UserScriptConfig.fromJson(json);
+
+      expect(script.name, equals('Auto Login'));
+      expect(script.source, equals('document.querySelector("#login").click();'));
+      expect(script.injectionTime, equals(UserScriptInjectionTime.atDocumentEnd));
+      expect(script.enabled, isTrue);
+    });
+
+    test('should handle missing JSON fields with defaults', () {
+      final script = UserScriptConfig.fromJson({});
+
+      expect(script.name, equals('Untitled'));
+      expect(script.source, equals(''));
+      expect(script.injectionTime, equals(UserScriptInjectionTime.atDocumentEnd));
+      expect(script.enabled, isTrue);
+    });
+
+    test('should roundtrip through JSON', () {
+      final original = UserScriptConfig(
+        name: 'Roundtrip',
+        source: 'alert(1);',
+        injectionTime: UserScriptInjectionTime.atDocumentStart,
+        enabled: false,
+      );
+
+      final restored = UserScriptConfig.fromJson(original.toJson());
+
+      expect(restored.name, equals(original.name));
+      expect(restored.source, equals(original.source));
+      expect(restored.injectionTime, equals(original.injectionTime));
+      expect(restored.enabled, equals(original.enabled));
+    });
+  });
+
+  group('WebViewModel user scripts integration', () {
+    test('should default to empty user scripts list', () {
+      final model = WebViewModel(initUrl: 'https://example.com');
+      expect(model.userScripts, isEmpty);
+    });
+
+    test('should serialize user scripts in toJson', () {
+      final model = WebViewModel(
+        initUrl: 'https://example.com',
+        userScripts: [
+          UserScriptConfig(
+            name: 'Script 1',
+            source: 'console.log(1);',
+          ),
+          UserScriptConfig(
+            name: 'Script 2',
+            source: 'console.log(2);',
+            injectionTime: UserScriptInjectionTime.atDocumentStart,
+            enabled: false,
+          ),
+        ],
+      );
+
+      final json = model.toJson();
+      final scripts = json['userScripts'] as List;
+
+      expect(scripts, hasLength(2));
+      expect(scripts[0]['name'], equals('Script 1'));
+      expect(scripts[1]['name'], equals('Script 2'));
+      expect(scripts[1]['enabled'], isFalse);
+    });
+
+    test('should deserialize user scripts from JSON', () {
+      final json = {
+        'initUrl': 'https://example.com',
+        'currentUrl': 'https://example.com',
+        'name': 'Example',
+        'cookies': [],
+        'proxySettings': {'type': 0},
+        'javascriptEnabled': true,
+        'userAgent': '',
+        'thirdPartyCookiesEnabled': false,
+        'incognito': false,
+        'clearUrlEnabled': true,
+        'dnsBlockEnabled': true,
+        'contentBlockEnabled': true,
+        'blockAutoRedirects': true,
+        'userScripts': [
+          {
+            'name': 'My Script',
+            'source': 'document.title = "Custom";',
+            'injectionTime': 0,
+            'enabled': true,
+          },
+        ],
+      };
+
+      final model = WebViewModel.fromJson(json, null);
+
+      expect(model.userScripts, hasLength(1));
+      expect(model.userScripts[0].name, equals('My Script'));
+      expect(model.userScripts[0].injectionTime, equals(UserScriptInjectionTime.atDocumentStart));
+    });
+
+    test('should handle missing userScripts in JSON (backward compat)', () {
+      final json = {
+        'initUrl': 'https://example.com',
+        'currentUrl': 'https://example.com',
+        'name': 'Example',
+        'cookies': [],
+        'proxySettings': {'type': 0},
+        'javascriptEnabled': true,
+        'userAgent': '',
+        'thirdPartyCookiesEnabled': false,
+        'incognito': false,
+        'clearUrlEnabled': true,
+        'dnsBlockEnabled': true,
+        'contentBlockEnabled': true,
+        'blockAutoRedirects': true,
+      };
+
+      final model = WebViewModel.fromJson(json, null);
+
+      expect(model.userScripts, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Adds support for injecting custom JavaScript into webviews on a per-site basis. Each script has a name, source code, injection timing (document start or end), and an enabled toggle. Scripts are managed through a dedicated UI accessible from per-site settings.

- UserScriptConfig model with JSON serialization (lib/settings/user_script.dart)
- Management UI with add/edit/delete/reorder/toggle (lib/screens/user_scripts.dart)
- Integration with WebViewFactory via initialUserScripts API
- Backward-compatible WebViewModel serialization
- Unit tests for model and WebViewModel integration
- OpenSpec, changelog entry, README update

https://claude.ai/code/session_01JvhBCvtqXzst6MA34x68ZH