### PR TITLE
Disable pull-to-refresh on desktop platforms

### DIFF
--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp show PullToRefreshController, PullToRefreshSettings;
@@ -39,7 +41,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen> {
   WebViewController? _controller;
   String? title;
   late String _currentUrl;
-  late final inapp.PullToRefreshController _pullToRefreshController;
+  late final inapp.PullToRefreshController? _pullToRefreshController;
 
   bool _isFindVisible = false;
   FindMatchesResult findMatches = FindMatchesResult();
@@ -50,12 +52,13 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen> {
     // Use home site title if provided
     title = widget.homeTitle;
     _currentUrl = widget.url;
-    _pullToRefreshController = inapp.PullToRefreshController(
+    final bool isMobile = Platform.isIOS || Platform.isAndroid;
+    _pullToRefreshController = isMobile ? inapp.PullToRefreshController(
       settings: inapp.PullToRefreshSettings(enabled: true),
       onRefresh: () async {
         _controller?.reload();
       },
-    );
+    ) : null;
   }
 
   void updateTitle(String newTitle) {

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -373,12 +374,13 @@ class WebViewModel {
       LogService.instance.log('WebView', 'Creating webview for "$name" (siteId: $siteId, initUrl: $initUrl)');
       LogService.instance.log('WebView', 'Language: $effectiveLanguage (param: $language)');
       LogService.instance.log('WebView', 'Using cached HTML: ${initialHtml != null} (${initialHtml?.length ?? 0} bytes)');
-      final pullToRefreshController = inapp.PullToRefreshController(
+      final bool isMobile = Platform.isIOS || Platform.isAndroid;
+      final pullToRefreshController = isMobile ? inapp.PullToRefreshController(
         settings: inapp.PullToRefreshSettings(enabled: true),
         onRefresh: () async {
           controller?.reload();
         },
-      );
+      ) : null;
       webview = WebViewFactory.createWebView(
         config: WebViewConfig(
           key: UniqueKey(), // Force new widget state when recreating


### PR DESCRIPTION
PullToRefreshController is only supported on iOS and Android. On desktop (macOS, Linux), pass null instead to avoid unsupported gesture handling.

https://claude.ai/code/session_01Nd8dqxG7TYMAEt8zTQebjQ