### PR TITLE
Replace incognito checkbox with icon toggle in add site screen

### DIFF
--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -335,20 +335,19 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
                     decoration: InputDecoration(
                       labelText: 'Site URL',
                       border: OutlineInputBorder(),
+                      suffixIcon: IconButton(
+                        icon: Icon(
+                          incognito ? Icons.visibility_off : Icons.visibility_off_outlined,
+                          color: incognito ? Theme.of(context).colorScheme.primary : null,
+                        ),
+                        tooltip: incognito ? 'Incognito mode on' : 'Incognito mode off',
+                        onPressed: () {
+                          setDialogState(() {
+                            incognito = !incognito;
+                          });
+                        },
+                      ),
                     ),
-                  ),
-                  SizedBox(height: 8),
-                  CheckboxListTile(
-                    title: Text('Incognito mode'),
-                    subtitle: Text('No cookies or cache persist'),
-                    value: incognito,
-                    onChanged: (bool? value) {
-                      setDialogState(() {
-                        incognito = value ?? false;
-                      });
-                    },
-                    controlAffinity: ListTileControlAffinity.leading,
-                    contentPadding: EdgeInsets.zero,
                   ),
                 ],
               ),
@@ -449,20 +448,21 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
                         autocorrect: false,
                         enableSuggestions: false,
                         keyboardType: TextInputType.url,
-                        decoration: InputDecoration(labelText: 'Enter website URL'),
-                      ),
-                      SizedBox(height: 8),
-                      CheckboxListTile(
-                        title: Text('Incognito mode'),
-                        subtitle: Text('No cookies or cache persist'),
-                        value: _incognito,
-                        onChanged: (bool? value) {
-                          setState(() {
-                            _incognito = value ?? false;
-                          });
-                        },
-                        controlAffinity: ListTileControlAffinity.leading,
-                        contentPadding: EdgeInsets.zero,
+                        decoration: InputDecoration(
+                          labelText: 'Enter website URL',
+                          suffixIcon: IconButton(
+                            icon: Icon(
+                              _incognito ? Icons.visibility_off : Icons.visibility_off_outlined,
+                              color: _incognito ? Theme.of(context).colorScheme.primary : null,
+                            ),
+                            tooltip: _incognito ? 'Incognito mode on' : 'Incognito mode off',
+                            onPressed: () {
+                              setState(() {
+                                _incognito = !_incognito;
+                              });
+                            },
+                          ),
+                        ),
                       ),
                       SizedBox(height: 8),
                       ElevatedButton(

--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../main.dart' show extractDomain;
 import '../services/icon_service.dart' show getFaviconUrlStream, getSvgContent, onSvgContentCached, invalidateFaviconFor, IconUpdate;
@@ -337,7 +338,7 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
                       border: OutlineInputBorder(),
                       suffixIcon: IconButton(
                         icon: Icon(
-                          incognito ? Icons.visibility_off : Icons.visibility_off_outlined,
+                          incognito ? MdiIcons.incognito : MdiIcons.incognitoOff,
                           color: incognito ? Theme.of(context).colorScheme.primary : null,
                         ),
                         tooltip: incognito ? 'Incognito mode on' : 'Incognito mode off',
@@ -452,7 +453,7 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
                           labelText: 'Enter website URL',
                           suffixIcon: IconButton(
                             icon: Icon(
-                              _incognito ? Icons.visibility_off : Icons.visibility_off_outlined,
+                              _incognito ? MdiIcons.incognito : MdiIcons.incognitoOff,
                               color: _incognito ? Theme.of(context).colorScheme.primary : null,
                             ),
                             tooltip: _incognito ? 'Incognito mode on' : 'Incognito mode off',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -503,6 +503,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.11.1"
+  material_design_icons_flutter:
+    dependency: "direct main"
+    description:
+      name: material_design_icons_flutter
+      sha256: "6f986b7a51f3ad4c00e33c5c84e8de1bdd140489bbcdc8b66fc1283dad4dea5a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.7296"
   meta:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   path_provider: ^2.1.0
   encrypt: ^5.0.3
   share_plus: ^12.0.0
+  material_design_icons_flutter: ^7.0.7296
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Move incognito mode from a full CheckboxListTile row to an IconButton suffix on the URL TextField, saving vertical space. Applied to both the main add site form and the suggestion dialog.

https://claude.ai/code/session_01GHd1YcLEcmQtn8YBGTPYQH