### PR TITLE
Fix nav bar refresh invalidating favicon cache unnecessarily

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1577,11 +1577,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                         tooltip: 'Refresh',
                         onPressed: () {
                           Navigator.pop(context);
-                          () async {
-                            getController()?.reload();
-                            await FaviconUrlCache.invalidate(_webViewModels[_currentIndex!].initUrl);
-                            setState(() {});
-                          }();
+                          getController()?.reload();
                         },
                       ),
                     ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1944,10 +1944,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         children: [
           IconButton(
             icon: Icon(Icons.refresh),
-            tooltip: 'Refresh title',
+            tooltip: 'Refresh title and icon',
             iconSize: 20,
             onPressed: () async {
               final url = _webViewModels[index].initUrl;
+              await FaviconUrlCache.invalidate(url);
+              if (!mounted) return;
               final title = await getPageTitle(url);
               if (!mounted) return;
               if (index >= _webViewModels.length) return;
@@ -1961,6 +1963,8 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(content: Text('Title updated to: $title')),
                 );
+              } else {
+                setState(() {});
               }
             },
           ),

--- a/openspec/specs/icon-fetching/spec.md
+++ b/openspec/specs/icon-fetching/spec.md
@@ -150,6 +150,13 @@ Fetched icons SHALL be cached to avoid redundant network requests.
 **Then** only the page is reloaded
 **And** the cached favicon is NOT re-fetched
 
+#### Scenario: Drawer refresh invalidates icon cache
+
+**Given** a site has a cached favicon
+**When** the user taps the refresh button in the drawer site list
+**Then** the favicon cache is invalidated and the icon is re-fetched
+**And** the page title is also refreshed
+
 ---
 
 ## Performance

--- a/openspec/specs/icon-fetching/spec.md
+++ b/openspec/specs/icon-fetching/spec.md
@@ -143,6 +143,13 @@ Fetched icons SHALL be cached to avoid redundant network requests.
 **When** the icon is requested again
 **Then** the cached result is returned immediately
 
+#### Scenario: Page refresh does not invalidate icon cache
+
+**Given** a site has a cached favicon
+**When** the user refreshes the page from the nav bar
+**Then** only the page is reloaded
+**And** the cached favicon is NOT re-fetched
+
 ---
 
 ## Performance


### PR DESCRIPTION
The nav bar refresh button was clearing the favicon cache and re-fetching icons on every page refresh. This caused icons to get stuck loading when offline. Nav bar refresh should only reload the page, not the icon.

https://claude.ai/code/session_01VmpyMU9k1JKwwSB5XfncYr