### PR TITLE
Ignore stored enabled flag for opted-in global user scripts

### DIFF
--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -454,7 +454,22 @@ class WebViewModel {
           contentBlockEnabled: contentBlockEnabled,
           localCdnEnabled: localCdnEnabled,
           userScripts: [
-            ...globalUserScripts.where((g) => enabledGlobalScriptIds.contains(g.id)),
+            // Globals have no master `enabled` toggle per spec — per-site
+            // opt-in is the only enable control. Force `enabled: true` on
+            // a copy so a stale stored flag (e.g. a disabled site script
+            // that was promoted via "Make Global") can't silently drop
+            // the script in `UserScriptService.buildInitialUserScripts`.
+            ...globalUserScripts
+                .where((g) => enabledGlobalScriptIds.contains(g.id))
+                .map((g) => UserScriptConfig(
+                      id: g.id,
+                      name: g.name,
+                      source: g.source,
+                      url: g.url,
+                      urlSource: g.urlSource,
+                      injectionTime: g.injectionTime,
+                      enabled: true,
+                    )),
             ...userScripts,
           ],
           onConfirmScriptFetch: onConfirmScriptFetch,


### PR DESCRIPTION
## Summary
- Global user scripts have no master `enabled` toggle per spec (US-001b/c) — per-site opt-in is the only enable control. Runtime still honored the stored flag, so a disabled site script promoted via "Make Global" stayed disabled forever.
- `WebViewModel.getWebView` now rebuilds each opted-in global as a fresh `UserScriptConfig` with `enabled: true` before passing to `UserScriptService`, so injection respects opt-in only. Stored flag in app state is left alone.

## Why
Symptom: `DarkReader.enable()` in dev tools → "DarkReader is not defined", even though the Global Library tile shows the script present and the site is opted in. The library's `urlSource` never ran because `UserScriptService.buildInitialUserScripts` silently skipped it on `!script.enabled`.

## Test plan
- [x] `fvm flutter test test/user_script_test.dart test/web_view_model_test.dart` — 73/73 pass
- [x] `fvm flutter analyze lib/web_view_model.dart` — only pre-existing warnings
- [ ] Manual: opt-in a global with `enabled=false` in JSON, reload a site, verify `DarkReader` is defined in the console

https://claude.ai/code/session_01TQNWyvfNzxKQmoQ18jBuTx