### PR TITLE
Add info hint buttons to privacy settings in app and site settings

### DIFF
--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -9,6 +9,7 @@ import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/services/localcdn_service.dart';
 import 'package:webspace/services/webview.dart';
+import 'package:webspace/widgets/hint_button.dart';
 
 // Accent color definitions for display
 const Map<AccentColor, Color> _accentColors = {
@@ -431,7 +432,17 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
           ),
           ListTile(
             leading: const Icon(Icons.cleaning_services),
-            title: const Text('ClearURLs Rules'),
+            title: const Row(
+              children: [
+                Text('ClearURLs Rules'),
+                HintButton(
+                  title: 'ClearURLs',
+                  description:
+                      'Downloads a list of known tracking parameters used by websites (like utm_source, fbclid, etc.). '
+                      'When enabled per-site, these parameters are automatically stripped from URLs to protect your privacy.',
+                ),
+              ],
+            ),
             subtitle: Text(
               _rulesLastUpdated != null
                   ? 'Updated: ${_rulesLastUpdated!.toLocal().toString().split('.')[0]}'
@@ -453,7 +464,18 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
           // DNS Blocklist
           ListTile(
             leading: const Icon(Icons.shield),
-            title: const Text('DNS Blocklist'),
+            title: const Row(
+              children: [
+                Text('DNS Blocklist'),
+                HintButton(
+                  title: 'DNS Blocklist',
+                  description:
+                      'Downloads the Hagezi blocklist to block known advertising, tracking, and malware domains. '
+                      'Choose a severity level from Light to Ultimate. Higher levels block more domains but may break some sites. '
+                      'Once downloaded, enable or disable per-site in each site\'s settings.',
+                ),
+              ],
+            ),
             subtitle: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -530,7 +552,18 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
           if (Platform.isAndroid)
             ListTile(
               leading: const Icon(Icons.storage),
-              title: const Text('LocalCDN'),
+              title: const Row(
+                children: [
+                  Text('LocalCDN'),
+                  HintButton(
+                    title: 'LocalCDN',
+                    description:
+                        'Downloads common JavaScript libraries, fonts, and CSS frameworks to serve locally '
+                        'instead of fetching them from third-party CDN servers (like Google, Cloudflare, jsDelivr). '
+                        'This prevents CDN providers from tracking your browsing across different websites.',
+                  ),
+                ],
+              ),
               subtitle: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
@@ -588,11 +621,23 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
             child: Row(
               children: [
                 Expanded(
-                  child: Text(
-                    'Content Blocker',
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
+                  child: Row(
+                    children: [
+                      Text(
+                        'Content Blocker',
+                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                      ),
+                      const HintButton(
+                        title: 'Content Blocker',
+                        description:
+                            'Blocks ads, trackers, and unwanted page elements using filter lists like EasyList. '
+                            'Supports domain-level blocking, CSS cosmetic filters to hide page elements, '
+                            'and text-based hiding rules. Enable or disable individual filter lists below, '
+                            'and toggle content blocking per-site in each site\'s settings.',
+                      ),
+                    ],
                   ),
                 ),
                 if (ContentBlockerService.instance.lists

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -10,6 +10,7 @@ import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/services/localcdn_service.dart';
 import 'package:webspace/screens/user_scripts.dart';
+import 'package:webspace/widgets/hint_button.dart';
 
 // Supported languages for webview
 const List<MapEntry<String?, String>> _languages = [
@@ -446,7 +447,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
             },
           ),
           SwitchListTile(
-            title: const Text('ClearURLs'),
+            title: Row(
+              children: [
+                const Text('ClearURLs'),
+                const HintButton(
+                  title: 'ClearURLs',
+                  description:
+                      'Removes tracking parameters (like utm_source, fbclid) from URLs before loading them. '
+                      'This helps protect your privacy by preventing sites from tracking where you came from.',
+                ),
+              ],
+            ),
             subtitle: const Text('Strip tracking parameters from URLs'),
             value: _clearUrlEnabled,
             onChanged: (bool value) {
@@ -456,7 +467,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
             },
           ),
           SwitchListTile(
-            title: const Text('DNS Blocklist'),
+            title: Row(
+              children: [
+                const Text('DNS Blocklist'),
+                const HintButton(
+                  title: 'DNS Blocklist',
+                  description:
+                      'Blocks known advertising, tracking, and malware domains at the DNS level before they can load. '
+                      'Uses the Hagezi blocklist with configurable severity levels. '
+                      'Configure the blocklist level in App Settings.',
+                ),
+              ],
+            ),
             subtitle: Text(
               DnsBlockService.instance.hasBlocklist
                   ? dnsBlockLevelNames[DnsBlockService.instance.level]
@@ -472,7 +494,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 : null,
           ),
           SwitchListTile(
-            title: const Text('Content Blocker'),
+            title: Row(
+              children: [
+                const Flexible(child: Text('Content Blocker')),
+                const HintButton(
+                  title: 'Content Blocker',
+                  description:
+                      'Blocks ads, trackers, and unwanted content using filter lists (like EasyList). '
+                      'Supports domain blocking, CSS cosmetic filters, and text-based hiding rules. '
+                      'Manage filter lists in App Settings.',
+                ),
+              ],
+            ),
             subtitle: Text(
               ContentBlockerService.instance.hasRules
                   ? '${ContentBlockerService.instance.totalRuleCount} rules'
@@ -511,7 +544,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ),
           if (Platform.isAndroid)
             SwitchListTile(
-              title: const Text('LocalCDN'),
+              title: Row(
+                children: [
+                  const Text('LocalCDN'),
+                  const HintButton(
+                    title: 'LocalCDN',
+                    description:
+                        'Serves common CDN resources (JavaScript libraries, fonts, CSS frameworks) from a local cache '
+                        'instead of fetching them from third-party CDN servers. '
+                        'This prevents CDN providers from tracking your browsing activity across sites.',
+                  ),
+                ],
+              ),
               subtitle: Text(
                 LocalCdnService.instance.hasCache
                     ? '${LocalCdnService.instance.resourceCount} cached resources'
@@ -525,7 +569,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
               },
             ),
           SwitchListTile(
-            title: const Text('Block auto-redirects'),
+            title: Row(
+              children: [
+                const Flexible(child: Text('Block auto-redirects')),
+                const HintButton(
+                  title: 'Block Auto-Redirects',
+                  description:
+                      'Prevents scripts from automatically navigating you to a different domain. '
+                      'This helps avoid being silently redirected to tracking or advertising pages.',
+                ),
+              ],
+            ),
             subtitle: const Text('Block script-initiated cross-domain navigations'),
             value: _blockAutoRedirects,
             onChanged: (bool value) {

--- a/lib/widgets/hint_button.dart
+++ b/lib/widgets/hint_button.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+/// A small info icon button that shows a descriptive tooltip dialog.
+class HintButton extends StatelessWidget {
+  final String title;
+  final String description;
+
+  const HintButton({
+    super.key,
+    required this.title,
+    required this.description,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: Icon(
+        Icons.info_outline,
+        size: 20,
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
+      ),
+      tooltip: title,
+      padding: EdgeInsets.zero,
+      constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+      onPressed: () {
+        showDialog(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: Text(title),
+            content: ConstrainedBox(
+              constraints: BoxConstraints(
+                maxWidth: MediaQuery.of(context).size.width * 0.8,
+              ),
+              child: SingleChildScrollView(
+                child: Text(description),
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('OK'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
Adds a reusable HintButton widget (info icon) that shows a description dialog when tapped. Applied to ClearURLs, DNS Blocklist, Content Blocker, LocalCDN, and Block Auto-Redirects in both site settings and app settings. Dialog uses ConstrainedBox + SingleChildScrollView to prevent overflow on small devices.

https://claude.ai/code/session_013CcqduqwLdkpEYvFR5hFw3