### PR TITLE
Add per-site cookie blocking (name + domain) 

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -912,10 +912,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
     LogService.instance.log('CookieIsolation', 'Restoring ${cookies.length} cookies for site $index: "${model.name}" (siteId: ${model.siteId})');
 
-    // Restore cookies to CookieManager
+    // Restore cookies to CookieManager, skipping blocked ones
     final url = Uri.parse(model.initUrl);
     for (final cookie in cookies) {
       if (cookie.value.isEmpty) continue;
+      if (model.isCookieBlocked(cookie.name, cookie.domain)) continue;
       await _cookieManager.setCookie(
         url: url,
         name: cookie.name,
@@ -1934,6 +1935,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                         builder: (context) => DevToolsScreen(
                           webViewModel: _webViewModels[_currentIndex!],
                           cookieManager: _cookieManager,
+                          onSave: _saveWebViewModels,
                         ),
                       ),
                     );
@@ -2301,6 +2303,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                   builder: (context) => DevToolsScreen(
                     webViewModel: _webViewModels[_currentIndex!],
                     cookieManager: _cookieManager,
+                    onSave: _saveWebViewModels,
                   ),
                 ),
               );

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -45,6 +45,9 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   final TextEditingController _searchController = TextEditingController();
   final FocusNode _searchFocusNode = FocusNode();
 
+  /// Snapshot of blocked cookies on entry, to detect changes on exit.
+  late final Set<BlockedCookie> _initialBlockedCookies;
+
   bool get _hasSite => widget.webViewModel != null;
 
   int get _tabCount => _hasSite ? 3 : 1;
@@ -52,6 +55,9 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   @override
   void initState() {
     super.initState();
+    _initialBlockedCookies = _hasSite
+        ? Set<BlockedCookie>.of(widget.webViewModel!.blockedCookies)
+        : <BlockedCookie>{};
     LogService.instance.addListener(_onLogUpdate);
     if (_hasSite) {
       widget.webViewModel!.onConsoleLogChanged = _onConsoleUpdate;
@@ -63,12 +69,24 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
     LogService.instance.removeListener(_onLogUpdate);
     if (_hasSite) {
       widget.webViewModel!.onConsoleLogChanged = null;
+      // If blocked cookies changed while DevTools was open, reload the page
+      // so the webview re-fetches cookies with the new rules applied.
+      final current = widget.webViewModel!.blockedCookies;
+      if (!_setEquals(current, _initialBlockedCookies)) {
+        widget.webViewModel!.controller?.reload();
+      }
     }
     _consoleScrollController.dispose();
     _logScrollController.dispose();
     _searchController.dispose();
     _searchFocusNode.dispose();
     super.dispose();
+  }
+
+  /// Value-equality check for two sets (avoid importing collection).
+  static bool _setEquals<T>(Set<T> a, Set<T> b) {
+    if (a.length != b.length) return false;
+    return a.every(b.contains);
   }
 
   void _onConsoleUpdate() {

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -13,14 +13,18 @@ import 'package:webspace/services/webview.dart';
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/settings/user_script.dart';
 
+typedef VoidAsyncCallback = Future<void> Function();
+
 class DevToolsScreen extends StatefulWidget {
   final WebViewModel? webViewModel;
   final CookieManager cookieManager;
+  final VoidAsyncCallback? onSave;
 
   const DevToolsScreen({
     super.key,
     this.webViewModel,
     required this.cookieManager,
+    this.onSave,
   });
 
   @override
@@ -266,6 +270,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
 
   Widget _buildCookiesTab() {
     final allCookies = widget.webViewModel!.cookies;
+    final blocked = widget.webViewModel!.blockedCookies;
     final cookies = _searchQuery.isEmpty
         ? allCookies
         : allCookies
@@ -274,18 +279,36 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
                 _matchesSearch(c.value) ||
                 _matchesSearch(c.domain ?? ''))
             .toList();
+    final filteredBlocked = _searchQuery.isEmpty
+        ? blocked.toList()
+        : blocked.where((b) => _matchesSearch(b.name) || _matchesSearch(b.domain)).toList();
     return Column(
       children: [
         _buildCookieActions(allCookies),
         Expanded(
           child: _loadingCookies
               ? const Center(child: CircularProgressIndicator())
-              : cookies.isEmpty
+              : (cookies.isEmpty && filteredBlocked.isEmpty)
                   ? Center(child: Text(_searchQuery.isEmpty ? 'No cookies' : 'No matches'))
-                  : ListView.builder(
-                      itemCount: cookies.length,
-                      itemBuilder: (context, index) =>
-                          _buildCookieTile(cookies[index]),
+                  : ListView(
+                      children: [
+                        if (filteredBlocked.isNotEmpty) ...[
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                            child: Text(
+                              'Blocked (${filteredBlocked.length})',
+                              style: TextStyle(
+                                fontSize: 13,
+                                fontWeight: FontWeight.bold,
+                                color: Colors.red.shade300,
+                              ),
+                            ),
+                          ),
+                          ...filteredBlocked.map(_buildBlockedCookieTile),
+                          const Divider(),
+                        ],
+                        ...cookies.map(_buildCookieTile),
+                      ],
                     ),
         ),
       ],
@@ -353,6 +376,29 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
     }
   }
 
+  Future<void> _blockCookie(Cookie cookie) async {
+    final domain = cookie.domain ?? extractDomain(widget.webViewModel!.currentUrl);
+    final rule = BlockedCookie(name: cookie.name, domain: domain);
+    setState(() {
+      widget.webViewModel!.blockedCookies.add(rule);
+    });
+    // Delete the cookie immediately from the webview
+    await _deleteCookie(cookie);
+    await widget.onSave?.call();
+  }
+
+  Future<void> _unblockCookie(BlockedCookie rule) async {
+    setState(() {
+      widget.webViewModel!.blockedCookies.remove(rule);
+    });
+    await widget.onSave?.call();
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Unblocked cookie "${rule.name}"')),
+      );
+    }
+  }
+
   Widget _buildCookieTile(Cookie cookie) {
     return ExpansionTile(
       title: Text(cookie.name, style: const TextStyle(fontFamily: 'monospace', fontSize: 13)),
@@ -393,15 +439,38 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
                 ],
               ),
               const SizedBox(height: 8),
-              TextButton.icon(
-                onPressed: () => _deleteCookie(cookie),
-                icon: const Icon(Icons.delete_outline, size: 16, color: Colors.red),
-                label: const Text('Delete', style: TextStyle(color: Colors.red, fontSize: 12)),
+              Row(
+                children: [
+                  TextButton.icon(
+                    onPressed: () => _deleteCookie(cookie),
+                    icon: const Icon(Icons.delete_outline, size: 16, color: Colors.red),
+                    label: const Text('Delete', style: TextStyle(color: Colors.red, fontSize: 12)),
+                  ),
+                  const SizedBox(width: 8),
+                  TextButton.icon(
+                    onPressed: () => _blockCookie(cookie),
+                    icon: const Icon(Icons.block, size: 16, color: Colors.orange),
+                    label: const Text('Block', style: TextStyle(color: Colors.orange, fontSize: 12)),
+                  ),
+                ],
               ),
             ],
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildBlockedCookieTile(BlockedCookie rule) {
+    return ListTile(
+      leading: Icon(Icons.block, color: Colors.red.shade300, size: 20),
+      title: Text(rule.name, style: const TextStyle(fontFamily: 'monospace', fontSize: 13)),
+      subtitle: Text(rule.domain, style: const TextStyle(fontSize: 11)),
+      trailing: TextButton.icon(
+        onPressed: () => _unblockCookie(rule),
+        icon: const Icon(Icons.check_circle_outline, size: 16, color: Colors.green),
+        label: const Text('Unblock', style: TextStyle(color: Colors.green, fontSize: 12)),
+      ),
     );
   }
 

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -216,6 +216,29 @@ String getNormalizedDomain(String url) {
   return secondLevel;
 }
 
+/// A cookie blocked by name + domain, per-site.
+/// When a cookie matches, it is deleted from the webview after each page load
+/// and skipped during cookie restore.
+class BlockedCookie {
+  final String name;
+  final String domain;
+
+  const BlockedCookie({required this.name, required this.domain});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is BlockedCookie && name == other.name && domain == other.domain;
+
+  @override
+  int get hashCode => Object.hash(name, domain);
+
+  Map<String, dynamic> toJson() => {'name': name, 'domain': domain};
+
+  factory BlockedCookie.fromJson(Map<String, dynamic> json) =>
+      BlockedCookie(name: json['name'] as String, domain: json['domain'] as String);
+}
+
 class WebViewModel {
   final String siteId; // Unique ID for per-site cookie isolation
   String initUrl; // Made non-final to allow URL editing
@@ -237,6 +260,7 @@ class WebViewModel {
   bool localCdnEnabled; // Serve CDN resources from local cache for privacy
   bool blockAutoRedirects; // Block script-initiated cross-domain navigations
   List<UserScriptConfig> userScripts; // Per-site user scripts
+  Set<BlockedCookie> blockedCookies; // Per-site blocked cookies (name + domain)
 
   final List<ConsoleLogEntry> consoleLogs = [];
   static const _maxConsoleLogs = 500;
@@ -265,12 +289,24 @@ class WebViewModel {
     this.localCdnEnabled = true,
     this.blockAutoRedirects = true,
     List<UserScriptConfig>? userScripts,
+    Set<BlockedCookie>? blockedCookies,
     this.stateSetterF,
   })  : userScripts = userScripts ?? [],
+        blockedCookies = blockedCookies ?? {},
         siteId = siteId ?? _generateSiteId(),
         currentUrl = currentUrl ?? initUrl,
         name = name ?? extractDomain(initUrl),
         proxySettings = proxySettings ?? UserProxySettings(type: ProxyType.DEFAULT);
+
+  /// Check if a cookie is blocked by name + domain for this site.
+  bool isCookieBlocked(String name, String? domain) {
+    if (blockedCookies.isEmpty) return false;
+    return blockedCookies.any((b) =>
+        b.name == name &&
+        (domain != null && (b.domain == domain ||
+            domain.endsWith('.${b.domain}') ||
+            b.domain.endsWith('.$domain'))));
+  }
 
   void removeThirdPartyCookies(WebViewController controller) async {
     String script = '''
@@ -519,7 +555,22 @@ class WebViewModel {
             await saveFunc();
           },
           onCookiesChanged: (newCookies) async {
-            cookies = newCookies;
+            // Remove blocked cookies from the webview cookie jar
+            if (blockedCookies.isNotEmpty) {
+              final blocked = newCookies.where((c) => isCookieBlocked(c.name, c.domain)).toList();
+              final url = Uri.parse(currentUrl.isNotEmpty ? currentUrl : initUrl);
+              for (final c in blocked) {
+                await cookieManager.deleteCookie(
+                  url: url,
+                  name: c.name,
+                  domain: c.domain,
+                  path: c.path ?? '/',
+                );
+              }
+              cookies = newCookies.where((c) => !isCookieBlocked(c.name, c.domain)).toList();
+            } else {
+              cookies = newCookies;
+            }
             if (!thirdPartyCookiesEnabled && controller != null) {
               removeThirdPartyCookies(controller!);
             }
@@ -649,6 +700,8 @@ class WebViewModel {
         'localCdnEnabled': localCdnEnabled,
         'blockAutoRedirects': blockAutoRedirects,
         'userScripts': userScripts.map((s) => s.toJson()).toList(),
+        if (blockedCookies.isNotEmpty)
+          'blockedCookies': blockedCookies.map((b) => b.toJson()).toList(),
       };
 
   factory WebViewModel.fromJson(Map<String, dynamic> json, Function? stateSetterF) {
@@ -674,6 +727,9 @@ class WebViewModel {
       userScripts: (json['userScripts'] as List<dynamic>?)
           ?.map((e) => UserScriptConfig.fromJson(e as Map<String, dynamic>))
           .toList(),
+      blockedCookies: (json['blockedCookies'] as List<dynamic>?)
+          ?.map((e) => BlockedCookie.fromJson(e as Map<String, dynamic>))
+          .toSet(),
       stateSetterF: stateSetterF,
     )..pageTitle = json['pageTitle'];
   }

--- a/openspec/specs/developer-tools/spec.md
+++ b/openspec/specs/developer-tools/spec.md
@@ -65,6 +65,22 @@ The app SHALL display cookies for the current site with security flag details.
 **When** the user taps "Copy as JSON"
 **Then** all cookies are copied to clipboard as formatted JSON
 
+#### Scenario: Block a cookie
+
+**Given** the Cookies tab shows cookies
+**When** the user expands a cookie and taps "Block"
+**Then** a `BlockedCookie(name, domain)` rule is added to the site's `blockedCookies`
+**And** the cookie is immediately deleted from CookieManager
+**And** the block rule is persisted
+**And** the cookie will be removed on every subsequent page load
+
+#### Scenario: Unblock a cookie
+
+**Given** the Blocked section at the top of the Cookies tab lists blocked rules
+**When** the user taps "Unblock" on a rule
+**Then** the `BlockedCookie` is removed from the set
+**And** the website can set the cookie again on next page load
+
 ---
 
 ### Requirement: DEVTOOLS-003 - Share HTML

--- a/openspec/specs/per-site-cookie-isolation/spec.md
+++ b/openspec/specs/per-site-cookie-isolation/spec.md
@@ -178,6 +178,19 @@ Uses `getNormalizedDomain()` for nested webview URL blocking only:
 
 **Important:** Domain aliases affect ONLY nested webview navigation, NOT cookie isolation. Two sites on `gmail.com` and `google.com` have separate cookie stores (different second-level domains).
 
+### Per-Site Cookie Blocking
+
+Each `WebViewModel` has a `Set<BlockedCookie> blockedCookies` field. A `BlockedCookie` is a pair of `(name, domain)` with value-based equality.
+
+**Enforcement points:**
+1. `onCookiesChanged` callback: after fetching cookies from the webview on page load, blocked cookies are filtered out and deleted from CookieManager
+2. `_restoreCookiesForSite()`: blocked cookies are skipped when restoring cookies to CookieManager
+3. Serialization: `blockedCookies` is included in `toJson()` / `fromJson()` (omitted when empty for backward compatibility)
+
+**Domain matching:** Supports exact match and subdomain matching. A rule for `example.com` also blocks cookies from `sub.example.com`.
+
+**UI:** The cookie inspector in DevTools shows a "Block" button on each cookie and a "Blocked" section listing blocked rules with "Unblock" buttons.
+
 ### Site ID Generation
 
 Each WebViewModel has a unique `siteId` field:
@@ -288,6 +301,48 @@ The system SHALL clean up all cookie-related data when a site is deleted.
 **When** the user adds a new site for `linkedin.com`
 **Then** the new site has no pre-existing cookies
 **And** the user must log in again
+
+---
+
+### Requirement: ISO-011 - Per-Site Cookie Blocking
+
+The system SHALL allow blocking specific cookies by name + domain on a per-site basis. Blocked cookies are deleted from the webview cookie jar after each page load and skipped during cookie restoration.
+
+#### Scenario: Block a cookie from the cookie inspector
+
+**Given** Site A has cookies including `_ga` on `.google.com`
+**When** the user opens Developer Tools -> Cookies tab and taps "Block" on `_ga`
+**Then** a `BlockedCookie(name: "_ga", domain: ".google.com")` is added to Site A's `blockedCookies` set
+**And** the cookie is immediately deleted from the webview
+**And** the block rule is persisted via site serialization
+
+#### Scenario: Blocked cookie re-set by website is removed
+
+**Given** Site A has `_ga` on `.google.com` blocked
+**When** a page load completes and the website sets `_ga` again
+**Then** `onCookiesChanged` filters out `_ga` and deletes it from CookieManager
+**And** the cookie does not appear in `model.cookies`
+
+#### Scenario: Blocked cookie skipped during restore
+
+**Given** Site A has `_ga` blocked and stored cookies include `_ga`
+**When** Site A is activated and `_restoreCookiesForSite()` runs
+**Then** `_ga` is NOT set in CookieManager
+**And** other non-blocked cookies are restored normally
+
+#### Scenario: Unblock a cookie
+
+**Given** Site A has `_ga` blocked
+**When** the user opens the Blocked section in the Cookies tab and taps "Unblock"
+**Then** the `BlockedCookie` is removed from `blockedCookies`
+**And** the cookie can be set again on next page load
+
+#### Scenario: Legacy data without blockedCookies
+
+**Given** a site was serialized before the cookie blocking feature existed
+**When** the site is deserialized
+**Then** `blockedCookies` defaults to an empty set
+**And** no cookies are blocked
 
 ---
 

--- a/test/cookie_blocking_test.dart
+++ b/test/cookie_blocking_test.dart
@@ -1,0 +1,199 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/web_view_model.dart';
+import 'package:webspace/services/webview.dart';
+
+void main() {
+  group('BlockedCookie', () {
+    test('equality by name and domain', () {
+      const a = BlockedCookie(name: '_ga', domain: '.google.com');
+      const b = BlockedCookie(name: '_ga', domain: '.google.com');
+      const c = BlockedCookie(name: '_ga', domain: '.facebook.com');
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('serialization round-trip', () {
+      const rule = BlockedCookie(name: 'session', domain: '.example.com');
+      final json = rule.toJson();
+      final restored = BlockedCookie.fromJson(json);
+
+      expect(restored.name, equals('session'));
+      expect(restored.domain, equals('.example.com'));
+      expect(restored, equals(rule));
+    });
+
+    test('Set deduplication', () {
+      final set = <BlockedCookie>{
+        const BlockedCookie(name: '_ga', domain: '.google.com'),
+        const BlockedCookie(name: '_ga', domain: '.google.com'),
+        const BlockedCookie(name: '_gid', domain: '.google.com'),
+      };
+
+      expect(set.length, equals(2));
+    });
+  });
+
+  group('WebViewModel.isCookieBlocked', () {
+    test('exact domain match', () {
+      final model = WebViewModel(
+        initUrl: 'https://example.com',
+        blockedCookies: {
+          const BlockedCookie(name: '_ga', domain: '.example.com'),
+        },
+      );
+
+      expect(model.isCookieBlocked('_ga', '.example.com'), isTrue);
+      expect(model.isCookieBlocked('_ga', '.other.com'), isFalse);
+      expect(model.isCookieBlocked('_gid', '.example.com'), isFalse);
+    });
+
+    test('subdomain matching', () {
+      final model = WebViewModel(
+        initUrl: 'https://example.com',
+        blockedCookies: {
+          const BlockedCookie(name: 'track', domain: 'example.com'),
+        },
+      );
+
+      // Subdomain of blocked domain
+      expect(model.isCookieBlocked('track', 'sub.example.com'), isTrue);
+      // Exact match
+      expect(model.isCookieBlocked('track', 'example.com'), isTrue);
+      // Different domain
+      expect(model.isCookieBlocked('track', 'notexample.com'), isFalse);
+    });
+
+    test('null domain never matches', () {
+      final model = WebViewModel(
+        initUrl: 'https://example.com',
+        blockedCookies: {
+          const BlockedCookie(name: '_ga', domain: '.example.com'),
+        },
+      );
+
+      expect(model.isCookieBlocked('_ga', null), isFalse);
+    });
+
+    test('empty blockedCookies returns false fast', () {
+      final model = WebViewModel(initUrl: 'https://example.com');
+
+      expect(model.blockedCookies, isEmpty);
+      expect(model.isCookieBlocked('anything', '.any.com'), isFalse);
+    });
+
+    test('multiple rules', () {
+      final model = WebViewModel(
+        initUrl: 'https://example.com',
+        blockedCookies: {
+          const BlockedCookie(name: '_ga', domain: '.google.com'),
+          const BlockedCookie(name: '_fbp', domain: '.facebook.com'),
+          const BlockedCookie(name: 'track', domain: '.example.com'),
+        },
+      );
+
+      expect(model.isCookieBlocked('_ga', '.google.com'), isTrue);
+      expect(model.isCookieBlocked('_fbp', '.facebook.com'), isTrue);
+      expect(model.isCookieBlocked('track', '.example.com'), isTrue);
+      expect(model.isCookieBlocked('_ga', '.facebook.com'), isFalse);
+      expect(model.isCookieBlocked('session', '.google.com'), isFalse);
+    });
+  });
+
+  group('WebViewModel serialization with blockedCookies', () {
+    test('empty blockedCookies omitted from JSON', () {
+      final model = WebViewModel(initUrl: 'https://example.com');
+      final json = model.toJson();
+
+      expect(json.containsKey('blockedCookies'), isFalse);
+    });
+
+    test('blockedCookies included in JSON when non-empty', () {
+      final model = WebViewModel(
+        initUrl: 'https://example.com',
+        blockedCookies: {
+          const BlockedCookie(name: '_ga', domain: '.google.com'),
+        },
+      );
+      final json = model.toJson();
+
+      expect(json.containsKey('blockedCookies'), isTrue);
+      expect(json['blockedCookies'], isList);
+      expect((json['blockedCookies'] as List).length, equals(1));
+    });
+
+    test('round-trip preserves blockedCookies', () {
+      final model = WebViewModel(
+        initUrl: 'https://example.com',
+        blockedCookies: {
+          const BlockedCookie(name: '_ga', domain: '.google.com'),
+          const BlockedCookie(name: '_fbp', domain: '.facebook.com'),
+        },
+      );
+
+      final json = model.toJson();
+      final restored = WebViewModel.fromJson(json, null);
+
+      expect(restored.blockedCookies.length, equals(2));
+      expect(
+        restored.blockedCookies,
+        contains(const BlockedCookie(name: '_ga', domain: '.google.com')),
+      );
+      expect(
+        restored.blockedCookies,
+        contains(const BlockedCookie(name: '_fbp', domain: '.facebook.com')),
+      );
+    });
+
+    test('legacy JSON without blockedCookies deserializes with empty set', () {
+      final legacyJson = {
+        'initUrl': 'https://example.com',
+        'currentUrl': 'https://example.com',
+        'name': 'Example',
+        'cookies': <dynamic>[],
+        'proxySettings': {'type': 0},
+        'javascriptEnabled': true,
+        'userAgent': '',
+        'thirdPartyCookiesEnabled': false,
+        'incognito': false,
+      };
+
+      final model = WebViewModel.fromJson(legacyJson, null);
+
+      expect(model.blockedCookies, isEmpty);
+      expect(model.isCookieBlocked('_ga', '.google.com'), isFalse);
+    });
+  });
+
+  group('Cookie blocking with real Cookie objects', () {
+    test('isCookieBlocked filters matching cookies', () {
+      final model = WebViewModel(
+        initUrl: 'https://example.com',
+        blockedCookies: {
+          const BlockedCookie(name: '_ga', domain: '.example.com'),
+        },
+      );
+
+      final cookies = [
+        Cookie(name: '_ga', value: 'GA1.2.123', domain: '.example.com'),
+        Cookie(name: 'session', value: 'abc', domain: '.example.com'),
+        Cookie(name: '_ga', value: 'GA1.2.456', domain: '.other.com'),
+      ];
+
+      final filtered = cookies
+          .where((c) => !model.isCookieBlocked(c.name, c.domain))
+          .toList();
+
+      expect(filtered.length, equals(2));
+      expect(filtered.map((c) => c.name), containsAll(['session', '_ga']));
+      // The _ga on .other.com should pass through
+      expect(filtered.any((c) => c.domain == '.other.com'), isTrue);
+      // The _ga on .example.com should be blocked
+      expect(
+        filtered.any((c) => c.name == '_ga' && c.domain == '.example.com'),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Allow users to block specific cookies by name and domain from the
DevTools cookie inspector. Blocked cookies are deleted from the webview
cookie jar after each page load and skipped during cookie restoration.

- Add BlockedCookie class with name/domain equality and serialization
- Add blockedCookies field to WebViewModel (persisted per-site)
- Enforce blocking in onCookiesChanged and _restoreCookiesForSite
- Add Block/Unblock UI in DevTools Cookies tab
- Add 13 unit tests for blocking logic and serialization
- Update per-site-cookie-isolation and developer-tools specs