### PR TITLE
Fix URL bar appearing below tab strip instead of above it

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1853,8 +1853,24 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                 _toggleFind();
               },
             ),
-          // Site tab strip for quick switching (with popup menu when tab strip is enabled)
-          if (hasTabStrip)
+          // URL bar (when visible) - above tab strip so keyboard doesn't obscure it
+          if (hasUrlBar)
+            UrlBar(
+              currentUrl: model.currentUrl,
+              onUrlSubmitted: (url) async {
+                final controller = model.getController(launchUrl, _cookieManager, _saveWebViewModels);
+                if (controller != null) {
+                  await controller.loadUrl(url, language: model.language);
+                  if (!mounted) return;
+                  setState(() {
+                    model.currentUrl = url;
+                  });
+                  await _saveWebViewModels();
+                }
+              },
+            ),
+          // Site tab strip for quick switching - hidden when keyboard is open to avoid being overlayed
+          if (hasTabStrip && MediaQuery.of(context).viewInsets.bottom == 0)
             Container(
               height: 52,
               decoration: BoxDecoration(
@@ -1933,22 +1949,6 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                   _buildBottomPopupMenu(),
                 ],
               ),
-            ),
-          // URL bar (when visible)
-          if (hasUrlBar)
-            UrlBar(
-              currentUrl: model.currentUrl,
-              onUrlSubmitted: (url) async {
-                final controller = model.getController(launchUrl, _cookieManager, _saveWebViewModels);
-                if (controller != null) {
-                  await controller.loadUrl(url, language: model.language);
-                  if (!mounted) return;
-                  setState(() {
-                    model.currentUrl = url;
-                  });
-                  await _saveWebViewModels();
-                }
-              },
             ),
         ],
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1853,6 +1853,22 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                 _toggleFind();
               },
             ),
+          // URL bar (when visible) - above tab strip
+          if (hasUrlBar)
+            UrlBar(
+              currentUrl: model.currentUrl,
+              onUrlSubmitted: (url) async {
+                final controller = model.getController(launchUrl, _cookieManager, _saveWebViewModels);
+                if (controller != null) {
+                  await controller.loadUrl(url, language: model.language);
+                  if (!mounted) return;
+                  setState(() {
+                    model.currentUrl = url;
+                  });
+                  await _saveWebViewModels();
+                }
+              },
+            ),
           // Site tab strip for quick switching - hidden when keyboard is open
           if (hasTabStrip && MediaQuery.of(context).viewInsets.bottom == 0)
             Container(
@@ -1933,22 +1949,6 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                   _buildBottomPopupMenu(),
                 ],
               ),
-            ),
-          // URL bar (when visible)
-          if (hasUrlBar)
-            UrlBar(
-              currentUrl: model.currentUrl,
-              onUrlSubmitted: (url) async {
-                final controller = model.getController(launchUrl, _cookieManager, _saveWebViewModels);
-                if (controller != null) {
-                  await controller.loadUrl(url, language: model.language);
-                  if (!mounted) return;
-                  setState(() {
-                    model.currentUrl = url;
-                  });
-                  await _saveWebViewModels();
-                }
-              },
             ),
         ],
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1853,23 +1853,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                 _toggleFind();
               },
             ),
-          // URL bar (when visible) - above tab strip so keyboard doesn't obscure it
-          if (hasUrlBar)
-            UrlBar(
-              currentUrl: model.currentUrl,
-              onUrlSubmitted: (url) async {
-                final controller = model.getController(launchUrl, _cookieManager, _saveWebViewModels);
-                if (controller != null) {
-                  await controller.loadUrl(url, language: model.language);
-                  if (!mounted) return;
-                  setState(() {
-                    model.currentUrl = url;
-                  });
-                  await _saveWebViewModels();
-                }
-              },
-            ),
-          // Site tab strip for quick switching - hidden when keyboard is open to avoid being overlayed
+          // Site tab strip for quick switching - hidden when keyboard is open
           if (hasTabStrip && MediaQuery.of(context).viewInsets.bottom == 0)
             Container(
               height: 52,
@@ -1949,6 +1933,22 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                   _buildBottomPopupMenu(),
                 ],
               ),
+            ),
+          // URL bar (when visible)
+          if (hasUrlBar)
+            UrlBar(
+              currentUrl: model.currentUrl,
+              onUrlSubmitted: (url) async {
+                final controller = model.getController(launchUrl, _cookieManager, _saveWebViewModels);
+                if (controller != null) {
+                  await controller.loadUrl(url, language: model.language);
+                  if (!mounted) return;
+                  setState(() {
+                    model.currentUrl = url;
+                  });
+                  await _saveWebViewModels();
+                }
+              },
             ),
         ],
       ),


### PR DESCRIPTION
Swap the order of URL bar and site tab strip in the bottom bar Column so the URL bar renders above the tab strip when both are enabled.

https://claude.ai/code/session_01DVr8HkAfdsZ7k8XHjfReWq