### PR TITLE
Standardize ClearURLs icon to match other settings

### DIFF
--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -455,8 +455,14 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
                     child: CircularProgressIndicator(strokeWidth: 2),
                   )
                 : IconButton(
-                    icon: const Icon(Icons.download),
-                    tooltip: 'Download rules',
+                    icon: Icon(
+                      _rulesLastUpdated != null
+                          ? Icons.sync
+                          : Icons.download,
+                    ),
+                    tooltip: _rulesLastUpdated != null
+                        ? 'Update rules'
+                        : 'Download rules',
                     onPressed: _downloadRules,
                   ),
           ),


### PR DESCRIPTION
ClearURLs always showed a download icon, while DNS Blocklist, LocalCDN, and Content Blocker show sync when already downloaded and download when not yet downloaded. Now ClearURLs follows the same pattern.

https://claude.ai/code/session_01CnCzftXsfHGFNn5gqdHRwB