### PR TITLE
Use high-resolution favicon for home screen shortcuts

### DIFF
--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -1,6 +1,7 @@
 package org.codeberg.theoden8.webspace
 
 import android.content.Intent
+import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.Build
 import androidx.core.content.pm.ShortcutInfoCompat
@@ -10,6 +11,7 @@ import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.engine.FlutterShellArgs
 import io.flutter.plugin.common.MethodChannel
+import java.net.HttpURLConnection
 import java.net.URL
 
 class MainActivity: FlutterActivity() {
@@ -78,12 +80,10 @@ class MainActivity: FlutterActivity() {
                 }
 
                 val icon = if (iconUrl != null) {
-                    try {
-                        val stream = URL(iconUrl).openStream()
-                        val bitmap = BitmapFactory.decodeStream(stream)
-                        stream.close()
-                        if (bitmap != null) IconCompat.createWithBitmap(bitmap) else IconCompat.createWithResource(this, R.mipmap.ic_launcher)
-                    } catch (e: Exception) {
+                    val bitmap = downloadBitmap(iconUrl)
+                    if (bitmap != null) {
+                        IconCompat.createWithBitmap(upscaleIfTiny(bitmap))
+                    } else {
                         IconCompat.createWithResource(this, R.mipmap.ic_launcher)
                     }
                 } else {
@@ -111,6 +111,62 @@ class MainActivity: FlutterActivity() {
                 }
             }
         }.start()
+    }
+
+    // Download a bitmap, following up to 3 redirects and sending a browser
+    // User-Agent so sites that block default Java clients still return the
+    // icon. Returns null on any failure.
+    private fun downloadBitmap(url: String): Bitmap? {
+        var current = url
+        var redirects = 0
+        while (redirects < 3) {
+            try {
+                val conn = URL(current).openConnection() as HttpURLConnection
+                conn.instanceFollowRedirects = false
+                conn.connectTimeout = 8000
+                conn.readTimeout = 8000
+                conn.setRequestProperty(
+                    "User-Agent",
+                    "Mozilla/5.0 (Android) WebSpace/1.0"
+                )
+                conn.setRequestProperty("Accept", "image/*,*/*;q=0.8")
+                val code = conn.responseCode
+                if (code in 300..399) {
+                    val location = conn.getHeaderField("Location") ?: return null
+                    current = URL(URL(current), location).toString()
+                    conn.disconnect()
+                    redirects++
+                    continue
+                }
+                if (code != 200) {
+                    conn.disconnect()
+                    return null
+                }
+                conn.inputStream.use { stream ->
+                    return BitmapFactory.decodeStream(stream)
+                }
+            } catch (e: Exception) {
+                return null
+            }
+        }
+        return null
+    }
+
+    // Android's launcher expects icons roughly 108dp (~162-432 px). Favicons
+    // at 16-48 px get blurry when the launcher upscales them, so pre-scale
+    // small icons with a better filter for a crisper look.
+    private fun upscaleIfTiny(bitmap: Bitmap): Bitmap {
+        val side = minOf(bitmap.width, bitmap.height)
+        if (side >= 128) return bitmap
+        val targetSide = 192
+        val scale = targetSide.toFloat() / side
+        val newW = (bitmap.width * scale).toInt().coerceAtLeast(targetSide)
+        val newH = (bitmap.height * scale).toInt().coerceAtLeast(targetSide)
+        return try {
+            Bitmap.createScaledBitmap(bitmap, newW, newH, true)
+        } catch (e: Exception) {
+            bitmap
+        }
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -798,6 +798,24 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await prefs.setBool('showUrlBar', _showUrlBar);
   }
 
+  /// Resolve the best bitmap favicon URL to hand to the native shortcut
+  /// pinning code. Prefers a freshly-scraped high-resolution icon
+  /// (apple-touch-icon / manifest / sized rel=icon). Falls back to whatever
+  /// is in FaviconUrlCache if the HD lookup turns up nothing usable. SVGs
+  /// are skipped because Android pinned shortcuts need a bitmap.
+  Future<String?> _resolveShortcutIconUrl(String siteUrl) async {
+    try {
+      final hd = await getHighResFaviconUrl(siteUrl);
+      if (hd != null) return hd;
+    } catch (_) {
+      // fall through
+    }
+    final cached = FaviconUrlCache.get(siteUrl);
+    if (cached == null) return null;
+    if (cached.toLowerCase().endsWith('.svg')) return null;
+    return cached;
+  }
+
   Future<void> _saveShowTabStrip() async {
     if (isDemoMode) return;
     SharedPreferences prefs = await SharedPreferences.getInstance();
@@ -2090,12 +2108,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                 case 'addToHome':
                   if (_currentIndex != null) {
                     final model = _webViewModels[_currentIndex!];
-                    final faviconUrl = FaviconUrlCache.get(model.initUrl);
-                    final isSvg = faviconUrl != null && faviconUrl.toLowerCase().endsWith('.svg');
+                    final iconUrl = await _resolveShortcutIconUrl(model.initUrl);
                     await ShortcutService.pinShortcut(
                       siteId: model.siteId,
                       label: model.name,
-                      iconUrl: isSvg ? null : faviconUrl,
+                      iconUrl: iconUrl,
                     );
                   }
                 break;
@@ -2483,12 +2500,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           case 'addToHome':
             if (_currentIndex != null) {
               final model = _webViewModels[_currentIndex!];
-              final faviconUrl = FaviconUrlCache.get(model.initUrl);
-              final isSvg = faviconUrl != null && faviconUrl.toLowerCase().endsWith('.svg');
+              final iconUrl = await _resolveShortcutIconUrl(model.initUrl);
               await ShortcutService.pinShortcut(
                 siteId: model.siteId,
                 label: model.name,
-                iconUrl: isSvg ? null : faviconUrl,
+                iconUrl: iconUrl,
               );
             }
           break;

--- a/lib/services/icon_service.dart
+++ b/lib/services/icon_service.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 import 'dart:collection';
+import 'dart:convert';
+import 'package:html/parser.dart' as html_parser;
 import 'package:http/http.dart' as http;
 import 'package:webspace/services/log_service.dart';
 import '../third_party/favicon/favicon.dart';
@@ -522,12 +524,159 @@ Future<_IconCandidate?> _tryFaviconPackage(String url) async {
   return null;
 }
 
+// Cache for high-resolution icons discovered by getHighResFaviconUrl.
+final Map<String, String?> _hdFaviconCache = {};
+
+/// Parse a "sizes" attribute like "96x96" or "192x192 128x128" into the max px.
+/// Returns 0 if unparseable or if value is "any" (vector).
+int _parseSizes(String? sizes) {
+  if (sizes == null || sizes.isEmpty) return 0;
+  int best = 0;
+  for (final part in sizes.toLowerCase().split(RegExp(r'\s+'))) {
+    if (part == 'any') continue;
+    final m = RegExp(r'^(\d+)x(\d+)$').firstMatch(part);
+    if (m != null) {
+      final w = int.tryParse(m.group(1)!) ?? 0;
+      final h = int.tryParse(m.group(2)!) ?? 0;
+      final side = w < h ? w : h;
+      if (side > best) best = side;
+    }
+  }
+  return best;
+}
+
+String _resolveUrl(Uri base, String href) {
+  var h = href.trim();
+  if (h.startsWith('//')) return '${base.scheme}:$h';
+  if (h.startsWith('http://') || h.startsWith('https://')) return h;
+  if (h.startsWith('/')) return '${base.scheme}://${base.host}${base.hasPort ? ':${base.port}' : ''}$h';
+  return base.resolve(h).toString();
+}
+
+bool _isBitmapIconUrl(String url) {
+  final lower = url.toLowerCase().split('?').first;
+  return lower.endsWith('.png') ||
+      lower.endsWith('.jpg') ||
+      lower.endsWith('.jpeg') ||
+      lower.endsWith('.webp') ||
+      lower.endsWith('.ico') ||
+      lower.endsWith('.gif');
+}
+
+/// Finds a high-resolution bitmap favicon suitable for an Android home screen
+/// shortcut (target ~192px). Scrapes the page for apple-touch-icon, sized
+/// link[rel=icon] tags, and the web app manifest. Returns the URL of the
+/// largest candidate; falls back to Google's 256px service for HTTPS hosts.
+/// SVG icons are skipped because Android ShortcutInfoCompat requires a bitmap.
+Future<String?> getHighResFaviconUrl(String siteUrl) async {
+  if (_hdFaviconCache.containsKey(siteUrl)) {
+    return _hdFaviconCache[siteUrl];
+  }
+
+  final uri = Uri.tryParse(siteUrl);
+  if (uri == null || uri.host.isEmpty) {
+    _hdFaviconCache[siteUrl] = null;
+    return null;
+  }
+
+  int bestScore = 0;
+  String? bestUrl;
+
+  void consider(String url, int score) {
+    if (!_isBitmapIconUrl(url)) return;
+    if (score > bestScore) {
+      bestScore = score;
+      bestUrl = url;
+    }
+  }
+
+  try {
+    final response = await http
+        .get(uri, headers: {'User-Agent': 'Mozilla/5.0'})
+        .timeout(const Duration(seconds: 8));
+    if (response.statusCode == 200) {
+      final doc = html_parser.parse(response.body);
+      final links = doc.querySelectorAll('link[rel]');
+      String? manifestUrl;
+      for (final link in links) {
+        final rel = (link.attributes['rel'] ?? '').toLowerCase();
+        final href = link.attributes['href'];
+        if (href == null || href.isEmpty) continue;
+        final resolved = _resolveUrl(uri, href);
+
+        if (rel == 'manifest') {
+          manifestUrl = resolved;
+          continue;
+        }
+
+        // apple-touch-icon is commonly 180x180 — the best default bitmap.
+        if (rel.contains('apple-touch-icon')) {
+          final sizedScore = _parseSizes(link.attributes['sizes']);
+          consider(resolved, sizedScore > 0 ? sizedScore : 180);
+          continue;
+        }
+
+        if (rel == 'icon' || rel == 'shortcut icon' || rel.contains('fluid-icon')) {
+          final sized = _parseSizes(link.attributes['sizes']);
+          // Prefer tags with explicit sizes; otherwise assume modest 32px.
+          consider(resolved, sized > 0 ? sized : 32);
+        }
+      }
+
+      if (manifestUrl != null) {
+        try {
+          final manifestResp = await http
+              .get(Uri.parse(manifestUrl), headers: {'User-Agent': 'Mozilla/5.0'})
+              .timeout(const Duration(seconds: 5));
+          if (manifestResp.statusCode == 200) {
+            final manifestUri = Uri.parse(manifestUrl);
+            final data = jsonDecode(manifestResp.body);
+            if (data is Map && data['icons'] is List) {
+              for (final icon in (data['icons'] as List)) {
+                if (icon is! Map) continue;
+                final src = icon['src'];
+                if (src is! String || src.isEmpty) continue;
+                final resolved = _resolveUrl(manifestUri, src);
+                final sizesRaw = icon['sizes'];
+                final score = _parseSizes(sizesRaw is String ? sizesRaw : null);
+                consider(resolved, score > 0 ? score : 64);
+              }
+            }
+          }
+        } catch (e) {
+          LogService.instance.log('Icon', 'HD: manifest fetch failed: $e');
+        }
+      }
+    }
+  } catch (e) {
+    LogService.instance.log('Icon', 'HD: page fetch failed for $siteUrl: $e');
+  }
+
+  // If the page didn't yield anything good (< 96px), fall back to Google 256.
+  if ((bestUrl == null || bestScore < 96) &&
+      uri.scheme == 'https' &&
+      !_isIpAddress(uri.host)) {
+    final domain = _applyDomainSubstitution(uri.host);
+    final google = 'https://www.google.com/s2/favicons?domain=$domain&sz=256';
+    if (await _verifyIconUrl(google) && 256 > bestScore) {
+      bestScore = 256;
+      bestUrl = google;
+    }
+  }
+
+  LogService.instance.log(
+      'Icon', 'HD favicon for $siteUrl: $bestUrl (score: $bestScore)');
+  _hdFaviconCache[siteUrl] = bestUrl;
+  return bestUrl;
+}
+
 /// Clears the favicon cache
 void clearFaviconCache() {
   _faviconCache.clear();
   _faviconQualityCache.clear();
   _verifiedUrls.clear();
   _svgContentCache.clear();
+  _hdFaviconCache.clear();
 }
 
 /// Gets current queue stats (for debugging)

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -54,17 +54,24 @@ The system SHALL navigate to the correct site when launched via a home screen sh
 
 ### Requirement: HS-003 - Shortcut Icon
 
-The system SHALL use the site's favicon as the shortcut icon when available, falling back to the app icon.
+The system SHALL use a high-resolution bitmap of the site's favicon as the shortcut icon when available, falling back to the app icon.
 
-#### Scenario: Site has favicon
+#### Scenario: Site exposes a high-resolution icon
 
-**Given** the site has a cached favicon URL (non-SVG)
+**Given** the site's HTML exposes an `apple-touch-icon`, a sized `link rel="icon"`, or a web app manifest with `icons`
 **When** a shortcut is created
-**Then** the shortcut icon is the site's favicon
+**Then** the shortcut icon is the largest bitmap found among those sources
+
+#### Scenario: Site has only a low-resolution favicon
+
+**Given** the site has only a small favicon (e.g. 16x16 `favicon.ico`)
+**When** a shortcut is created
+**Then** the system falls back to Google's 256px favicon service (HTTPS hosts)
+**And** otherwise uses the small favicon, scaled up for launcher display
 
 #### Scenario: Site has no favicon or SVG favicon
 
-**Given** the site has no cached favicon, or the favicon is SVG (not supported by Android shortcuts)
+**Given** the favicon discovery yields no bitmap (only SVG or nothing)
 **When** a shortcut is created
 **Then** the shortcut icon is the WebSpace app icon
 
@@ -105,6 +112,22 @@ On app start and on `onNewIntent` (app already running), check for `siteId` in t
 1. Find the site index matching the `siteId`
 2. Call `_setCurrentIndex(index)` to switch to that site
 
+### High-Resolution Favicon Discovery
+
+When the user taps "Add to Home Screen" the app calls `getHighResFaviconUrl(siteUrl)`
+in `lib/services/icon_service.dart` before pinning. It scrapes the site's HTML for:
+1. `link[rel="apple-touch-icon"]` / `apple-touch-icon-precomposed` (default score 180, or the parsed `sizes`)
+2. `link[rel="icon"]` with a parsed `sizes` attribute (e.g. `96x96`)
+3. The web app manifest (`link[rel="manifest"]`) and its `icons[].sizes`
+
+SVG icons are excluded because `ShortcutInfoCompat` requires a bitmap. If the best
+candidate is still smaller than 96 px (or absent), the service falls back to
+`https://www.google.com/s2/favicons?domain=<host>&sz=256` for HTTPS hosts.
+
+On the native side, `MainActivity.downloadBitmap` fetches the chosen URL with a
+browser User-Agent, follows up to 3 redirects, and `upscaleIfTiny` scales small
+bitmaps up to ~192 px with bilinear filtering before the launcher shows them.
+
 ### Files
 
 #### New
@@ -112,8 +135,9 @@ On app start and on `onNewIntent` (app already running), check for `siteId` in t
 - `openspec/specs/home-shortcut/spec.md` — this specification
 
 #### Modified
-- `android/app/src/main/kotlin/.../MainActivity.kt` — native shortcut creation and intent handling
-- `lib/main.dart` — menu item, shortcut action, launch intent handling
+- `android/app/src/main/kotlin/.../MainActivity.kt` — native shortcut creation, intent handling, HD bitmap download/scale
+- `lib/main.dart` — menu item, shortcut action, launch intent handling, HD favicon resolution
+- `lib/services/icon_service.dart` — `getHighResFaviconUrl` for apple-touch-icon / manifest discovery
 
 ---
 


### PR DESCRIPTION
Scrape apple-touch-icon, sized link[rel=icon], and web app manifest icons when the user adds a site to the home screen, so shortcuts use a crisp bitmap instead of defaulting to the WebSpace app icon. Falls back to Google's 256px favicon service for HTTPS hosts when the page only exposes tiny favicons, and upscales small bitmaps on the native side so the launcher does not blur them.