### PR TITLE
Fix Navigator _debugLocked assertion when saving site settings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,6 +45,7 @@ import 'package:webspace/screens/dev_tools.dart';
 import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/settings/user_script.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:webspace/widgets/root_messenger.dart';
 
 // Accent color enum
 enum AccentColor {
@@ -639,6 +640,7 @@ class _WebSpaceAppState extends State<WebSpaceApp> {
     final Color accentColor = _accentColorToColor(_themeSettings.accentColor);
     return MaterialApp(
       title: 'WebSpace',
+      scaffoldMessengerKey: rootScaffoldMessengerKey,
       theme: ThemeData(
         colorScheme: _buildAccentColorScheme(accentColor, Brightness.light),
         scaffoldBackgroundColor: Color(0xFFFFFFFF),

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -12,6 +12,7 @@ import 'package:webspace/services/localcdn_service.dart';
 import 'package:webspace/screens/user_scripts.dart';
 import 'package:webspace/settings/user_script.dart';
 import 'package:webspace/widgets/hint_button.dart';
+import 'package:webspace/widgets/root_messenger.dart';
 
 // Supported languages for webview
 const List<MapEntry<String?, String>> _languages = [
@@ -310,18 +311,21 @@ class _SettingsScreenState extends State<SettingsScreen> {
       // Update current URL to ensure reload
       widget.webViewModel.currentUrl = currentUrl;
 
-      // Notify parent to rebuild (this will recreate the webview)
-      widget.onSettingsSaved?.call();
+      // Pop first so the Settings route leaves the tree before the parent
+      // rebuilds. Notifying the parent inline would mark the Navigator dirty
+      // while it is locked during the pop, tripping the '!_debugLocked'
+      // assertion in NavigatorState.build.
+      Navigator.pop(context);
 
-      ScaffoldMessenger.of(context).showSnackBar(
+      rootScaffoldMessengerKey.currentState?.showSnackBar(
         SnackBar(content: Text('Settings saved and webview reloaded')),
       );
 
-      Navigator.pop(context);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        widget.onSettingsSaved?.call();
+      });
     } catch (e) {
-      if (!mounted) return;
-
-      ScaffoldMessenger.of(context).showSnackBar(
+      rootScaffoldMessengerKey.currentState?.showSnackBar(
         SnackBar(content: Text('Error saving settings: $e')),
       );
     }

--- a/lib/widgets/root_messenger.dart
+++ b/lib/widgets/root_messenger.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/material.dart';
+
+/// Global key for the root [ScaffoldMessenger] so snackbars can be shown from
+/// contexts that may be deactivating (e.g. immediately after popping a route).
+final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey =
+    GlobalKey<ScaffoldMessengerState>();


### PR DESCRIPTION
The settings save flow called onSettingsSaved (which triggers setState on WebSpacePage) before Navigator.pop. That marked the MaterialApp's Navigator dirty while pop was running, tripping the '!_debugLocked' assertion in NavigatorState.build. When the subsequent throw hit the catch block, ScaffoldMessenger.of(context) then tried to look up an ancestor on the deactivated settings context, producing the second error.

Pop the settings route first, show the snackbar via a root ScaffoldMessengerKey (so it survives the route leaving the tree), and defer the parent rebuild to a post-frame callback so it happens after the pop commits.