### PR TITLE
Add JavaScript console eval to developer tools

### DIFF
--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -410,8 +410,12 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
       ));
       widget.webViewModel!.onConsoleLogChanged?.call();
 
-      final js = _buildEvalJs(source);
-      await controller.evaluateJavascript(js);
+      // Directly embed code (no eval/Function) to respect CSP.
+      // Phase 1: set sentinel. Phase 2: try as expression.
+      // Phase 3: if expression had a parse error, try as statements.
+      await controller.evaluateJavascript('window.__wsEvalOk=false');
+      await controller.evaluateJavascript(_buildExprJs(source));
+      await controller.evaluateJavascript(_buildStmtJs(source));
 
       _evalController.clear();
     } finally {
@@ -421,9 +425,12 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
     }
   }
 
-  String _buildEvalJs(String source) {
-    final jsonStr = jsonEncode(source);
-    return 'try{var __r=eval($jsonStr);if(__r!==undefined){if(typeof __r==="object"&&__r!==null){try{console.log(JSON.stringify(__r,null,2))}catch(e){console.log(String(__r))}}else{console.log(String(__r))}}}catch(__e){console.error((__e&&__e.message)?__e.message:String(__e))}';
+  String _buildExprJs(String source) {
+    return '(function(){try{var __r=(\n$source\n);if(__r!==undefined){if(typeof __r==="object"&&__r!==null){try{console.log(JSON.stringify(__r,null,2))}catch(e){console.log(String(__r))}}else{console.log(String(__r))}}window.__wsEvalOk=true}catch(__e){console.error((__e&&__e.message)?__e.message:String(__e));window.__wsEvalOk=true}})()';
+  }
+
+  String _buildStmtJs(String source) {
+    return 'if(!window.__wsEvalOk){try{\n$source\n}catch(__e){console.error((__e&&__e.message)?__e.message:String(__e))}delete window.__wsEvalOk}else{delete window.__wsEvalOk}';
   }
 
   void _historyUp() {

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -45,6 +45,12 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   final TextEditingController _searchController = TextEditingController();
   final FocusNode _searchFocusNode = FocusNode();
 
+  final TextEditingController _evalController = TextEditingController();
+  final FocusNode _evalFocusNode = FocusNode();
+  final List<String> _evalHistory = [];
+  int _evalHistoryIndex = -1;
+  bool _isEvaluating = false;
+
   /// Snapshot of blocked cookies on entry, to detect changes on exit.
   late final Set<BlockedCookie> _initialBlockedCookies;
 
@@ -80,6 +86,8 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
     _logScrollController.dispose();
     _searchController.dispose();
     _searchFocusNode.dispose();
+    _evalController.dispose();
+    _evalFocusNode.dispose();
     super.dispose();
   }
 
@@ -223,6 +231,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
                   },
                 ),
         ),
+        _buildEvalInput(),
       ],
     );
   }
@@ -263,26 +272,184 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
 
   Widget _buildConsoleEntry(ConsoleLogEntry entry) {
     Color color;
-    switch (entry.level) {
-      case ConsoleMessageLevel.WARNING:
-        color = Colors.amber;
-        break;
-      case ConsoleMessageLevel.ERROR:
-        color = Colors.red;
-        break;
-      default:
-        color = Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white;
+    if (entry.isEvalInput) {
+      color = Theme.of(context).colorScheme.primary;
+    } else {
+      switch (entry.level) {
+        case ConsoleMessageLevel.WARNING:
+          color = Colors.amber;
+          break;
+        case ConsoleMessageLevel.ERROR:
+          color = Colors.red;
+          break;
+        default:
+          color = Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white;
+      }
     }
+    final text = entry.isEvalInput
+        ? '> ${entry.message}'
+        : '[${_formatTimeMs(entry.timestamp)}] ${entry.message}';
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 2.0),
       child: SelectableText(
-        '[${_formatTimeMs(entry.timestamp)}] ${entry.message}',
+        text,
         style: TextStyle(
           fontFamily: 'monospace',
           fontSize: 12,
           color: color,
+          fontWeight: entry.isEvalInput ? FontWeight.bold : FontWeight.normal,
         ),
       ),
+    );
+  }
+
+  // ── Console Eval ──
+
+  Widget _buildEvalInput() {
+    final hasController = widget.webViewModel?.controller != null;
+    return Container(
+      decoration: BoxDecoration(
+        border: Border(top: BorderSide(color: Theme.of(context).dividerColor)),
+      ),
+      padding: const EdgeInsets.only(left: 8.0, right: 4.0, top: 4.0, bottom: 4.0),
+      child: SafeArea(
+        top: false,
+        child: Row(
+          children: [
+            Text('>', style: TextStyle(
+              fontFamily: 'monospace',
+              fontSize: 14,
+              fontWeight: FontWeight.bold,
+              color: hasController
+                  ? Theme.of(context).colorScheme.primary
+                  : Theme.of(context).disabledColor,
+            )),
+            const SizedBox(width: 6),
+            Expanded(
+              child: TextField(
+                controller: _evalController,
+                focusNode: _evalFocusNode,
+                enabled: hasController && !_isEvaluating,
+                autocorrect: false,
+                enableSuggestions: false,
+                style: const TextStyle(fontFamily: 'monospace', fontSize: 13),
+                decoration: const InputDecoration(
+                  hintText: 'Evaluate JavaScript...',
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(vertical: 8.0, horizontal: 8.0),
+                  border: InputBorder.none,
+                ),
+                onSubmitted: hasController ? (_) => _evaluateJs() : null,
+                textInputAction: TextInputAction.send,
+              ),
+            ),
+            if (_evalHistory.isNotEmpty) ...[
+              SizedBox(
+                width: 28,
+                height: 28,
+                child: IconButton(
+                  icon: const Icon(Icons.keyboard_arrow_up, size: 18),
+                  padding: EdgeInsets.zero,
+                  tooltip: 'Previous command',
+                  onPressed: hasController ? _historyUp : null,
+                ),
+              ),
+              SizedBox(
+                width: 28,
+                height: 28,
+                child: IconButton(
+                  icon: const Icon(Icons.keyboard_arrow_down, size: 18),
+                  padding: EdgeInsets.zero,
+                  tooltip: 'Next command',
+                  onPressed: hasController ? _historyDown : null,
+                ),
+              ),
+            ],
+            SizedBox(
+              width: 36,
+              height: 36,
+              child: IconButton(
+                icon: _isEvaluating
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.play_arrow, size: 20),
+                tooltip: 'Run',
+                onPressed: hasController && !_isEvaluating ? _evaluateJs : null,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _evaluateJs() async {
+    final source = _evalController.text.trim();
+    if (source.isEmpty) return;
+
+    final controller = widget.webViewModel?.controller;
+    if (controller == null) return;
+
+    if (_isEvaluating) return;
+    setState(() => _isEvaluating = true);
+
+    try {
+      if (_evalHistory.isEmpty || _evalHistory.last != source) {
+        _evalHistory.add(source);
+      }
+      _evalHistoryIndex = -1;
+
+      widget.webViewModel!.consoleLogs.add(ConsoleLogEntry(
+        timestamp: DateTime.now(),
+        message: source,
+        level: ConsoleMessageLevel.LOG,
+        isEvalInput: true,
+      ));
+      widget.webViewModel!.onConsoleLogChanged?.call();
+
+      final js = _buildEvalJs(source);
+      await controller.evaluateJavascript(js);
+
+      _evalController.clear();
+    } finally {
+      if (mounted) {
+        setState(() => _isEvaluating = false);
+      }
+    }
+  }
+
+  String _buildEvalJs(String source) {
+    final jsonStr = jsonEncode(source);
+    return 'try{var __r=eval($jsonStr);if(__r!==undefined){if(typeof __r==="object"&&__r!==null){try{console.log(JSON.stringify(__r,null,2))}catch(e){console.log(String(__r))}}else{console.log(String(__r))}}}catch(__e){console.error((__e&&__e.message)?__e.message:String(__e))}';
+  }
+
+  void _historyUp() {
+    if (_evalHistory.isEmpty) return;
+    if (_evalHistoryIndex == -1) {
+      _evalHistoryIndex = _evalHistory.length - 1;
+    } else if (_evalHistoryIndex > 0) {
+      _evalHistoryIndex--;
+    }
+    _evalController.text = _evalHistory[_evalHistoryIndex];
+    _evalController.selection = TextSelection.fromPosition(
+      TextPosition(offset: _evalController.text.length),
+    );
+  }
+
+  void _historyDown() {
+    if (_evalHistory.isEmpty || _evalHistoryIndex == -1) return;
+    if (_evalHistoryIndex < _evalHistory.length - 1) {
+      _evalHistoryIndex++;
+      _evalController.text = _evalHistory[_evalHistoryIndex];
+    } else {
+      _evalHistoryIndex = -1;
+      _evalController.clear();
+    }
+    _evalController.selection = TextSelection.fromPosition(
+      TextPosition(offset: _evalController.text.length),
     );
   }
 

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -13,11 +13,13 @@ class ConsoleLogEntry {
   final DateTime timestamp;
   final String message;
   final ConsoleMessageLevel level;
+  final bool isEvalInput;
 
   ConsoleLogEntry({
     required this.timestamp,
     required this.message,
     required this.level,
+    this.isEvalInput = false,
   });
 }
 

--- a/openspec/specs/developer-tools/spec.md
+++ b/openspec/specs/developer-tools/spec.md
@@ -219,7 +219,7 @@ The app SHALL provide a JavaScript evaluation input in the Console tab, allowing
 **Given** a site is loaded and the Console tab is open
 **When** the user types a JS expression (e.g. `document.title`) in the eval input and taps Run or presses Enter
 **Then** the input is shown in the console log as `> document.title` in bold primary color
-**And** the expression is evaluated via `eval()` in the page context
+**And** the expression is evaluated via direct code injection (CSP-safe, no `eval()`)
 **And** the result is output via `console.log()` (or `console.error()` on exception)
 **And** the result appears in the console log below the input
 

--- a/openspec/specs/developer-tools/spec.md
+++ b/openspec/specs/developer-tools/spec.md
@@ -210,6 +210,41 @@ The app SHALL show active user scripts for the current site via an AppBar action
 
 ---
 
+### Requirement: DEVTOOLS-007 - Console Eval
+
+The app SHALL provide a JavaScript evaluation input in the Console tab, allowing users to execute arbitrary JS in the context of the current page and see results inline, like a standard browser console.
+
+#### Scenario: Evaluate a JavaScript expression
+
+**Given** a site is loaded and the Console tab is open
+**When** the user types a JS expression (e.g. `document.title`) in the eval input and taps Run or presses Enter
+**Then** the input is shown in the console log as `> document.title` in bold primary color
+**And** the expression is evaluated via `eval()` in the page context
+**And** the result is output via `console.log()` (or `console.error()` on exception)
+**And** the result appears in the console log below the input
+
+#### Scenario: Error handling
+
+**Given** the eval input contains invalid JavaScript
+**When** the user submits it
+**Then** the error message is shown as a red console error entry
+
+#### Scenario: Command history
+
+**Given** the user has previously evaluated one or more commands
+**When** the user taps the up arrow button
+**Then** the previous command is loaded into the input field
+**When** the user taps the down arrow button
+**Then** the next command is loaded, or the input is cleared at the end of history
+
+#### Scenario: Eval disabled without controller
+
+**Given** the webview controller is not available (site not loaded)
+**When** the Console tab is shown
+**Then** the eval input is disabled and the prompt is dimmed
+
+---
+
 ## Implementation Details
 
 ### Files


### PR DESCRIPTION
Adds an interactive JS evaluation input at the bottom of the Console tab, similar to standard browser developer consoles. Users can type JavaScript expressions, see results inline, and navigate command history.

https://claude.ai/code/session_01KpyTEQv7LYjqreVXo7Ncfw