### PR TITLE
Android: two-step back-to-exit via drawer

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3054,16 +3054,29 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   Widget build(BuildContext context) {
     final bool webviewIsVisible = _currentIndex != null && _currentIndex! < _webViewModels.length;
     return PopScope(
-      // Allow pop only when no webview is visible (webspace list screen)
-      canPop: !webviewIsVisible,
+      // On Android, always intercept back so we can implement the two-step
+      // exit pattern (back → open drawer → back → exit app).
+      // On other platforms, allow pop only when no webview is visible.
+      canPop: Platform.isAndroid ? false : !webviewIsVisible,
       onPopInvokedWithResult: (didPop, _) async {
         if (didPop || _isBackHandling) return;
         _isBackHandling = true;
         try {
           final scaffoldState = _scaffoldKey.currentState;
           if (scaffoldState != null && scaffoldState.isDrawerOpen) {
-            LogService.instance.log('Navigation', 'Back gesture: closing open drawer');
-            Navigator.pop(context);
+            if (Platform.isAndroid) {
+              LogService.instance.log('Navigation', 'Back gesture: drawer open, exiting app');
+              SystemNavigator.pop();
+            } else {
+              LogService.instance.log('Navigation', 'Back gesture: closing open drawer');
+              Navigator.pop(context);
+            }
+            return;
+          }
+          // Android homepage (no webview visible): open drawer as exit warning
+          if (Platform.isAndroid && !webviewIsVisible) {
+            LogService.instance.log('Navigation', 'Back gesture: homepage, opening drawer as exit hint');
+            scaffoldState?.openDrawer();
             return;
           }
           // Webview is visible - try to go back in its history.

--- a/openspec/specs/navigation/spec.md
+++ b/openspec/specs/navigation/spec.md
@@ -51,15 +51,29 @@ The system back gesture (Android back button, iOS edge swipe via PopScope) SHALL
 **When** the user triggers the system back gesture
 **Then** the drawer opens
 
-#### Scenario: Drawer is already open
+#### Scenario: Drawer is already open (Android)
 
-**Given** the drawer is open
+**Given** the drawer is open on Android
+**When** the user triggers the system back gesture
+**Then** the app exits (via `SystemNavigator.pop()`)
+
+**Rationale:** On Android, the drawer serves as a visual "you're about to leave" cue. The first back gesture opens the drawer; the second exits. This two-step pattern prevents accidental exits in a multi-site browser where reloading webviews is costly, without resorting to an annoying "press back again to exit" toast.
+
+#### Scenario: Drawer is already open (non-Android)
+
+**Given** the drawer is open on iOS/macOS
 **When** the user triggers the system back gesture
 **Then** the drawer closes
 
-#### Scenario: No webview visible (webspace list)
+#### Scenario: No webview visible — Android
 
-**Given** the webspace list screen is visible (no webview selected)
+**Given** the webspace list screen is visible (no webview selected) on Android
+**When** the user triggers the system back gesture
+**Then** the drawer opens (as an exit warning)
+
+#### Scenario: No webview visible — non-Android
+
+**Given** the webspace list screen is visible (no webview selected) on iOS/macOS
 **When** the user triggers the system back gesture
 **Then** the system pop behavior proceeds normally (app may exit)
 
@@ -252,7 +266,11 @@ System back gesture received
   ├─ didPop? ──────────────────── return (system handled it)
   ├─ _isBackHandling? ─────────── return (drop concurrent)
   │
-  ├─ Drawer open? ─────────────── close drawer
+  ├─ Drawer open?
+  │   ├─ Android? ─────────────── exit app (SystemNavigator.pop)
+  │   └─ Other? ───────────────── close drawer
+  │
+  ├─ Android && no webview? ───── open drawer (exit warning)
   │
   ├─ No controller? ───────────── open drawer
   │
@@ -307,7 +325,7 @@ Home button pressed
 - `_isHomeUrl()` — static helper: compares URLs ignoring trailing slash normalization
 - `_updateCanGoBack()` — async check of `controller.canGoBack()` with version guard and synchronous home-URL fast-path (RACE-005)
 - `_goHome()` — synchronous: dispose webview, reset URL, invalidate version
-- `PopScope` widget — wraps Scaffold, handles system back gesture with URL comparison
+- `PopScope` widget — wraps Scaffold; `canPop: false` always on Android (two-step exit), `!webviewIsVisible` on other platforms; handles system back gesture with URL comparison
 - `drawerEdgeDragWidth` — conditional drawer edge swipe based on platform and `_canGoBack`
 - Back button `IconButton` (portrait ~line 1685, landscape ~line 2047)
 - Home button `IconButton` (portrait ~line 1701, landscape ~line 2063)
@@ -347,6 +365,18 @@ Home button pressed
 3. Press system back (Android) or trigger PopScope (iOS)
 4. Verify each press navigates back one page
 5. When at the initial URL, verify back opens the drawer
+
+### Manual Test: Android Two-Step Exit (Webview)
+
+1. (Android) Add a site and navigate to its initial URL
+2. Press system back — verify the drawer opens
+3. Press system back again — verify the app exits/minimizes
+
+### Manual Test: Android Two-Step Exit (Homepage)
+
+1. (Android) Go to the webspace list (no webview selected)
+2. Press system back — verify the drawer opens
+3. Press system back again — verify the app exits/minimizes
 
 ### Manual Test: Home Button Clears History
 


### PR DESCRIPTION
## Summary

On Android, the system back gesture now implements a **two-step exit pattern**:

1. **First back press** (at homepage or webview with no history) → opens the drawer
2. **Second back press** (drawer already open) → exits the app via `SystemNavigator.pop()`

Non-Android platforms (iOS/macOS) keep existing behavior unchanged.

## Why this approach?

Standard Android apps just exit on back at root, but WebSpace keeps multiple loaded webviews in memory. Accidentally exiting is more costly here than in a typical app — you'd lose webview state and need to reload everything.

The drawer acts as a natural **visual "you're about to leave" signal** — the user sees the site list and understands they're at the edge of the app. This avoids the annoying "press back again to exit" toast that many apps use as an alternative, while still only requiring two quick back gestures to exit so it doesn't feel slow.

## Changes

- **`lib/main.dart`**: `PopScope.canPop` is now always `false` on Android so the handler intercepts all back gestures. The handler exits the app when the drawer is open, and opens the drawer on the homepage when no webview is visible.
- **`openspec/specs/navigation/spec.md`**: Updated NAV-001 scenarios with Android-specific drawer-open and homepage behavior, updated the decision flow diagram, added two manual test cases for the two-step exit pattern.

## Test plan

- [ ] **Android webview two-step exit**: Navigate to a site's initial URL → back opens drawer → back again exits app
- [ ] **Android homepage two-step exit**: Go to webspace list (no site selected) → back opens drawer → back again exits app
- [ ] **Android webview back navigation**: Navigate several pages deep → back navigates history as before → at initial URL, back opens drawer → back exits
- [ ] **iOS/macOS unchanged**: Verify back gesture still closes drawer (not exit) and homepage back still exits normally