### PR TITLE
Opt-in global user scripts per site

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -827,6 +827,26 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     }
   }
 
+  /// Migrate pre-opt-in data: older builds ran every enabled global script
+  /// on every site. After switching to per-site opt-in, sites that haven't
+  /// declared [WebViewModel.enabledGlobalScriptIds] would silently lose
+  /// their global scripts. For each site with an empty opt-in set, opt it
+  /// into all currently-defined globals once. A marker key prevents this
+  /// running again after the user starts curating per-site opt-ins.
+  Future<void> _migrateGlobalScriptOptIn() async {
+    if (_globalUserScripts.isEmpty || _webViewModels.isEmpty) return;
+    final prefs = await SharedPreferences.getInstance();
+    if (prefs.getBool('globalUserScriptsOptInMigrated') == true) return;
+    final allIds = _globalUserScripts.map((s) => s.id).toSet();
+    for (final model in _webViewModels) {
+      if (model.enabledGlobalScriptIds.isEmpty) {
+        model.enabledGlobalScriptIds = {...allIds};
+      }
+    }
+    await prefs.setBool('globalUserScriptsOptInMigrated', true);
+    await _saveWebViewModels();
+  }
+
   Future<void> _saveWebspaces() async {
     if (isDemoMode) return; // Don't persist in demo mode
     SharedPreferences prefs = await SharedPreferences.getInstance();
@@ -1172,6 +1192,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await _loadWebspaces();
     await _loadGlobalUserScripts();
     await _loadWebViewModels();
+    await _migrateGlobalScriptOptIn();
     _suggestedSites = await suggested_sites.getEffectiveSuggestedSites();
 
     // Always start at home screen on launch - only restore index if launched via shortcut

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -463,7 +463,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
             subtitle: Text(
               widget.globalUserScripts.isEmpty
                   ? 'No global scripts'
-                  : '${widget.globalUserScripts.where((s) => s.enabled).length} active (all sites)',
+                  : '${widget.globalUserScripts.length} defined — opt in per site',
             ),
             trailing: const Icon(Icons.chevron_right),
             onTap: () {
@@ -471,11 +471,12 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
                 context,
                 MaterialPageRoute(
                   builder: (_) => UserScriptsScreen(
-                    title: 'User Scripts',
+                    title: 'Global User Scripts',
                     userScripts: widget.globalUserScripts,
                     onSave: (scripts) {
                       widget.onGlobalUserScriptsChanged?.call(scripts);
                     },
+                    isGlobalLibrary: true,
                   ),
                 ),
               );

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -192,7 +192,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   String _userScriptsSubtitle() {
     final siteCount = widget.webViewModel.userScripts.where((s) => s.enabled).length;
-    final globalCount = widget.globalUserScripts.where((s) => s.enabled).length;
+    final enabledIds = widget.webViewModel.enabledGlobalScriptIds;
+    final globalCount = widget.globalUserScripts
+        .where((s) => enabledIds.contains(s.id))
+        .length;
     final parts = <String>[];
     if (siteCount > 0) parts.add('$siteCount site');
     if (globalCount > 0) parts.add('$globalCount global');
@@ -602,6 +605,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     },
                     globalUserScripts: widget.globalUserScripts,
                     onGlobalUserScriptsChanged: widget.onGlobalUserScriptsChanged,
+                    enabledGlobalScriptIds: widget.webViewModel.enabledGlobalScriptIds,
+                    onEnabledGlobalScriptIdsChanged: (ids) {
+                      widget.webViewModel.enabledGlobalScriptIds = ids;
+                    },
                     onRun: widget.webViewModel.controller != null
                         ? (source) async {
                             final logsBefore = widget.webViewModel.consoleLogs.length;

--- a/lib/screens/user_scripts.dart
+++ b/lib/screens/user_scripts.dart
@@ -3,9 +3,21 @@ import 'package:http/http.dart' as http;
 
 import 'package:webspace/settings/user_script.dart';
 
-/// Screen for managing per-site user scripts.
+/// Screen for managing user scripts.
 ///
-/// Edits apply to the model immediately via [onSave]. The parent Settings
+/// Two usage modes:
+///   1. **Per-site mode** ([enabledGlobalScriptIds] non-null) — edits per-site
+///      scripts (via [onSave]) and per-site opt-in for global scripts (via
+///      [onEnabledGlobalScriptIdsChanged]). Global script toggle controls
+///      whether this site injects the global script, NOT the global master
+///      switch. Edits to a global script's content propagate to all sites
+///      via [onGlobalUserScriptsChanged].
+///   2. **App Settings mode** ([enabledGlobalScriptIds] null) — manages the
+///      global script library. The tiles shown come from [userScripts]
+///      (treated as the master list). Toggling flips the script's master
+///      [UserScriptConfig.enabled]; disabling stops the script on all sites.
+///
+/// Edits apply to the model immediately via callbacks. The parent Settings
 /// screen handles webview reload when "Save Settings" is tapped.
 class UserScriptsScreen extends StatefulWidget {
   final String title;
@@ -18,10 +30,23 @@ class UserScriptsScreen extends StatefulWidget {
   /// context menu offers "Make Global". The callback receives the script
   /// to add to global scripts; the caller is responsible for persisting it.
   final void Function(UserScriptConfig script)? onMakeGlobal;
-  /// Global scripts displayed alongside site scripts (editable).
+  /// Global scripts displayed alongside site scripts (per-site mode) or as
+  /// the primary list (App Settings mode passes them as [userScripts]).
   final List<UserScriptConfig> globalUserScripts;
-  /// Callback when global scripts change (edit/toggle).
+  /// Callback when global scripts change (edit / add / delete).
   final void Function(List<UserScriptConfig>)? onGlobalUserScriptsChanged;
+  /// Per-site opt-in set for global scripts. Non-null in per-site mode;
+  /// the global tile switch toggles membership in this set. Null in
+  /// App Settings (global library) mode.
+  final Set<String>? enabledGlobalScriptIds;
+  /// Callback when the per-site opt-in set changes. Required in per-site
+  /// mode.
+  final void Function(Set<String>)? onEnabledGlobalScriptIdsChanged;
+  /// When true, the [userScripts] list IS the global library: tiles are
+  /// rendered with the "Global" badge and have no enabled toggle (globals
+  /// have no master switch — per-site opt-in is the only enable control).
+  /// Add / edit / delete all operate on the global library.
+  final bool isGlobalLibrary;
 
   const UserScriptsScreen({
     super.key,
@@ -32,6 +57,9 @@ class UserScriptsScreen extends StatefulWidget {
     this.onMakeGlobal,
     this.globalUserScripts = const [],
     this.onGlobalUserScriptsChanged,
+    this.enabledGlobalScriptIds,
+    this.onEnabledGlobalScriptIdsChanged,
+    this.isGlobalLibrary = false,
   });
 
   @override
@@ -41,19 +69,23 @@ class UserScriptsScreen extends StatefulWidget {
 class _UserScriptsScreenState extends State<UserScriptsScreen> {
   late List<UserScriptConfig> _scripts;
   late List<UserScriptConfig> _globalScripts;
+  late Set<String> _enabledGlobalIds;
 
   bool get _hasGlobal => _globalScripts.isNotEmpty;
+  bool get _isPerSiteMode => widget.enabledGlobalScriptIds != null;
 
   @override
   void initState() {
     super.initState();
     _scripts = _deepCopy(widget.userScripts);
     _globalScripts = _deepCopy(widget.globalUserScripts);
+    _enabledGlobalIds = {...?widget.enabledGlobalScriptIds};
   }
 
   static List<UserScriptConfig> _deepCopy(List<UserScriptConfig> scripts) {
     return scripts
         .map((s) => UserScriptConfig(
+              id: s.id,
               name: s.name,
               source: s.source,
               url: s.url,
@@ -70,6 +102,10 @@ class _UserScriptsScreenState extends State<UserScriptsScreen> {
 
   void _syncGlobal() {
     widget.onGlobalUserScriptsChanged?.call(_globalScripts);
+  }
+
+  void _syncEnabledGlobalIds() {
+    widget.onEnabledGlobalScriptIdsChanged?.call(_enabledGlobalIds);
   }
 
   void _addScript() async {
@@ -107,8 +143,13 @@ class _UserScriptsScreenState extends State<UserScriptsScreen> {
   }
 
   void _deleteGlobalScript(int index) {
-    setState(() => _globalScripts.removeAt(index));
+    final removed = _globalScripts[index];
+    setState(() {
+      _globalScripts.removeAt(index);
+      _enabledGlobalIds.remove(removed.id);
+    });
     _syncGlobal();
+    if (_isPerSiteMode) _syncEnabledGlobalIds();
   }
 
   Future<bool> _confirmDelete(UserScriptConfig script, {required bool isGlobal}) async {
@@ -220,10 +261,14 @@ class _UserScriptsScreenState extends State<UserScriptsScreen> {
     );
     if (confirmed == true && mounted) {
       setState(() {
-        _globalScripts.add(_scripts.removeAt(index));
+        final promoted = _scripts.removeAt(index);
+        _globalScripts.add(promoted);
+        // Keep the script running on this site: opt in to its global id.
+        if (_isPerSiteMode) _enabledGlobalIds.add(promoted.id);
       });
       _syncSite();
       _syncGlobal();
+      if (_isPerSiteMode) _syncEnabledGlobalIds();
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('"${script.name}" moved to global scripts')),
@@ -287,6 +332,11 @@ class _UserScriptsScreenState extends State<UserScriptsScreen> {
             buildDefaultDragHandles: false,
             itemBuilder: (context, index) {
               final script = _scripts[index];
+              // In global library mode the primary list IS the global
+              // scripts: render with the "Global" badge, hide the per-item
+              // enabled switch (globals have no master switch), and skip
+              // the "Make Global" long-press action.
+              final isGlobal = widget.isGlobalLibrary;
               return Dismissible(
                 key: ValueKey('site_${script.name}_$index'),
                 direction: DismissDirection.endToStart,
@@ -296,28 +346,50 @@ class _UserScriptsScreenState extends State<UserScriptsScreen> {
                   padding: const EdgeInsets.only(right: 16),
                   child: const Icon(Icons.delete, color: Colors.white),
                 ),
-                confirmDismiss: (_) => _confirmDelete(script, isGlobal: false),
+                confirmDismiss: (_) => _confirmDelete(script, isGlobal: isGlobal),
                 onDismissed: (_) => _deleteScript(index),
                 child: ListTile(
                   leading: ReorderableDragStartListener(
                     index: index,
                     child: const Icon(Icons.drag_handle),
                   ),
-                  title: Text(script.name),
+                  title: isGlobal
+                      ? Row(
+                          children: [
+                            Expanded(child: Text(script.name)),
+                            Container(
+                              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                              decoration: BoxDecoration(
+                                color: Theme.of(context).colorScheme.primaryContainer,
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                              child: Text(
+                                'Global',
+                                style: TextStyle(
+                                  fontSize: 10,
+                                  color: Theme.of(context).colorScheme.onPrimaryContainer,
+                                ),
+                              ),
+                            ),
+                          ],
+                        )
+                      : Text(script.name),
                   subtitle: Text(
                     script.injectionTime == UserScriptInjectionTime.atDocumentStart
                         ? 'Runs at document start'
                         : 'Runs at document end',
                   ),
-                  trailing: Switch(
-                    value: script.enabled,
-                    onChanged: (value) {
-                      setState(() => script.enabled = value);
-                      _syncSite();
-                    },
-                  ),
+                  trailing: isGlobal
+                      ? null
+                      : Switch(
+                          value: script.enabled,
+                          onChanged: (value) {
+                            setState(() => script.enabled = value);
+                            _syncSite();
+                          },
+                        ),
                   onTap: () => _editScript(index),
-                  onLongPress: () => _showSiteScriptActions(index),
+                  onLongPress: isGlobal ? null : () => _showSiteScriptActions(index),
                 ),
               );
             },
@@ -328,6 +400,11 @@ class _UserScriptsScreenState extends State<UserScriptsScreen> {
 
   Widget _buildGlobalTile(int index) {
     final script = _globalScripts[index];
+    final injectionLabel = script.injectionTime == UserScriptInjectionTime.atDocumentStart
+        ? 'Runs at document start'
+        : 'Runs at document end';
+    final isOptedIn = _enabledGlobalIds.contains(script.id);
+
     return ListTile(
       leading: Icon(Icons.public, size: 20, color: Theme.of(context).colorScheme.primary),
       title: Row(
@@ -349,20 +426,25 @@ class _UserScriptsScreenState extends State<UserScriptsScreen> {
           ),
         ],
       ),
-      subtitle: Text(
-        script.injectionTime == UserScriptInjectionTime.atDocumentStart
-            ? 'Runs at document start'
-            : 'Runs at document end',
-      ),
-      trailing: Switch(
-        value: script.enabled,
-        onChanged: widget.onGlobalUserScriptsChanged != null
-            ? (value) {
-                setState(() => script.enabled = value);
-                _syncGlobal();
-              }
-            : null,
-      ),
+      subtitle: Text(injectionLabel),
+      // Per-site opt-in is the only enable control for global scripts.
+      // In per-site mode the switch toggles membership in this site's
+      // [enabledGlobalScriptIds] set. No toggle otherwise.
+      trailing: _isPerSiteMode
+          ? Switch(
+              value: isOptedIn,
+              onChanged: (value) {
+                setState(() {
+                  if (value) {
+                    _enabledGlobalIds.add(script.id);
+                  } else {
+                    _enabledGlobalIds.remove(script.id);
+                  }
+                });
+                _syncEnabledGlobalIds();
+              },
+            )
+          : null,
       onTap: widget.onGlobalUserScriptsChanged != null
           ? () => _editGlobalScript(index)
           : null,
@@ -480,6 +562,10 @@ class _UserScriptEditScreenState extends State<UserScriptEditScreen> {
     Navigator.pop(
       context,
       UserScriptConfig(
+        // Preserve the original id when editing so per-site opt-in sets
+        // (enabledGlobalScriptIds) stay valid. A fresh script generates
+        // a new id automatically.
+        id: widget.script?.id,
         name: name,
         source: _sourceController.text,
         url: url.isEmpty ? null : url,

--- a/lib/settings/user_script.dart
+++ b/lib/settings/user_script.dart
@@ -1,12 +1,20 @@
+import 'dart:math';
+
 /// Model for a user-defined script to inject into webviews.
 ///
-/// Each script has a name, source code, injection time, and enabled toggle.
-/// Optionally, a [url] can be set to fetch script source from a CDN.
-/// The fetched content is cached in [urlSource]. At injection time the
-/// full script is [urlSource] + [source], so users can load a library
-/// from URL and call its API in [source].
+/// Each script has a stable [id], a name, source code, injection time, and
+/// an [enabled] flag. Optionally, a [url] can be set to fetch script source
+/// from a CDN. The fetched content is cached in [urlSource]. At injection
+/// time the full script is [urlSource] + [source], so users can load a
+/// library from URL and call its API in [source].
 ///
-/// Scripts are stored per-site in WebViewModel and serialized to JSON.
+/// Scripts are stored either per-site in WebViewModel (site-specific
+/// scripts) or globally in app state. For **site-specific scripts**,
+/// [enabled] controls whether the script is injected on that site. For
+/// **global scripts**, [enabled] is ignored — a global script runs ONLY on
+/// sites that have explicitly opted it in via
+/// [WebViewModel.enabledGlobalScriptIds]. Global scripts have no master
+/// switch; per-site opt-in is the only enable control.
 enum UserScriptInjectionTime {
   atDocumentStart,
   atDocumentEnd,
@@ -79,7 +87,18 @@ ScriptFetchUrlStatus classifyScriptFetchUrl(String url) {
   return ScriptFetchUrlStatus.requiresConfirmation;
 }
 
+/// Generate a stable unique identifier for a user script.
+String _generateUserScriptId() {
+  final now = DateTime.now().microsecondsSinceEpoch;
+  final random = Random().nextInt(999999);
+  return 'us-${now.toRadixString(36)}-${random.toRadixString(36)}';
+}
+
 class UserScriptConfig {
+  /// Stable unique identifier. For global scripts this is used to track
+  /// which sites have opted into the script. Auto-generated if omitted;
+  /// preserved across JSON roundtrips.
+  final String id;
   String name;
   String source;
   /// Optional URL to fetch script source from (e.g., CDN-hosted library).
@@ -88,16 +107,20 @@ class UserScriptConfig {
   /// Cached content downloaded from [url].
   String? urlSource;
   UserScriptInjectionTime injectionTime;
+  /// Master switch. For global scripts this disables the script on all
+  /// sites regardless of per-site opt-in; for site scripts this simply
+  /// controls whether the script is injected.
   bool enabled;
 
   UserScriptConfig({
+    String? id,
     required this.name,
     required this.source,
     this.url,
     this.urlSource,
     this.injectionTime = UserScriptInjectionTime.atDocumentEnd,
     this.enabled = true,
-  });
+  }) : id = id ?? _generateUserScriptId();
 
   /// The full script to inject: URL source (if any) followed by user source.
   String get fullSource {
@@ -111,6 +134,7 @@ class UserScriptConfig {
   }
 
   Map<String, dynamic> toJson() => {
+        'id': id,
         'name': name,
         'source': source,
         if (url != null) 'url': url,
@@ -121,6 +145,7 @@ class UserScriptConfig {
 
   factory UserScriptConfig.fromJson(Map<String, dynamic> json) {
     return UserScriptConfig(
+      id: json['id'] as String?,
       name: json['name'] ?? 'Untitled',
       source: json['source'] ?? '',
       url: json['url'],

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -263,6 +263,10 @@ class WebViewModel {
   bool blockAutoRedirects; // Block script-initiated cross-domain navigations
   bool fullscreenMode; // Auto-enter fullscreen when this site is selected
   List<UserScriptConfig> userScripts; // Per-site user scripts
+  /// IDs of global user scripts opted into for this site. Global scripts
+  /// are stored once in app state (shared source/URL) and each site
+  /// independently enables which ones to inject.
+  Set<String> enabledGlobalScriptIds;
   Set<BlockedCookie> blockedCookies; // Per-site blocked cookies (name + domain)
 
   final List<ConsoleLogEntry> consoleLogs = [];
@@ -293,9 +297,11 @@ class WebViewModel {
     this.blockAutoRedirects = true,
     this.fullscreenMode = false,
     List<UserScriptConfig>? userScripts,
+    Set<String>? enabledGlobalScriptIds,
     Set<BlockedCookie>? blockedCookies,
     this.stateSetterF,
   })  : userScripts = userScripts ?? [],
+        enabledGlobalScriptIds = enabledGlobalScriptIds ?? {},
         blockedCookies = blockedCookies ?? {},
         siteId = siteId ?? _generateSiteId(),
         currentUrl = currentUrl ?? initUrl,
@@ -447,7 +453,10 @@ class WebViewModel {
           dnsBlockEnabled: dnsBlockEnabled,
           contentBlockEnabled: contentBlockEnabled,
           localCdnEnabled: localCdnEnabled,
-          userScripts: [...globalUserScripts, ...userScripts],
+          userScripts: [
+            ...globalUserScripts.where((g) => enabledGlobalScriptIds.contains(g.id)),
+            ...userScripts,
+          ],
           onConfirmScriptFetch: onConfirmScriptFetch,
           pullToRefreshController: pullToRefreshController,
           onWindowRequested: onWindowRequested,
@@ -740,6 +749,8 @@ class WebViewModel {
         'blockAutoRedirects': blockAutoRedirects,
         'fullscreenMode': fullscreenMode,
         'userScripts': userScripts.map((s) => s.toJson()).toList(),
+        if (enabledGlobalScriptIds.isNotEmpty)
+          'enabledGlobalScriptIds': enabledGlobalScriptIds.toList(),
         if (blockedCookies.isNotEmpty)
           'blockedCookies': blockedCookies.map((b) => b.toJson()).toList(),
       };
@@ -768,6 +779,9 @@ class WebViewModel {
       userScripts: (json['userScripts'] as List<dynamic>?)
           ?.map((e) => UserScriptConfig.fromJson(e as Map<String, dynamic>))
           .toList(),
+      enabledGlobalScriptIds: (json['enabledGlobalScriptIds'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toSet(),
       blockedCookies: (json['blockedCookies'] as List<dynamic>?)
           ?.map((e) => BlockedCookie.fromJson(e as Map<String, dynamic>))
           .toSet(),

--- a/openspec/specs/user-scripts/spec.md
+++ b/openspec/specs/user-scripts/spec.md
@@ -5,15 +5,24 @@
 
 ## Purpose
 
-Allow users to inject custom JavaScript into webviews on a per-site or global basis, enabling personalization, automation, and enhanced browsing experiences. Supports loading external libraries from CDN URLs with CORS-bypassing fetch.
+Allow users to inject custom JavaScript into webviews on a per-site basis, enabling personalization, automation, and enhanced browsing experiences. Scripts can be defined once at the **global** level (shared source code + URL) and then **opted in per site**, so users don't have to copy the same source to every site where they want it to run. Supports loading external libraries from CDN URLs with CORS-bypassing fetch.
 
 ## Problem Statement
 
 Users often want to customize website behavior — hiding annoyances, injecting dark mode CSS, auto-filling forms, extracting data, or fixing broken layouts. Without user script support, these customizations require external tools or are impossible on mobile.
 
+Users also routinely want the SAME script on many sites (e.g. a pop-up remover, a reader-mode helper). Copy-pasting the source into every site's settings is error-prone and painful to maintain. Sharing the definition globally while still giving each site control over whether the script runs solves this.
+
 ## Solution
 
-User scripts stored either per-site in `WebViewModel` or globally in app state, injected via `flutter_inappwebview`'s `UserScript` API. Each script has a name, source code, optional CDN URL, injection timing (document start or end), and an enabled toggle. Scripts are managed through a dedicated UI accessible from per-site settings. Global scripts run on all sites; per-site scripts run only on their configured site.
+Scripts are stored in two places:
+
+- **Per-site** in `WebViewModel.userScripts` — a list of site-specific scripts with their own `enabled` toggle.
+- **Globally** in app state (`_globalUserScripts`) — a shared library of script definitions (name, source, optional CDN URL, injection time).
+
+Global scripts are **not implicitly active** anywhere. They run on a site only when that site opts in by adding the script's stable `id` to its `WebViewModel.enabledGlobalScriptIds` set. This set is edited from the per-site User Scripts screen via a per-site toggle. Global scripts have NO master "enabled" switch — per-site opt-in is the only enable control.
+
+Each script has a stable `id` (auto-generated at creation time, preserved across JSON roundtrips and edits) that the opt-in set references. Injection is performed via `flutter_inappwebview`'s `UserScript` API.
 
 ---
 
@@ -21,7 +30,7 @@ User scripts stored either per-site in `WebViewModel` or globally in app state, 
 
 ### Requirement: US-001 - Per-Site Script Storage
 
-Each site SHALL support zero or more user scripts, each with a name, JavaScript source, optional URL, injection time, and enabled flag.
+Each site SHALL support zero or more user scripts, each with a stable id, a name, JavaScript source, optional URL, injection time, and enabled flag.
 
 #### Scenario: Add a user script to a site
 
@@ -35,27 +44,86 @@ Each site SHALL support zero or more user scripts, each with a name, JavaScript 
 **When** the app is restarted
 **Then** the user scripts are restored from SharedPreferences via `WebViewModel.fromJson()`
 
-### Requirement: US-001b - Global Script Storage
+### Requirement: US-001b - Global Script Library
 
-The app SHALL support global user scripts that run on all sites.
+The app SHALL support a shared library of global user scripts. Each script has a stable `id`. Global scripts are NOT active on any site by default — they run only on sites that explicitly opt them in.
 
 #### Scenario: Add a global user script
 
 **Given** no global scripts configured
-**When** the user adds a global script via App Settings > User Scripts
-**Then** the script is stored in app-level state and persisted to SharedPreferences under `'globalUserScripts'`
+**When** the user adds a global script via App Settings > Global User Scripts
+**Then** the script is stored in app-level state with a generated stable `id` and persisted to SharedPreferences under `'globalUserScripts'`
 
-#### Scenario: Global scripts run on all sites
+#### Scenario: Global scripts do NOT run automatically
 
-**Given** a global script configured and enabled
+**Given** a global script is defined in the global library
+**And** no site has opted it in
 **When** any site's webview loads a page
-**Then** the global script is injected (global scripts run before per-site scripts)
+**Then** the global script is NOT injected
+
+#### Scenario: Global scripts run only on opted-in sites
+
+**Given** a global script with id `us-abc-123`
+**And** site A has `us-abc-123` in its `enabledGlobalScriptIds`
+**And** site B does NOT
+**When** both sites load a page
+**Then** the script is injected on site A and NOT on site B
+
+#### Scenario: No master enable toggle for global scripts
+
+**Given** a global script
+**When** the user views the Global User Scripts screen in App Settings
+**Then** the tile shows no enable switch. Per-site opt-in is the only enable control.
 
 #### Scenario: Global scripts survive app restart
 
 **Given** global user scripts configured
 **When** the app is restarted
-**Then** the global scripts are restored from SharedPreferences
+**Then** the global scripts (including their ids) are restored from SharedPreferences
+
+### Requirement: US-001c - Per-Site Global Opt-In
+
+Each `WebViewModel` SHALL store a `Set<String> enabledGlobalScriptIds` indicating which global scripts run on it. The set is independent of other sites.
+
+#### Scenario: Opt a site into a global script
+
+**Given** a site with an empty `enabledGlobalScriptIds` and a global script `us-abc-123`
+**When** the user toggles the global script's switch ON in the site's User Scripts screen
+**Then** `us-abc-123` is added to the site's `enabledGlobalScriptIds` and persisted; the script runs on the next page load
+
+#### Scenario: Opt out of a global script on one site only
+
+**Given** sites A and B both opted into global script `us-abc-123`
+**When** the user toggles the global script OFF from site A's User Scripts screen
+**Then** `us-abc-123` is removed from site A's `enabledGlobalScriptIds` only; site B is unaffected
+
+#### Scenario: Deleting a global script cleans up opt-ins for the current site
+
+**Given** the current site has opted into global script `us-abc-123`
+**When** the user deletes that global script from the per-site User Scripts screen (long-press → Delete)
+**Then** the script is removed from the global library AND from the current site's `enabledGlobalScriptIds`. Other sites may retain the stale id; stale ids do not match any global and are simply ignored during injection.
+
+#### Scenario: Editing a global script preserves its id
+
+**Given** a global script with id `us-abc-123`
+**When** the user edits its name, source, URL, or injection time
+**Then** the id is preserved so existing per-site opt-ins continue to reference the correct script
+
+### Requirement: US-001d - Migration from Pre-Opt-In Data
+
+Data saved before the opt-in model (where global scripts ran on every site) SHALL not silently lose script functionality. On first launch after upgrade, sites with empty `enabledGlobalScriptIds` SHALL be opted into every currently-defined global script. A migration marker in SharedPreferences SHALL prevent the one-time fill from re-running after the user starts curating per-site opt-ins.
+
+#### Scenario: First launch after upgrade
+
+**Given** a SharedPreferences state from the pre-opt-in model with N global scripts and M sites, no `globalUserScriptsOptInMigrated` marker
+**When** the app starts
+**Then** every site's `enabledGlobalScriptIds` is populated with all N global script ids (for sites whose set was empty), the `globalUserScriptsOptInMigrated` marker is set, and the opt-ins are persisted
+
+#### Scenario: Subsequent launches do not re-migrate
+
+**Given** the `globalUserScriptsOptInMigrated` marker is set
+**When** the app starts
+**Then** `enabledGlobalScriptIds` is NOT modified, even if the user has since opted sites out of scripts
 
 ### Requirement: US-002 - Script Injection
 
@@ -105,7 +173,10 @@ The `;null;` suffix is appended to all injected scripts because WebKit (macOS/iO
 
 ### Requirement: US-003 - Script Management UI
 
-Users SHALL be able to add, edit, delete, reorder, and toggle scripts from per-site settings. Global scripts SHALL also be visible and editable from the per-site screen.
+The User Scripts screen SHALL operate in two distinct modes:
+
+- **Per-site mode** — reached from a site's Settings. Lists the site's own scripts (with an `enabled` toggle, reorder, swipe-to-delete, Make Global) AND the global library (each global shown with a per-site opt-in toggle that edits this site's `enabledGlobalScriptIds`).
+- **Global library mode** — reached from App Settings > Global User Scripts. Lists the global scripts themselves. Each tile shows a "Global" badge and has NO enable switch (globals have no master toggle). Add / edit / delete / reorder / swipe-to-delete operate on the global library.
 
 #### Scenario: Add a new script
 
@@ -159,23 +230,47 @@ Users SHALL be able to add, edit, delete, reorder, and toggle scripts from per-s
 
 **Given** global scripts are configured
 **When** the user opens User Scripts from any site's settings
-**Then** global scripts appear at the top with a "Global" badge and globe icon, followed by site-specific scripts below a divider. Global scripts are editable (toggle, tap to edit) and changes save to the global list.
+**Then** global scripts appear at the top with a "Global" badge and globe icon, followed by site-specific scripts below a divider. The trailing switch on each global tile toggles this site's opt-in (not a master flag). Tap-to-edit opens the global script editor; changes save to the global list and preserve the script's `id`.
+
+#### Scenario: Opt-in toggle on a global tile
+
+**Given** a site in per-site mode
+**When** the user flips the Switch on a global script tile from off to on
+**Then** the script's `id` is added to this site's `enabledGlobalScriptIds`. Flipping it back off removes the `id`. No other site is affected.
+
+#### Scenario: Global library tile has no enable switch
+
+**Given** the user is on App Settings > Global User Scripts
+**When** the list renders
+**Then** each tile shows a "Global" badge and a drag handle, but NO trailing Switch. The tile is tap-to-edit and long-press-to-delete. Reorder and swipe-to-delete are available.
 
 #### Scenario: Promote site script to global
 
 **Given** the user opens User Scripts from site settings
 **When** they long-press a site-specific script and select "Make Global" from the bottom sheet
-**Then** a confirmation dialog offers to move it to global scripts. On confirmation, the script is moved from the site list to the global list.
+**Then** a confirmation dialog offers to move it to global scripts. On confirmation, the script is moved from the site list to the global list, and the current site is automatically opted into the promoted script so it keeps running here.
 
 ### Requirement: US-004 - Backward Compatibility
 
-Legacy data without `userScripts` field SHALL be handled gracefully.
+Legacy data without `userScripts`, `enabledGlobalScriptIds`, or script `id` fields SHALL be handled gracefully.
 
-#### Scenario: Load legacy data
+#### Scenario: Load legacy data without userScripts
 
 **Given** a `WebViewModel` JSON without the `userScripts` field
 **When** `fromJson()` is called
 **Then** `userScripts` defaults to an empty list
+
+#### Scenario: Load legacy data without enabledGlobalScriptIds
+
+**Given** a `WebViewModel` JSON without the `enabledGlobalScriptIds` field
+**When** `fromJson()` is called
+**Then** `enabledGlobalScriptIds` defaults to an empty set
+
+#### Scenario: Load legacy script without id
+
+**Given** a `UserScriptConfig` JSON without the `id` field
+**When** `fromJson()` is called
+**Then** a fresh unique id is generated so future opt-in references remain stable
 
 ### Requirement: US-005 - Settings Backup Integration
 
@@ -191,7 +286,7 @@ User scripts SHALL be included in settings export/import.
 
 **Given** a backup file containing user scripts
 **When** settings are imported
-**Then** user scripts are restored for each site and global scripts are restored to app state
+**Then** user scripts are restored for each site, per-site `enabledGlobalScriptIds` sets are restored, and global scripts (with their `id`s) are restored to app state
 
 ---
 
@@ -203,6 +298,9 @@ User scripts SHALL be included in settings export/import.
 enum UserScriptInjectionTime { atDocumentStart, atDocumentEnd }
 
 class UserScriptConfig {
+  /// Stable unique identifier. Auto-generated at creation time, preserved
+  /// across JSON roundtrips and edits. Referenced by per-site opt-in sets.
+  final String id;
   String name;
   String source;
   /// Optional URL to fetch script source from (e.g., CDN-hosted library).
@@ -211,6 +309,9 @@ class UserScriptConfig {
   /// Cached content downloaded from [url].
   String? urlSource;
   UserScriptInjectionTime injectionTime;
+  /// For SITE-SPECIFIC scripts, controls whether the script is injected.
+  /// For GLOBAL scripts this field is ignored — per-site opt-in via
+  /// [WebViewModel.enabledGlobalScriptIds] is the only enable control.
   bool enabled;
 
   /// The full script to inject: urlSource (if any) followed by source.
@@ -221,17 +322,26 @@ class UserScriptConfig {
 ### WebViewModel Integration
 
 - `userScripts` field: `List<UserScriptConfig>`, defaults to `[]`
-- Serialized in `toJson()`, deserialized in `fromJson()` with `?? []` fallback
+- `enabledGlobalScriptIds` field: `Set<String>`, defaults to `{}`. Stores ids of global scripts that should run on this site.
+- Serialized in `toJson()`; deserialized in `fromJson()` with `?? []` / `?? {}` fallbacks
 - Passed to `WebViewConfig` when creating the webview
-- Global scripts are prepended: `[...globalUserScripts, ...userScripts]`
+- Injection merge at webview creation time:
+  ```dart
+  userScripts: [
+    ...globalUserScripts.where((g) => enabledGlobalScriptIds.contains(g.id)),
+    ...userScripts,
+  ]
+  ```
+  Global scripts the site opted into run first, then site-specific scripts.
 
 ### Global Scripts Integration
 
 - Stored in `_WebSpacePageState._globalUserScripts`
 - Persisted to SharedPreferences under `'globalUserScripts'` key
 - Loaded during `_restoreAppState()` via `_loadGlobalUserScripts()`
-- Passed through `getWebView()` and `getController()` to merge with per-site scripts
-- Included in `SettingsBackup` model for export/import
+- After sites load, `_migrateGlobalScriptOptIn()` one-time-fills empty per-site opt-in sets with all current global ids (gated by the `globalUserScriptsOptInMigrated` SharedPreferences marker)
+- Passed through `getWebView()` and `getController()` to the merge site-filter
+- Included in `SettingsBackup` model for export/import. Per-site `enabledGlobalScriptIds` are exported as part of each site's JSON.
 
 ### Injection Mechanism
 
@@ -323,10 +433,12 @@ At injection time: `fullSource = urlSource + '\n' + source`
 
 ### UI
 
-- `UserScriptsScreen`: Combined list showing global scripts (with "Global" badge, globe icon) at the top and site scripts below. Site scripts have drag handles, swipe-to-delete (with confirmation), and long-press for a bottom-sheet action menu (Delete / Make Global). Global scripts support long-press to show a bottom-sheet menu with a Delete action. All destructive actions require a confirmation dialog. Both global and site scripts support toggle and tap-to-edit. Edits sync immediately to the appropriate list.
-- `UserScriptEditScreen`: Form with name, optional script URL (auto-downloads on save), injection time dropdown, enabled switch, monospace source editor, and play button with inline console output
-- Per-site settings: "User Scripts" tile — shows both global and site scripts
-- App settings: "User Scripts" section — manages global scripts that run on all sites
+- `UserScriptsScreen` operates in two modes selected by the `isGlobalLibrary` flag and the presence of `enabledGlobalScriptIds`:
+  - **Per-site mode** (`enabledGlobalScriptIds` non-null, `isGlobalLibrary` false): the screen shows globals at the top (each with a "Global" badge and a per-site opt-in Switch that edits `enabledGlobalScriptIds`), then a divider, then the site's own scripts with drag handles, an enabled Switch, swipe-to-delete, and a long-press action sheet (Delete / Make Global).
+  - **Global library mode** (`isGlobalLibrary` true): the screen shows the global scripts themselves, each with a "Global" badge and a drag handle but NO enabled Switch. Tap-to-edit, long-press for Delete (no Make Global), swipe-to-delete, and reorder are supported. The FAB adds a new global script.
+- `UserScriptEditScreen`: Form with name, optional script URL (auto-downloads on save), injection time dropdown, enabled switch (meaningful for site scripts only), monospace source editor, and play button with inline console output. When editing an existing script, the script's `id` is preserved so per-site opt-in references remain valid.
+- Per-site settings: "User Scripts" tile — subtitle shows the count of active site scripts and globals opted in for this site.
+- App settings: "Global User Scripts" tile — subtitle shows the total count of global scripts defined with the note "opt in per site".
 
 ---
 
@@ -339,12 +451,14 @@ At injection time: `fullSource = urlSource + '\n' + source`
 - `test/user_script_test.dart` — Unit tests for model and WebViewModel integration
 
 ### Modified
-- `lib/web_view_model.dart` — Added `userScripts` field, serialization, global scripts merge in `getWebView`/`getController`
+- `lib/settings/user_script.dart` — Added stable `id` field (auto-generated, preserved in JSON roundtrips)
+- `lib/web_view_model.dart` — Added `userScripts` and `enabledGlobalScriptIds` fields, serialization, and the per-site global filter in `getWebView`/`getController`
 - `lib/services/webview.dart` — Added `userScripts` to WebViewConfig, injection in createWebView, SPA detection
-- `lib/screens/settings.dart` — "User Scripts" tile for per-site scripts, with Make Global support
-- `lib/screens/app_settings.dart` — "User Scripts" section for global scripts
-- `lib/main.dart` — Global user scripts state, persistence, backup/restore integration
-- `lib/services/settings_backup.dart` — Added `globalUserScripts` to SettingsBackup model
+- `lib/screens/user_scripts.dart` — Per-site opt-in Switch for globals, `isGlobalLibrary` mode for App Settings, id-preserving edits
+- `lib/screens/settings.dart` — "User Scripts" tile passes `enabledGlobalScriptIds` and its onChanged callback
+- `lib/screens/app_settings.dart` — "Global User Scripts" section, `isGlobalLibrary: true`
+- `lib/main.dart` — Global user scripts state, persistence, `_migrateGlobalScriptOptIn`, backup/restore integration
+- `lib/services/settings_backup.dart` — Added `globalUserScripts` to SettingsBackup model (per-site opt-ins ride along in each site's JSON)
 
 ---
 
@@ -379,20 +493,31 @@ fvm flutter test test/user_script_test.dart
 7. Hit "Save Settings" — site should reload with the page title set to `lodash <version>`
 8. Navigate within the SPA — the library should remain loaded on URL changes
 
-#### Global scripts
-1. Open App Settings (gear icon) > "User Scripts"
-2. Add a script (e.g. the CDN library script from above)
-3. Save — navigate back and reload a site
-4. Switch to a different site — the global script should also run there
-5. Force-close and reopen — global scripts should persist
+#### Global scripts (library + per-site opt-in)
+1. Open App Settings (gear icon) > "Global User Scripts"
+2. Add a global script (e.g. `document.title = '[global] ' + document.title;`). Note: tiles have NO enable switch here.
+3. Navigate back. Reload a site — the global script must NOT yet run (no site has opted in).
+4. Open that site's Settings > "User Scripts". The global tile appears at the top with a per-site Switch. Toggle it ON.
+5. Tap "Save Settings" (or navigate back to reload) — the script now runs on THIS site.
+6. Switch to a different site — the global script must NOT run there (it hasn't opted in).
+7. Opt the second site in from its User Scripts screen — the script now runs on both.
+8. Toggle OFF on the first site — it stops running there only; the second site is unaffected.
+9. Force-close and reopen — global scripts and per-site opt-ins should persist.
+
+#### Migration from pre-opt-in data
+1. On a build that still has the pre-opt-in layout (sites without `enabledGlobalScriptIds`), add a global script that previously ran everywhere.
+2. Upgrade / reinstall with this build.
+3. On first launch: every existing site should be auto-opted into all existing globals (one-time fill).
+4. Subsequent launches: opting a site out should stick; the migration must not re-fill.
 
 #### Promote site script to global
 1. Open a site's settings > "User Scripts"
 2. Long-press on a site script
 3. Tap "Make Global" in the bottom sheet
 4. Confirm the "Make Global" dialog
-5. The script moves to global scripts and is removed from the site
-6. Open App Settings > "User Scripts" to verify it's there
+5. The script moves to global scripts and is removed from the site list; the current site is automatically opted in so the script keeps running on it.
+6. Open App Settings > "Global User Scripts" to verify it's there.
+7. Visit a different site's User Scripts screen — the promoted script appears as a global with the per-site Switch OFF (not opted in).
 
 #### Delete scripts with confirmation
 1. Open a site's settings > "User Scripts"

--- a/test/user_script_test.dart
+++ b/test/user_script_test.dart
@@ -14,6 +14,35 @@ void main() {
       expect(script.source, equals('console.log("hello");'));
       expect(script.injectionTime, equals(UserScriptInjectionTime.atDocumentEnd));
       expect(script.enabled, isTrue);
+      // Each script gets an auto-generated, non-empty id.
+      expect(script.id, isNotEmpty);
+    });
+
+    test('fresh scripts get unique ids', () {
+      final a = UserScriptConfig(name: 'A', source: '1');
+      final b = UserScriptConfig(name: 'B', source: '2');
+      expect(a.id, isNot(equals(b.id)));
+    });
+
+    test('explicit id is preserved and survives JSON roundtrip', () {
+      final original = UserScriptConfig(
+        id: 'us-fixed-id',
+        name: 'Test',
+        source: 'x',
+      );
+      expect(original.id, 'us-fixed-id');
+      final restored = UserScriptConfig.fromJson(original.toJson());
+      expect(restored.id, 'us-fixed-id');
+    });
+
+    test('legacy JSON without id gets a fresh generated id', () {
+      final script = UserScriptConfig.fromJson({
+        'name': 'Legacy',
+        'source': 'x',
+        'injectionTime': 1,
+        'enabled': true,
+      });
+      expect(script.id, isNotEmpty);
     });
 
     test('should serialize to JSON', () {
@@ -158,6 +187,46 @@ void main() {
       final model = WebViewModel.fromJson(json, null);
 
       expect(model.userScripts, isEmpty);
+    });
+
+    test('enabledGlobalScriptIds defaults to empty set', () {
+      final model = WebViewModel(initUrl: 'https://example.com');
+      expect(model.enabledGlobalScriptIds, isEmpty);
+    });
+
+    test('enabledGlobalScriptIds survives JSON roundtrip', () {
+      final model = WebViewModel(
+        initUrl: 'https://example.com',
+        enabledGlobalScriptIds: {'us-aaa', 'us-bbb'},
+      );
+      final restored = WebViewModel.fromJson(model.toJson(), null);
+      expect(restored.enabledGlobalScriptIds, {'us-aaa', 'us-bbb'});
+    });
+
+    test('legacy WebViewModel JSON without enabledGlobalScriptIds defaults to empty', () {
+      final json = {
+        'initUrl': 'https://example.com',
+        'currentUrl': 'https://example.com',
+        'name': 'Example',
+        'cookies': [],
+        'proxySettings': {'type': 0},
+        'javascriptEnabled': true,
+        'userAgent': '',
+        'thirdPartyCookiesEnabled': false,
+        'incognito': false,
+        'clearUrlEnabled': true,
+        'dnsBlockEnabled': true,
+        'contentBlockEnabled': true,
+        'blockAutoRedirects': true,
+      };
+      final model = WebViewModel.fromJson(json, null);
+      expect(model.enabledGlobalScriptIds, isEmpty);
+    });
+
+    test('toJson omits enabledGlobalScriptIds when empty', () {
+      final model = WebViewModel(initUrl: 'https://example.com');
+      final json = model.toJson();
+      expect(json.containsKey('enabledGlobalScriptIds'), isFalse);
     });
   });
 


### PR DESCRIPTION
Global scripts are no longer implicitly active. Sites enable each global script independently via a Set<String> enabledGlobalScriptIds keyed by the script's new stable id; source + URL stay shared so users don't copy paste the body into every site.

UserScriptConfig gains an auto-generated id that is preserved across JSON roundtrips and edits. Global scripts drop their master "enabled" switch in the UI — per-site opt-in is the only enable control. App Settings shows the global library (add/edit/delete) with isGlobalLibrary mode; the per-site screen shows globals with a per-site toggle next to site-specific scripts. Make Global now auto-opts the current site in.

A one-time migration (globalUserScriptsOptInMigrated marker) fills each site's opt-in set with all existing global ids so upgrades don't lose script coverage.

https://claude.ai/code/session_01Ksx7xXS5wsdwCgTkbKnp3f