### PR TITLE
Make suggested sites list configurable with empty default for fdroid

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,5 +105,6 @@ Detailed feature specs are in `openspec/specs/`. Each spec uses Given/When/Then 
 | developer-tools | In-app dev tools: JS console, cookie inspector, HTML export, app logs |
 | localcdn | LocalCDN - cache CDN resources locally to prevent CDN tracking (Android) |
 | user-scripts | Per-site custom JavaScript injection with injection timing control |
+| configurable-suggested-sites | Configurable suggested sites list with empty default for fdroid flavor |
 
 Read the relevant spec before modifying a feature. Specs include file paths, data models, and manual test procedures.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,7 @@ import 'package:html/dom.dart' as html_dom;
 import 'package:webspace/web_view_model.dart';
 import 'package:webspace/webspace_model.dart';
 import 'package:webspace/services/webview.dart';
-import 'package:webspace/screens/add_site.dart' show AddSiteScreen, UnifiedFaviconImage, FaviconUrlCache;
+import 'package:webspace/screens/add_site.dart' show AddSiteScreen, UnifiedFaviconImage, FaviconUrlCache, SiteSuggestion;
 import 'package:webspace/screens/settings.dart';
 import 'package:webspace/screens/app_settings.dart';
 import 'package:webspace/services/icon_service.dart';
@@ -38,6 +38,7 @@ import 'package:webspace/services/localcdn_service.dart';
 import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/shortcut_service.dart';
 import 'package:webspace/services/log_service.dart';
+import 'package:webspace/services/suggested_sites_service.dart' as suggested_sites;
 import 'package:webspace/screens/dev_tools.dart';
 import 'package:webspace/settings/proxy.dart';
 import 'package:share_plus/share_plus.dart';
@@ -604,6 +605,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   // Only webviews in this set will be created - others remain as placeholders
   final Set<int> _loadedIndices = {};
 
+  // Configurable suggested sites
+  List<SiteSuggestion> _suggestedSites = [];
+
   @override
   void initState() {
     super.initState();
@@ -991,6 +995,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     });
     await _loadWebspaces();
     await _loadWebViewModels();
+    _suggestedSites = await suggested_sites.getEffectiveSuggestedSites();
 
     // Always start at home screen on launch - only restore index if launched via shortcut
     int? indexToRestore;
@@ -1269,6 +1274,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       showUrlBar: _showUrlBar,
       selectedWebspaceId: _selectedWebspaceId,
       currentIndex: _currentIndex,
+      suggestedSites: _suggestedSites
+          .map((s) => {'name': s.name, 'url': s.url, 'domain': s.domain})
+          .toList(),
     );
   }
 
@@ -1376,6 +1384,18 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await _saveShowUrlBar();
     await _saveSelectedWebspaceId();
     await _saveCurrentIndex();
+
+    // Restore suggested sites if present in backup
+    if (backup.suggestedSites != null) {
+      _suggestedSites = backup.suggestedSites!
+          .map((e) => SiteSuggestion(
+                name: e['name'] as String,
+                url: e['url'] as String,
+                domain: e['domain'] as String,
+              ))
+          .toList();
+      await suggested_sites.saveSuggestedSites(_suggestedSites);
+    }
 
     // Clean up orphaned cookies and HTML cache (for siteIds no longer in any site)
     final activeSiteIds = _webViewModels
@@ -1764,6 +1784,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
             for (var webViewModel in _webViewModels) {
               await webViewModel.setTheme(webViewTheme);
             }
+          },
+          suggestions: _suggestedSites,
+          onSuggestionsChanged: (sites) {
+            _suggestedSites = sites;
+            suggested_sites.saveSuggestedSites(sites);
           },
         ),
       ),

--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -279,10 +279,14 @@ class FaviconImage extends StatelessWidget {
 class AddSiteScreen extends StatefulWidget {
   final ThemeMode themeMode;
   final Function(ThemeMode) onThemeModeChanged;
+  final List<SiteSuggestion> suggestions;
+  final Function(List<SiteSuggestion>) onSuggestionsChanged;
 
   AddSiteScreen({
     required this.themeMode,
     required this.onThemeModeChanged,
+    required this.suggestions,
+    required this.onSuggestionsChanged,
   });
 
   @override
@@ -294,10 +298,12 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
   bool _incognito = false;
   Timer? _debounceTimer;
   String? _previewUrl;
+  late List<SiteSuggestion> _suggestions;
 
   @override
   void initState() {
     super.initState();
+    _suggestions = List.of(widget.suggestions);
     _urlController.addListener(_onUrlChanged);
   }
 
@@ -366,29 +372,79 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
     }
   }
 
-  static const List<SiteSuggestion> _suggestions = [
-    SiteSuggestion(name: 'DuckDuckGo', url: 'https://duckduckgo.com', domain: 'duckduckgo.com'),
-    SiteSuggestion(name: 'Claude', url: 'https://claude.ai', domain: 'claude.ai'),
-    SiteSuggestion(name: 'ChatGPT', url: 'https://chatgpt.com', domain: 'chatgpt.com'),
-    SiteSuggestion(name: 'Perplexity', url: 'https://perplexity.ai', domain: 'perplexity.ai'),
-    SiteSuggestion(name: 'Instagram', url: 'https://instagram.com', domain: 'instagram.com'),
-    SiteSuggestion(name: 'Facebook', url: 'https://facebook.com', domain: 'facebook.com'),
-    SiteSuggestion(name: 'X (Twitter)', url: 'https://x.com', domain: 'x.com'),
-    SiteSuggestion(name: 'Google Chat', url: 'https://chat.google.com', domain: 'chat.google.com'),
-    SiteSuggestion(name: 'GitHub', url: 'https://github.com', domain: 'github.com'),
-    SiteSuggestion(name: 'GitLab', url: 'https://gitlab.com', domain: 'gitlab.com'),
-    SiteSuggestion(name: 'Gitea', url: 'https://gitea.com', domain: 'gitea.com'),
-    SiteSuggestion(name: 'Codeberg', url: 'https://codeberg.org', domain: 'codeberg.org'),
-    SiteSuggestion(name: 'Slack', url: 'https://slack.com', domain: 'slack.com'),
-    SiteSuggestion(name: 'Discord', url: 'https://discord.com/login', domain: 'discord.com'),
-    SiteSuggestion(name: 'Mattermost', url: 'https://mattermost.com', domain: 'mattermost.com'),
-    SiteSuggestion(name: 'Gmail', url: 'https://gmail.com', domain: 'gmail.com'),
-    SiteSuggestion(name: 'LinkedIn', url: 'https://linkedin.com', domain: 'linkedin.com'),
-    SiteSuggestion(name: 'Reddit', url: 'https://reddit.com', domain: 'reddit.com'),
-    SiteSuggestion(name: 'Mastodon', url: 'https://mastodon.social', domain: 'mastodon.social'),
-    SiteSuggestion(name: 'Bluesky', url: 'https://bsky.app', domain: 'bsky.app'),
-    SiteSuggestion(name: 'Hugging Face', url: 'https://huggingface.co', domain: 'huggingface.co'),
-  ];
+  void _removeSuggestion(int index) {
+    setState(() {
+      _suggestions.removeAt(index);
+    });
+    widget.onSuggestionsChanged(_suggestions);
+  }
+
+  void _showAddSuggestionDialog() {
+    final nameController = TextEditingController();
+    final urlController = TextEditingController();
+
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text('Add Suggested Site'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: nameController,
+                decoration: InputDecoration(
+                  labelText: 'Name',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              SizedBox(height: 8),
+              TextField(
+                controller: urlController,
+                autocorrect: false,
+                enableSuggestions: false,
+                keyboardType: TextInputType.url,
+                decoration: InputDecoration(
+                  labelText: 'URL',
+                  border: OutlineInputBorder(),
+                  hintText: 'https://example.com',
+                ),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: Text('Cancel'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                final name = nameController.text.trim();
+                var url = urlController.text.trim();
+                if (name.isEmpty || url.isEmpty) return;
+                if (!url.startsWith('http://') && !url.startsWith('https://')) {
+                  url = 'https://$url';
+                }
+                final uri = Uri.tryParse(url);
+                if (uri == null || uri.host.isEmpty) return;
+                final suggestion = SiteSuggestion(
+                  name: name,
+                  url: url,
+                  domain: uri.host,
+                );
+                Navigator.of(context).pop();
+                setState(() {
+                  _suggestions.add(suggestion);
+                });
+                widget.onSuggestionsChanged(_suggestions);
+              },
+              child: Text('Add'),
+            ),
+          ],
+        );
+      },
+    );
+  }
 
   void _showSuggestionDialog(SiteSuggestion suggestion) {
     final TextEditingController urlController = TextEditingController(text: suggestion.url);
@@ -573,65 +629,112 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
                         textAlign: TextAlign.center,
                       ),
                       SizedBox(height: 24),
-                      Text(
-                        'Suggested Sites',
-                        style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              'Suggested Sites',
+                              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                            ),
+                          ),
+                          IconButton(
+                            icon: Icon(Icons.add, size: 20),
+                            tooltip: 'Add suggested site',
+                            onPressed: _showAddSuggestionDialog,
+                            visualDensity: VisualDensity.compact,
+                          ),
+                        ],
                       ),
                       SizedBox(height: 12),
                     ],
                   ),
                 ),
-                SliverGrid(
-                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 4,
-                    crossAxisSpacing: 12,
-                    mainAxisSpacing: 12,
-                    childAspectRatio: 1,
-                  ),
-                  delegate: SliverChildBuilderDelegate(
-                    (context, index) {
-                      final suggestion = _suggestions[index];
-                      return InkWell(
-                        onTap: () => _showSuggestionDialog(suggestion),
-                        borderRadius: BorderRadius.circular(12),
-                        child: Container(
-                          decoration: BoxDecoration(
-                            color: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.5),
-                            borderRadius: BorderRadius.circular(12),
-                            border: Border.all(
-                              color: Theme.of(context).colorScheme.outline.withOpacity(0.2),
+                if (_suggestions.isNotEmpty)
+                  SliverGrid(
+                    gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 4,
+                      crossAxisSpacing: 12,
+                      mainAxisSpacing: 12,
+                      childAspectRatio: 1,
+                    ),
+                    delegate: SliverChildBuilderDelegate(
+                      (context, index) {
+                        final suggestion = _suggestions[index];
+                        return InkWell(
+                          onTap: () => _showSuggestionDialog(suggestion),
+                          onLongPress: () {
+                            showDialog(
+                              context: context,
+                              builder: (context) => AlertDialog(
+                                title: Text('Remove ${suggestion.name}?'),
+                                content: Text('Remove this site from suggestions?'),
+                                actions: [
+                                  TextButton(
+                                    onPressed: () => Navigator.of(context).pop(),
+                                    child: Text('Cancel'),
+                                  ),
+                                  TextButton(
+                                    onPressed: () {
+                                      Navigator.of(context).pop();
+                                      _removeSuggestion(index);
+                                    },
+                                    child: Text('Remove'),
+                                  ),
+                                ],
+                              ),
+                            );
+                          },
+                          borderRadius: BorderRadius.circular(12),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.5),
+                              borderRadius: BorderRadius.circular(12),
+                              border: Border.all(
+                                color: Theme.of(context).colorScheme.outline.withOpacity(0.2),
+                              ),
                             ),
-                          ),
-                          child: Padding(
-                            padding: const EdgeInsets.all(4.0),
-                            child: Column(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Expanded(
-                                  child: Center(
-                                    child: FaviconImage(
-                                      domain: suggestion.domain,
-                                      size: iconSize,
+                            child: Padding(
+                              padding: const EdgeInsets.all(4.0),
+                              child: Column(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Expanded(
+                                    child: Center(
+                                      child: FaviconImage(
+                                        domain: suggestion.domain,
+                                        size: iconSize,
+                                      ),
                                     ),
                                   ),
-                                ),
-                                SizedBox(height: 2),
-                                Text(
-                                  suggestion.name,
-                                  style: TextStyle(fontSize: 10),
-                                  textAlign: TextAlign.center,
-                                  maxLines: 2,
-                                  overflow: TextOverflow.ellipsis,
-                                ),
-                              ],
+                                  SizedBox(height: 2),
+                                  Text(
+                                    suggestion.name,
+                                    style: TextStyle(fontSize: 10),
+                                    textAlign: TextAlign.center,
+                                    maxLines: 2,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ],
+                              ),
                             ),
                           ),
-                        ),
-                      );
-                    },
-                    childCount: _suggestions.length,
+                        );
+                      },
+                      childCount: _suggestions.length,
+                    ),
                   ),
-                ),
+                if (_suggestions.isEmpty)
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 24.0),
+                      child: Center(
+                        child: Text(
+                          'No suggested sites. Tap + to add some.',
+                          style: TextStyle(color: Colors.grey),
+                        ),
+                      ),
+                    ),
+                  ),
                 SliverPadding(
                   padding: EdgeInsets.only(
                     bottom: MediaQuery.of(context).padding.bottom,

--- a/lib/services/settings_backup.dart
+++ b/lib/services/settings_backup.dart
@@ -21,6 +21,7 @@ class SettingsBackup {
   final String? selectedWebspaceId;
   final int? currentIndex;
   final DateTime exportedAt;
+  final List<Map<String, dynamic>>? suggestedSites;
 
   SettingsBackup({
     required this.version,
@@ -31,6 +32,7 @@ class SettingsBackup {
     this.selectedWebspaceId,
     this.currentIndex,
     required this.exportedAt,
+    this.suggestedSites,
   });
 
   Map<String, dynamic> toJson() => {
@@ -42,6 +44,7 @@ class SettingsBackup {
         'selectedWebspaceId': selectedWebspaceId,
         'currentIndex': currentIndex,
         'exportedAt': exportedAt.toIso8601String(),
+        if (suggestedSites != null) 'suggestedSites': suggestedSites,
       };
 
   factory SettingsBackup.fromJson(Map<String, dynamic> json) {
@@ -60,6 +63,9 @@ class SettingsBackup {
       exportedAt: json['exportedAt'] != null
           ? DateTime.parse(json['exportedAt'])
           : DateTime.now(),
+      suggestedSites: (json['suggestedSites'] as List<dynamic>?)
+          ?.map((e) => e as Map<String, dynamic>)
+          .toList(),
     );
   }
 }
@@ -76,6 +82,7 @@ class SettingsBackupService {
     required bool showUrlBar,
     String? selectedWebspaceId,
     int? currentIndex,
+    List<Map<String, dynamic>>? suggestedSites,
   }) {
     // Convert sites to JSON, including only non-secure cookies
     final sitesJson = webViewModels.map((model) {
@@ -103,6 +110,7 @@ class SettingsBackupService {
       selectedWebspaceId: selectedWebspaceId,
       currentIndex: currentIndex,
       exportedAt: DateTime.now(),
+      suggestedSites: suggestedSites,
     );
   }
 
@@ -120,6 +128,7 @@ class SettingsBackupService {
     required bool showUrlBar,
     String? selectedWebspaceId,
     int? currentIndex,
+    List<Map<String, dynamic>>? suggestedSites,
   }) async {
     try {
       final backup = createBackup(
@@ -129,6 +138,7 @@ class SettingsBackupService {
         showUrlBar: showUrlBar,
         selectedWebspaceId: selectedWebspaceId,
         currentIndex: currentIndex,
+        suggestedSites: suggestedSites,
       );
 
       final jsonString = exportToJson(backup);

--- a/lib/services/suggested_sites_service.dart
+++ b/lib/services/suggested_sites_service.dart
@@ -1,0 +1,82 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webspace/screens/add_site.dart' show SiteSuggestion;
+
+/// Default suggested sites for non-fdroid builds.
+const List<SiteSuggestion> kDefaultSuggestions = [
+  SiteSuggestion(name: 'DuckDuckGo', url: 'https://duckduckgo.com', domain: 'duckduckgo.com'),
+  SiteSuggestion(name: 'Claude', url: 'https://claude.ai', domain: 'claude.ai'),
+  SiteSuggestion(name: 'ChatGPT', url: 'https://chatgpt.com', domain: 'chatgpt.com'),
+  SiteSuggestion(name: 'Perplexity', url: 'https://perplexity.ai', domain: 'perplexity.ai'),
+  SiteSuggestion(name: 'Instagram', url: 'https://instagram.com', domain: 'instagram.com'),
+  SiteSuggestion(name: 'Facebook', url: 'https://facebook.com', domain: 'facebook.com'),
+  SiteSuggestion(name: 'X (Twitter)', url: 'https://x.com', domain: 'x.com'),
+  SiteSuggestion(name: 'Google Chat', url: 'https://chat.google.com', domain: 'chat.google.com'),
+  SiteSuggestion(name: 'GitHub', url: 'https://github.com', domain: 'github.com'),
+  SiteSuggestion(name: 'GitLab', url: 'https://gitlab.com', domain: 'gitlab.com'),
+  SiteSuggestion(name: 'Gitea', url: 'https://gitea.com', domain: 'gitea.com'),
+  SiteSuggestion(name: 'Codeberg', url: 'https://codeberg.org', domain: 'codeberg.org'),
+  SiteSuggestion(name: 'Slack', url: 'https://slack.com', domain: 'slack.com'),
+  SiteSuggestion(name: 'Discord', url: 'https://discord.com/login', domain: 'discord.com'),
+  SiteSuggestion(name: 'Mattermost', url: 'https://mattermost.com', domain: 'mattermost.com'),
+  SiteSuggestion(name: 'Gmail', url: 'https://gmail.com', domain: 'gmail.com'),
+  SiteSuggestion(name: 'LinkedIn', url: 'https://linkedin.com', domain: 'linkedin.com'),
+  SiteSuggestion(name: 'Reddit', url: 'https://reddit.com', domain: 'reddit.com'),
+  SiteSuggestion(name: 'Mastodon', url: 'https://mastodon.social', domain: 'mastodon.social'),
+  SiteSuggestion(name: 'Bluesky', url: 'https://bsky.app', domain: 'bsky.app'),
+  SiteSuggestion(name: 'Hugging Face', url: 'https://huggingface.co', domain: 'huggingface.co'),
+];
+
+const String _prefsKey = 'suggested_sites';
+
+/// Whether the current build is the fdroid flavor.
+bool get isFdroidFlavor {
+  const flavor = String.fromEnvironment('FLUTTER_APP_FLAVOR');
+  return flavor == 'fdroid';
+}
+
+/// Returns the flavor-appropriate default suggestions.
+List<SiteSuggestion> get flavorDefaultSuggestions =>
+    isFdroidFlavor ? const [] : kDefaultSuggestions;
+
+/// Load user-customized suggested sites from SharedPreferences.
+/// Returns null if user has not customized (use defaults).
+Future<List<SiteSuggestion>?> loadSuggestedSites() async {
+  final prefs = await SharedPreferences.getInstance();
+  final json = prefs.getString(_prefsKey);
+  if (json == null) return null;
+  try {
+    final list = jsonDecode(json) as List<dynamic>;
+    return list
+        .map((e) => SiteSuggestion(
+              name: e['name'] as String,
+              url: e['url'] as String,
+              domain: e['domain'] as String,
+            ))
+        .toList();
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Save user-customized suggested sites to SharedPreferences.
+Future<void> saveSuggestedSites(List<SiteSuggestion> sites) async {
+  final prefs = await SharedPreferences.getInstance();
+  final json = jsonEncode(sites
+      .map((s) => {'name': s.name, 'url': s.url, 'domain': s.domain})
+      .toList());
+  await prefs.setString(_prefsKey, json);
+}
+
+/// Reset suggested sites to flavor defaults (removes customization).
+Future<void> resetSuggestedSites() async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.remove(_prefsKey);
+}
+
+/// Get the effective suggested sites list: user-customized or flavor default.
+Future<List<SiteSuggestion>> getEffectiveSuggestedSites() async {
+  final custom = await loadSuggestedSites();
+  return custom ?? flavorDefaultSuggestions;
+}

--- a/openspec/specs/configurable-suggested-sites/spec.md
+++ b/openspec/specs/configurable-suggested-sites/spec.md
@@ -1,0 +1,251 @@
+# Configurable Suggested Sites Specification
+
+## Purpose
+
+Allow users to customize the suggested sites shown on the "Add new site" screen. The default list varies by build flavor: fdroid ships with an empty list (no third-party site suggestions), while other flavors include a curated default set.
+
+## Status
+
+- **Date**: 2026-03-28
+- **Status**: Completed
+
+---
+
+## Requirements
+
+### Requirement: SUGGEST-001 - Flavor-Dependent Defaults
+
+The default suggested sites list SHALL depend on the build flavor.
+
+#### Scenario: fdroid flavor has empty defaults
+
+**Given** the app is built with the `fdroid` flavor
+**When** the user opens the "Add new site" screen for the first time
+**Then** no suggested sites are shown
+**And** an empty state message says "No suggested sites. Tap + to add some."
+
+#### Scenario: Other flavors have curated defaults
+
+**Given** the app is built with the `fmain` or `fdebug` flavor
+**When** the user opens the "Add new site" screen for the first time
+**Then** the curated default list of suggested sites is shown (DuckDuckGo, Claude, ChatGPT, etc.)
+
+---
+
+### Requirement: SUGGEST-002 - Add Custom Suggested Site
+
+Users SHALL be able to add sites to the suggestions list.
+
+#### Scenario: Add a new suggestion
+
+**Given** the user is on the "Add new site" screen
+**When** the user taps the "+" button in the "Suggested Sites" header
+**Then** a dialog appears with Name and URL fields
+**And** after entering valid data and tapping "Add", the site appears in the suggestions grid
+
+#### Scenario: URL auto-prefixing
+
+**Given** the user enters a URL without a protocol (e.g. `example.com`)
+**When** the user confirms the addition
+**Then** the URL is prefixed with `https://`
+
+#### Scenario: Invalid input rejected
+
+**Given** the user leaves the Name or URL field empty
+**When** the user taps "Add"
+**Then** nothing happens (the dialog stays open)
+
+---
+
+### Requirement: SUGGEST-003 - Remove Suggested Site
+
+Users SHALL be able to remove sites from the suggestions list.
+
+#### Scenario: Remove a suggestion via long-press
+
+**Given** the suggestions grid contains sites
+**When** the user long-presses a suggestion tile
+**Then** a confirmation dialog appears asking "Remove [site name]?"
+**And** tapping "Remove" deletes the suggestion from the list
+
+#### Scenario: Cancel removal
+
+**Given** the removal confirmation dialog is shown
+**When** the user taps "Cancel"
+**Then** the suggestion remains in the list
+
+---
+
+### Requirement: SUGGEST-004 - Persistence
+
+User customizations to the suggested sites list SHALL be persisted across app restarts.
+
+#### Scenario: Customizations survive restart
+
+**Given** the user has added or removed suggested sites
+**When** the app is closed and reopened
+**Then** the customized suggestions list is restored
+
+#### Scenario: No customization uses flavor defaults
+
+**Given** the user has never modified the suggestions list
+**When** the app starts
+**Then** the flavor-appropriate default list is shown
+
+---
+
+### Requirement: SUGGEST-005 - Settings Backup Integration
+
+Suggested sites SHALL be included in settings backup/restore.
+
+#### Scenario: Export includes suggested sites
+
+**Given** the user has customized their suggested sites
+**When** settings are exported
+**Then** the backup JSON includes a `suggestedSites` array
+
+#### Scenario: Import restores suggested sites
+
+**Given** a backup contains a `suggestedSites` array
+**When** settings are imported
+**Then** the suggested sites list is restored from the backup
+
+#### Scenario: Import without suggested sites
+
+**Given** a backup from an older version without `suggestedSites`
+**When** settings are imported
+**Then** the suggested sites list is unchanged (keeps current customization or flavor defaults)
+
+---
+
+### Requirement: SUGGEST-006 - Suggestion Tile Interaction
+
+Tapping a suggested site SHALL open a confirmation dialog to add the site, same as the existing behavior.
+
+#### Scenario: Add site from suggestion
+
+**Given** the suggestions grid shows "GitHub"
+**When** the user taps the "GitHub" tile
+**Then** a dialog appears pre-filled with the GitHub URL
+**And** the user can toggle incognito mode
+**And** tapping "Add" creates the site
+
+---
+
+## Data Model
+
+### SiteSuggestion
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | String | Display name for the site |
+| url | String | Full URL (including protocol) |
+| domain | String | Domain used for favicon display |
+
+### SharedPreferences Key
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `suggested_sites` | String (JSON) | Serialized list of SiteSuggestion objects. Absent = use flavor defaults. |
+
+### Backup JSON Format
+
+```json
+{
+  "suggestedSites": [
+    { "name": "DuckDuckGo", "url": "https://duckduckgo.com", "domain": "duckduckgo.com" },
+    { "name": "GitHub", "url": "https://github.com", "domain": "github.com" }
+  ]
+}
+```
+
+---
+
+## Flavor Detection
+
+The build flavor is detected at runtime via:
+
+```dart
+const flavor = String.fromEnvironment('FLUTTER_APP_FLAVOR');
+```
+
+Flutter automatically sets `FLUTTER_APP_FLAVOR` when building with `--flavor`. The fdroid flavor results in an empty default list; all other flavors use the curated list defined in `kDefaultSuggestions`.
+
+---
+
+## Default Suggested Sites (non-fdroid)
+
+| Name | URL | Domain |
+|------|-----|--------|
+| DuckDuckGo | https://duckduckgo.com | duckduckgo.com |
+| Claude | https://claude.ai | claude.ai |
+| ChatGPT | https://chatgpt.com | chatgpt.com |
+| Perplexity | https://perplexity.ai | perplexity.ai |
+| Instagram | https://instagram.com | instagram.com |
+| Facebook | https://facebook.com | facebook.com |
+| X (Twitter) | https://x.com | x.com |
+| Google Chat | https://chat.google.com | chat.google.com |
+| GitHub | https://github.com | github.com |
+| GitLab | https://gitlab.com | gitlab.com |
+| Gitea | https://gitea.com | gitea.com |
+| Codeberg | https://codeberg.org | codeberg.org |
+| Slack | https://slack.com | slack.com |
+| Discord | https://discord.com/login | discord.com |
+| Mattermost | https://mattermost.com | mattermost.com |
+| Gmail | https://gmail.com | gmail.com |
+| LinkedIn | https://linkedin.com | linkedin.com |
+| Reddit | https://reddit.com | reddit.com |
+| Mastodon | https://mastodon.social | mastodon.social |
+| Bluesky | https://bsky.app | bsky.app |
+| Hugging Face | https://huggingface.co | huggingface.co |
+
+---
+
+## Files
+
+### Created
+- `lib/services/suggested_sites_service.dart` - Service for loading, saving, and managing suggested sites with flavor-aware defaults
+
+### Modified
+- `lib/screens/add_site.dart` - Accept configurable suggestions, add/remove UI
+- `lib/main.dart` - Load suggested sites on startup, pass to AddSiteScreen, include in backup
+- `lib/services/settings_backup.dart` - Optional `suggestedSites` field in SettingsBackup
+
+---
+
+## Manual Test Procedure
+
+### Test: Verify fdroid empty defaults
+1. Build with `flutter build apk --flavor fdroid`
+2. Fresh install (clear app data)
+3. Tap "+" to add a site
+4. **Expected**: Empty suggestions grid with "No suggested sites" message
+
+### Test: Verify non-fdroid defaults
+1. Build with `flutter build apk --flavor fmain` or `fdebug`
+2. Fresh install
+3. Tap "+" to add a site
+4. **Expected**: Full curated suggestions grid (21 sites)
+
+### Test: Add a custom suggestion
+1. On "Add new site" screen, tap the "+" next to "Suggested Sites"
+2. Enter Name: "Wikipedia", URL: "wikipedia.org"
+3. Tap "Add"
+4. **Expected**: "Wikipedia" tile appears in the grid with favicon
+
+### Test: Remove a suggestion
+1. Long-press any suggestion tile
+2. Confirm removal
+3. **Expected**: Tile disappears from grid
+
+### Test: Persistence
+1. Add/remove suggestions
+2. Close and reopen the app
+3. Open "Add new site"
+4. **Expected**: Customized list is preserved
+
+### Test: Backup/restore
+1. Customize suggestions
+2. Export settings
+3. Clear app data, reimport
+4. **Expected**: Customized suggestions are restored

--- a/test/suggested_sites_test.dart
+++ b/test/suggested_sites_test.dart
@@ -1,0 +1,281 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webspace/screens/add_site.dart' show SiteSuggestion;
+import 'package:webspace/services/settings_backup.dart';
+import 'package:webspace/services/suggested_sites_service.dart';
+
+void main() {
+  group('SiteSuggestion', () {
+    test('should store name, url, and domain', () {
+      const s = SiteSuggestion(
+        name: 'GitHub',
+        url: 'https://github.com',
+        domain: 'github.com',
+      );
+      expect(s.name, 'GitHub');
+      expect(s.url, 'https://github.com');
+      expect(s.domain, 'github.com');
+    });
+  });
+
+  group('kDefaultSuggestions', () {
+    test('should contain expected sites', () {
+      expect(kDefaultSuggestions, isNotEmpty);
+      expect(kDefaultSuggestions.length, 21);
+
+      final names = kDefaultSuggestions.map((s) => s.name).toList();
+      expect(names, contains('DuckDuckGo'));
+      expect(names, contains('GitHub'));
+      expect(names, contains('Claude'));
+    });
+
+    test('all entries should have valid URLs', () {
+      for (final s in kDefaultSuggestions) {
+        expect(s.name, isNotEmpty);
+        expect(s.url, startsWith('https://'));
+        expect(s.domain, isNotEmpty);
+        final uri = Uri.parse(s.url);
+        expect(uri.host, isNotEmpty);
+      }
+    });
+  });
+
+  group('Flavor detection', () {
+    // In test environment, FLUTTER_APP_FLAVOR is not set,
+    // so isFdroidFlavor should be false.
+    test('isFdroidFlavor is false when FLUTTER_APP_FLAVOR is not set', () {
+      expect(isFdroidFlavor, isFalse);
+    });
+
+    test('flavorDefaultSuggestions returns full list when not fdroid', () {
+      expect(flavorDefaultSuggestions, equals(kDefaultSuggestions));
+      expect(flavorDefaultSuggestions, isNotEmpty);
+    });
+  });
+
+  group('Persistence', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('loadSuggestedSites returns null when no customization saved', () async {
+      final result = await loadSuggestedSites();
+      expect(result, isNull);
+    });
+
+    test('saveSuggestedSites and loadSuggestedSites round-trip', () async {
+      final sites = [
+        const SiteSuggestion(name: 'Test', url: 'https://test.com', domain: 'test.com'),
+        const SiteSuggestion(name: 'Example', url: 'https://example.org', domain: 'example.org'),
+      ];
+
+      await saveSuggestedSites(sites);
+      final loaded = await loadSuggestedSites();
+
+      expect(loaded, isNotNull);
+      expect(loaded!.length, 2);
+      expect(loaded[0].name, 'Test');
+      expect(loaded[0].url, 'https://test.com');
+      expect(loaded[0].domain, 'test.com');
+      expect(loaded[1].name, 'Example');
+      expect(loaded[1].url, 'https://example.org');
+      expect(loaded[1].domain, 'example.org');
+    });
+
+    test('saveSuggestedSites with empty list persists empty list', () async {
+      await saveSuggestedSites([]);
+      final loaded = await loadSuggestedSites();
+
+      expect(loaded, isNotNull);
+      expect(loaded, isEmpty);
+    });
+
+    test('resetSuggestedSites removes customization', () async {
+      final sites = [
+        const SiteSuggestion(name: 'Test', url: 'https://test.com', domain: 'test.com'),
+      ];
+
+      await saveSuggestedSites(sites);
+      expect(await loadSuggestedSites(), isNotNull);
+
+      await resetSuggestedSites();
+      expect(await loadSuggestedSites(), isNull);
+    });
+
+    test('loadSuggestedSites returns null on corrupted JSON', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('suggested_sites', 'not valid json');
+
+      final result = await loadSuggestedSites();
+      expect(result, isNull);
+    });
+
+    test('loadSuggestedSites returns null on wrong JSON structure', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('suggested_sites', '{"foo": "bar"}');
+
+      final result = await loadSuggestedSites();
+      expect(result, isNull);
+    });
+  });
+
+  group('getEffectiveSuggestedSites', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('returns flavor defaults when no customization', () async {
+      final result = await getEffectiveSuggestedSites();
+      // In test env, flavor is not fdroid, so we get full defaults
+      expect(result, equals(kDefaultSuggestions));
+    });
+
+    test('returns custom list when customization saved', () async {
+      final custom = [
+        const SiteSuggestion(name: 'Custom', url: 'https://custom.io', domain: 'custom.io'),
+      ];
+      await saveSuggestedSites(custom);
+
+      final result = await getEffectiveSuggestedSites();
+      expect(result.length, 1);
+      expect(result[0].name, 'Custom');
+    });
+
+    test('returns empty list when empty customization saved', () async {
+      await saveSuggestedSites([]);
+
+      final result = await getEffectiveSuggestedSites();
+      expect(result, isEmpty);
+    });
+
+    test('returns defaults after reset', () async {
+      await saveSuggestedSites([
+        const SiteSuggestion(name: 'Temp', url: 'https://temp.com', domain: 'temp.com'),
+      ]);
+      await resetSuggestedSites();
+
+      final result = await getEffectiveSuggestedSites();
+      expect(result, equals(kDefaultSuggestions));
+    });
+  });
+
+  group('JSON serialization', () {
+    test('serialized format matches expected structure', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      final sites = [
+        const SiteSuggestion(name: 'GitHub', url: 'https://github.com', domain: 'github.com'),
+      ];
+      await saveSuggestedSites(sites);
+
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString('suggested_sites')!;
+      final parsed = jsonDecode(raw) as List<dynamic>;
+
+      expect(parsed.length, 1);
+      expect(parsed[0]['name'], 'GitHub');
+      expect(parsed[0]['url'], 'https://github.com');
+      expect(parsed[0]['domain'], 'github.com');
+    });
+
+    test('handles many sites', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      await saveSuggestedSites(kDefaultSuggestions);
+      final loaded = await loadSuggestedSites();
+
+      expect(loaded, isNotNull);
+      expect(loaded!.length, kDefaultSuggestions.length);
+      for (var i = 0; i < kDefaultSuggestions.length; i++) {
+        expect(loaded[i].name, kDefaultSuggestions[i].name);
+        expect(loaded[i].url, kDefaultSuggestions[i].url);
+        expect(loaded[i].domain, kDefaultSuggestions[i].domain);
+      }
+    });
+  });
+
+  group('SettingsBackup suggestedSites integration', () {
+    test('backup with suggestedSites serializes correctly', () {
+      final backup = SettingsBackup(
+        version: 1,
+        sites: [],
+        webspaces: [],
+        themeMode: 0,
+        showUrlBar: false,
+        exportedAt: DateTime(2026, 3, 28),
+        suggestedSites: [
+          {'name': 'Test', 'url': 'https://test.com', 'domain': 'test.com'},
+        ],
+      );
+
+      final json = backup.toJson();
+      expect(json['suggestedSites'], isNotNull);
+      expect((json['suggestedSites'] as List).length, 1);
+      expect((json['suggestedSites'] as List)[0]['name'], 'Test');
+    });
+
+    test('backup without suggestedSites omits the field', () {
+      final backup = SettingsBackup(
+        version: 1,
+        sites: [],
+        webspaces: [],
+        themeMode: 0,
+        showUrlBar: false,
+        exportedAt: DateTime(2026, 3, 28),
+      );
+
+      final json = backup.toJson();
+      expect(json.containsKey('suggestedSites'), isFalse);
+    });
+
+    test('fromJson parses suggestedSites', () {
+      final json = {
+        'sites': [],
+        'webspaces': [],
+        'suggestedSites': [
+          {'name': 'A', 'url': 'https://a.com', 'domain': 'a.com'},
+          {'name': 'B', 'url': 'https://b.com', 'domain': 'b.com'},
+        ],
+      };
+
+      final backup = SettingsBackup.fromJson(json);
+      expect(backup.suggestedSites, isNotNull);
+      expect(backup.suggestedSites!.length, 2);
+      expect(backup.suggestedSites![0]['name'], 'A');
+      expect(backup.suggestedSites![1]['name'], 'B');
+    });
+
+    test('fromJson handles missing suggestedSites (backward compat)', () {
+      final json = {
+        'sites': [],
+        'webspaces': [],
+      };
+
+      final backup = SettingsBackup.fromJson(json);
+      expect(backup.suggestedSites, isNull);
+    });
+
+    test('round-trip preserves suggestedSites', () {
+      final original = SettingsBackup(
+        version: 1,
+        sites: [],
+        webspaces: [],
+        themeMode: 2,
+        showUrlBar: true,
+        exportedAt: DateTime(2026, 3, 28),
+        suggestedSites: [
+          {'name': 'GitHub', 'url': 'https://github.com', 'domain': 'github.com'},
+        ],
+      );
+
+      final jsonString = jsonEncode(original.toJson());
+      final restored = SettingsBackup.fromJson(jsonDecode(jsonString));
+
+      expect(restored.suggestedSites, isNotNull);
+      expect(restored.suggestedSites!.length, 1);
+      expect(restored.suggestedSites![0]['name'], 'GitHub');
+    });
+  });
+}


### PR DESCRIPTION
- Move hardcoded suggested sites to SuggestedSitesService with SharedPreferences persistence
- Detect fdroid flavor via FLUTTER_APP_FLAVOR and default to empty list
- Add UI to add new suggestions (+) and remove via long-press
- Show empty state message when no suggestions configured
- Include suggested sites in settings backup/restore

https://claude.ai/code/session_014n5i73agnQUxnMgBvLyX9X