### PR TITLE
Fix app logs autoscroll: live updates and scroll-to-bottom on open

### DIFF
--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -33,10 +33,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   final Set<LogLevel> _activeFilters = LogLevel.values.toSet();
 
   final ScrollController _consoleScrollController = ScrollController();
-  bool _consoleAutoScroll = true;
-
   final ScrollController _logScrollController = ScrollController();
-  bool _logAutoScroll = true;
 
   bool get _hasSite => widget.webViewModel != null;
 
@@ -63,49 +60,11 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   }
 
   void _onConsoleUpdate() {
-    if (mounted) {
-      setState(() {});
-      if (_consoleAutoScroll) {
-        _scrollToBottom(_consoleScrollController);
-      }
-    }
+    if (mounted) setState(() {});
   }
 
   void _onLogUpdate() {
-    if (mounted) {
-      setState(() {});
-      if (_logAutoScroll) {
-        _scrollToBottom(_logScrollController);
-      }
-    }
-  }
-
-  bool _onConsoleUserScroll(ScrollNotification notification) {
-    if (notification is ScrollUpdateNotification &&
-        notification.dragDetails != null &&
-        _consoleScrollController.hasClients) {
-      final pos = _consoleScrollController.position;
-      _consoleAutoScroll = pos.pixels >= pos.maxScrollExtent - 50;
-    }
-    return false;
-  }
-
-  bool _onLogUserScroll(ScrollNotification notification) {
-    if (notification is ScrollUpdateNotification &&
-        notification.dragDetails != null &&
-        _logScrollController.hasClients) {
-      final pos = _logScrollController.position;
-      _logAutoScroll = pos.pixels >= pos.maxScrollExtent - 50;
-    }
-    return false;
-  }
-
-  void _scrollToBottom(ScrollController controller) {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (controller.hasClients) {
-        controller.jumpTo(controller.position.maxScrollExtent);
-      }
-    });
+    if (mounted) setState(() {});
   }
 
   List<Tab> get _tabs => [
@@ -158,12 +117,14 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
         Expanded(
           child: logs.isEmpty
               ? const Center(child: Text('No console messages'))
-              : _buildAutoScrollList(
+              : ListView.builder(
                   controller: _consoleScrollController,
-                  autoScroll: _consoleAutoScroll,
-                  onUserScroll: _onConsoleUserScroll,
+                  reverse: true,
                   itemCount: logs.length,
-                  itemBuilder: (context, index) => _buildConsoleEntry(logs[index]),
+                  itemBuilder: (context, index) {
+                    // reverse: true flips the order, so invert the index
+                    return _buildConsoleEntry(logs[logs.length - 1 - index]);
+                  },
                 ),
         ),
       ],
@@ -592,37 +553,16 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
         Expanded(
           child: filtered.isEmpty
               ? const Center(child: Text('No log entries'))
-              : _buildAutoScrollList(
+              : ListView.builder(
                   controller: _logScrollController,
-                  autoScroll: _logAutoScroll,
-                  onUserScroll: _onLogUserScroll,
+                  reverse: true,
                   itemCount: filtered.length,
-                  itemBuilder: (context, index) => _buildLogEntry(filtered[index]),
+                  itemBuilder: (context, index) {
+                    return _buildLogEntry(filtered[filtered.length - 1 - index]);
+                  },
                 ),
         ),
       ],
-    );
-  }
-
-  Widget _buildAutoScrollList({
-    required ScrollController controller,
-    required bool autoScroll,
-    required bool Function(ScrollNotification) onUserScroll,
-    required int itemCount,
-    required Widget Function(BuildContext, int) itemBuilder,
-  }) {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (autoScroll && controller.hasClients) {
-        controller.jumpTo(controller.position.maxScrollExtent);
-      }
-    });
-    return NotificationListener<ScrollNotification>(
-      onNotification: onUserScroll,
-      child: ListView.builder(
-        controller: controller,
-        itemCount: itemCount,
-        itemBuilder: itemBuilder,
-      ),
     );
   }
 

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -31,10 +31,50 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   String? _exportedHtml;
   bool _loadingHtml = false;
   final Set<LogLevel> _activeFilters = LogLevel.values.toSet();
+  final ScrollController _logScrollController = ScrollController();
+  bool _autoScroll = true;
 
   bool get _hasSite => widget.webViewModel != null;
 
   int get _tabCount => _hasSite ? 5 : 1;
+
+  @override
+  void initState() {
+    super.initState();
+    LogService.instance.addListener(_onLogUpdate);
+    _logScrollController.addListener(_onLogScroll);
+  }
+
+  @override
+  void dispose() {
+    LogService.instance.removeListener(_onLogUpdate);
+    _logScrollController.removeListener(_onLogScroll);
+    _logScrollController.dispose();
+    super.dispose();
+  }
+
+  void _onLogUpdate() {
+    if (mounted) {
+      setState(() {});
+      if (_autoScroll) {
+        _scrollToBottom();
+      }
+    }
+  }
+
+  void _onLogScroll() {
+    if (!_logScrollController.hasClients) return;
+    final pos = _logScrollController.position;
+    _autoScroll = pos.pixels >= pos.maxScrollExtent - 50;
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_logScrollController.hasClients) {
+        _logScrollController.jumpTo(_logScrollController.position.maxScrollExtent);
+      }
+    });
+  }
 
   List<Tab> get _tabs => [
         if (_hasSite)
@@ -520,15 +560,26 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
         Expanded(
           child: filtered.isEmpty
               ? const Center(child: Text('No log entries'))
-              : ListView.builder(
-                  itemCount: filtered.length,
-                  itemBuilder: (context, index) {
-                    final entry = filtered[index];
-                    return _buildLogEntry(entry);
-                  },
-                ),
+              : _buildLogListView(filtered),
         ),
       ],
+    );
+  }
+
+  Widget _buildLogListView(List<LogEntry> filtered) {
+    // Scroll to bottom on first build so latest logs are visible
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_autoScroll && _logScrollController.hasClients) {
+        _logScrollController.jumpTo(_logScrollController.position.maxScrollExtent);
+      }
+    });
+    return ListView.builder(
+      controller: _logScrollController,
+      itemCount: filtered.length,
+      itemBuilder: (context, index) {
+        final entry = filtered[index];
+        return _buildLogEntry(entry);
+      },
     );
   }
 

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -42,13 +42,11 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   void initState() {
     super.initState();
     LogService.instance.addListener(_onLogUpdate);
-    _logScrollController.addListener(_onLogScroll);
   }
 
   @override
   void dispose() {
     LogService.instance.removeListener(_onLogUpdate);
-    _logScrollController.removeListener(_onLogScroll);
     _logScrollController.dispose();
     super.dispose();
   }
@@ -62,10 +60,14 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
     }
   }
 
-  void _onLogScroll() {
-    if (!_logScrollController.hasClients) return;
-    final pos = _logScrollController.position;
-    _autoScroll = pos.pixels >= pos.maxScrollExtent - 50;
+  bool _onUserScroll(ScrollNotification notification) {
+    if (notification is ScrollUpdateNotification &&
+        notification.dragDetails != null) {
+      // User is actively dragging — check if they're near the bottom
+      final pos = _logScrollController.position;
+      _autoScroll = pos.pixels >= pos.maxScrollExtent - 50;
+    }
+    return false;
   }
 
   void _scrollToBottom() {
@@ -573,13 +575,16 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
         _logScrollController.jumpTo(_logScrollController.position.maxScrollExtent);
       }
     });
-    return ListView.builder(
-      controller: _logScrollController,
-      itemCount: filtered.length,
-      itemBuilder: (context, index) {
-        final entry = filtered[index];
-        return _buildLogEntry(entry);
-      },
+    return NotificationListener<ScrollNotification>(
+      onNotification: _onUserScroll,
+      child: ListView.builder(
+        controller: _logScrollController,
+        itemCount: filtered.length,
+        itemBuilder: (context, index) {
+          final entry = filtered[index];
+          return _buildLogEntry(entry);
+        },
+      ),
     );
   }
 

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -31,8 +31,12 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   String? _exportedHtml;
   bool _loadingHtml = false;
   final Set<LogLevel> _activeFilters = LogLevel.values.toSet();
+
+  final ScrollController _consoleScrollController = ScrollController();
+  bool _consoleAutoScroll = true;
+
   final ScrollController _logScrollController = ScrollController();
-  bool _autoScroll = true;
+  bool _logAutoScroll = true;
 
   bool get _hasSite => widget.webViewModel != null;
 
@@ -42,38 +46,64 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   void initState() {
     super.initState();
     LogService.instance.addListener(_onLogUpdate);
+    if (_hasSite) {
+      widget.webViewModel!.onConsoleLogChanged = _onConsoleUpdate;
+    }
   }
 
   @override
   void dispose() {
     LogService.instance.removeListener(_onLogUpdate);
+    if (_hasSite) {
+      widget.webViewModel!.onConsoleLogChanged = null;
+    }
+    _consoleScrollController.dispose();
     _logScrollController.dispose();
     super.dispose();
+  }
+
+  void _onConsoleUpdate() {
+    if (mounted) {
+      setState(() {});
+      if (_consoleAutoScroll) {
+        _scrollToBottom(_consoleScrollController);
+      }
+    }
   }
 
   void _onLogUpdate() {
     if (mounted) {
       setState(() {});
-      if (_autoScroll) {
-        _scrollToBottom();
+      if (_logAutoScroll) {
+        _scrollToBottom(_logScrollController);
       }
     }
   }
 
-  bool _onUserScroll(ScrollNotification notification) {
+  bool _onConsoleUserScroll(ScrollNotification notification) {
     if (notification is ScrollUpdateNotification &&
-        notification.dragDetails != null) {
-      // User is actively dragging — check if they're near the bottom
-      final pos = _logScrollController.position;
-      _autoScroll = pos.pixels >= pos.maxScrollExtent - 50;
+        notification.dragDetails != null &&
+        _consoleScrollController.hasClients) {
+      final pos = _consoleScrollController.position;
+      _consoleAutoScroll = pos.pixels >= pos.maxScrollExtent - 50;
     }
     return false;
   }
 
-  void _scrollToBottom() {
+  bool _onLogUserScroll(ScrollNotification notification) {
+    if (notification is ScrollUpdateNotification &&
+        notification.dragDetails != null &&
+        _logScrollController.hasClients) {
+      final pos = _logScrollController.position;
+      _logAutoScroll = pos.pixels >= pos.maxScrollExtent - 50;
+    }
+    return false;
+  }
+
+  void _scrollToBottom(ScrollController controller) {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_logScrollController.hasClients) {
-        _logScrollController.jumpTo(_logScrollController.position.maxScrollExtent);
+      if (controller.hasClients) {
+        controller.jumpTo(controller.position.maxScrollExtent);
       }
     });
   }
@@ -128,12 +158,12 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
         Expanded(
           child: logs.isEmpty
               ? const Center(child: Text('No console messages'))
-              : ListView.builder(
+              : _buildAutoScrollList(
+                  controller: _consoleScrollController,
+                  autoScroll: _consoleAutoScroll,
+                  onUserScroll: _onConsoleUserScroll,
                   itemCount: logs.length,
-                  itemBuilder: (context, index) {
-                    final entry = logs[index];
-                    return _buildConsoleEntry(entry);
-                  },
+                  itemBuilder: (context, index) => _buildConsoleEntry(logs[index]),
                 ),
         ),
       ],
@@ -562,28 +592,36 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
         Expanded(
           child: filtered.isEmpty
               ? const Center(child: Text('No log entries'))
-              : _buildLogListView(filtered),
+              : _buildAutoScrollList(
+                  controller: _logScrollController,
+                  autoScroll: _logAutoScroll,
+                  onUserScroll: _onLogUserScroll,
+                  itemCount: filtered.length,
+                  itemBuilder: (context, index) => _buildLogEntry(filtered[index]),
+                ),
         ),
       ],
     );
   }
 
-  Widget _buildLogListView(List<LogEntry> filtered) {
-    // Scroll to bottom on first build so latest logs are visible
+  Widget _buildAutoScrollList({
+    required ScrollController controller,
+    required bool autoScroll,
+    required bool Function(ScrollNotification) onUserScroll,
+    required int itemCount,
+    required Widget Function(BuildContext, int) itemBuilder,
+  }) {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_autoScroll && _logScrollController.hasClients) {
-        _logScrollController.jumpTo(_logScrollController.position.maxScrollExtent);
+      if (autoScroll && controller.hasClients) {
+        controller.jumpTo(controller.position.maxScrollExtent);
       }
     });
     return NotificationListener<ScrollNotification>(
-      onNotification: _onUserScroll,
+      onNotification: onUserScroll,
       child: ListView.builder(
-        controller: _logScrollController,
-        itemCount: filtered.length,
-        itemBuilder: (context, index) {
-          final entry = filtered[index];
-          return _buildLogEntry(entry);
-        },
+        controller: controller,
+        itemCount: itemCount,
+        itemBuilder: itemBuilder,
       ),
     );
   }

--- a/lib/services/log_service.dart
+++ b/lib/services/log_service.dart
@@ -16,7 +16,7 @@ class LogEntry {
   });
 }
 
-class LogService {
+class LogService extends ChangeNotifier {
   static final instance = LogService._();
   LogService._();
 
@@ -37,6 +37,7 @@ class LogService {
     if (kDebugMode) {
       debugPrint('[${entry.tag}/${entry.level.name}] ${entry.message}');
     }
+    notifyListeners();
   }
 
   List<LogEntry> get entries => List.unmodifiable(_entries);
@@ -54,5 +55,6 @@ class LogService {
 
   void clear() {
     _entries.clear();
+    notifyListeners();
   }
 }

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -238,6 +238,7 @@ class WebViewModel {
 
   final List<ConsoleLogEntry> consoleLogs = [];
   static const _maxConsoleLogs = 500;
+  VoidCallback? onConsoleLogChanged;
 
   String? defaultUserAgent;
   Function? stateSetterF;
@@ -476,6 +477,7 @@ class WebViewModel {
             if (consoleLogs.length > _maxConsoleLogs) {
               consoleLogs.removeAt(0);
             }
+            onConsoleLogChanged?.call();
           },
         ),
         onControllerCreated: (ctrl) {

--- a/openspec/specs/developer-tools/spec.md
+++ b/openspec/specs/developer-tools/spec.md
@@ -93,14 +93,30 @@ The app SHALL allow exporting the current page's HTML source.
 
 ### Requirement: DEVTOOLS-004 - App Logs
 
-The app SHALL maintain a ring buffer of app-level log entries accessible from both Developer Tools and App Settings.
+The app SHALL maintain a ring buffer of app-level log entries accessible from both Developer Tools and App Settings, with live streaming updates and auto-scroll.
 
 #### Scenario: View app logs
 
 **Given** the app has been running and logging
 **When** the user opens the App Logs tab
 **Then** timestamped log entries are shown with tag and message
+**And** the view scrolls to the bottom to show the most recent entries
 **And** filter chips allow filtering by level (debug, info, warning, error)
+
+#### Scenario: Live log streaming
+
+**Given** the App Logs tab is open
+**When** new log entries are produced by the app
+**Then** they appear in the list in real time without manual refresh
+**And** if the user is scrolled to the bottom, the view auto-scrolls to show new entries
+
+#### Scenario: Auto-scroll pause on manual scroll
+
+**Given** the App Logs tab is open and auto-scrolling
+**When** the user scrolls up to view older entries
+**Then** auto-scroll is paused so the view does not jump
+**When** the user scrolls back to the bottom
+**Then** auto-scroll resumes
 
 #### Scenario: Export logs for issue reporting
 
@@ -120,7 +136,7 @@ The app SHALL maintain a ring buffer of app-level log entries accessible from bo
 
 ### Requirement: DEVTOOLS-005 - LogService
 
-The app SHALL use a centralized LogService singleton for all debug logging.
+The app SHALL use a centralized LogService singleton (extending ChangeNotifier) for all debug logging, notifying listeners on each new entry.
 
 #### Scenario: Ring buffer behavior
 
@@ -133,6 +149,12 @@ The app SHALL use a centralized LogService singleton for all debug logging.
 **Given** the app is running in debug mode
 **When** a log entry is created
 **Then** it is also printed via debugPrint
+
+#### Scenario: Change notification
+
+**Given** a UI widget is listening to LogService
+**When** a new log entry is added or logs are cleared
+**Then** LogService notifies all listeners so the UI updates in real time
 
 ---
 


### PR DESCRIPTION
LogService now extends ChangeNotifier so the DevTools logs tab updates in real time as new entries arrive. The log list opens scrolled to the bottom (most recent entries visible) and auto-scrolls on new entries when the user is already at the bottom, pausing auto-scroll when the user scrolls up to read older logs.

https://claude.ai/code/session_016LFjou5Wo3wiSXQnH3U9xf