### PR TITLE
Add DNS blocking transparency: live banner, query log, and per-site s…

### DIFF
--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/DnsBlockPlugin.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/DnsBlockPlugin.kt
@@ -1,0 +1,109 @@
+package org.codeberg.theoden8.webspace
+
+import android.app.Activity
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebResourceResponse
+import com.pichillilorenzo.flutter_inappwebview_android.content_blocker.ContentBlockerHandler
+import com.pichillilorenzo.flutter_inappwebview_android.types.WebResourceRequestExt
+import com.pichillilorenzo.flutter_inappwebview_android.webview.in_app_webview.InAppWebView
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+import java.net.URI
+
+class DnsBlockPlugin(private val activity: Activity, flutterEngine: FlutterEngine) {
+    private val channel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
+    private val blockedDomains = HashSet<String>()
+    private val handler = android.os.Handler(android.os.Looper.getMainLooper())
+
+    init {
+        channel.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "setBlockedDomains" -> {
+                    val domains = call.argument<List<String>>("domains")
+                    if (domains != null) {
+                        blockedDomains.clear()
+                        blockedDomains.addAll(domains)
+                        result.success(blockedDomains.size)
+                    } else {
+                        result.error("INVALID_ARGS", "domains list required", null)
+                    }
+                }
+                "attachToWebViews" -> {
+                    val count = attachToAllWebViews()
+                    result.success(count)
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    private fun reportBlocked(host: String) {
+        handler.post {
+            channel.invokeMethod("onDnsBlocked", host)
+        }
+    }
+
+    private fun attachToAllWebViews(): Int {
+        val rootView = activity.window.decorView.rootView
+        val webViews = mutableListOf<InAppWebView>()
+        findInAppWebViews(rootView, webViews)
+        for (webView in webViews) {
+            if (webView.contentBlockerHandler !is FastDnsBlockerHandler) {
+                webView.contentBlockerHandler = FastDnsBlockerHandler(blockedDomains, ::reportBlocked)
+            }
+        }
+        return webViews.size
+    }
+
+    private fun findInAppWebViews(view: View, results: MutableList<InAppWebView>) {
+        if (view is InAppWebView) {
+            results.add(view)
+        }
+        if (view is ViewGroup) {
+            for (i in 0 until view.childCount) {
+                findInAppWebViews(view.getChildAt(i), results)
+            }
+        }
+    }
+
+    companion object {
+        const val CHANNEL = "org.codeberg.theoden8.webspace/dns_block"
+    }
+}
+
+class FastDnsBlockerHandler(
+    private val blockedDomains: HashSet<String>,
+    private val onBlocked: (String) -> Unit
+) : ContentBlockerHandler() {
+
+    override fun checkUrl(
+        webView: InAppWebView,
+        request: WebResourceRequestExt
+    ): WebResourceResponse? {
+        val url = request.url ?: return null
+        val host = try {
+            URI(url).host?.lowercase() ?: return null
+        } catch (e: Exception) {
+            return null
+        }
+        if (host.isEmpty()) return null
+
+        if (isBlockedDomain(host)) {
+            onBlocked(host)
+            return WebResourceResponse("text/plain", "utf-8", null)
+        }
+        return null
+    }
+
+    private fun isBlockedDomain(host: String): Boolean {
+        if (blockedDomains.contains(host)) return true
+        val parts = host.split(".")
+        for (i in 1 until parts.size - 1) {
+            if (blockedDomains.contains(parts.subList(i, parts.size).joinToString("."))) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/DnsBlockPlugin.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/DnsBlockPlugin.kt
@@ -1,7 +1,6 @@
 package org.codeberg.theoden8.webspace
 
 import android.app.Activity
-import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebResourceResponse
@@ -34,7 +33,8 @@ class DnsBlockPlugin(private val activity: Activity, flutterEngine: FlutterEngin
                     }
                 }
                 "attachToWebViews" -> {
-                    val count = attachToAllWebViews()
+                    val siteId = call.argument<String>("siteId")
+                    val count = attachToAllWebViews(siteId)
                     result.success(count)
                 }
                 else -> result.notImplemented()
@@ -42,23 +42,32 @@ class DnsBlockPlugin(private val activity: Activity, flutterEngine: FlutterEngin
         }
     }
 
-    private fun reportBlocked(host: String) {
+    private fun reportBlocked(siteId: String, host: String) {
         handler.post {
-            channel.invokeMethod("onDnsBlocked", host)
+            channel.invokeMethod("onDnsBlocked", mapOf("siteId" to siteId, "host" to host))
         }
     }
 
-    private fun attachToAllWebViews(): Int {
+    private fun attachToAllWebViews(newSiteId: String?): Int {
         val rootView = activity.window.decorView.rootView
         val webViews = mutableListOf<InAppWebView>()
         findInAppWebViews(rootView, webViews)
         for (webView in webViews) {
-            if (webView.contentBlockerHandler !is FastDnsBlockerHandler) {
-                webView.contentBlockerHandler = FastDnsBlockerHandler(blockedDomains, ::reportBlocked)
+            val isNew = webView.contentBlockerHandler !is FastDnsBlockerHandler
+            if (isNew && newSiteId != null) {
+                siteIdMap[webView] = newSiteId
+            }
+            if (isNew) {
+                val siteId = siteIdMap[webView] ?: "unknown"
+                webView.contentBlockerHandler = FastDnsBlockerHandler(blockedDomains) { host ->
+                    reportBlocked(siteId, host)
+                }
             }
         }
         return webViews.size
     }
+
+    private val siteIdMap = HashMap<InAppWebView, String>()
 
     private fun findInAppWebViews(view: View, results: MutableList<InAppWebView>) {
         if (view is InAppWebView) {
@@ -100,9 +109,7 @@ class FastDnsBlockerHandler(
         }
         if (host.isEmpty()) return null
 
-        val blocked = isBlockedDomain(host)
-        Log.d("DnsBlock", "[Native] $host ${if (blocked) "BLOCKED" else "allowed"}")
-        if (blocked) {
+        if (isBlockedDomain(host)) {
             onBlocked(host)
             return WebResourceResponse("text/plain", "utf-8", null)
         }

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/DnsBlockPlugin.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/DnsBlockPlugin.kt
@@ -4,7 +4,10 @@ import android.app.Activity
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebResourceResponse
+import com.pichillilorenzo.flutter_inappwebview_android.content_blocker.ContentBlocker
+import com.pichillilorenzo.flutter_inappwebview_android.content_blocker.ContentBlockerAction
 import com.pichillilorenzo.flutter_inappwebview_android.content_blocker.ContentBlockerHandler
+import com.pichillilorenzo.flutter_inappwebview_android.content_blocker.ContentBlockerTrigger
 import com.pichillilorenzo.flutter_inappwebview_android.types.WebResourceRequestExt
 import com.pichillilorenzo.flutter_inappwebview_android.webview.in_app_webview.InAppWebView
 import io.flutter.embedding.engine.FlutterEngine
@@ -76,6 +79,13 @@ class FastDnsBlockerHandler(
     private val blockedDomains: HashSet<String>,
     private val onBlocked: (String) -> Unit
 ) : ContentBlockerHandler() {
+
+    init {
+        // Dummy rule so the Java guard `ruleList.size() > 0` passes
+        val trigger = ContentBlockerTrigger(".*", null, null, null, null, null, null, null)
+        val action = ContentBlockerAction.fromMap(mapOf("type" to "block"))
+        ruleList.add(ContentBlocker(trigger, action))
+    }
 
     override fun checkUrl(
         webView: InAppWebView,

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/DnsBlockPlugin.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/DnsBlockPlugin.kt
@@ -1,6 +1,7 @@
 package org.codeberg.theoden8.webspace
 
 import android.app.Activity
+import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebResourceResponse
@@ -99,7 +100,9 @@ class FastDnsBlockerHandler(
         }
         if (host.isEmpty()) return null
 
-        if (isBlockedDomain(host)) {
+        val blocked = isBlockedDomain(host)
+        Log.d("DnsBlock", "[Native] $host ${if (blocked) "BLOCKED" else "allowed"}")
+        if (blocked) {
             onBlocked(host)
             return WebResourceResponse("text/plain", "utf-8", null)
         }

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/DnsBlockPlugin.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/DnsBlockPlugin.kt
@@ -13,11 +13,19 @@ import com.pichillilorenzo.flutter_inappwebview_android.webview.in_app_webview.I
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 import java.net.URI
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 
 class DnsBlockPlugin(private val activity: Activity, flutterEngine: FlutterEngine) {
     private val channel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
     private val blockedDomains = HashSet<String>()
-    private val handler = android.os.Handler(android.os.Looper.getMainLooper())
+    private val mainHandler = android.os.Handler(android.os.Looper.getMainLooper())
+
+    // Per-site pending events. Java is the source of truth; Dart pulls on demand.
+    private val pendingBlocked = ConcurrentHashMap<String, MutableList<String>>()
+    // Whether a signal is in flight for this siteId (prevents signal spam).
+    private val signalPending = ConcurrentHashMap<String, AtomicBoolean>()
 
     init {
         channel.setMethodCallHandler { call, result ->
@@ -37,30 +45,46 @@ class DnsBlockPlugin(private val activity: Activity, flutterEngine: FlutterEngin
                     val count = attachToAllWebViews(siteId)
                     result.success(count)
                 }
+                "fetchBlocked" -> {
+                    val siteId = call.argument<String>("siteId")
+                    if (siteId == null) {
+                        result.error("INVALID_ARGS", "siteId required", null)
+                    } else {
+                        val list = pendingBlocked[siteId]
+                        if (list == null) {
+                            result.success(emptyList<String>())
+                        } else {
+                            val snapshot: List<String>
+                            synchronized(list) {
+                                snapshot = ArrayList(list)
+                                list.clear()
+                            }
+                            result.success(snapshot)
+                        }
+                    }
+                }
                 else -> result.notImplemented()
             }
         }
     }
 
-    private val pendingBlocked = mutableListOf<Map<String, String>>()
-    private var flushScheduled = false
+    /// Records a blocked event for this site and signals Dart once per batch.
+    /// If Dart is already processing an earlier signal for this site,
+    /// subsequent blocks just accumulate — no duplicate signals.
+    private fun recordBlocked(siteId: String, host: String) {
+        val list = pendingBlocked.computeIfAbsent(siteId) {
+            Collections.synchronizedList(mutableListOf())
+        }
+        list.add(host)
 
-    private fun reportBlocked(siteId: String, host: String) {
-        synchronized(pendingBlocked) {
-            pendingBlocked.add(mapOf("siteId" to siteId, "host" to host))
-            if (!flushScheduled) {
-                flushScheduled = true
-                handler.postDelayed({
-                    val batch: List<Map<String, String>>
-                    synchronized(pendingBlocked) {
-                        batch = pendingBlocked.toList()
-                        pendingBlocked.clear()
-                        flushScheduled = false
-                    }
-                    if (batch.isNotEmpty()) {
-                        channel.invokeMethod("onDnsBlockedBatch", batch)
-                    }
-                }, 200)
+        val signaled = signalPending.computeIfAbsent(siteId) { AtomicBoolean(false) }
+        if (signaled.compareAndSet(false, true)) {
+            mainHandler.post {
+                channel.invokeMethod("dnsBlockedReady", siteId, object : MethodChannel.Result {
+                    override fun success(result: Any?) { signaled.set(false) }
+                    override fun error(code: String, message: String?, details: Any?) { signaled.set(false) }
+                    override fun notImplemented() { signaled.set(false) }
+                })
             }
         }
     }
@@ -77,7 +101,7 @@ class DnsBlockPlugin(private val activity: Activity, flutterEngine: FlutterEngin
             if (isNew) {
                 val siteId = siteIdMap[webView] ?: "unknown"
                 webView.contentBlockerHandler = FastDnsBlockerHandler(blockedDomains) { host ->
-                    reportBlocked(siteId, host)
+                    recordBlocked(siteId, host)
                 }
             }
         }

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/DnsBlockPlugin.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/DnsBlockPlugin.kt
@@ -42,9 +42,26 @@ class DnsBlockPlugin(private val activity: Activity, flutterEngine: FlutterEngin
         }
     }
 
+    private val pendingBlocked = mutableListOf<Map<String, String>>()
+    private var flushScheduled = false
+
     private fun reportBlocked(siteId: String, host: String) {
-        handler.post {
-            channel.invokeMethod("onDnsBlocked", mapOf("siteId" to siteId, "host" to host))
+        synchronized(pendingBlocked) {
+            pendingBlocked.add(mapOf("siteId" to siteId, "host" to host))
+            if (!flushScheduled) {
+                flushScheduled = true
+                handler.postDelayed({
+                    val batch: List<Map<String, String>>
+                    synchronized(pendingBlocked) {
+                        batch = pendingBlocked.toList()
+                        pendingBlocked.clear()
+                        flushScheduled = false
+                    }
+                    if (batch.isNotEmpty()) {
+                        channel.invokeMethod("onDnsBlockedBatch", batch)
+                    }
+                }, 200)
+            }
         }
     }
 

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/DnsBlockPlugin.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/DnsBlockPlugin.kt
@@ -23,7 +23,8 @@ class DnsBlockPlugin(private val activity: Activity, flutterEngine: FlutterEngin
     private val mainHandler = android.os.Handler(android.os.Looper.getMainLooper())
 
     // Per-site pending events. Java is the source of truth; Dart pulls on demand.
-    private val pendingBlocked = ConcurrentHashMap<String, MutableList<String>>()
+    // Each event is {"host": String, "blocked": Boolean}.
+    private val pendingEvents = ConcurrentHashMap<String, MutableList<Map<String, Any>>>()
     // Whether a signal is in flight for this siteId (prevents signal spam).
     private val signalPending = ConcurrentHashMap<String, AtomicBoolean>()
 
@@ -45,16 +46,16 @@ class DnsBlockPlugin(private val activity: Activity, flutterEngine: FlutterEngin
                     val count = attachToAllWebViews(siteId)
                     result.success(count)
                 }
-                "fetchBlocked" -> {
+                "fetchEvents" -> {
                     val siteId = call.argument<String>("siteId")
                     if (siteId == null) {
                         result.error("INVALID_ARGS", "siteId required", null)
                     } else {
-                        val list = pendingBlocked[siteId]
+                        val list = pendingEvents[siteId]
                         if (list == null) {
-                            result.success(emptyList<String>())
+                            result.success(emptyList<Map<String, Any>>())
                         } else {
-                            val snapshot: List<String>
+                            val snapshot: List<Map<String, Any>>
                             synchronized(list) {
                                 snapshot = ArrayList(list)
                                 list.clear()
@@ -68,19 +69,19 @@ class DnsBlockPlugin(private val activity: Activity, flutterEngine: FlutterEngin
         }
     }
 
-    /// Records a blocked event for this site and signals Dart once per batch.
-    /// If Dart is already processing an earlier signal for this site,
-    /// subsequent blocks just accumulate — no duplicate signals.
-    private fun recordBlocked(siteId: String, host: String) {
-        val list = pendingBlocked.computeIfAbsent(siteId) {
+    /// Records a DNS event (allowed or blocked) for this site and signals
+    /// Dart once per batch. If Dart is already processing an earlier signal
+    /// for this site, subsequent events just accumulate — no duplicate signals.
+    private fun recordEvent(siteId: String, host: String, blocked: Boolean) {
+        val list = pendingEvents.computeIfAbsent(siteId) {
             Collections.synchronizedList(mutableListOf())
         }
-        list.add(host)
+        list.add(mapOf("host" to host, "blocked" to blocked))
 
         val signaled = signalPending.computeIfAbsent(siteId) { AtomicBoolean(false) }
         if (signaled.compareAndSet(false, true)) {
             mainHandler.post {
-                channel.invokeMethod("dnsBlockedReady", siteId, object : MethodChannel.Result {
+                channel.invokeMethod("dnsEventsReady", siteId, object : MethodChannel.Result {
                     override fun success(result: Any?) { signaled.set(false) }
                     override fun error(code: String, message: String?, details: Any?) { signaled.set(false) }
                     override fun notImplemented() { signaled.set(false) }
@@ -100,8 +101,8 @@ class DnsBlockPlugin(private val activity: Activity, flutterEngine: FlutterEngin
             }
             if (isNew) {
                 val siteId = siteIdMap[webView] ?: "unknown"
-                webView.contentBlockerHandler = FastDnsBlockerHandler(blockedDomains) { host ->
-                    recordBlocked(siteId, host)
+                webView.contentBlockerHandler = FastDnsBlockerHandler(blockedDomains) { host, blocked ->
+                    recordEvent(siteId, host, blocked)
                 }
             }
         }
@@ -128,7 +129,7 @@ class DnsBlockPlugin(private val activity: Activity, flutterEngine: FlutterEngin
 
 class FastDnsBlockerHandler(
     private val blockedDomains: HashSet<String>,
-    private val onBlocked: (String) -> Unit
+    private val onChecked: (String, Boolean) -> Unit
 ) : ContentBlockerHandler() {
 
     init {
@@ -150,8 +151,9 @@ class FastDnsBlockerHandler(
         }
         if (host.isEmpty()) return null
 
-        if (isBlockedDomain(host)) {
-            onBlocked(host)
+        val blocked = isBlockedDomain(host)
+        onChecked(host, blocked)
+        if (blocked) {
             return WebResourceResponse("text/plain", "utf-8", null)
         }
         return null

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -14,6 +14,7 @@ import java.net.URL
 
 class MainActivity: FlutterActivity() {
     private val CHANNEL = "org.codeberg.theoden8.webspace/shortcuts"
+    private var dnsBlockPlugin: DnsBlockPlugin? = null
 
     override fun getFlutterShellArgs(): FlutterShellArgs {
         val args = FlutterShellArgs.fromIntent(intent)
@@ -29,6 +30,7 @@ class MainActivity: FlutterActivity() {
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
+        dnsBlockPlugin = DnsBlockPlugin(this, flutterEngine)
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
             when (call.method) {
                 "pinShortcut" -> {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -634,6 +634,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   bool _isFullscreen = false; // Runtime fullscreen state (hides appBar, tabStrip, system UI)
   bool _showUrlBar = false;
   bool _showTabStrip = false;
+  bool _showDnsBanner = true;
   bool _canGoBack = false; // Tracks webview back history for iOS drawer gesture
   int _canGoBackVersion = 0; // Guards _updateCanGoBack against stale async results
 
@@ -757,6 +758,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     if (isDemoMode) return;
     SharedPreferences prefs = await SharedPreferences.getInstance();
     await prefs.setBool('showTabStrip', _showTabStrip);
+  }
+
+  Future<void> _saveShowDnsBanner() async {
+    if (isDemoMode) return;
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('showDnsBanner', _showDnsBanner);
   }
 
   Future<void> _saveGlobalUserScripts() async {
@@ -1115,6 +1122,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       }
       _showUrlBar = prefs.getBool('showUrlBar') ?? false;
       _showTabStrip = prefs.getBool('showTabStrip') ?? false;
+      _showDnsBanner = prefs.getBool('showDnsBanner') ?? true;
       widget.onThemeSettingsChanged(_themeSettings);
     });
     await _loadWebspaces();
@@ -1771,6 +1779,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                         _showTabStrip = value;
                       });
                       _saveShowTabStrip();
+                    },
+                    showDnsBanner: _showDnsBanner,
+                    onShowDnsBannerChanged: (value) {
+                      setState(() {
+                        _showDnsBanner = value;
+                      });
+                      _saveShowDnsBanner();
                     },
                     globalUserScripts: _globalUserScripts,
                     onGlobalUserScriptsChanged: (scripts) {
@@ -3094,10 +3109,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                           key: ValueKey(webViewModel.siteId),
                           child: Column(
                             children: [
-                              DnsBlockBanner(
-                                siteId: webViewModel.siteId,
-                                dnsBlockEnabled: webViewModel.dnsBlockEnabled,
-                              ),
+                              if (_showDnsBanner)
+                                DnsBlockBanner(
+                                  siteId: webViewModel.siteId,
+                                  dnsBlockEnabled: webViewModel.dnsBlockEnabled,
+                                ),
                               Expanded(
                                 child: webViewModel.getWebView(
                                   launchUrl,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,7 @@ import 'package:webspace/services/icon_service.dart';
 import 'package:webspace/screens/inappbrowser.dart';
 import 'package:webspace/screens/webspaces_list.dart';
 import 'package:webspace/screens/webspace_detail.dart';
+import 'package:webspace/widgets/dns_block_banner.dart';
 import 'package:webspace/widgets/find_toolbar.dart';
 import 'package:webspace/widgets/url_bar.dart';
 import 'package:webspace/demo_data.dart' show seedDemoData, isDemoMode;
@@ -3089,42 +3090,52 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
                         return SizedBox.expand(
                           key: ValueKey(webViewModel.siteId),
-                          child: webViewModel.getWebView(
-                            launchUrl,
-                            _cookieManager,
-                            _saveWebViewModels,
-                            onWindowRequested: _showPopupWindow,
-                            language: webViewModel.language,
-                            globalUserScripts: _globalUserScripts,
-                            onHtmlLoaded: webViewModel.incognito ? null : (url, html) {
-                              HtmlCacheService.instance.saveHtml(webViewModel.siteId, html, url);
-                            },
-                            initialHtml: webViewModel.incognito ? null : HtmlCacheService.instance.getHtmlSync(webViewModel.siteId),
-                            isActive: () => _currentIndex == index,
-                            onConfirmScriptFetch: (url) async {
-                              if (!mounted) return false;
-                              final result = await showDialog<bool>(
-                                context: context,
-                                builder: (ctx) => AlertDialog(
-                                  title: const Text('Load external script?'),
-                                  content: Text(
-                                    'A user script wants to load:\n\n$url\n\n'
-                                    'This URL is not on the trusted CDN list. Allow?',
-                                  ),
-                                  actions: [
-                                    TextButton(
-                                      onPressed: () => Navigator.pop(ctx, false),
-                                      child: const Text('Deny'),
-                                    ),
-                                    TextButton(
-                                      onPressed: () => Navigator.pop(ctx, true),
-                                      child: const Text('Allow'),
-                                    ),
-                                  ],
+                          child: Column(
+                            children: [
+                              DnsBlockBanner(
+                                siteId: webViewModel.siteId,
+                                dnsBlockEnabled: webViewModel.dnsBlockEnabled,
+                              ),
+                              Expanded(
+                                child: webViewModel.getWebView(
+                                  launchUrl,
+                                  _cookieManager,
+                                  _saveWebViewModels,
+                                  onWindowRequested: _showPopupWindow,
+                                  language: webViewModel.language,
+                                  globalUserScripts: _globalUserScripts,
+                                  onHtmlLoaded: webViewModel.incognito ? null : (url, html) {
+                                    HtmlCacheService.instance.saveHtml(webViewModel.siteId, html, url);
+                                  },
+                                  initialHtml: webViewModel.incognito ? null : HtmlCacheService.instance.getHtmlSync(webViewModel.siteId),
+                                  isActive: () => _currentIndex == index,
+                                  onConfirmScriptFetch: (url) async {
+                                    if (!mounted) return false;
+                                    final result = await showDialog<bool>(
+                                      context: context,
+                                      builder: (ctx) => AlertDialog(
+                                        title: const Text('Load external script?'),
+                                        content: Text(
+                                          'A user script wants to load:\n\n$url\n\n'
+                                          'This URL is not on the trusted CDN list. Allow?',
+                                        ),
+                                        actions: [
+                                          TextButton(
+                                            onPressed: () => Navigator.pop(ctx, false),
+                                            child: const Text('Deny'),
+                                          ),
+                                          TextButton(
+                                            onPressed: () => Navigator.pop(ctx, true),
+                                            child: const Text('Allow'),
+                                          ),
+                                        ],
+                                      ),
+                                    );
+                                    return result ?? false;
+                                  },
                                 ),
-                              );
-                              return result ?? false;
-                            },
+                              ),
+                            ],
                           ),
                         );
                       }).toList(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,6 +35,7 @@ import 'package:webspace/services/cookie_secure_storage.dart';
 import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
+import 'package:webspace/services/dns_block_native.dart';
 import 'package:webspace/services/localcdn_service.dart';
 import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/shortcut_service.dart';
@@ -429,6 +430,12 @@ void main() async {
   // Initialize DNS block service (loads cached blocklist from disk)
   await DnsBlockService.instance.initialize();
 
+  // Initialize native DNS block handler for sub-resource blocking (Android)
+  DnsBlockNative.initialize();
+  if (DnsBlockService.instance.hasBlocklist) {
+    await DnsBlockNative.sendDomains(DnsBlockService.instance.blockedDomains);
+  }
+
   // Initialize content blocker service (loads cached filter lists from disk)
   await ContentBlockerService.instance.initialize();
 
@@ -820,6 +827,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
     final target = _webViewModels[index];
 
+    DnsBlockNative.activeSiteId = target.siteId;
     LogService.instance.log('CookieIsolation', 'Switching to site $index: "${target.name}" (siteId: ${target.siteId})');
     LogService.instance.log('CookieIsolation', 'Target domain: ${getBaseDomain(target.initUrl)}');
     LogService.instance.log('CookieIsolation', 'Currently loaded indices: $_loadedIndices');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -827,7 +827,6 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
     final target = _webViewModels[index];
 
-    DnsBlockNative.activeSiteId = target.siteId;
     LogService.instance.log('CookieIsolation', 'Switching to site $index: "${target.name}" (siteId: ${target.siteId})');
     LogService.instance.log('CookieIsolation', 'Target domain: ${getBaseDomain(target.initUrl)}');
     LogService.instance.log('CookieIsolation', 'Currently loaded indices: $_loadedIndices');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1148,6 +1148,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
   Future<void> launchUrl(String url, {
     String? homeTitle,
+    required String? siteId,
     required bool incognito,
     required bool thirdPartyCookiesEnabled,
     required bool clearUrlEnabled,
@@ -1161,6 +1162,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         builder: (context) => InAppWebViewScreen(
           url: url,
           homeTitle: homeTitle,
+          siteId: siteId,
           incognito: incognito,
           thirdPartyCookiesEnabled: thirdPartyCookiesEnabled,
           clearUrlEnabled: clearUrlEnabled,

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -433,8 +433,8 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
             },
           ),
           SwitchListTile(
-            title: const Text('DNS Stats Bar'),
-            subtitle: const Text('Show live DNS request stats at the top of each site'),
+            title: const Text('Stats Bar'),
+            subtitle: const Text('Show live request stats at the top of each site'),
             value: _showDnsBanner,
             onChanged: (value) {
               setState(() {

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -8,6 +8,7 @@ import 'package:webspace/screens/dev_tools.dart';
 import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
+import 'package:webspace/services/dns_block_native.dart';
 import 'package:webspace/services/localcdn_service.dart';
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/settings/user_script.dart';
@@ -133,6 +134,8 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
 
       if (success) {
         await _loadBlocklistState();
+        await DnsBlockNative.sendDomains(DnsBlockService.instance.blockedDomains);
+        await DnsBlockNative.attachToWebViews();
         final domainCount = DnsBlockService.instance.domainCount;
         final message = level == 0
             ? 'DNS blocklist disabled'

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -433,8 +433,8 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
             },
           ),
           SwitchListTile(
-            title: const Text('DNS Block Banner'),
-            subtitle: const Text('Show live DNS blocking stats at the top of each site'),
+            title: const Text('DNS Stats Bar'),
+            subtitle: const Text('Show live DNS request stats at the top of each site'),
             value: _showDnsBanner,
             onChanged: (value) {
               setState(() {

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -33,6 +33,8 @@ class AppSettingsScreen extends StatefulWidget {
   final VoidCallback onImportSettings;
   final bool showTabStrip;
   final ValueChanged<bool> onShowTabStripChanged;
+  final bool showDnsBanner;
+  final ValueChanged<bool> onShowDnsBannerChanged;
   final List<UserScriptConfig> globalUserScripts;
   final void Function(List<UserScriptConfig>)? onGlobalUserScriptsChanged;
 
@@ -44,6 +46,8 @@ class AppSettingsScreen extends StatefulWidget {
     required this.onImportSettings,
     required this.showTabStrip,
     required this.onShowTabStripChanged,
+    required this.showDnsBanner,
+    required this.onShowDnsBannerChanged,
     this.globalUserScripts = const [],
     this.onGlobalUserScriptsChanged,
   });
@@ -56,6 +60,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
     with SingleTickerProviderStateMixin {
   late AppThemeSettings _settings;
   late bool _showTabStrip;
+  late bool _showDnsBanner;
   bool _isDownloadingRules = false;
   DateTime? _rulesLastUpdated;
 
@@ -82,6 +87,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
     super.initState();
     _settings = widget.currentSettings;
     _showTabStrip = widget.showTabStrip;
+    _showDnsBanner = widget.showDnsBanner;
     _spinController = AnimationController(
       vsync: this,
       duration: const Duration(seconds: 1),
@@ -421,6 +427,17 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
                 _showTabStrip = value;
               });
               widget.onShowTabStripChanged(value);
+            },
+          ),
+          SwitchListTile(
+            title: const Text('DNS Block Banner'),
+            subtitle: const Text('Show live DNS blocking stats at the top of each site'),
+            value: _showDnsBanner,
+            onChanged: (value) {
+              setState(() {
+                _showDnsBanner = value;
+              });
+              widget.onShowDnsBannerChanged(value);
             },
           ),
 

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -11,6 +11,7 @@ import 'package:share_plus/share_plus.dart';
 import 'package:webspace/web_view_model.dart';
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/services/log_service.dart';
+import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/settings/user_script.dart';
 
 typedef VoidAsyncCallback = Future<void> Function();
@@ -56,7 +57,12 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
 
   bool get _hasSite => widget.webViewModel != null;
 
-  int get _tabCount => _hasSite ? 3 : 1;
+  bool get _hasDnsBlocklist => DnsBlockService.instance.hasBlocklist;
+  int get _tabCount => _hasSite ? (_hasDnsBlocklist ? 4 : 3) : 1;
+
+  /// Filter for DNS log: null = all, true = blocked only, false = allowed only.
+  bool? _dnsFilter;
+  final ScrollController _dnsScrollController = ScrollController();
 
   @override
   void initState() {
@@ -65,6 +71,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
         ? Set<BlockedCookie>.of(widget.webViewModel!.blockedCookies)
         : <BlockedCookie>{};
     LogService.instance.addListener(_onLogUpdate);
+    DnsBlockService.instance.addDnsLogListener(_onDnsLogUpdate);
     if (_hasSite) {
       widget.webViewModel!.onConsoleLogChanged = _onConsoleUpdate;
     }
@@ -73,6 +80,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   @override
   void dispose() {
     LogService.instance.removeListener(_onLogUpdate);
+    DnsBlockService.instance.removeDnsLogListener(_onDnsLogUpdate);
     if (_hasSite) {
       widget.webViewModel!.onConsoleLogChanged = null;
       // If blocked cookies changed while DevTools was open, reload the page
@@ -84,6 +92,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
     }
     _consoleScrollController.dispose();
     _logScrollController.dispose();
+    _dnsScrollController.dispose();
     _searchController.dispose();
     _searchFocusNode.dispose();
     _evalController.dispose();
@@ -105,11 +114,17 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
     if (mounted) setState(() {});
   }
 
+  void _onDnsLogUpdate() {
+    if (mounted) setState(() {});
+  }
+
   List<Tab> get _tabs => [
         if (_hasSite)
           const Tab(icon: Icon(Icons.terminal, size: 18), text: 'Console'),
         if (_hasSite)
           const Tab(icon: Icon(Icons.cookie_outlined, size: 18), text: 'Cookies'),
+        if (_hasSite && _hasDnsBlocklist)
+          const Tab(icon: Icon(Icons.shield_outlined, size: 18), text: 'DNS'),
         const Tab(icon: Icon(Icons.list_alt, size: 18), text: 'Logs'),
       ];
 
@@ -199,6 +214,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
                 children: [
                   if (_hasSite) _buildConsoleTab(),
                   if (_hasSite) _buildCookiesTab(),
+                  if (_hasSite && _hasDnsBlocklist) _buildDnsTab(),
                   _buildAppLogsTab(),
                 ],
               ),
@@ -946,6 +962,176 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
         const SnackBar(content: Text('HTML copied to clipboard')),
       );
     }
+  }
+
+  // ── DNS Tab ──
+
+  Widget _buildDnsTab() {
+    final stats = DnsBlockService.instance.statsForSite(widget.webViewModel!.siteId);
+    final allEntries = stats.log;
+    List<DnsLogEntry> entries = _dnsFilter == null
+        ? allEntries
+        : allEntries.where((e) => e.blocked == _dnsFilter).toList();
+    if (_searchQuery.isNotEmpty) {
+      entries = entries.where((e) => _matchesSearch(e.domain)).toList();
+    }
+
+    return Column(
+      children: [
+        _buildDnsStats(stats),
+        _buildDnsFilters(stats),
+        _buildDnsActions(stats),
+        Expanded(
+          child: entries.isEmpty
+              ? Center(child: Text(_searchQuery.isEmpty ? 'No DNS queries recorded' : 'No matches'))
+              : ListView.builder(
+                  controller: _dnsScrollController,
+                  reverse: _searchQuery.isEmpty,
+                  itemCount: entries.length,
+                  itemBuilder: (context, index) {
+                    final entry = entries[entries.length - 1 - index];
+                    return _buildDnsEntry(entry);
+                  },
+                ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDnsStats(DnsStats stats) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+      child: Row(
+        children: [
+          _buildDnsStatCard('Total', stats.total.toString(), Colors.blue),
+          const SizedBox(width: 8),
+          _buildDnsStatCard('Allowed', stats.allowed.toString(), Colors.green),
+          const SizedBox(width: 8),
+          _buildDnsStatCard('Blocked', stats.blocked.toString(), Colors.red),
+          const SizedBox(width: 8),
+          _buildDnsStatCard('Block %', '${stats.blockRate.toStringAsFixed(1)}%',
+              stats.blockRate > 0 ? Colors.orange : Colors.grey),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDnsStatCard(String label, String value, Color color) {
+    return Expanded(
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+        decoration: BoxDecoration(
+          color: color.withAlpha(20),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: color.withAlpha(60)),
+        ),
+        child: Column(
+          children: [
+            Text(value,
+                style: TextStyle(
+                    fontSize: 16, fontWeight: FontWeight.bold, color: color)),
+            const SizedBox(height: 2),
+            Text(label,
+                style: TextStyle(fontSize: 10, color: color.withAlpha(180))),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDnsFilters(DnsStats stats) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      child: Row(
+        children: [
+          FilterChip(
+            label: const Text('All', style: TextStyle(fontSize: 12)),
+            selected: _dnsFilter == null,
+            onSelected: (_) => setState(() => _dnsFilter = null),
+            visualDensity: VisualDensity.compact,
+          ),
+          const SizedBox(width: 6),
+          FilterChip(
+            label: Text('Allowed (${stats.allowed})',
+                style: const TextStyle(fontSize: 12)),
+            selected: _dnsFilter == false,
+            onSelected: (_) =>
+                setState(() => _dnsFilter = _dnsFilter == false ? null : false),
+            visualDensity: VisualDensity.compact,
+          ),
+          const SizedBox(width: 6),
+          FilterChip(
+            label: Text('Blocked (${stats.blocked})',
+                style: const TextStyle(fontSize: 12)),
+            selected: _dnsFilter == true,
+            onSelected: (_) =>
+                setState(() => _dnsFilter = _dnsFilter == true ? null : true),
+            visualDensity: VisualDensity.compact,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDnsActions(DnsStats stats) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: Row(
+        children: [
+          TextButton.icon(
+            onPressed: () {
+              DnsBlockService.instance.clearStatsForSite(widget.webViewModel!.siteId);
+            },
+            icon: const Icon(Icons.delete_outline, size: 18),
+            label: const Text('Clear'),
+          ),
+          TextButton.icon(
+            onPressed: stats.log.isEmpty
+                ? null
+                : () {
+                    final text = stats.log
+                        .map((e) =>
+                            '[${_formatTimeMs(e.timestamp)}] ${e.blocked ? 'BLOCKED' : 'ALLOWED'} ${e.domain}')
+                        .join('\n');
+                    Clipboard.setData(ClipboardData(text: text));
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('DNS log copied')),
+                    );
+                  },
+            icon: const Icon(Icons.copy, size: 18),
+            label: const Text('Copy'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDnsEntry(DnsLogEntry entry) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 1),
+      child: Row(
+        children: [
+          Icon(
+            entry.blocked ? Icons.block : Icons.check_circle_outline,
+            size: 14,
+            color: entry.blocked ? Colors.red : Colors.green,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: SelectableText(
+              '[${_formatTimeMs(entry.timestamp)}] ${entry.domain}',
+              style: TextStyle(
+                fontFamily: 'monospace',
+                fontSize: 11,
+                color: entry.blocked
+                    ? Colors.red
+                    : Theme.of(context).textTheme.bodyMedium?.color,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 
   // ── App Logs Tab ──

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -13,6 +13,7 @@ import 'package:webspace/widgets/url_bar.dart';
 class InAppWebViewScreen extends StatefulWidget {
   final String url;
   final String? homeTitle;
+  final String? siteId;
   final bool incognito;
   final bool thirdPartyCookiesEnabled;
   final bool clearUrlEnabled;
@@ -24,6 +25,7 @@ class InAppWebViewScreen extends StatefulWidget {
   InAppWebViewScreen({
     required this.url,
     this.homeTitle,
+    this.siteId,
     required this.incognito,
     required this.thirdPartyCookiesEnabled,
     required this.clearUrlEnabled,
@@ -255,6 +257,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen> {
           Expanded(
             child: WebViewFactory.createWebView(
               config: WebViewConfig(
+                siteId: widget.siteId,
                 initialUrl: widget.url,
                 incognito: widget.incognito,
                 thirdPartyCookiesEnabled: widget.thirdPartyCookiesEnabled,

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -198,6 +198,46 @@ class _SettingsScreenState extends State<SettingsScreen> {
     return parts.isEmpty ? 'None' : '${parts.join(', ')} active';
   }
 
+  Widget _buildDnsStatsCard() {
+    final stats = DnsBlockService.instance.statsForSite(widget.webViewModel.siteId);
+    if (stats.total == 0) {
+      return const SizedBox.shrink();
+    }
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: Row(
+        children: [
+          _buildDnsStatChip('${stats.total}', 'total', Colors.blue),
+          const SizedBox(width: 6),
+          _buildDnsStatChip('${stats.allowed}', 'allowed', Colors.green),
+          const SizedBox(width: 6),
+          _buildDnsStatChip('${stats.blocked}', 'blocked', Colors.red),
+          const SizedBox(width: 6),
+          _buildDnsStatChip('${stats.blockRate.toStringAsFixed(1)}%', 'blocked', Colors.orange),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDnsStatChip(String value, String label, Color color) {
+    return Expanded(
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+        decoration: BoxDecoration(
+          color: color.withAlpha(20),
+          borderRadius: BorderRadius.circular(6),
+          border: Border.all(color: color.withAlpha(50)),
+        ),
+        child: Column(
+          children: [
+            Text(value, style: TextStyle(fontSize: 13, fontWeight: FontWeight.bold, color: color)),
+            Text(label, style: TextStyle(fontSize: 9, color: color.withAlpha(180))),
+          ],
+        ),
+      ),
+    );
+  }
+
   Future<void> _saveSettings() async {
     // Only validate and update proxy settings on supported platforms
     if (PlatformInfo.isProxySupported) {
@@ -512,6 +552,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   }
                 : null,
           ),
+          if (DnsBlockService.instance.hasBlocklist) _buildDnsStatsCard(),
           SwitchListTile(
             title: Row(
               children: [

--- a/lib/services/bloom_filter.dart
+++ b/lib/services/bloom_filter.dart
@@ -1,0 +1,76 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+/// Simple Bloom filter for fast probabilistic set membership checks.
+/// False positives possible (configurable rate), false negatives impossible.
+///
+/// Uses FNV-1a hash with multiple seeds via the Kirsch-Mitzenmacher technique.
+/// JS-compatible: see [toMap] for the binary format that mirrors the JS reader.
+class BloomFilter {
+  final Uint8List bits;
+  final int bitCount;
+  final int k;
+
+  BloomFilter._(this.bits, this.bitCount, this.k);
+
+  /// Build a Bloom filter sized for items with target false positive [fpRate].
+  /// Default 0.001 (0.1%) gives ~1MB for 588K items, ~10 hash functions.
+  factory BloomFilter.build(Iterable<String> items, {double fpRate = 0.001}) {
+    final n = items.length;
+    if (n == 0) {
+      return BloomFilter._(Uint8List(8), 64, 1);
+    }
+    // Optimal: m = -n * ln(p) / (ln 2)^2, k = (m/n) * ln 2
+    final ln2 = math.ln2;
+    final m = (-n * math.log(fpRate) / (ln2 * ln2)).ceil();
+    final byteCount = (m / 8).ceil();
+    final bitCount = byteCount * 8;
+    final k = ((m / n) * ln2).round().clamp(1, 16);
+    final bits = Uint8List(byteCount);
+
+    for (final item in items) {
+      _setBits(bits, bitCount, k, item);
+    }
+    return BloomFilter._(bits, bitCount, k);
+  }
+
+  static int _hash(String s, int seed) {
+    int h = seed & 0xFFFFFFFF;
+    for (int i = 0; i < s.length; i++) {
+      h ^= s.codeUnitAt(i);
+      h = (h * 16777619) & 0xFFFFFFFF;
+    }
+    return h;
+  }
+
+  static void _setBits(Uint8List bits, int bitCount, int k, String item) {
+    final h1 = _hash(item, 0x811C9DC5);
+    final h2 = _hash(item, 0xCBF29CE4);
+    for (int i = 0; i < k; i++) {
+      final h = (h1 + i * h2) & 0xFFFFFFFF;
+      final pos = h % bitCount;
+      bits[pos >> 3] |= 1 << (pos & 7);
+    }
+  }
+
+  bool contains(String item) {
+    final h1 = _hash(item, 0x811C9DC5);
+    final h2 = _hash(item, 0xCBF29CE4);
+    for (int i = 0; i < k; i++) {
+      final h = (h1 + i * h2) & 0xFFFFFFFF;
+      final pos = h % bitCount;
+      if ((bits[pos >> 3] & (1 << (pos & 7))) == 0) return false;
+    }
+    return true;
+  }
+
+  /// Serialize to a Map suitable for JS consumption.
+  /// JS reads `bits` (List<int> bytes), `bitCount` (int), `k` (int).
+  Map<String, dynamic> toMap() => {
+        'bits': bits,
+        'bitCount': bitCount,
+        'k': k,
+      };
+
+  int get sizeInBytes => bits.length;
+}

--- a/lib/services/bloom_filter.dart
+++ b/lib/services/bloom_filter.dart
@@ -14,8 +14,10 @@ class BloomFilter {
   BloomFilter._(this.bits, this.bitCount, this.k);
 
   /// Build a Bloom filter sized for items with target false positive [fpRate].
-  /// Default 0.001 (0.1%) gives ~1MB for 588K items, ~10 hash functions.
-  factory BloomFilter.build(Iterable<String> items, {double fpRate = 0.001}) {
+  /// Default 0.05 (5%) gives ~430KB for 588K items, ~4 hash functions.
+  /// Higher FPR is acceptable when paired with per-site domain caching
+  /// (each domain is checked via Dart at most once, then cached in JS).
+  factory BloomFilter.build(Iterable<String> items, {double fpRate = 0.05}) {
     final n = items.length;
     if (n == 0) {
       return BloomFilter._(Uint8List(8), 64, 1);

--- a/lib/services/dns_block_native.dart
+++ b/lib/services/dns_block_native.dart
@@ -12,17 +12,22 @@ class DnsBlockNative {
   static void initialize() {
     if (!isSupported) return;
     _channel.setMethodCallHandler((call) async {
-      if (call.method == 'dnsBlockedReady') {
-        // Java signals that new blocked events are available for this site.
-        // We pull the list (Java clears it atomically).
+      if (call.method == 'dnsEventsReady') {
+        // Java signals that new DNS events are available for this site.
+        // We pull the list (Java clears it atomically). Each event is
+        // {host: String, blocked: bool} for both allowed and blocked.
         final siteId = call.arguments as String?;
         if (siteId == null) return;
         try {
-          final list = await _channel.invokeMethod('fetchBlocked', {'siteId': siteId});
+          final list = await _channel.invokeMethod('fetchEvents', {'siteId': siteId});
           if (list is List) {
-            for (final host in list) {
-              if (host is String) {
-                DnsBlockService.instance.recordRequest(siteId, 'https://$host/', true);
+            for (final entry in list) {
+              if (entry is Map) {
+                final host = entry['host'] as String?;
+                final blocked = entry['blocked'] as bool?;
+                if (host != null && blocked != null) {
+                  DnsBlockService.instance.recordRequest(siteId, 'https://$host/', blocked);
+                }
               }
             }
           }

--- a/lib/services/dns_block_native.dart
+++ b/lib/services/dns_block_native.dart
@@ -13,10 +13,11 @@ class DnsBlockNative {
     if (!isSupported) return;
     _channel.setMethodCallHandler((call) async {
       if (call.method == 'onDnsBlocked') {
-        final args = call.arguments as Map;
+        final args = Map<String, dynamic>.from(call.arguments as Map);
         final siteId = args['siteId'] as String?;
         final host = args['host'] as String?;
         if (siteId != null && host != null) {
+          LogService.instance.log('DnsBlock', '[NativeBlocked] $host (site: $siteId)');
           DnsBlockService.instance.recordRequest(siteId, 'https://$host/', true);
         }
       }

--- a/lib/services/dns_block_native.dart
+++ b/lib/services/dns_block_native.dart
@@ -9,15 +9,16 @@ class DnsBlockNative {
 
   static bool get isSupported => Platform.isAndroid;
 
-  /// Current site ID for attributing blocked requests. Set by the app when switching sites.
-  static String? activeSiteId;
-
   static void initialize() {
     if (!isSupported) return;
     _channel.setMethodCallHandler((call) async {
-      if (call.method == 'onDnsBlocked' && activeSiteId != null) {
-        final host = call.arguments as String;
-        DnsBlockService.instance.recordRequest(activeSiteId!, 'https://$host/', true);
+      if (call.method == 'onDnsBlocked') {
+        final args = call.arguments as Map;
+        final siteId = args['siteId'] as String?;
+        final host = args['host'] as String?;
+        if (siteId != null && host != null) {
+          DnsBlockService.instance.recordRequest(siteId, 'https://$host/', true);
+        }
       }
     });
   }
@@ -34,11 +35,13 @@ class DnsBlockNative {
     }
   }
 
-  static Future<int> attachToWebViews() async {
+  static Future<int> attachToWebViews({String? siteId}) async {
     if (!isSupported) return 0;
     try {
-      final count = await _channel.invokeMethod('attachToWebViews');
-      LogService.instance.log('DnsBlock', 'Attached native DNS handler to $count webviews');
+      final count = await _channel.invokeMethod('attachToWebViews', {
+        if (siteId != null) 'siteId': siteId,
+      });
+      LogService.instance.log('DnsBlock', 'Attached native DNS handler to $count webviews (siteId: $siteId)');
       return count as int;
     } catch (e) {
       LogService.instance.log('DnsBlock', 'Failed to attach native handler: $e', level: LogLevel.error);

--- a/lib/services/dns_block_native.dart
+++ b/lib/services/dns_block_native.dart
@@ -12,13 +12,15 @@ class DnsBlockNative {
   static void initialize() {
     if (!isSupported) return;
     _channel.setMethodCallHandler((call) async {
-      if (call.method == 'onDnsBlocked') {
-        final args = Map<String, dynamic>.from(call.arguments as Map);
-        final siteId = args['siteId'] as String?;
-        final host = args['host'] as String?;
-        if (siteId != null && host != null) {
-          LogService.instance.log('DnsBlock', '[NativeBlocked] $host (site: $siteId)');
-          DnsBlockService.instance.recordRequest(siteId, 'https://$host/', true);
+      if (call.method == 'onDnsBlockedBatch') {
+        final batch = (call.arguments as List).cast<Map>();
+        for (final entry in batch) {
+          final args = Map<String, dynamic>.from(entry);
+          final siteId = args['siteId'] as String?;
+          final host = args['host'] as String?;
+          if (siteId != null && host != null) {
+            DnsBlockService.instance.recordRequest(siteId, 'https://$host/', true);
+          }
         }
       }
     });

--- a/lib/services/dns_block_native.dart
+++ b/lib/services/dns_block_native.dart
@@ -12,16 +12,21 @@ class DnsBlockNative {
   static void initialize() {
     if (!isSupported) return;
     _channel.setMethodCallHandler((call) async {
-      if (call.method == 'onDnsBlockedBatch') {
-        final batch = (call.arguments as List).cast<Map>();
-        for (final entry in batch) {
-          final args = Map<String, dynamic>.from(entry);
-          final siteId = args['siteId'] as String?;
-          final host = args['host'] as String?;
-          if (siteId != null && host != null) {
-            DnsBlockService.instance.recordRequest(siteId, 'https://$host/', true);
+      if (call.method == 'dnsBlockedReady') {
+        // Java signals that new blocked events are available for this site.
+        // We pull the list (Java clears it atomically).
+        final siteId = call.arguments as String?;
+        if (siteId == null) return;
+        try {
+          final list = await _channel.invokeMethod('fetchBlocked', {'siteId': siteId});
+          if (list is List) {
+            for (final host in list) {
+              if (host is String) {
+                DnsBlockService.instance.recordRequest(siteId, 'https://$host/', true);
+              }
+            }
           }
-        }
+        } catch (_) {}
       }
     });
   }

--- a/lib/services/dns_block_native.dart
+++ b/lib/services/dns_block_native.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:webspace/services/dns_block_service.dart';
+import 'package:webspace/services/log_service.dart';
+
+class DnsBlockNative {
+  static const _channel = MethodChannel('org.codeberg.theoden8.webspace/dns_block');
+
+  static bool get isSupported => Platform.isAndroid;
+
+  /// Current site ID for attributing blocked requests. Set by the app when switching sites.
+  static String? activeSiteId;
+
+  static void initialize() {
+    if (!isSupported) return;
+    _channel.setMethodCallHandler((call) async {
+      if (call.method == 'onDnsBlocked' && activeSiteId != null) {
+        final host = call.arguments as String;
+        DnsBlockService.instance.recordRequest(activeSiteId!, 'https://$host/', true);
+      }
+    });
+  }
+
+  static Future<void> sendDomains(Set<String> domains) async {
+    if (!isSupported) return;
+    try {
+      final count = await _channel.invokeMethod('setBlockedDomains', {
+        'domains': domains.toList(),
+      });
+      LogService.instance.log('DnsBlock', 'Sent $count domains to native handler', level: LogLevel.info);
+    } catch (e) {
+      LogService.instance.log('DnsBlock', 'Failed to send domains to native: $e', level: LogLevel.error);
+    }
+  }
+
+  static Future<int> attachToWebViews() async {
+    if (!isSupported) return 0;
+    try {
+      final count = await _channel.invokeMethod('attachToWebViews');
+      LogService.instance.log('DnsBlock', 'Attached native DNS handler to $count webviews');
+      return count as int;
+    } catch (e) {
+      LogService.instance.log('DnsBlock', 'Failed to attach native handler: $e', level: LogLevel.error);
+      return 0;
+    }
+  }
+}

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -6,6 +6,52 @@ import 'package:webspace/services/log_service.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+/// A single DNS query log entry (allowed or blocked).
+class DnsLogEntry {
+  final DateTime timestamp;
+  final String domain;
+  final bool blocked;
+
+  const DnsLogEntry({
+    required this.timestamp,
+    required this.domain,
+    required this.blocked,
+  });
+}
+
+/// Per-site DNS request statistics.
+class DnsStats {
+  int allowed = 0;
+  int blocked = 0;
+  final List<DnsLogEntry> log = [];
+  static const int _maxLogEntries = 500;
+
+  int get total => allowed + blocked;
+  double get blockRate => total > 0 ? blocked / total * 100 : 0;
+
+  void record(String domain, bool wasBlocked) {
+    if (wasBlocked) {
+      blocked++;
+    } else {
+      allowed++;
+    }
+    log.add(DnsLogEntry(
+      timestamp: DateTime.now(),
+      domain: domain,
+      blocked: wasBlocked,
+    ));
+    if (log.length > _maxLogEntries) {
+      log.removeAt(0);
+    }
+  }
+
+  void clear() {
+    allowed = 0;
+    blocked = 0;
+    log.clear();
+  }
+}
+
 /// Level names for DNS blocklist severity levels (0-5).
 const List<String> dnsBlockLevelNames = [
   'Off',
@@ -48,6 +94,12 @@ class DnsBlockService {
   Set<String> _blockedDomains = {};
   int _level = 0;
 
+  /// Per-site DNS statistics, keyed by siteId.
+  final Map<String, DnsStats> _siteStats = {};
+
+  /// Listeners notified when a DNS request is logged (for live UI updates).
+  final List<VoidCallback> _dnsLogListeners = [];
+
   /// Whether a blocklist is loaded and active.
   bool get hasBlocklist => _blockedDomains.isNotEmpty;
 
@@ -56,6 +108,41 @@ class DnsBlockService {
 
   /// Number of domains in the current blocklist.
   int get domainCount => _blockedDomains.length;
+
+  /// Get DNS stats for a specific site. Creates on first access.
+  DnsStats statsForSite(String siteId) {
+    return _siteStats.putIfAbsent(siteId, () => DnsStats());
+  }
+
+  /// Record a DNS request (allowed or blocked) for a site.
+  void recordRequest(String siteId, String url, bool wasBlocked) {
+    final uri = Uri.tryParse(url);
+    if (uri == null || uri.host.isEmpty) return;
+    statsForSite(siteId).record(uri.host, wasBlocked);
+    _notifyDnsLogListeners();
+  }
+
+  /// Clear stats for a specific site.
+  void clearStatsForSite(String siteId) {
+    _siteStats[siteId]?.clear();
+    _notifyDnsLogListeners();
+  }
+
+  /// Add a listener for DNS log changes (live UI updates).
+  void addDnsLogListener(VoidCallback listener) {
+    _dnsLogListeners.add(listener);
+  }
+
+  /// Remove a DNS log listener.
+  void removeDnsLogListener(VoidCallback listener) {
+    _dnsLogListeners.remove(listener);
+  }
+
+  void _notifyDnsLogListeners() {
+    for (final listener in _dnsLogListeners) {
+      listener();
+    }
+  }
 
   /// Initialize the service by loading the cached domain file from disk (no network).
   /// Call in main() at app startup.

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -114,31 +114,30 @@ class DnsBlockService {
   List<inapp.ContentBlocker>? _contentBlockerRules;
 
   /// Generate ContentBlocker rules from the blocked domains.
-  /// Each rule uses a urlFilter regex matching one domain and its subdomains.
-  /// Runs in Java natively — no Dart roundtrip per request.
+  /// Uses a single rule with all domains in ifDomain — matched by the
+  /// native engine against request URL hosts with simple string comparison.
   List<inapp.ContentBlocker> getContentBlockerRules() {
     if (_contentBlockerRules != null) return _contentBlockerRules!;
     if (_blockedDomains.isEmpty) return const [];
 
     final sw = Stopwatch()..start();
-    final rules = <inapp.ContentBlocker>[];
-
-    for (final domain in _blockedDomains) {
-      final escaped = domain.replaceAll('.', '\\\\.');
-      rules.add(inapp.ContentBlocker(
+    final domains = _blockedDomains.map((d) => '*$d').toList();
+    final rules = [
+      inapp.ContentBlocker(
         trigger: inapp.ContentBlockerTrigger(
-          urlFilter: '.*$escaped',
+          urlFilter: '.*',
+          ifDomain: domains,
           loadType: [inapp.ContentBlockerTriggerLoadType.THIRD_PARTY],
         ),
         action: inapp.ContentBlockerAction(
           type: inapp.ContentBlockerActionType.BLOCK,
         ),
-      ));
-    }
+      ),
+    ];
 
     sw.stop();
     LogService.instance.log('DnsBlock',
-        'Generated ${rules.length} content blocker rules in ${sw.elapsedMilliseconds}ms',
+        'Generated content blocker rule with ${domains.length} domains in ${sw.elapsedMilliseconds}ms',
         level: LogLevel.info);
     _contentBlockerRules = rules;
     return rules;

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -117,70 +118,70 @@ class DnsBlockService {
   /// Cached Bloom filter for fast JS-side membership checks.
   BloomFilter? _bloomFilter;
 
-  /// Per-site resolver cache: siteId -> {host: blocked_bool}.
-  /// Loaded from disk on init, saved on updates.
-  final Map<String, Map<String, bool>> _perSiteCache = {};
+  /// Global per-domain resolver cache: host -> blocked_bool.
+  /// Shared across all sites since the same tracker/CDN domains appear
+  /// everywhere. Loaded from disk on init, invalidated on blocklist update.
+  final Map<String, bool> _domainCache = {};
 
-  static const _perSiteCacheKey = 'dns_per_site_cache';
-  static const _maxCacheEntriesPerSite = 500;
+  static const _domainCacheKey = 'dns_domain_cache';
+  static const _maxDomainCacheEntries = 5000;
 
-  /// Get the persisted JS cache for a site (empty map if none).
-  Map<String, bool> getCacheForSite(String siteId) {
-    return _perSiteCache[siteId] ?? const {};
-  }
+  /// Get the current domain cache (for hydrating new webviews).
+  Map<String, bool> getDomainCache() => _domainCache;
 
-  /// Replace the cache for a site with an updated version from JS.
-  /// Called on onLoadStop to persist what the webview has learned.
-  Future<void> setCacheForSite(String siteId, Map<String, bool> cache) async {
-    // Trim to limit
-    if (cache.length > _maxCacheEntriesPerSite) {
-      final trimmed = <String, bool>{};
-      int i = 0;
-      for (final e in cache.entries) {
-        if (i++ >= _maxCacheEntriesPerSite) break;
-        trimmed[e.key] = e.value;
-      }
-      cache = trimmed;
+  /// Record a confirmed decision for a host. Persists asynchronously.
+  void recordDomainDecision(String host, bool blocked) {
+    if (host.isEmpty) return;
+    final prev = _domainCache[host];
+    if (prev == blocked) return; // no change, no write
+    _domainCache[host] = blocked;
+    if (_domainCache.length > _maxDomainCacheEntries) {
+      // FIFO trim by deleting the first inserted key
+      final first = _domainCache.keys.first;
+      _domainCache.remove(first);
     }
-    _perSiteCache[siteId] = cache;
-    await _persistPerSiteCache();
+    _schedulePersistDomainCache();
   }
 
-  Future<void> _persistPerSiteCache() async {
+  Timer? _persistTimer;
+
+  void _schedulePersistDomainCache() {
+    _persistTimer?.cancel();
+    _persistTimer = Timer(const Duration(seconds: 2), _persistDomainCache);
+  }
+
+  Future<void> _persistDomainCache() async {
     try {
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setString(_perSiteCacheKey, jsonEncode(_perSiteCache));
+      await prefs.setString(_domainCacheKey, jsonEncode(_domainCache));
     } catch (e) {
-      LogService.instance.log('DnsBlock', 'Failed to persist per-site cache: $e', level: LogLevel.error);
+      LogService.instance.log('DnsBlock', 'Failed to persist domain cache: $e', level: LogLevel.error);
     }
   }
 
-  Future<void> _loadPerSiteCache() async {
+  Future<void> _loadDomainCache() async {
     try {
       final prefs = await SharedPreferences.getInstance();
-      final raw = prefs.getString(_perSiteCacheKey);
+      final raw = prefs.getString(_domainCacheKey);
       if (raw == null) return;
       final data = jsonDecode(raw) as Map<String, dynamic>;
-      for (final entry in data.entries) {
-        final siteCache = <String, bool>{};
-        final inner = entry.value as Map<String, dynamic>;
-        for (final e in inner.entries) {
-          siteCache[e.key] = e.value as bool;
-        }
-        _perSiteCache[entry.key] = siteCache;
+      _domainCache.clear();
+      for (final e in data.entries) {
+        _domainCache[e.key] = e.value as bool;
       }
     } catch (e) {
-      LogService.instance.log('DnsBlock', 'Failed to load per-site cache: $e', level: LogLevel.error);
+      LogService.instance.log('DnsBlock', 'Failed to load domain cache: $e', level: LogLevel.error);
     }
   }
 
-  /// Clear all per-site caches. Called when the blocklist changes since
-  /// old cached decisions may no longer be valid.
-  Future<void> _clearPerSiteCache() async {
-    _perSiteCache.clear();
+  /// Clear the global domain cache. Called when the blocklist changes
+  /// since cached decisions may no longer be valid.
+  Future<void> _clearDomainCache() async {
+    _domainCache.clear();
+    _persistTimer?.cancel();
     try {
       final prefs = await SharedPreferences.getInstance();
-      await prefs.remove(_perSiteCacheKey);
+      await prefs.remove(_domainCacheKey);
     } catch (_) {}
   }
 
@@ -203,10 +204,13 @@ class DnsBlockService {
   }
 
   /// Record a DNS request (allowed or blocked) for a site.
+  /// Also updates the global per-domain cache so other webviews skip
+  /// re-checking the same host.
   void recordRequest(String siteId, String url, bool wasBlocked) {
     final uri = Uri.tryParse(url);
     if (uri == null || uri.host.isEmpty) return;
     statsForSite(siteId).record(uri.host, wasBlocked);
+    recordDomainDecision(uri.host, wasBlocked);
     _notifyDnsLogListeners();
   }
 
@@ -247,7 +251,7 @@ class DnsBlockService {
           LogService.instance.log('DnsBlock', 'Loaded ${_blockedDomains.length} domains from cache (level $_level)', level: LogLevel.info);
         }
       }
-      await _loadPerSiteCache();
+      await _loadDomainCache();
     } catch (e) {
       LogService.instance.log('DnsBlock', 'Error loading cached blocklist: $e', level: LogLevel.error);
     }
@@ -273,7 +277,7 @@ class DnsBlockService {
       } catch (e) {
         LogService.instance.log('DnsBlock', 'Error clearing blocklist: $e', level: LogLevel.error);
       }
-      await _clearPerSiteCache();
+      await _clearDomainCache();
       return true;
     }
 
@@ -308,7 +312,7 @@ class DnsBlockService {
         await prefs.setString(_lastUpdatedKey, DateTime.now().toIso8601String());
 
         // Blocklist changed - invalidate per-site caches
-        await _clearPerSiteCache();
+        await _clearDomainCache();
 
         LogService.instance.log('DnsBlock', 'Downloaded ${_blockedDomains.length} domains (level $level)', level: LogLevel.info);
 

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -116,6 +117,73 @@ class DnsBlockService {
   /// Cached Bloom filter for fast JS-side membership checks.
   BloomFilter? _bloomFilter;
 
+  /// Per-site resolver cache: siteId -> {host: blocked_bool}.
+  /// Loaded from disk on init, saved on updates.
+  final Map<String, Map<String, bool>> _perSiteCache = {};
+
+  static const _perSiteCacheKey = 'dns_per_site_cache';
+  static const _maxCacheEntriesPerSite = 500;
+
+  /// Get the persisted JS cache for a site (empty map if none).
+  Map<String, bool> getCacheForSite(String siteId) {
+    return _perSiteCache[siteId] ?? const {};
+  }
+
+  /// Replace the cache for a site with an updated version from JS.
+  /// Called on onLoadStop to persist what the webview has learned.
+  Future<void> setCacheForSite(String siteId, Map<String, bool> cache) async {
+    // Trim to limit
+    if (cache.length > _maxCacheEntriesPerSite) {
+      final trimmed = <String, bool>{};
+      int i = 0;
+      for (final e in cache.entries) {
+        if (i++ >= _maxCacheEntriesPerSite) break;
+        trimmed[e.key] = e.value;
+      }
+      cache = trimmed;
+    }
+    _perSiteCache[siteId] = cache;
+    await _persistPerSiteCache();
+  }
+
+  Future<void> _persistPerSiteCache() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_perSiteCacheKey, jsonEncode(_perSiteCache));
+    } catch (e) {
+      LogService.instance.log('DnsBlock', 'Failed to persist per-site cache: $e', level: LogLevel.error);
+    }
+  }
+
+  Future<void> _loadPerSiteCache() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(_perSiteCacheKey);
+      if (raw == null) return;
+      final data = jsonDecode(raw) as Map<String, dynamic>;
+      for (final entry in data.entries) {
+        final siteCache = <String, bool>{};
+        final inner = entry.value as Map<String, dynamic>;
+        for (final e in inner.entries) {
+          siteCache[e.key] = e.value as bool;
+        }
+        _perSiteCache[entry.key] = siteCache;
+      }
+    } catch (e) {
+      LogService.instance.log('DnsBlock', 'Failed to load per-site cache: $e', level: LogLevel.error);
+    }
+  }
+
+  /// Clear all per-site caches. Called when the blocklist changes since
+  /// old cached decisions may no longer be valid.
+  Future<void> _clearPerSiteCache() async {
+    _perSiteCache.clear();
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(_perSiteCacheKey);
+    } catch (_) {}
+  }
+
   /// Get (and cache) a Bloom filter built from all blocked domains plus
   /// their hierarchical suffixes. Used for iOS JS-side prefiltering.
   BloomFilter getBloomFilter() {
@@ -179,6 +247,7 @@ class DnsBlockService {
           LogService.instance.log('DnsBlock', 'Loaded ${_blockedDomains.length} domains from cache (level $_level)', level: LogLevel.info);
         }
       }
+      await _loadPerSiteCache();
     } catch (e) {
       LogService.instance.log('DnsBlock', 'Error loading cached blocklist: $e', level: LogLevel.error);
     }
@@ -204,6 +273,7 @@ class DnsBlockService {
       } catch (e) {
         LogService.instance.log('DnsBlock', 'Error clearing blocklist: $e', level: LogLevel.error);
       }
+      await _clearPerSiteCache();
       return true;
     }
 
@@ -236,6 +306,9 @@ class DnsBlockService {
         final prefs = await SharedPreferences.getInstance();
         await prefs.setInt(_levelKey, level);
         await prefs.setString(_lastUpdatedKey, DateTime.now().toIso8601String());
+
+        // Blocklist changed - invalidate per-site caches
+        await _clearPerSiteCache();
 
         LogService.instance.log('DnsBlock', 'Downloaded ${_blockedDomains.length} domains (level $level)', level: LogLevel.info);
 

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -109,6 +109,9 @@ class DnsBlockService {
   /// Number of domains in the current blocklist.
   int get domainCount => _blockedDomains.length;
 
+  /// The raw blocked domains set (for sending to native handler).
+  Set<String> get blockedDomains => _blockedDomains;
+
   /// Get DNS stats for a specific site. Creates on first access.
   DnsStats statsForSite(String siteId) {
     return _siteStats.putIfAbsent(siteId, () => DnsStats());

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -116,25 +116,38 @@ class DnsBlockService {
   /// Cached iOS content blocker rules.
   List<inapp.ContentBlocker>? _iosContentBlockerRules;
 
+  /// WKContentRuleList has a hard limit of 150K rules and compilation slows
+  /// dramatically past ~10K rules. Total regex length affects compile time.
+  /// We cap at maxDomains and batch to produce <= maxRules.
+  static const int _iosMaxDomains = 50000;
+  static const int _iosMaxRules = 1000;
+
   /// Generate ContentBlocker rules for iOS WKContentRuleList.
-  /// Batches domains into regex alternations (~100 per rule) to keep
-  /// rule count manageable while covering all blocked domains.
+  /// WKContentRuleList has strict regex syntax (no grouping parens, limited features).
+  /// Each rule uses a simple alternation of escaped domain names.
   List<inapp.ContentBlocker> getIosContentBlockerRules() {
     if (_iosContentBlockerRules != null) return _iosContentBlockerRules!;
     if (_blockedDomains.isEmpty) return const [];
 
     final sw = Stopwatch()..start();
     final rules = <inapp.ContentBlocker>[];
-    final domainList = _blockedDomains.toList();
-    const batchSize = 100;
+    var domainList = _blockedDomains.toList();
+    if (domainList.length > _iosMaxDomains) {
+      LogService.instance.log('DnsBlock',
+          'iOS: capping blocklist from ${domainList.length} to $_iosMaxDomains domains (WKContentRuleList limit)',
+          level: LogLevel.warning);
+      domainList = domainList.sublist(0, _iosMaxDomains);
+    }
+    final batchSize = (domainList.length / _iosMaxRules).ceil().clamp(1, 1000);
 
     for (int i = 0; i < domainList.length; i += batchSize) {
       final end = (i + batchSize < domainList.length) ? i + batchSize : domainList.length;
       final batch = domainList.sublist(i, end);
+      // Simple alternation without grouping parens; WKContentRuleList supports |
       final pattern = batch.map((d) => d.replaceAll('.', '\\.')).join('|');
       rules.add(inapp.ContentBlocker(
         trigger: inapp.ContentBlockerTrigger(
-          urlFilter: '($pattern)',
+          urlFilter: pattern,
           loadType: [inapp.ContentBlockerTriggerLoadType.THIRD_PARTY],
         ),
         action: inapp.ContentBlockerAction(
@@ -145,7 +158,7 @@ class DnsBlockService {
 
     sw.stop();
     LogService.instance.log('DnsBlock',
-        'Generated ${rules.length} iOS content blocker rules from ${_blockedDomains.length} domains in ${sw.elapsedMilliseconds}ms',
+        'Generated ${rules.length} iOS content blocker rules (batch=$batchSize) from ${domainList.length} domains in ${sw.elapsedMilliseconds}ms',
         level: LogLevel.info);
     _iosContentBlockerRules = rules;
     return rules;

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
 import 'package:http/http.dart' as http;
 import 'package:webspace/services/log_service.dart';
 import 'package:path_provider/path_provider.dart';
@@ -112,57 +111,6 @@ class DnsBlockService {
 
   /// The raw blocked domains set (for sending to native handler).
   Set<String> get blockedDomains => _blockedDomains;
-
-  /// Cached iOS content blocker rules.
-  List<inapp.ContentBlocker>? _iosContentBlockerRules;
-
-  /// WKContentRuleList has a hard limit of 150K rules and compilation slows
-  /// dramatically past ~10K rules. Total regex length affects compile time.
-  /// We cap at maxDomains and batch to produce <= maxRules.
-  static const int _iosMaxDomains = 50000;
-  static const int _iosMaxRules = 1000;
-
-  /// Generate ContentBlocker rules for iOS WKContentRuleList.
-  /// WKContentRuleList has strict regex syntax (no grouping parens, limited features).
-  /// Each rule uses a simple alternation of escaped domain names.
-  List<inapp.ContentBlocker> getIosContentBlockerRules() {
-    if (_iosContentBlockerRules != null) return _iosContentBlockerRules!;
-    if (_blockedDomains.isEmpty) return const [];
-
-    final sw = Stopwatch()..start();
-    final rules = <inapp.ContentBlocker>[];
-    var domainList = _blockedDomains.toList();
-    if (domainList.length > _iosMaxDomains) {
-      LogService.instance.log('DnsBlock',
-          'iOS: capping blocklist from ${domainList.length} to $_iosMaxDomains domains (WKContentRuleList limit)',
-          level: LogLevel.warning);
-      domainList = domainList.sublist(0, _iosMaxDomains);
-    }
-    final batchSize = (domainList.length / _iosMaxRules).ceil().clamp(1, 1000);
-
-    for (int i = 0; i < domainList.length; i += batchSize) {
-      final end = (i + batchSize < domainList.length) ? i + batchSize : domainList.length;
-      final batch = domainList.sublist(i, end);
-      // Simple alternation without grouping parens; WKContentRuleList supports |
-      final pattern = batch.map((d) => d.replaceAll('.', '\\.')).join('|');
-      rules.add(inapp.ContentBlocker(
-        trigger: inapp.ContentBlockerTrigger(
-          urlFilter: pattern,
-          loadType: [inapp.ContentBlockerTriggerLoadType.THIRD_PARTY],
-        ),
-        action: inapp.ContentBlockerAction(
-          type: inapp.ContentBlockerActionType.BLOCK,
-        ),
-      ));
-    }
-
-    sw.stop();
-    LogService.instance.log('DnsBlock',
-        'Generated ${rules.length} iOS content blocker rules (batch=$batchSize) from ${domainList.length} domains in ${sw.elapsedMilliseconds}ms',
-        level: LogLevel.info);
-    _iosContentBlockerRules = rules;
-    return rules;
-  }
 
   /// Get DNS stats for a specific site. Creates on first access.
   DnsStats statsForSite(String siteId) {
@@ -330,7 +278,6 @@ class DnsBlockService {
       domains.add(trimmed);
     }
     _blockedDomains = domains;
-    _iosContentBlockerRules = null;
   }
 
   Future<File> _getCacheFile() async {

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
 import 'package:http/http.dart' as http;
 import 'package:webspace/services/log_service.dart';
 import 'package:path_provider/path_provider.dart';
@@ -108,6 +109,40 @@ class DnsBlockService {
 
   /// Number of domains in the current blocklist.
   int get domainCount => _blockedDomains.length;
+
+  /// Cached content blocker rules for native webview engine blocking.
+  List<inapp.ContentBlocker>? _contentBlockerRules;
+
+  /// Generate ContentBlocker rules from the blocked domains.
+  /// Each rule uses a urlFilter regex matching one domain and its subdomains.
+  /// Runs in Java natively — no Dart roundtrip per request.
+  List<inapp.ContentBlocker> getContentBlockerRules() {
+    if (_contentBlockerRules != null) return _contentBlockerRules!;
+    if (_blockedDomains.isEmpty) return const [];
+
+    final sw = Stopwatch()..start();
+    final rules = <inapp.ContentBlocker>[];
+
+    for (final domain in _blockedDomains) {
+      final escaped = domain.replaceAll('.', '\\\\.');
+      rules.add(inapp.ContentBlocker(
+        trigger: inapp.ContentBlockerTrigger(
+          urlFilter: '.*$escaped',
+          loadType: [inapp.ContentBlockerTriggerLoadType.THIRD_PARTY],
+        ),
+        action: inapp.ContentBlockerAction(
+          type: inapp.ContentBlockerActionType.BLOCK,
+        ),
+      ));
+    }
+
+    sw.stop();
+    LogService.instance.log('DnsBlock',
+        'Generated ${rules.length} content blocker rules in ${sw.elapsedMilliseconds}ms',
+        level: LogLevel.info);
+    _contentBlockerRules = rules;
+    return rules;
+  }
 
   /// Get DNS stats for a specific site. Creates on first access.
   DnsStats statsForSite(String siteId) {
@@ -275,6 +310,7 @@ class DnsBlockService {
       domains.add(trimmed);
     }
     _blockedDomains = domains;
+    _contentBlockerRules = null;
   }
 
   Future<File> _getCacheFile() async {

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
+import 'package:webspace/services/bloom_filter.dart';
 import 'package:webspace/services/log_service.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -111,6 +112,22 @@ class DnsBlockService {
 
   /// The raw blocked domains set (for sending to native handler).
   Set<String> get blockedDomains => _blockedDomains;
+
+  /// Cached Bloom filter for fast JS-side membership checks.
+  BloomFilter? _bloomFilter;
+
+  /// Get (and cache) a Bloom filter built from all blocked domains plus
+  /// their hierarchical suffixes. Used for iOS JS-side prefiltering.
+  BloomFilter getBloomFilter() {
+    if (_bloomFilter != null) return _bloomFilter!;
+    final sw = Stopwatch()..start();
+    _bloomFilter = BloomFilter.build(_blockedDomains, fpRate: 0.001);
+    sw.stop();
+    LogService.instance.log('DnsBlock',
+        'Built bloom filter: ${_bloomFilter!.sizeInBytes} bytes, k=${_bloomFilter!.k}, from ${_blockedDomains.length} domains in ${sw.elapsedMilliseconds}ms',
+        level: LogLevel.info);
+    return _bloomFilter!;
+  }
 
   /// Get DNS stats for a specific site. Creates on first access.
   DnsStats statsForSite(String siteId) {
@@ -278,6 +295,7 @@ class DnsBlockService {
       domains.add(trimmed);
     }
     _blockedDomains = domains;
+    _bloomFilter = null;
   }
 
   Future<File> _getCacheFile() async {

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
 import 'package:http/http.dart' as http;
 import 'package:webspace/services/log_service.dart';
 import 'package:path_provider/path_provider.dart';
@@ -111,6 +112,44 @@ class DnsBlockService {
 
   /// The raw blocked domains set (for sending to native handler).
   Set<String> get blockedDomains => _blockedDomains;
+
+  /// Cached iOS content blocker rules.
+  List<inapp.ContentBlocker>? _iosContentBlockerRules;
+
+  /// Generate ContentBlocker rules for iOS WKContentRuleList.
+  /// Batches domains into regex alternations (~100 per rule) to keep
+  /// rule count manageable while covering all blocked domains.
+  List<inapp.ContentBlocker> getIosContentBlockerRules() {
+    if (_iosContentBlockerRules != null) return _iosContentBlockerRules!;
+    if (_blockedDomains.isEmpty) return const [];
+
+    final sw = Stopwatch()..start();
+    final rules = <inapp.ContentBlocker>[];
+    final domainList = _blockedDomains.toList();
+    const batchSize = 100;
+
+    for (int i = 0; i < domainList.length; i += batchSize) {
+      final end = (i + batchSize < domainList.length) ? i + batchSize : domainList.length;
+      final batch = domainList.sublist(i, end);
+      final pattern = batch.map((d) => d.replaceAll('.', '\\.')).join('|');
+      rules.add(inapp.ContentBlocker(
+        trigger: inapp.ContentBlockerTrigger(
+          urlFilter: '($pattern)',
+          loadType: [inapp.ContentBlockerTriggerLoadType.THIRD_PARTY],
+        ),
+        action: inapp.ContentBlockerAction(
+          type: inapp.ContentBlockerActionType.BLOCK,
+        ),
+      ));
+    }
+
+    sw.stop();
+    LogService.instance.log('DnsBlock',
+        'Generated ${rules.length} iOS content blocker rules from ${_blockedDomains.length} domains in ${sw.elapsedMilliseconds}ms',
+        level: LogLevel.info);
+    _iosContentBlockerRules = rules;
+    return rules;
+  }
 
   /// Get DNS stats for a specific site. Creates on first access.
   DnsStats statsForSite(String siteId) {
@@ -278,6 +317,7 @@ class DnsBlockService {
       domains.add(trimmed);
     }
     _blockedDomains = domains;
+    _iosContentBlockerRules = null;
   }
 
   Future<File> _getCacheFile() async {

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -24,15 +24,12 @@ class DnsStats {
   int allowed = 0;
   int blocked = 0;
   final List<DnsLogEntry> log = [];
-  final Set<String> _seen = {};
   static const int _maxLogEntries = 500;
 
   int get total => allowed + blocked;
   double get blockRate => total > 0 ? blocked / total * 100 : 0;
 
   void record(String domain, bool wasBlocked) {
-    final key = '${wasBlocked ? 'B' : 'A'}:$domain';
-    if (!_seen.add(key)) return;
     if (wasBlocked) {
       blocked++;
     } else {
@@ -52,7 +49,6 @@ class DnsStats {
     allowed = 0;
     blocked = 0;
     log.clear();
-    _seen.clear();
   }
 }
 

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
 import 'package:http/http.dart' as http;
 import 'package:webspace/services/log_service.dart';
 import 'package:path_provider/path_provider.dart';
@@ -109,40 +108,6 @@ class DnsBlockService {
 
   /// Number of domains in the current blocklist.
   int get domainCount => _blockedDomains.length;
-
-  /// Cached content blocker rules for native webview engine blocking.
-  List<inapp.ContentBlocker>? _contentBlockerRules;
-
-  /// Generate ContentBlocker rules from the blocked domains.
-  /// Each rule uses a urlFilter regex matching one domain and its subdomains.
-  /// Runs in Java natively — no Dart roundtrip per request.
-  List<inapp.ContentBlocker> getContentBlockerRules() {
-    if (_contentBlockerRules != null) return _contentBlockerRules!;
-    if (_blockedDomains.isEmpty) return const [];
-
-    final sw = Stopwatch()..start();
-    final rules = <inapp.ContentBlocker>[];
-
-    for (final domain in _blockedDomains) {
-      final escaped = domain.replaceAll('.', '\\\\.');
-      rules.add(inapp.ContentBlocker(
-        trigger: inapp.ContentBlockerTrigger(
-          urlFilter: '.*$escaped',
-          loadType: [inapp.ContentBlockerTriggerLoadType.THIRD_PARTY],
-        ),
-        action: inapp.ContentBlockerAction(
-          type: inapp.ContentBlockerActionType.BLOCK,
-        ),
-      ));
-    }
-
-    sw.stop();
-    LogService.instance.log('DnsBlock',
-        'Generated ${rules.length} content blocker rules in ${sw.elapsedMilliseconds}ms',
-        level: LogLevel.info);
-    _contentBlockerRules = rules;
-    return rules;
-  }
 
   /// Get DNS stats for a specific site. Creates on first access.
   DnsStats statsForSite(String siteId) {
@@ -310,7 +275,6 @@ class DnsBlockService {
       domains.add(trimmed);
     }
     _blockedDomains = domains;
-    _contentBlockerRules = null;
   }
 
   Future<File> _getCacheFile() async {

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -121,7 +121,7 @@ class DnsBlockService {
   BloomFilter getBloomFilter() {
     if (_bloomFilter != null) return _bloomFilter!;
     final sw = Stopwatch()..start();
-    _bloomFilter = BloomFilter.build(_blockedDomains, fpRate: 0.001);
+    _bloomFilter = BloomFilter.build(_blockedDomains, fpRate: 0.05);
     sw.stop();
     LogService.instance.log('DnsBlock',
         'Built bloom filter: ${_bloomFilter!.sizeInBytes} bytes, k=${_bloomFilter!.k}, from ${_blockedDomains.length} domains in ${sw.elapsedMilliseconds}ms',

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -368,7 +368,12 @@ class DnsBlockService {
       domains.add(trimmed);
     }
     _blockedDomains = domains;
+    // Rebuild bloom filter eagerly so the first webview page load doesn't
+    // pay the ~500ms build cost synchronously.
     _bloomFilter = null;
+    if (domains.isNotEmpty) {
+      getBloomFilter();
+    }
   }
 
   Future<File> _getCacheFile() async {

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -114,30 +114,31 @@ class DnsBlockService {
   List<inapp.ContentBlocker>? _contentBlockerRules;
 
   /// Generate ContentBlocker rules from the blocked domains.
-  /// Uses a single rule with all domains in ifDomain — matched by the
-  /// native engine against request URL hosts with simple string comparison.
+  /// Each rule uses a urlFilter regex matching one domain and its subdomains.
+  /// Runs in Java natively — no Dart roundtrip per request.
   List<inapp.ContentBlocker> getContentBlockerRules() {
     if (_contentBlockerRules != null) return _contentBlockerRules!;
     if (_blockedDomains.isEmpty) return const [];
 
     final sw = Stopwatch()..start();
-    final domains = _blockedDomains.map((d) => '*$d').toList();
-    final rules = [
-      inapp.ContentBlocker(
+    final rules = <inapp.ContentBlocker>[];
+
+    for (final domain in _blockedDomains) {
+      final escaped = domain.replaceAll('.', '\\\\.');
+      rules.add(inapp.ContentBlocker(
         trigger: inapp.ContentBlockerTrigger(
-          urlFilter: '.*',
-          ifDomain: domains,
+          urlFilter: '.*$escaped',
           loadType: [inapp.ContentBlockerTriggerLoadType.THIRD_PARTY],
         ),
         action: inapp.ContentBlockerAction(
           type: inapp.ContentBlockerActionType.BLOCK,
         ),
-      ),
-    ];
+      ));
+    }
 
     sw.stop();
     LogService.instance.log('DnsBlock',
-        'Generated content blocker rule with ${domains.length} domains in ${sw.elapsedMilliseconds}ms',
+        'Generated ${rules.length} content blocker rules in ${sw.elapsedMilliseconds}ms',
         level: LogLevel.info);
     _contentBlockerRules = rules;
     return rules;

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -24,12 +24,15 @@ class DnsStats {
   int allowed = 0;
   int blocked = 0;
   final List<DnsLogEntry> log = [];
+  final Set<String> _seen = {};
   static const int _maxLogEntries = 500;
 
   int get total => allowed + blocked;
   double get blockRate => total > 0 ? blocked / total * 100 : 0;
 
   void record(String domain, bool wasBlocked) {
+    final key = '${wasBlocked ? 'B' : 'A'}:$domain';
+    if (!_seen.add(key)) return;
     if (wasBlocked) {
       blocked++;
     } else {
@@ -49,6 +52,7 @@ class DnsStats {
     allowed = 0;
     blocked = 0;
     log.clear();
+    _seen.clear();
   }
 }
 

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -690,8 +690,8 @@ class WebViewFactory {
   var po = new PerformanceObserver(function(list) {
     list.getEntries().forEach(function(e) { report(e.name); });
   });
-  po.observe({entryTypes: ['resource', 'navigation']});
-  // Flush pending + retroactive entries once bridge is ready
+  po.observe({type: 'resource', buffered: true});
+  po.observe({type: 'navigation', buffered: true});
   function flush() {
     if (!window.flutter_inappwebview || !window.flutter_inappwebview.callHandler) {
       setTimeout(flush, 50);
@@ -701,10 +701,6 @@ class WebViewFactory {
       window.flutter_inappwebview.callHandler('dnsResourceLoaded', url);
     });
     pending = [];
-    if (performance.getEntriesByType) {
-      performance.getEntriesByType('resource').forEach(function(e) { report(e.name); });
-      performance.getEntriesByType('navigation').forEach(function(e) { report(e.name); });
-    }
   }
   flush();
 })();

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -785,7 +785,6 @@ class WebViewFactory {
               final url = args[0] as String;
               final blocked = DnsBlockService.instance.isBlocked(url);
               DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
-              LogService.instance.log('DnsBlock', '[PerfObserver] $url (${blocked ? "BLOCKED" : "allowed"})');
             }
             return null;
           });
@@ -802,11 +801,9 @@ class WebViewFactory {
             wrappedController.loadUrl(config.initialUrl, language: config.language);
           }
         }
-        // Attach native DNS block handler after view is in hierarchy
-        if (DnsBlockService.instance.hasBlocklist && config.dnsBlockEnabled) {
-          Future.delayed(const Duration(milliseconds: 100), () {
-            DnsBlockNative.attachToWebViews();
-          });
+        // Attach native DNS block handler once view is in hierarchy
+        if (DnsBlockService.instance.hasBlocklist) {
+          Future.microtask(() => DnsBlockNative.attachToWebViews());
         }
       },
       shouldOverrideUrlLoading: (controller, navigationAction) async {
@@ -876,7 +873,6 @@ class WebViewFactory {
       shouldInterceptRequest: Platform.isAndroid
           ? (controller, request) async {
               final url = request.url.toString();
-              LogService.instance.log('DnsBlock', '[InterceptReq] $url');
 
               // Record every sub-resource request for DNS stats
               if (config.siteId != null && DnsBlockService.instance.hasBlocklist) {
@@ -915,7 +911,6 @@ class WebViewFactory {
       shouldInterceptAjaxRequest: DnsBlockService.instance.hasBlocklist
           ? (controller, ajaxRequest) async {
               final url = ajaxRequest.url?.toString();
-              if (url != null) LogService.instance.log('DnsBlock', '[AjaxReq] $url');
               if (url != null && config.siteId != null) {
                 final blocked = DnsBlockService.instance.isBlocked(url);
                 DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
@@ -931,7 +926,6 @@ class WebViewFactory {
       shouldInterceptFetchRequest: DnsBlockService.instance.hasBlocklist
           ? (controller, fetchRequest) async {
               final url = fetchRequest.url?.toString();
-              if (url != null) LogService.instance.log('DnsBlock', '[FetchReq] $url');
               if (url != null && config.siteId != null) {
                 final blocked = DnsBlockService.instance.isBlocked(url);
                 DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
@@ -947,6 +941,13 @@ class WebViewFactory {
       onLoadStart: (controller, url) async {
         // Track that this URL has a real page load (not SPA navigation)
         lastLoadStartUrl = url?.toString();
+        // Record the page navigation for DNS stats so the banner shows immediately
+        if (config.siteId != null && DnsBlockService.instance.hasBlocklist
+            && url != null && url.toString().startsWith('http')) {
+          final urlStr = url.toString();
+          DnsBlockService.instance.recordRequest(config.siteId!, urlStr,
+              DnsBlockService.instance.isBlocked(urlStr));
+        }
         // Re-inject CSS for in-page navigations (initialUserScripts only runs on first load)
         if (config.contentBlockEnabled && url != null) {
           final script = ContentBlockerService.instance.getEarlyCssScript(url.toString());

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -699,7 +699,7 @@ class WebViewFactory {
         incognito: config.incognito,
         supportZoom: true,
         useShouldOverrideUrlLoading: true,
-        useShouldInterceptRequest: Platform.isAndroid && (config.dnsBlockEnabled || config.localCdnEnabled),
+        useShouldInterceptRequest: Platform.isAndroid && (DnsBlockService.instance.hasBlocklist || config.localCdnEnabled),
         supportMultipleWindows: true,
         // Required for Cloudflare Turnstile and other challenge systems
         domStorageEnabled: true,
@@ -812,14 +812,13 @@ class WebViewFactory {
           ? (controller, request) async {
               final url = request.url.toString();
 
-              // DNS blocklist check for sub-resource requests
-              if (config.dnsBlockEnabled && DnsBlockService.instance.hasBlocklist) {
+              // DNS blocklist: record + block sub-resource requests
+              if (DnsBlockService.instance.hasBlocklist) {
                 final blocked = DnsBlockService.instance.isBlocked(url);
                 if (config.siteId != null) {
                   DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
                 }
-                if (blocked) {
-                  // Return empty response to block the request
+                if (blocked && config.dnsBlockEnabled) {
                   return inapp.WebResourceResponse(
                     contentType: 'text/plain',
                     contentEncoding: 'utf-8',
@@ -851,14 +850,6 @@ class WebViewFactory {
       onLoadStart: (controller, url) async {
         // Track that this URL has a real page load (not SPA navigation)
         lastLoadStartUrl = url?.toString();
-        // Record the main-frame navigation for DNS stats (catches initial
-        // page loads that bypass shouldOverrideUrlLoading).
-        if (config.dnsBlockEnabled && DnsBlockService.instance.hasBlocklist
-            && config.siteId != null && url != null) {
-          final urlStr = url.toString();
-          final blocked = DnsBlockService.instance.isBlocked(urlStr);
-          DnsBlockService.instance.recordRequest(config.siteId!, urlStr, blocked);
-        }
         // Re-inject CSS for in-page navigations (initialUserScripts only runs on first load)
         if (config.contentBlockEnabled && url != null) {
           final script = ContentBlockerService.instance.getEarlyCssScript(url.toString());

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -8,6 +8,7 @@ import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
+import 'package:webspace/services/dns_block_native.dart';
 import 'package:webspace/services/localcdn_service.dart';
 import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/services/log_service.dart';
@@ -800,6 +801,12 @@ class WebViewFactory {
             ));
             wrappedController.loadUrl(config.initialUrl, language: config.language);
           }
+        }
+        // Attach native DNS block handler after view is in hierarchy
+        if (DnsBlockService.instance.hasBlocklist && config.dnsBlockEnabled) {
+          Future.delayed(const Duration(milliseconds: 100), () {
+            DnsBlockNative.attachToWebViews();
+          });
         }
       },
       shouldOverrideUrlLoading: (controller, navigationAction) async {

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -743,10 +743,13 @@ class WebViewFactory {
         incognito: config.incognito,
         supportZoom: true,
         useShouldOverrideUrlLoading: true,
-        useShouldInterceptRequest: Platform.isAndroid,
+        useShouldInterceptRequest: Platform.isAndroid && config.localCdnEnabled,
         useShouldInterceptAjaxRequest: DnsBlockService.instance.hasBlocklist,
         useShouldInterceptFetchRequest: DnsBlockService.instance.hasBlocklist,
         useOnLoadResource: false,
+        contentBlockers: config.dnsBlockEnabled
+            ? DnsBlockService.instance.getContentBlockerRules()
+            : [],
         supportMultipleWindows: true,
         // Required for Cloudflare Turnstile and other challenge systems
         domStorageEnabled: true,
@@ -866,42 +869,20 @@ class WebViewFactory {
 
         return false;
       },
-      shouldInterceptRequest: Platform.isAndroid
+      shouldInterceptRequest: (Platform.isAndroid && config.localCdnEnabled)
           ? (controller, request) async {
               final url = request.url.toString();
-              LogService.instance.log('DnsBlock', '[InterceptReq] $url');
-
-              // Record every sub-resource request for DNS stats
-              if (config.siteId != null && DnsBlockService.instance.hasBlocklist) {
-                final blocked = DnsBlockService.instance.isBlocked(url);
-                DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
-                if (blocked && config.dnsBlockEnabled) {
-                  LogService.instance.log('DnsBlock', 'Blocked sub-resource: $url (site: ${config.siteId})');
+              final service = LocalCdnService.instance;
+              if (service.isCdnUrl(url)) {
+                final data = await service.getOrFetchResource(url);
+                if (data != null) {
                   return inapp.WebResourceResponse(
-                    contentType: 'text/plain',
+                    contentType: service.getContentType(url),
                     contentEncoding: 'utf-8',
-                    data: Uint8List(0),
-                    statusCode: 403,
-                    reasonPhrase: 'Blocked by DNS blocklist',
+                    data: data,
                   );
                 }
               }
-
-              // LocalCDN: serve CDN resources from local cache
-              if (config.localCdnEnabled) {
-                final service = LocalCdnService.instance;
-                if (service.isCdnUrl(url)) {
-                  final data = await service.getOrFetchResource(url);
-                  if (data != null) {
-                    return inapp.WebResourceResponse(
-                      contentType: service.getContentType(url),
-                      contentEncoding: 'utf-8',
-                      data: data,
-                    );
-                  }
-                }
-              }
-
               return null;
             }
           : null,

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1,5 +1,4 @@
 import 'dart:collection';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -776,13 +775,6 @@ class WebViewFactory {
     }
   }
 
-  // Expose a snapshot for Dart to persist
-  window.__dnsCacheSnapshot = function() {
-    var snap = {};
-    for (var h in allowedCache) snap[h] = false;
-    for (var h in blockedCache) snap[h] = true;
-    return snap;
-  };
 
   function check(url) {
     if (!url || typeof url !== 'string' || !url.startsWith('http')) {
@@ -1017,10 +1009,10 @@ class WebViewFactory {
               DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
               return blocked;
             });
-            // One-shot bloom filter + persisted cache delivery to JS
+            // One-shot bloom filter + global domain cache delivery to JS
             controller.addJavaScriptHandler(handlerName: 'getDnsBloom', callback: (args) {
               final map = Map<String, dynamic>.from(DnsBlockService.instance.getBloomFilter().toMap());
-              map['cache'] = DnsBlockService.instance.getCacheForSite(config.siteId!);
+              map['cache'] = DnsBlockService.instance.getDomainCache();
               return map;
             });
           }
@@ -1192,22 +1184,6 @@ class WebViewFactory {
             }
           }
           await userScriptService.reinjectOnLoadStop(controller);
-          // Persist the JS DNS cache for this site (iOS only)
-          if (!Platform.isAndroid
-              && config.siteId != null
-              && config.dnsBlockEnabled
-              && DnsBlockService.instance.hasBlocklist) {
-            try {
-              final result = await controller.evaluateJavascript(
-                source: 'JSON.stringify(window.__dnsCacheSnapshot ? window.__dnsCacheSnapshot() : {})',
-              );
-              if (result is String) {
-                final decoded = jsonDecode(result) as Map<String, dynamic>;
-                final cache = decoded.map((k, v) => MapEntry(k, v as bool));
-                await DnsBlockService.instance.setCacheForSite(config.siteId!, cache);
-              }
-            } catch (_) {}
-          }
           // Cache HTML for offline viewing
           if (config.onHtmlLoaded != null) {
             try {

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -668,8 +668,10 @@ class WebViewFactory {
       ));
     }
 
-    // DNS stats: inject PerformanceObserver to report loaded resource URLs
-    if (config.siteId != null && DnsBlockService.instance.hasBlocklist) {
+    // DNS stats: inject PerformanceObserver to report loaded resource URLs.
+    // On Android, the native FastDnsBlockerHandler reports events directly,
+    // so skip PerformanceObserver to avoid double-counting.
+    if (!Platform.isAndroid && config.siteId != null && DnsBlockService.instance.hasBlocklist) {
       userScripts.add(inapp.UserScript(
         groupName: 'dns_resource_observer',
         source: '''

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -750,7 +750,7 @@ class WebViewFactory {
         useOnLoadResource: false,
         contentBlockers: (!Platform.isAndroid && config.dnsBlockEnabled)
             ? DnsBlockService.instance.getIosContentBlockerRules()
-            : [],
+            : null,
         supportMultipleWindows: true,
         // Required for Cloudflare Turnstile and other challenge systems
         domStorageEnabled: true,

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -750,9 +750,7 @@ class WebViewFactory {
         // DNS blocklist check
         if (config.dnsBlockEnabled && DnsBlockService.instance.hasBlocklist) {
           final blocked = DnsBlockService.instance.isBlocked(url);
-          // On Android, sub-resource recording happens in shouldInterceptRequest.
-          // Only record navigation-level requests here on non-Android platforms.
-          if (config.siteId != null && !Platform.isAndroid) {
+          if (config.siteId != null) {
             DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
           }
           if (blocked) {
@@ -853,6 +851,14 @@ class WebViewFactory {
       onLoadStart: (controller, url) async {
         // Track that this URL has a real page load (not SPA navigation)
         lastLoadStartUrl = url?.toString();
+        // Record the main-frame navigation for DNS stats (catches initial
+        // page loads that bypass shouldOverrideUrlLoading).
+        if (config.dnsBlockEnabled && DnsBlockService.instance.hasBlocklist
+            && config.siteId != null && url != null) {
+          final urlStr = url.toString();
+          final blocked = DnsBlockService.instance.isBlocked(urlStr);
+          DnsBlockService.instance.recordRequest(config.siteId!, urlStr, blocked);
+        }
         // Re-inject CSS for in-page navigations (initialUserScripts only runs on first load)
         if (config.contentBlockEnabled && url != null) {
           final script = ContentBlockerService.instance.getEarlyCssScript(url.toString());

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -750,7 +750,9 @@ class WebViewFactory {
         // DNS blocklist check
         if (config.dnsBlockEnabled && DnsBlockService.instance.hasBlocklist) {
           final blocked = DnsBlockService.instance.isBlocked(url);
-          if (config.siteId != null) {
+          // On Android, sub-resource recording happens in shouldInterceptRequest.
+          // Only record navigation-level requests here on non-Android platforms.
+          if (config.siteId != null && !Platform.isAndroid) {
             DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
           }
           if (blocked) {
@@ -808,20 +810,44 @@ class WebViewFactory {
 
         return false;
       },
-      shouldInterceptRequest: config.localCdnEnabled && Platform.isAndroid
+      shouldInterceptRequest: Platform.isAndroid
           ? (controller, request) async {
               final url = request.url.toString();
-              final service = LocalCdnService.instance;
-              if (!service.isCdnUrl(url)) return null;
 
-              final data = await service.getOrFetchResource(url);
-              if (data == null) return null;
+              // DNS blocklist check for sub-resource requests
+              if (config.dnsBlockEnabled && DnsBlockService.instance.hasBlocklist) {
+                final blocked = DnsBlockService.instance.isBlocked(url);
+                if (config.siteId != null) {
+                  DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
+                }
+                if (blocked) {
+                  // Return empty response to block the request
+                  return inapp.WebResourceResponse(
+                    contentType: 'text/plain',
+                    contentEncoding: 'utf-8',
+                    data: Uint8List(0),
+                    statusCode: 403,
+                    reasonPhrase: 'Blocked by DNS blocklist',
+                  );
+                }
+              }
 
-              return inapp.WebResourceResponse(
-                contentType: service.getContentType(url),
-                contentEncoding: 'utf-8',
-                data: data,
-              );
+              // LocalCDN: serve CDN resources from local cache
+              if (config.localCdnEnabled) {
+                final service = LocalCdnService.instance;
+                if (service.isCdnUrl(url)) {
+                  final data = await service.getOrFetchResource(url);
+                  if (data != null) {
+                    return inapp.WebResourceResponse(
+                      contentType: service.getContentType(url),
+                      contentEncoding: 'utf-8',
+                      data: data,
+                    );
+                  }
+                }
+              }
+
+              return null;
             }
           : null,
       onLoadStart: (controller, url) async {

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -757,6 +757,23 @@ class WebViewFactory {
     return false;
   }
 
+  // Per-site domain result cache (LRU-ish: evict oldest when full)
+  var allowedCache = {};
+  var blockedCache = {};
+  var cacheKeys = [];
+  var MAX_CACHE = 500;
+
+  function cacheResult(host, blocked) {
+    if (blocked) { blockedCache[host] = 1; }
+    else { allowedCache[host] = 1; }
+    cacheKeys.push(host);
+    if (cacheKeys.length > MAX_CACHE) {
+      var old = cacheKeys.shift();
+      delete allowedCache[old];
+      delete blockedCache[old];
+    }
+  }
+
   function check(url) {
     if (!url || typeof url !== 'string' || !url.startsWith('http')) {
       return Promise.resolve(false);
@@ -766,14 +783,20 @@ class WebViewFactory {
     }
     var host;
     try { host = new URL(url).hostname; } catch (e) { return Promise.resolve(false); }
+    // Check per-site cache first (instant)
+    if (allowedCache[host]) return Promise.resolve(false);
+    if (blockedCache[host]) return Promise.resolve(true);
     // Bloom prefilter: if definitely not in set, allow without roundtrip
     if (!maybeBlocked(host)) {
-      // Still record the allowed request fire-and-forget
+      cacheResult(host, false);
       window.flutter_inappwebview.callHandler('dnsResourceLoaded', url);
       return Promise.resolve(false);
     }
-    // Possibly blocked — confirm via Dart (handles false positives + records)
-    return window.flutter_inappwebview.callHandler('dnsCheck', url);
+    // Possibly blocked — confirm via Dart, then cache result
+    return window.flutter_inappwebview.callHandler('dnsCheck', url).then(function(blocked) {
+      cacheResult(host, blocked);
+      return blocked;
+    });
   }
 
   // Fetch Bloom filter from Dart once at startup

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -744,7 +744,7 @@ class WebViewFactory {
         incognito: config.incognito,
         supportZoom: true,
         useShouldOverrideUrlLoading: true,
-        useShouldInterceptRequest: Platform.isAndroid,
+        useShouldInterceptRequest: Platform.isAndroid && config.localCdnEnabled && LocalCdnService.instance.hasCache,
         useShouldInterceptAjaxRequest: DnsBlockService.instance.hasBlocklist,
         useShouldInterceptFetchRequest: DnsBlockService.instance.hasBlocklist,
         useOnLoadResource: false,

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -729,6 +729,8 @@ class WebViewFactory {
         supportZoom: true,
         useShouldOverrideUrlLoading: true,
         useShouldInterceptRequest: Platform.isAndroid,
+        useShouldInterceptAjaxRequest: DnsBlockService.instance.hasBlocklist,
+        useShouldInterceptFetchRequest: DnsBlockService.instance.hasBlocklist,
         useOnLoadResource: false,
         supportMultipleWindows: true,
         // Required for Cloudflare Turnstile and other challenge systems
@@ -886,6 +888,36 @@ class WebViewFactory {
               }
 
               return null;
+            }
+          : null,
+      shouldInterceptAjaxRequest: DnsBlockService.instance.hasBlocklist
+          ? (controller, ajaxRequest) async {
+              final url = ajaxRequest.url?.toString();
+              if (url != null && config.siteId != null) {
+                final blocked = DnsBlockService.instance.isBlocked(url);
+                DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
+                if (blocked && config.dnsBlockEnabled) {
+                  ajaxRequest.action = inapp.AjaxRequestAction.ABORT;
+                  return ajaxRequest;
+                }
+              }
+              ajaxRequest.action = inapp.AjaxRequestAction.PROCEED;
+              return ajaxRequest;
+            }
+          : null,
+      shouldInterceptFetchRequest: DnsBlockService.instance.hasBlocklist
+          ? (controller, fetchRequest) async {
+              final url = fetchRequest.url?.toString();
+              if (url != null && config.siteId != null) {
+                final blocked = DnsBlockService.instance.isBlocked(url);
+                DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
+                if (blocked && config.dnsBlockEnabled) {
+                  fetchRequest.action = inapp.FetchRequestAction.ABORT;
+                  return fetchRequest;
+                }
+              }
+              fetchRequest.action = inapp.FetchRequestAction.PROCEED;
+              return fetchRequest;
             }
           : null,
       onLoadStart: (controller, url) async {

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -667,6 +667,33 @@ class WebViewFactory {
       ));
     }
 
+    // DNS stats: inject PerformanceObserver to report loaded resource URLs
+    if (config.siteId != null && DnsBlockService.instance.hasBlocklist) {
+      userScripts.add(inapp.UserScript(
+        groupName: 'dns_resource_observer',
+        source: '''
+(function() {
+  var seen = {};
+  function report(url) {
+    if (!url || seen[url] || !url.startsWith('http')) return;
+    seen[url] = 1;
+    try { window.flutter_inappwebview.callHandler('dnsResourceLoaded', url); } catch(e) {}
+  }
+  var po = new PerformanceObserver(function(list) {
+    list.getEntries().forEach(function(e) { report(e.name); });
+  });
+  po.observe({entryTypes: ['resource', 'navigation']});
+  // Report already-loaded resources
+  if (performance.getEntriesByType) {
+    performance.getEntriesByType('resource').forEach(function(e) { report(e.name); });
+    performance.getEntriesByType('navigation').forEach(function(e) { report(e.name); });
+  }
+})();
+;null;''',
+        injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
+      ));
+    }
+
     // User script injection: shim for external dependency resolution + scripts
     final userScriptService = UserScriptService(
       scripts: config.userScripts,
@@ -677,6 +704,8 @@ class WebViewFactory {
     // Track last URL that triggered onLoadStart, used to distinguish
     // SPA navigations (pushState) from real page loads in onUpdateVisitedHistory.
     String? lastLoadStartUrl;
+
+    LogService.instance.log('DnsBlock', 'Creating webview: siteId=${config.siteId} dnsBlock=${config.dnsBlockEnabled} hasBlocklist=${DnsBlockService.instance.hasBlocklist} isAndroid=${Platform.isAndroid} url=${config.initialUrl}');
 
     return inapp.InAppWebView(
       key: config.key,
@@ -731,6 +760,17 @@ class WebViewFactory {
             return args.isNotEmpty ? args[0] : '';
           });
         }
+        // DNS stats: register handler for resource observer JS
+        if (config.siteId != null && DnsBlockService.instance.hasBlocklist) {
+          controller.addJavaScriptHandler(handlerName: 'dnsResourceLoaded', callback: (args) {
+            if (args.isNotEmpty && args[0] is String) {
+              final url = args[0] as String;
+              final blocked = DnsBlockService.instance.isBlocked(url);
+              DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
+            }
+            return null;
+          });
+        }
         userScriptService.registerHandlers(controller);
         // If we loaded cached HTML, navigate to the real URL when online
         if (usesCachedHtml) {
@@ -748,12 +788,16 @@ class WebViewFactory {
         final url = navigationAction.request.url.toString();
         if (_shouldBlockUrl(url)) return inapp.NavigationActionPolicy.CANCEL;
         if (isCaptchaChallenge(url)) return inapp.NavigationActionPolicy.ALLOW;
-        // DNS blocklist check
-        if (config.dnsBlockEnabled && DnsBlockService.instance.isBlocked(url)) {
+        // DNS blocklist check + record navigation for stats
+        if (DnsBlockService.instance.hasBlocklist) {
+          final blocked = DnsBlockService.instance.isBlocked(url);
           if (config.siteId != null) {
-            DnsBlockService.instance.recordRequest(config.siteId!, url, true);
+            DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
           }
-          return inapp.NavigationActionPolicy.CANCEL;
+          if (blocked && config.dnsBlockEnabled) {
+            LogService.instance.log('DnsBlock', 'Blocked navigation: $url');
+            return inapp.NavigationActionPolicy.CANCEL;
+          }
         }
         // Content blocker domain check
         if (config.contentBlockEnabled && ContentBlockerService.instance.isBlocked(url)) {
@@ -815,6 +859,7 @@ class WebViewFactory {
                 final blocked = DnsBlockService.instance.isBlocked(url);
                 DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
                 if (blocked && config.dnsBlockEnabled) {
+                  LogService.instance.log('DnsBlock', 'Blocked sub-resource: $url (site: ${config.siteId})');
                   return inapp.WebResourceResponse(
                     contentType: 'text/plain',
                     contentEncoding: 'utf-8',

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -743,13 +743,10 @@ class WebViewFactory {
         incognito: config.incognito,
         supportZoom: true,
         useShouldOverrideUrlLoading: true,
-        useShouldInterceptRequest: Platform.isAndroid && config.localCdnEnabled,
+        useShouldInterceptRequest: Platform.isAndroid,
         useShouldInterceptAjaxRequest: DnsBlockService.instance.hasBlocklist,
         useShouldInterceptFetchRequest: DnsBlockService.instance.hasBlocklist,
         useOnLoadResource: false,
-        contentBlockers: config.dnsBlockEnabled
-            ? DnsBlockService.instance.getContentBlockerRules()
-            : [],
         supportMultipleWindows: true,
         // Required for Cloudflare Turnstile and other challenge systems
         domStorageEnabled: true,
@@ -869,20 +866,42 @@ class WebViewFactory {
 
         return false;
       },
-      shouldInterceptRequest: (Platform.isAndroid && config.localCdnEnabled)
+      shouldInterceptRequest: Platform.isAndroid
           ? (controller, request) async {
               final url = request.url.toString();
-              final service = LocalCdnService.instance;
-              if (service.isCdnUrl(url)) {
-                final data = await service.getOrFetchResource(url);
-                if (data != null) {
+              LogService.instance.log('DnsBlock', '[InterceptReq] $url');
+
+              // Record every sub-resource request for DNS stats
+              if (config.siteId != null && DnsBlockService.instance.hasBlocklist) {
+                final blocked = DnsBlockService.instance.isBlocked(url);
+                DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
+                if (blocked && config.dnsBlockEnabled) {
+                  LogService.instance.log('DnsBlock', 'Blocked sub-resource: $url (site: ${config.siteId})');
                   return inapp.WebResourceResponse(
-                    contentType: service.getContentType(url),
+                    contentType: 'text/plain',
                     contentEncoding: 'utf-8',
-                    data: data,
+                    data: Uint8List(0),
+                    statusCode: 403,
+                    reasonPhrase: 'Blocked by DNS blocklist',
                   );
                 }
               }
+
+              // LocalCDN: serve CDN resources from local cache
+              if (config.localCdnEnabled) {
+                final service = LocalCdnService.instance;
+                if (service.isCdnUrl(url)) {
+                  final data = await service.getOrFetchResource(url);
+                  if (data != null) {
+                    return inapp.WebResourceResponse(
+                      contentType: service.getContentType(url),
+                      contentEncoding: 'utf-8',
+                      data: data,
+                    );
+                  }
+                }
+              }
+
               return null;
             }
           : null,

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -745,8 +745,8 @@ class WebViewFactory {
         supportZoom: true,
         useShouldOverrideUrlLoading: true,
         useShouldInterceptRequest: Platform.isAndroid && config.localCdnEnabled && LocalCdnService.instance.hasCache,
-        useShouldInterceptAjaxRequest: DnsBlockService.instance.hasBlocklist,
-        useShouldInterceptFetchRequest: DnsBlockService.instance.hasBlocklist,
+        useShouldInterceptAjaxRequest: false,
+        useShouldInterceptFetchRequest: false,
         useOnLoadResource: false,
         supportMultipleWindows: true,
         // Required for Cloudflare Turnstile and other challenge systems
@@ -908,36 +908,8 @@ class WebViewFactory {
               return null;
             }
           : null,
-      shouldInterceptAjaxRequest: DnsBlockService.instance.hasBlocklist
-          ? (controller, ajaxRequest) async {
-              final url = ajaxRequest.url?.toString();
-              if (url != null && config.siteId != null) {
-                final blocked = DnsBlockService.instance.isBlocked(url);
-                DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
-                if (blocked && config.dnsBlockEnabled) {
-                  ajaxRequest.action = inapp.AjaxRequestAction.ABORT;
-                  return ajaxRequest;
-                }
-              }
-              ajaxRequest.action = inapp.AjaxRequestAction.PROCEED;
-              return ajaxRequest;
-            }
-          : null,
-      shouldInterceptFetchRequest: DnsBlockService.instance.hasBlocklist
-          ? (controller, fetchRequest) async {
-              final url = fetchRequest.url?.toString();
-              if (url != null && config.siteId != null) {
-                final blocked = DnsBlockService.instance.isBlocked(url);
-                DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
-                if (blocked && config.dnsBlockEnabled) {
-                  fetchRequest.action = inapp.FetchRequestAction.ABORT;
-                  return fetchRequest;
-                }
-              }
-              fetchRequest.action = inapp.FetchRequestAction.PROCEED;
-              return fetchRequest;
-            }
-          : null,
+      // fetch/XHR interception disabled — Dart roundtrip bottlenecks page loading.
+      // Native FastDnsBlockerHandler handles sub-resource blocking in Java instead.
       onLoadStart: (controller, url) async {
         // Track that this URL has a real page load (not SPA navigation)
         lastLoadStartUrl = url?.toString();

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -748,6 +748,9 @@ class WebViewFactory {
         useShouldInterceptAjaxRequest: false,
         useShouldInterceptFetchRequest: false,
         useOnLoadResource: false,
+        contentBlockers: (!Platform.isAndroid && config.dnsBlockEnabled)
+            ? DnsBlockService.instance.getIosContentBlockerRules()
+            : [],
         supportMultipleWindows: true,
         // Required for Cloudflare Turnstile and other challenge systems
         domStorageEnabled: true,

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -699,8 +699,8 @@ class WebViewFactory {
         incognito: config.incognito,
         supportZoom: true,
         useShouldOverrideUrlLoading: true,
-        useShouldInterceptRequest: Platform.isAndroid && (config.dnsBlockEnabled || config.localCdnEnabled),
-        useOnLoadResource: config.siteId != null && DnsBlockService.instance.hasBlocklist,
+        useShouldInterceptRequest: Platform.isAndroid,
+        useOnLoadResource: false,
         supportMultipleWindows: true,
         // Required for Cloudflare Turnstile and other challenge systems
         domStorageEnabled: true,
@@ -810,15 +810,19 @@ class WebViewFactory {
           ? (controller, request) async {
               final url = request.url.toString();
 
-              // DNS blocklist: block sub-resource requests
-              if (config.dnsBlockEnabled && DnsBlockService.instance.isBlocked(url)) {
-                return inapp.WebResourceResponse(
-                  contentType: 'text/plain',
-                  contentEncoding: 'utf-8',
-                  data: Uint8List(0),
-                  statusCode: 403,
-                  reasonPhrase: 'Blocked by DNS blocklist',
-                );
+              // Record every sub-resource request for DNS stats
+              if (config.siteId != null && DnsBlockService.instance.hasBlocklist) {
+                final blocked = DnsBlockService.instance.isBlocked(url);
+                DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
+                if (blocked && config.dnsBlockEnabled) {
+                  return inapp.WebResourceResponse(
+                    contentType: 'text/plain',
+                    contentEncoding: 'utf-8',
+                    data: Uint8List(0),
+                    statusCode: 403,
+                    reasonPhrase: 'Blocked by DNS blocklist',
+                  );
+                }
               }
 
               // LocalCDN: serve CDN resources from local cache
@@ -837,15 +841,6 @@ class WebViewFactory {
               }
 
               return null;
-            }
-          : null,
-      onLoadResource: (config.siteId != null && DnsBlockService.instance.hasBlocklist)
-          ? (controller, resource) {
-              final url = resource.url?.toString();
-              if (url != null && url.startsWith('http')) {
-                final blocked = DnsBlockService.instance.isBlocked(url);
-                DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
-              }
             }
           : null,
       onLoadStart: (controller, url) async {

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -699,7 +699,7 @@ class WebViewFactory {
         incognito: config.incognito,
         supportZoom: true,
         useShouldOverrideUrlLoading: true,
-        useShouldInterceptRequest: config.localCdnEnabled && Platform.isAndroid,
+        useShouldInterceptRequest: Platform.isAndroid && (config.dnsBlockEnabled || config.localCdnEnabled),
         supportMultipleWindows: true,
         // Required for Cloudflare Turnstile and other challenge systems
         domStorageEnabled: true,

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -803,7 +803,7 @@ class WebViewFactory {
         }
         // Attach native DNS block handler once view is in hierarchy
         if (DnsBlockService.instance.hasBlocklist) {
-          Future.microtask(() => DnsBlockNative.attachToWebViews());
+          Future.microtask(() => DnsBlockNative.attachToWebViews(siteId: config.siteId));
         }
       },
       shouldOverrideUrlLoading: (controller, navigationAction) async {

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -699,7 +699,8 @@ class WebViewFactory {
         incognito: config.incognito,
         supportZoom: true,
         useShouldOverrideUrlLoading: true,
-        useShouldInterceptRequest: Platform.isAndroid && (DnsBlockService.instance.hasBlocklist || config.localCdnEnabled),
+        useShouldInterceptRequest: Platform.isAndroid && (config.dnsBlockEnabled || config.localCdnEnabled),
+        useOnLoadResource: config.siteId != null && DnsBlockService.instance.hasBlocklist,
         supportMultipleWindows: true,
         // Required for Cloudflare Turnstile and other challenge systems
         domStorageEnabled: true,
@@ -748,14 +749,11 @@ class WebViewFactory {
         if (_shouldBlockUrl(url)) return inapp.NavigationActionPolicy.CANCEL;
         if (isCaptchaChallenge(url)) return inapp.NavigationActionPolicy.ALLOW;
         // DNS blocklist check
-        if (config.dnsBlockEnabled && DnsBlockService.instance.hasBlocklist) {
-          final blocked = DnsBlockService.instance.isBlocked(url);
+        if (config.dnsBlockEnabled && DnsBlockService.instance.isBlocked(url)) {
           if (config.siteId != null) {
-            DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
+            DnsBlockService.instance.recordRequest(config.siteId!, url, true);
           }
-          if (blocked) {
-            return inapp.NavigationActionPolicy.CANCEL;
-          }
+          return inapp.NavigationActionPolicy.CANCEL;
         }
         // Content blocker domain check
         if (config.contentBlockEnabled && ContentBlockerService.instance.isBlocked(url)) {
@@ -812,21 +810,15 @@ class WebViewFactory {
           ? (controller, request) async {
               final url = request.url.toString();
 
-              // DNS blocklist: record + block sub-resource requests
-              if (DnsBlockService.instance.hasBlocklist) {
-                final blocked = DnsBlockService.instance.isBlocked(url);
-                if (config.siteId != null) {
-                  DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
-                }
-                if (blocked && config.dnsBlockEnabled) {
-                  return inapp.WebResourceResponse(
-                    contentType: 'text/plain',
-                    contentEncoding: 'utf-8',
-                    data: Uint8List(0),
-                    statusCode: 403,
-                    reasonPhrase: 'Blocked by DNS blocklist',
-                  );
-                }
+              // DNS blocklist: block sub-resource requests
+              if (config.dnsBlockEnabled && DnsBlockService.instance.isBlocked(url)) {
+                return inapp.WebResourceResponse(
+                  contentType: 'text/plain',
+                  contentEncoding: 'utf-8',
+                  data: Uint8List(0),
+                  statusCode: 403,
+                  reasonPhrase: 'Blocked by DNS blocklist',
+                );
               }
 
               // LocalCDN: serve CDN resources from local cache
@@ -845,6 +837,15 @@ class WebViewFactory {
               }
 
               return null;
+            }
+          : null,
+      onLoadResource: (config.siteId != null && DnsBlockService.instance.hasBlocklist)
+          ? (controller, resource) {
+              final url = resource.url?.toString();
+              if (url != null && url.startsWith('http')) {
+                final blocked = DnsBlockService.instance.isBlocked(url);
+                DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
+              }
             }
           : null,
       onLoadStart: (controller, url) async {

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -674,20 +674,39 @@ class WebViewFactory {
         source: '''
 (function() {
   var seen = {};
+  var pending = [];
+  function send(url) {
+    if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
+      window.flutter_inappwebview.callHandler('dnsResourceLoaded', url);
+    } else {
+      pending.push(url);
+    }
+  }
   function report(url) {
     if (!url || seen[url] || !url.startsWith('http')) return;
     seen[url] = 1;
-    try { window.flutter_inappwebview.callHandler('dnsResourceLoaded', url); } catch(e) {}
+    send(url);
   }
   var po = new PerformanceObserver(function(list) {
     list.getEntries().forEach(function(e) { report(e.name); });
   });
   po.observe({entryTypes: ['resource', 'navigation']});
-  // Report already-loaded resources
-  if (performance.getEntriesByType) {
-    performance.getEntriesByType('resource').forEach(function(e) { report(e.name); });
-    performance.getEntriesByType('navigation').forEach(function(e) { report(e.name); });
+  // Flush pending + retroactive entries once bridge is ready
+  function flush() {
+    if (!window.flutter_inappwebview || !window.flutter_inappwebview.callHandler) {
+      setTimeout(flush, 50);
+      return;
+    }
+    pending.forEach(function(url) {
+      window.flutter_inappwebview.callHandler('dnsResourceLoaded', url);
+    });
+    pending = [];
+    if (performance.getEntriesByType) {
+      performance.getEntriesByType('resource').forEach(function(e) { report(e.name); });
+      performance.getEntriesByType('navigation').forEach(function(e) { report(e.name); });
+    }
   }
+  flush();
 })();
 ;null;''',
         injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
@@ -769,6 +788,7 @@ class WebViewFactory {
               final url = args[0] as String;
               final blocked = DnsBlockService.instance.isBlocked(url);
               DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
+              LogService.instance.log('DnsBlock', '[PerfObserver] $url (${blocked ? "BLOCKED" : "allowed"})');
             }
             return null;
           });
@@ -791,13 +811,11 @@ class WebViewFactory {
         if (_shouldBlockUrl(url)) return inapp.NavigationActionPolicy.CANCEL;
         if (isCaptchaChallenge(url)) return inapp.NavigationActionPolicy.ALLOW;
         // DNS blocklist check + record navigation for stats
-        if (DnsBlockService.instance.hasBlocklist) {
+        if (DnsBlockService.instance.hasBlocklist && config.siteId != null) {
+          LogService.instance.log('DnsBlock', '[Navigation] $url');
           final blocked = DnsBlockService.instance.isBlocked(url);
-          if (config.siteId != null) {
-            DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
-          }
+          DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
           if (blocked && config.dnsBlockEnabled) {
-            LogService.instance.log('DnsBlock', 'Blocked navigation: $url');
             return inapp.NavigationActionPolicy.CANCEL;
           }
         }
@@ -855,6 +873,7 @@ class WebViewFactory {
       shouldInterceptRequest: Platform.isAndroid
           ? (controller, request) async {
               final url = request.url.toString();
+              LogService.instance.log('DnsBlock', '[InterceptReq] $url');
 
               // Record every sub-resource request for DNS stats
               if (config.siteId != null && DnsBlockService.instance.hasBlocklist) {
@@ -893,6 +912,7 @@ class WebViewFactory {
       shouldInterceptAjaxRequest: DnsBlockService.instance.hasBlocklist
           ? (controller, ajaxRequest) async {
               final url = ajaxRequest.url?.toString();
+              if (url != null) LogService.instance.log('DnsBlock', '[AjaxReq] $url');
               if (url != null && config.siteId != null) {
                 final blocked = DnsBlockService.instance.isBlocked(url);
                 DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
@@ -908,6 +928,7 @@ class WebViewFactory {
       shouldInterceptFetchRequest: DnsBlockService.instance.hasBlocklist
           ? (controller, fetchRequest) async {
               final url = fetchRequest.url?.toString();
+              if (url != null) LogService.instance.log('DnsBlock', '[FetchReq] $url');
               if (url != null && config.siteId != null) {
                 final blocked = DnsBlockService.instance.isBlocked(url);
                 DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -710,6 +710,121 @@ class WebViewFactory {
       ));
     }
 
+    // iOS DNS sub-resource blocking: intercepts fetch/XHR/src setters and
+    // checks each URL via Dart roundtrip (Android uses native FastDnsBlockerHandler).
+    if (!Platform.isAndroid
+        && config.siteId != null
+        && config.dnsBlockEnabled
+        && DnsBlockService.instance.hasBlocklist) {
+      userScripts.add(inapp.UserScript(
+        groupName: 'dns_js_blocker',
+        source: '''
+(function() {
+  function check(url) {
+    if (!url || typeof url !== 'string' || !url.startsWith('http')) {
+      return Promise.resolve(false);
+    }
+    if (!window.flutter_inappwebview || !window.flutter_inappwebview.callHandler) {
+      return Promise.resolve(false);
+    }
+    return window.flutter_inappwebview.callHandler('dnsCheck', url);
+  }
+
+  // fetch
+  var origFetch = window.fetch;
+  if (origFetch) {
+    window.fetch = function(input, init) {
+      var url = typeof input === 'string' ? input : (input && input.url);
+      return check(url).then(function(blocked) {
+        if (blocked) return Promise.reject(new TypeError('Blocked by DNS blocklist: ' + url));
+        return origFetch.call(this, input, init);
+      }.bind(this));
+    };
+  }
+
+  // XMLHttpRequest
+  var origOpen = XMLHttpRequest.prototype.open;
+  XMLHttpRequest.prototype.open = function(method, url) {
+    this.__dnsBlockUrl = url;
+    return origOpen.apply(this, arguments);
+  };
+  var origSend = XMLHttpRequest.prototype.send;
+  XMLHttpRequest.prototype.send = function(body) {
+    var self = this;
+    var args = arguments;
+    check(self.__dnsBlockUrl).then(function(blocked) {
+      if (blocked) { try { self.abort(); } catch(e) {} return; }
+      origSend.apply(self, args);
+    });
+  };
+
+  // Property setters for src/href on resource elements
+  function patchSetter(proto, attr) {
+    var desc = Object.getOwnPropertyDescriptor(proto, attr);
+    if (!desc || !desc.set) return;
+    var origSet = desc.set;
+    Object.defineProperty(proto, attr, {
+      configurable: true,
+      enumerable: desc.enumerable,
+      get: desc.get,
+      set: function(value) {
+        var el = this;
+        check(value).then(function(blocked) {
+          if (!blocked) origSet.call(el, value);
+        });
+      }
+    });
+  }
+  patchSetter(HTMLImageElement.prototype, 'src');
+  patchSetter(HTMLScriptElement.prototype, 'src');
+  patchSetter(HTMLLinkElement.prototype, 'href');
+  patchSetter(HTMLIFrameElement.prototype, 'src');
+
+  // MutationObserver for statically-parsed HTML elements
+  function checkElement(el) {
+    var attr = null;
+    if (el.tagName === 'IMG' || el.tagName === 'SCRIPT' || el.tagName === 'IFRAME') attr = 'src';
+    else if (el.tagName === 'LINK') attr = 'href';
+    if (attr) {
+      var url = el.getAttribute(attr);
+      if (url && url.indexOf('http') === 0) {
+        check(url).then(function(blocked) {
+          if (blocked) {
+            el.removeAttribute(attr);
+            if (el.parentNode) el.parentNode.removeChild(el);
+          }
+        });
+      }
+    }
+  }
+  var mo = new MutationObserver(function(mutations) {
+    for (var i = 0; i < mutations.length; i++) {
+      var added = mutations[i].addedNodes;
+      for (var j = 0; j < added.length; j++) {
+        var node = added[j];
+        if (node.nodeType !== 1) continue;
+        checkElement(node);
+        if (node.querySelectorAll) {
+          var els = node.querySelectorAll('img, script, link, iframe');
+          for (var k = 0; k < els.length; k++) checkElement(els[k]);
+        }
+      }
+    }
+  });
+  function startObserving() {
+    if (document.documentElement) {
+      mo.observe(document.documentElement, {childList: true, subtree: true});
+    } else {
+      setTimeout(startObserving, 10);
+    }
+  }
+  startObserving();
+})();
+;null;''',
+        injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
+      ));
+    }
+
     // User script injection: shim for external dependency resolution + scripts
     final userScriptService = UserScriptService(
       scripts: config.userScripts,
@@ -748,9 +863,6 @@ class WebViewFactory {
         useShouldInterceptAjaxRequest: false,
         useShouldInterceptFetchRequest: false,
         useOnLoadResource: false,
-        contentBlockers: (!Platform.isAndroid && config.dnsBlockEnabled)
-            ? DnsBlockService.instance.getIosContentBlockerRules()
-            : null,
         supportMultipleWindows: true,
         // Required for Cloudflare Turnstile and other challenge systems
         domStorageEnabled: true,
@@ -791,6 +903,16 @@ class WebViewFactory {
             }
             return null;
           });
+          // iOS sub-resource blocking: per-URL check from JS interceptor
+          if (!Platform.isAndroid && config.dnsBlockEnabled) {
+            controller.addJavaScriptHandler(handlerName: 'dnsCheck', callback: (args) {
+              if (args.isEmpty || args[0] is! String) return false;
+              final url = args[0] as String;
+              final blocked = DnsBlockService.instance.isBlocked(url);
+              DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
+              return blocked;
+            });
+          }
         }
         userScriptService.registerHandlers(controller);
         // If we loaded cached HTML, navigate to the real URL when online

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -199,6 +199,8 @@ class WebViewConfig {
   /// Unique key to force widget recreation when settings change.
   /// When this key changes, Flutter will create a new widget state.
   final Key? key;
+  /// Site ID for per-site DNS statistics tracking.
+  final String? siteId;
   final String initialUrl;
   final bool javascriptEnabled;
   final String? userAgent;
@@ -240,6 +242,7 @@ class WebViewConfig {
 
   WebViewConfig({
     this.key,
+    this.siteId,
     required this.initialUrl,
     this.javascriptEnabled = true,
     this.userAgent,
@@ -745,8 +748,14 @@ class WebViewFactory {
         if (_shouldBlockUrl(url)) return inapp.NavigationActionPolicy.CANCEL;
         if (isCaptchaChallenge(url)) return inapp.NavigationActionPolicy.ALLOW;
         // DNS blocklist check
-        if (config.dnsBlockEnabled && DnsBlockService.instance.isBlocked(url)) {
-          return inapp.NavigationActionPolicy.CANCEL;
+        if (config.dnsBlockEnabled && DnsBlockService.instance.hasBlocklist) {
+          final blocked = DnsBlockService.instance.isBlocked(url);
+          if (config.siteId != null) {
+            DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
+          }
+          if (blocked) {
+            return inapp.NavigationActionPolicy.CANCEL;
+          }
         }
         // Content blocker domain check
         if (config.contentBlockEnabled && ContentBlockerService.instance.isBlocked(url)) {

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -757,7 +758,8 @@ class WebViewFactory {
     return false;
   }
 
-  // Per-site domain result cache (LRU-ish: evict oldest when full)
+  // Per-site domain result cache (LRU-ish: evict oldest when full).
+  // Restored from Dart persistence on startup, sent back on page load.
   var allowedCache = {};
   var blockedCache = {};
   var cacheKeys = [];
@@ -773,6 +775,14 @@ class WebViewFactory {
       delete blockedCache[old];
     }
   }
+
+  // Expose a snapshot for Dart to persist
+  window.__dnsCacheSnapshot = function() {
+    var snap = {};
+    for (var h in allowedCache) snap[h] = false;
+    for (var h in blockedCache) snap[h] = true;
+    return snap;
+  };
 
   function check(url) {
     if (!url || typeof url !== 'string' || !url.startsWith('http')) {
@@ -799,7 +809,7 @@ class WebViewFactory {
     });
   }
 
-  // Fetch Bloom filter from Dart once at startup
+  // Fetch Bloom filter + persisted per-site cache from Dart at startup
   function loadBloom() {
     if (!window.flutter_inappwebview || !window.flutter_inappwebview.callHandler) {
       setTimeout(loadBloom, 50);
@@ -811,6 +821,15 @@ class WebViewFactory {
       bloomBits = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
       bloomBitCount = map.bitCount;
       bloomK = map.k;
+      // Restore persisted per-site cache
+      var persisted = map.cache;
+      if (persisted) {
+        for (var h in persisted) {
+          if (persisted[h]) blockedCache[h] = 1;
+          else allowedCache[h] = 1;
+          cacheKeys.push(h);
+        }
+      }
       bloomReady = true;
     });
   }
@@ -998,9 +1017,11 @@ class WebViewFactory {
               DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
               return blocked;
             });
-            // One-shot bloom filter delivery to JS for fast prefiltering
+            // One-shot bloom filter + persisted cache delivery to JS
             controller.addJavaScriptHandler(handlerName: 'getDnsBloom', callback: (args) {
-              return DnsBlockService.instance.getBloomFilter().toMap();
+              final map = Map<String, dynamic>.from(DnsBlockService.instance.getBloomFilter().toMap());
+              map['cache'] = DnsBlockService.instance.getCacheForSite(config.siteId!);
+              return map;
             });
           }
         }
@@ -1171,6 +1192,22 @@ class WebViewFactory {
             }
           }
           await userScriptService.reinjectOnLoadStop(controller);
+          // Persist the JS DNS cache for this site (iOS only)
+          if (!Platform.isAndroid
+              && config.siteId != null
+              && config.dnsBlockEnabled
+              && DnsBlockService.instance.hasBlocklist) {
+            try {
+              final result = await controller.evaluateJavascript(
+                source: 'JSON.stringify(window.__dnsCacheSnapshot ? window.__dnsCacheSnapshot() : {})',
+              );
+              if (result is String) {
+                final decoded = jsonDecode(result) as Map<String, dynamic>;
+                final cache = decoded.map((k, v) => MapEntry(k, v as bool));
+                await DnsBlockService.instance.setCacheForSite(config.siteId!, cache);
+              }
+            } catch (_) {}
+          }
           // Cache HTML for offline viewing
           if (config.onHtmlLoaded != null) {
             try {

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -710,8 +710,9 @@ class WebViewFactory {
       ));
     }
 
-    // iOS DNS sub-resource blocking: intercepts fetch/XHR/src setters and
-    // checks each URL via Dart roundtrip (Android uses native FastDnsBlockerHandler).
+    // iOS DNS sub-resource blocking: JS interceptor with Bloom-filter
+    // prefilter. Bloom filter check is pure JS (microseconds). Only
+    // ~0.1% of allowed URLs trigger a Dart roundtrip for confirmation.
     if (!Platform.isAndroid
         && config.siteId != null
         && config.dnsBlockEnabled
@@ -720,6 +721,42 @@ class WebViewFactory {
         groupName: 'dns_js_blocker',
         source: '''
 (function() {
+  var bloomReady = false;
+  var bloomBits = null;
+  var bloomBitCount = 0;
+  var bloomK = 0;
+
+  // FNV-1a 32-bit hash, matching Dart implementation
+  function fnv1a(s, seed) {
+    var h = seed >>> 0;
+    for (var i = 0; i < s.length; i++) {
+      h ^= s.charCodeAt(i);
+      h = Math.imul(h, 16777619) >>> 0;
+    }
+    return h >>> 0;
+  }
+
+  function bloomContains(s) {
+    if (!bloomReady) return true; // safe default while loading: ask Dart
+    var h1 = fnv1a(s, 0x811C9DC5);
+    var h2 = fnv1a(s, 0xCBF29CE4);
+    for (var i = 0; i < bloomK; i++) {
+      var pos = ((h1 + i * h2) >>> 0) % bloomBitCount;
+      if ((bloomBits[pos >> 3] & (1 << (pos & 7))) === 0) return false;
+    }
+    return true;
+  }
+
+  // Hierarchy walk-up: check host, then each parent suffix
+  function maybeBlocked(host) {
+    if (bloomContains(host)) return true;
+    var parts = host.split('.');
+    for (var i = 1; i < parts.length - 1; i++) {
+      if (bloomContains(parts.slice(i).join('.'))) return true;
+    }
+    return false;
+  }
+
   function check(url) {
     if (!url || typeof url !== 'string' || !url.startsWith('http')) {
       return Promise.resolve(false);
@@ -727,8 +764,34 @@ class WebViewFactory {
     if (!window.flutter_inappwebview || !window.flutter_inappwebview.callHandler) {
       return Promise.resolve(false);
     }
+    var host;
+    try { host = new URL(url).hostname; } catch (e) { return Promise.resolve(false); }
+    // Bloom prefilter: if definitely not in set, allow without roundtrip
+    if (!maybeBlocked(host)) {
+      // Still record the allowed request fire-and-forget
+      window.flutter_inappwebview.callHandler('dnsResourceLoaded', url);
+      return Promise.resolve(false);
+    }
+    // Possibly blocked — confirm via Dart (handles false positives + records)
     return window.flutter_inappwebview.callHandler('dnsCheck', url);
   }
+
+  // Fetch Bloom filter from Dart once at startup
+  function loadBloom() {
+    if (!window.flutter_inappwebview || !window.flutter_inappwebview.callHandler) {
+      setTimeout(loadBloom, 50);
+      return;
+    }
+    window.flutter_inappwebview.callHandler('getDnsBloom').then(function(map) {
+      if (!map) return;
+      var bytes = map.bits;
+      bloomBits = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+      bloomBitCount = map.bitCount;
+      bloomK = map.k;
+      bloomReady = true;
+    });
+  }
+  loadBloom();
 
   // fetch
   var origFetch = window.fetch;
@@ -911,6 +974,10 @@ class WebViewFactory {
               final blocked = DnsBlockService.instance.isBlocked(url);
               DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
               return blocked;
+            });
+            // One-shot bloom filter delivery to JS for fast prefiltering
+            controller.addJavaScriptHandler(handlerName: 'getDnsBloom', callback: (args) {
+              return DnsBlockService.instance.getBloomFilter().toMap();
             });
           }
         }

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -436,6 +436,7 @@ class WebViewModel {
       webview = WebViewFactory.createWebView(
         config: WebViewConfig(
           key: UniqueKey(), // Force new widget state when recreating
+          siteId: siteId,
           initialUrl: currentUrl,
           javascriptEnabled: javascriptEnabled,
           userAgent: userAgent.isNotEmpty ? userAgent : null,

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -399,7 +399,7 @@ class WebViewModel {
   }
 
   Widget getWebView(
-    Function(String url, {String? homeTitle, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required String? language}) launchUrlFunc,
+    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required String? language}) launchUrlFunc,
     CookieManager cookieManager,
     Function saveFunc, {
     Future<void> Function(int windowId, String url)? onWindowRequested,
@@ -511,7 +511,7 @@ class WebViewModel {
 
             // Open in nested webview with home site title
             LogService.instance.log('WebView', '  -> CANCEL (opening nested webview)');
-            launchUrlFunc(url, homeTitle: name, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, language: this.language);
+            launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, language: this.language);
             return false; // Cancel
           },
           onUrlChanged: (url) async {
@@ -557,7 +557,7 @@ class WebViewModel {
               LogService.instance.log('WebView', 'onUrlChanged: cross-domain redirect detected: $url (expected domain: $initDomain)');
               // Open in nested webview if this site is active
               if (isActive == null || isActive()) {
-                launchUrlFunc(url, homeTitle: name, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, language: this.language);
+                launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, language: this.language);
               }
               return;
             }
@@ -647,7 +647,7 @@ class WebViewModel {
   }
 
   WebViewController? getController(
-    Function(String url, {String? homeTitle, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required String? language}) launchUrlFunc,
+    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required String? language}) launchUrlFunc,
     CookieManager cookieManager,
     Function saveFunc, {
     List<UserScriptConfig> globalUserScripts = const [],

--- a/lib/widgets/dns_block_banner.dart
+++ b/lib/widgets/dns_block_banner.dart
@@ -39,12 +39,12 @@ class _DnsBlockBannerState extends State<DnsBlockBanner> {
 
   @override
   Widget build(BuildContext context) {
-    if (!widget.dnsBlockEnabled || !DnsBlockService.instance.hasBlocklist) {
+    if (!DnsBlockService.instance.hasBlocklist) {
       return const SizedBox.shrink();
     }
 
     final stats = DnsBlockService.instance.statsForSite(widget.siteId);
-    if (stats.blocked == 0) {
+    if (stats.total == 0) {
       return const SizedBox.shrink();
     }
 

--- a/lib/widgets/dns_block_banner.dart
+++ b/lib/widgets/dns_block_banner.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:webspace/services/dns_block_service.dart';
+
+/// A compact banner displayed at the top of the webview showing live DNS
+/// blocking activity. Shows recently blocked domains and per-site stats.
+/// Taps expand/collapse the banner. Automatically hides when no blocks occur.
+class DnsBlockBanner extends StatefulWidget {
+  final String siteId;
+  final bool dnsBlockEnabled;
+
+  const DnsBlockBanner({
+    super.key,
+    required this.siteId,
+    required this.dnsBlockEnabled,
+  });
+
+  @override
+  State<DnsBlockBanner> createState() => _DnsBlockBannerState();
+}
+
+class _DnsBlockBannerState extends State<DnsBlockBanner> {
+  bool _expanded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    DnsBlockService.instance.addDnsLogListener(_onUpdate);
+  }
+
+  @override
+  void dispose() {
+    DnsBlockService.instance.removeDnsLogListener(_onUpdate);
+    super.dispose();
+  }
+
+  void _onUpdate() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.dnsBlockEnabled || !DnsBlockService.instance.hasBlocklist) {
+      return const SizedBox.shrink();
+    }
+
+    final stats = DnsBlockService.instance.statsForSite(widget.siteId);
+    if (stats.blocked == 0) {
+      return const SizedBox.shrink();
+    }
+
+    // Get the most recent blocked domains (unique, up to 5)
+    final recentBlocked = <String>[];
+    for (int i = stats.log.length - 1; i >= 0 && recentBlocked.length < 5; i--) {
+      final entry = stats.log[i];
+      if (entry.blocked && !recentBlocked.contains(entry.domain)) {
+        recentBlocked.add(entry.domain);
+      }
+    }
+
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final bgColor = isDark
+        ? Colors.red.shade900.withAlpha(180)
+        : Colors.red.shade50;
+    final textColor = isDark ? Colors.red.shade100 : Colors.red.shade800;
+    final subtleColor = isDark ? Colors.red.shade200 : Colors.red.shade600;
+
+    return GestureDetector(
+      onTap: () => setState(() => _expanded = !_expanded),
+      child: AnimatedSize(
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeInOut,
+        alignment: Alignment.topCenter,
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: bgColor,
+            border: Border(
+              bottom: BorderSide(
+                color: isDark ? Colors.red.shade700 : Colors.red.shade200,
+                width: 0.5,
+              ),
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                children: [
+                  Icon(Icons.shield, size: 14, color: textColor),
+                  const SizedBox(width: 6),
+                  Text(
+                    '${stats.blocked} blocked',
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      color: textColor,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    '${stats.allowed} allowed',
+                    style: TextStyle(fontSize: 11, color: subtleColor),
+                  ),
+                  const Spacer(),
+                  Icon(
+                    _expanded
+                        ? Icons.keyboard_arrow_up
+                        : Icons.keyboard_arrow_down,
+                    size: 16,
+                    color: subtleColor,
+                  ),
+                ],
+              ),
+              if (_expanded) ...[
+                const SizedBox(height: 4),
+                ...recentBlocked.map((domain) => Padding(
+                      padding: const EdgeInsets.only(left: 20, top: 1),
+                      child: Row(
+                        children: [
+                          Icon(Icons.block, size: 11, color: subtleColor),
+                          const SizedBox(width: 4),
+                          Flexible(
+                            child: Text(
+                              domain,
+                              style: TextStyle(
+                                fontFamily: 'monospace',
+                                fontSize: 10,
+                                color: subtleColor,
+                              ),
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
+                      ),
+                    )),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/dns_block_banner.dart
+++ b/lib/widgets/dns_block_banner.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:webspace/services/dns_block_service.dart';
 
@@ -20,24 +22,26 @@ class DnsBlockBanner extends StatefulWidget {
 
 class _DnsBlockBannerState extends State<DnsBlockBanner> {
   bool _expanded = false;
+  Timer? _refreshTimer;
+  int _lastTotal = 0;
 
   @override
   void initState() {
     super.initState();
-    DnsBlockService.instance.addDnsLogListener(_onUpdate);
+    _refreshTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (!mounted) return;
+      final stats = DnsBlockService.instance.statsForSite(widget.siteId);
+      if (stats.total != _lastTotal) {
+        _lastTotal = stats.total;
+        setState(() {});
+      }
+    });
   }
 
   @override
   void dispose() {
-    DnsBlockService.instance.removeDnsLogListener(_onUpdate);
+    _refreshTimer?.cancel();
     super.dispose();
-  }
-
-  void _onUpdate() {
-    if (mounted) {
-      setState(() {});
-      WidgetsBinding.instance.scheduleFrame();
-    }
   }
 
   @override

--- a/lib/widgets/dns_block_banner.dart
+++ b/lib/widgets/dns_block_banner.dart
@@ -34,7 +34,10 @@ class _DnsBlockBannerState extends State<DnsBlockBanner> {
   }
 
   void _onUpdate() {
-    if (mounted) setState(() {});
+    if (mounted) {
+      setState(() {});
+      WidgetsBinding.instance.scheduleFrame();
+    }
   }
 
   @override

--- a/lib/widgets/dns_block_banner.dart
+++ b/lib/widgets/dns_block_banner.dart
@@ -60,10 +60,10 @@ class _DnsBlockBannerState extends State<DnsBlockBanner> {
     final theme = Theme.of(context);
     final isDark = theme.brightness == Brightness.dark;
     final bgColor = isDark
-        ? Colors.red.shade900.withAlpha(180)
-        : Colors.red.shade50;
-    final textColor = isDark ? Colors.red.shade100 : Colors.red.shade800;
-    final subtleColor = isDark ? Colors.red.shade200 : Colors.red.shade600;
+        ? Colors.grey.shade900.withAlpha(200)
+        : Colors.grey.shade100;
+    final textColor = isDark ? Colors.grey.shade300 : Colors.grey.shade700;
+    final subtleColor = isDark ? Colors.grey.shade400 : Colors.grey.shade500;
 
     return GestureDetector(
       onTap: () => setState(() => _expanded = !_expanded),
@@ -78,7 +78,7 @@ class _DnsBlockBannerState extends State<DnsBlockBanner> {
             color: bgColor,
             border: Border(
               bottom: BorderSide(
-                color: isDark ? Colors.red.shade700 : Colors.red.shade200,
+                color: isDark ? Colors.grey.shade700 : Colors.grey.shade300,
                 width: 0.5,
               ),
             ),

--- a/openspec/specs/clearurls/spec.md
+++ b/openspec/specs/clearurls/spec.md
@@ -66,7 +66,7 @@ Downloaded rules SHALL be cached on disk and loaded at app startup without netwo
 
 ### Requirement: CURL-003 - Query Parameter Stripping
 
-The system SHALL strip query parameters matching provider rules from URLs during navigation.
+The system SHALL strip query parameters matching provider rules from URLs during navigation. Cleaning is applied ONLY to navigation-level requests via `shouldOverrideUrlLoading` — sub-resource requests (`<script>`, `<img>`, `<link>`), `fetch()`, and `XMLHttpRequest` are NOT cleaned, as stripping query parameters from API endpoints or resource URLs would risk breaking site functionality.
 
 #### Scenario: Strip utm parameters
 
@@ -288,13 +288,15 @@ For each provider whose `urlPattern` matches the URL:
 
 ### Hook Point in WebView
 
-ClearURL cleaning is inserted in `shouldOverrideUrlLoading` in `WebViewFactory.createWebView()`, after the blocked URL check and captcha allowlist, but before the per-site domain navigation callback:
+ClearURL cleaning is inserted in `shouldOverrideUrlLoading` in `WebViewFactory.createWebView()`, after the DNS blocklist check and captcha allowlist, but before the per-site domain navigation callback:
 
 ```dart
 shouldOverrideUrlLoading: (controller, navigationAction) async {
   final url = navigationAction.request.url.toString();
   if (_shouldBlockUrl(url)) return CANCEL;
   if (_isCaptchaChallenge(url)) return ALLOW;
+  // DNS blocklist check ...
+  // Content blocker check ...
   // ClearURLs processing
   if (config.clearUrlEnabled && ClearUrlService.instance.hasRules) {
     final cleanedUrl = ClearUrlService.instance.cleanUrl(url);
@@ -309,6 +311,17 @@ shouldOverrideUrlLoading: (controller, navigationAction) async {
 ```
 
 No redirect loops occur because `cleanUrl()` is idempotent — a cleaned URL produces the same output when cleaned again.
+
+#### Scope: What ClearURLs does and does NOT clean
+
+| Request type | Cleaned? | Reason |
+|---|---|---|
+| Navigation (link clicks, typed URLs, redirects) | Yes | Primary use case — user-facing URLs |
+| Shared/copied URLs (clipboard, Web Share API) | Yes | Via injected JS (`_clearUrlShareScript`) |
+| Sub-resources (`<script>`, `<img>`, `<link>`) | No | Stripping params would break resource loading |
+| `fetch()` API calls | No | API endpoints need their query parameters |
+| `XMLHttpRequest` calls | No | Same as fetch — would break API calls |
+| `navigator.sendBeacon()` | No | Analytics beacons — params are the payload |
 
 ### Clipboard/Share URL Cleaning
 

--- a/openspec/specs/dns-blocklist/spec.md
+++ b/openspec/specs/dns-blocklist/spec.md
@@ -255,16 +255,34 @@ Instead, iOS uses a JavaScript interceptor injected at `DOCUMENT_START`:
   elements (e.g., `<img src="tracker.com">` in initial HTML), clears the src
   attribute and removes the element if blocked
 
-To minimize Dart roundtrips, a Bloom filter built from the blocked domains is
-sent to JS once at startup (~1 MB for 588K domains, 0.1% false positive rate).
-The JS interceptor checks each URL host against the Bloom filter first:
+To minimize Dart roundtrips, the iOS interceptor uses three tiers:
 
-- Bloom says "definitely not" → allow without roundtrip (record only, fire-and-forget)
-- Bloom says "possibly yes" → roundtrip to Dart `dnsCheck` handler for confirmation
+**1. Per-site domain cache (JS Map)** — instant lookup:
+Each webview maintains `allowedCache` and `blockedCache` maps keyed by host.
+Capped at 500 entries with FIFO eviction. On page load (`onLoadStop`), Dart
+snapshots the cache via JS `__dnsCacheSnapshot()` and persists it in
+SharedPreferences under `dns_per_site_cache` keyed by siteId. On webview
+creation, the persisted cache is sent alongside the Bloom filter and hydrated
+in JS. Result: revisited sites skip the Bloom filter check AND the Dart
+roundtrip for known domains. Cache is cleared when the blocklist changes
+(stale entries could be incorrect).
 
-Roughly 99.9% of allowed URLs skip the Dart roundtrip entirely. Only blocked
-URLs and ~0.1% of allowed URLs (false positives) hit Dart. Dart does the
-proper O(1) HashSet lookup with hierarchy walk-up and records the request.
+**2. Bloom filter (JS byte array)** — microsecond lookup:
+Built from the blocked domains (~430 KB for 588K domains at 5% false positive
+rate). Sent to JS once on webview creation. Uses FNV-1a hash with
+Kirsch-Mitzenmacher double-hashing for k hash functions. JS implementation
+byte-compatible with Dart `BloomFilter` class.
+
+- Bloom says "definitely not" → allow without roundtrip, record via `dnsResourceLoaded`, add to JS cache
+- Bloom says "possibly yes" → roundtrip to Dart `dnsCheck` handler for confirmation, add result to JS cache
+
+**3. Dart authoritative check** — handles false positives + blocks:
+Only ~5% of first-time allowed URLs + all blocked URLs hit Dart. Dart does
+the proper O(1) HashSet lookup with hierarchy walk-up and records the request.
+
+On a typical page with 50 unique domains: ~47 pass the Bloom filter instantly,
+~3 trigger Dart roundtrips (bloom false positives, cached after). Second page
+load on same site: 0 roundtrips (all cached, persisted to disk).
 
 **Catches:** `fetch()`, `XMLHttpRequest`, dynamically created resource elements,
 property-set src/href, elements inserted into DOM after script runs.

--- a/openspec/specs/dns-blocklist/spec.md
+++ b/openspec/specs/dns-blocklist/spec.md
@@ -255,9 +255,16 @@ Instead, iOS uses a JavaScript interceptor injected at `DOCUMENT_START`:
   elements (e.g., `<img src="tracker.com">` in initial HTML), clears the src
   attribute and removes the element if blocked
 
-Each URL check is a `callHandler('dnsCheck', url)` roundtrip to Dart, which does
-O(1) HashSet lookup in `DnsBlockService.isBlocked()`. Dart also records the
-request for stats.
+To minimize Dart roundtrips, a Bloom filter built from the blocked domains is
+sent to JS once at startup (~1 MB for 588K domains, 0.1% false positive rate).
+The JS interceptor checks each URL host against the Bloom filter first:
+
+- Bloom says "definitely not" → allow without roundtrip (record only, fire-and-forget)
+- Bloom says "possibly yes" → roundtrip to Dart `dnsCheck` handler for confirmation
+
+Roughly 99.9% of allowed URLs skip the Dart roundtrip entirely. Only blocked
+URLs and ~0.1% of allowed URLs (false positives) hit Dart. Dart does the
+proper O(1) HashSet lookup with hierarchy walk-up and records the request.
 
 **Catches:** `fetch()`, `XMLHttpRequest`, dynamically created resource elements,
 property-set src/href, elements inserted into DOM after script runs.

--- a/openspec/specs/dns-blocklist/spec.md
+++ b/openspec/specs/dns-blocklist/spec.md
@@ -596,8 +596,13 @@ The `DnsBlockPlugin` manages the lifecycle:
 1. `setBlockedDomains` — receives domain list from Dart, stores in Java `HashSet`
 2. `attachToWebViews(siteId)` — traverses view hierarchy, finds `InAppWebView`
    instances, replaces `contentBlockerHandler` field with `FastDnsBlockerHandler`
-3. `onDnsBlocked(siteId, host)` — reports blocked domains back to Dart via
-   MethodChannel for DNS stats (each handler has its own siteId)
+3. **Pull-based event delivery** — Java accumulates blocked events in a
+   per-site list. On first block, signals Dart via `dnsBlockedReady(siteId)`
+   (siteId-only payload, no data). If more blocks arrive while the signal is
+   in flight, they silently append to the list — no duplicate signals. Dart
+   responds to the signal by calling `fetchBlocked(siteId)`, which atomically
+   drains the list and returns it. This coalesces bursts of blocked events
+   into a single MethodChannel roundtrip, regardless of how many fire.
 
 **Critical constraint:** `useShouldInterceptRequest` must be `false` (or only
 enabled for LocalCDN). When true, the Dart callback runs and returns early,

--- a/openspec/specs/dns-blocklist/spec.md
+++ b/openspec/specs/dns-blocklist/spec.md
@@ -206,7 +206,7 @@ App Settings SHALL display when the blocklist was last downloaded, along with th
 
 ### Requirement: DNS-008 - Request Interception Hooks
 
-DNS blocking and recording uses multiple hooks to cover different request types. Each hook has different platform support and capabilities.
+The system SHALL use multiple interception hooks to block and record DNS requests across different request types and platforms. Each hook has different platform support and capabilities.
 
 #### Hook: shouldOverrideUrlLoading (all platforms)
 

--- a/openspec/specs/dns-blocklist/spec.md
+++ b/openspec/specs/dns-blocklist/spec.md
@@ -499,6 +499,80 @@ The per-site settings screen SHALL display a compact DNS stats summary below the
 
 ---
 
+### Requirement: DNS-016 - Global Domain Decision Cache
+
+The system SHALL maintain a single global cache of blocked/allowed decisions
+keyed by host, shared across all sites and persisted across app restarts.
+Trackers and CDN domains appear on many sites — one site's learning benefits
+all sites. The cache SHALL be invalidated when the blocklist changes.
+
+#### Scenario: Cached decision reused across sites
+
+**Given** site A's webview has previously checked `cdn.example.com` and
+Dart recorded it as allowed
+**When** site B's webview later encounters `cdn.example.com`
+**Then** the decision is served from the global cache without re-checking
+**And** no Dart roundtrip or Bloom filter check is needed on the JS side
+
+#### Scenario: Cache survives app restart
+
+**Given** the global domain cache contains decisions
+**When** the app is restarted
+**Then** the cache is loaded from SharedPreferences (`dns_domain_cache`)
+**And** is available to new webviews on creation
+
+#### Scenario: Cache invalidated on blocklist update
+
+**Given** the user downloads a new blocklist level
+**When** the download completes
+**Then** the global domain cache is cleared
+**And** SharedPreferences key `dns_domain_cache` is removed
+**Because** previously cached decisions may be invalidated by the new list
+
+#### Scenario: Cache size capped
+
+**Given** the cache has grown to 5000 entries
+**When** a new entry is added
+**Then** the oldest (first-inserted) entry is evicted (FIFO)
+
+#### Scenario: Persistence is write-debounced
+
+**Given** many DNS decisions occur in rapid succession
+**When** `recordRequest` is called repeatedly
+**Then** SharedPreferences is written once after a 2-second idle window
+**And** individual writes do not block the recording path
+
+---
+
+### Requirement: DNS-017 - Android Pull-Based Event Delivery
+
+The Android native DNS handler SHALL deliver blocked events to Dart using a
+signal-then-pull pattern: Java accumulates events in per-site lists, signals
+Dart when new events arrive, and Dart pulls the batched list in a single call.
+Duplicate signals SHALL be suppressed while one is in flight.
+
+#### Scenario: Single block signals Dart
+
+**Given** a sub-resource request is blocked by `FastDnsBlockerHandler`
+**When** the block is recorded
+**Then** Dart receives a `dnsBlockedReady` method call with the siteId only
+(no event data in the signal payload)
+
+#### Scenario: Burst of blocks coalesced
+
+**Given** 100 sub-resources are blocked within 10ms
+**When** the first block fires the signal
+**Then** subsequent blocks append to the per-site list without firing new signals
+**And** Dart's single `fetchBlocked` call retrieves all 100 events atomically
+
+#### Scenario: Signal repeats after completion
+
+**Given** Dart has completed a `fetchBlocked` call and cleared the list
+**When** a new block occurs
+**Then** a new `dnsBlockedReady` signal is sent
+
+---
+
 ## Implementation Details
 
 ### DnsBlockService Singleton

--- a/openspec/specs/dns-blocklist/spec.md
+++ b/openspec/specs/dns-blocklist/spec.md
@@ -204,11 +204,58 @@ App Settings SHALL display when the blocklist was last downloaded, along with th
 
 ---
 
-### Requirement: DNS-008 - Hook Ordering
+### Requirement: DNS-008 - Request Interception Hooks
 
-The DNS block check SHALL be inserted in `shouldOverrideUrlLoading` AFTER the captcha challenge allowlist and BEFORE ClearURLs processing.
+DNS blocking and recording uses multiple hooks to cover different request types. Each hook has different platform support and capabilities.
 
-#### Scenario: Hook ordering
+#### Hook: shouldOverrideUrlLoading (all platforms)
+
+Fires for navigation-level requests (link clicks, page loads, redirects). Inserted AFTER the captcha challenge allowlist and BEFORE ClearURLs processing. Records all navigations (allowed + blocked). Blocks navigations to blocklisted domains.
+
+**Catches:** Link clicks, typed URLs, redirects, `window.location` changes
+**Does NOT catch:** Sub-resources (`<script>`, `<img>`, `<link>`, CSS, fonts)
+
+#### Hook: shouldInterceptRequest (Android only)
+
+Native Android WebView hook that fires for every network request including sub-resources. Used for blocking sub-resources on Android. May not fire for cached resources depending on Android WebView version.
+
+**Catches:** All network requests (main document + sub-resources)
+**Does NOT catch:** Cached resources (on some WebView versions), requests on iOS/macOS
+
+#### Hook: shouldInterceptFetchRequest (all platforms, JS injection)
+
+Intercepts JavaScript `fetch()` API calls. Records and blocks fetch requests to blocklisted domains.
+
+**Catches:** `fetch()` calls (analytics, API requests, dynamic content loading)
+**Does NOT catch:** `XMLHttpRequest`, static resources, `navigator.sendBeacon()`
+
+#### Hook: shouldInterceptAjaxRequest (all platforms, JS injection)
+
+Intercepts `XMLHttpRequest` calls. Records and blocks XHR requests to blocklisted domains.
+
+**Catches:** `XMLHttpRequest` calls (legacy analytics, AJAX requests)
+**Does NOT catch:** `fetch()`, static resources, `navigator.sendBeacon()`
+
+#### Hook: PerformanceObserver JS injection (all platforms)
+
+Injected at `DOCUMENT_START`, observes the Resource Timing API to record all loaded resources after they complete. Cannot block — recording only. Deduplicates via a `seen` map. Also retroactively reports resources loaded before the observer started via `performance.getEntriesByType()`.
+
+**Catches:** All completed resources: `<script>`, `<img>`, `<link>`, CSS, fonts, `fetch()`, `XMLHttpRequest`, `navigator.sendBeacon()`
+**Does NOT catch:** WebSocket connections, resources inside cross-origin iframes (separate JS context), requests blocked before they complete
+
+#### Summary: Platform coverage
+
+| Request type | Android block | Android record | iOS/macOS block | iOS/macOS record |
+|---|---|---|---|---|
+| Navigation (links, redirects) | shouldOverrideUrlLoading | shouldOverrideUrlLoading | shouldOverrideUrlLoading | shouldOverrideUrlLoading |
+| Static sub-resources (`<script>`, `<img>`, `<link>`) | shouldInterceptRequest | PerformanceObserver | No | PerformanceObserver |
+| `fetch()` API | shouldInterceptFetchRequest | shouldInterceptFetchRequest + PerformanceObserver | shouldInterceptFetchRequest | shouldInterceptFetchRequest + PerformanceObserver |
+| `XMLHttpRequest` | shouldInterceptAjaxRequest | shouldInterceptAjaxRequest + PerformanceObserver | shouldInterceptAjaxRequest | shouldInterceptAjaxRequest + PerformanceObserver |
+| `navigator.sendBeacon()` | No | PerformanceObserver | No | PerformanceObserver |
+| WebSocket | No | No | No | No |
+| Cross-origin iframe resources | No | No | No | No |
+
+#### Scenario: Hook ordering in shouldOverrideUrlLoading
 
 **Given** a URL matches a captcha challenge domain
 **When** `shouldOverrideUrlLoading` is called
@@ -267,14 +314,26 @@ Existing sites without `dnsBlockEnabled` in their stored JSON SHALL default to `
 
 ### Requirement: DNS-012 - Per-Site DNS Statistics
 
-The system SHALL track allowed and blocked DNS request counts per site at runtime, with a log of recent queries.
+The system SHALL track allowed and blocked DNS request counts per site at runtime, with a log of recent queries. Recording happens regardless of whether the per-site DNS blocking toggle is on or off — stats always record when a blocklist is loaded.
 
 #### Scenario: Record DNS requests
 
-**Given** DNS blocking is enabled for a site
-**When** the webview navigates to any URL
-**Then** the request is recorded as allowed or blocked in per-site stats
+**Given** a DNS blocklist is loaded
+**When** the webview loads resources (navigations, scripts, images, fetch/XHR)
+**Then** each request is recorded as allowed or blocked in per-site stats via multiple hooks (see DNS-008)
 **And** the domain, timestamp, and block status are stored in a log (capped at 500 entries)
+
+#### Scenario: Stats recorded even when blocking is off
+
+**Given** a DNS blocklist is loaded
+**And** DNS blocking is disabled for a site
+**When** the webview loads resources
+**Then** requests are still recorded (with blocked=true for domains on the list, even though they were not actually blocked)
+
+#### Scenario: Duplicate recording
+
+**Given** the same URL is intercepted by multiple hooks (e.g., PerformanceObserver and shouldInterceptFetchRequest)
+**Then** duplicate entries may appear in the log — this is expected and reflects the actual request pipeline
 
 #### Scenario: Stats not persisted
 
@@ -290,21 +349,20 @@ The system SHALL track allowed and blocked DNS request counts per site at runtim
 
 ---
 
-### Requirement: DNS-013 - Live Blocked-Domains Banner
+### Requirement: DNS-013 - Live DNS Activity Banner
 
-A collapsible banner SHALL appear at the top of the webview showing live DNS blocking activity for the active site.
+A collapsible banner SHALL appear at the top of the webview showing live DNS activity for the active site. The banner uses subtle grey styling (not alarming red) and can be toggled off in App Settings.
 
-#### Scenario: Banner visible when blocks occur
+#### Scenario: Banner visible when queries recorded
 
-**Given** DNS blocking is enabled for a site
-**And** at least one request has been blocked
+**Given** a DNS blocklist is loaded
+**And** at least one DNS query has been recorded for the site
 **When** the user views the site
-**Then** a compact banner at the top shows blocked and allowed counts
+**Then** a compact grey banner at the top shows blocked and allowed counts
 
-#### Scenario: Banner hidden when no blocks
+#### Scenario: Banner hidden when no queries
 
-**Given** DNS blocking is enabled for a site
-**And** no requests have been blocked
+**Given** no DNS queries have been recorded for the site
 **When** the user views the site
 **Then** no banner is shown
 
@@ -314,10 +372,17 @@ A collapsible banner SHALL appear at the top of the webview showing live DNS blo
 **When** the user taps it
 **Then** it expands to show the 5 most recently blocked domains (unique, monospace)
 
-#### Scenario: Banner hidden when DNS blocking disabled
+#### Scenario: Toggle banner off in App Settings
 
-**Given** DNS blocking is disabled for a site
-**When** the user views the site
+**Given** the user opens App Settings
+**When** the user disables the "DNS Block Banner" toggle
+**Then** the banner is hidden for all sites
+**And** the setting persists across app restarts
+
+#### Scenario: Banner hidden when no blocklist
+
+**Given** no DNS blocklist has been downloaded
+**When** the user views any site
 **Then** no banner is shown
 
 ---
@@ -448,27 +513,42 @@ class DnsStats {
 
 A listener pattern (`addDnsLogListener`/`removeDnsLogListener`) notifies UI widgets of new log entries for live updates.
 
-### Hook Point in WebView
+### Multi-Hook Request Interception
 
-DNS blocking is inserted in `shouldOverrideUrlLoading` in `WebViewFactory.createWebView()`. Each request is recorded for statistics:
+DNS blocking and recording uses five complementary hooks in `WebViewFactory.createWebView()`:
 
+**1. shouldOverrideUrlLoading** (all platforms) — navigation blocking + recording:
 ```dart
-shouldOverrideUrlLoading: (controller, navigationAction) async {
-  final url = navigationAction.request.url.toString();
-  if (_shouldBlockUrl(url)) return CANCEL;
-  if (_isCaptchaChallenge(url)) return ALLOW;
-  // DNS blocklist check + statistics recording
-  if (config.dnsBlockEnabled && DnsBlockService.instance.hasBlocklist) {
-    final blocked = DnsBlockService.instance.isBlocked(url);
-    if (config.siteId != null) {
-      DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
-    }
-    if (blocked) return CANCEL;
-  }
-  // ClearURLs processing
-  // ... per-site navigation callback
+if (DnsBlockService.instance.hasBlocklist) {
+  final blocked = DnsBlockService.instance.isBlocked(url);
+  DnsBlockService.instance.recordRequest(siteId, url, blocked);
+  if (blocked && config.dnsBlockEnabled) return CANCEL;
 }
 ```
+
+**2. shouldInterceptRequest** (Android only) — sub-resource blocking:
+```dart
+if (DnsBlockService.instance.isBlocked(url)) {
+  DnsBlockService.instance.recordRequest(siteId, url, true);
+  return WebResourceResponse(statusCode: 403, data: empty);
+}
+```
+
+**3. shouldInterceptFetchRequest** (all platforms) — fetch() blocking + recording:
+```dart
+final blocked = DnsBlockService.instance.isBlocked(url);
+DnsBlockService.instance.recordRequest(siteId, url, blocked);
+if (blocked) fetchRequest.action = ABORT;
+```
+
+**4. shouldInterceptAjaxRequest** (all platforms) — XHR blocking + recording:
+Same pattern as fetch, with `ajaxRequest.action = ABORT`.
+
+**5. PerformanceObserver JS injection** (all platforms) — record-only fallback:
+Injected at `DOCUMENT_START`, observes Resource Timing API entries and calls
+back to Dart via `addJavaScriptHandler('dnsResourceLoaded')`. Catches all
+completed resources including those missed by native hooks (e.g., cached
+resources, `navigator.sendBeacon()`).
 
 ### Storage
 

--- a/openspec/specs/dns-blocklist/spec.md
+++ b/openspec/specs/dns-blocklist/spec.md
@@ -257,15 +257,21 @@ Instead, iOS uses a JavaScript interceptor injected at `DOCUMENT_START`:
 
 To minimize Dart roundtrips, the iOS interceptor uses three tiers:
 
-**1. Per-site domain cache (JS Map)** — instant lookup:
-Each webview maintains `allowedCache` and `blockedCache` maps keyed by host.
-Capped at 500 entries with FIFO eviction. On page load (`onLoadStop`), Dart
-snapshots the cache via JS `__dnsCacheSnapshot()` and persists it in
-SharedPreferences under `dns_per_site_cache` keyed by siteId. On webview
-creation, the persisted cache is sent alongside the Bloom filter and hydrated
-in JS. Result: revisited sites skip the Bloom filter check AND the Dart
-roundtrip for known domains. Cache is cleared when the blocklist changes
-(stale entries could be incorrect).
+**1. Global domain cache** — instant lookup:
+Dart maintains a single `_domainCache: Map<String, bool>` keyed by host (NOT
+per-site — trackers and CDNs are shared across sites, so one site learning
+about `googleapis.com` benefits all sites). Updated transparently via
+`recordRequest` whenever any webview reports a DNS decision (via native
+handler, JS `dnsCheck`, or JS `dnsResourceLoaded`). Persisted in
+SharedPreferences under `dns_domain_cache`, write-debounced to 2 seconds.
+Capped at 5000 entries with FIFO eviction. Invalidated (cleared) when the
+blocklist changes, since cached decisions may become stale.
+
+On the JS side (iOS), each webview also maintains `allowedCache` /
+`blockedCache` for instant in-webview lookup without MethodChannel calls.
+Hydrated on webview creation from the Dart global cache via the
+`getDnsBloom` handler (which returns `{bits, bitCount, k, cache}`).
+Capped at 500 entries with FIFO eviction.
 
 **2. Bloom filter (JS byte array)** — microsecond lookup:
 Built from the blocked domains (~430 KB for 588K domains at 5% false positive

--- a/openspec/specs/dns-blocklist/spec.md
+++ b/openspec/specs/dns-blocklist/spec.md
@@ -206,52 +206,46 @@ App Settings SHALL display when the blocklist was last downloaded, along with th
 
 ### Requirement: DNS-008 - Request Interception Hooks
 
-The system SHALL use multiple interception hooks to block and record DNS requests across different request types and platforms. Each hook has different platform support and capabilities.
+The system SHALL use multiple interception hooks to block and record DNS requests across different request types and platforms.
 
-#### Hook: shouldOverrideUrlLoading (all platforms)
+#### Blocking: Native FastDnsBlockerHandler (Android)
+
+On Android, sub-resource blocking runs entirely in Java via a custom `FastDnsBlockerHandler` that subclasses `ContentBlockerHandler`. The handler is injected into each `InAppWebView` by replacing the `contentBlockerHandler` public field. It uses an O(1) `HashSet<String>` lookup with domain hierarchy walk-up — no Dart roundtrip, no regex matching.
+
+The blocked domains are sent to Java once at startup via MethodChannel. Each handler is created with a `siteId` so blocked requests are attributed to the correct site.
+
+**Important constraint:** flutter_inappwebview's `shouldInterceptRequest` Dart callback uses a synchronous blocking platform channel. If `useShouldInterceptRequest` is true, the Dart roundtrip runs first and returns early, **skipping** `contentBlockerHandler` entirely. Therefore `useShouldInterceptRequest` MUST be false (or only enabled when LocalCDN has cached resources).
+
+**Catches:** All sub-resource requests (`<script>`, `<img>`, `<link>`, CSS, fonts, fetch, XHR)
+**Does NOT catch:** Navigations (handled by shouldOverrideUrlLoading), iOS/macOS requests
+
+#### Blocking: shouldOverrideUrlLoading (all platforms)
 
 Fires for navigation-level requests (link clicks, page loads, redirects). Inserted AFTER the captcha challenge allowlist and BEFORE ClearURLs processing. Records all navigations (allowed + blocked). Blocks navigations to blocklisted domains.
 
 **Catches:** Link clicks, typed URLs, redirects, `window.location` changes
-**Does NOT catch:** Sub-resources (`<script>`, `<img>`, `<link>`, CSS, fonts)
+**Does NOT catch:** Sub-resources
 
-#### Hook: shouldInterceptRequest (Android only)
+#### Recording: PerformanceObserver JS injection (all platforms)
 
-Native Android WebView hook that fires for every network request including sub-resources. Used for blocking sub-resources on Android. May not fire for cached resources depending on Android WebView version.
+Injected at `DOCUMENT_START` with `buffered: true`, observes the Resource Timing API to record all loaded resources. Reports URLs back to Dart via `addJavaScriptHandler`. Cannot block — recording only. Deduplicates via a `seen` map in JS.
 
-**Catches:** All network requests (main document + sub-resources)
-**Does NOT catch:** Cached resources (on some WebView versions), requests on iOS/macOS
+**Catches:** All completed resources including blocked ones (browser creates a performance entry even for 403 responses)
+**Does NOT catch:** WebSocket connections, resources inside cross-origin iframes
 
-#### Hook: shouldInterceptFetchRequest (all platforms, JS injection)
+#### Recording: onLoadStart (all platforms)
 
-Intercepts JavaScript `fetch()` API calls. Records and blocks fetch requests to blocklisted domains.
-
-**Catches:** `fetch()` calls (analytics, API requests, dynamic content loading)
-**Does NOT catch:** `XMLHttpRequest`, static resources, `navigator.sendBeacon()`
-
-#### Hook: shouldInterceptAjaxRequest (all platforms, JS injection)
-
-Intercepts `XMLHttpRequest` calls. Records and blocks XHR requests to blocklisted domains.
-
-**Catches:** `XMLHttpRequest` calls (legacy analytics, AJAX requests)
-**Does NOT catch:** `fetch()`, static resources, `navigator.sendBeacon()`
-
-#### Hook: PerformanceObserver JS injection (all platforms)
-
-Injected at `DOCUMENT_START`, observes the Resource Timing API to record all loaded resources after they complete. Cannot block — recording only. Deduplicates via a `seen` map. Also retroactively reports resources loaded before the observer started via `performance.getEntriesByType()`.
-
-**Catches:** All completed resources: `<script>`, `<img>`, `<link>`, CSS, fonts, `fetch()`, `XMLHttpRequest`, `navigator.sendBeacon()`
-**Does NOT catch:** WebSocket connections, resources inside cross-origin iframes (separate JS context), requests blocked before they complete
+Records the page URL when a navigation starts. Ensures the banner shows immediately even for cached HTML loads that bypass shouldOverrideUrlLoading.
 
 #### Summary: Platform coverage
 
 | Request type | Android block | Android record | iOS/macOS block | iOS/macOS record |
 |---|---|---|---|---|
-| Navigation (links, redirects) | shouldOverrideUrlLoading | shouldOverrideUrlLoading | shouldOverrideUrlLoading | shouldOverrideUrlLoading |
-| Static sub-resources (`<script>`, `<img>`, `<link>`) | shouldInterceptRequest | PerformanceObserver | No | PerformanceObserver |
-| `fetch()` API | shouldInterceptFetchRequest | shouldInterceptFetchRequest + PerformanceObserver | shouldInterceptFetchRequest | shouldInterceptFetchRequest + PerformanceObserver |
-| `XMLHttpRequest` | shouldInterceptAjaxRequest | shouldInterceptAjaxRequest + PerformanceObserver | shouldInterceptAjaxRequest | shouldInterceptAjaxRequest + PerformanceObserver |
-| `navigator.sendBeacon()` | No | PerformanceObserver | No | PerformanceObserver |
+| Navigation (links, redirects) | shouldOverrideUrlLoading | shouldOverrideUrlLoading + onLoadStart | shouldOverrideUrlLoading | shouldOverrideUrlLoading + onLoadStart |
+| Static sub-resources (`<script>`, `<img>`, `<link>`) | FastDnsBlockerHandler (Java) | PerformanceObserver | No | PerformanceObserver |
+| `fetch()` API | FastDnsBlockerHandler (Java) | PerformanceObserver | No | PerformanceObserver |
+| `XMLHttpRequest` | FastDnsBlockerHandler (Java) | PerformanceObserver | No | PerformanceObserver |
+| `navigator.sendBeacon()` | FastDnsBlockerHandler (Java) | PerformanceObserver | No | PerformanceObserver |
 | WebSocket | No | No | No | No |
 | Cross-origin iframe resources | No | No | No | No |
 
@@ -513,42 +507,61 @@ class DnsStats {
 
 A listener pattern (`addDnsLogListener`/`removeDnsLogListener`) notifies UI widgets of new log entries for live updates.
 
-### Multi-Hook Request Interception
+### Native Android Sub-Resource Blocking
 
-DNS blocking and recording uses five complementary hooks in `WebViewFactory.createWebView()`:
+flutter_inappwebview's `shouldInterceptRequest` Dart callback uses a synchronous
+blocking platform channel that serializes concurrent sub-resource loads — only ~1
+request gets through to Dart. This makes Dart-side sub-resource blocking impossible.
 
-**1. shouldOverrideUrlLoading** (all platforms) — navigation blocking + recording:
+The solution is `FastDnsBlockerHandler` (`DnsBlockPlugin.kt`), a Kotlin class that
+subclasses `ContentBlockerHandler` and runs entirely in Java:
+
+```kotlin
+class FastDnsBlockerHandler(
+    private val blockedDomains: HashSet<String>,
+    private val onBlocked: (String) -> Unit
+) : ContentBlockerHandler() {
+    init {
+        // Dummy rule so Java guard `ruleList.size() > 0` passes
+        ruleList.add(ContentBlocker(trigger, action))
+    }
+    override fun checkUrl(webView, request): WebResourceResponse? {
+        val host = URI(request.url).host
+        if (isBlockedDomain(host)) {  // O(1) HashSet + hierarchy walk-up
+            onBlocked(host)
+            return WebResourceResponse("text/plain", "utf-8", null)
+        }
+        return null
+    }
+}
+```
+
+The `DnsBlockPlugin` manages the lifecycle:
+1. `setBlockedDomains` — receives domain list from Dart, stores in Java `HashSet`
+2. `attachToWebViews(siteId)` — traverses view hierarchy, finds `InAppWebView`
+   instances, replaces `contentBlockerHandler` field with `FastDnsBlockerHandler`
+3. `onDnsBlocked(siteId, host)` — reports blocked domains back to Dart via
+   MethodChannel for DNS stats (each handler has its own siteId)
+
+**Critical constraint:** `useShouldInterceptRequest` must be `false` (or only
+enabled for LocalCDN). When true, the Dart callback runs and returns early,
+skipping `contentBlockerHandler.checkUrl()` entirely.
+
+### Recording Hooks
+
+**shouldOverrideUrlLoading** (all platforms) — navigation blocking + recording:
 ```dart
 if (DnsBlockService.instance.hasBlocklist) {
-  final blocked = DnsBlockService.instance.isBlocked(url);
   DnsBlockService.instance.recordRequest(siteId, url, blocked);
   if (blocked && config.dnsBlockEnabled) return CANCEL;
 }
 ```
 
-**2. shouldInterceptRequest** (Android only) — sub-resource blocking:
-```dart
-if (DnsBlockService.instance.isBlocked(url)) {
-  DnsBlockService.instance.recordRequest(siteId, url, true);
-  return WebResourceResponse(statusCode: 403, data: empty);
-}
-```
+**onLoadStart** (all platforms) — records page URL for immediate banner display.
 
-**3. shouldInterceptFetchRequest** (all platforms) — fetch() blocking + recording:
-```dart
-final blocked = DnsBlockService.instance.isBlocked(url);
-DnsBlockService.instance.recordRequest(siteId, url, blocked);
-if (blocked) fetchRequest.action = ABORT;
-```
-
-**4. shouldInterceptAjaxRequest** (all platforms) — XHR blocking + recording:
-Same pattern as fetch, with `ajaxRequest.action = ABORT`.
-
-**5. PerformanceObserver JS injection** (all platforms) — record-only fallback:
-Injected at `DOCUMENT_START`, observes Resource Timing API entries and calls
-back to Dart via `addJavaScriptHandler('dnsResourceLoaded')`. Catches all
-completed resources including those missed by native hooks (e.g., cached
-resources, `navigator.sendBeacon()`).
+**PerformanceObserver JS** (all platforms) — injected at `DOCUMENT_START` with
+`buffered: true`, records all completed resources via Resource Timing API.
+Reports back to Dart via `addJavaScriptHandler('dnsResourceLoaded')`.
 
 ### Storage
 
@@ -570,22 +583,22 @@ resources, `navigator.sendBeacon()`).
 
 ### Created
 - `lib/services/dns_block_service.dart` — Singleton service: download, cache, parse, lookup, per-site stats
-- `lib/widgets/dns_block_banner.dart` — Live blocked-domains banner widget for webview overlay
+- `lib/services/dns_block_native.dart` — Dart-side interface for native Android DNS blocker
+- `lib/widgets/dns_block_banner.dart` — Live DNS activity banner widget for webview overlay
+- `android/app/src/main/kotlin/.../DnsBlockPlugin.kt` — Native Android plugin: FastDnsBlockerHandler (Java HashSet), DnsBlockPlugin (MethodChannel + view traversal)
 - `test/dns_block_service_test.dart` — 12 unit tests for domain matching logic
 - `test/dns_block_benchmark_test.dart` — Performance benchmark (522K domains parse + lookup)
 - `openspec/specs/dns-blocklist/spec.md` — This specification
 
 ### Modified
 - `lib/web_view_model.dart` — Added `dnsBlockEnabled` field, serialization, pass to WebViewConfig with `siteId`
-- `lib/services/webview.dart` — Added `dnsBlockEnabled` and `siteId` to WebViewConfig, DNS block hook with stats recording
-- `lib/screens/settings.dart` — Per-site DNS Blocklist toggle (SwitchListTile) with stats summary chips
+- `lib/services/webview.dart` — WebViewConfig with siteId, PerformanceObserver injection, native handler attach
+- `lib/screens/settings.dart` — Per-site DNS Blocklist toggle with stats summary chips
 - `lib/screens/dev_tools.dart` — DNS tab with query log, stats cards, filters, copy/clear actions
-- `lib/screens/app_settings.dart` — Privacy section with slider, download button, spinning icon, domain count
-- `lib/main.dart` — DnsBlockService initialization, GPL-3.0 license registration, DnsBlockBanner in webview stack
+- `lib/screens/app_settings.dart` — Privacy section with slider, download, DNS Block Banner toggle, native domain sync
+- `lib/main.dart` — DnsBlockService + DnsBlockNative initialization, DnsBlockBanner in webview stack
+- `android/app/src/main/kotlin/.../MainActivity.kt` — DnsBlockPlugin registration
 - `test/web_view_model_test.dart` — Tests for dnsBlockEnabled serialization and defaults
-- `README.md` — Feature bullet point, Tech Stack credit
-- `fastlane/metadata/android/en-US/full_description.txt` — Feature mention
-- `fastlane/metadata/android/en-US/changelogs/8.txt` — Changelog entry
 
 ---
 

--- a/openspec/specs/dns-blocklist/spec.md
+++ b/openspec/specs/dns-blocklist/spec.md
@@ -546,30 +546,47 @@ Dart recorded it as allowed
 
 ### Requirement: DNS-017 - Android Pull-Based Event Delivery
 
-The Android native DNS handler SHALL deliver blocked events to Dart using a
-signal-then-pull pattern: Java accumulates events in per-site lists, signals
-Dart when new events arrive, and Dart pulls the batched list in a single call.
-Duplicate signals SHALL be suppressed while one is in flight.
+The Android native DNS handler SHALL deliver DNS events (both blocked and
+allowed) to Dart using a signal-then-pull pattern: Java accumulates events
+in per-site lists, signals Dart when new events arrive, and Dart pulls the
+batched list in a single call. Duplicate signals SHALL be suppressed while
+one is in flight.
 
-#### Scenario: Single block signals Dart
+#### Scenario: Both allowed and blocked events captured
 
-**Given** a sub-resource request is blocked by `FastDnsBlockerHandler`
-**When** the block is recorded
-**Then** Dart receives a `dnsBlockedReady` method call with the siteId only
+**Given** `FastDnsBlockerHandler.checkUrl()` is called for a sub-resource
+**When** the check completes (either allowed or blocked)
+**Then** Java records `{host, blocked}` in the per-site events list
+**And** the page receives a 403 empty response if blocked, or proceeds normally if allowed
+
+#### Scenario: Single event signals Dart
+
+**Given** the events list for a site is empty
+**When** the first event is recorded (allowed or blocked)
+**Then** Dart receives a `dnsEventsReady` method call with the siteId only
 (no event data in the signal payload)
 
-#### Scenario: Burst of blocks coalesced
+#### Scenario: Burst of events coalesced
 
-**Given** 100 sub-resources are blocked within 10ms
-**When** the first block fires the signal
-**Then** subsequent blocks append to the per-site list without firing new signals
-**And** Dart's single `fetchBlocked` call retrieves all 100 events atomically
+**Given** 100 sub-resources are checked within 10ms
+**When** the first event fires the signal
+**Then** subsequent events append to the per-site list without firing new signals
+**And** Dart's single `fetchEvents` call retrieves all 100 events atomically
+(each as `{host, blocked}`)
 
 #### Scenario: Signal repeats after completion
 
-**Given** Dart has completed a `fetchBlocked` call and cleared the list
-**When** a new block occurs
-**Then** a new `dnsBlockedReady` signal is sent
+**Given** Dart has completed a `fetchEvents` call and cleared the list
+**When** a new event occurs
+**Then** a new `dnsEventsReady` signal is sent
+
+#### Scenario: Stats update without PerformanceObserver lag
+
+**Given** a page makes 50 sub-resource requests
+**When** the page loads on Android
+**Then** allowed and blocked counts in the stats banner update in near real-time
+(via the native event pipeline)
+**And** do NOT depend on the PerformanceObserver completion timing
 
 ---
 

--- a/openspec/specs/dns-blocklist/spec.md
+++ b/openspec/specs/dns-blocklist/spec.md
@@ -265,6 +265,119 @@ Existing sites without `dnsBlockEnabled` in their stored JSON SHALL default to `
 
 ---
 
+### Requirement: DNS-012 - Per-Site DNS Statistics
+
+The system SHALL track allowed and blocked DNS request counts per site at runtime, with a log of recent queries.
+
+#### Scenario: Record DNS requests
+
+**Given** DNS blocking is enabled for a site
+**When** the webview navigates to any URL
+**Then** the request is recorded as allowed or blocked in per-site stats
+**And** the domain, timestamp, and block status are stored in a log (capped at 500 entries)
+
+#### Scenario: Stats not persisted
+
+**Given** DNS stats have been recorded for a site
+**When** the app is restarted
+**Then** the stats are reset (runtime-only, not persisted to storage)
+
+#### Scenario: Clear stats
+
+**Given** DNS stats have been recorded for a site
+**When** the user taps "Clear" in the DNS tab of Developer Tools
+**Then** all stats and log entries for that site are reset to zero
+
+---
+
+### Requirement: DNS-013 - Live Blocked-Domains Banner
+
+A collapsible banner SHALL appear at the top of the webview showing live DNS blocking activity for the active site.
+
+#### Scenario: Banner visible when blocks occur
+
+**Given** DNS blocking is enabled for a site
+**And** at least one request has been blocked
+**When** the user views the site
+**Then** a compact banner at the top shows blocked and allowed counts
+
+#### Scenario: Banner hidden when no blocks
+
+**Given** DNS blocking is enabled for a site
+**And** no requests have been blocked
+**When** the user views the site
+**Then** no banner is shown
+
+#### Scenario: Expand banner
+
+**Given** the DNS banner is visible
+**When** the user taps it
+**Then** it expands to show the 5 most recently blocked domains (unique, monospace)
+
+#### Scenario: Banner hidden when DNS blocking disabled
+
+**Given** DNS blocking is disabled for a site
+**When** the user views the site
+**Then** no banner is shown
+
+---
+
+### Requirement: DNS-014 - DNS Query Log in Developer Tools
+
+Developer Tools SHALL include a DNS tab with a Pi-hole-style query log showing all recorded DNS requests.
+
+#### Scenario: DNS tab in Developer Tools
+
+**Given** a DNS blocklist is configured
+**And** the user opens Developer Tools for a site
+**Then** a "DNS" tab with a shield icon is shown
+
+#### Scenario: Stats cards
+
+**Given** DNS requests have been recorded for a site
+**When** the user views the DNS tab
+**Then** four stat cards are shown: Total, Allowed, Blocked, Block %
+
+#### Scenario: Filter by status
+
+**Given** the DNS query log contains both allowed and blocked entries
+**When** the user selects the "Blocked" filter chip
+**Then** only blocked entries are shown
+**And** the "Blocked" chip shows the count
+
+#### Scenario: Search queries
+
+**Given** the DNS query log contains entries
+**When** the user types a domain in the search field
+**Then** only entries matching the search are shown
+
+#### Scenario: Copy log
+
+**Given** DNS entries are recorded
+**When** the user taps "Copy"
+**Then** the full log is copied to the clipboard in `[timestamp] BLOCKED/ALLOWED domain` format
+
+---
+
+### Requirement: DNS-015 - DNS Stats in Site Settings
+
+The per-site settings screen SHALL display a compact DNS stats summary below the DNS Blocklist toggle.
+
+#### Scenario: Stats visible
+
+**Given** DNS blocking is active
+**And** DNS requests have been recorded for the current site
+**When** the user opens site settings
+**Then** a row of stat chips shows total, allowed, blocked counts, and block rate percentage
+
+#### Scenario: Stats hidden when no requests
+
+**Given** no DNS requests have been recorded for the current site
+**When** the user opens site settings
+**Then** no stats row is shown
+
+---
+
 ## Implementation Details
 
 ### DnsBlockService Singleton
@@ -319,18 +432,38 @@ Three mirrors are tried in order with 15-second timeouts:
 2. `https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/`
 3. `https://codeberg.org/hagezi/mirror2/raw/branch/main/dns-blocklists/`
 
+### Per-Site DNS Statistics
+
+`DnsBlockService` tracks per-site statistics via `DnsStats` objects keyed by `siteId`:
+
+```dart
+class DnsStats {
+  int allowed = 0;
+  int blocked = 0;
+  final List<DnsLogEntry> log = [];  // Capped at 500 entries
+  int get total => allowed + blocked;
+  double get blockRate => total > 0 ? blocked / total * 100 : 0;
+}
+```
+
+A listener pattern (`addDnsLogListener`/`removeDnsLogListener`) notifies UI widgets of new log entries for live updates.
+
 ### Hook Point in WebView
 
-DNS blocking is inserted in `shouldOverrideUrlLoading` in `WebViewFactory.createWebView()`:
+DNS blocking is inserted in `shouldOverrideUrlLoading` in `WebViewFactory.createWebView()`. Each request is recorded for statistics:
 
 ```dart
 shouldOverrideUrlLoading: (controller, navigationAction) async {
   final url = navigationAction.request.url.toString();
   if (_shouldBlockUrl(url)) return CANCEL;
   if (_isCaptchaChallenge(url)) return ALLOW;
-  // DNS blocklist check
-  if (config.dnsBlockEnabled && DnsBlockService.instance.isBlocked(url)) {
-    return CANCEL;
+  // DNS blocklist check + statistics recording
+  if (config.dnsBlockEnabled && DnsBlockService.instance.hasBlocklist) {
+    final blocked = DnsBlockService.instance.isBlocked(url);
+    if (config.siteId != null) {
+      DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
+    }
+    if (blocked) return CANCEL;
   }
   // ClearURLs processing
   // ... per-site navigation callback
@@ -356,17 +489,19 @@ shouldOverrideUrlLoading: (controller, navigationAction) async {
 ## Files
 
 ### Created
-- `lib/services/dns_block_service.dart` — Singleton service: download, cache, parse, lookup
+- `lib/services/dns_block_service.dart` — Singleton service: download, cache, parse, lookup, per-site stats
+- `lib/widgets/dns_block_banner.dart` — Live blocked-domains banner widget for webview overlay
 - `test/dns_block_service_test.dart` — 12 unit tests for domain matching logic
 - `test/dns_block_benchmark_test.dart` — Performance benchmark (522K domains parse + lookup)
 - `openspec/specs/dns-blocklist/spec.md` — This specification
 
 ### Modified
-- `lib/web_view_model.dart` — Added `dnsBlockEnabled` field, serialization, pass to WebViewConfig
-- `lib/services/webview.dart` — Added `dnsBlockEnabled` to WebViewConfig, DNS block hook in shouldOverrideUrlLoading
-- `lib/screens/settings.dart` — Per-site DNS Blocklist toggle (SwitchListTile)
+- `lib/web_view_model.dart` — Added `dnsBlockEnabled` field, serialization, pass to WebViewConfig with `siteId`
+- `lib/services/webview.dart` — Added `dnsBlockEnabled` and `siteId` to WebViewConfig, DNS block hook with stats recording
+- `lib/screens/settings.dart` — Per-site DNS Blocklist toggle (SwitchListTile) with stats summary chips
+- `lib/screens/dev_tools.dart` — DNS tab with query log, stats cards, filters, copy/clear actions
 - `lib/screens/app_settings.dart` — Privacy section with slider, download button, spinning icon, domain count
-- `lib/main.dart` — DnsBlockService initialization, GPL-3.0 license registration
+- `lib/main.dart` — DnsBlockService initialization, GPL-3.0 license registration, DnsBlockBanner in webview stack
 - `test/web_view_model_test.dart` — Tests for dnsBlockEnabled serialization and defaults
 - `README.md` — Feature bullet point, Tech Stack credit
 - `fastlane/metadata/android/en-US/full_description.txt` — Feature mention
@@ -418,3 +553,17 @@ Benchmark tests cover:
 8. Set slider to Off (0), tap download, verify "DNS blocklist disabled" SnackBar
 9. Navigate to the previously blocked domain, verify it loads normally
 10. Check Licenses page shows "Hagezi DNS Blocklists (domain data)" with GPL-3.0
+
+#### DNS Transparency Testing
+
+11. With DNS blocking enabled, browse a website that loads third-party trackers
+12. Verify the DNS banner appears at the top showing blocked and allowed counts
+13. Tap the banner to expand it, verify recently blocked domains are shown
+14. Open Developer Tools, switch to the DNS tab
+15. Verify stats cards show Total, Allowed, Blocked, Block % with correct values
+16. Use filter chips to show only blocked or only allowed entries
+17. Search for a specific domain in the query log
+18. Tap "Copy" and verify the log is copied to clipboard
+19. Tap "Clear" and verify stats and log are reset
+20. Open site Settings, verify DNS stats row appears below the DNS toggle
+21. Disable DNS blocking for the site, verify the banner disappears

--- a/openspec/specs/dns-blocklist/spec.md
+++ b/openspec/specs/dns-blocklist/spec.md
@@ -237,14 +237,45 @@ Injected at `DOCUMENT_START` with `buffered: true`, observes the Resource Timing
 
 Records the page URL when a navigation starts. Ensures the banner shows immediately even for cached HTML loads that bypass shouldOverrideUrlLoading.
 
+#### Blocking: iOS JS Interceptor
+
+iOS/macOS cannot intercept sub-resources natively. WKWebView runs its network
+stack in a separate process and exposes no equivalent to Android's
+`shouldInterceptRequest`. The only native option is `WKContentRuleList`, but it
+has a ~150K rule limit and compilation takes tens of seconds, while even the
+smallest Hagezi blocklist ("Light") is 146K domains.
+
+Instead, iOS uses a JavaScript interceptor injected at `DOCUMENT_START`:
+
+- Overrides `window.fetch` — async check via `dnsCheck` handler, reject if blocked
+- Overrides `XMLHttpRequest.prototype.open`/`send` — abort if blocked
+- Patches `src`/`href` setters on `HTMLImageElement`, `HTMLScriptElement`,
+  `HTMLLinkElement`, `HTMLIFrameElement` — defers the assignment pending the check
+- `MutationObserver` on `document.documentElement` — catches statically-parsed
+  elements (e.g., `<img src="tracker.com">` in initial HTML), clears the src
+  attribute and removes the element if blocked
+
+Each URL check is a `callHandler('dnsCheck', url)` roundtrip to Dart, which does
+O(1) HashSet lookup in `DnsBlockService.isBlocked()`. Dart also records the
+request for stats.
+
+**Catches:** `fetch()`, `XMLHttpRequest`, dynamically created resource elements,
+property-set src/href, elements inserted into DOM after script runs.
+
+**Does NOT catch:** Resources loaded before the interceptor runs (rare at
+DOCUMENT_START), static elements whose load completes before MutationObserver
+fires (the initial request may go out but response is discarded when src is
+cleared — some privacy leak), WebSocket, cross-origin iframe contents,
+`navigator.sendBeacon()` (can be added).
+
 #### Summary: Platform coverage
 
 | Request type | Android block | Android record | iOS/macOS block | iOS/macOS record |
 |---|---|---|---|---|
 | Navigation (links, redirects) | shouldOverrideUrlLoading | shouldOverrideUrlLoading + onLoadStart | shouldOverrideUrlLoading | shouldOverrideUrlLoading + onLoadStart |
-| Static sub-resources (`<script>`, `<img>`, `<link>`) | FastDnsBlockerHandler (Java) | PerformanceObserver | No | PerformanceObserver |
-| `fetch()` API | FastDnsBlockerHandler (Java) | PerformanceObserver | No | PerformanceObserver |
-| `XMLHttpRequest` | FastDnsBlockerHandler (Java) | PerformanceObserver | No | PerformanceObserver |
+| Static sub-resources (`<script>`, `<img>`, `<link>`) | FastDnsBlockerHandler (Java) | PerformanceObserver | JS interceptor (MutationObserver + src setter) | JS interceptor + PerformanceObserver |
+| `fetch()` API | FastDnsBlockerHandler (Java) | PerformanceObserver | JS interceptor (fetch override) | JS interceptor + PerformanceObserver |
+| `XMLHttpRequest` | FastDnsBlockerHandler (Java) | PerformanceObserver | JS interceptor (XHR override) | JS interceptor + PerformanceObserver |
 | `navigator.sendBeacon()` | FastDnsBlockerHandler (Java) | PerformanceObserver | No | PerformanceObserver |
 | WebSocket | No | No | No | No |
 | Cross-origin iframe resources | No | No | No | No |

--- a/openspec/specs/localcdn/spec.md
+++ b/openspec/specs/localcdn/spec.md
@@ -201,21 +201,38 @@ The cache index SHALL be persisted via SharedPreferences and the resource files 
 - **When** the app is restarted
 - **Then** the cache index is loaded from SharedPreferences and cached resources are available immediately
 
-### LCDN-013: Platform Support
+### LCDN-013: Platform Support and Interception Scope
 
-LocalCDN resource interception SHALL work on Android via `shouldInterceptRequest`. On iOS/macOS, the feature SHALL degrade gracefully.
+LocalCDN resource interception SHALL work on Android via `shouldInterceptRequest`. On iOS/macOS, the feature SHALL degrade gracefully. LocalCDN does NOT intercept `fetch()` or `XMLHttpRequest` CDN requests — in practice this is a non-issue because CDN resources are almost always loaded via static HTML tags (`<script>`, `<link>`), not JS-initiated requests.
 
-#### Scenario: Android
+#### Scenario: Android — static resources
 
 - **Given** the app is running on Android
-- **When** `localCdnEnabled` is true
-- **Then** `useShouldInterceptRequest` is enabled and CDN requests are intercepted
+- **When** a page loads `<script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js">`
+- **Then** `shouldInterceptRequest` intercepts the request and serves the cached copy
+
+#### Scenario: Android — fetch/XHR CDN requests (not intercepted)
+
+- **Given** the app is running on Android
+- **When** JavaScript calls `fetch('https://cdn.jsdelivr.net/npm/some-lib@1.0/file.js')`
+- **Then** the request passes through to the CDN normally (LocalCDN does not intercept fetch/XHR)
 
 #### Scenario: iOS/macOS
 
 - **Given** the app is running on iOS or macOS
 - **When** `localCdnEnabled` is true
-- **Then** the toggle is available but CDN requests pass through normally (no interception)
+- **Then** the toggle is available but all CDN requests pass through normally (`shouldInterceptRequest` is Android-only)
+
+#### Summary: What LocalCDN intercepts
+
+| Request type | Android | iOS/macOS |
+|---|---|---|
+| `<script src="cdn...">` | Intercepted via shouldInterceptRequest | Not intercepted |
+| `<link href="cdn...">` | Intercepted via shouldInterceptRequest | Not intercepted |
+| `<img src="cdn...">` | Intercepted via shouldInterceptRequest | Not intercepted |
+| CSS `@font-face url(cdn...)` | Intercepted via shouldInterceptRequest | Not intercepted |
+| `fetch('cdn...')` | Not intercepted | Not intercepted |
+| `XMLHttpRequest` to CDN | Not intercepted | Not intercepted |
 
 ## Implementation Details
 
@@ -266,7 +283,21 @@ A curated list of ~80 popular resources is built into the service, covering:
 
 ### Hook Ordering
 
-The `shouldInterceptRequest` callback is independent from `shouldOverrideUrlLoading` (which handles navigation). It intercepts subresource loading (scripts, stylesheets, fonts, etc.).
+LocalCDN runs inside the `shouldInterceptRequest` callback on Android, AFTER DNS blocklist checking. If a CDN URL is on the DNS blocklist, DNS blocking takes priority and the request is blocked before LocalCDN can serve it.
+
+```dart
+shouldInterceptRequest: (controller, request) async {
+  // 1. DNS blocklist check + recording (runs first)
+  // 2. LocalCDN check (runs second)
+  if (config.localCdnEnabled && service.isCdnUrl(url)) {
+    final data = await service.getOrFetchResource(url);
+    if (data != null) return WebResourceResponse(data: data);
+  }
+  return null; // pass through
+}
+```
+
+Note: `shouldInterceptRequest` is Android-only and fires for static sub-resources only. It is NOT called for `fetch()` or `XMLHttpRequest` — those go through separate JS-injected hooks (`shouldInterceptFetchRequest`, `shouldInterceptAjaxRequest`) which do not include LocalCDN interception.
 
 ### Data Model
 
@@ -277,8 +308,8 @@ bool localCdnEnabled; // default: true
 // WebViewConfig field
 final bool localCdnEnabled; // default: true
 
-// InAppWebViewSettings
-useShouldInterceptRequest: config.localCdnEnabled && Platform.isAndroid
+// InAppWebViewSettings — always enabled on Android for DNS blocking
+useShouldInterceptRequest: Platform.isAndroid
 ```
 
 ## Files

--- a/test/bloom_filter_test.dart
+++ b/test/bloom_filter_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/bloom_filter.dart';
+
+void main() {
+  group('BloomFilter', () {
+    test('empty filter never reports membership', () {
+      final bf = BloomFilter.build([]);
+      expect(bf.contains('anything.com'), isFalse);
+      expect(bf.contains('example.org'), isFalse);
+    });
+
+    test('all added items are reported as present (no false negatives)', () {
+      final domains = [
+        'tracker.net',
+        'ads.example.com',
+        'malware.evil.org',
+        'analytics.foo.bar',
+        'pixel.tracker.io',
+      ];
+      final bf = BloomFilter.build(domains);
+      for (final d in domains) {
+        expect(bf.contains(d), isTrue, reason: '$d should be present');
+      }
+    });
+
+    test('no false negatives across 10K domains', () {
+      final domains = List.generate(10000, (i) => 'domain$i.example.com');
+      final bf = BloomFilter.build(domains);
+      for (final d in domains) {
+        expect(bf.contains(d), isTrue, reason: '$d should be present');
+      }
+    });
+
+    test('false positive rate stays close to target (0.1%)', () {
+      // Build with 10K items at default 0.1% FPR
+      final added = List.generate(10000, (i) => 'added$i.example.com');
+      final bf = BloomFilter.build(added);
+
+      // Probe with 50K items NOT in the set
+      const probeCount = 50000;
+      int falsePositives = 0;
+      for (int i = 0; i < probeCount; i++) {
+        if (bf.contains('probe$i.notpresent.test')) falsePositives++;
+      }
+      final actualFpr = falsePositives / probeCount;
+      // Allow some variance: target 0.001 (0.1%), assert < 0.5% as a safety margin
+      expect(actualFpr, lessThan(0.005),
+          reason: 'False positive rate $actualFpr exceeds tolerance (target 0.001)');
+    });
+
+    test('toMap returns bits, bitCount, k', () {
+      final bf = BloomFilter.build(['a.com', 'b.com']);
+      final map = bf.toMap();
+      expect(map['bits'], isNotNull);
+      expect(map['bitCount'], isPositive);
+      expect(map['k'], isPositive);
+      expect((map['bits'] as List).length * 8, greaterThanOrEqualTo(map['bitCount'] as int));
+    });
+
+    test('hash function is JS-compatible (FNV-1a)', () {
+      // Sanity check: known FNV-1a values for "abc" with FNV offset basis 0x811C9DC5
+      // We can't easily reach the private hash, but we can verify reproducibility:
+      // building a filter twice with same items must produce identical bytes
+      final bf1 = BloomFilter.build(['a', 'b', 'c']);
+      final bf2 = BloomFilter.build(['a', 'b', 'c']);
+      expect(bf1.bits, equals(bf2.bits));
+      expect(bf1.bitCount, equals(bf2.bitCount));
+      expect(bf1.k, equals(bf2.k));
+    });
+
+    test('larger blocklist produces proportionally larger filter', () {
+      final small = BloomFilter.build(List.generate(1000, (i) => 'x$i.com'));
+      final large = BloomFilter.build(List.generate(10000, (i) => 'x$i.com'));
+      expect(large.sizeInBytes, greaterThan(small.sizeInBytes));
+    });
+
+    test('domain hierarchy walk-up works via bloom contains', () {
+      // Simulate the iOS JS check: check host + parent suffixes
+      final bf = BloomFilter.build(['tracker.net', 'ads.example.com']);
+
+      bool maybeBlocked(String host) {
+        if (bf.contains(host)) return true;
+        final parts = host.split('.');
+        for (int i = 1; i < parts.length - 1; i++) {
+          if (bf.contains(parts.sublist(i).join('.'))) return true;
+        }
+        return false;
+      }
+
+      expect(maybeBlocked('tracker.net'), isTrue);
+      expect(maybeBlocked('sub.tracker.net'), isTrue); // parent in set
+      expect(maybeBlocked('deep.sub.tracker.net'), isTrue);
+      expect(maybeBlocked('ads.example.com'), isTrue);
+      // not present (and unlikely false positive in a tiny filter)
+      expect(maybeBlocked('safe.org'), isFalse);
+    });
+  });
+}

--- a/test/bloom_filter_test.dart
+++ b/test/bloom_filter_test.dart
@@ -31,8 +31,8 @@ void main() {
       }
     });
 
-    test('false positive rate stays close to target (0.1%)', () {
-      // Build with 10K items at default 0.1% FPR
+    test('false positive rate stays close to target (5%)', () {
+      // Build with 10K items at default 5% FPR
       final added = List.generate(10000, (i) => 'added$i.example.com');
       final bf = BloomFilter.build(added);
 
@@ -43,9 +43,9 @@ void main() {
         if (bf.contains('probe$i.notpresent.test')) falsePositives++;
       }
       final actualFpr = falsePositives / probeCount;
-      // Allow some variance: target 0.001 (0.1%), assert < 0.5% as a safety margin
-      expect(actualFpr, lessThan(0.005),
-          reason: 'False positive rate $actualFpr exceeds tolerance (target 0.001)');
+      // Allow some variance: target 0.05 (5%), assert < 10%
+      expect(actualFpr, lessThan(0.10),
+          reason: 'False positive rate $actualFpr exceeds tolerance (target 0.05)');
     });
 
     test('toMap returns bits, bitCount, k', () {


### PR DESCRIPTION
…tats

Shows which DNS requests are blocked/allowed for each site, inspired by Pi-hole's query log. Three complementary views:

- Live banner at top of webview showing blocked count with expandable list of recently blocked domains
- DNS tab in Developer Tools with full query log, filterable by allowed/blocked, searchable, with stats cards (total, allowed, blocked, block rate percentage)
- Per-site DNS stats summary in site settings below the DNS toggle

The DnsBlockService now tracks per-site statistics with a listener pattern for live UI updates. Stats are runtime-only (not persisted) and capped at 500 log entries per site.

https://claude.ai/code/session_01SV2NzjyweLGFfoynijgHBY