### PR TITLE
Fix keyboard auto-closing by stabilizing input bar widget tree

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2840,16 +2840,16 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   Widget _buildBodyWithBottomBar() {
     final inputBar = _buildInputBar();
     // Tab strip in bottomNavigationBar handles bottom safe area when visible.
-    // When it's absent the body needs safe area for the home indicator.
+    // Input bar has its own SafeArea. Only apply body safe area when neither
+    // is present (e.g. webspace list screen).
     final filteredIndices = _getFilteredSiteIndices();
-    final tabStripVisible = _currentIndex != null
+    final hasTabStrip = _currentIndex != null
         && _currentIndex! < _webViewModels.length
         && _showTabStrip
-        && filteredIndices.length > 1
-        && MediaQuery.of(context).viewInsets.bottom == 0;
+        && filteredIndices.length > 1;
     return SafeArea(
       top: false, // AppBar handles top inset
-      bottom: !tabStripVisible && inputBar == null,
+      bottom: !hasTabStrip && inputBar == null,
       // Use Stack + Offstage so the IndexedStack (and its webview States)
       // stay mounted when showing the webspace list. Removing the
       // IndexedStack from the tree destroys webview States, losing
@@ -2907,9 +2907,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
               ],
             ),
           ),
-          if (inputBar != null && tabStripVisible) inputBar,
-          if (inputBar != null && !tabStripVisible)
-            SafeArea(top: false, child: inputBar),
+          // Always wrap in SafeArea to keep the widget tree stable when
+          // the keyboard opens/closes (changing tree structure would unmount
+          // the UrlBar, losing TextField focus and closing the keyboard).
+          // SafeArea naturally adds 0 padding when keyboard is open.
+          if (inputBar != null) SafeArea(top: false, child: inputBar),
         ],
       ),
     );


### PR DESCRIPTION
The input bar was conditionally wrapped in SafeArea only when the tab strip was hidden, causing the widget tree to change when the keyboard opened (tabStripVisible toggled). This unmounted and remounted the UrlBar, making the TextField lose focus and closing the keyboard.

Always wrap the input bar in SafeArea regardless of state. SafeArea naturally adds 0 bottom padding when the keyboard is open, so it's a no-op in that case. Also simplify hasTabStrip to not depend on viewInsets since it's only used for the outer SafeArea bottom flag.

https://claude.ai/code/session_01W5YXdyt12RuCWUu5kBCu9e