### PR TITLE
Make developer tools tabs horizontally scrollable

### DIFF
--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -37,11 +37,15 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   int get _tabCount => _hasSite ? 5 : 1;
 
   List<Tab> get _tabs => [
-        if (_hasSite) const Tab(text: 'Console'),
-        if (_hasSite) const Tab(text: 'Cookies'),
-        if (_hasSite) const Tab(text: 'Scripts'),
-        if (_hasSite) const Tab(text: 'Export'),
-        const Tab(text: 'App Logs'),
+        if (_hasSite)
+          const Tab(icon: Icon(Icons.terminal, size: 18), text: 'Console'),
+        if (_hasSite)
+          const Tab(icon: Icon(Icons.cookie_outlined, size: 18), text: 'Cookies'),
+        if (_hasSite)
+          const Tab(icon: Icon(Icons.code, size: 18), text: 'Scripts'),
+        if (_hasSite)
+          const Tab(icon: Icon(Icons.download, size: 18), text: 'Export'),
+        const Tab(icon: Icon(Icons.list_alt, size: 18), text: 'Logs'),
       ];
 
   @override
@@ -55,6 +59,8 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
             tabs: _tabs,
             isScrollable: true,
             tabAlignment: TabAlignment.start,
+            labelPadding:
+                const EdgeInsets.symmetric(horizontal: 12),
           ),
         ),
         body: TabBarView(

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -51,7 +51,11 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Developer Tools'),
-          bottom: TabBar(tabs: _tabs),
+          bottom: TabBar(
+            tabs: _tabs,
+            isScrollable: true,
+            tabAlignment: TabAlignment.start,
+          ),
         ),
         body: TabBarView(
           children: [


### PR DESCRIPTION
Set isScrollable: true and tabAlignment: TabAlignment.start on the DevTools TabBar so tabs scroll horizontally on narrow screens instead of being squished.

https://claude.ai/code/session_019vqcrLsy9kGXJznnTd5Nv7