### PR TITLE
Fix duck.ai favicon rendering as empty white square

### DIFF
--- a/lib/services/icon_service.dart
+++ b/lib/services/icon_service.dart
@@ -136,7 +136,11 @@ Future<bool> _verifyIconUrl(String iconUrl) async {
   }
 }
 
-// Helper: Check if SVG is monochrome (returns true if it's a colored SVG)
+// Helper: Check if SVG is monochrome (returns true if it's a colored SVG).
+// Also returns false for SVGs that rely on CSS-based visibility switching
+// (e.g. theme-aware icons with `<style>` blocks toggling `display: none`),
+// since flutter_svg's limited CSS support renders all groups simultaneously
+// and those SVGs end up with overlay rectangles obscuring the actual icon.
 Future<bool> _isSvgColored(String svgUrl) async {
   try {
     final response = await http.get(Uri.parse(svgUrl)).timeout(
@@ -145,6 +149,20 @@ Future<bool> _isSvgColored(String svgUrl) async {
     if (response.statusCode != 200) return false;
 
     final svgContent = response.body.toLowerCase();
+
+    // Detect CSS-driven visibility toggles in <style> blocks. flutter_svg
+    // does not honor `display: none` from style sheets, so both variants
+    // render and a hidden background rect can cover the visible icon (e.g.
+    // duck.ai's favicon.svg with light/dark icon swap).
+    final styleBlockPattern = RegExp(r'<style[^>]*>(.*?)</style>', dotAll: true);
+    for (var styleMatch in styleBlockPattern.allMatches(svgContent)) {
+      final styleContent = styleMatch.group(1) ?? '';
+      if (RegExp(r'display\s*:\s*none').hasMatch(styleContent)) {
+        LogService.instance.log('Icon',
+            'SVG uses CSS visibility switching, treating as low quality: $svgUrl');
+        return false;
+      }
+    }
 
     // Check for hex colors in attributes (fill="..." stroke="...")
     final attrColorPattern = RegExp(

--- a/openspec/specs/icon-fetching/spec.md
+++ b/openspec/specs/icon-fetching/spec.md
@@ -83,11 +83,27 @@ The system SHALL detect whether SVG icons are colored or monochrome.
 **When** color detection runs
 **Then** the SVG is marked as monochrome (quality 50)
 
+#### Scenario: Reject CSS visibility-switching SVG
+
+**Given** an SVG contains a `<style>` block with `display: none` (e.g. theme-aware
+icons that toggle between `#light-icon` and `#dark-icon` groups via CSS or
+`@media (prefers-color-scheme: dark)`)
+**When** color detection runs
+**Then** the SVG is treated as low quality (not colored)
+**And** a bitmap icon is preferred instead
+
+This guards against flutter_svg's limited CSS support: `display: none` from
+`<style>` blocks is not honored, so every `<g>` group renders and hidden
+background rects can obscure the visible icon. duck.ai's favicon.svg is a
+concrete example — without this guard, the icon appears as a near-empty
+white rounded square.
+
 ---
 
 ### Requirement: ICON-005 - SVG Dark Mode Support
 
-SVG icons with CSS media queries SHALL render correctly based on app theme.
+SVG icons with CSS media queries SHALL render correctly based on app theme
+when flutter_svg supports the CSS features used.
 
 #### Scenario: Render SVG in dark mode
 
@@ -95,6 +111,17 @@ SVG icons with CSS media queries SHALL render correctly based on app theme.
 **And** the app is in dark mode
 **When** the SVG is rendered
 **Then** the dark mode styles are applied
+
+#### Scenario: Reject SVGs relying on CSS visibility toggles
+
+**Given** an SVG uses `<style>` with `display: none` to hide the inactive
+theme variant (rather than conditional styling of a single rendered tree)
+**When** icon selection runs
+**Then** the SVG is rejected by ICON-004's color detection
+**And** a bitmap icon from the same site is selected instead
+
+This avoids rendering all theme variants simultaneously, which flutter_svg
+would otherwise do.
 
 ---
 


### PR DESCRIPTION
The duck.ai favicon.svg uses a `<style>` block with `display: none` and `@media (prefers-color-scheme: dark)` to swap visibility between light/dark icon groups. flutter_svg's CSS support does not honor `display: none` from style sheets, so both groups render and the dark-icon's `<rect fill="#fafafa">` covers the actual colored duck logo.

Detect SVGs with CSS-driven visibility toggles in `_isSvgColored` and treat them as low quality so a bitmap icon (e.g. duck.ai's favicon-96x96.png) is preferred instead.