### PR TITLE
Fix iOS drawer not opening after swiping back to home URL

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1526,7 +1526,19 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       if (_canGoBack) setState(() => _canGoBack = false);
       return;
     }
-    final controller = _webViewModels[_currentIndex!].controller;
+    final model = _webViewModels[_currentIndex!];
+    // Synchronous fast-path: if the current URL matches the site's home URL,
+    // there is no meaningful back history.  Set _canGoBack = false immediately
+    // so the drawer edge-swipe is enabled without waiting for the async
+    // canGoBack() call, which can race with other callbacks.
+    if (model.currentUrl == model.initUrl) {
+      if (_canGoBack) {
+        LogService.instance.log('Navigation', '_updateCanGoBack: at home URL, forcing false');
+        setState(() => _canGoBack = false);
+      }
+      return;
+    }
+    final controller = model.controller;
     if (controller == null) {
       if (_canGoBack) setState(() => _canGoBack = false);
       return;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1532,8 +1532,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       return;
     }
     final canGoBack = await controller.canGoBack();
-    if (!mounted || version != _canGoBackVersion) return;
+    if (!mounted || version != _canGoBackVersion) {
+      LogService.instance.log('Navigation', '_updateCanGoBack: stale (v$version != v$_canGoBackVersion), discarding canGoBack=$canGoBack');
+      return;
+    }
     if (canGoBack != _canGoBack) {
+      LogService.instance.log('Navigation', '_updateCanGoBack: $_canGoBack -> $canGoBack');
       setState(() => _canGoBack = canGoBack);
     }
   }
@@ -2963,6 +2967,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         try {
           final scaffoldState = _scaffoldKey.currentState;
           if (scaffoldState != null && scaffoldState.isDrawerOpen) {
+            LogService.instance.log('Navigation', 'Back gesture: closing open drawer');
             Navigator.pop(context);
             return;
           }
@@ -2973,6 +2978,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           // check whether the URL actually changed.
           final controller = getController();
           if (controller == null) {
+            LogService.instance.log('Navigation', 'Back gesture: no controller, opening drawer');
             scaffoldState?.openDrawer();
             return;
           }
@@ -2983,15 +2989,20 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           if (!mounted) return;
           final urlAfter = (await controller.getUrl())?.toString();
           if (urlBefore == urlAfter) {
+            LogService.instance.log('Navigation', 'Back gesture: URL unchanged ($urlAfter), opening drawer');
             scaffoldState?.openDrawer();
-          } else if (Platform.isIOS && _currentIndex != null && _currentIndex! < _webViewModels.length) {
-            // After a successful goBack(), if we've landed on the home URL,
-            // synchronously clear _canGoBack so the drawer edge-swipe is
-            // enabled immediately for the next gesture.
-            final homeUrl = _webViewModels[_currentIndex!].initUrl;
-            if (urlAfter != null && urlAfter == homeUrl) {
-              ++_canGoBackVersion;
-              setState(() => _canGoBack = false);
+          } else {
+            LogService.instance.log('Navigation', 'Back gesture: navigated back from $urlBefore to $urlAfter');
+            if (Platform.isIOS && _currentIndex != null && _currentIndex! < _webViewModels.length) {
+              // After a successful goBack(), if we've landed on the home URL,
+              // synchronously clear _canGoBack so the drawer edge-swipe is
+              // enabled immediately for the next gesture.
+              final homeUrl = _webViewModels[_currentIndex!].initUrl;
+              if (urlAfter != null && urlAfter == homeUrl) {
+                LogService.instance.log('Navigation', 'Back gesture: landed on home URL, enabling drawer swipe');
+                ++_canGoBackVersion;
+                setState(() => _canGoBack = false);
+              }
             }
           }
         } finally {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2984,6 +2984,15 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           final urlAfter = (await controller.getUrl())?.toString();
           if (urlBefore == urlAfter) {
             scaffoldState?.openDrawer();
+          } else if (Platform.isIOS && _currentIndex != null && _currentIndex! < _webViewModels.length) {
+            // After a successful goBack(), if we've landed on the home URL,
+            // synchronously clear _canGoBack so the drawer edge-swipe is
+            // enabled immediately for the next gesture.
+            final homeUrl = _webViewModels[_currentIndex!].initUrl;
+            if (urlAfter != null && urlAfter == homeUrl) {
+              ++_canGoBackVersion;
+              setState(() => _canGoBack = false);
+            }
           }
         } finally {
           _isBackHandling = false;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1513,6 +1513,15 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     return _webViewModels[_currentIndex!].getController(launchUrl, _cookieManager, _saveWebViewModels);
   }
 
+  /// Compare a current URL against a site's initUrl, ignoring trailing slashes.
+  /// Webviews often normalize "https://example.com" to "https://example.com/"
+  /// so a plain == comparison misses the match.
+  static bool _isHomeUrl(String currentUrl, String initUrl) {
+    final a = currentUrl.endsWith('/') ? currentUrl.substring(0, currentUrl.length - 1) : currentUrl;
+    final b = initUrl.endsWith('/') ? initUrl.substring(0, initUrl.length - 1) : initUrl;
+    return a == b;
+  }
+
   /// Update _canGoBack from the current webview's controller.
   /// Used on iOS to enable drawer edge-swipe when there's no back history.
   /// Note: canGoBack() can return false for pushState/SPA navigations even
@@ -1531,7 +1540,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     // there is no meaningful back history.  Set _canGoBack = false immediately
     // so the drawer edge-swipe is enabled without waiting for the async
     // canGoBack() call, which can race with other callbacks.
-    if (model.currentUrl == model.initUrl) {
+    if (_isHomeUrl(model.currentUrl, model.initUrl)) {
       if (_canGoBack) {
         LogService.instance.log('Navigation', '_updateCanGoBack: at home URL, forcing false');
         setState(() => _canGoBack = false);
@@ -3010,7 +3019,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
               // synchronously clear _canGoBack so the drawer edge-swipe is
               // enabled immediately for the next gesture.
               final homeUrl = _webViewModels[_currentIndex!].initUrl;
-              if (urlAfter != null && urlAfter == homeUrl) {
+              if (urlAfter != null && _isHomeUrl(urlAfter, homeUrl)) {
                 LogService.instance.log('Navigation', 'Back gesture: landed on home URL, enabling drawer swipe');
                 ++_canGoBackVersion;
                 setState(() => _canGoBack = false);

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -177,7 +177,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
     }
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 2.0),
-      child: Text(
+      child: SelectableText(
         '[${_formatTimeMs(entry.timestamp)}] ${entry.message}',
         style: TextStyle(
           fontFamily: 'monospace',
@@ -642,7 +642,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
     }
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 1.0),
-      child: Text(
+      child: SelectableText(
         '[${_formatTime(entry.timestamp)}] [${entry.tag}] ${entry.message}',
         style: TextStyle(fontFamily: 'monospace', fontSize: 11, color: color),
       ),

--- a/openspec/specs/navigation/spec.md
+++ b/openspec/specs/navigation/spec.md
@@ -193,6 +193,7 @@ The URL bar SHALL stay in sync with the current webview URL across all navigatio
 - At the start of each `_updateCanGoBack()` call
 - When `_goHome()` resets state
 - When `_setCurrentIndex()` switches sites
+- When the PopScope handler detects landing on the home URL
 
 After the `await`, the result is discarded if `version != _canGoBackVersion`.
 
@@ -203,6 +204,16 @@ _updateCanGoBack() called         _goHome() called
   ... IPC resolves true ...
   version(1) != counter(2) → DISCARD
 ```
+
+### Guard: RACE-005 - Home URL Synchronous Fast-Path
+
+**Problem:** After `goBack()` lands on the site's home URL, `_canGoBack` must become `false` to enable the iOS drawer edge swipe. But `_updateCanGoBack()` is async — it calls `await canGoBack()` which takes indeterminate time. Meanwhile, `onLoadStop` or `onUpdateVisitedHistory` callbacks can fire and start *new* `_updateCanGoBack()` calls whose version counters post-date the PopScope handler's bump, making the version guard (RACE-001) ineffective against them.
+
+**Solution:** `_updateCanGoBack()` checks `currentUrl` against `initUrl` *synchronously* before the async `canGoBack()` call (using `_isHomeUrl()` which normalizes trailing slashes). When at the home URL, `_canGoBack` is set to `false` immediately and the async path is skipped entirely, eliminating the race window.
+
+Additionally, the PopScope handler performs the same check right after a successful `goBack()` to cover the window before `onUrlChanged` fires.
+
+**Note:** URL comparison uses `_isHomeUrl()` which strips trailing slashes, since webviews normalize `https://example.com` to `https://example.com/`.
 
 ### Guard: RACE-002 - _isBackHandling Flag
 
@@ -251,7 +262,8 @@ System back gesture received
       ├─ wait 150ms
       ├─ urlAfter = getUrl()
       │
-      ├─ URL changed? ─────────── back succeeded (done)
+      ├─ URL changed? ─────────── back succeeded
+      │   └─ (iOS) at home URL? ── _canGoBack=false (enable drawer swipe)
       └─ URL same? ────────────── open drawer (fallback)
 ```
 
@@ -292,7 +304,8 @@ Home button pressed
 - `_canGoBack` — iOS-only state: whether current webview has back history
 - `_canGoBackVersion` — version counter guarding `_updateCanGoBack`
 - `_isBackHandling` — boolean guard for PopScope handler
-- `_updateCanGoBack()` — async check of `controller.canGoBack()` with version guard
+- `_isHomeUrl()` — static helper: compares URLs ignoring trailing slash normalization
+- `_updateCanGoBack()` — async check of `controller.canGoBack()` with version guard and synchronous home-URL fast-path (RACE-005)
 - `_goHome()` — synchronous: dispose webview, reset URL, invalidate version
 - `PopScope` widget — wraps Scaffold, handles system back gesture with URL comparison
 - `drawerEdgeDragWidth` — conditional drawer edge swipe based on platform and `_canGoBack`
@@ -347,9 +360,8 @@ Home button pressed
 
 1. (iOS) Start at a site's home URL
 2. Navigate to a second page
-3. Press the back button in the menu to return to the home URL
-4. Wait ~200ms for `_updateCanGoBack` to resolve
-5. Swipe from the left edge — verify the drawer opens
+3. Swipe back (system back gesture) to return to the home URL
+4. Immediately swipe from the left edge — verify the drawer opens (no delay needed; home URL fast-path in `_updateCanGoBack` enables drawer synchronously)
 
 ### Manual Test: Rapid Home Tap (Race Condition)
 


### PR DESCRIPTION
After goBack() lands on the site's initUrl, synchronously set _canGoBack=false so the drawer edge-swipe is enabled immediately for the next gesture, instead of waiting for the async _updateCanGoBack() callback.

https://claude.ai/code/session_016mDUQsq1HZfv8zRKctz9yV