### PR TITLE
Fix accent colors desaturated by ColorScheme.fromSeed

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -568,6 +568,8 @@ class _WebSpaceAppState extends State<WebSpaceApp> {
         colorScheme: ColorScheme.fromSeed(
           seedColor: accentColor,
           brightness: Brightness.light,
+        ).copyWith(
+          primary: accentColor,
         ),
         scaffoldBackgroundColor: Color(0xFFFFFFFF),
       ),
@@ -575,6 +577,8 @@ class _WebSpaceAppState extends State<WebSpaceApp> {
         colorScheme: ColorScheme.fromSeed(
           seedColor: accentColor,
           brightness: Brightness.dark,
+        ).copyWith(
+          primary: accentColor,
         ),
         scaffoldBackgroundColor: Color(0xFF000000),
       ),


### PR DESCRIPTION
ColorScheme.fromSeed() runs the seed color through Material 3's HCT tonal palette, which significantly reduces saturation. Override the primary color with the original accent color after palette generation to restore vibrant accent colors while keeping M3 harmony for the rest of the scheme.

https://claude.ai/code/session_016KTUH7Jn4CLRcxfAadWhpb