### PR TITLE
Add full screen mode with per-site auto-fullscreen setting (#179)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ Detailed feature specs are in `openspec/specs/`. Each spec uses Given/When/Then 
 | user-scripts | Per-site custom JavaScript injection with injection timing control |
 | webspaces | Site organization into named collections |
 | webview-hints | Webview theme and display hints |
+| fullscreen-mode | Full screen mode: hide app bar/tab strip/system UI, per-site auto-fullscreen setting |
 
 Read the relevant spec before modifying a feature. Specs include file paths, data models, and manual test procedures.
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1643,6 +1643,10 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     setState(() {
       _canGoBack = false;
     });
+    // Re-apply fullscreen for sites with auto-fullscreen after webview recreation
+    if (model.fullscreenMode) {
+      _enterFullscreen();
+    }
     _saveWebViewModels();
   }
 
@@ -1681,9 +1685,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     return AppBar(
       title: _currentIndex != null && _currentIndex! < _webViewModels.length
           ? GestureDetector(
-              onTap: () {
-                _editSite(_currentIndex!);
-              },
+              onDoubleTap: _toggleFullscreen,
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -1695,8 +1697,6 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                       softWrap: false,
                     ),
                   ),
-                  SizedBox(width: 8),
-                  Icon(Icons.edit, size: 18),
                 ],
               ),
             )
@@ -1937,6 +1937,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                               : null;
                           final urlToLoad = model?.currentUrl;
                           final languageToUse = model?.language;
+
+                          // Apply fullscreen setting immediately
+                          if (model != null && model.fullscreenMode) {
+                            _enterFullscreen();
+                          } else {
+                            _exitFullscreen();
+                          }
 
                           setState(() {});
 
@@ -2320,6 +2327,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                         : null;
                     final urlToLoad = model?.currentUrl;
                     final languageToUse = model?.language;
+
+                    // Apply fullscreen setting immediately
+                    if (model != null && model.fullscreenMode) {
+                      _enterFullscreen();
+                    } else {
+                      _exitFullscreen();
+                    }
 
                     setState(() {});
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -630,6 +630,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
   bool _isBackHandling = false;
   bool _isFindVisible = false;
+  bool _isFullscreen = false; // Runtime fullscreen state (hides appBar, tabStrip, system UI)
   bool _showUrlBar = false;
   bool _showTabStrip = false;
   bool _canGoBack = false; // Tracks webview back history for iOS drawer gesture
@@ -691,6 +692,10 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     }
     if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
       await _webViewModels[_currentIndex!].resumeWebView();
+    }
+    // Re-apply fullscreen system UI mode after resume
+    if (_isFullscreen) {
+      SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
     }
   }
 
@@ -801,6 +806,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       }
       _currentIndex = index;
       _canGoBack = false;
+      _exitFullscreen();
       return;
     }
 
@@ -856,6 +862,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     // Resume the newly active webview
     await _webViewModels[index].resumeWebView();
     _updateCanGoBack();
+
+    // Auto-enter fullscreen if the site has fullscreenMode enabled
+    if (target.fullscreenMode) {
+      _enterFullscreen();
+    } else {
+      _exitFullscreen();
+    }
 
     LogService.instance.log('CookieIsolation', 'After switch, loaded indices: $_loadedIndices');
   }
@@ -1163,6 +1176,30 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     setState(() {
       _isFindVisible = !_isFindVisible;
     });
+  }
+
+  void _enterFullscreen() {
+    if (_isFullscreen) return;
+    setState(() {
+      _isFullscreen = true;
+    });
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+  }
+
+  void _exitFullscreen() {
+    if (!_isFullscreen) return;
+    setState(() {
+      _isFullscreen = false;
+    });
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+  }
+
+  void _toggleFullscreen() {
+    if (_isFullscreen) {
+      _exitFullscreen();
+    } else {
+      _enterFullscreen();
+    }
   }
 
   // Webspace management methods
@@ -1813,6 +1850,16 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                   ),
                 ),
                 PopupMenuItem<String>(
+                  value: "fullscreen",
+                  child: Row(
+                    children: [
+                      Icon(Icons.fullscreen),
+                      SizedBox(width: 8),
+                      Text("Full Screen"),
+                    ],
+                  ),
+                ),
+                PopupMenuItem<String>(
                   value: "settings",
                   child: Row(
                     children: [
@@ -1849,6 +1896,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
               switch(value) {
                 case 'search':
                   _toggleFind();
+                break;
+                case 'fullscreen':
+                  _enterFullscreen();
                 break;
                 case 'settings':
                   await Navigator.push(
@@ -1951,6 +2001,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   /// Build the tab strip shown in bottomNavigationBar.
   /// This stays at the screen bottom and doesn't need to be above the keyboard.
   Widget? _buildTabStrip() {
+    if (_isFullscreen) return null;
     if (_currentIndex == null || _currentIndex! >= _webViewModels.length) {
       return null;
     }
@@ -2056,6 +2107,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   /// Build the URL bar and find toolbar, placed in the body so that
   /// resizeToAvoidBottomInset keeps them above the keyboard.
   Widget? _buildInputBar() {
+    if (_isFullscreen) return null;
     if (_currentIndex == null || _currentIndex! >= _webViewModels.length) {
       return null;
     }
@@ -2181,6 +2233,16 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
             ),
           ),
           PopupMenuItem<String>(
+            value: "fullscreen",
+            child: Row(
+              children: [
+                Icon(Icons.fullscreen),
+                SizedBox(width: 8),
+                Text("Full Screen"),
+              ],
+            ),
+          ),
+          PopupMenuItem<String>(
             value: "settings",
             child: Row(
               children: [
@@ -2217,6 +2279,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         switch(value) {
           case 'search':
             _toggleFind();
+          break;
+          case 'fullscreen':
+            _enterFullscreen();
           break;
           case 'settings':
             await Navigator.push(
@@ -2956,8 +3021,8 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         && _showTabStrip
         && filteredIndices.isNotEmpty;
     return SafeArea(
-      top: false, // AppBar handles top inset
-      bottom: !hasTabStrip && inputBar == null,
+      top: false, // AppBar handles top inset; in fullscreen there's no AppBar either
+      bottom: _isFullscreen ? false : (!hasTabStrip && inputBar == null),
       // Use Stack + Offstage so the IndexedStack (and its webview States)
       // stay mounted when showing the webspace list. Removing the
       // IndexedStack from the tree destroys webview States, losing
@@ -3037,6 +3102,18 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                       }).toList(),
                     ),
                   ),
+                // Fullscreen exit zone: a thin touch target at the top edge
+                if (_isFullscreen)
+                  Positioned(
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    height: 24,
+                    child: GestureDetector(
+                      behavior: HitTestBehavior.translucent,
+                      onTap: _exitFullscreen,
+                    ),
+                  ),
               ],
             ),
           ),
@@ -3060,6 +3137,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       canPop: Platform.isAndroid ? false : !webviewIsVisible,
       onPopInvokedWithResult: (didPop, _) async {
         if (didPop || _isBackHandling) return;
+        // Exit fullscreen on back gesture before any other back handling
+        if (_isFullscreen) {
+          _exitFullscreen();
+          return;
+        }
         _isBackHandling = true;
         try {
           final scaffoldState = _scaffoldKey.currentState;
@@ -3127,7 +3209,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       drawerEdgeDragWidth: webviewIsVisible
           ? (Platform.isIOS && !_canGoBack ? null : 0)
           : null,
-      appBar: _buildAppBar(),
+      appBar: _isFullscreen ? null : _buildAppBar(),
       drawer: Drawer(
         child: Column(
           children: [

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -105,6 +105,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late bool _contentBlockEnabled;
   late bool _localCdnEnabled;
   late bool _blockAutoRedirects;
+  late bool _fullscreenMode;
   String? _selectedLanguage;
   bool _obscureProxyPassword = true;
   bool _showProxyCredentials = false;
@@ -151,6 +152,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _contentBlockEnabled = widget.webViewModel.contentBlockEnabled;
     _localCdnEnabled = widget.webViewModel.localCdnEnabled;
     _blockAutoRedirects = widget.webViewModel.blockAutoRedirects;
+    _fullscreenMode = widget.webViewModel.fullscreenMode;
     _selectedLanguage = widget.webViewModel.language;
     // Show credentials section if credentials already exist
     _showProxyCredentials = _proxySettings.hasCredentials;
@@ -254,6 +256,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       widget.webViewModel.contentBlockEnabled = _contentBlockEnabled;
       widget.webViewModel.localCdnEnabled = _localCdnEnabled;
       widget.webViewModel.blockAutoRedirects = _blockAutoRedirects;
+      widget.webViewModel.fullscreenMode = _fullscreenMode;
       widget.webViewModel.language = _selectedLanguage;
 
       if (!mounted) return;
@@ -612,6 +615,27 @@ class _SettingsScreenState extends State<SettingsScreen> {
             onChanged: (bool value) {
               setState(() {
                 _blockAutoRedirects = value;
+              });
+            },
+          ),
+          SwitchListTile(
+            title: Row(
+              children: [
+                const Flexible(child: Text('Full screen mode')),
+                const HintButton(
+                  title: 'Full Screen Mode',
+                  description:
+                      'Automatically enters full screen when this site is selected. '
+                      'Hides the app bar, tab strip, and system UI for an immersive experience. '
+                      'Tap the edge of the screen or use the back gesture to exit full screen.',
+                ),
+              ],
+            ),
+            subtitle: const Text('Auto-enter full screen for this site'),
+            value: _fullscreenMode,
+            onChanged: (bool value) {
+              setState(() {
+                _fullscreenMode = value;
               });
             },
           ),

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -259,6 +259,7 @@ class WebViewModel {
   bool contentBlockEnabled; // Block ads/trackers via ABP filter list rules
   bool localCdnEnabled; // Serve CDN resources from local cache for privacy
   bool blockAutoRedirects; // Block script-initiated cross-domain navigations
+  bool fullscreenMode; // Auto-enter fullscreen when this site is selected
   List<UserScriptConfig> userScripts; // Per-site user scripts
   Set<BlockedCookie> blockedCookies; // Per-site blocked cookies (name + domain)
 
@@ -288,6 +289,7 @@ class WebViewModel {
     this.contentBlockEnabled = true,
     this.localCdnEnabled = true,
     this.blockAutoRedirects = true,
+    this.fullscreenMode = false,
     List<UserScriptConfig>? userScripts,
     Set<BlockedCookie>? blockedCookies,
     this.stateSetterF,
@@ -733,6 +735,7 @@ class WebViewModel {
         'contentBlockEnabled': contentBlockEnabled,
         'localCdnEnabled': localCdnEnabled,
         'blockAutoRedirects': blockAutoRedirects,
+        'fullscreenMode': fullscreenMode,
         'userScripts': userScripts.map((s) => s.toJson()).toList(),
         if (blockedCookies.isNotEmpty)
           'blockedCookies': blockedCookies.map((b) => b.toJson()).toList(),
@@ -758,6 +761,7 @@ class WebViewModel {
       contentBlockEnabled: json['contentBlockEnabled'] ?? true,
       localCdnEnabled: json['localCdnEnabled'] ?? true,
       blockAutoRedirects: json['blockAutoRedirects'] ?? true,
+      fullscreenMode: json['fullscreenMode'] ?? false,
       userScripts: (json['userScripts'] as List<dynamic>?)
           ?.map((e) => UserScriptConfig.fromJson(e as Map<String, dynamic>))
           .toList(),

--- a/openspec/specs/fullscreen-mode/spec.md
+++ b/openspec/specs/fullscreen-mode/spec.md
@@ -19,16 +19,24 @@ Users who use WebSpace as a web-app launcher want a full app experience without 
 
 ## Requirements
 
-### Requirement: FS-001 - Toggle Full Screen from Menu
+### Requirement: FS-001 - Toggle Full Screen
 
-The system SHALL allow users to enter full screen mode from the overflow menu.
+The system SHALL allow users to enter full screen mode from the overflow menu or by double-tapping the app bar title.
 
-#### Scenario: Enter full screen from app bar menu
+#### Scenario: Enter full screen from menu
 
 **Given** the user has a site loaded
 **When** the user opens the overflow menu (app bar or tab strip) and taps "Full Screen"
 **Then** the app bar, tab strip, URL bar, find toolbar, and system UI are hidden
 **And** the webview fills the entire screen
+
+#### Scenario: Toggle full screen by double-tapping title
+
+**Given** the user has a site loaded
+**When** the user double-taps the site name in the app bar
+**Then** the app enters full screen mode
+**When** the user exits full screen and double-taps the title again
+**Then** the app enters full screen mode again
 
 ---
 
@@ -73,6 +81,14 @@ The system SHALL support a per-site setting to automatically enter full screen w
 **When** the user enables the "Full screen mode" toggle
 **And** saves settings
 **Then** the `fullscreenMode` field is persisted for that site
+**And** full screen mode is entered immediately
+
+#### Scenario: Pressing Home on auto-fullscreen site
+
+**Given** site "MyApp" has "Full screen mode" enabled
+**And** the user is viewing "MyApp"
+**When** the user presses the Home button (which disposes and recreates the webview)
+**Then** full screen mode remains active
 
 ---
 

--- a/openspec/specs/fullscreen-mode/spec.md
+++ b/openspec/specs/fullscreen-mode/spec.md
@@ -1,0 +1,174 @@
+# Full Screen Mode Specification
+
+## Purpose
+
+Allow users to view sites in full screen mode, hiding the app bar, tab strip, URL bar, and system UI for an immersive experience. Supports both on-demand toggling and a per-site auto-fullscreen setting.
+
+## Status
+
+- **Date**: 2026-04-12
+- **Status**: Implemented
+
+---
+
+## Problem Statement
+
+Users who use WebSpace as a web-app launcher want a full app experience without browser chrome. The app bar, tab strip, and system status/navigation bars consume screen space that could be used by the web content. A full screen mode gives users an immersive, app-like experience.
+
+---
+
+## Requirements
+
+### Requirement: FS-001 - Toggle Full Screen from Menu
+
+The system SHALL allow users to enter full screen mode from the overflow menu.
+
+#### Scenario: Enter full screen from app bar menu
+
+**Given** the user has a site loaded
+**When** the user opens the overflow menu (app bar or tab strip) and taps "Full Screen"
+**Then** the app bar, tab strip, URL bar, find toolbar, and system UI are hidden
+**And** the webview fills the entire screen
+
+---
+
+### Requirement: FS-002 - Exit Full Screen
+
+The system SHALL provide multiple ways to exit full screen mode.
+
+#### Scenario: Exit via back gesture
+
+**Given** the user is in full screen mode
+**When** the user performs a back gesture (swipe or button)
+**Then** full screen mode is exited
+**And** the app bar, tab strip, and system UI are restored
+
+#### Scenario: Exit via top edge tap
+
+**Given** the user is in full screen mode
+**When** the user taps the top 24px edge of the screen
+**Then** full screen mode is exited
+
+---
+
+### Requirement: FS-003 - Per-Site Auto Full Screen
+
+The system SHALL support a per-site setting to automatically enter full screen when the site is selected.
+
+#### Scenario: Site with auto-fullscreen enabled
+
+**Given** site "MyApp" has "Full screen mode" enabled in its settings
+**When** the user switches to "MyApp"
+**Then** the app automatically enters full screen mode
+
+#### Scenario: Site without auto-fullscreen
+
+**Given** site "Gmail" does NOT have "Full screen mode" enabled
+**When** the user switches to "Gmail"
+**Then** full screen mode is exited (if it was active)
+
+#### Scenario: Configure auto-fullscreen
+
+**Given** the user is on the Settings screen for a site
+**When** the user enables the "Full screen mode" toggle
+**And** saves settings
+**Then** the `fullscreenMode` field is persisted for that site
+
+---
+
+### Requirement: FS-004 - Full Screen Persistence Across Lifecycle
+
+The system SHALL maintain the correct full screen state across app lifecycle transitions.
+
+#### Scenario: App resumed while in full screen
+
+**Given** the user is in full screen mode
+**When** the app is backgrounded and then resumed
+**Then** the immersive system UI mode is re-applied
+
+---
+
+### Requirement: FS-005 - Full Screen with Navigation Away
+
+The system SHALL exit full screen when navigating to the webspaces list.
+
+#### Scenario: Navigate to webspaces list
+
+**Given** the user is in full screen mode
+**When** the user navigates back to the webspaces list (index = null)
+**Then** full screen mode is exited and system UI is restored
+
+---
+
+## Implementation Details
+
+### Data Model
+
+**WebViewModel** (`lib/web_view_model.dart`):
+- `bool fullscreenMode = false` - Per-site setting for auto-fullscreen
+- Serialized in `toJson()` / `fromJson()` with default `false`
+
+### Runtime State
+
+**_WebSpacePageState** (`lib/main.dart`):
+- `bool _isFullscreen = false` - Current fullscreen state (not persisted; runtime only)
+
+### UI Changes
+
+- **App bar**: Hidden when `_isFullscreen` is true (`appBar: _isFullscreen ? null : _buildAppBar()`)
+- **Tab strip**: `_buildTabStrip()` returns null when `_isFullscreen`
+- **Input bar**: `_buildInputBar()` returns null when `_isFullscreen`
+- **Exit zone**: 24px transparent GestureDetector at top edge when fullscreen
+- **Menu items**: "Full Screen" added to both app bar and tab strip popup menus
+
+### System UI
+
+- Enter: `SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky)`
+- Exit: `SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge)`
+- Re-applied on app resume via `_resumeAfterLifecyclePause()`
+
+### Site Switching
+
+In `_setCurrentIndex()`:
+- If target site has `fullscreenMode = true`, calls `_enterFullscreen()`
+- Otherwise, calls `_exitFullscreen()`
+- Navigating to null index (webspaces list) always exits fullscreen
+
+### Back Gesture
+
+In `onPopInvokedWithResult`:
+- If `_isFullscreen`, exits fullscreen and returns (no further back handling)
+
+### Settings Backup
+
+- `fullscreenMode` is included in site JSON via `toJson()`/`fromJson()`
+- No changes needed to `SettingsBackup` class (it serializes full site JSON)
+
+---
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `lib/web_view_model.dart` | Added `fullscreenMode` field, constructor param, toJson/fromJson |
+| `lib/screens/settings.dart` | Added fullscreen mode toggle switch |
+| `lib/main.dart` | Added `_isFullscreen` state, enter/exit/toggle methods, menu items, scaffold/body changes, back handler, lifecycle handling |
+
+---
+
+## Manual Test Procedure
+
+1. Open the app and navigate to a site
+2. Open the overflow menu and tap "Full Screen"
+3. Verify: app bar, tab strip, URL bar, and system bars are hidden
+4. Tap the top edge of the screen to exit full screen
+5. Verify: all UI elements are restored
+6. Enter full screen again, then perform a back gesture
+7. Verify: full screen is exited
+8. Go to site Settings, enable "Full screen mode", save
+9. Switch to another site, then switch back
+10. Verify: full screen is automatically entered
+11. Switch to a site without full screen mode enabled
+12. Verify: full screen is exited
+13. In full screen, background the app and resume
+14. Verify: immersive mode is re-applied

--- a/test/web_view_model_test.dart
+++ b/test/web_view_model_test.dart
@@ -23,6 +23,7 @@ void main() {
       expect(model.dnsBlockEnabled, isTrue);
       expect(model.contentBlockEnabled, isTrue);
       expect(model.localCdnEnabled, isTrue);
+      expect(model.fullscreenMode, isFalse);
     });
 
     test('should serialize to JSON correctly', () {
@@ -47,6 +48,7 @@ void main() {
       expect(json['dnsBlockEnabled'], equals(true));
       expect(json['contentBlockEnabled'], equals(true));
       expect(json['localCdnEnabled'], equals(true));
+      expect(json['fullscreenMode'], equals(false));
       expect(json['cookies'], isList);
       expect(json['proxySettings'], isMap);
     });
@@ -101,6 +103,7 @@ void main() {
       expect(restored.dnsBlockEnabled, equals(original.dnsBlockEnabled));
       expect(restored.contentBlockEnabled, equals(original.contentBlockEnabled));
       expect(restored.localCdnEnabled, equals(original.localCdnEnabled));
+      expect(restored.fullscreenMode, equals(original.fullscreenMode));
     });
 
     test('clearUrlEnabled defaults to true when missing from JSON', () {
@@ -213,6 +216,34 @@ void main() {
 
       final restored = WebViewModel.fromJson(json, null);
       expect(restored.localCdnEnabled, isFalse);
+    });
+
+    test('fullscreenMode defaults to false when missing from JSON', () {
+      final json = {
+        'initUrl': 'https://example.com',
+        'currentUrl': 'https://example.com',
+        'cookies': [],
+        'proxySettings': {'type': 0, 'address': null},
+        'javascriptEnabled': true,
+        'userAgent': '',
+        'thirdPartyCookiesEnabled': false,
+      };
+
+      final model = WebViewModel.fromJson(json, null);
+      expect(model.fullscreenMode, isFalse);
+    });
+
+    test('fullscreenMode true is preserved through serialization', () {
+      final model = WebViewModel(
+        initUrl: 'https://example.com',
+        fullscreenMode: true,
+      );
+
+      final json = model.toJson();
+      expect(json['fullscreenMode'], equals(true));
+
+      final restored = WebViewModel.fromJson(json, null);
+      expect(restored.fullscreenMode, isTrue);
     });
   });
 


### PR DESCRIPTION
Adds an immersive full screen mode that hides the app bar, tab strip, URL bar, and system UI. Users can toggle it from the overflow menu or enable auto-fullscreen per site in Settings. Exit via back gesture or tapping the top screen edge.

https://claude.ai/code/session_012x6o3F69X7Cg7iNnHX1XEA