### PR TITLE
Clean tracking params from shared/copied URLs via ClearURLs

### DIFF
--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -436,6 +436,75 @@ String _themeInjectionScript(String themeValue) => '''
 })();
 ''';
 
+/// JavaScript that intercepts clipboard writes and Web Share API calls to clean
+/// tracking parameters from URLs before they leave the webview. Sends URLs to
+/// Dart via the 'clearUrl' handler for cleaning with ClearURLs rules.
+const String _clearUrlShareScript = r'''
+(function() {
+  const URL_RE = /^https?:\/\//i;
+
+  // Intercept navigator.clipboard.writeText
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    const origWriteText = navigator.clipboard.writeText.bind(navigator.clipboard);
+    navigator.clipboard.writeText = async function(text) {
+      if (typeof text === 'string' && URL_RE.test(text.trim())) {
+        try {
+          const cleaned = await window.flutter_inappwebview.callHandler('clearUrl', text.trim());
+          if (typeof cleaned === 'string' && cleaned.length > 0) {
+            text = cleaned;
+          }
+        } catch (e) {}
+      }
+      return origWriteText(text);
+    };
+  }
+
+  // Intercept navigator.share (Web Share API)
+  if (navigator.share) {
+    const origShare = navigator.share.bind(navigator);
+    navigator.share = async function(data) {
+      if (data && typeof data === 'object') {
+        const cleaned = Object.assign({}, data);
+        if (typeof cleaned.url === 'string' && URL_RE.test(cleaned.url)) {
+          try {
+            const r = await window.flutter_inappwebview.callHandler('clearUrl', cleaned.url);
+            if (typeof r === 'string' && r.length > 0) cleaned.url = r;
+          } catch (e) {}
+        }
+        if (typeof cleaned.text === 'string' && URL_RE.test(cleaned.text.trim())) {
+          try {
+            const r = await window.flutter_inappwebview.callHandler('clearUrl', cleaned.text.trim());
+            if (typeof r === 'string' && r.length > 0) cleaned.text = r;
+          } catch (e) {}
+        }
+        return origShare(cleaned);
+      }
+      return origShare(data);
+    };
+  }
+
+  // Intercept document.execCommand('copy') by cleaning selected text if it's a URL
+  const origExecCommand = document.execCommand.bind(document);
+  document.execCommand = function(command, showUI, value) {
+    if (command === 'copy') {
+      const selection = window.getSelection();
+      if (selection && selection.toString) {
+        const text = selection.toString().trim();
+        if (URL_RE.test(text)) {
+          // Use async clipboard API to write the cleaned URL instead
+          window.flutter_inappwebview.callHandler('clearUrl', text).then(function(cleaned) {
+            if (typeof cleaned === 'string' && cleaned.length > 0 && cleaned !== text) {
+              navigator.clipboard.writeText(cleaned).catch(function() {});
+            }
+          }).catch(function() {});
+        }
+      }
+    }
+    return origExecCommand(command, showUI, value);
+  };
+})();
+''';
+
 /// Factory for creating webviews
 class WebViewFactory {
   /// Determine if a navigation was triggered by a user gesture.
@@ -550,6 +619,16 @@ class WebViewFactory {
       }
     }
 
+    // ClearURLs: intercept clipboard writes and Web Share API to clean tracking
+    // parameters from shared URLs before they leave the webview.
+    if (config.clearUrlEnabled) {
+      userScripts.add(inapp.UserScript(
+        groupName: 'clearurl_share',
+        source: _clearUrlShareScript,
+        injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
+      ));
+    }
+
     // Inject per-site user scripts
     for (final script in config.userScripts) {
       if (!script.enabled || script.source.isEmpty) continue;
@@ -604,6 +683,15 @@ class WebViewFactory {
       onWebViewCreated: (controller) async {
         final wrappedController = _WebViewController(controller);
         onControllerCreated(wrappedController);
+        // Register ClearURLs handler for clipboard/share URL cleaning
+        if (config.clearUrlEnabled) {
+          controller.addJavaScriptHandler(handlerName: 'clearUrl', callback: (args) {
+            if (args.isNotEmpty && args[0] is String) {
+              return ClearUrlService.instance.cleanUrl(args[0] as String);
+            }
+            return args.isNotEmpty ? args[0] : '';
+          });
+        }
         // If we loaded cached HTML, navigate to the real URL when online
         if (usesCachedHtml) {
           final online = await ConnectivityService.instance.isOnline();
@@ -686,6 +774,10 @@ class WebViewFactory {
           if (script != null) {
             await controller.evaluateJavascript(source: script);
           }
+        }
+        // Re-inject ClearURLs share script for in-page navigations
+        if (config.clearUrlEnabled) {
+          await controller.evaluateJavascript(source: _clearUrlShareScript);
         }
       },
       onLoadStop: (controller, url) async {

--- a/openspec/specs/clearurls/spec.md
+++ b/openspec/specs/clearurls/spec.md
@@ -162,6 +162,37 @@ Each site SHALL have a `clearUrlEnabled` setting (default: true) that controls w
 
 ---
 
+### Requirement: CURL-013 - Clean Shared/Copied URLs
+
+When ClearURLs is enabled, URLs copied to clipboard or shared via the Web Share API from within a webview SHALL have tracking parameters stripped.
+
+#### Scenario: Copy share link from site
+
+**Given** ClearURLs is enabled for the site and rules are loaded
+**When** the user clicks a "Share" or "Copy Link" button inside a website (e.g., Reddit share button)
+**And** the site writes a URL with tracking parameters to the clipboard
+**Then** the tracking parameters are stripped before the URL reaches the clipboard
+
+#### Scenario: Web Share API
+
+**Given** ClearURLs is enabled and rules are loaded
+**When** the site calls `navigator.share()` with a URL containing tracking parameters
+**Then** the URL is cleaned before being passed to the native share sheet
+
+#### Scenario: document.execCommand('copy') with URL
+
+**Given** ClearURLs is enabled and rules are loaded
+**When** the site uses `document.execCommand('copy')` and the selected text is a URL
+**Then** the clipboard receives the cleaned URL
+
+#### Scenario: ClearURLs disabled
+
+**Given** ClearURLs is disabled for the site
+**When** the user copies a URL via any method
+**Then** the URL is not modified
+
+---
+
 ### Requirement: CURL-009 - Idempotent Cleaning
 
 Cleaning SHALL be idempotent: applying `cleanUrl()` to an already-cleaned URL SHALL return the same URL, preventing redirect loops.
@@ -279,6 +310,15 @@ shouldOverrideUrlLoading: (controller, navigationAction) async {
 
 No redirect loops occur because `cleanUrl()` is idempotent — a cleaned URL produces the same output when cleaned again.
 
+### Clipboard/Share URL Cleaning
+
+A JavaScript snippet (`_clearUrlShareScript`) is injected at `DOCUMENT_START` that intercepts:
+- `navigator.clipboard.writeText()` — overridden to send URLs to Dart for cleaning via `callHandler('clearUrl', url)` before writing
+- `navigator.share()` — overridden to clean URLs in `data.url` and `data.text` fields
+- `document.execCommand('copy')` — overridden to detect copied URLs and replace with cleaned version via async clipboard API
+
+The Dart-side handler is registered in `onWebViewCreated` via `addJavaScriptHandler(handlerName: 'clearUrl')`, which calls `ClearUrlService.instance.cleanUrl()`. The script is re-injected in `onLoadStart` for in-page navigations.
+
 ### Rules File Storage
 
 - Cached at `getApplicationDocumentsDirectory()/clearurl_rules.json`
@@ -351,3 +391,5 @@ ClearURL service tests cover:
 6. Navigate to the same URL with tracking params
 7. Verify parameters are preserved
 8. Check Licenses page shows "ClearURLs (rules data)" with LGPL-3.0
+9. **Share URL cleaning**: Open Reddit (or similar site with share buttons), click "Share" on a post, paste the copied URL — verify tracking parameters (utm_source, share_id, etc.) are stripped
+10. Disable ClearURLs for the site, repeat step 9 — verify tracking parameters are preserved


### PR DESCRIPTION
When sites use clipboard.writeText, navigator.share, or execCommand('copy') to share URLs (e.g. Reddit share button), inject JS that intercepts these APIs and sends URLs to Dart's ClearUrlService for cleaning before they reach the clipboard or share sheet. The script is injected at document start and re-injected on in-page navigations.

https://claude.ai/code/session_01GDz7VJAk6fNAFZnhnkB2un