### PR TITLE
Add cdnjs MIT license to Flutter license registry for LocalCDN feature

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -499,6 +499,35 @@ Source: https://easylist.to/''',
     );
   });
 
+  LicenseRegistry.addLicense(() async* {
+    yield const LicenseEntryWithLineBreaks(
+      ['cdnjs (LocalCDN resource data)'],
+      '''MIT License
+
+Copyright (c) cdnjs contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Source: https://github.com/cdnjs/cdnjs''',
+    );
+  });
+
   // Initialize platform info to detect proxy support before UI loads
   await PlatformInfo.initialize();
   runApp(WebSpaceApp());


### PR DESCRIPTION
The LocalCDN feature downloads resources from cdnjs.cloudflare.com. The cdnjs project is MIT licensed and should be attributed in the app's license page.

https://claude.ai/code/session_01VybfxdSzPW8gfGKKHHfFfr