### PR TITLE
Pause/resume background webviews on site switch

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -608,6 +608,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   // Configurable suggested sites
   List<SiteSuggestion> _suggestedSites = [];
 
+  // Guards lifecycle pause/resume against rapid state transitions.
+  // Without this, a quick inactive→resumed sequence could let the resume
+  // platform call complete before the pause call, leaving the webview stuck.
+  Future<void>? _lifecyclePauseFuture;
+
   @override
   void initState() {
     super.initState();
@@ -626,14 +631,22 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     if (state == AppLifecycleState.paused || state == AppLifecycleState.inactive) {
       // Pause the active webview when the app goes to background
       if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
-        _webViewModels[_currentIndex!].pauseWebView();
+        _lifecyclePauseFuture = _webViewModels[_currentIndex!].pauseWebView();
       }
     } else if (state == AppLifecycleState.resumed) {
-      // Resume the active webview when the app comes back
-      if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
-        _webViewModels[_currentIndex!].resumeWebView();
-      }
+      // Await any in-flight pause before resuming to prevent ordering inversion
+      _resumeAfterLifecyclePause();
       _handleShortcutIntent();
+    }
+  }
+
+  Future<void> _resumeAfterLifecyclePause() async {
+    if (_lifecyclePauseFuture != null) {
+      await _lifecyclePauseFuture;
+      _lifecyclePauseFuture = null;
+    }
+    if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
+      await _webViewModels[_currentIndex!].resumeWebView();
     }
   }
 
@@ -717,6 +730,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       // Pause the previously active webview when navigating away
       if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
         await _webViewModels[_currentIndex!].pauseWebView();
+        if (version != _setCurrentIndexVersion) return;
       }
       _currentIndex = index;
       return;
@@ -756,6 +770,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     // Pause the previously active webview to save resources
     if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
       await _webViewModels[_currentIndex!].pauseWebView();
+      if (version != _setCurrentIndexVersion) return;
     }
 
     // Restore cookies for target site before loading

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -623,7 +623,16 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.resumed) {
+    if (state == AppLifecycleState.paused || state == AppLifecycleState.inactive) {
+      // Pause the active webview when the app goes to background
+      if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
+        _webViewModels[_currentIndex!].pauseWebView();
+      }
+    } else if (state == AppLifecycleState.resumed) {
+      // Resume the active webview when the app comes back
+      if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
+        _webViewModels[_currentIndex!].resumeWebView();
+      }
       _handleShortcutIntent();
     }
   }
@@ -705,6 +714,10 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     final version = ++_setCurrentIndexVersion;
 
     if (index == null || index < 0 || index >= _webViewModels.length) {
+      // Pause the previously active webview when navigating away
+      if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
+        await _webViewModels[_currentIndex!].pauseWebView();
+      }
       _currentIndex = index;
       return;
     }
@@ -740,6 +753,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       }
     }
 
+    // Pause the previously active webview to save resources
+    if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
+      await _webViewModels[_currentIndex!].pauseWebView();
+    }
+
     // Restore cookies for target site before loading
     await _restoreCookiesForSite(index);
     if (version != _setCurrentIndexVersion) return;
@@ -749,6 +767,10 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
     _currentIndex = index;
     _loadedIndices.add(index);
+
+    // Resume the newly active webview
+    await _webViewModels[index].resumeWebView();
+
     LogService.instance.log('CookieIsolation', 'After switch, loaded indices: $_loadedIndices');
   }
 

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -277,6 +277,11 @@ abstract class WebViewController {
   Future<void> setThemePreference(WebViewTheme theme);
   Future<void> goBack();
   Future<bool> canGoBack();
+  /// Pause the webview (stop rendering and JS execution).
+  /// On Android this pauses the WebView entirely; on iOS it pauses timers.
+  Future<void> pause();
+  /// Resume a previously paused webview.
+  Future<void> resume();
 }
 
 /// InAppWebView controller wrapper
@@ -376,6 +381,22 @@ class _WebViewController implements WebViewController {
 
   @override
   Future<bool> canGoBack() => _c.canGoBack();
+
+  @override
+  Future<void> pause() async {
+    if (Platform.isAndroid) {
+      await _c.pause();
+    }
+    await _c.pauseTimers();
+  }
+
+  @override
+  Future<void> resume() async {
+    if (Platform.isAndroid) {
+      await _c.resume();
+    }
+    await _c.resumeTimers();
+  }
 }
 
 String _themeInjectionScript(String themeValue) => '''

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -523,6 +523,30 @@ class WebViewModel {
     cookies = await cookieManager.getCookies(url: url);
   }
 
+  /// Pause the webview to reduce resource usage when in background.
+  /// Stops rendering (Android) and JS timers. The webview remains in the
+  /// widget tree but consumes minimal resources.
+  Future<void> pauseWebView() async {
+    if (controller == null) return;
+    try {
+      await controller!.pause();
+      LogService.instance.log('WebView', 'Paused webview for "$name" (siteId: $siteId)');
+    } catch (_) {
+      // Controller may have been disposed
+    }
+  }
+
+  /// Resume a previously paused webview when it becomes active again.
+  Future<void> resumeWebView() async {
+    if (controller == null) return;
+    try {
+      await controller!.resume();
+      LogService.instance.log('WebView', 'Resumed webview for "$name" (siteId: $siteId)');
+    } catch (_) {
+      // Controller may have been disposed
+    }
+  }
+
   /// Dispose the webview and controller to release resources.
   /// Used when unloading a site due to domain conflict.
   void disposeWebView() {


### PR DESCRIPTION
When switching sites, the previously active webview is now paused (rendering stopped on Android, JS timers stopped on all platforms) and the newly active webview is resumed. This reduces CPU and memory usage from background webviews that remain in the IndexedStack.

Also pauses/resumes the active webview on app lifecycle changes (background/foreground).

https://claude.ai/code/session_01Euh4LdtRasn96ANAr1fBs1