### PR TITLE
Split ABI version codes for F-Droid compatibility

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -93,6 +93,16 @@ android {
     }
 }
 
+def abiCodes = ["armeabi-v7a": 1, "arm64-v8a": 2, "x86_64": 3]
+android.applicationVariants.configureEach { variant ->
+    variant.outputs.forEach { output ->
+        def abiVersionCode = abiCodes.get(output.getFilter(com.android.build.OutputFile.ABI))
+        if (abiVersionCode != null) {
+            output.versionCodeOverride = variant.versionCode * 10 + abiVersionCode
+        }
+    }
+}
+
 flutter {
     source '../..'
 }


### PR DESCRIPTION
Multiply base versionCode by 10 and add ABI suffix (1=armeabi-v7a, 2=arm64-v8a, 3=x86_64) so each split APK gets a unique version code.

https://claude.ai/code/session_01SvzYdQqBmK1p6svXTuZGcg