### PR TITLE
Add site icon preview in URL field (#136)

### DIFF
--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -289,6 +292,79 @@ class AddSiteScreen extends StatefulWidget {
 class _AddSiteScreenState extends State<AddSiteScreen> {
   final TextEditingController _urlController = TextEditingController();
   bool _incognito = false;
+  Timer? _debounceTimer;
+  String? _previewUrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _urlController.addListener(_onUrlChanged);
+  }
+
+  @override
+  void dispose() {
+    _debounceTimer?.cancel();
+    _urlController.removeListener(_onUrlChanged);
+    _urlController.dispose();
+    super.dispose();
+  }
+
+  void _onUrlChanged() {
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(const Duration(milliseconds: 600), () {
+      _updatePreview();
+    });
+  }
+
+  /// Check if a host is an IP address or localhost (no DNS needed)
+  bool _isDirectHost(String host) {
+    return host == 'localhost' ||
+        host.contains(':') || // IPv6
+        RegExp(r'^(\d{1,3}\.){3}\d{1,3}$').hasMatch(host); // IPv4
+  }
+
+  Future<void> _updatePreview() async {
+    final text = _urlController.text.trim();
+    if (text.isEmpty) {
+      if (_previewUrl != null) {
+        setState(() => _previewUrl = null);
+      }
+      return;
+    }
+
+    String url = text;
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      url = 'https://$url';
+    }
+
+    final uri = Uri.tryParse(url);
+    if (uri == null || uri.host.isEmpty ||
+        !(uri.host.contains('.') || uri.host.contains(':') || uri.host == 'localhost')) {
+      if (_previewUrl != null) {
+        setState(() => _previewUrl = null);
+      }
+      return;
+    }
+
+    // Skip DNS check for IP addresses and localhost
+    if (!_isDirectHost(uri.host)) {
+      try {
+        await InternetAddress.lookup(uri.host);
+      } catch (_) {
+        // DNS lookup failed — domain doesn't exist
+        if (mounted && _previewUrl != null) {
+          setState(() => _previewUrl = null);
+        }
+        return;
+      }
+    }
+
+    if (!mounted) return;
+    final newPreview = '${uri.scheme}://${uri.host}';
+    if (_previewUrl != newPreview) {
+      setState(() => _previewUrl = newPreview);
+    }
+  }
 
   static const List<SiteSuggestion> _suggestions = [
     SiteSuggestion(name: 'DuckDuckGo', url: 'https://duckduckgo.com', domain: 'duckduckgo.com'),
@@ -451,6 +527,19 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
                         keyboardType: TextInputType.url,
                         decoration: InputDecoration(
                           labelText: 'Enter website URL',
+                          prefixIcon: _previewUrl != null
+                              ? Padding(
+                                  padding: const EdgeInsets.all(12.0),
+                                  child: SizedBox(
+                                    width: 24,
+                                    height: 24,
+                                    child: UnifiedFaviconImage(
+                                      url: _previewUrl!,
+                                      size: 24,
+                                    ),
+                                  ),
+                                )
+                              : null,
                           suffixIcon: IconButton(
                             icon: Icon(
                               _incognito ? MdiIcons.incognito : MdiIcons.incognitoOff,


### PR DESCRIPTION
* Add site icon preview in URL field with debounced validation

Shows a favicon preview as a prefix icon in the "Add new site" URL text field. After the user pauses typing for 600ms, the input is validated as a proper domain (with a TLD of 2+ letters), and the existing UnifiedFaviconImage widget fetches/displays the favicon.

https://claude.ai/code/session_01LuLBbZTzn94CAR9Qiz6R1W

* Allow icon preview for IP addresses and localhost

The icon service's favicon package (Phase 3) fetches icons from HTML for all URLs including IPs and localhost, so the preview should also accept these hosts rather than restricting to domain names only.

https://claude.ai/code/session_01LuLBbZTzn94CAR9Qiz6R1W

* Simplify URL preview to use Uri.tryParse like the rest of the app

Remove custom regex validation — just check that Uri.tryParse produces a non-empty host, which is the same gate the app uses when actually adding a site.

https://claude.ai/code/session_01LuLBbZTzn94CAR9Qiz6R1W

* Require a dot or localhost for icon preview

Bare words like 'asdf' parse as valid URIs but aren't real sites. Require the host to contain a dot (e.g. github.com, 192.168.1.1) or be 'localhost' before showing the preview.

https://claude.ai/code/session_01LuLBbZTzn94CAR9Qiz6R1W

* Support IPv6 addresses in icon preview

Dart's Uri.tryParse strips brackets from IPv6 hosts (e.g. [::1] becomes ::1), so check for colons in the host as well.

https://claude.ai/code/session_01LuLBbZTzn94CAR9Qiz6R1W

* Skip icon preview for domains with no DNS record

Performs a DNS lookup before fetching the favicon, so non-existent domains like asdfasdf.com don't trigger unnecessary icon requests. IP addresses and localhost skip the DNS check since they don't need name resolution.

https://claude.ai/code/session_01LuLBbZTzn94CAR9Qiz6R1W

---------