### PR TITLE
Extend native sub-resource interceptor to ABP domain blocking

### DIFF
--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/WebInterceptPlugin.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/WebInterceptPlugin.kt
@@ -24,7 +24,12 @@ class WebInterceptPlugin(private val activity: Activity, flutterEngine: FlutterE
     private val mainHandler = android.os.Handler(android.os.Looper.getMainLooper())
 
     // DNS blocklist (mutated in place; FastSubresourceInterceptor holds a reference)
-    private val blockedDomains = HashSet<String>()
+    private val dnsBlockedDomains = HashSet<String>()
+
+    // ABP blocklist built from enabled filter lists' `||domain^` rules.
+    // Kept separate from DNS so each block event can be attributed to the
+    // list that matched it (see FastSubresourceInterceptor.checkUrl).
+    private val abpBlockedDomains = HashSet<String>()
 
     // LocalCDN: regex patterns matching CDN URLs. Each pattern must expose
     // groups 1/2/3 = library/version/file (matching the Dart _cdnPatterns table).
@@ -32,9 +37,12 @@ class WebInterceptPlugin(private val activity: Activity, flutterEngine: FlutterE
     // LocalCDN: cacheKey ("lib/ver/file") -> absolute file path on disk.
     private val cdnCacheIndex = mutableMapOf<String, String>()
 
-    // Per-site pending DNS events. Java is the source of truth; Dart pulls on demand.
-    private val pendingDnsEvents = ConcurrentHashMap<String, MutableList<Map<String, Any>>>()
-    private val dnsSignalPending = ConcurrentHashMap<String, AtomicBoolean>()
+    // Per-site pending block events (DNS + ABP + allowed). Java is the
+    // source of truth; Dart pulls on demand. Each event carries a
+    // "source" string identifying which blocklist matched ("dns", "abp")
+    // or null/absent for allowed requests.
+    private val pendingBlockEvents = ConcurrentHashMap<String, MutableList<Map<String, Any>>>()
+    private val blockSignalPending = ConcurrentHashMap<String, AtomicBoolean>()
 
     // Per-site pending LocalCDN replacement events. Events carry the cache key
     // that was served; Dart turns each into a recordReplacement(siteId) call.
@@ -44,12 +52,22 @@ class WebInterceptPlugin(private val activity: Activity, flutterEngine: FlutterE
     init {
         channel.setMethodCallHandler { call, result ->
             when (call.method) {
-                "setBlockedDomains" -> {
+                "setDnsBlockedDomains" -> {
                     val domains = call.argument<List<String>>("domains")
                     if (domains != null) {
-                        blockedDomains.clear()
-                        blockedDomains.addAll(domains)
-                        result.success(blockedDomains.size)
+                        dnsBlockedDomains.clear()
+                        dnsBlockedDomains.addAll(domains)
+                        result.success(dnsBlockedDomains.size)
+                    } else {
+                        result.error("INVALID_ARGS", "domains list required", null)
+                    }
+                }
+                "setAbpBlockedDomains" -> {
+                    val domains = call.argument<List<String>>("domains")
+                    if (domains != null) {
+                        abpBlockedDomains.clear()
+                        abpBlockedDomains.addAll(domains)
+                        result.success(abpBlockedDomains.size)
                     } else {
                         result.error("INVALID_ARGS", "domains list required", null)
                     }
@@ -90,12 +108,12 @@ class WebInterceptPlugin(private val activity: Activity, flutterEngine: FlutterE
                     val count = attachToAllWebViews(siteId)
                     result.success(count)
                 }
-                "fetchDnsEvents" -> {
+                "fetchBlockEvents" -> {
                     val siteId = call.argument<String>("siteId")
                     if (siteId == null) {
                         result.error("INVALID_ARGS", "siteId required", null)
                     } else {
-                        result.success(drainEvents(pendingDnsEvents, siteId))
+                        result.success(drainEvents(pendingBlockEvents, siteId))
                     }
                 }
                 "fetchCdnEvents" -> {
@@ -123,19 +141,24 @@ class WebInterceptPlugin(private val activity: Activity, flutterEngine: FlutterE
         }
     }
 
-    /// Records a DNS event (allowed or blocked) and signals Dart once per
-    /// batch. If Dart is already processing an earlier signal for this
-    /// site, subsequent events just accumulate — no duplicate signals.
-    private fun recordDnsEvent(siteId: String, host: String, blocked: Boolean) {
-        val list = pendingDnsEvents.computeIfAbsent(siteId) {
+    /// Records a block event (allowed or blocked, source-tagged) and
+    /// signals Dart once per batch. If Dart is already processing an
+    /// earlier signal for this site, subsequent events just accumulate —
+    /// no duplicate signals.
+    private fun recordBlockEvent(siteId: String, host: String, blocked: Boolean, source: String?) {
+        val list = pendingBlockEvents.computeIfAbsent(siteId) {
             Collections.synchronizedList(mutableListOf())
         }
-        list.add(mapOf("host" to host, "blocked" to blocked))
+        val event = HashMap<String, Any>(3)
+        event["host"] = host
+        event["blocked"] = blocked
+        if (source != null) event["source"] = source
+        list.add(event)
 
-        val signaled = dnsSignalPending.computeIfAbsent(siteId) { AtomicBoolean(false) }
+        val signaled = blockSignalPending.computeIfAbsent(siteId) { AtomicBoolean(false) }
         if (signaled.compareAndSet(false, true)) {
             mainHandler.post {
-                channel.invokeMethod("dnsEventsReady", siteId, object : MethodChannel.Result {
+                channel.invokeMethod("blockEventsReady", siteId, object : MethodChannel.Result {
                     override fun success(result: Any?) { signaled.set(false) }
                     override fun error(code: String, message: String?, details: Any?) { signaled.set(false) }
                     override fun notImplemented() { signaled.set(false) }
@@ -184,16 +207,20 @@ class WebInterceptPlugin(private val activity: Activity, flutterEngine: FlutterE
             if (isNew) {
                 val siteId = siteIdMap[webView] ?: "unknown"
                 webView.contentBlockerHandler = FastSubresourceInterceptor(
-                    blockedDomains = blockedDomains,
+                    dnsBlockedDomains = dnsBlockedDomains,
+                    abpBlockedDomains = abpBlockedDomains,
                     cdnPatterns = cdnPatterns,
                     cdnCacheIndex = cdnCacheIndex,
-                    onDnsChecked = { host, blocked -> recordDnsEvent(siteId, host, blocked) },
+                    onBlockChecked = { host, blocked, source ->
+                        recordBlockEvent(siteId, host, blocked, source)
+                    },
                     onCdnReplaced = { cacheKey, url -> recordCdnEvent(siteId, cacheKey, url) },
                     onLog = { tag, message -> log(tag, message) }
                 )
                 log("WebIntercept",
-                    "Attached interceptor: siteId=$siteId domains=${blockedDomains.size} " +
-                    "cdnPatterns=${cdnPatterns.size} cdnCache=${cdnCacheIndex.size}")
+                    "Attached interceptor: siteId=$siteId dns=${dnsBlockedDomains.size} " +
+                    "abp=${abpBlockedDomains.size} cdnPatterns=${cdnPatterns.size} " +
+                    "cdnCache=${cdnCacheIndex.size}")
             }
         }
         return webViews.size
@@ -217,16 +244,21 @@ class WebInterceptPlugin(private val activity: Activity, flutterEngine: FlutterE
     }
 }
 
-/// Native ContentBlockerHandler that handles both DNS blocking and LocalCDN
-/// replacement for sub-resource requests. Runs on the WebView thread (no
-/// main-thread roundtrip), which is why it actually fires for sub-resources
-/// where Dart-side shouldInterceptRequest only catches the main document
-/// navigation on modern Chromium WebView.
+/// Native ContentBlockerHandler that handles DNS + ABP domain blocking
+/// and LocalCDN replacement for sub-resource requests. Runs on the
+/// WebView thread (no main-thread roundtrip), which is why it actually
+/// fires for sub-resources where Dart-side shouldInterceptRequest only
+/// catches the main document navigation on modern Chromium WebView.
+///
+/// DNS is checked before ABP so that requests which appear in both lists
+/// are attributed to DNS (the user-facing blocklist with the tighter
+/// severity settings). Stats downstream can be disentangled by source.
 class FastSubresourceInterceptor(
-    private val blockedDomains: HashSet<String>,
+    private val dnsBlockedDomains: HashSet<String>,
+    private val abpBlockedDomains: HashSet<String>,
     private val cdnPatterns: MutableList<Regex>,
     private val cdnCacheIndex: MutableMap<String, String>,
-    private val onDnsChecked: (String, Boolean) -> Unit,
+    private val onBlockChecked: (String, Boolean, String?) -> Unit,
     private val onCdnReplaced: (String, String) -> Unit,
     private val onLog: (String, String) -> Unit = { _, _ -> }
 ) : ContentBlockerHandler() {
@@ -260,11 +292,19 @@ class FastSubresourceInterceptor(
             onLog("WebIntercept", "checkUrl #$checkCount host=$host url=$url")
         }
 
-        // 1. DNS blocking + stats recording
-        val blocked = isBlockedDomain(host)
-        onDnsChecked(host, blocked)
-        if (blocked) {
-            return WebResourceResponse("text/plain", "utf-8", null)
+        // 1. Domain blocking (DNS first, then ABP) with source attribution
+        when {
+            isInSet(host, dnsBlockedDomains) -> {
+                onBlockChecked(host, true, "dns")
+                return WebResourceResponse("text/plain", "utf-8", null)
+            }
+            isInSet(host, abpBlockedDomains) -> {
+                onBlockChecked(host, true, "abp")
+                return WebResourceResponse("text/plain", "utf-8", null)
+            }
+            else -> {
+                onBlockChecked(host, false, null)
+            }
         }
 
         // 2. LocalCDN: try to serve from the pre-downloaded cache
@@ -313,11 +353,12 @@ class FastSubresourceInterceptor(
         return null
     }
 
-    private fun isBlockedDomain(host: String): Boolean {
-        if (blockedDomains.contains(host)) return true
+    private fun isInSet(host: String, set: HashSet<String>): Boolean {
+        if (set.isEmpty()) return false
+        if (set.contains(host)) return true
         val parts = host.split(".")
         for (i in 1 until parts.size - 1) {
-            if (blockedDomains.contains(parts.subList(i, parts.size).joinToString("."))) {
+            if (set.contains(parts.subList(i, parts.size).joinToString("."))) {
                 return true
             }
         }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -430,17 +430,38 @@ void main() async {
   // Initialize DNS block service (loads cached blocklist from disk)
   await DnsBlockService.instance.initialize();
 
-  // Initialize native interceptor bridge for sub-resource DNS blocking and
-  // LocalCDN serving (Android). The Dart shouldInterceptRequest callback
-  // only fires for main-document navigations on modern Chromium WebView, so
-  // everything per-subresource has to go through the native path.
+  // Initialize native interceptor bridge for sub-resource DNS + ABP
+  // blocking and LocalCDN serving (Android). The Dart shouldInterceptRequest
+  // callback only fires for main-document navigations on modern Chromium
+  // WebView, so everything per-subresource has to go through the native
+  // path.
   WebInterceptNative.initialize();
   if (DnsBlockService.instance.hasBlocklist) {
-    await WebInterceptNative.sendDomains(DnsBlockService.instance.blockedDomains);
+    await WebInterceptNative.sendDnsDomains(
+        DnsBlockService.instance.blockedDomains);
   }
 
   // Initialize content blocker service (loads cached filter lists from disk)
   await ContentBlockerService.instance.initialize();
+
+  // Seed the native interceptor with ABP domains once ContentBlocker has
+  // parsed its cached lists.
+  if (ContentBlockerService.instance.blockedDomains.isNotEmpty) {
+    await WebInterceptNative.sendAbpDomains(
+        ContentBlockerService.instance.blockedDomains);
+  }
+
+  // Keep native + JS Bloom in sync whenever either blocklist changes.
+  // Individual download / toggle call sites don't need to know about the
+  // interceptor — they just mutate the service, the listener re-pushes.
+  DnsBlockService.instance.addBlocklistChangedListener(() {
+    WebInterceptNative.sendDnsDomains(DnsBlockService.instance.blockedDomains);
+  });
+  ContentBlockerService.instance.addRulesChangedListener(() {
+    DnsBlockService.instance.invalidateMergedBloom();
+    WebInterceptNative.sendAbpDomains(
+        ContentBlockerService.instance.blockedDomains);
+  });
 
   // Initialize LocalCDN service (loads cache index from disk)
   await LocalCdnService.instance.initialize();

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -134,7 +134,8 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
 
       if (success) {
         await _loadBlocklistState();
-        await WebInterceptNative.sendDomains(DnsBlockService.instance.blockedDomains);
+        // DnsBlockService fires a change listener that re-pushes domains
+        // to the native interceptor; we only need to (re)attach webviews.
         await WebInterceptNative.attachToWebViews();
         final domainCount = DnsBlockService.instance.domainCount;
         final message = level == 0

--- a/lib/services/content_blocker_service.dart
+++ b/lib/services/content_blocker_service.dart
@@ -114,6 +114,30 @@ class ContentBlockerService {
   /// Whether any rules are loaded.
   bool get hasRules => _blockedDomains.isNotEmpty || _cosmeticSelectors.isNotEmpty || _textHideRules.isNotEmpty;
 
+  /// Aggregated ABP blocked domains across all enabled lists. Shared with
+  /// the sub-resource interceptor (native Android + iOS JS Bloom) so ABP
+  /// network blocking extends beyond main-document navigations.
+  Set<String> get blockedDomains => _blockedDomains;
+
+  /// Listeners invoked when the aggregated rule set changes (download,
+  /// toggle, remove, re-init). main.dart uses this to re-push domains to
+  /// the native interceptor and invalidate the merged JS Bloom.
+  final List<VoidCallback> _rulesChangedListeners = [];
+
+  void addRulesChangedListener(VoidCallback listener) {
+    _rulesChangedListeners.add(listener);
+  }
+
+  void removeRulesChangedListener(VoidCallback listener) {
+    _rulesChangedListeners.remove(listener);
+  }
+
+  void _notifyRulesChanged() {
+    for (final listener in List<VoidCallback>.from(_rulesChangedListeners)) {
+      listener();
+    }
+  }
+
   /// Check if a URL's domain (or any parent domain) is blocked.
   bool isBlocked(String url) {
     if (_blockedDomains.isEmpty) return false;
@@ -429,6 +453,7 @@ class ContentBlockerService {
     _blockedDomains = allDomains;
     _cosmeticSelectors = allSelectors;
     _textHideRules = allTextRules;
+    _notifyRulesChanged();
   }
 
   Future<void> _saveLists() async {

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -5,36 +5,62 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:webspace/services/bloom_filter.dart';
+import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/log_service.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-/// A single DNS query log entry (allowed or blocked).
+/// Which blocklist attributed a block decision. Allowed requests have no
+/// source. Stats preserve this so the UI can show a merged count while
+/// still disentangling DNS vs ABP hits when needed.
+enum BlockSource { dns, abp }
+
+/// A single request log entry (allowed or blocked).
 class DnsLogEntry {
   final DateTime timestamp;
   final String domain;
   final bool blocked;
+  final BlockSource? source;
 
   const DnsLogEntry({
     required this.timestamp,
     required this.domain,
     required this.blocked,
+    this.source,
   });
 }
 
-/// Per-site DNS request statistics.
+/// Per-site block request statistics (DNS + ABP combined).
+///
+/// `blocked`/`allowed` are merged totals; `blockedByDns`/`blockedByAbp` let
+/// callers break it down without iterating the log.
 class DnsStats {
   int allowed = 0;
   int blocked = 0;
+  int blockedByDns = 0;
+  int blockedByAbp = 0;
   final List<DnsLogEntry> log = [];
   static const int _maxLogEntries = 500;
 
   int get total => allowed + blocked;
   double get blockRate => total > 0 ? blocked / total * 100 : 0;
 
-  void record(String domain, bool wasBlocked) {
+  void record(String domain, bool wasBlocked, {BlockSource? source}) {
     if (wasBlocked) {
       blocked++;
+      switch (source) {
+        case BlockSource.dns:
+          blockedByDns++;
+          break;
+        case BlockSource.abp:
+          blockedByAbp++;
+          break;
+        case null:
+          // Unsourced block — count toward the total only. Callers should
+          // always pass a source for blocked requests; this branch exists
+          // so the counters stay consistent if they don't.
+          break;
+      }
     } else {
       allowed++;
     }
@@ -42,6 +68,7 @@ class DnsStats {
       timestamp: DateTime.now(),
       domain: domain,
       blocked: wasBlocked,
+      source: wasBlocked ? source : null,
     ));
     if (log.length > _maxLogEntries) {
       log.removeAt(0);
@@ -51,6 +78,8 @@ class DnsStats {
   void clear() {
     allowed = 0;
     blocked = 0;
+    blockedByDns = 0;
+    blockedByAbp = 0;
     log.clear();
   }
 }
@@ -115,8 +144,41 @@ class DnsBlockService {
   /// The raw blocked domains set (for sending to native handler).
   Set<String> get blockedDomains => _blockedDomains;
 
-  /// Cached Bloom filter for fast JS-side membership checks.
+  /// Cached Bloom filter built from DNS domains only.
   BloomFilter? _bloomFilter;
+
+  /// Cached Bloom filter built from DNS ∪ ABP blocked domains. Used by the
+  /// iOS/macOS JS sub-resource interceptor as a "maybe blocked" prefilter;
+  /// the authoritative DNS-vs-ABP decision happens in Dart on hit.
+  BloomFilter? _mergedBloomFilter;
+
+  /// Listeners invoked whenever the DNS blocklist changes (download, level
+  /// change, clear). main.dart re-pushes to the native interceptor from
+  /// here so individual call sites don't each have to remember to sync.
+  final List<VoidCallback> _blocklistChangedListeners = [];
+
+  void addBlocklistChangedListener(VoidCallback listener) {
+    _blocklistChangedListeners.add(listener);
+  }
+
+  void removeBlocklistChangedListener(VoidCallback listener) {
+    _blocklistChangedListeners.remove(listener);
+  }
+
+  void _notifyBlocklistChanged() {
+    // Invalidate the merged Bloom since the DNS half changed. The
+    // ContentBlockerService change path invalidates it too.
+    _mergedBloomFilter = null;
+    for (final listener in List<VoidCallback>.from(_blocklistChangedListeners)) {
+      listener();
+    }
+  }
+
+  /// Invalidate the merged Bloom so the next getter rebuilds it. Called by
+  /// ContentBlockerService when its rules change.
+  void invalidateMergedBloom() {
+    _mergedBloomFilter = null;
+  }
 
   /// Global per-domain resolver cache: host -> blocked_bool.
   /// Shared across all sites since the same tracker/CDN domains appear
@@ -185,8 +247,9 @@ class DnsBlockService {
     } catch (_) {}
   }
 
-  /// Get (and cache) a Bloom filter built from all blocked domains plus
-  /// their hierarchical suffixes. Used for iOS JS-side prefiltering.
+  /// Get (and cache) a Bloom filter built from all DNS-blocked domains.
+  /// Kept for callers that want the DNS-only set; the webview JS
+  /// interceptor uses [getMergedBlockBloom] instead.
   BloomFilter getBloomFilter() {
     if (_bloomFilter != null) return _bloomFilter!;
     final sw = Stopwatch()..start();
@@ -198,18 +261,49 @@ class DnsBlockService {
     return _bloomFilter!;
   }
 
+  /// Get (and cache) a Bloom filter built from DNS ∪ ABP blocked domains.
+  /// Used as the JS-side prefilter for sub-resource interception. On a hit
+  /// the JS interceptor asks Dart for the authoritative decision, which
+  /// tags the stat entry with the right [BlockSource].
+  BloomFilter getMergedBlockBloom() {
+    if (_mergedBloomFilter != null) return _mergedBloomFilter!;
+    final abp = ContentBlockerService.instance.blockedDomains;
+    final sw = Stopwatch()..start();
+    if (_blockedDomains.isEmpty && abp.isEmpty) {
+      _mergedBloomFilter = BloomFilter.build(const <String>{}, fpRate: 0.05);
+    } else if (abp.isEmpty) {
+      _mergedBloomFilter = getBloomFilter();
+    } else {
+      final merged = <String>{..._blockedDomains, ...abp};
+      _mergedBloomFilter = BloomFilter.build(merged, fpRate: 0.05);
+    }
+    sw.stop();
+    LogService.instance.log(
+        'BlockBloom',
+        'Built merged bloom: ${_mergedBloomFilter!.sizeInBytes} bytes, k=${_mergedBloomFilter!.k}, '
+        'from ${_blockedDomains.length} DNS + ${abp.length} ABP domains in ${sw.elapsedMilliseconds}ms',
+        level: LogLevel.info);
+    return _mergedBloomFilter!;
+  }
+
   /// Get DNS stats for a specific site. Creates on first access.
   DnsStats statsForSite(String siteId) {
     return _siteStats.putIfAbsent(siteId, () => DnsStats());
   }
 
-  /// Record a DNS request (allowed or blocked) for a site.
+  /// Record a request (allowed or blocked) for a site. [source] identifies
+  /// which blocklist attributed the block (`dns` vs `abp`); null for
+  /// allowed requests.
+  ///
   /// Also updates the global per-domain cache so other webviews skip
-  /// re-checking the same host.
-  void recordRequest(String siteId, String url, bool wasBlocked) {
+  /// re-checking the same host. The domain cache only persists the
+  /// blocked-or-not bit — the DNS vs ABP distinction is recovered on the
+  /// next request because both services can answer independently.
+  void recordRequest(String siteId, String url, bool wasBlocked,
+      {BlockSource? source}) {
     final uri = Uri.tryParse(url);
     if (uri == null || uri.host.isEmpty) return;
-    statsForSite(siteId).record(uri.host, wasBlocked);
+    statsForSite(siteId).record(uri.host, wasBlocked, source: source);
     recordDomainDecision(uri.host, wasBlocked);
     _notifyDnsLogListeners();
   }
@@ -266,6 +360,7 @@ class DnsBlockService {
     if (level == 0) {
       _blockedDomains = {};
       _level = 0;
+      _bloomFilter = null;
       try {
         final file = await _getCacheFile();
         if (await file.exists()) {
@@ -278,6 +373,7 @@ class DnsBlockService {
         LogService.instance.log('DnsBlock', 'Error clearing blocklist: $e', level: LogLevel.error);
       }
       await _clearDomainCache();
+      _notifyBlocklistChanged();
       return true;
     }
 
@@ -378,6 +474,7 @@ class DnsBlockService {
     if (domains.isNotEmpty) {
       getBloomFilter();
     }
+    _notifyBlocklistChanged();
   }
 
   Future<File> _getCacheFile() async {

--- a/lib/services/web_intercept_native.dart
+++ b/lib/services/web_intercept_native.dart
@@ -7,10 +7,10 @@ import 'package:webspace/services/log_service.dart';
 
 /// Dart-side bridge to the native Android interceptor that runs as part of
 /// flutter_inappwebview's ContentBlockerHandler path. The native handler
-/// blocks DNS-listed domains and serves pre-downloaded LocalCDN resources
-/// for sub-resource requests — the Dart shouldInterceptRequest callback
-/// only fires for the main document on modern Chromium WebView, so any
-/// sub-resource interception has to happen natively.
+/// blocks DNS + ABP-listed domains and serves pre-downloaded LocalCDN
+/// resources for sub-resource requests — the Dart shouldInterceptRequest
+/// callback only fires for the main document on modern Chromium WebView,
+/// so any sub-resource interception has to happen natively.
 class WebInterceptNative {
   static const _channel =
       MethodChannel('org.codeberg.theoden8.webspace/web_intercept');
@@ -21,8 +21,8 @@ class WebInterceptNative {
     if (!isSupported) return;
     _channel.setMethodCallHandler((call) async {
       switch (call.method) {
-        case 'dnsEventsReady':
-          await _drainDnsEvents(call.arguments as String?);
+        case 'blockEventsReady':
+          await _drainBlockEvents(call.arguments as String?);
           break;
         case 'cdnEventsReady':
           await _drainCdnEvents(call.arguments as String?);
@@ -39,20 +39,25 @@ class WebInterceptNative {
     });
   }
 
-  static Future<void> _drainDnsEvents(String? siteId) async {
+  static Future<void> _drainBlockEvents(String? siteId) async {
     if (siteId == null) return;
     try {
       final list =
-          await _channel.invokeMethod('fetchDnsEvents', {'siteId': siteId});
+          await _channel.invokeMethod('fetchBlockEvents', {'siteId': siteId});
       if (list is! List) return;
       for (final entry in list) {
         if (entry is Map) {
           final host = entry['host'] as String?;
           final blocked = entry['blocked'] as bool?;
-          if (host != null && blocked != null) {
-            DnsBlockService.instance
-                .recordRequest(siteId, 'https://$host/', blocked);
-          }
+          if (host == null || blocked == null) continue;
+          final sourceStr = entry['source'] as String?;
+          final source = switch (sourceStr) {
+            'dns' => BlockSource.dns,
+            'abp' => BlockSource.abp,
+            _ => null,
+          };
+          DnsBlockService.instance
+              .recordRequest(siteId, 'https://$host/', blocked, source: source);
         }
       }
     } catch (_) {}
@@ -70,19 +75,40 @@ class WebInterceptNative {
     } catch (_) {}
   }
 
-  // ========== DNS ==========
+  // ========== Domain blocklists ==========
 
-  static Future<void> sendDomains(Set<String> domains) async {
+  /// Push the DNS blocklist domains to the native interceptor.
+  static Future<void> sendDnsDomains(Set<String> domains) async {
     if (!isSupported) return;
     try {
-      final count = await _channel.invokeMethod('setBlockedDomains', {
+      final count = await _channel.invokeMethod('setDnsBlockedDomains', {
         'domains': domains.toList(),
       });
       LogService.instance.log(
-          'DnsBlock', 'Sent $count domains to native handler',
+          'DnsBlock', 'Sent $count DNS domains to native handler',
           level: LogLevel.info);
     } catch (e) {
-      LogService.instance.log('DnsBlock', 'Failed to send domains to native: $e',
+      LogService.instance.log('DnsBlock',
+          'Failed to send DNS domains to native: $e',
+          level: LogLevel.error);
+    }
+  }
+
+  /// Push the ABP blocklist domains (aggregated from enabled filter
+  /// lists' `||domain^` rules) to the native interceptor. Hits are
+  /// attributed to ABP in the per-site block log.
+  static Future<void> sendAbpDomains(Set<String> domains) async {
+    if (!isSupported) return;
+    try {
+      final count = await _channel.invokeMethod('setAbpBlockedDomains', {
+        'domains': domains.toList(),
+      });
+      LogService.instance.log(
+          'ContentBlocker', 'Sent $count ABP domains to native handler',
+          level: LogLevel.info);
+    } catch (e) {
+      LogService.instance.log('ContentBlocker',
+          'Failed to send ABP domains to native: $e',
           level: LogLevel.error);
     }
   }

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -667,19 +667,25 @@ class WebViewFactory {
       ));
     }
 
-    // DNS stats: inject PerformanceObserver to report loaded resource URLs.
+    // Block stats: inject PerformanceObserver to report loaded resource
+    // URLs so allowed requests show up in the per-site log on iOS/macOS.
     // On Android, the native FastSubresourceInterceptor reports events
     // directly, so skip PerformanceObserver to avoid double-counting.
-    if (!Platform.isAndroid && config.siteId != null && DnsBlockService.instance.hasBlocklist) {
+    final hasDnsRules = DnsBlockService.instance.hasBlocklist;
+    final hasAbpRules =
+        ContentBlockerService.instance.blockedDomains.isNotEmpty;
+    if (!Platform.isAndroid &&
+        config.siteId != null &&
+        (hasDnsRules || hasAbpRules)) {
       userScripts.add(inapp.UserScript(
-        groupName: 'dns_resource_observer',
+        groupName: 'block_resource_observer',
         source: '''
 (function() {
   var seen = {};
   var pending = [];
   function send(url) {
     if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
-      window.flutter_inappwebview.callHandler('dnsResourceLoaded', url);
+      window.flutter_inappwebview.callHandler('blockResourceLoaded', url);
     } else {
       pending.push(url);
     }
@@ -700,7 +706,7 @@ class WebViewFactory {
       return;
     }
     pending.forEach(function(url) {
-      window.flutter_inappwebview.callHandler('dnsResourceLoaded', url);
+      window.flutter_inappwebview.callHandler('blockResourceLoaded', url);
     });
     pending = [];
   }
@@ -711,15 +717,16 @@ class WebViewFactory {
       ));
     }
 
-    // iOS DNS sub-resource blocking: JS interceptor with Bloom-filter
-    // prefilter. Bloom filter check is pure JS (microseconds). Only
-    // ~0.1% of allowed URLs trigger a Dart roundtrip for confirmation.
+    // iOS sub-resource blocking: JS interceptor with merged DNS+ABP
+    // Bloom-filter prefilter. Bloom check is pure JS (microseconds).
+    // Only ~0.1% of allowed URLs trigger a Dart roundtrip; Dart's
+    // blockCheck handler decides DNS vs ABP and records the source.
     if (!Platform.isAndroid
         && config.siteId != null
-        && config.dnsBlockEnabled
-        && DnsBlockService.instance.hasBlocklist) {
+        && ((config.dnsBlockEnabled && hasDnsRules) ||
+            (config.contentBlockEnabled && hasAbpRules))) {
       userScripts.add(inapp.UserScript(
-        groupName: 'dns_js_blocker',
+        groupName: 'block_js_interceptor',
         source: '''
 (function() {
   var bloomReady = false;
@@ -792,23 +799,25 @@ class WebViewFactory {
     // Bloom prefilter: if definitely not in set, allow without roundtrip
     if (!maybeBlocked(host)) {
       cacheResult(host, false);
-      window.flutter_inappwebview.callHandler('dnsResourceLoaded', url);
+      window.flutter_inappwebview.callHandler('blockResourceLoaded', url);
       return Promise.resolve(false);
     }
-    // Possibly blocked — confirm via Dart, then cache result
-    return window.flutter_inappwebview.callHandler('dnsCheck', url).then(function(blocked) {
+    // Possibly blocked — confirm via Dart, then cache result. Dart
+    // decides DNS vs ABP and records the source in per-site stats.
+    return window.flutter_inappwebview.callHandler('blockCheck', url).then(function(blocked) {
       cacheResult(host, blocked);
       return blocked;
     });
   }
 
-  // Fetch Bloom filter + persisted per-site cache from Dart at startup
+  // Fetch merged DNS+ABP Bloom filter + persisted per-site cache from
+  // Dart at startup.
   function loadBloom() {
     if (!window.flutter_inappwebview || !window.flutter_inappwebview.callHandler) {
       setTimeout(loadBloom, 50);
       return;
     }
-    window.flutter_inappwebview.callHandler('getDnsBloom').then(function(map) {
+    window.flutter_inappwebview.callHandler('getBlockBloom').then(function(map) {
       if (!map) return;
       var bytes = map.bits;
       bloomBits = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
@@ -996,28 +1005,58 @@ class WebViewFactory {
             return args.isNotEmpty ? args[0] : '';
           });
         }
-        // DNS stats: register handler for resource observer JS
-        if (config.siteId != null && DnsBlockService.instance.hasBlocklist) {
-          controller.addJavaScriptHandler(handlerName: 'dnsResourceLoaded', callback: (args) {
+        // Block stats: register handler for resource observer JS. Runs
+        // whenever either blocklist is active so allowed requests are
+        // tallied even if DNS is off but ABP is on (or vice versa).
+        final hasAnyBlocklistDomains =
+            DnsBlockService.instance.hasBlocklist ||
+                ContentBlockerService.instance.blockedDomains.isNotEmpty;
+        if (config.siteId != null && hasAnyBlocklistDomains) {
+          controller.addJavaScriptHandler(handlerName: 'blockResourceLoaded', callback: (args) {
             if (args.isNotEmpty && args[0] is String) {
               final url = args[0] as String;
-              final blocked = DnsBlockService.instance.isBlocked(url);
-              DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
+              final dnsBlocked = config.dnsBlockEnabled &&
+                  DnsBlockService.instance.isBlocked(url);
+              final abpBlocked = !dnsBlocked &&
+                  config.contentBlockEnabled &&
+                  ContentBlockerService.instance.isBlocked(url);
+              final blocked = dnsBlocked || abpBlocked;
+              final source = dnsBlocked
+                  ? BlockSource.dns
+                  : (abpBlocked ? BlockSource.abp : null);
+              DnsBlockService.instance
+                  .recordRequest(config.siteId!, url, blocked, source: source);
             }
             return null;
           });
-          // iOS sub-resource blocking: per-URL check from JS interceptor
-          if (!Platform.isAndroid && config.dnsBlockEnabled) {
-            controller.addJavaScriptHandler(handlerName: 'dnsCheck', callback: (args) {
+          // iOS sub-resource blocking: per-URL check from JS interceptor.
+          // Merged Bloom prefilter runs in JS; Dart resolves DNS vs ABP.
+          if (!Platform.isAndroid) {
+            controller.addJavaScriptHandler(handlerName: 'blockCheck', callback: (args) {
               if (args.isEmpty || args[0] is! String) return false;
               final url = args[0] as String;
-              final blocked = DnsBlockService.instance.isBlocked(url);
-              DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
-              return blocked;
+              if (config.dnsBlockEnabled &&
+                  DnsBlockService.instance.isBlocked(url)) {
+                DnsBlockService.instance.recordRequest(
+                    config.siteId!, url, true,
+                    source: BlockSource.dns);
+                return true;
+              }
+              if (config.contentBlockEnabled &&
+                  ContentBlockerService.instance.isBlocked(url)) {
+                DnsBlockService.instance.recordRequest(
+                    config.siteId!, url, true,
+                    source: BlockSource.abp);
+                return true;
+              }
+              DnsBlockService.instance
+                  .recordRequest(config.siteId!, url, false);
+              return false;
             });
-            // One-shot bloom filter + global domain cache delivery to JS
-            controller.addJavaScriptHandler(handlerName: 'getDnsBloom', callback: (args) {
-              final map = Map<String, dynamic>.from(DnsBlockService.instance.getBloomFilter().toMap());
+            // One-shot merged Bloom filter + global domain cache delivery to JS
+            controller.addJavaScriptHandler(handlerName: 'getBlockBloom', callback: (args) {
+              final map = Map<String, dynamic>.from(
+                  DnsBlockService.instance.getMergedBlockBloom().toMap());
               map['cache'] = DnsBlockService.instance.getDomainCache();
               return map;
             });
@@ -1052,13 +1091,19 @@ class WebViewFactory {
         if (DnsBlockService.instance.hasBlocklist && config.siteId != null) {
           LogService.instance.log('DnsBlock', '[Navigation] $url');
           final blocked = DnsBlockService.instance.isBlocked(url);
-          DnsBlockService.instance.recordRequest(config.siteId!, url, blocked);
+          DnsBlockService.instance.recordRequest(config.siteId!, url, blocked,
+              source: blocked ? BlockSource.dns : null);
           if (blocked && config.dnsBlockEnabled) {
             return inapp.NavigationActionPolicy.CANCEL;
           }
         }
-        // Content blocker domain check
+        // Content blocker domain check (main-doc navigation; sub-resources
+        // are caught by the native / JS interceptor).
         if (config.contentBlockEnabled && ContentBlockerService.instance.isBlocked(url)) {
+          if (config.siteId != null) {
+            DnsBlockService.instance.recordRequest(config.siteId!, url, true,
+                source: BlockSource.abp);
+          }
           return inapp.NavigationActionPolicy.CANCEL;
         }
         // ClearURLs: strip tracking parameters from URLs
@@ -1115,12 +1160,24 @@ class WebViewFactory {
       onLoadStart: (controller, url) async {
         // Track that this URL has a real page load (not SPA navigation)
         lastLoadStartUrl = url?.toString();
-        // Record the page navigation for DNS stats so the banner shows immediately
-        if (config.siteId != null && DnsBlockService.instance.hasBlocklist
-            && url != null && url.toString().startsWith('http')) {
+        // Record the page navigation for the block stats banner so it
+        // appears immediately. Tag the source (DNS or ABP) so the log
+        // keeps the attribution even for main-doc loads.
+        if (config.siteId != null &&
+            (DnsBlockService.instance.hasBlocklist ||
+                ContentBlockerService.instance.blockedDomains.isNotEmpty) &&
+            url != null &&
+            url.toString().startsWith('http')) {
           final urlStr = url.toString();
-          DnsBlockService.instance.recordRequest(config.siteId!, urlStr,
-              DnsBlockService.instance.isBlocked(urlStr));
+          final dnsBlocked = DnsBlockService.instance.isBlocked(urlStr);
+          final abpBlocked = !dnsBlocked &&
+              ContentBlockerService.instance.isBlocked(urlStr);
+          final blocked = dnsBlocked || abpBlocked;
+          final source = dnsBlocked
+              ? BlockSource.dns
+              : (abpBlocked ? BlockSource.abp : null);
+          DnsBlockService.instance
+              .recordRequest(config.siteId!, urlStr, blocked, source: source);
         }
         // Re-inject CSS for in-page navigations (initialUserScripts only runs on first load)
         if (config.contentBlockEnabled && url != null) {

--- a/lib/widgets/stats_banner.dart
+++ b/lib/widgets/stats_banner.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 
-/// A compact banner displayed at the top of the webview showing live DNS
-/// blocking activity per site. Taps expand/collapse the banner. Automatically
-/// hides when there's no activity to report.
+/// A compact banner displayed at the top of the webview showing live
+/// block activity per site (DNS + ABP merged). Taps expand/collapse the
+/// banner. Automatically hides when there's no activity to report.
 class StatsBanner extends StatefulWidget {
   final String siteId;
   final bool dnsBlockEnabled;
@@ -46,7 +47,9 @@ class _StatsBannerState extends State<StatsBanner> {
 
   @override
   Widget build(BuildContext context) {
-    if (!DnsBlockService.instance.hasBlocklist) {
+    final hasAnyBlocklist = DnsBlockService.instance.hasBlocklist ||
+        ContentBlockerService.instance.blockedDomains.isNotEmpty;
+    if (!hasAnyBlocklist) {
       return const SizedBox.shrink();
     }
 

--- a/openspec/specs/content-blocker/spec.md
+++ b/openspec/specs/content-blocker/spec.md
@@ -18,11 +18,12 @@ A custom implementation is needed that parses ABP filter syntax directly and app
 
 ## Solution
 
-Three-layer content blocking:
+Four-layer content blocking:
 
-1. **Domain blocking** — O(1) hash set lookup in `shouldOverrideUrlLoading` for `||domain^` rules
-2. **CSS cosmetic filtering** — `<style>` tag injection via `UserScript` at `DOCUMENT_START` for `##selector` rules, with `MutationObserver` for dynamic content
-3. **Text-based hiding** — JavaScript DOM walking for `#?#` rules with `:-abp-contains()` patterns (e.g., hiding posts containing "Promoted" or "Sponsored")
+1. **Main-document domain blocking** — O(1) hash set lookup in `shouldOverrideUrlLoading` for `||domain^` rules
+2. **Sub-resource domain blocking** — ABP's `||domain^` set is pushed into the shared sub-resource interceptor alongside the DNS blocklist. Android uses the native `FastSubresourceInterceptor`; iOS/macOS use a JS interceptor backed by a Bloom-filter prefilter. Hits are attributed per source so per-site stats can show a merged "blocked" count while keeping DNS vs ABP separable.
+3. **CSS cosmetic filtering** — `<style>` tag injection via `UserScript` at `DOCUMENT_START` for `##selector` rules, with `MutationObserver` for dynamic content
+4. **Text-based hiding** — JavaScript DOM walking for `#?#` rules with `:-abp-contains()` patterns (e.g., hiding posts containing "Promoted" or "Sponsored")
 
 Filter lists are downloaded on-demand, cached to disk, and parsed in a background isolate.
 
@@ -153,7 +154,7 @@ Users SHALL be able to manage multiple filter lists with download, enable/disabl
 
 ### Requirement: CB-003 - Domain Blocking
 
-The system SHALL block navigation to domains matched by `||domain^` rules using O(1) hash set lookups.
+The system SHALL block navigation to domains matched by `||domain^` rules using O(1) hash set lookups, for both main-document navigations and sub-resource requests.
 
 #### Scenario: Exact domain match
 
@@ -177,6 +178,39 @@ The system SHALL block navigation to domains matched by `||domain^` rules using 
 
 **Given** a URL in shouldOverrideUrlLoading
 **Then** the content blocker check runs after captcha allowlist and DNS blocklist, before ClearURLs processing
+
+#### Scenario: Sub-resource domain blocking (Android)
+
+**Given** `ads.example.com` is in the ABP blocked domains set
+**And** an enabled filter list contains `||ads.example.com^`
+**When** a page on another origin issues an `<img src="https://ads.example.com/banner.png">` sub-resource request
+**Then** the native `FastSubresourceInterceptor` cancels the request before it reaches the network
+**And** the per-site block log records the event with source `abp`
+
+#### Scenario: Sub-resource domain blocking (iOS/macOS)
+
+**Given** the ABP blocklist contains `tracker.example.com`
+**And** the merged DNS+ABP Bloom filter has been delivered to the webview's JS interceptor
+**When** the page issues a `fetch('https://tracker.example.com/beacon')` call
+**Then** the Bloom prefilter identifies the host as "possibly blocked"
+**And** the Dart `blockCheck` handler confirms the block via `ContentBlockerService.isBlocked`
+**And** the request is rejected with `TypeError: Blocked by DNS blocklist`
+**And** the per-site block log records the event with source `abp`
+
+#### Scenario: Source attribution when domain appears in both lists
+
+**Given** `doubleclick.net` is in both the DNS blocklist and the ABP blocklist
+**When** a sub-resource request to `doubleclick.net` is blocked
+**Then** the interceptor attributes the hit to `dns` (DNS is checked first)
+**And** the ABP block counter is not incremented for that request
+
+#### Scenario: Per-source counters preserved in stats
+
+**Given** a page load produces 10 DNS-blocked sub-resources and 3 ABP-blocked sub-resources
+**Then** `DnsStats.blocked` equals 13 (merged)
+**And** `DnsStats.blockedByDns` equals 10
+**And** `DnsStats.blockedByAbp` equals 3
+**And** the stats banner displays `13 blocked`
 
 ---
 
@@ -301,7 +335,33 @@ The EasyList filter lists SHALL be credited under CC BY-SA 3.0 in the app's lice
 
 ---
 
-### Requirement: CB-008 - Backward Compatibility
+### Requirement: CB-008 - Native Interceptor Synchronization
+
+Whenever the aggregated ABP rule set changes (download, toggle, remove, add custom list), the system SHALL re-push the current `ContentBlockerService.blockedDomains` set to the native Android interceptor and invalidate the merged DNS+ABP JS Bloom filter.
+
+#### Scenario: Rules change fires listener
+
+**Given** a caller has subscribed via `ContentBlockerService.addRulesChangedListener`
+**When** any of `downloadList`, `downloadAllLists`, `toggleList`, `removeList`, `addCustomList`, or `initialize` completes
+**Then** `_rebuildRules` runs and invokes the listener after the aggregated sets are updated
+
+#### Scenario: Main wiring pushes to native and invalidates Bloom
+
+**Given** app startup has registered `ContentBlockerService.addRulesChangedListener`
+**When** the listener fires
+**Then** `WebInterceptNative.sendAbpDomains` is called with the current blocked-domains set (Android only; no-op on other platforms)
+**And** `DnsBlockService.invalidateMergedBloom` clears the cached Bloom so the next webview creation rebuilds it
+
+#### Scenario: Initial sync on startup
+
+**Given** cached filter lists include 50,000 blocked domains at startup
+**When** `ContentBlockerService.initialize` completes
+**Then** main.dart explicitly calls `WebInterceptNative.sendAbpDomains` once
+**And** the listener is registered afterwards so subsequent changes re-sync automatically
+
+---
+
+### Requirement: CB-009 - Backward Compatibility
 
 Existing sites without `contentBlockEnabled` in their stored JSON SHALL default to `true` on deserialization.
 
@@ -426,21 +486,32 @@ Two-phase injection:
 
 ### Hook Point in WebView
 
-Domain blocking in `shouldOverrideUrlLoading`:
+Main-document domain blocking in `shouldOverrideUrlLoading`:
 
 ```dart
 shouldOverrideUrlLoading: (controller, navigationAction) async {
   final url = navigationAction.request.url.toString();
   if (_shouldBlockUrl(url)) return CANCEL;
   if (isCaptchaChallenge(url)) return ALLOW;
+  // DNS check records stats with source: BlockSource.dns on hit
   if (config.dnsBlockEnabled && DnsBlockService.instance.isBlocked(url)) return CANCEL;
-  // Content blocker domain check
+  // Content blocker domain check — records stats with source: BlockSource.abp on hit
   if (config.contentBlockEnabled && ContentBlockerService.instance.isBlocked(url)) {
     return CANCEL;
   }
   // ClearURLs processing...
 }
 ```
+
+### Sub-resource Domain Blocking Integration
+
+ABP's `||domain^` rules extend beyond main-document navigation into every sub-resource request, by feeding the same aggregated set to the shared sub-resource interceptor used by the DNS blocklist.
+
+**Android (native):** `WebInterceptPlugin.kt` maintains two parallel hash sets, `dnsBlockedDomains` and `abpBlockedDomains`. `FastSubresourceInterceptor.checkUrl` tries DNS first (with hierarchy walk-up), then ABP. On match it calls `onBlockChecked(host, true, "dns"|"abp")`, which the Dart bridge drains via `fetchBlockEvents` and records on `DnsBlockService` with the right `BlockSource`.
+
+**iOS/macOS (JS):** A single merged Bloom filter built from DNS ∪ ABP blocked domains is shipped to the JS interceptor via the `getBlockBloom` handler. The JS layer wraps `fetch`, `XMLHttpRequest`, and property setters on `img/script/link/iframe`; a Bloom match triggers the `blockCheck` roundtrip, which in Dart resolves DNS vs ABP (respecting the per-site `dnsBlockEnabled` and `contentBlockEnabled` toggles) and records the decision.
+
+Both paths feed the same `DnsBlockService.DnsStats` structure so the stats banner and dev-tools DNS tab show a single merged "blocked" count while `blockedByDns` / `blockedByAbp` remain separately countable. When one filter list ships a domain that also appears in the DNS blocklist, the DNS side wins attribution (it's checked first).
 
 ### Storage
 
@@ -469,11 +540,16 @@ shouldOverrideUrlLoading: (controller, navigationAction) async {
 
 ### Modified
 - `lib/web_view_model.dart` — Added `contentBlockEnabled` field, serialization, pass to WebViewConfig
-- `lib/services/webview.dart` — Added `contentBlockEnabled` to WebViewConfig, domain block hook, UserScript CSS injection at DOCUMENT_START, cosmetic script injection at onLoadStop
+- `lib/services/webview.dart` — Added `contentBlockEnabled` to WebViewConfig, domain block hook, UserScript CSS injection at DOCUMENT_START, cosmetic script injection at onLoadStop, merged DNS+ABP JS Bloom interceptor, source-tagged stat recording
+- `lib/services/content_blocker_service.dart` — Public `blockedDomains` getter, `addRulesChangedListener`/`removeRulesChangedListener` for native + JS Bloom sync
+- `lib/services/dns_block_service.dart` — `BlockSource` enum, source field on `DnsLogEntry`, `blockedByDns`/`blockedByAbp` counters, `getMergedBlockBloom` for DNS ∪ ABP, blocklist-changed listeners
+- `lib/services/web_intercept_native.dart` — `sendDnsDomains` + `sendAbpDomains` split, source-tagged block events drained via `fetchBlockEvents`
+- `android/app/src/main/kotlin/org/codeberg/theoden8/webspace/WebInterceptPlugin.kt` — Split DNS/ABP domain sets, source-tagged block events, renamed method channel handlers to `setDnsBlockedDomains` / `setAbpBlockedDomains` / `fetchBlockEvents` / `blockEventsReady`
+- `lib/widgets/stats_banner.dart` — Shows banner when either DNS or ABP has populated domain sets
 - `lib/screens/settings.dart` — Per-site Content Blocker toggle (SwitchListTile)
 - `lib/screens/app_settings.dart` — Content Blocker section with list management UI, download/toggle/remove, custom list dialog
 - `lib/screens/inappbrowser.dart` — Propagate `contentBlockEnabled` to nested webview
-- `lib/main.dart` — ContentBlockerService initialization, CC BY-SA 3.0 license registration
+- `lib/main.dart` — ContentBlockerService initialization, change-listener wiring for native + Bloom sync, CC BY-SA 3.0 license registration
 - `test/web_view_model_test.dart` — Tests for contentBlockEnabled serialization and defaults
 - `README.md` — Feature bullet point, Tech Stack credit with license info
 - `fastlane/metadata/android/en-US/changelogs/9.txt` — Changelog entry

--- a/openspec/specs/dns-blocklist/spec.md
+++ b/openspec/specs/dns-blocklist/spec.md
@@ -245,9 +245,14 @@ stack in a separate process and exposes no equivalent to Android's
 has a ~150K rule limit and compilation takes tens of seconds, while even the
 smallest Hagezi blocklist ("Light") is 146K domains.
 
-Instead, iOS uses a JavaScript interceptor injected at `DOCUMENT_START`:
+Instead, iOS uses a JavaScript interceptor injected at `DOCUMENT_START`.
+The interceptor is shared with the ABP content blocker: the Bloom filter
+shipped to JS is built from DNS ∪ ABP blocked domains, and the Dart
+`blockCheck` handler decides DNS vs ABP on each positive hit, recording
+the decision with the matching [BlockSource] so per-site stats stay
+disentangleable.
 
-- Overrides `window.fetch` — async check via `dnsCheck` handler, reject if blocked
+- Overrides `window.fetch` — async check via `blockCheck` handler, reject if blocked
 - Overrides `XMLHttpRequest.prototype.open`/`send` — abort if blocked
 - Patches `src`/`href` setters on `HTMLImageElement`, `HTMLScriptElement`,
   `HTMLLinkElement`, `HTMLIFrameElement` — defers the assignment pending the check
@@ -261,8 +266,8 @@ To minimize Dart roundtrips, the iOS interceptor uses three tiers:
 Dart maintains a single `_domainCache: Map<String, bool>` keyed by host (NOT
 per-site — trackers and CDNs are shared across sites, so one site learning
 about `googleapis.com` benefits all sites). Updated transparently via
-`recordRequest` whenever any webview reports a DNS decision (via native
-handler, JS `dnsCheck`, or JS `dnsResourceLoaded`). Persisted in
+`recordRequest` whenever any webview reports a block decision (via native
+handler, JS `blockCheck`, or JS `blockResourceLoaded`). Persisted in
 SharedPreferences under `dns_domain_cache`, write-debounced to 2 seconds.
 Capped at 5000 entries with FIFO eviction. Invalidated (cleared) when the
 blocklist changes, since cached decisions may become stale.
@@ -270,17 +275,19 @@ blocklist changes, since cached decisions may become stale.
 On the JS side (iOS), each webview also maintains `allowedCache` /
 `blockedCache` for instant in-webview lookup without MethodChannel calls.
 Hydrated on webview creation from the Dart global cache via the
-`getDnsBloom` handler (which returns `{bits, bitCount, k, cache}`).
+`getBlockBloom` handler (which returns `{bits, bitCount, k, cache}`).
 Capped at 500 entries with FIFO eviction.
 
 **2. Bloom filter (JS byte array)** — microsecond lookup:
-Built from the blocked domains (~430 KB for 588K domains at 5% false positive
-rate). Sent to JS once on webview creation. Uses FNV-1a hash with
-Kirsch-Mitzenmacher double-hashing for k hash functions. JS implementation
-byte-compatible with Dart `BloomFilter` class.
+Built from the merged DNS ∪ ABP blocked domains (~430 KB for 588K domains
+at 5% false positive rate). Sent to JS once on webview creation via
+`getBlockBloom`. Uses FNV-1a hash with Kirsch-Mitzenmacher double-hashing
+for k hash functions. JS implementation byte-compatible with Dart
+`BloomFilter` class. Rebuilt lazily; invalidated whenever either the DNS
+blocklist or the aggregated ABP rule set changes.
 
-- Bloom says "definitely not" → allow without roundtrip, record via `dnsResourceLoaded`, add to JS cache
-- Bloom says "possibly yes" → roundtrip to Dart `dnsCheck` handler for confirmation, add result to JS cache
+- Bloom says "definitely not" → allow without roundtrip, record via `blockResourceLoaded`, add to JS cache
+- Bloom says "possibly yes" → roundtrip to Dart `blockCheck` handler for confirmation, add result to JS cache
 
 **3. Dart authoritative check** — handles false positives + blocks:
 Only ~5% of first-time allowed URLs + all blocked URLs hit Dart. Dart does
@@ -563,7 +570,7 @@ one is in flight.
 
 **Given** the events list for a site is empty
 **When** the first event is recorded (allowed or blocked)
-**Then** Dart receives a `dnsEventsReady` method call with the siteId only
+**Then** Dart receives a `blockEventsReady` method call with the siteId only
 (no event data in the signal payload)
 
 #### Scenario: Burst of events coalesced
@@ -578,7 +585,7 @@ one is in flight.
 
 **Given** Dart has completed a `fetchEvents` call and cleared the list
 **When** a new event occurs
-**Then** a new `dnsEventsReady` signal is sent
+**Then** a new `blockEventsReady` signal is sent
 
 #### Scenario: Stats update without PerformanceObserver lag
 
@@ -690,7 +697,7 @@ class FastSubresourceInterceptor(
 ```
 
 The `WebInterceptPlugin` manages the lifecycle:
-1. `setBlockedDomains` — receives domain list from Dart, stores in Java `HashSet`
+1. `setDnsBlockedDomains` / `setAbpBlockedDomains` — receives per-source domain lists from Dart, stores in two Java `HashSet`s kept separate so events can be attributed
 2. `attachToWebViews(siteId)` — traverses view hierarchy, finds `InAppWebView`
    instances, replaces `contentBlockerHandler` field with `FastSubresourceInterceptor`
 3. **Pull-based event delivery** — Java accumulates blocked events in a
@@ -717,9 +724,9 @@ if (DnsBlockService.instance.hasBlocklist) {
 
 **onLoadStart** (all platforms) — records page URL for immediate banner display.
 
-**PerformanceObserver JS** (all platforms) — injected at `DOCUMENT_START` with
+**PerformanceObserver JS** (iOS/macOS) — injected at `DOCUMENT_START` with
 `buffered: true`, records all completed resources via Resource Timing API.
-Reports back to Dart via `addJavaScriptHandler('dnsResourceLoaded')`.
+Reports back to Dart via `addJavaScriptHandler('blockResourceLoaded')`.
 
 ### Storage
 


### PR DESCRIPTION
Pipe ContentBlockerService.blockedDomains through the same paths DNS already uses, so ABP `||domain^` rules catch sub-resource requests (previously they only applied to main-document navigation).

- Android native: split dns/abp HashSets in FastSubresourceInterceptor, check DNS first, attribute each hit with a source tag in block events.
- iOS/macOS JS: merged DNS ∪ ABP Bloom filter for the prefilter; Dart `blockCheck` resolves DNS vs ABP respecting per-site toggles.
- Stats: BlockSource enum + blockedByDns/blockedByAbp counters keep the banner's merged count while preserving source attribution. DNS wins attribution when a domain appears in both lists (no double-counting).
- Change listeners on both services push to native + invalidate the merged Bloom automatically; individual call sites no longer sync.
- Handler/channel renames: dnsCheck → blockCheck, getDnsBloom → getBlockBloom, setBlockedDomains → setDnsBlockedDomains + setAbpBlockedDomains, dnsEventsReady/fetchDnsEvents → block*.

Specs updated (content-blocker CB-003, CB-008; dns-blocklist handler names + merged Bloom note). Full test suite passes (559/559).

https://claude.ai/code/session_01HxA1mTMC1Wii2wjvAH9xNR