### PR TITLE
Show tabstrip even with a single site in webspace

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1916,7 +1916,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     final isDark = theme.brightness == Brightness.dark;
     final filteredIndices = _getFilteredSiteIndices();
 
-    final hasTabStrip = _showTabStrip && filteredIndices.length > 1;
+    final hasTabStrip = _showTabStrip && filteredIndices.isNotEmpty;
     if (!hasTabStrip) {
       return null;
     }
@@ -2905,7 +2905,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     final hasTabStrip = _currentIndex != null
         && _currentIndex! < _webViewModels.length
         && _showTabStrip
-        && filteredIndices.length > 1;
+        && filteredIndices.isNotEmpty;
     return SafeArea(
       top: false, // AppBar handles top inset
       bottom: !hasTabStrip && inputBar == null,


### PR DESCRIPTION
The tabstrip visibility required more than one site in the current webspace (filteredIndices.length > 1). Changed to isNotEmpty so the tabstrip appears whenever the toggle is enabled, regardless of site count.

https://claude.ai/code/session_01Y7dhNALgjZTKmnR33kMnDg