### PR TITLE
Add passkey/WebAuthn support for Android (#194)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,7 @@ Detailed feature specs are in `openspec/specs/`. Each spec uses Given/When/Then 
 | nested-url-blocking | Cross-domain navigation control: nested InAppBrowser, gesture-based auto-redirect blocking |
 | per-site-cookie-isolation | Cookie isolation via domain conflict detection, siteId storage (legacy / fallback engine) |
 | per-site-containers | Native per-site containers via `androidx.webkit.Profile` (Android, System WebView 110+) and `WKWebsiteDataStore(forIdentifier:)` (iOS 17+ / macOS 14+); supersedes per-site-cookie-isolation when supported |
+| passkey-support | WebAuthn/passkey authentication via JS polyfill + Android Credential Manager (iOS pending) |
 | per-site-location | Per-site geolocation spoofing, IANA timezone override, WebRTC leak lockdown |
 | platform-support | Platform abstraction layer for iOS, Android, macOS |
 | proxy | Per-site HTTP/HTTPS/SOCKS5 proxy (Android only) |

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -121,5 +121,4 @@ dependencies {
     implementation "androidx.webkit:webkit:1.14.0"
     // WebAuthn/Passkey support via Android Credential Manager
     implementation "androidx.credentials:credentials:1.5.0"
-    implementation "androidx.credentials:credentials-play-services-auth:1.5.0"
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -116,12 +116,10 @@ flutter {
 }
 
 dependencies {
-    // Profile API for per-site cookie/storage isolation. Used by the
-    // fork's flutter_inappwebview_android (ws-<siteId> containers) and
-    // by WebSpaceContainerPlugin's MULTI_PROFILE runtime probe — see
-    // openspec/specs/per-site-containers/spec.md. The MULTI_PROFILE
-    // feature is gated at runtime via WebViewFeature.isFeatureSupported;
-    // devices whose System WebView does not advertise it fall through
-    // to the legacy capture-nuke-restore engine.
-    implementation "androidx.webkit:webkit:1.12.1"
+    // AndroidX WebKit for per-site container isolation (Profile API) and
+    // WebAuthn/passkey support (setWebAuthenticationSupport API).
+    implementation "androidx.webkit:webkit:1.14.0"
+    // WebAuthn/Passkey support via Android Credential Manager
+    implementation "androidx.credentials:credentials:1.5.0"
+    implementation "androidx.credentials:credentials-play-services-auth:1.5.0"
 }

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -14,9 +14,11 @@ import java.net.URL
 
 class MainActivity: FlutterActivity() {
     private val CHANNEL = "org.codeberg.theoden8.webspace/shortcuts"
+    private val WEBAUTHN_CHANNEL = "org.codeberg.theoden8.webspace/webauthn"
     private var webInterceptPlugin: WebInterceptPlugin? = null
     private var locationPlugin: LocationPlugin? = null
     private var webSpaceContainerPlugin: WebSpaceContainerPlugin? = null
+    private lateinit var webAuthnHandler: WebAuthnHandler
 
     override fun getFlutterShellArgs(): FlutterShellArgs {
         val args = FlutterShellArgs.fromIntent(intent)
@@ -35,6 +37,40 @@ class MainActivity: FlutterActivity() {
         webInterceptPlugin = WebInterceptPlugin(this, flutterEngine)
         locationPlugin = LocationPlugin(this, flutterEngine)
         webSpaceContainerPlugin = WebSpaceContainerPlugin(flutterEngine)
+        webAuthnHandler = WebAuthnHandler(this)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, WEBAUTHN_CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "setupWebAuthn" -> {
+                    val info = webAuthnHandler.setupWebAuthn()
+                    result.success(info)
+                }
+                "create" -> {
+                    val requestJson = call.argument<String>("requestJson") ?: ""
+                    val origin = call.argument<String>("origin") ?: ""
+                    webAuthnHandler.handleCreate(requestJson, origin, object : WebAuthnHandler.WebAuthnResultCallback {
+                        override fun onSuccess(responseJson: String) {
+                            runOnUiThread { result.success(responseJson) }
+                        }
+                        override fun onError(errorType: String, errorMessage: String) {
+                            runOnUiThread { result.error(errorType, errorMessage, null) }
+                        }
+                    })
+                }
+                "get" -> {
+                    val requestJson = call.argument<String>("requestJson") ?: ""
+                    val origin = call.argument<String>("origin") ?: ""
+                    webAuthnHandler.handleGet(requestJson, origin, object : WebAuthnHandler.WebAuthnResultCallback {
+                        override fun onSuccess(responseJson: String) {
+                            runOnUiThread { result.success(responseJson) }
+                        }
+                        override fun onError(errorType: String, errorMessage: String) {
+                            runOnUiThread { result.error(errorType, errorMessage, null) }
+                        }
+                    })
+                }
+                else -> result.notImplemented()
+            }
+        }
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
             when (call.method) {
                 "pinShortcut" -> {

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/WebAuthnHandler.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/WebAuthnHandler.kt
@@ -1,0 +1,158 @@
+package org.codeberg.theoden8.webspace
+
+import android.app.Activity
+import android.os.CancellationSignal
+import android.util.Log
+import android.view.ViewGroup
+import android.webkit.WebView
+import androidx.credentials.CreateCredentialResponse
+import androidx.credentials.CreatePublicKeyCredentialRequest
+import androidx.credentials.CredentialManager
+import androidx.credentials.CredentialManagerCallback
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetCredentialResponse
+import androidx.credentials.GetPublicKeyCredentialOption
+import androidx.credentials.exceptions.CreateCredentialException
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewFeature
+import java.util.concurrent.Executors
+
+private const val TAG = "WebAuthnHandler"
+
+class WebAuthnHandler(private val activity: Activity) {
+
+    interface WebAuthnResultCallback {
+        fun onSuccess(responseJson: String)
+        fun onError(errorType: String, errorMessage: String)
+    }
+
+    private val credentialManager = CredentialManager.create(activity)
+    private val executor = Executors.newSingleThreadExecutor()
+
+    /**
+     * Set up WebAuthn support on all WebViews in the activity's view hierarchy.
+     * Returns a diagnostic string with the result of the setup.
+     */
+    fun setupWebAuthn(): String {
+        val supported = try {
+            WebViewFeature.isFeatureSupported(WebViewFeature.WEB_AUTHENTICATION)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to check WEB_AUTHENTICATION feature support", e)
+            false
+        }
+
+        if (!supported) {
+            val msg = "WEB_AUTHENTICATION feature not supported by this WebView"
+            Log.w(TAG, msg)
+            return msg
+        }
+
+        val webViews = findWebViews(activity.window.decorView as? ViewGroup)
+        if (webViews.isEmpty()) {
+            val msg = "WEB_AUTHENTICATION supported but no WebViews found in hierarchy"
+            Log.w(TAG, msg)
+            return msg
+        }
+
+        var configured = 0
+        for (wv in webViews) {
+            try {
+                WebSettingsCompat.setWebAuthenticationSupport(
+                    wv.settings,
+                    WebSettingsCompat.WEB_AUTHENTICATION_SUPPORT_FOR_APP
+                )
+                configured++
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to set WebAuthentication support on WebView", e)
+            }
+        }
+
+        val msg = "WebAuthn: configured $configured/${webViews.size} WebViews (FOR_APP mode)"
+        Log.i(TAG, msg)
+        return msg
+    }
+
+    /**
+     * Handle a WebAuthn navigator.credentials.create() request via Credential Manager.
+     *
+     * Note: We use CreatePublicKeyCredentialRequest WITHOUT setting origin because
+     * CREDENTIAL_MANAGER_SET_ORIGIN requires a system-level permission that third-party
+     * apps cannot obtain. The Credential Manager will use the app's package identity.
+     */
+    fun handleCreate(requestJson: String, origin: String, callback: WebAuthnResultCallback) {
+        Log.d(TAG, "handleCreate: origin=$origin requestJson=${requestJson.take(200)}...")
+
+        val request = CreatePublicKeyCredentialRequest(
+            requestJson = requestJson
+        )
+
+        credentialManager.createCredentialAsync(
+            context = activity,
+            request = request,
+            cancellationSignal = CancellationSignal(),
+            executor = executor,
+            callback = object : CredentialManagerCallback<CreateCredentialResponse, CreateCredentialException> {
+                override fun onResult(result: CreateCredentialResponse) {
+                    Log.d(TAG, "createCredential success: type=${result.type}")
+                    callback.onSuccess(result.data.getString("androidx.credentials.BUNDLE_KEY_REGISTRATION_RESPONSE_JSON", "{}"))
+                }
+
+                override fun onError(e: CreateCredentialException) {
+                    Log.e(TAG, "createCredential error: type=${e.type} message=${e.message}")
+                    callback.onError(e.type, e.message ?: "Unknown error")
+                }
+            }
+        )
+    }
+
+    /**
+     * Handle a WebAuthn navigator.credentials.get() request via Credential Manager.
+     */
+    fun handleGet(requestJson: String, origin: String, callback: WebAuthnResultCallback) {
+        Log.d(TAG, "handleGet: origin=$origin requestJson=${requestJson.take(200)}...")
+
+        val option = GetPublicKeyCredentialOption(
+            requestJson = requestJson
+        )
+
+        val request = GetCredentialRequest.Builder()
+            .addCredentialOption(option)
+            .build()
+
+        credentialManager.getCredentialAsync(
+            context = activity,
+            request = request,
+            cancellationSignal = CancellationSignal(),
+            executor = executor,
+            callback = object : CredentialManagerCallback<GetCredentialResponse, GetCredentialException> {
+                override fun onResult(result: GetCredentialResponse) {
+                    Log.d(TAG, "getCredential success: type=${result.credential.type}")
+                    callback.onSuccess(result.credential.data.getString("androidx.credentials.BUNDLE_KEY_AUTHENTICATION_RESPONSE_JSON", "{}"))
+                }
+
+                override fun onError(e: GetCredentialException) {
+                    Log.e(TAG, "getCredential error: type=${e.type} message=${e.message}")
+                    callback.onError(e.type, e.message ?: "Unknown error")
+                }
+            }
+        )
+    }
+
+    /**
+     * Recursively find all WebView instances in a ViewGroup hierarchy.
+     */
+    private fun findWebViews(viewGroup: ViewGroup?): List<WebView> {
+        if (viewGroup == null) return emptyList()
+        val result = mutableListOf<WebView>()
+        for (i in 0 until viewGroup.childCount) {
+            val child = viewGroup.getChildAt(i)
+            if (child is WebView) {
+                result.add(child)
+            } else if (child is ViewGroup) {
+                result.addAll(findWebViews(child))
+            }
+        }
+        return result
+    }
+}

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
 import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/connectivity_service.dart';
@@ -942,6 +943,219 @@ String _languageOverrideScript(String language) {
 }
 
 
+/// Method channel for WebAuthn/passkey support (Android only).
+const MethodChannel _webAuthnChannel =
+    MethodChannel('org.codeberg.theoden8.webspace/webauthn');
+
+/// JavaScript polyfill for WebAuthn/passkey support.
+///
+/// Injected at DOCUMENT_START on Android. The polyfill:
+///   - Defines `PublicKeyCredential` if it doesn't exist and always
+///     overrides its static methods (isUserVerifyingPlatformAuthenticatorAvailable
+///     returns true, isConditionalMediationAvailable returns false).
+///   - Saves originals of `navigator.credentials.create/get`.
+///   - Defines bridge functions that serialize options (ArrayBuffer to
+///     Base64URL) and call `window.flutter_inappwebview.callHandler('webauthn', ...)`
+///   - Overrides create/get to TRY NATIVE FIRST (call origCreate), and on
+///     failure fall back to bridge.
+///   - Uses `__webauthnPolyfilled` guard to prevent double-override of
+///     create/get (but detection methods are always set).
+const String _webAuthnPolyfillScript = r'''
+(function() {
+  // --- Detection: always override (no guard) ---
+  if (typeof PublicKeyCredential === 'undefined') {
+    window.PublicKeyCredential = function() {};
+    window.PublicKeyCredential.prototype = {};
+  }
+  PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable = function() {
+    return Promise.resolve(true);
+  };
+  PublicKeyCredential.isConditionalMediationAvailable = function() {
+    return Promise.resolve(false);
+  };
+
+  // Guard create/get override
+  if (window.__webauthnPolyfilled) return;
+  window.__webauthnPolyfilled = true;
+
+  console.log('[WebAuthn polyfill] installing create/get overrides');
+
+  // --- Helpers ---
+  function bufferToBase64url(buffer) {
+    var bytes = new Uint8Array(buffer instanceof ArrayBuffer ? buffer : buffer.buffer);
+    var binary = '';
+    for (var i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  }
+
+  function base64urlToBuffer(base64url) {
+    var base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+    while (base64.length % 4) base64 += '=';
+    var binary = atob(base64);
+    var bytes = new Uint8Array(binary.length);
+    for (var i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes.buffer;
+  }
+
+  function serializeCreateOptions(options) {
+    var pk = options.publicKey;
+    if (!pk) return JSON.stringify(options);
+    var obj = JSON.parse(JSON.stringify(pk, function(key, value) {
+      if (value && value.buffer instanceof ArrayBuffer) {
+        return bufferToBase64url(value);
+      }
+      if (value instanceof ArrayBuffer) {
+        return bufferToBase64url(value);
+      }
+      return value;
+    }));
+    if (pk.challenge) obj.challenge = bufferToBase64url(pk.challenge);
+    if (pk.user && pk.user.id) obj.user.id = bufferToBase64url(pk.user.id);
+    if (pk.excludeCredentials) {
+      obj.excludeCredentials = pk.excludeCredentials.map(function(c) {
+        var r = Object.assign({}, c);
+        if (c.id) r.id = bufferToBase64url(c.id);
+        return r;
+      });
+    }
+    return JSON.stringify(obj);
+  }
+
+  function serializeGetOptions(options) {
+    var pk = options.publicKey;
+    if (!pk) return JSON.stringify(options);
+    var obj = JSON.parse(JSON.stringify(pk, function(key, value) {
+      if (value && value.buffer instanceof ArrayBuffer) {
+        return bufferToBase64url(value);
+      }
+      if (value instanceof ArrayBuffer) {
+        return bufferToBase64url(value);
+      }
+      return value;
+    }));
+    if (pk.challenge) obj.challenge = bufferToBase64url(pk.challenge);
+    if (pk.allowCredentials) {
+      obj.allowCredentials = pk.allowCredentials.map(function(c) {
+        var r = Object.assign({}, c);
+        if (c.id) r.id = bufferToBase64url(c.id);
+        return r;
+      });
+    }
+    return JSON.stringify(obj);
+  }
+
+  // --- Bridge functions ---
+  function bridgeCreate(options) {
+    console.log('[WebAuthn polyfill] bridge create');
+    var requestJson = serializeCreateOptions(options);
+    var origin = window.location.origin;
+    return window.flutter_inappwebview.callHandler('webauthn', 'create', requestJson, origin)
+      .then(function(responseJson) {
+        console.log('[WebAuthn polyfill] bridge create response received');
+        var resp = JSON.parse(responseJson);
+        var credential = {
+          id: resp.id || '',
+          rawId: resp.rawId ? base64urlToBuffer(resp.rawId) : new ArrayBuffer(0),
+          type: resp.type || 'public-key',
+          response: {
+            clientDataJSON: resp.response && resp.response.clientDataJSON
+              ? base64urlToBuffer(resp.response.clientDataJSON)
+              : new ArrayBuffer(0),
+            attestationObject: resp.response && resp.response.attestationObject
+              ? base64urlToBuffer(resp.response.attestationObject)
+              : new ArrayBuffer(0),
+            getTransports: function() { return resp.response && resp.response.transports || []; },
+            getAuthenticatorData: function() {
+              return resp.response && resp.response.authenticatorData
+                ? base64urlToBuffer(resp.response.authenticatorData)
+                : new ArrayBuffer(0);
+            },
+            getPublicKey: function() {
+              return resp.response && resp.response.publicKey
+                ? base64urlToBuffer(resp.response.publicKey)
+                : null;
+            },
+            getPublicKeyAlgorithm: function() {
+              return resp.response && resp.response.publicKeyAlgorithm || -7;
+            }
+          },
+          authenticatorAttachment: resp.authenticatorAttachment || 'platform',
+          getClientExtensionResults: function() { return resp.clientExtensionResults || {}; }
+        };
+        return credential;
+      });
+  }
+
+  function bridgeGet(options) {
+    console.log('[WebAuthn polyfill] bridge get');
+    var requestJson = serializeGetOptions(options);
+    var origin = window.location.origin;
+    return window.flutter_inappwebview.callHandler('webauthn', 'get', requestJson, origin)
+      .then(function(responseJson) {
+        console.log('[WebAuthn polyfill] bridge get response received');
+        var resp = JSON.parse(responseJson);
+        var credential = {
+          id: resp.id || '',
+          rawId: resp.rawId ? base64urlToBuffer(resp.rawId) : new ArrayBuffer(0),
+          type: resp.type || 'public-key',
+          response: {
+            clientDataJSON: resp.response && resp.response.clientDataJSON
+              ? base64urlToBuffer(resp.response.clientDataJSON)
+              : new ArrayBuffer(0),
+            authenticatorData: resp.response && resp.response.authenticatorData
+              ? base64urlToBuffer(resp.response.authenticatorData)
+              : new ArrayBuffer(0),
+            signature: resp.response && resp.response.signature
+              ? base64urlToBuffer(resp.response.signature)
+              : new ArrayBuffer(0),
+            userHandle: resp.response && resp.response.userHandle
+              ? base64urlToBuffer(resp.response.userHandle)
+              : null
+          },
+          authenticatorAttachment: resp.authenticatorAttachment || 'platform',
+          getClientExtensionResults: function() { return resp.clientExtensionResults || {}; }
+        };
+        return credential;
+      });
+  }
+
+  // --- Override create/get: try native first, fall back to bridge ---
+  var origCreate = navigator.credentials && navigator.credentials.create
+    ? navigator.credentials.create.bind(navigator.credentials) : null;
+  var origGet = navigator.credentials && navigator.credentials.get
+    ? navigator.credentials.get.bind(navigator.credentials) : null;
+
+  if (navigator.credentials) {
+    navigator.credentials.create = function(options) {
+      if (!options || !options.publicKey) {
+        return origCreate ? origCreate(options) : Promise.reject(new Error('No publicKey in options'));
+      }
+      if (origCreate) {
+        console.log('[WebAuthn polyfill] trying native create first');
+        return origCreate(options).catch(function(err) {
+          console.log('[WebAuthn polyfill] native create failed (' + err.message + '), falling back to bridge');
+          return bridgeCreate(options);
+        });
+      }
+      return bridgeCreate(options);
+    };
+    navigator.credentials.get = function(options) {
+      if (!options || !options.publicKey) {
+        return origGet ? origGet(options) : Promise.reject(new Error('No publicKey in options'));
+      }
+      if (origGet) {
+        console.log('[WebAuthn polyfill] trying native get first');
+        return origGet(options).catch(function(err) {
+          console.log('[WebAuthn polyfill] native get failed (' + err.message + '), falling back to bridge');
+          return bridgeGet(options);
+        });
+      }
+      return bridgeGet(options);
+    };
+  }
+})();
+''';
+
 /// Factory for creating webviews
 class WebViewFactory {
   /// System font scale → webview text zoom percent. Tracks the OS-level
@@ -1223,6 +1437,18 @@ class WebViewFactory {
       userScripts.add(inapp.UserScript(
         groupName: 'clearurl_share',
         source: '$_clearUrlShareScript\n;null;',
+        injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
+      ));
+    }
+
+    // WebAuthn/passkey polyfill (Android only). Injects a JS shim that
+    // overrides navigator.credentials.create/get to try the native WebAuthn
+    // path first, falling back to the Credential Manager bridge via
+    // flutter_inappwebview JS handler.
+    if (Platform.isAndroid) {
+      userScripts.add(inapp.UserScript(
+        groupName: 'webauthn_polyfill',
+        source: '$_webAuthnPolyfillScript\n;null;',
         injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
       ));
     }
@@ -1830,6 +2056,40 @@ class WebViewFactory {
         // fires, the WebView is already bound to its per-site container
         // and every cookie / IDB / ServiceWorker / cache write that
         // follows is partitioned to that container.
+        // WebAuthn/passkey: register JS handler and set up native WebAuthn
+        // support on Android. The handler bridges navigator.credentials
+        // create/get calls from the JS polyfill to the native Credential
+        // Manager via the platform channel.
+        if (Platform.isAndroid) {
+          controller.addJavaScriptHandler(
+            handlerName: 'webauthn',
+            callback: (args) async {
+              if (args.length < 3) return null;
+              final action = args[0] as String;
+              final requestJson = args[1] as String;
+              final origin = args[2] as String;
+              try {
+                final result = await _webAuthnChannel.invokeMethod(action, {
+                  'requestJson': requestJson,
+                  'origin': origin,
+                });
+                return result;
+              } on PlatformException catch (e) {
+                throw Exception('WebAuthn $action failed: ${e.code} ${e.message}');
+              }
+            },
+          );
+          // Set up native WebAuthn support on the WebView after it's
+          // been added to the view hierarchy.
+          Future.microtask(() async {
+            try {
+              final info = await _webAuthnChannel.invokeMethod('setupWebAuthn');
+              debugPrint('WebAuthn setup: $info');
+            } catch (e) {
+              debugPrint('WebAuthn setup failed: $e');
+            }
+          });
+        }
         // Attach native interceptor (DNS blocking + LocalCDN serving) once
         // the view is in the hierarchy. Always attach on Android — the
         // handler no-ops cheaply when neither blocklist nor CDN cache are
@@ -2067,6 +2327,13 @@ class WebViewFactory {
         }
         if (config.clearUrlEnabled) {
           earlyScripts.add(_clearUrlShareScript);
+        }
+        // Re-inject WebAuthn polyfill on each page load so the shim is
+        // in place before any site script runs. The DOCUMENT_START user
+        // script covers the initial load; this covers subsequent
+        // navigations within the same WebView instance.
+        if (Platform.isAndroid) {
+          earlyScripts.add(_webAuthnPolyfillScript);
         }
         if (earlyScripts.isNotEmpty && stillCurrent()) {
           try {

--- a/openspec/specs/passkey-support/spec.md
+++ b/openspec/specs/passkey-support/spec.md
@@ -1,0 +1,153 @@
+# Passkey / WebAuthn Support
+
+## Purpose
+
+WebAuthn/passkey authentication for sites loaded inside WebSpace's InAppWebView. On Android, a JS polyfill bridges `navigator.credentials.create()` / `.get()` calls to the Android Credential Manager API via a flutter_inappwebview JavaScript handler and a platform channel. iOS support is pending.
+
+## Requirements
+
+### Requirement: PK-001 - Passkey Feature Detection
+
+The app SHALL mock `PublicKeyCredential` and its static detection methods on Android so sites detect passkey support.
+
+#### Scenario: Site checks for passkey availability
+
+**Given** a website calls `PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()`
+**When** the polyfill is active on Android
+**Then** the method resolves to `true`
+**And** the site shows passkey sign-in options
+
+---
+
+### Requirement: PK-002 - Passkey Creation
+
+The app SHALL bridge `navigator.credentials.create({ publicKey })` to the Android Credential Manager on Android 9+.
+
+#### Scenario: Create a passkey
+
+**Given** a site calls `navigator.credentials.create()` with a `publicKey` option
+**When** the polyfill intercepts the call
+**Then** native WebView WebAuthn is tried first
+**And** if native fails, the Credential Manager bridge is used as fallback
+**And** the site receives a `PublicKeyCredential` response or an appropriate error
+
+---
+
+### Requirement: PK-003 - Passkey Authentication
+
+The app SHALL bridge `navigator.credentials.get({ publicKey })` to the Android Credential Manager on Android 9+.
+
+#### Scenario: Sign in with passkey
+
+**Given** a site calls `navigator.credentials.get()` with a `publicKey` option
+**When** the polyfill intercepts the call
+**Then** native WebView WebAuthn is tried first
+**And** if native fails, the Credential Manager bridge is used as fallback
+
+---
+
+### Requirement: PK-004 - Non-PublicKey Passthrough
+
+The polyfill SHALL NOT intercept credential requests that do not use the `publicKey` option.
+
+#### Scenario: Password credential request
+
+**Given** a site calls `navigator.credentials.get()` without `publicKey`
+**When** the call is evaluated
+**Then** the original `navigator.credentials.get()` is called unmodified
+
+---
+
+### Requirement: PK-005 - Polyfill Re-injection
+
+The WebAuthn polyfill SHALL be re-injected on every page navigation.
+
+#### Scenario: Navigate to a new page
+
+**Given** the user navigates from page A to page B
+**When** page B loads
+**Then** the polyfill is active on page B
+
+## Architecture
+
+### JS Polyfill (`_webAuthnPolyfillScript` in `lib/services/webview.dart`)
+
+Injected at `DOCUMENT_START` on Android. The polyfill:
+
+1. **Detection methods** (no guard -- always set):
+   - `PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()` -> `true`
+   - `PublicKeyCredential.isConditionalMediationAvailable()` -> `false`
+
+2. **create/get overrides** (guarded by `__webauthnPolyfilled` flag):
+   - Saves original `navigator.credentials.create` / `.get`
+   - On `create({ publicKey })` or `get({ publicKey })`:
+     - Tries the original (native) method first
+     - On failure, serializes the `PublicKeyCredentialCreationOptions` / `RequestOptions` (converting ArrayBuffers to Base64URL) and calls `window.flutter_inappwebview.callHandler('webauthn', action, requestJson, origin)`
+     - Deserializes the JSON response back into a `PublicKeyCredential`-shaped object with ArrayBuffer fields
+
+### Native Handler (`WebAuthnHandler.kt`)
+
+- `setupWebAuthn()`: Walks the Activity's view hierarchy looking for `android.webkit.WebView` instances. For each, calls `WebSettingsCompat.setWebAuthenticationSupport(settings, WEB_AUTHENTICATION_SUPPORT_FOR_APP)` if `WebViewFeature.WEB_AUTHENTICATION` is supported.
+- `handleCreate(requestJson, origin, callback)`: Creates a `CreatePublicKeyCredentialRequest` and calls `CredentialManager.createCredentialAsync`. Returns the registration response JSON via the callback.
+- `handleGet(requestJson, origin, callback)`: Creates a `GetPublicKeyCredentialOption` wrapped in `GetCredentialRequest` and calls `CredentialManager.getCredentialAsync`. Returns the authentication response JSON.
+
+Uses callback-based async (`CredentialManagerCallback`), not Kotlin coroutines.
+
+### Platform Channel (`MainActivity.kt`)
+
+Channel: `org.codeberg.theoden8.webspace/webauthn`
+
+Methods:
+- `setupWebAuthn` -> `String` (diagnostic info)
+- `create` -> `String` (response JSON), args: `requestJson`, `origin`
+- `get` -> `String` (response JSON), args: `requestJson`, `origin`
+
+### Dart Side (`lib/services/webview.dart`)
+
+- `_webAuthnChannel`: `MethodChannel('org.codeberg.theoden8.webspace/webauthn')`
+- In `onWebViewCreated`: registers `'webauthn'` JS handler that forwards to the platform channel, then calls `setupWebAuthn` via `Future.microtask`.
+- In `onLoadStart`: re-injects the polyfill script alongside the ClearURLs and content-blocker early scripts.
+- In `createWebView` user scripts: adds the polyfill as a `UserScript` at `AT_DOCUMENT_START`.
+
+## Known Limitations
+
+### FOR_BROWSER crashes
+
+`WebSettingsCompat.WEB_AUTHENTICATION_SUPPORT_FOR_BROWSER` causes a crash on most devices because it requires a Digital Asset Links (DAL) file at `/.well-known/assetlinks.json` on the site's domain that declares the app's signing certificate. Since WebSpace loads arbitrary user-chosen sites, FOR_BROWSER is not viable.
+
+### CREDENTIAL_MANAGER_SET_ORIGIN is system-only
+
+The `CREDENTIAL_MANAGER_SET_ORIGIN` permission required by `CreatePublicKeyCredentialRequest(requestJson, origin)` (the two-arg constructor) is a signature-level permission granted only to system apps (e.g. Chrome, GMS). Third-party apps cannot set the origin, so the Credential Manager uses the app's package identity instead.
+
+### FOR_APP requires DAL
+
+`WEB_AUTHENTICATION_SUPPORT_FOR_APP` tells the System WebView to route WebAuthn requests to the embedding app. For this to work end-to-end with a relying party, the RP's `/.well-known/assetlinks.json` must list the app's package name and signing certificate hash. Without a DAL entry, the RP server rejects the attestation/assertion because the origin doesn't match. This limits passkey support to sites that have explicitly registered the WebSpace app -- which in practice means it works as a proof-of-concept but won't work on arbitrary sites until they add WebSpace to their DAL.
+
+### iOS pending
+
+iOS WKWebView has no equivalent of `setWebAuthenticationSupport`. ASWebAuthenticationSession provides OAuth flows but not raw WebAuthn. Passkey support on iOS requires a different approach (possibly an Authentication Services extension) and is not yet implemented.
+
+## Files
+
+| File | Role |
+|------|------|
+| `android/app/build.gradle` | Dependencies: `androidx.webkit:webkit:1.14.0`, `androidx.credentials:credentials:1.5.0`, `credentials-play-services-auth:1.5.0` |
+| `android/app/src/main/kotlin/.../WebAuthnHandler.kt` | Native WebAuthn handler (Credential Manager + WebSettingsCompat) |
+| `android/app/src/main/kotlin/.../MainActivity.kt` | Platform channel registration |
+| `lib/services/webview.dart` | JS polyfill, handler registration, re-injection |
+
+## Manual Test
+
+### Given
+- Android device with System WebView >= 110 and Google Play Services
+- A site that supports passkeys (e.g. webauthn.io, passkeys.io)
+
+### When
+1. Add the site to WebSpace
+2. Navigate to the passkey registration / login page
+3. Tap "Register" or "Sign in with passkey"
+
+### Then
+- The Android Credential Manager UI appears
+- On successful authentication, the site proceeds as if passkey auth succeeded
+- Console logs show `[WebAuthn polyfill]` messages indicating the bridge path


### PR DESCRIPTION
Implements passkey support by bridging the Web Authentication API from the WebView to Android's Credential Manager. Uses a dual approach:

1. JavaScript polyfill injected at DOCUMENT_START that overrides navigator.credentials.create() and navigator.credentials.get(), serializing WebAuthn options and forwarding them via flutter_inappwebview's JavaScript handler mechanism.

2. Native Android handler (WebAuthnHandler.kt) that receives the serialized requests via MethodChannel and forwards them to the Android Credential Manager API, which shows the system passkey UI and delegates to the user's credential provider (e.g. Bitwarden, Google Password Manager).

Also attempts to enable native WebView WebAuthn support via AndroidX WebKit reflection APIs (setWebAuthenticationSupport) on devices where available.

Closes #194

https://claude.ai/code/session_01LWdqTrH8o8QtKfPJ2c8EyC