### PR TITLE
Reduce drawer header spacing between back button and site grid

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2592,9 +2592,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         child: Column(
           children: [
             SafeArea(
-              child: Container(
-                width: double.infinity,
-                padding: const EdgeInsets.symmetric(vertical: 16.0),
+              bottom: false,
+              child: Padding(
+                padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
@@ -2609,46 +2609,51 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                         Navigator.pop(context);
                       },
                       child: Padding(
-                        padding: const EdgeInsets.all(8.0),
+                        padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
                         child: Column(
                           children: [
                             AccentLogo(
                               accentColor: _themeSettings.accentColor,
-                              size: 72,
+                              size: 48,
                               brightness: Theme.of(context).brightness,
                             ),
-                          SizedBox(height: 8),
-                          Text(
-                            _selectedWebspaceId != null
-                                ? _webspaces.firstWhere((ws) => ws.id == _selectedWebspaceId, orElse: () => Webspace(name: 'Unknown')).name
-                                : 'No webspace',
-                            style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
-                          ),
-                        ],
+                            SizedBox(height: 4),
+                            Text(
+                              _selectedWebspaceId != null
+                                  ? _webspaces.firstWhere((ws) => ws.id == _selectedWebspaceId, orElse: () => Webspace(name: 'Unknown')).name
+                                  : 'No webspace',
+                              style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
-                  ),
-                  Semantics(
-                    label: 'Back to Webspaces',
-                    button: true,
-                    enabled: true,
-                    child: TextButton.icon(
-                      onPressed: () async {
-                        await _setCurrentIndex(null);
-                        if (!mounted) return;
-                        setState(() {});
-                        await _saveSelectedWebspaceId();
-                        await _saveCurrentIndex();
-                        if (!mounted) return;
-                        Navigator.pop(context);
-                      },
-                      icon: Icon(Icons.arrow_back, size: 16),
-                      label: Text('Back to Webspaces', style: TextStyle(fontSize: 12)),
+                    Semantics(
+                      label: 'Back to Webspaces',
+                      button: true,
+                      enabled: true,
+                      child: TextButton.icon(
+                        style: TextButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 0),
+                          minimumSize: Size(0, 32),
+                          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        ),
+                        onPressed: () async {
+                          await _setCurrentIndex(null);
+                          if (!mounted) return;
+                          setState(() {});
+                          await _saveSelectedWebspaceId();
+                          await _saveCurrentIndex();
+                          if (!mounted) return;
+                          Navigator.pop(context);
+                        },
+                        icon: Icon(Icons.arrow_back, size: 16),
+                        label: Text('Back to Webspaces', style: TextStyle(fontSize: 12)),
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
             ),
             Expanded(
               child: _selectedWebspaceId == null

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2521,43 +2521,40 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
               onSecondaryTapDown: (details) {
                 _showSiteContextMenu(context, index, details.globalPosition);
               },
-              child: InkWell(
-                borderRadius: BorderRadius.circular(12),
-                onTap: () async {
-                  Navigator.pop(context);
-                  await _webspaceSwitchCompleter?.future;
-                  await _setCurrentIndex(index);
-                  if (!mounted) return;
-                  setState(() {});
-                  await _saveCurrentIndex();
-                },
-                child: Stack(
-                  fit: StackFit.expand,
-                  children: [
-                    _buildSiteGridTileContent(context, index, isSelected, theme),
-                    Positioned(
-                      top: 2,
-                      right: 2,
-                      child: GestureDetector(
-                        onTap: () {
-                          final renderBox = context.findRenderObject() as RenderBox;
-                          final center = renderBox.localToGlobal(
-                            Offset(renderBox.size.width - 8, 8),
-                          );
-                          _showSiteContextMenu(context, index, center);
-                        },
-                        child: Padding(
-                          padding: const EdgeInsets.all(4.0),
-                          child: Icon(Icons.more_vert, size: 16, color: theme.colorScheme.onSurfaceVariant.withAlpha(150)),
-                        ),
+              onTap: () async {
+                Navigator.pop(context);
+                await _webspaceSwitchCompleter?.future;
+                await _setCurrentIndex(index);
+                if (!mounted) return;
+                setState(() {});
+                await _saveCurrentIndex();
+              },
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  _buildSiteGridTileContent(context, index, isSelected, theme),
+                  Positioned(
+                    top: 2,
+                    right: 2,
+                    child: GestureDetector(
+                      onTap: () {
+                        final renderBox = context.findRenderObject() as RenderBox;
+                        final center = renderBox.localToGlobal(
+                          Offset(renderBox.size.width - 8, 8),
+                        );
+                        _showSiteContextMenu(context, index, center);
+                      },
+                      child: Padding(
+                        padding: const EdgeInsets.all(4.0),
+                        child: Icon(Icons.more_vert, size: 16, color: theme.colorScheme.onSurfaceVariant.withAlpha(150)),
                       ),
                     ),
-                  ],
-                ),
+                  ),
+                ],
               ),
             ),
-            ),
-          );
+          ),
+        );
       },
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2594,7 +2594,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
             SafeArea(
               bottom: false,
               child: Padding(
-                padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
+                padding: const EdgeInsets.only(top: 8.0),
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
@@ -2614,7 +2614,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                           children: [
                             AccentLogo(
                               accentColor: _themeSettings.accentColor,
-                              size: 48,
+                              size: 72,
                               brightness: Theme.of(context).brightness,
                             ),
                             SizedBox(height: 4),
@@ -2672,7 +2672,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                         builder: (context, constraints) {
                           final itemCount = filteredIndices.length;
                           const itemHeight = 88.0;
-                          final availableHeight = constraints.maxHeight - 16; // padding
+                          final availableHeight = constraints.maxHeight - 12; // padding (top: 4 + bottom: 8)
                           final maxRows = (availableHeight / itemHeight).floor().clamp(1, itemCount);
 
                           int crossAxisCount = 1;
@@ -2681,7 +2681,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                           }
 
                           return GridView.builder(
-                            padding: const EdgeInsets.all(8),
+                            padding: const EdgeInsets.only(left: 8, right: 8, bottom: 8, top: 4),
                             gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
                               crossAxisCount: crossAxisCount,
                               mainAxisSpacing: 4,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2532,6 +2532,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                   await _saveCurrentIndex();
                 },
                 child: Stack(
+                  fit: StackFit.expand,
                   children: [
                     _buildSiteGridTileContent(context, index, isSelected, theme),
                     Positioned(
@@ -2668,44 +2669,92 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   }
 
   Widget _buildSiteGridTileContent(BuildContext context, int index, bool isSelected, ThemeData theme) {
-    return Container(
-      decoration: isSelected
-          ? BoxDecoration(
-              borderRadius: BorderRadius.circular(12),
-              color: theme.colorScheme.primaryContainer.withAlpha(80),
-            )
-          : null,
-      padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 2),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Container(
-            width: 48,
-            height: 48,
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(12),
-              color: theme.colorScheme.surfaceContainerHighest,
-            ),
-            clipBehavior: Clip.antiAlias,
-            child: Center(
-              child: UnifiedFaviconImage(
-                url: _webViewModels[index].initUrl,
-                size: 36,
-              ),
-            ),
-          ),
-          const SizedBox(height: 4),
-          Flexible(
-            child: Text(
-              _webViewModels[index].getDisplayName(),
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              textAlign: TextAlign.center,
-              style: TextStyle(fontSize: 11),
-            ),
-          ),
-        ],
-      ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isWide = constraints.maxWidth > constraints.maxHeight * 1.5;
+        return Container(
+          decoration: isSelected
+              ? BoxDecoration(
+                  borderRadius: BorderRadius.circular(12),
+                  color: theme.colorScheme.primaryContainer.withAlpha(80),
+                )
+              : null,
+          padding: isWide
+              ? const EdgeInsets.symmetric(vertical: 4, horizontal: 12)
+              : const EdgeInsets.symmetric(vertical: 6, horizontal: 2),
+          child: isWide
+              ? Row(
+                  children: [
+                    Container(
+                      width: 36,
+                      height: 36,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(8),
+                        color: theme.colorScheme.surfaceContainerHighest,
+                      ),
+                      clipBehavior: Clip.antiAlias,
+                      child: Center(
+                        child: UnifiedFaviconImage(
+                          url: _webViewModels[index].initUrl,
+                          size: 28,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            _webViewModels[index].getDisplayName(),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(fontSize: 13),
+                          ),
+                          Text(
+                            extractDomain(_webViewModels[index].initUrl),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(fontSize: 11, color: Colors.grey),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                )
+              : Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Container(
+                      width: 48,
+                      height: 48,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(12),
+                        color: theme.colorScheme.surfaceContainerHighest,
+                      ),
+                      clipBehavior: Clip.antiAlias,
+                      child: Center(
+                        child: UnifiedFaviconImage(
+                          url: _webViewModels[index].initUrl,
+                          size: 36,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Flexible(
+                      child: Text(
+                        _webViewModels[index].getDisplayName(),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        textAlign: TextAlign.center,
+                        style: TextStyle(fontSize: 11),
+                      ),
+                    ),
+                  ],
+                ),
+        );
+      },
     );
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2469,19 +2469,99 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     Navigator.pop(context);
   }
 
-  Widget _buildSiteGridTile(BuildContext context, int index) {
+  Widget _buildSiteGridTile(BuildContext context, int index, int listIndex) {
     final isSelected = _currentIndex == index;
     final theme = Theme.of(context);
+    final isCustomWebspace = _selectedWebspaceId != null && _selectedWebspaceId != kAllWebspaceId;
     return Semantics(
       key: Key('site_$index'),
       label: _webViewModels[index].getDisplayName(),
       button: true,
       enabled: true,
-      child: GestureDetector(
-        onLongPressStart: (details) {
-          _showSiteContextMenu(context, index, details.globalPosition);
-        },
-        child: InkWell(
+      child: isCustomWebspace
+        ? _buildDraggableSiteGridTile(context, index, listIndex, isSelected, theme)
+        : _buildStaticSiteGridTile(context, index, isSelected, theme),
+    );
+  }
+
+  Widget _buildDraggableSiteGridTile(BuildContext context, int index, int listIndex, bool isSelected, ThemeData theme) {
+    return DragTarget<int>(
+      onWillAcceptWithDetails: (details) => details.data != listIndex,
+      onAcceptWithDetails: (details) {
+        _reorderSiteInWebspace(details.data, listIndex);
+      },
+      builder: (context, candidateData, rejectedData) {
+        final isHovered = candidateData.isNotEmpty;
+        return LongPressDraggable<int>(
+          data: listIndex,
+          feedback: Material(
+            elevation: 4,
+            borderRadius: BorderRadius.circular(12),
+            child: SizedBox(
+              width: 80,
+              height: 88,
+              child: Opacity(
+                opacity: 0.85,
+                child: _buildSiteGridTileContent(context, index, isSelected, theme),
+              ),
+            ),
+          ),
+          childWhenDragging: Opacity(
+            opacity: 0.3,
+            child: _buildSiteGridTileContent(context, index, isSelected, theme),
+          ),
+          child: Container(
+            decoration: isHovered
+                ? BoxDecoration(
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(color: theme.colorScheme.primary, width: 2),
+                  )
+                : null,
+            child: GestureDetector(
+              onSecondaryTapDown: (details) {
+                _showSiteContextMenu(context, index, details.globalPosition);
+              },
+              child: InkWell(
+                borderRadius: BorderRadius.circular(12),
+                onTap: () async {
+                  Navigator.pop(context);
+                  await _webspaceSwitchCompleter?.future;
+                  await _setCurrentIndex(index);
+                  if (!mounted) return;
+                  setState(() {});
+                  await _saveCurrentIndex();
+                },
+                child: Stack(
+                  children: [
+                    _buildSiteGridTileContent(context, index, isSelected, theme),
+                    Positioned(
+                      top: 2,
+                      right: 2,
+                      child: GestureDetector(
+                        onTapDown: (details) {
+                          final renderBox = context.findRenderObject() as RenderBox;
+                          final globalPosition = renderBox.localToGlobal(details.localPosition);
+                          _showSiteContextMenu(context, index, globalPosition);
+                        },
+                        child: Icon(Icons.more_vert, size: 16, color: theme.colorScheme.onSurfaceVariant.withAlpha(150)),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            ),
+          );
+      },
+    );
+  }
+
+  Widget _buildStaticSiteGridTile(BuildContext context, int index, bool isSelected, ThemeData theme) {
+    return GestureDetector(
+      onLongPressStart: (details) {
+        _showSiteContextMenu(context, index, details.globalPosition);
+      },
+      child: InkWell(
           borderRadius: BorderRadius.circular(12),
           onTap: () async {
             Navigator.pop(context);
@@ -2579,6 +2659,47 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
             },
           ),
         ),
+    );
+  }
+
+  Widget _buildSiteGridTileContent(BuildContext context, int index, bool isSelected, ThemeData theme) {
+    return Container(
+      decoration: isSelected
+          ? BoxDecoration(
+              borderRadius: BorderRadius.circular(12),
+              color: theme.colorScheme.primaryContainer.withAlpha(80),
+            )
+          : null,
+      padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 2),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(12),
+              color: theme.colorScheme.surfaceContainerHighest,
+            ),
+            clipBehavior: Clip.antiAlias,
+            child: Center(
+              child: UnifiedFaviconImage(
+                url: _webViewModels[index].initUrl,
+                size: 36,
+              ),
+            ),
+          ),
+          const SizedBox(height: 4),
+          Flexible(
+            child: Text(
+              _webViewModels[index].getDisplayName(),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 11),
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -2691,7 +2812,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                             itemCount: itemCount,
                             itemBuilder: (BuildContext context, int listIndex) {
                               final index = filteredIndices[listIndex];
-                              return _buildSiteGridTile(context, index);
+                              return _buildSiteGridTile(context, index, listIndex);
                             },
                           );
                         },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2538,12 +2538,17 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                       top: 2,
                       right: 2,
                       child: GestureDetector(
-                        onTapDown: (details) {
+                        onTap: () {
                           final renderBox = context.findRenderObject() as RenderBox;
-                          final globalPosition = renderBox.localToGlobal(details.localPosition);
-                          _showSiteContextMenu(context, index, globalPosition);
+                          final center = renderBox.localToGlobal(
+                            Offset(renderBox.size.width - 8, 8),
+                          );
+                          _showSiteContextMenu(context, index, center);
                         },
-                        child: Icon(Icons.more_vert, size: 16, color: theme.colorScheme.onSurfaceVariant.withAlpha(150)),
+                        child: Padding(
+                          padding: const EdgeInsets.all(4.0),
+                          child: Icon(Icons.more_vert, size: 16, color: theme.colorScheme.onSurfaceVariant.withAlpha(150)),
+                        ),
                       ),
                     ),
                   ],


### PR DESCRIPTION
Shrink logo (72→48px), reduce padding/gaps, and minimize the TextButton tap target so the header takes less vertical space.

https://claude.ai/code/session_01B7PC4gCdb8yLJZNcDxYeAd