### PR TITLE
Show enabled global user scripts in dev tools scripts sheet

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2108,6 +2108,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                           webViewModel: _webViewModels[_currentIndex!],
                           cookieManager: _cookieManager,
                           onSave: _saveWebViewModels,
+                          globalUserScripts: _globalUserScripts,
                         ),
                       ),
                     );
@@ -2500,6 +2501,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                     webViewModel: _webViewModels[_currentIndex!],
                     cookieManager: _cookieManager,
                     onSave: _saveWebViewModels,
+                    globalUserScripts: _globalUserScripts,
                   ),
                 ),
               );

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -20,12 +20,14 @@ class DevToolsScreen extends StatefulWidget {
   final WebViewModel? webViewModel;
   final CookieManager cookieManager;
   final VoidAsyncCallback? onSave;
+  final List<UserScriptConfig> globalUserScripts;
 
   const DevToolsScreen({
     super.key,
     this.webViewModel,
     required this.cookieManager,
     this.onSave,
+    this.globalUserScripts = const [],
   });
 
   @override
@@ -713,7 +715,13 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   // ── Scripts Bottom Sheet ──
 
   void _showScriptsSheet() {
-    final scripts = widget.webViewModel!.userScripts;
+    final siteScripts = widget.webViewModel!.userScripts;
+    final enabledIds = widget.webViewModel!.enabledGlobalScriptIds;
+    final activeGlobals = widget.globalUserScripts
+        .where((g) => enabledIds.contains(g.id))
+        .toList();
+    final scripts = [...activeGlobals, ...siteScripts];
+    final globalCount = activeGlobals.length;
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
@@ -758,14 +766,39 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
                     itemCount: scripts.length,
                     itemBuilder: (context, index) {
                       final script = scripts[index];
+                      final isGlobal = index < globalCount;
+                      final active = isGlobal || script.enabled;
                       return ExpansionTile(
                         leading: Icon(
-                          script.enabled ? Icons.code : Icons.code_off,
-                          color: script.enabled ? Colors.green : Colors.grey,
+                          active ? Icons.code : Icons.code_off,
+                          color: active ? Colors.green : Colors.grey,
                           size: 20,
                         ),
-                        title: Text(script.name,
-                            style: const TextStyle(fontFamily: 'monospace', fontSize: 13)),
+                        title: Row(
+                          children: [
+                            Flexible(
+                              child: Text(script.name,
+                                  style: const TextStyle(fontFamily: 'monospace', fontSize: 13)),
+                            ),
+                            if (isGlobal) ...[
+                              const SizedBox(width: 6),
+                              Container(
+                                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                                decoration: BoxDecoration(
+                                  color: Theme.of(context).colorScheme.secondaryContainer,
+                                  borderRadius: BorderRadius.circular(4),
+                                ),
+                                child: Text(
+                                  'global',
+                                  style: TextStyle(
+                                    fontSize: 10,
+                                    color: Theme.of(context).colorScheme.onSecondaryContainer,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ],
+                        ),
                         subtitle: Text(
                           script.injectionTime == UserScriptInjectionTime.atDocumentStart
                               ? 'document start'


### PR DESCRIPTION
The dev tools Scripts sheet only listed per-site userScripts, so global scripts opted in for the current site did not appear even though they were being injected. Pass globalUserScripts into DevToolsScreen and merge the site's enabled globals ahead of the per-site list, tagged with a "global" badge. Global scripts ignore the per-script enabled flag per the user-scripts spec.