### PR TITLE
Drop cached HTML on script/home changes; guard scripts per document

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -852,16 +852,28 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   /// script list — toggling `enabled` on a script does nothing at runtime
   /// because the native WKUserScript / Android UserScript objects are
   /// baked at webview creation time.
+  ///
+  /// Also drops the cached HTML: the snapshot was captured with the
+  /// previous script set applied, so showing it on next load would render
+  /// the pre-edit DOM before the new scripts re-run.
   void _resetCurrentSiteWebView() {
     if (_currentIndex == null || _currentIndex! >= _webViewModels.length) return;
+    HtmlCacheService.instance.deleteCache(_webViewModels[_currentIndex!].siteId);
     setState(() {
       _webViewModels[_currentIndex!].disposeWebView();
     });
   }
 
   /// Dispose every loaded webview. Used after global user script edits,
-  /// which can affect any site that has opted in.
+  /// which can affect any site that has opted in. Caches for sites that
+  /// have any global opt-in are dropped for the same reason as
+  /// [_resetCurrentSiteWebView].
   void _resetAllWebViews() {
+    for (final model in _webViewModels) {
+      if (model.enabledGlobalScriptIds.isNotEmpty) {
+        HtmlCacheService.instance.deleteCache(model.siteId);
+      }
+    }
     setState(() {
       for (final model in _webViewModels) {
         model.disposeWebView();
@@ -1739,9 +1751,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
   /// Navigate to the site's initial URL and clear navigation history.
   /// Disposes the webview so it's recreated fresh with no back history.
+  /// Drops the HTML cache so the next load starts from the live site rather
+  /// than a stale cached frame (which can flash before user scripts re-run).
   void _goHome() {
     if (_currentIndex == null || _currentIndex! >= _webViewModels.length) return;
     final model = _webViewModels[_currentIndex!];
+    HtmlCacheService.instance.deleteCache(model.siteId);
     model.currentUrl = model.initUrl;
     model.disposeWebView();
     _canGoBackVersion++; // Invalidate any in-flight _updateCanGoBack
@@ -3219,7 +3234,16 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                                   onHtmlLoaded: webViewModel.incognito ? null : (url, html) {
                                     HtmlCacheService.instance.saveHtml(webViewModel.siteId, html, url);
                                   },
-                                  initialHtml: webViewModel.incognito ? null : HtmlCacheService.instance.getHtmlSync(webViewModel.siteId),
+                                  initialHtml: webViewModel.incognito
+                                      ? null
+                                      : () {
+                                          final cached = HtmlCacheService.instance.getHtmlSync(webViewModel.siteId);
+                                          if (cached == null) return null;
+                                          final isDark = webViewModel.currentTheme == WebViewTheme.dark ||
+                                              (webViewModel.currentTheme == WebViewTheme.system &&
+                                                  MediaQuery.platformBrightnessOf(context) == Brightness.dark);
+                                          return HtmlCacheService.applyThemePrelude(cached, dark: isDark);
+                                        }(),
                                   isActive: () => _currentIndex == index,
                                   onConfirmScriptFetch: (url) async {
                                     if (!mounted) return false;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -847,18 +847,34 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await _saveWebViewModels();
   }
 
+  /// Drop the cached HTML for a site — but only when we're online. When
+  /// offline the cached snapshot is the only content we can render, so
+  /// preserve it until a live reload can overwrite it (via the
+  /// `onHtmlLoaded` callback on the next successful `onLoadStop`).
+  ///
+  /// Fire-and-forget so synchronous call sites (notably `_goHome`, which is
+  /// synchronous by design per navigation spec RACE-004) stay synchronous.
+  /// The connectivity probe resolves in a few ms; the worst case is a brief
+  /// window where a freshly-rebuilt webview renders the stale snapshot, and
+  /// then the next live navigation replaces it.
+  void _deleteCacheIfOnline(String siteId) {
+    ConnectivityService.instance.isOnline().then((online) {
+      if (online) HtmlCacheService.instance.deleteCache(siteId);
+    });
+  }
+
   /// Dispose the current site's webview so the next render recreates it
   /// with fresh [initialUserScripts]. Used after the user edits the
   /// script list — toggling `enabled` on a script does nothing at runtime
   /// because the native WKUserScript / Android UserScript objects are
   /// baked at webview creation time.
   ///
-  /// Also drops the cached HTML: the snapshot was captured with the
-  /// previous script set applied, so showing it on next load would render
-  /// the pre-edit DOM before the new scripts re-run.
+  /// Also drops the cached HTML (online only): the snapshot was captured
+  /// with the previous script set applied, so showing it on next load
+  /// would render the pre-edit DOM before the new scripts re-run.
   void _resetCurrentSiteWebView() {
     if (_currentIndex == null || _currentIndex! >= _webViewModels.length) return;
-    HtmlCacheService.instance.deleteCache(_webViewModels[_currentIndex!].siteId);
+    _deleteCacheIfOnline(_webViewModels[_currentIndex!].siteId);
     setState(() {
       _webViewModels[_currentIndex!].disposeWebView();
     });
@@ -866,12 +882,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
   /// Dispose every loaded webview. Used after global user script edits,
   /// which can affect any site that has opted in. Caches for sites that
-  /// have any global opt-in are dropped for the same reason as
-  /// [_resetCurrentSiteWebView].
+  /// have any global opt-in are dropped (online only) for the same reason
+  /// as [_resetCurrentSiteWebView].
   void _resetAllWebViews() {
     for (final model in _webViewModels) {
       if (model.enabledGlobalScriptIds.isNotEmpty) {
-        HtmlCacheService.instance.deleteCache(model.siteId);
+        _deleteCacheIfOnline(model.siteId);
       }
     }
     setState(() {
@@ -1751,12 +1767,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
   /// Navigate to the site's initial URL and clear navigation history.
   /// Disposes the webview so it's recreated fresh with no back history.
-  /// Drops the HTML cache so the next load starts from the live site rather
-  /// than a stale cached frame (which can flash before user scripts re-run).
+  /// Drops the HTML cache (online only) so the next load starts from the
+  /// live site rather than a stale cached frame. Offline: the cache is
+  /// preserved — it's the only content we can render without network.
   void _goHome() {
     if (_currentIndex == null || _currentIndex! >= _webViewModels.length) return;
     final model = _webViewModels[_currentIndex!];
-    HtmlCacheService.instance.deleteCache(model.siteId);
+    _deleteCacheIfOnline(model.siteId);
     model.currentUrl = model.initUrl;
     model.disposeWebView();
     _canGoBackVersion++; // Invalidate any in-flight _updateCanGoBack

--- a/lib/services/html_cache_service.dart
+++ b/lib/services/html_cache_service.dart
@@ -171,6 +171,34 @@ class HtmlCacheService {
   /// Max HTML size to cache (10MB)
   static const int _maxHtmlSize = 10 * 1024 * 1024;
 
+  /// Inline style prepended to cached HTML for dark-theme sites so the
+  /// pre-paint frame (before stylesheets and user scripts run on reload)
+  /// matches the app/webview theme instead of flashing white.
+  ///
+  /// `color-scheme: dark` hints the engine to use dark scrollbars and form
+  /// controls. The background rule is a hard override so content rendered
+  /// against `<html>`/`<body>` with no explicit background doesn't flash
+  /// default white. Real site styles still load afterward and take over.
+  static const String _darkCachePrelude =
+      '<meta name="color-scheme" content="dark">'
+      '<style id="__ws_cache_prelude">'
+      'html,body{background:#111 !important;color-scheme:dark}'
+      '</style>';
+
+  /// Prepend [_darkCachePrelude] to [html] when [dark] is true. No-op if
+  /// the prelude is already present (so re-caching on navigations within
+  /// the same site does not accumulate duplicates).
+  static String applyThemePrelude(String html, {required bool dark}) {
+    if (!dark) return html;
+    if (html.contains('id="__ws_cache_prelude"')) return html;
+    final headMatch = RegExp(r'<head(?:\s[^>]*)?>', caseSensitive: false).firstMatch(html);
+    if (headMatch != null) {
+      return html.replaceRange(headMatch.end, headMatch.end, _darkCachePrelude);
+    }
+    // No <head> tag — prepend so the prelude still reaches the parser.
+    return '$_darkCachePrelude$html';
+  }
+
   /// Save HTML content for a site (encrypted)
   Future<void> saveHtml(String siteId, String html, String url) async {
     if (_cacheDirectory == null || _encrypter == null) return;

--- a/lib/services/user_script_service.dart
+++ b/lib/services/user_script_service.dart
@@ -249,13 +249,27 @@ class UserScriptService {
       LogService.instance.log('UserScript', 'Adding to initialUserScripts: "${script.name}" at $time (${src.length} chars, url=${script.url ?? "none"})');
       result.add(inapp.UserScript(
         groupName: 'user_scripts',
-        source: '$src\n;null;',
+        source: '${_guarded(script.id, src)}\n;null;',
         injectionTime: script.injectionTime == UserScriptInjectionTime.atDocumentStart
             ? inapp.UserScriptInjectionTime.AT_DOCUMENT_START
             : inapp.UserScriptInjectionTime.AT_DOCUMENT_END,
       ));
     }
     return result;
+  }
+
+  /// Wrap [source] in a once-per-document guard so the same script does not
+  /// run twice when [initialUserScripts] (native WKUserScript) and
+  /// [reinjectOnLoadStart]/[reinjectOnLoadStop] (evaluateJavascript) both
+  /// fire on a full page load.
+  ///
+  /// The flag lives on `window`, which is fresh per document, so guards
+  /// never need explicit resetting. SPA re-injection (where `window`
+  /// persists) deliberately bypasses this helper so that scripts can
+  /// re-initialize on route changes.
+  static String _guarded(String scriptId, String source) {
+    final safeId = scriptId.replaceAll(RegExp(r'[^A-Za-z0-9_]'), '_');
+    return 'if (!window.__wsRan_$safeId) { window.__wsRan_$safeId = true;\n$source\n}';
   }
 
   /// Register JS handlers on the controller for script fetching and
@@ -359,7 +373,7 @@ class UserScriptService {
       if (src.isEmpty) continue;
       if (script.injectionTime == UserScriptInjectionTime.atDocumentStart) {
         LogService.instance.log('UserScript', 'onLoadStart: re-injecting "${script.name}" (${src.length} chars)');
-        await _safeEval(controller, src);
+        await _safeEval(controller, _guarded(script.id, src));
       }
     }
   }
@@ -377,7 +391,7 @@ class UserScriptService {
       if (src.isEmpty) continue;
       if (script.injectionTime == UserScriptInjectionTime.atDocumentEnd) {
         LogService.instance.log('UserScript', 'onLoadStop: re-injecting "${script.name}" (${src.length} chars)');
-        await _safeEval(controller, src);
+        await _safeEval(controller, _guarded(script.id, src));
       }
     }
   }

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -278,6 +278,11 @@ class WebViewModel {
   FindMatchesResult findMatches = FindMatchesResult();
   WebViewTheme _currentTheme = WebViewTheme.light;
 
+  /// The theme most recently applied to this webview via [setTheme]. Used
+  /// by callers (e.g. HTML cache prelude) that need to render a frame that
+  /// matches the current theme before scripts and stylesheets load.
+  WebViewTheme get currentTheme => _currentTheme;
+
   WebViewModel({
     String? siteId,
     required this.initUrl,

--- a/openspec/specs/navigation/spec.md
+++ b/openspec/specs/navigation/spec.md
@@ -246,7 +246,7 @@ Additionally, the PopScope handler performs the same check right after a success
 **Problem:** If `_goHome()` were async, rapid taps could interleave with webview recreation.
 
 **Solution:** `_goHome()` is fully synchronous. It completes in a single microtask:
-1. Drops the site's cached HTML via `HtmlCacheService.deleteCache(siteId)` so the next load starts from the live page instead of a stale snapshot (the cached frame could otherwise flash with pre-edit content or mismatched theme before user scripts re-run)
+1. Drops the site's cached HTML via `_deleteCacheIfOnline(siteId)` so the next load starts from the live page instead of a stale snapshot (the cached frame could otherwise flash with pre-edit content or mismatched theme before user scripts re-run). The helper is fire-and-forget and skips deletion when the device is offline, so offline users keep a renderable snapshot.
 2. Resets `currentUrl` to `initUrl`
 3. Disposes webview (`webview = null`, `controller = null`)
 4. Bumps `_canGoBackVersion`

--- a/openspec/specs/navigation/spec.md
+++ b/openspec/specs/navigation/spec.md
@@ -246,13 +246,14 @@ Additionally, the PopScope handler performs the same check right after a success
 **Problem:** If `_goHome()` were async, rapid taps could interleave with webview recreation.
 
 **Solution:** `_goHome()` is fully synchronous. It completes in a single microtask:
-1. Resets `currentUrl` to `initUrl`
-2. Disposes webview (`webview = null`, `controller = null`)
-3. Bumps `_canGoBackVersion`
-4. Sets `_canGoBack = false` via `setState`
-5. Saves state (fire-and-forget async, but idempotent)
+1. Drops the site's cached HTML via `HtmlCacheService.deleteCache(siteId)` so the next load starts from the live page instead of a stale snapshot (the cached frame could otherwise flash with pre-edit content or mismatched theme before user scripts re-run)
+2. Resets `currentUrl` to `initUrl`
+3. Disposes webview (`webview = null`, `controller = null`)
+4. Bumps `_canGoBackVersion`
+5. Sets `_canGoBack = false` via `setState`
+6. Saves state (fire-and-forget async, but idempotent)
 
-Double-tap is harmless: second call disposes an already-null webview.
+Double-tap is harmless: second call disposes an already-null webview. `deleteCache` on the second call is also a no-op (file already removed).
 
 ---
 

--- a/openspec/specs/user-scripts/spec.md
+++ b/openspec/specs/user-scripts/spec.md
@@ -157,7 +157,13 @@ Scripts SHALL be injected at the correct time through multiple mechanisms to han
 
 2. **`reinjectOnLoadStart` / `reinjectOnLoadStop`**: Re-injects simple scripts (without `urlSource`) via `evaluateJavascript` as a safety net. Scripts with `urlSource` are **skipped** to avoid racing with the native WKUserScript mechanism, which would cause ReferenceErrors.
 
-3. **`reinjectOnSpaNavigation`**: On SPA navigations (URL changes without full page load, detected via `onUpdateVisitedHistory`), re-runs only the user's `source` code (not the library from `urlSource`). The JS context persists on SPA navigations, so the library is still loaded — only the user's initialization code (e.g. `MyLib.init()`) needs to re-run.
+   Both the `initialUserScripts` path and the re-injection path wrap each script's body in a once-per-document guard:
+   ```js
+   if (!window.__wsRan_<scriptId>) { window.__wsRan_<scriptId> = true; /* script */ }
+   ```
+   The flag lives on `window`, which is fresh per document, so full page loads reset it automatically. If `initialUserScripts` already ran the script, the re-injection on `onLoadStart` / `onLoadStop` becomes a no-op — preventing duplicate side-effects (double event listeners, double DOM insertions) for scripts that aren't internally idempotent. If `initialUserScripts` did NOT fire (e.g. cached-HTML loads that skip the native injector on some platforms), the re-injection still runs.
+
+3. **`reinjectOnSpaNavigation`**: On SPA navigations (URL changes without full page load, detected via `onUpdateVisitedHistory`), re-runs only the user's `source` code (not the library from `urlSource`). The JS context persists on SPA navigations, so the library is still loaded — only the user's initialization code (e.g. `MyLib.init()`) needs to re-run. This path intentionally **bypasses** the `__wsRan_<id>` guard: the page document hasn't changed, so the flag is still set from the initial load, but the user's init code should fire again on every route change.
 
 #### Execution order within a single injection
 
@@ -170,6 +176,26 @@ When a script has both `urlSource` (cached library) and `source` (user code):
 ```
 
 The `;null;` suffix is appended to all injected scripts because WebKit (macOS/iOS) errors when `evaluateJavascript` returns `undefined`. Returning `null` (a serializable value) prevents this. All `evaluateJavascript` calls are also wrapped in try-catch at the Dart level via `_safeEval`.
+
+### Requirement: US-002c - HTML Cache Invalidation on Script Changes
+
+Cached HTML SHALL be invalidated whenever the set of scripts that would run against a site changes, because the saved snapshot was captured with the **previous** script set applied. Showing that stale frame on next load would briefly render the pre-edit DOM before the new scripts re-run.
+
+- **Per-site script edits** (`onScriptsChanged` → `_resetCurrentSiteWebView`): `HtmlCacheService.deleteCache(siteId)` for the current site before disposing its webview.
+- **Global library edits** (`onGlobalUserScriptsChanged` → `_resetAllWebViews`): `HtmlCacheService.deleteCache(model.siteId)` for every site whose `enabledGlobalScriptIds` is non-empty. Sites with no global opt-ins are unaffected by a global edit and keep their cache.
+- **Home button** (`_goHome`): deletes the current site's cache as well, so a fresh home navigation never renders a stale snapshot captured under a different script set or theme.
+
+#### Scenario: Edit a site script, navigate away, navigate back
+
+**Given** a site with a dark-mode user script enabled and a cached HTML snapshot
+**When** the user edits the script's source and saves
+**Then** the site's cached HTML is deleted. The next time the site is displayed, `initialHtml` is null and the live page loads directly — no stale pre-edit frame flashes.
+
+#### Scenario: Edit a global script, navigate to a site that opts in
+
+**Given** a global script is opted in on site A, not on site B
+**When** the user edits the global script's source in App Settings
+**Then** site A's cache is cleared; site B's cache is preserved.
 
 ### Requirement: US-003 - Script Management UI
 

--- a/openspec/specs/user-scripts/spec.md
+++ b/openspec/specs/user-scripts/spec.md
@@ -185,6 +185,8 @@ Cached HTML SHALL be invalidated whenever the set of scripts that would run agai
 - **Global library edits** (`onGlobalUserScriptsChanged` → `_resetAllWebViews`): `HtmlCacheService.deleteCache(model.siteId)` for every site whose `enabledGlobalScriptIds` is non-empty. Sites with no global opt-ins are unaffected by a global edit and keep their cache.
 - **Home button** (`_goHome`): deletes the current site's cache as well, so a fresh home navigation never renders a stale snapshot captured under a different script set or theme.
 
+**Offline gate.** All three invalidation paths route through `_deleteCacheIfOnline(siteId)` which probes `ConnectivityService.instance.isOnline()` before deleting. When the device is offline the cache is **preserved** — a stale snapshot is strictly better than a blank webview, and the next successful `onLoadStop` (once connectivity returns) will overwrite the file via `onHtmlLoaded` with the up-to-date DOM. The probe is fire-and-forget so synchronous callers (notably `_goHome`, which is synchronous by design per navigation spec RACE-004) don't need to `await`.
+
 #### Scenario: Edit a site script, navigate away, navigate back
 
 **Given** a site with a dark-mode user script enabled and a cached HTML snapshot

--- a/openspec/specs/webview-hints/spec.md
+++ b/openspec/specs/webview-hints/spec.md
@@ -212,6 +212,19 @@ The theme hint is applied via JavaScript that:
 3. Maintains listeners for dynamic theme changes
 4. Updates color-scheme meta tag and CSS property
 
+### HTML Cache Theme Prelude
+
+When `HtmlCacheService` returns a cached snapshot for rendering via `initialHtml`, `HtmlCacheService.applyThemePrelude()` is applied at **load time** (not save time) based on the webview's current theme. For dark themes it prepends this to the cached HTML's `<head>`:
+
+```html
+<meta name="color-scheme" content="dark">
+<style id="__ws_cache_prelude">
+html,body{background:#111 !important;color-scheme:dark}
+</style>
+```
+
+This eliminates the white-frame flash while the cached HTML's stylesheets and user scripts re-run on the live load. The prelude is keyed on the live `WebViewModel.currentTheme` plus platform brightness (for `WebViewTheme.system`), so a theme switch takes effect on the next cache load without cache invalidation. The helper is idempotent — duplicate prelude insertion is detected via the `__ws_cache_prelude` id.
+
 ### Language Header
 
 The language hint is sent via HTTP header:


### PR DESCRIPTION
Stale cached HTML could flash against a different script set or theme before the live page finished loading, producing the visible dark-to-light flicker reported for dark-mode userscripts. Tightens three paths so the cached frame stays consistent with current scripts and theme:

- _goHome() and per/global script-save paths now drop HtmlCacheService entries before the webview is disposed, so the next load renders from the live page rather than a mismatched snapshot.
- UserScriptService wraps each injected script in a if (!window.__wsRan_<id>) { ... } gate, making reinjectOnLoadStart/Stop a no-op when initialUserScripts already ran (preventing duplicate event listeners or DOM insertions) while still covering paths where the native injector doesn't fire. SPA reinjection deliberately bypasses the guard.
- HtmlCacheService.applyThemePrelude is invoked at cache-load time from main.dart's initialHtml callback, prepending a dark color-scheme + bg override to the cached HTML when the webview's current theme is dark. Applied at load (not save) so theme changes take effect without cache churn; idempotent via an id="__ws_cache_prelude" marker.

Specs updated: navigation (RACE-004), user-scripts (US-002b + new US-002c), webview-hints (new HTML cache prelude section).

https://claude.ai/code/session_01TJSRpCXkgHa2eebKJE7aCJ