### PR TITLE
Fix drawer not opening when selecting webspace

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/13.txt
+++ b/fastlane/metadata/android/en-US/changelogs/13.txt
@@ -1,0 +1,2 @@
+🐛 Bug Fixes:
+• Fixed drawer not opening when tapping a webspace due to a race condition with async network check

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1153,12 +1153,16 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       _selectedWebspaceId = webspace.id;
     });
 
+    // Open drawer immediately so the user sees instant feedback on tap
+    _scaffoldKey.currentState?.openDrawer();
+
     // Get indices in the new webspace
     final newIndices = _getFilteredSiteIndices().toSet();
 
     // Only unload sites when online - preserve live webviews when offline
     // so users can still view cached content
     final online = await ConnectivityService.instance.isOnline();
+    if (!mounted) return;
 
     if (online) {
       // Find loaded sites that were in previous webspace but not in new one
@@ -1179,11 +1183,10 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     }
 
     await _setCurrentIndex(null);
+    if (!mounted) return;
     setState(() {}); // Update UI
     _saveSelectedWebspaceId();
     _saveCurrentIndex();
-    // Open drawer after selecting workspace
-    _scaffoldKey.currentState?.openDrawer();
   }
 
   void _reorderWebspaces(int oldIndex, int newIndex) {


### PR DESCRIPTION
openDrawer() was called after a DNS lookup (up to 3s timeout) and multiple async gaps/setState calls, causing it to silently fail due to race conditions with Flutter's build cycle. Move openDrawer() to before the async work so it fires immediately on tap, giving instant feedback. Add mounted guards after awaits to prevent setState on a disposed widget.

https://claude.ai/code/session_018JAPN7zt9Fekdr8MCq9EMZ