### PR TITLE
Use back button to toggle drawer when webview can't go back

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,3 +108,12 @@ Detailed feature specs are in `openspec/specs/`. Each spec uses Given/When/Then 
 | configurable-suggested-sites | Configurable suggested sites list with empty default for fdroid flavor |
 
 Read the relevant spec before modifying a feature. Specs include file paths, data models, and manual test procedures.
+
+## UI Race Conditions
+
+Async event handlers in the UI (e.g. button callbacks, `onPopInvokedWithResult`, gesture handlers) can be invoked multiple times before the first invocation completes. Always review UI code changes for race conditions:
+
+- **Rapid input**: Users can tap/press buttons faster than async operations resolve. If a handler does `await` before acting, a second invocation can enter the same handler concurrently.
+- **Guard pattern**: Use a boolean flag (e.g. `_isHandling`) to drop concurrent invocations. Always clear the flag in a `finally` block.
+- **State between await gaps**: After any `await`, re-check assumptions — widget may have unmounted (`if (!mounted) return;`), indices may have changed, or another handler may have mutated shared state.
+- **Drawer/dialog flash**: Opening UI in an async callback without a guard can cause a second press to immediately close it, producing a visible flash.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -627,6 +627,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   final CookieSecureStorage _cookieSecureStorage = CookieSecureStorage();
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
+  bool _isBackHandling = false;
   bool _isFindVisible = false;
   bool _showUrlBar = false;
   bool _showTabStrip = false;
@@ -2924,18 +2925,23 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       // Allow pop only when no webview is visible (webspace list screen)
       canPop: !webviewIsVisible,
       onPopInvokedWithResult: (didPop, _) async {
-        if (didPop) return;
-        final scaffoldState = _scaffoldKey.currentState;
-        if (scaffoldState != null && scaffoldState.isDrawerOpen) {
-          Navigator.pop(context);
-          return;
-        }
-        // Webview is visible - try to go back in its history
-        final controller = getController();
-        if (controller != null && await controller.canGoBack()) {
-          await controller.goBack();
-        } else {
-          scaffoldState?.openDrawer();
+        if (didPop || _isBackHandling) return;
+        _isBackHandling = true;
+        try {
+          final scaffoldState = _scaffoldKey.currentState;
+          if (scaffoldState != null && scaffoldState.isDrawerOpen) {
+            Navigator.pop(context);
+            return;
+          }
+          // Webview is visible - try to go back in its history
+          final controller = getController();
+          if (controller != null && await controller.canGoBack()) {
+            await controller.goBack();
+          } else {
+            scaffoldState?.openDrawer();
+          }
+        } finally {
+          _isBackHandling = false;
         }
       },
       child: Scaffold(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2925,10 +2925,17 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       canPop: !webviewIsVisible,
       onPopInvokedWithResult: (didPop, _) async {
         if (didPop) return;
+        final scaffoldState = _scaffoldKey.currentState;
+        if (scaffoldState != null && scaffoldState.isDrawerOpen) {
+          Navigator.pop(context);
+          return;
+        }
         // Webview is visible - try to go back in its history
         final controller = getController();
         if (controller != null && await controller.canGoBack()) {
           await controller.goBack();
+        } else {
+          scaffoldState?.openDrawer();
         }
       },
       child: Scaffold(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -628,7 +628,6 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
   bool _isBackHandling = false;
-  DateTime? _lastGoBackTime;
   bool _isFindVisible = false;
   bool _showUrlBar = false;
   bool _showTabStrip = false;
@@ -2935,20 +2934,22 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
             return;
           }
           // Webview is visible - try to go back in its history.
-          // After goBack(), the native back-forward list may not have
-          // settled yet, so canGoBack() can return a stale false. Skip
-          // the check when we recently navigated back and just retry
-          // goBack() (it's a no-op when there's truly no history).
+          // Don't trust canGoBack(): it can return false for pushState
+          // entries on some webview versions. Instead, always attempt
+          // goBack() (which is a no-op when there's no history) and
+          // check whether the URL actually changed.
           final controller = getController();
-          final recentGoBack = _lastGoBackTime != null &&
-              DateTime.now().difference(_lastGoBackTime!) <
-                  const Duration(milliseconds: 500);
-          if (controller != null &&
-              (recentGoBack || await controller.canGoBack())) {
-            _lastGoBackTime = DateTime.now();
-            await controller.goBack();
-          } else {
-            _lastGoBackTime = null;
+          if (controller == null) {
+            scaffoldState?.openDrawer();
+            return;
+          }
+          final urlBefore = (await controller.getUrl())?.toString();
+          await controller.goBack();
+          // Give the native webview time to process the navigation
+          await Future.delayed(const Duration(milliseconds: 150));
+          if (!mounted) return;
+          final urlAfter = (await controller.getUrl())?.toString();
+          if (urlBefore == urlAfter) {
             scaffoldState?.openDrawer();
           }
         } finally {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -628,6 +628,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
   bool _isBackHandling = false;
+  DateTime? _lastGoBackTime;
   bool _isFindVisible = false;
   bool _showUrlBar = false;
   bool _showTabStrip = false;
@@ -2933,11 +2934,21 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
             Navigator.pop(context);
             return;
           }
-          // Webview is visible - try to go back in its history
+          // Webview is visible - try to go back in its history.
+          // After goBack(), the native back-forward list may not have
+          // settled yet, so canGoBack() can return a stale false. Skip
+          // the check when we recently navigated back and just retry
+          // goBack() (it's a no-op when there's truly no history).
           final controller = getController();
-          if (controller != null && await controller.canGoBack()) {
+          final recentGoBack = _lastGoBackTime != null &&
+              DateTime.now().difference(_lastGoBackTime!) <
+                  const Duration(milliseconds: 500);
+          if (controller != null &&
+              (recentGoBack || await controller.canGoBack())) {
+            _lastGoBackTime = DateTime.now();
             await controller.goBack();
           } else {
+            _lastGoBackTime = null;
             scaffoldState?.openDrawer();
           }
         } finally {


### PR DESCRIPTION
When a webview is visible and the back button is pressed:
- If the drawer is open, close it
- If the webview can go back, navigate back in history
- Otherwise, open the drawer as a fallback

https://claude.ai/code/session_01Usih9KXP3K12QYt6HE5KWG