### PR TITLE
Fix URL bar not updating on Safari back gesture

### DIFF
--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -834,6 +834,14 @@ class WebViewFactory {
           }
         }
       },
+      onUpdateVisitedHistory: (controller, url, androidIsReload) {
+        // Fires on every history change including back/forward gestures.
+        // onLoadStop may not fire for BFCache restorations (iOS Safari back
+        // gesture), so this ensures the URL bar stays in sync.
+        if (url != null) {
+          config.onUrlChanged?.call(url.toString());
+        }
+      },
       onFindResultReceived: (controller, activeMatchOrdinal, numberOfMatches, isDoneCounting) {
         config.onFindResult?.call(activeMatchOrdinal, numberOfMatches);
       },


### PR DESCRIPTION
The URL bar only updated via onLoadStop, which doesn't reliably fire for BFCache page restorations during iOS back/forward gestures. Add onUpdateVisitedHistory callback which fires on every history change including gesture-based navigation.

https://claude.ai/code/session_01MmFK7Xu1xBgpq3hf1mbyZ7