### PR TITLE
Copy in dev tools now respects active filters

### DIFF
--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -210,7 +210,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
         : allLogs.where((e) => _matchesSearch(e.message)).toList();
     return Column(
       children: [
-        _buildConsoleActions(),
+        _buildConsoleActions(logs),
         Expanded(
           child: logs.isEmpty
               ? Center(child: Text(_searchQuery.isEmpty ? 'No console messages' : 'No matches'))
@@ -227,7 +227,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
     );
   }
 
-  Widget _buildConsoleActions() {
+  Widget _buildConsoleActions(List<ConsoleLogEntry> logs) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
       child: Row(
@@ -242,17 +242,19 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
             label: const Text('Clear'),
           ),
           TextButton.icon(
-            onPressed: () {
-              final text = widget.webViewModel!.consoleLogs
-                  .map((e) => '[${_formatTime(e.timestamp)}] [${_consoleLevelName(e.level)}] ${e.message}')
-                  .join('\n');
-              Clipboard.setData(ClipboardData(text: text));
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('Console logs copied')),
-              );
-            },
+            onPressed: logs.isEmpty
+                ? null
+                : () {
+                    final text = logs
+                        .map((e) => '[${_formatTime(e.timestamp)}] [${_consoleLevelName(e.level)}] ${e.message}')
+                        .join('\n');
+                    Clipboard.setData(ClipboardData(text: text));
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('Copied ${logs.length} console log${logs.length == 1 ? '' : 's'}')),
+                    );
+                  },
             icon: const Icon(Icons.copy, size: 18),
-            label: const Text('Copy All'),
+            label: const Text('Copy'),
           ),
         ],
       ),
@@ -302,7 +304,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
         : blocked.where((b) => _matchesSearch(b.name) || _matchesSearch(b.domain)).toList();
     return Column(
       children: [
-        _buildCookieActions(allCookies),
+        _buildCookieActions(cookies),
         Expanded(
           child: _loadingCookies
               ? const Center(child: CircularProgressIndicator())
@@ -350,7 +352,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
                 Clipboard.setData(
                     ClipboardData(text: const JsonEncoder.withIndent('  ').convert(json)));
                 ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Cookies copied as JSON')),
+                  SnackBar(content: Text('Copied ${cookies.length} cookie${cookies.length == 1 ? '' : 's'} as JSON')),
                 );
               },
               icon: const Icon(Icons.copy, size: 18),
@@ -787,7 +789,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
 
     return Column(
       children: [
-        _buildLogActions(),
+        _buildLogActions(filtered),
         _buildLogFilters(),
         Expanded(
           child: filtered.isEmpty
@@ -805,7 +807,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
     );
   }
 
-  Widget _buildLogActions() {
+  Widget _buildLogActions(List<LogEntry> filtered) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
       child: Row(
@@ -816,12 +818,17 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
             label: const Text('Export'),
           ),
           TextButton.icon(
-            onPressed: () {
-              Clipboard.setData(ClipboardData(text: LogService.instance.export()));
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('Logs copied to clipboard')),
-              );
-            },
+            onPressed: filtered.isEmpty
+                ? null
+                : () {
+                    final text = filtered
+                        .map((e) => '[${_formatTime(e.timestamp)}] [${e.tag}/${e.level.name}] ${e.message}')
+                        .join('\n');
+                    Clipboard.setData(ClipboardData(text: text));
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('Copied ${filtered.length} log entr${filtered.length == 1 ? 'y' : 'ies'}')),
+                    );
+                  },
             icon: const Icon(Icons.copy, size: 18),
             label: const Text('Copy'),
           ),

--- a/openspec/specs/developer-tools/spec.md
+++ b/openspec/specs/developer-tools/spec.md
@@ -31,8 +31,9 @@ The app SHALL capture JS console messages (log, warn, error) from webviews and d
 **Given** the Console tab has messages
 **When** the user taps "Clear"
 **Then** all console messages are removed
-**When** the user taps "Copy All"
-**Then** all messages are copied to clipboard as formatted text
+**When** the user taps "Copy"
+**Then** only the currently visible (filtered) messages are copied to clipboard as formatted text
+**And** the snackbar shows the count of copied entries
 
 ---
 
@@ -63,7 +64,8 @@ The app SHALL display cookies for the current site with security flag details.
 **When** the user taps "Refresh"
 **Then** cookies are re-fetched from CookieManager
 **When** the user taps "Copy as JSON"
-**Then** all cookies are copied to clipboard as formatted JSON
+**Then** only the currently visible (filtered) cookies are copied to clipboard as formatted JSON
+**And** the snackbar shows the count of copied cookies
 
 #### Scenario: Block a cookie
 
@@ -145,9 +147,10 @@ The app SHALL maintain a ring buffer of app-level log entries accessible from bo
 
 **Given** the App Logs tab has entries
 **When** the user taps "Export"
-**Then** logs are saved as a .txt file via file picker
+**Then** all logs are saved as a .txt file via file picker (ignoring filters)
 **When** the user taps "Copy"
-**Then** logs are copied to clipboard for pasting into GitHub issues
+**Then** only the currently visible (filtered by level chips and search query) log entries are copied to clipboard
+**And** the snackbar shows the count of copied entries
 
 #### Scenario: Access from App Settings
 
@@ -253,5 +256,6 @@ class ConsoleLogEntry {
 4. **Cookies tab**: verify cookies listed with security chips; delete a cookie and confirm removal
 5. **Share HTML** (AppBar share icon): tap and verify bottom sheet with Share/Save/Copy options; test each option
 6. **Scripts** (AppBar code icon): tap and verify bottom sheet shows user scripts (or "no scripts" message); expand a script and copy its source
-7. **App Logs tab**: verify app log entries appear; use filter chips; tap "Copy" and paste
-8. Go back, open App Settings -> App Logs: verify it works without a site loaded (share and scripts icons should not appear)
+7. **App Logs tab**: verify app log entries appear; use filter chips; tap "Copy" and paste — verify only filtered entries are copied
+8. **Filtered copy**: on each tab, enter a search query, tap Copy, and verify clipboard contains only the matching entries (not all)
+9. Go back, open App Settings -> App Logs: verify it works without a site loaded (share and scripts icons should not appear)


### PR DESCRIPTION
All three tabs (Console, Cookies, App Logs) now copy only the currently visible entries when a search query or level filter is active. Copy buttons are disabled when the filtered list is empty, and the snackbar shows the count of copied entries.

https://claude.ai/code/session_01CA7Fxz2C8k5rEqNRejrph3