### PR TITLE
Fix fdroid APK not installable from CI by adding debug signing

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -70,6 +70,9 @@ android {
     productFlavors {
       fdroid {
         dimension "deploy"
+        // fdroid flavor is unsigned for F-Droid distribution (F-Droid signs
+        // APKs server-side). Use debug signing so CI artifacts are installable.
+        signingConfig signingConfigs.debug
       }
 
       fdebug {


### PR DESCRIPTION
The fdroid flavor had no signingConfig, producing unsigned release APKs that Android refuses to install. Add debug signing so CI-built APKs are directly installable while preserving F-Droid's server-side re-signing workflow.

https://claude.ai/code/session_013KNAPkmnYPK9FcMMVaMV5h