### PR TITLE
Fix race condition in AccentLogo causing wrong accent color on iOS

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -298,7 +298,7 @@ class _AccentLogoState extends State<AccentLogo> {
     final processed = await completer.future;
     _cache[key] = processed;
 
-    if (mounted) {
+    if (mounted && _cacheKey == key) {
       setState(() => _image = processed);
     }
   }


### PR DESCRIPTION
Concurrent _loadAndProcess() calls (e.g. during widget rebuild) would race: a stale async completion could overwrite _image with the wrong (old) accent/brightness result because only `mounted` was checked, not whether the captured cache key still matched the widget's current state.

Guard the final setState with `_cacheKey == key` so stale completions are discarded.

https://claude.ai/code/session_01GdRPNEAtUWWnDXnSApCqmz