### PR TITLE
Add Duck.ai to default suggested sites

### DIFF
--- a/lib/services/suggested_sites_service.dart
+++ b/lib/services/suggested_sites_service.dart
@@ -8,6 +8,7 @@ const List<SiteSuggestion> kDefaultSuggestions = [
   SiteSuggestion(name: 'DuckDuckGo', url: 'https://duckduckgo.com', domain: 'duckduckgo.com'),
   SiteSuggestion(name: 'Claude', url: 'https://claude.ai', domain: 'claude.ai'),
   SiteSuggestion(name: 'ChatGPT', url: 'https://chatgpt.com', domain: 'chatgpt.com'),
+  SiteSuggestion(name: 'Duck.ai', url: 'https://duck.ai', domain: 'duck.ai'),
   SiteSuggestion(name: 'Perplexity', url: 'https://perplexity.ai', domain: 'perplexity.ai'),
   SiteSuggestion(name: 'Instagram', url: 'https://instagram.com', domain: 'instagram.com'),
   SiteSuggestion(name: 'Facebook', url: 'https://facebook.com', domain: 'facebook.com'),

--- a/lib/services/suggested_sites_service.dart
+++ b/lib/services/suggested_sites_service.dart
@@ -5,10 +5,9 @@ import 'package:webspace/screens/add_site.dart' show SiteSuggestion;
 
 /// Default suggested sites for non-fdroid builds.
 const List<SiteSuggestion> kDefaultSuggestions = [
-  SiteSuggestion(name: 'DuckDuckGo', url: 'https://duckduckgo.com', domain: 'duckduckgo.com'),
+  SiteSuggestion(name: 'Duck.ai', url: 'https://duck.ai', domain: 'duck.ai'),
   SiteSuggestion(name: 'Claude', url: 'https://claude.ai', domain: 'claude.ai'),
   SiteSuggestion(name: 'ChatGPT', url: 'https://chatgpt.com', domain: 'chatgpt.com'),
-  SiteSuggestion(name: 'Duck.ai', url: 'https://duck.ai', domain: 'duck.ai'),
   SiteSuggestion(name: 'Perplexity', url: 'https://perplexity.ai', domain: 'perplexity.ai'),
   SiteSuggestion(name: 'Instagram', url: 'https://instagram.com', domain: 'instagram.com'),
   SiteSuggestion(name: 'Facebook', url: 'https://facebook.com', domain: 'facebook.com'),

--- a/openspec/specs/configurable-suggested-sites/spec.md
+++ b/openspec/specs/configurable-suggested-sites/spec.md
@@ -28,7 +28,7 @@ The default suggested sites list SHALL depend on the build flavor.
 
 **Given** the app is built with the `fmain` or `fdebug` flavor
 **When** the user opens the "Add new site" screen for the first time
-**Then** the curated default list of suggested sites is shown (DuckDuckGo, Claude, ChatGPT, etc.)
+**Then** the curated default list of suggested sites is shown (Duck.ai, Claude, ChatGPT, etc.)
 
 ---
 
@@ -177,7 +177,7 @@ Flutter automatically sets `FLUTTER_APP_FLAVOR` when building with `--flavor`. T
 
 | Name | URL | Domain |
 |------|-----|--------|
-| DuckDuckGo | https://duckduckgo.com | duckduckgo.com |
+| Duck.ai | https://duck.ai | duck.ai |
 | Claude | https://claude.ai | claude.ai |
 | ChatGPT | https://chatgpt.com | chatgpt.com |
 | Perplexity | https://perplexity.ai | perplexity.ai |

--- a/test/suggested_sites_test.dart
+++ b/test/suggested_sites_test.dart
@@ -23,13 +23,13 @@ void main() {
   group('kDefaultSuggestions', () {
     test('should contain expected sites', () {
       expect(kDefaultSuggestions, isNotEmpty);
-      expect(kDefaultSuggestions.length, 22);
+      expect(kDefaultSuggestions.length, 21);
 
       final names = kDefaultSuggestions.map((s) => s.name).toList();
-      expect(names, contains('DuckDuckGo'));
+      expect(names, contains('Duck.ai'));
       expect(names, contains('GitHub'));
       expect(names, contains('Claude'));
-      expect(names, contains('Duck.ai'));
+      expect(names, isNot(contains('DuckDuckGo')));
     });
 
     test('all entries should have valid URLs', () {

--- a/test/suggested_sites_test.dart
+++ b/test/suggested_sites_test.dart
@@ -23,12 +23,13 @@ void main() {
   group('kDefaultSuggestions', () {
     test('should contain expected sites', () {
       expect(kDefaultSuggestions, isNotEmpty);
-      expect(kDefaultSuggestions.length, 21);
+      expect(kDefaultSuggestions.length, 22);
 
       final names = kDefaultSuggestions.map((s) => s.name).toList();
       expect(names, contains('DuckDuckGo'));
       expect(names, contains('GitHub'));
       expect(names, contains('Claude'));
+      expect(names, contains('Duck.ai'));
     });
 
     test('all entries should have valid URLs', () {


### PR DESCRIPTION
Placed next to Claude and ChatGPT in the non-fdroid default suggestions. The fdroid flavor remains unaffected since its default list is empty.

https://claude.ai/code/session_01EY6do2c698bCgFkZEPEJh2