### PR TITLE
Fix cookie leak from deleted sites via shared native jar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -995,8 +995,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     LogService.instance.log('CookieIsolation', 'After switch, loaded indices: $_loadedIndices');
   }
 
-  /// Unloads a site due to domain conflict with another site.
-  /// Captures cookies for ALL loaded sites, clears CookieManager, disposes conflicting webview.
+  /// Unloads a site due to domain conflict with another site. Captures the
+  /// departing site's cookies to its siteId-keyed storage (it's the only
+  /// chance — the webview is about to be disposed), then removes it from the
+  /// loaded set. The native cookie jar is NOT nuked here; `_restoreCookiesForSite`
+  /// does that next and captures any other still-loaded sites' cookies first,
+  /// which avoids wiping their saved sessions with empty captures.
   Future<void> _unloadSiteForDomainSwitch(int index) async {
     if (index < 0 || index >= _webViewModels.length) return;
 
@@ -1004,26 +1008,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
     LogService.instance.log('CookieIsolation', 'Unloading site $index: "${model.name}" (siteId: ${model.siteId})');
 
-    // Capture cookies for ALL loaded sites before clearing
-    // This preserves cookies for sites on other domains
-    for (final loadedIndex in _loadedIndices) {
-      if (loadedIndex >= _webViewModels.length) continue;
-      final loadedModel = _webViewModels[loadedIndex];
-      if (loadedModel.incognito) continue;
-
-      await loadedModel.captureCookies(_cookieManager);
-      await _cookieSecureStorage.saveCookiesForSite(loadedModel.siteId, loadedModel.cookies);
-
-      LogService.instance.log('CookieIsolation', 'Captured ${loadedModel.cookies.length} cookies for site $loadedIndex: "${loadedModel.name}"');
+    if (!model.incognito) {
+      await model.captureCookies(_cookieManager);
+      await _cookieSecureStorage.saveCookiesForSite(model.siteId, model.cookies);
+      LogService.instance.log('CookieIsolation', 'Captured ${model.cookies.length} cookies for site $index: "${model.name}"');
     }
-
-    // Clear ALL cookies from CookieManager
-    // We use deleteAllCookies() because sites like Google set cookies on multiple
-    // domains (.google.com, accounts.google.com, etc.) that wouldn't be captured
-    // by a single URL query.
-    await _cookieManager.deleteAllCookies();
-
-    LogService.instance.log('CookieIsolation', 'Cleared ALL cookies from CookieManager', level: LogLevel.info);
 
     // Dispose webview for the conflicting site only
     model.disposeWebView();
@@ -1035,19 +1024,65 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   }
 
   /// Restores cookies for a site from secure storage before loading.
+  ///
+  /// The native cookie jar (e.g. iOS `WKHTTPCookieStorage`) is a process-wide
+  /// shared store, so residual cookies from previously-deleted sites, legacy
+  /// pre-siteId sessions, or cookies set on sibling subdomains (e.g.
+  /// `accounts.google.com` when only `mail.google.com` was deleted) can leak
+  /// into the newly-activated site's requests. To prevent this:
+  ///
+  ///   1. Snapshot ALL cookies via `getAllCookies()` (not URL-scoped — that
+  ///      would miss sibling-subdomain cookies like `accounts.google.com`
+  ///      when capturing from a `mail.google.com` site).
+  ///   2. Attribute cookies to each loaded non-incognito site by base-domain
+  ///      match and save to per-siteId encrypted storage.
+  ///   3. Nuke the native jar.
+  ///   4. Restore cookies for the target site AND every other still-loaded
+  ///      non-incognito site — parallel-loaded sites share the same native
+  ///      jar and must not lose their sessions.
   Future<void> _restoreCookiesForSite(int index) async {
     if (index < 0 || index >= _webViewModels.length) return;
+    final version = _setCurrentIndexVersion;
 
     final model = _webViewModels[index];
     if (model.incognito) return; // Don't restore cookies for incognito sites
 
-    // Load persisted cookies by siteId
+    // Step 1: snapshot all cookies from the native jar.
+    final allCookies = await _cookieManager.getAllCookies();
+    if (version != _setCurrentIndexVersion) return;
+
+    // Step 2: attribute to every loaded non-incognito site by base-domain
+    // match and persist. Per-site cookie isolation (ISO-001) guarantees at
+    // most one loaded site per base domain, so attribution is unambiguous.
+    // Target is included if it's already loaded (e.g. re-activation after
+    // goHome) so its live session is persisted before the nuke.
+    final otherLoadedModels = <WebViewModel>[];
+    for (final loadedIndex in _loadedIndices) {
+      if (loadedIndex >= _webViewModels.length) continue;
+      final loadedModel = _webViewModels[loadedIndex];
+      if (loadedModel.incognito) continue;
+
+      final base = getBaseDomain(loadedModel.initUrl);
+      final cookies = allCookies
+          .where((c) => _cookieMatchesBaseDomain(c, base))
+          .toList();
+      loadedModel.cookies = cookies;
+      await _cookieSecureStorage.saveCookiesForSite(loadedModel.siteId, cookies);
+      if (version != _setCurrentIndexVersion) return;
+      if (loadedIndex != index) otherLoadedModels.add(loadedModel);
+    }
+
+    // Step 3: nuke native jar to evict anything from deleted or legacy sites.
+    await _cookieManager.deleteAllCookies();
+    if (version != _setCurrentIndexVersion) return;
+
+    // Step 4a: restore target's cookies from storage.
     final cookies = await _cookieSecureStorage.loadCookiesForSite(model.siteId);
     model.cookies = cookies;
+    if (version != _setCurrentIndexVersion) return;
 
     LogService.instance.log('CookieIsolation', 'Restoring ${cookies.length} cookies for site $index: "${model.name}" (siteId: ${model.siteId})');
 
-    // Restore cookies to CookieManager, skipping blocked ones
     final url = Uri.parse(model.initUrl);
     for (final cookie in cookies) {
       if (cookie.value.isEmpty) continue;
@@ -1062,7 +1097,39 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         isSecure: cookie.isSecure,
         isHttpOnly: cookie.isHttpOnly,
       );
+      if (version != _setCurrentIndexVersion) return;
     }
+
+    // Step 4b: restore other still-loaded sites' cookies.
+    for (final other in otherLoadedModels) {
+      final otherUrl = Uri.parse(other.initUrl);
+      for (final cookie in other.cookies) {
+        if (cookie.value.isEmpty) continue;
+        if (other.isCookieBlocked(cookie.name, cookie.domain)) continue;
+        await _cookieManager.setCookie(
+          url: otherUrl,
+          name: cookie.name,
+          value: cookie.value,
+          domain: cookie.domain,
+          path: cookie.path ?? '/',
+          expiresDate: cookie.expiresDate,
+          isSecure: cookie.isSecure,
+          isHttpOnly: cookie.isHttpOnly,
+        );
+        if (version != _setCurrentIndexVersion) return;
+      }
+    }
+  }
+
+  /// Returns true if `cookie.domain` falls under `baseDomain` per standard
+  /// HTTP cookie domain-match semantics (exact match or any subdomain).
+  /// Leading `.` is stripped before comparison.
+  static bool _cookieMatchesBaseDomain(Cookie cookie, String baseDomain) {
+    var domain = (cookie.domain ?? '').trim().toLowerCase();
+    if (domain.isEmpty || baseDomain.isEmpty) return false;
+    if (domain.startsWith('.')) domain = domain.substring(1);
+    final base = baseDomain.toLowerCase();
+    return domain == base || domain.endsWith('.$base');
   }
 
   /// Shows a popup window for handling window.open() requests from webviews.
@@ -1244,6 +1311,16 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await _loadWebViewModels();
     await _migrateGlobalScriptOptIn();
     _suggestedSites = await suggested_sites.getEffectiveSuggestedSites();
+
+    // Startup GC: sweep orphaned per-siteId encrypted storage and HTML cache
+    // (sites deleted in previous sessions), then nuke the native cookie jar
+    // so residual cookies from deleted/legacy sites don't leak into the next
+    // activated site. `_restoreCookiesForSite` re-nukes on every switch; this
+    // extra pass covers launch before any site is activated.
+    final activeSiteIdsAtStartup = _webViewModels.map((m) => m.siteId).toSet();
+    await _cookieSecureStorage.removeOrphanedCookies(activeSiteIdsAtStartup);
+    await HtmlCacheService.instance.removeOrphanedCaches(activeSiteIdsAtStartup);
+    await _cookieManager.deleteAllCookies();
 
     // Always start at home screen on launch - only restore index if launched via shortcut
     int? indexToRestore;
@@ -1688,7 +1765,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       await suggested_sites.saveSuggestedSites(_suggestedSites);
     }
 
-    // Clean up orphaned cookies and HTML cache (for siteIds no longer in any site)
+    // Clean up orphaned cookies and HTML cache (for siteIds no longer in any site).
+    // Note: we do NOT nuke the native cookie jar here — `_setCurrentIndex` above
+    // already routed through `_restoreCookiesForSite`, which nuked and restored
+    // the imported active site's cookies. Another nuke here would wipe the
+    // session we just restored and log the user out of the imported active site.
     final activeSiteIds = _webViewModels
         .map((model) => model.siteId)
         .toSet();
@@ -2825,18 +2906,64 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await ShortcutService.removeShortcut(deletedModel.siteId);
     if (!mounted) return;
 
-    final deletedDomain = getBaseDomain(deletedModel.initUrl);
-    final otherSiteSameDomain = _webViewModels
-        .where((m) => m != deletedModel && getBaseDomain(m.initUrl) == deletedDomain)
-        .isNotEmpty;
-    if (!otherSiteSameDomain) {
-      await _cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.initUrl));
-      if (deletedModel.currentUrl.isNotEmpty && deletedModel.currentUrl != deletedModel.initUrl) {
-        await _cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.currentUrl));
+    // Always clear native cookies for the deleted site. The previous
+    // "skip if another site shares the same base domain" optimization was
+    // unsafe: leaving native cookies behind leaks the deleted site's session
+    // (e.g. `accounts.google.com` login) into any freshly-added sibling site.
+    //
+    // Caveat: if a surviving loaded site shares a base domain with the
+    // deleted one, a URL-scoped delete would also wipe that surviving site's
+    // live session from the native jar. Snapshot its cookies first (via
+    // `getAllCookies` so sibling-subdomain cookies are included) and restore
+    // after the delete so the active webview keeps its session.
+    final survivingSameBase = <WebViewModel>[];
+    final deletedBase = getBaseDomain(deletedModel.initUrl);
+    for (final loadedIdx in _loadedIndices) {
+      if (loadedIdx == index) continue;
+      if (loadedIdx >= _webViewModels.length) continue;
+      final loaded = _webViewModels[loadedIdx];
+      if (loaded.incognito) continue;
+      if (getBaseDomain(loaded.initUrl) == deletedBase) {
+        survivingSameBase.add(loaded);
       }
+    }
+
+    List<Cookie> survivingCookiesSnapshot = const [];
+    if (survivingSameBase.isNotEmpty) {
+      final allCookies = await _cookieManager.getAllCookies();
+      survivingCookiesSnapshot = allCookies
+          .where((c) => _cookieMatchesBaseDomain(c, deletedBase))
+          .toList();
+    }
+
+    await _cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.initUrl));
+    if (deletedModel.currentUrl.isNotEmpty && deletedModel.currentUrl != deletedModel.initUrl) {
+      await _cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.currentUrl));
     }
     await _cookieSecureStorage.saveCookiesForSite(deletedModel.siteId, []);
     await HtmlCacheService.instance.deleteCache(deletedModel.siteId);
+
+    // Restore the surviving same-base-domain site's session snapshot. The
+    // deleted site's cookies are NOT in this snapshot because they were
+    // persisted to `deletedModel.siteId` storage (now cleared) — only the
+    // snapshot taken against the live jar is used, and any cookies owned by
+    // the surviving site's own session are preserved.
+    if (survivingSameBase.isNotEmpty && survivingCookiesSnapshot.isNotEmpty) {
+      final restoreUrl = Uri.parse(survivingSameBase.first.initUrl);
+      for (final cookie in survivingCookiesSnapshot) {
+        if (cookie.value.isEmpty) continue;
+        await _cookieManager.setCookie(
+          url: restoreUrl,
+          name: cookie.name,
+          value: cookie.value,
+          domain: cookie.domain,
+          path: cookie.path ?? '/',
+          expiresDate: cookie.expiresDate,
+          isSecure: cookie.isSecure,
+          isHttpOnly: cookie.isHttpOnly,
+        );
+      }
+    }
     if (!mounted) return;
     final currentModelIndex = _webViewModels.indexOf(deletedModel);
     if (currentModelIndex == -1) return;
@@ -2862,6 +2989,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     }
     await _saveWebViewModels();
     await _saveWebspaces();
+
+    // Defense in depth: sweep orphaned per-siteId storage entries.
+    final activeSiteIds = _webViewModels.map((m) => m.siteId).toSet();
+    await _cookieSecureStorage.removeOrphanedCookies(activeSiteIds);
+    await HtmlCacheService.instance.removeOrphanedCaches(activeSiteIds);
+
     if (!mounted) return;
     Navigator.pop(context);
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,6 +31,7 @@ import 'package:webspace/demo_data.dart' show seedDemoData, isDemoMode;
 import 'package:webspace/services/image_cache_service.dart';
 import 'package:webspace/services/html_cache_service.dart';
 import 'package:webspace/services/settings_backup.dart';
+import 'package:webspace/services/cookie_isolation.dart';
 import 'package:webspace/services/cookie_secure_storage.dart';
 import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
@@ -671,6 +672,10 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   AppThemeSettings _themeSettings = const AppThemeSettings();
   final CookieManager _cookieManager = CookieManager();
   final CookieSecureStorage _cookieSecureStorage = CookieSecureStorage();
+  late final CookieIsolationEngine _cookieIsolation = CookieIsolationEngine(
+    cookieManager: _cookieManager,
+    storage: _cookieSecureStorage,
+  );
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
   bool _isBackHandling = false;
@@ -995,141 +1000,26 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     LogService.instance.log('CookieIsolation', 'After switch, loaded indices: $_loadedIndices');
   }
 
-  /// Unloads a site due to domain conflict with another site. Captures the
-  /// departing site's cookies to its siteId-keyed storage (it's the only
-  /// chance — the webview is about to be disposed), then removes it from the
-  /// loaded set. The native cookie jar is NOT nuked here; `_restoreCookiesForSite`
-  /// does that next and captures any other still-loaded sites' cookies first,
-  /// which avoids wiping their saved sessions with empty captures.
+  /// Unloads a site due to domain conflict with another site. Delegates to
+  /// the isolation engine so the orchestration is shared with tests.
   Future<void> _unloadSiteForDomainSwitch(int index) async {
-    if (index < 0 || index >= _webViewModels.length) return;
-
-    final model = _webViewModels[index];
-
-    LogService.instance.log('CookieIsolation', 'Unloading site $index: "${model.name}" (siteId: ${model.siteId})');
-
-    if (!model.incognito) {
-      await model.captureCookies(_cookieManager);
-      await _cookieSecureStorage.saveCookiesForSite(model.siteId, model.cookies);
-      LogService.instance.log('CookieIsolation', 'Captured ${model.cookies.length} cookies for site $index: "${model.name}"');
-    }
-
-    // Dispose webview for the conflicting site only
-    model.disposeWebView();
-
-    LogService.instance.log('CookieIsolation', 'Disposed webview for site $index');
-
-    // Remove from loaded indices
-    _loadedIndices.remove(index);
+    await _cookieIsolation.unloadSiteForDomainSwitch(
+      index: index,
+      models: _webViewModels,
+      loadedIndices: _loadedIndices,
+    );
   }
 
-  /// Restores cookies for a site from secure storage before loading.
-  ///
-  /// The native cookie jar (e.g. iOS `WKHTTPCookieStorage`) is a process-wide
-  /// shared store, so residual cookies from previously-deleted sites, legacy
-  /// pre-siteId sessions, or cookies set on sibling subdomains (e.g.
-  /// `accounts.google.com` when only `mail.google.com` was deleted) can leak
-  /// into the newly-activated site's requests. To prevent this:
-  ///
-  ///   1. Snapshot ALL cookies via `getAllCookies()` (not URL-scoped — that
-  ///      would miss sibling-subdomain cookies like `accounts.google.com`
-  ///      when capturing from a `mail.google.com` site).
-  ///   2. Attribute cookies to each loaded non-incognito site by base-domain
-  ///      match and save to per-siteId encrypted storage.
-  ///   3. Nuke the native jar.
-  ///   4. Restore cookies for the target site AND every other still-loaded
-  ///      non-incognito site — parallel-loaded sites share the same native
-  ///      jar and must not lose their sessions.
+  /// Restores cookies for a site before activation. Delegates to the engine.
   Future<void> _restoreCookiesForSite(int index) async {
-    if (index < 0 || index >= _webViewModels.length) return;
     final version = _setCurrentIndexVersion;
-
-    final model = _webViewModels[index];
-    if (model.incognito) return; // Don't restore cookies for incognito sites
-
-    // Step 1: snapshot all cookies from the native jar.
-    final allCookies = await _cookieManager.getAllCookies();
-    if (version != _setCurrentIndexVersion) return;
-
-    // Step 2: attribute to every loaded non-incognito site by base-domain
-    // match and persist. Per-site cookie isolation (ISO-001) guarantees at
-    // most one loaded site per base domain, so attribution is unambiguous.
-    // Target is included if it's already loaded (e.g. re-activation after
-    // goHome) so its live session is persisted before the nuke.
-    final otherLoadedModels = <WebViewModel>[];
-    for (final loadedIndex in _loadedIndices) {
-      if (loadedIndex >= _webViewModels.length) continue;
-      final loadedModel = _webViewModels[loadedIndex];
-      if (loadedModel.incognito) continue;
-
-      final base = getBaseDomain(loadedModel.initUrl);
-      final cookies = allCookies
-          .where((c) => _cookieMatchesBaseDomain(c, base))
-          .toList();
-      loadedModel.cookies = cookies;
-      await _cookieSecureStorage.saveCookiesForSite(loadedModel.siteId, cookies);
-      if (version != _setCurrentIndexVersion) return;
-      if (loadedIndex != index) otherLoadedModels.add(loadedModel);
-    }
-
-    // Step 3: nuke native jar to evict anything from deleted or legacy sites.
-    await _cookieManager.deleteAllCookies();
-    if (version != _setCurrentIndexVersion) return;
-
-    // Step 4a: restore target's cookies from storage.
-    final cookies = await _cookieSecureStorage.loadCookiesForSite(model.siteId);
-    model.cookies = cookies;
-    if (version != _setCurrentIndexVersion) return;
-
-    LogService.instance.log('CookieIsolation', 'Restoring ${cookies.length} cookies for site $index: "${model.name}" (siteId: ${model.siteId})');
-
-    final url = Uri.parse(model.initUrl);
-    for (final cookie in cookies) {
-      if (cookie.value.isEmpty) continue;
-      if (model.isCookieBlocked(cookie.name, cookie.domain)) continue;
-      await _cookieManager.setCookie(
-        url: url,
-        name: cookie.name,
-        value: cookie.value,
-        domain: cookie.domain,
-        path: cookie.path ?? '/',
-        expiresDate: cookie.expiresDate,
-        isSecure: cookie.isSecure,
-        isHttpOnly: cookie.isHttpOnly,
-      );
-      if (version != _setCurrentIndexVersion) return;
-    }
-
-    // Step 4b: restore other still-loaded sites' cookies.
-    for (final other in otherLoadedModels) {
-      final otherUrl = Uri.parse(other.initUrl);
-      for (final cookie in other.cookies) {
-        if (cookie.value.isEmpty) continue;
-        if (other.isCookieBlocked(cookie.name, cookie.domain)) continue;
-        await _cookieManager.setCookie(
-          url: otherUrl,
-          name: cookie.name,
-          value: cookie.value,
-          domain: cookie.domain,
-          path: cookie.path ?? '/',
-          expiresDate: cookie.expiresDate,
-          isSecure: cookie.isSecure,
-          isHttpOnly: cookie.isHttpOnly,
-        );
-        if (version != _setCurrentIndexVersion) return;
-      }
-    }
-  }
-
-  /// Returns true if `cookie.domain` falls under `baseDomain` per standard
-  /// HTTP cookie domain-match semantics (exact match or any subdomain).
-  /// Leading `.` is stripped before comparison.
-  static bool _cookieMatchesBaseDomain(Cookie cookie, String baseDomain) {
-    var domain = (cookie.domain ?? '').trim().toLowerCase();
-    if (domain.isEmpty || baseDomain.isEmpty) return false;
-    if (domain.startsWith('.')) domain = domain.substring(1);
-    final base = baseDomain.toLowerCase();
-    return domain == base || domain.endsWith('.$base');
+    await _cookieIsolation.restoreCookiesForSite(
+      index: index,
+      models: _webViewModels,
+      loadedIndices: _loadedIndices,
+      versionAtEntry: version,
+      currentVersion: () => _setCurrentIndexVersion,
+    );
   }
 
   /// Shows a popup window for handling window.open() requests from webviews.
@@ -1730,6 +1620,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         backup.currentIndex! >= 0 &&
         backup.currentIndex! < _webViewModels.length) {
       indexToRestore = backup.currentIndex;
+    }
+    // If no site is activated, _setCurrentIndex returns without routing
+    // through _restoreCookiesForSite — which means pre-import cookies from
+    // the previously-active site remain in the native jar. Nuke explicitly.
+    if (indexToRestore == null) {
+      await _cookieManager.deleteAllCookies();
     }
     await _setCurrentIndex(indexToRestore);
     setState(() {}); // Update UI after async operation
@@ -2906,64 +2802,17 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await ShortcutService.removeShortcut(deletedModel.siteId);
     if (!mounted) return;
 
-    // Always clear native cookies for the deleted site. The previous
-    // "skip if another site shares the same base domain" optimization was
-    // unsafe: leaving native cookies behind leaks the deleted site's session
-    // (e.g. `accounts.google.com` login) into any freshly-added sibling site.
-    //
-    // Caveat: if a surviving loaded site shares a base domain with the
-    // deleted one, a URL-scoped delete would also wipe that surviving site's
-    // live session from the native jar. Snapshot its cookies first (via
-    // `getAllCookies` so sibling-subdomain cookies are included) and restore
-    // after the delete so the active webview keeps its session.
-    final survivingSameBase = <WebViewModel>[];
-    final deletedBase = getBaseDomain(deletedModel.initUrl);
-    for (final loadedIdx in _loadedIndices) {
-      if (loadedIdx == index) continue;
-      if (loadedIdx >= _webViewModels.length) continue;
-      final loaded = _webViewModels[loadedIdx];
-      if (loaded.incognito) continue;
-      if (getBaseDomain(loaded.initUrl) == deletedBase) {
-        survivingSameBase.add(loaded);
-      }
-    }
-
-    List<Cookie> survivingCookiesSnapshot = const [];
-    if (survivingSameBase.isNotEmpty) {
-      final allCookies = await _cookieManager.getAllCookies();
-      survivingCookiesSnapshot = allCookies
-          .where((c) => _cookieMatchesBaseDomain(c, deletedBase))
-          .toList();
-    }
-
-    await _cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.initUrl));
-    if (deletedModel.currentUrl.isNotEmpty && deletedModel.currentUrl != deletedModel.initUrl) {
-      await _cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.currentUrl));
-    }
-    await _cookieSecureStorage.saveCookiesForSite(deletedModel.siteId, []);
+    // Delegate cookie cleanup to the isolation engine: it snapshots any
+    // loaded same-base-domain site's session, clears the deleted site's
+    // native cookies, and restores the surviving session so the active
+    // webview isn't silently logged out.
+    await _cookieIsolation.preDeleteCookieCleanup(
+      deletedModel: deletedModel,
+      deletedIndex: index,
+      models: _webViewModels,
+      loadedIndices: _loadedIndices,
+    );
     await HtmlCacheService.instance.deleteCache(deletedModel.siteId);
-
-    // Restore the surviving same-base-domain site's session snapshot. The
-    // deleted site's cookies are NOT in this snapshot because they were
-    // persisted to `deletedModel.siteId` storage (now cleared) — only the
-    // snapshot taken against the live jar is used, and any cookies owned by
-    // the surviving site's own session are preserved.
-    if (survivingSameBase.isNotEmpty && survivingCookiesSnapshot.isNotEmpty) {
-      final restoreUrl = Uri.parse(survivingSameBase.first.initUrl);
-      for (final cookie in survivingCookiesSnapshot) {
-        if (cookie.value.isEmpty) continue;
-        await _cookieManager.setCookie(
-          url: restoreUrl,
-          name: cookie.name,
-          value: cookie.value,
-          domain: cookie.domain,
-          path: cookie.path ?? '/',
-          expiresDate: cookie.expiresDate,
-          isSecure: cookie.isSecure,
-          isHttpOnly: cookie.isHttpOnly,
-        );
-      }
-    }
     if (!mounted) return;
     final currentModelIndex = _webViewModels.indexOf(deletedModel);
     if (currentModelIndex == -1) return;

--- a/lib/services/cookie_isolation.dart
+++ b/lib/services/cookie_isolation.dart
@@ -1,0 +1,274 @@
+import 'package:webspace/services/cookie_secure_storage.dart';
+import 'package:webspace/services/log_service.dart';
+import 'package:webspace/services/webview.dart';
+import 'package:webspace/web_view_model.dart';
+
+/// Returns true if `cookie.domain` falls under `baseDomain` per standard
+/// HTTP cookie domain-match semantics (exact match or any subdomain).
+/// Leading `.` is stripped before comparison.
+bool cookieMatchesBaseDomain(Cookie cookie, String baseDomain) {
+  var domain = (cookie.domain ?? '').trim().toLowerCase();
+  if (domain.isEmpty || baseDomain.isEmpty) return false;
+  if (domain.startsWith('.')) domain = domain.substring(1);
+  final base = baseDomain.toLowerCase();
+  return domain == base || domain.endsWith('.$base');
+}
+
+/// Pure cookie-isolation logic, extracted so tests can exercise the real
+/// code with mocked [CookieManager] and [CookieSecureStorage] instead of
+/// re-implementing the orchestration in a test harness.
+///
+/// The engine is stateless; it operates on mutable state (`models`,
+/// `loadedIndices`) passed into each method. All native cookie-jar writes
+/// go through [cookieManager]; all per-site persistence goes through
+/// [storage]. Concurrency is serialized by an optional version check —
+/// callers pass a version captured at entry and a current-version getter;
+/// if they diverge, the operation bails early.
+class CookieIsolationEngine {
+  final CookieManager cookieManager;
+  final CookieSecureStorage storage;
+
+  CookieIsolationEngine({
+    required this.cookieManager,
+    required this.storage,
+  });
+
+  /// Captures the conflicting site's cookies to siteId-keyed storage (last
+  /// chance — the webview is about to be disposed), then disposes it and
+  /// removes it from `loadedIndices`.
+  ///
+  /// The native cookie jar is NOT nuked here. Callers MUST invoke
+  /// [restoreCookiesForSite] immediately after so the jar is wiped and the
+  /// target's cookies are restored in the same transaction.
+  Future<void> unloadSiteForDomainSwitch({
+    required int index,
+    required List<WebViewModel> models,
+    required Set<int> loadedIndices,
+  }) async {
+    if (index < 0 || index >= models.length) return;
+
+    final model = models[index];
+    LogService.instance.log(
+      'CookieIsolation',
+      'Unloading site $index: "${model.name}" (siteId: ${model.siteId})',
+    );
+
+    if (!model.incognito) {
+      // Snapshot the full native jar and attribute by base-domain so
+      // sibling-subdomain cookies (e.g. `accounts.google.com` for a
+      // `mail.google.com` site) aren't lost — a URL-scoped capture alone
+      // would only return cookies applicable to the site's primary URL.
+      final allCookies = await cookieManager.getAllCookies(
+        candidateUrls: _candidateUrlsFor([model]),
+      );
+      final base = getBaseDomain(model.initUrl);
+      model.cookies = allCookies
+          .where((c) => cookieMatchesBaseDomain(c, base))
+          .toList();
+      await storage.saveCookiesForSite(model.siteId, model.cookies);
+      LogService.instance.log(
+        'CookieIsolation',
+        'Captured ${model.cookies.length} cookies for site $index: "${model.name}"',
+      );
+    }
+
+    model.disposeWebView();
+    LogService.instance.log('CookieIsolation', 'Disposed webview for site $index');
+    loadedIndices.remove(index);
+  }
+
+  /// Restores cookies for a site before it's activated:
+  ///
+  ///   1. Snapshot ALL native cookies via `getAllCookies()` (not URL-scoped
+  ///      — that would miss sibling-subdomain cookies).
+  ///   2. Attribute to every loaded non-incognito site (including target
+  ///      if already loaded, so its live session is persisted before the
+  ///      nuke) by base-domain match and save to siteId-keyed storage.
+  ///   3. Nuke the native jar to evict cookies from deleted/legacy sites.
+  ///   4. Restore target's cookies from storage, then every other
+  ///      still-loaded site's cookies (parallel-loaded sites share the
+  ///      native jar and must not lose their sessions).
+  ///
+  /// [versionAtEntry] and [currentVersion] implement the race guard: the
+  /// function bails (returns without further mutation) between every
+  /// `await` if a newer caller has bumped the version. Callers that don't
+  /// need the guard can pass matching ints and a lambda that returns that
+  /// same int.
+  Future<void> restoreCookiesForSite({
+    required int index,
+    required List<WebViewModel> models,
+    required Set<int> loadedIndices,
+    required int versionAtEntry,
+    required int Function() currentVersion,
+  }) async {
+    if (index < 0 || index >= models.length) return;
+
+    final model = models[index];
+    if (model.incognito) return;
+
+    // Snapshot _loadedIndices before iterating: a concurrent _setCurrentIndex
+    // may mutate it via unloadSiteForDomainSwitch between our awaits. The
+    // version guard ultimately aborts us, but iterating a mutating Set
+    // directly would throw ConcurrentModificationError first.
+    final loadedSnapshot = loadedIndices.toList();
+
+    // Step 1: snapshot all cookies. Pass candidate URLs for Android fallback
+    // (iOS ignores them and uses the native getAllCookies API).
+    final candidateModels = <WebViewModel>[];
+    for (final i in loadedSnapshot) {
+      if (i < 0 || i >= models.length) continue;
+      if (models[i].incognito) continue;
+      candidateModels.add(models[i]);
+    }
+    if (!loadedSnapshot.contains(index) && !model.incognito) {
+      candidateModels.add(model);
+    }
+    final allCookies = await cookieManager.getAllCookies(
+      candidateUrls: _candidateUrlsFor(candidateModels),
+    );
+    if (versionAtEntry != currentVersion()) return;
+
+    // Step 2: attribute and persist.
+    final otherLoadedModels = <WebViewModel>[];
+    for (final loadedIndex in loadedSnapshot) {
+      if (loadedIndex >= models.length) continue;
+      final loadedModel = models[loadedIndex];
+      if (loadedModel.incognito) continue;
+
+      final base = getBaseDomain(loadedModel.initUrl);
+      final cookies = allCookies
+          .where((c) => cookieMatchesBaseDomain(c, base))
+          .toList();
+      loadedModel.cookies = cookies;
+      await storage.saveCookiesForSite(loadedModel.siteId, cookies);
+      if (versionAtEntry != currentVersion()) return;
+      if (loadedIndex != index) otherLoadedModels.add(loadedModel);
+    }
+
+    // Step 3: nuke.
+    await cookieManager.deleteAllCookies();
+    if (versionAtEntry != currentVersion()) return;
+
+    // Step 4a: restore target's cookies.
+    final cookies = await storage.loadCookiesForSite(model.siteId);
+    model.cookies = cookies;
+    if (versionAtEntry != currentVersion()) return;
+
+    LogService.instance.log(
+      'CookieIsolation',
+      'Restoring ${cookies.length} cookies for site $index: "${model.name}" (siteId: ${model.siteId})',
+    );
+
+    await _setCookies(model, cookies);
+    if (versionAtEntry != currentVersion()) return;
+
+    // Step 4b: restore every other still-loaded site's cookies.
+    for (final other in otherLoadedModels) {
+      await _setCookies(other, other.cookies);
+      if (versionAtEntry != currentVersion()) return;
+    }
+  }
+
+  /// Clears native cookies for a site about to be deleted. If a loaded
+  /// same-base-domain site exists, snapshots its session first and
+  /// restores after — the URL-scoped delete would otherwise evict the
+  /// surviving site's live cookies too.
+  Future<void> preDeleteCookieCleanup({
+    required WebViewModel deletedModel,
+    required int deletedIndex,
+    required List<WebViewModel> models,
+    required Set<int> loadedIndices,
+  }) async {
+    final deletedBase = getBaseDomain(deletedModel.initUrl);
+
+    final survivingSameBase = <WebViewModel>[];
+    for (final loadedIdx in loadedIndices) {
+      if (loadedIdx == deletedIndex) continue;
+      if (loadedIdx >= models.length) continue;
+      final loaded = models[loadedIdx];
+      if (loaded.incognito) continue;
+      if (getBaseDomain(loaded.initUrl) == deletedBase) {
+        survivingSameBase.add(loaded);
+      }
+    }
+
+    List<Cookie> survivingSnapshot = const [];
+    if (survivingSameBase.isNotEmpty) {
+      final allCookies = await cookieManager.getAllCookies(
+        candidateUrls: _candidateUrlsFor(survivingSameBase),
+      );
+      survivingSnapshot = allCookies
+          .where((c) => cookieMatchesBaseDomain(c, deletedBase))
+          .toList();
+    }
+
+    await cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.initUrl));
+    if (deletedModel.currentUrl.isNotEmpty &&
+        deletedModel.currentUrl != deletedModel.initUrl) {
+      await cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.currentUrl));
+    }
+    await storage.saveCookiesForSite(deletedModel.siteId, []);
+
+    if (survivingSameBase.isNotEmpty && survivingSnapshot.isNotEmpty) {
+      final restoreUrl = Uri.parse(survivingSameBase.first.initUrl);
+      for (final cookie in survivingSnapshot) {
+        if (cookie.value.isEmpty) continue;
+        await cookieManager.setCookie(
+          url: restoreUrl,
+          name: cookie.name,
+          value: cookie.value,
+          domain: cookie.domain,
+          path: cookie.path ?? '/',
+          expiresDate: cookie.expiresDate,
+          isSecure: cookie.isSecure,
+          isHttpOnly: cookie.isHttpOnly,
+        );
+      }
+    }
+  }
+
+  /// Candidate URLs passed to `CookieManager.getAllCookies` on Android (where
+  /// there's no native "get all" API and we aggregate per-URL instead). We
+  /// include each model's `initUrl`, `currentUrl` (if different), and a
+  /// bare `https://<baseDomain>/` to pick up parent-domain cookies like
+  /// `Domain=.example.com`. On iOS this list is ignored.
+  static List<Uri> _candidateUrlsFor(Iterable<WebViewModel> models) {
+    final urls = <String>{};
+    for (final m in models) {
+      if (m.initUrl.isNotEmpty) urls.add(m.initUrl);
+      if (m.currentUrl.isNotEmpty && m.currentUrl != m.initUrl) {
+        urls.add(m.currentUrl);
+      }
+      final base = getBaseDomain(m.initUrl);
+      if (base.isNotEmpty) urls.add('https://$base/');
+    }
+    return urls
+        .map((s) {
+          try {
+            return Uri.parse(s);
+          } catch (_) {
+            return null;
+          }
+        })
+        .whereType<Uri>()
+        .toList();
+  }
+
+  Future<void> _setCookies(WebViewModel model, List<Cookie> cookies) async {
+    final url = Uri.parse(model.initUrl);
+    for (final cookie in cookies) {
+      if (cookie.value.isEmpty) continue;
+      if (model.isCookieBlocked(cookie.name, cookie.domain)) continue;
+      await cookieManager.setCookie(
+        url: url,
+        name: cookie.name,
+        value: cookie.value,
+        domain: cookie.domain,
+        path: cookie.path ?? '/',
+        expiresDate: cookie.expiresDate,
+        isSecure: cookie.isSecure,
+        isHttpOnly: cookie.isHttpOnly,
+      );
+    }
+  }
+}

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -60,10 +60,32 @@ class CookieManager {
   /// Returns every cookie in the native jar regardless of URL scoping.
   /// `getCookies(url)` only returns cookies that would be sent with a request
   /// to that URL, which misses cookies scoped to sibling subdomains (e.g.
-  /// `accounts.google.com` when querying with `mail.google.com`). Callers that
-  /// need to capture a site's complete cookie set before a nuke-and-restore
-  /// cycle should use this method and filter by domain-match themselves.
-  Future<List<Cookie>> getAllCookies() async => _manager.getAllCookies();
+  /// `accounts.google.com` when querying with `mail.google.com`).
+  ///
+  /// Platform support for the underlying `WKHTTPCookieStore.getAllCookies()`
+  /// is iOS/macOS only — Android's `CookieManager` has no "get all" endpoint.
+  /// On Android, callers MUST pass [candidateUrls] (typically every loaded
+  /// site's `initUrl` and `currentUrl`); the result is aggregated via
+  /// per-URL `getCookies`, deduplicated by `(name, domain, path)`. This is
+  /// a best-effort capture — cookies on subdomains of a candidate URL that
+  /// aren't reachable from it (e.g. `accounts.google.com` when only
+  /// `mail.google.com` has been visited) cannot be discovered on Android.
+  Future<List<Cookie>> getAllCookies({List<Uri>? candidateUrls}) async {
+    if (Platform.isIOS || Platform.isMacOS) {
+      return _manager.getAllCookies();
+    }
+    if (candidateUrls == null || candidateUrls.isEmpty) return [];
+    final seen = <String>{};
+    final out = <Cookie>[];
+    for (final url in candidateUrls) {
+      final cookies = await getCookies(url: url);
+      for (final c in cookies) {
+        final key = '${c.name}|${c.domain ?? ''}|${c.path ?? ''}';
+        if (seen.add(key)) out.add(c);
+      }
+    }
+    return out;
+  }
 
   Future<void> setCookie({
     required Uri url,

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -57,6 +57,14 @@ class CookieManager {
   Future<List<Cookie>> getCookies({required Uri url}) async =>
       _manager.getCookies(url: inapp.WebUri(url.toString()));
 
+  /// Returns every cookie in the native jar regardless of URL scoping.
+  /// `getCookies(url)` only returns cookies that would be sent with a request
+  /// to that URL, which misses cookies scoped to sibling subdomains (e.g.
+  /// `accounts.google.com` when querying with `mail.google.com`). Callers that
+  /// need to capture a site's complete cookie set before a nuke-and-restore
+  /// cycle should use this method and filter by domain-match themselves.
+  Future<List<Cookie>> getAllCookies() async => _manager.getAllCookies();
+
   Future<void> setCookie({
     required Uri url,
     required String name,

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -133,6 +133,16 @@ String getBaseDomain(String url) {
 /// All Google properties (gmail.com, regional domains, etc.) are treated as google.com.
 const Map<String, String> _domainAliases = {
   'gmail.com': 'google.com',
+  // YouTube is part of Google's SSO family — `accounts.youtube.com/SetSID`
+  // is a mandatory hop when signing into play.google.com, gmail, etc.,
+  // since Google syncs session cookies into the YouTube jar. Without this
+  // alias, the nested-webview guard treats the SetSID redirect as a
+  // cross-domain navigation, opens it in a nested browser, and the main
+  // webview never receives the redirect-back — the user gets stuck
+  // looking "signed out" despite completing the SSO flow.
+  'youtube.com': 'google.com',
+  'youtu.be': 'google.com',
+  'youtube-nocookie.com': 'google.com',
   // Discord
   'discordapp.com': 'discord.com',
   'discord.gg': 'discord.com',

--- a/openspec/specs/per-site-cookie-isolation/spec.md
+++ b/openspec/specs/per-site-cookie-isolation/spec.md
@@ -52,14 +52,79 @@ The system SHALL capture cookies before unloading a webview due to domain confli
 
 ### Requirement: ISO-003 - Cookie Restoration on Load
 
-The system SHALL restore site-specific cookies when activating a site.
+The system SHALL restore site-specific cookies when activating a site via
+a capture → nuke → restore cycle:
+
+1. **Snapshot** — call `CookieManager.getAllCookies()` (NOT URL-scoped, so
+   sibling-subdomain cookies like `accounts.google.com` are included even
+   when the loaded site is `mail.google.com`).
+2. **Attribute** — for every loaded non-incognito site (including the
+   target if it is already loaded), filter the snapshot by base-domain
+   match (`cookie.domain` equals or is a subdomain of the site's base
+   domain) and save to that site's siteId-keyed encrypted storage.
+3. **Nuke** — `CookieManager.deleteAllCookies()` to evict cookies from
+   previously-deleted sites, legacy pre-siteId sessions, and sibling
+   subdomains that would otherwise leak into the target's requests.
+4. **Restore** — load the target's cookies from storage and set them, then
+   restore every other still-loaded site's cookies (parallel-loaded sites
+   share the same native jar).
+
+All async steps SHALL check `_setCurrentIndexVersion` and early-return if a
+newer `_setCurrentIndex` invocation has started, to prevent concurrent
+cookie mutations from interleaving under rapid tab switching.
 
 #### Scenario: Restore cookies on activation
 
 **Given** Site B has previously stored cookies
 **When** Site B is activated
-**Then** Site B's cookies are loaded from secure storage
-**And** cookies are set in CookieManager before webview creation
+**Then** the native jar is snapshotted via `getAllCookies`
+**And** every loaded non-incognito site's cookies are attributed by
+  base-domain match and persisted to encrypted storage
+**And** the native CookieManager is fully cleared
+**And** Site B's cookies are loaded from secure storage and set
+**And** every other still-loaded site's cookies are restored to the jar
+
+#### Scenario: No leak from previously-deleted same-base-domain site
+
+**Given** a site on `mail.google.com` was previously deleted while signed in
+  (leaving `accounts.google.com` cookies in the native cookie jar)
+**When** the user creates a new site for `play.google.com/console` and
+  activates it
+**Then** the native CookieManager is nuked during activation
+**And** the new site loads with only its own (empty) siteId-keyed cookies
+**And** no Google account is auto-logged-in
+
+#### Scenario: Sibling-subdomain cookies preserved for still-loaded site
+
+**Given** Site A (`mail.google.com`) has navigated to `accounts.google.com`,
+  which set cookies with `Domain=accounts.google.com`
+**And** Site B (`example.com`) is also loaded
+**When** the user activates Site B
+**Then** the native jar is snapshotted via `getAllCookies` (which returns
+  cookies for ALL domains, not just those scoped to a single URL)
+**And** all of Site A's cookies — including the `accounts.google.com`-scoped
+  ones — are attributed to Site A by base-domain match and saved
+**And** after the nuke-and-restore, Site A's full cookie set is back in the
+  native jar; no session is lost
+
+#### Scenario: Re-activating an already-loaded site preserves its live session
+
+**Given** Site A is active and logged in, the user goes to the home screen
+  (`goHome`) without unloading Site A
+**When** the user re-activates Site A
+**Then** Site A's current native-jar cookies are captured to its siteId
+  storage before the nuke
+**And** after the nuke-and-restore, Site A's session is intact
+
+#### Scenario: Concurrent activation is serialized
+
+**Given** the user taps Site B, then taps Site C before Site B's activation
+  completes
+**When** Site C's activation runs
+**Then** any in-flight step of Site B's activation SHALL early-return on the
+  version mismatch
+**And** the cookie jar and encrypted storage SHALL NOT reflect interleaved
+  captures from the two activations
 
 ### Requirement: ISO-004 - CookieManager Cleanup
 
@@ -208,10 +273,40 @@ Cookies stored in `CookieSecureStorage` keyed by siteId:
 
 ### Aggressive Cookie Clearing
 
-When switching between same-domain sites, ALL cookies are cleared:
-- Uses `CookieManager.deleteAllCookies()` instead of URL-specific deletion
-- Required because services like Google set cookies on multiple domains
-- Before clearing, ALL loaded sites have their cookies captured and saved
+The native cookie jar is nuked on EVERY site activation (not just same-domain
+switches). The capture uses `CookieManager.getAllCookies()` rather than
+URL-scoped `getCookies(url)` because sibling-subdomain cookies (e.g.
+`accounts.google.com` when the site is `mail.google.com`) are NOT returned
+by a URL-scoped query and would otherwise be lost across the nuke.
+
+Attribution to a site is by base-domain match: a cookie with `domain`
+equal to the site's base domain, or ending with `.<baseDomain>`, is
+attributed to that site. Per-site cookie isolation (ISO-001) guarantees
+at most one loaded site per base domain, so attribution is unambiguous.
+
+The sequence in `_restoreCookiesForSite`:
+1. `getAllCookies()`
+2. For each loaded non-incognito site (including target if already
+   loaded): filter by base-domain, save to siteId storage.
+3. `deleteAllCookies()`
+4. Restore target's cookies from storage.
+5. Restore every other still-loaded site's cookies.
+
+Also runs at startup (before first activation). Settings import routes
+activation through the same path and MUST NOT nuke afterwards.
+
+### Orphan GC
+
+Per-siteId encrypted storage and HTML cache accumulate entries for deleted
+sites. `CookieSecureStorage.removeOrphanedCookies(activeSiteIds)` and
+`HtmlCacheService.removeOrphanedCaches(activeSiteIds)` sweep entries whose
+siteId is not in the active set. These run:
+- On app startup (in `_restoreAppState`)
+- On site deletion (in `_deleteSite`)
+- On settings import (in backup restore)
+
+The native cookie jar is GC'd by `deleteAllCookies()` at the same boundaries
+(see Aggressive Cookie Clearing above).
 
 ### UI Updates on Navigation
 
@@ -290,10 +385,28 @@ The system SHALL clean up all cookie-related data when a site is deleted.
 
 **Given** Site A (`github.com/personal`) and Site B (`github.com/work`) exist
 **When** the user deletes Site A
-**Then** cookies in the webview cookie jar are NOT deleted (Site B still needs them)
+**Then** cookies for Site A's URL(s) are deleted from the native cookie jar
+  unconditionally
 **And** Site A's cookies are removed from secure storage (by siteId)
 **And** Site A's HTML cache is deleted
-**And** Site B continues to function with its cookies intact
+**And** orphaned per-siteId entries are swept from encrypted storage and
+  HTML cache as defense in depth
+**And** Site B continues to function with its cookies intact after next
+  activation (which triggers restore from its siteId-keyed storage)
+
+#### Scenario: Deleting a site while a same-base-domain site is loaded preserves its live session
+
+**Given** Site A (`github.com/personal`) and Site B (`github.com/work`) exist
+**And** Site B is currently active/loaded with a live session in the native
+  cookie jar
+**When** the user deletes Site A
+**Then** before the URL-scoped delete, the system snapshots all native
+  cookies matching the deleted base domain via `getAllCookies()`
+**And** after the URL-scoped delete (which would otherwise wipe Site B's
+  session because `github.com/personal` and `github.com/work` share a
+  host), Site B's snapshot is restored to the native jar
+**And** Site B's live session is NOT interrupted — no reload or re-login
+  is required
 
 #### Scenario: Re-adding a deleted site starts fresh
 
@@ -343,6 +456,51 @@ The system SHALL allow blocking specific cookies by name + domain on a per-site 
 **When** the site is deserialized
 **Then** `blockedCookies` defaults to an empty set
 **And** no cookies are blocked
+
+---
+
+### Requirement: ISO-012 - Native Cookie Jar Garbage Collection
+
+The native cookie jar (iOS `WKHTTPCookieStorage`, Android `CookieManager`) is
+a process-wide shared store that persists across app launches. Because it is
+not keyed by siteId, cookies from deleted sites, sibling subdomains not
+visited by the active site, or legacy pre-siteId sessions can accumulate and
+leak into unrelated sites. The system SHALL garbage-collect the native cookie
+jar at every boundary where site cookies could leak:
+
+- **On app startup** — after loading persisted models but before activating
+  any site
+- **On site switch** — inside `_restoreCookiesForSite`, after capturing
+  cookies for other loaded sites
+- **On settings import** — `_setCurrentIndex` during import routes through
+  `_restoreCookiesForSite`, which performs the nuke-and-restore cycle; the
+  import path MUST NOT issue a subsequent `deleteAllCookies()` or it would
+  wipe the session just restored for the imported active site
+- **On site deletion** — for the deleted site's `initUrl` and `currentUrl`
+  unconditionally, followed by an orphan sweep of siteId-keyed storage; if
+  a loaded same-base-domain site exists, its session SHALL be snapshotted
+  via `getAllCookies()` before the delete and restored after
+
+#### Scenario: Startup evicts cookies from deleted-in-previous-session sites
+
+**Given** in a previous session the user had Site A (`mail.google.com`)
+  signed in, then deleted it
+**And** `WKHTTPCookieStorage` still contains `.google.com` and
+  `accounts.google.com` cookies from that session
+**When** the app launches
+**Then** orphaned siteId-keyed entries are swept from encrypted storage and
+  HTML cache
+**And** the native cookie jar is cleared before any site is activated
+**And** the first activated site restores only its own siteId-keyed cookies
+
+#### Scenario: Orphan sweep runs on site deletion
+
+**Given** the user deletes a site
+**When** the delete flow completes
+**Then** `removeOrphanedCookies` runs with the updated active siteId set
+**And** `removeOrphanedCaches` runs with the updated active siteId set
+**And** any encrypted-storage or HTML-cache entries not referenced by a
+  surviving site are removed
 
 ---
 

--- a/test/cookie_isolation_integration_test.dart
+++ b/test/cookie_isolation_integration_test.dart
@@ -1,34 +1,52 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:webspace/web_view_model.dart';
+import 'package:webspace/services/cookie_isolation.dart';
+import 'package:webspace/services/cookie_secure_storage.dart';
 import 'package:webspace/services/webview.dart';
+import 'package:webspace/web_view_model.dart';
 
-/// Mock CookieManager for testing cookie isolation behavior.
-/// Tracks which cookies are "in the manager" to verify mutual exclusion.
-class MockCookieManager {
-  final Map<String, List<Cookie>> _cookies = {};
+/// In-memory cookie jar that models RFC 6265 domain-match semantics so the
+/// sibling-subdomain scenarios the real fix addresses can actually be
+/// exercised. Implements the real `CookieManager` interface so the engine
+/// under test is unaware that it's talking to a mock.
+///
+/// Cookies are stored as a flat list. `getCookies(url)` returns cookies
+/// whose Domain attribute matches per RFC 6265:
+///   - cookie.domain equals url.host (host-only), OR
+///   - cookie.domain is a parent of url.host (domain cookie — leading
+///     `.` is optional per modern browsers)
+/// plus path matching (cookie.path is a prefix of url.path).
+class MockCookieManager implements CookieManager {
+  final List<Cookie> _cookies = [];
 
-  /// Get all cookies currently in the manager (for assertions)
-  Map<String, List<Cookie>> get allCookies => Map.from(_cookies);
+  /// All cookies in the jar (for assertions).
+  List<Cookie> get all => List.unmodifiable(_cookies);
 
-  /// Get domains that have cookies in the manager
-  Set<String> get domainsWithCookies => _cookies.keys.toSet();
+  /// Unique domains present in the jar.
+  Set<String> get domainsWithCookies => {
+        for (final c in _cookies)
+          if (c.domain != null) _canonical(c.domain!),
+      };
 
+  @override
   Future<List<Cookie>> getCookies({required Uri url}) async {
-    final domain = url.host;
-    return _cookies[domain] ?? [];
+    final host = url.host.toLowerCase();
+    final path = url.path.isEmpty ? '/' : url.path;
+    return _cookies.where((c) {
+      if (!_domainMatches(c.domain, host)) return false;
+      if (!_pathMatches(c.path ?? '/', path)) return false;
+      return true;
+    }).toList();
   }
 
-  /// Returns every cookie in the store regardless of URL. Mirrors the real
-  /// `CookieManager.getAllCookies()` wrapper used by the app to avoid missing
-  /// sibling-subdomain cookies.
-  Future<List<Cookie>> getAllCookies() async {
-    final out = <Cookie>[];
-    for (final list in _cookies.values) {
-      out.addAll(list);
-    }
-    return out;
+  @override
+  Future<List<Cookie>> getAllCookies({List<Uri>? candidateUrls}) async {
+    // The real iOS/macOS path ignores candidateUrls. On Android the wrapper
+    // aggregates per-URL; for tests the mock returns everything so we don't
+    // need to thread a platform switch through the tests.
+    return List.from(_cookies);
   }
 
+  @override
   Future<void> setCookie({
     required Uri url,
     required String name,
@@ -39,48 +57,101 @@ class MockCookieManager {
     bool? isSecure,
     bool? isHttpOnly,
   }) async {
-    final cookieDomain = domain ?? url.host;
-    _cookies.putIfAbsent(cookieDomain, () => []);
-    // Remove existing cookie with same name
-    _cookies[cookieDomain]!.removeWhere((c) => c.name == name);
-    _cookies[cookieDomain]!.add(Cookie(
+    final effectiveDomain = (domain ?? url.host).toLowerCase();
+    final effectivePath = path ?? '/';
+    _cookies.removeWhere((c) =>
+        c.name == name &&
+        _canonical(c.domain ?? '') == _canonical(effectiveDomain) &&
+        (c.path ?? '/') == effectivePath);
+    _cookies.add(Cookie(
       name: name,
       value: value,
-      domain: cookieDomain,
-      path: path ?? '/',
+      domain: effectiveDomain,
+      path: effectivePath,
+      expiresDate: expiresDate,
+      isSecure: isSecure,
+      isHttpOnly: isHttpOnly,
     ));
   }
 
+  @override
   Future<void> deleteCookie({
     required Uri url,
     required String name,
     String? domain,
     String? path,
   }) async {
-    final cookieDomain = domain ?? url.host;
-    _cookies[cookieDomain]?.removeWhere((c) => c.name == name);
-    if (_cookies[cookieDomain]?.isEmpty ?? false) {
-      _cookies.remove(cookieDomain);
-    }
+    final effectiveDomain = (domain ?? url.host).toLowerCase();
+    final effectivePath = path ?? '/';
+    _cookies.removeWhere((c) =>
+        c.name == name &&
+        _canonical(c.domain ?? '') == _canonical(effectiveDomain) &&
+        (c.path ?? '/') == effectivePath);
   }
 
+  @override
   Future<void> deleteAllCookies() async {
     _cookies.clear();
   }
 
+  @override
   Future<void> deleteAllCookiesForUrl(Uri url) async {
-    _cookies.remove(url.host);
+    final cookies = await getCookies(url: url);
+    for (final c in cookies) {
+      await deleteCookie(url: url, name: c.name, domain: c.domain, path: c.path);
+    }
   }
+
+  /// Strip a leading `.` so `.google.com` and `google.com` compare equal.
+  static String _canonical(String domain) {
+    var d = domain.trim().toLowerCase();
+    if (d.startsWith('.')) d = d.substring(1);
+    return d;
+  }
+
+  /// RFC 6265 §5.1.3 domain-match.
+  static bool _domainMatches(String? cookieDomain, String host) {
+    if (cookieDomain == null || cookieDomain.isEmpty) return false;
+    final d = _canonical(cookieDomain);
+    final h = host.toLowerCase();
+    if (d == h) return true;
+    if (h.endsWith('.$d')) return true;
+    return false;
+  }
+
+  /// RFC 6265 §5.1.4 path-match.
+  static bool _pathMatches(String cookiePath, String requestPath) {
+    if (cookiePath == requestPath) return true;
+    if (requestPath.startsWith(cookiePath)) {
+      if (cookiePath.endsWith('/')) return true;
+      final next = requestPath.length > cookiePath.length
+          ? requestPath[cookiePath.length]
+          : '';
+      if (next == '/') return true;
+    }
+    return false;
+  }
+
+  // CookieManager exposes a handful of other methods this mock doesn't need.
+  // Route unimplemented calls through noSuchMethod so the type-level
+  // `implements CookieManager` contract holds without us having to stub
+  // every member.
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-/// Mock CookieSecureStorage for testing persistence
-class MockCookieSecureStorage {
+/// In-memory per-siteId cookie store implementing the real
+/// `CookieSecureStorage` interface. Only the methods the engine touches
+/// are meaningful; everything else routes through `noSuchMethod`.
+class MockCookieSecureStorage implements CookieSecureStorage {
   final Map<String, List<Cookie>> _storage = {};
 
+  @override
   Future<List<Cookie>> loadCookiesForSite(String siteId) async {
-    return List.from(_storage[siteId] ?? []);
+    return List.from(_storage[siteId] ?? const []);
   }
 
+  @override
   Future<void> saveCookiesForSite(String siteId, List<Cookie> cookies) async {
     if (cookies.isEmpty) {
       _storage.remove(siteId);
@@ -89,206 +160,131 @@ class MockCookieSecureStorage {
     }
   }
 
+  @override
+  Future<void> removeOrphanedCookies(Set<String> activeSiteIds) async {
+    _storage.removeWhere((siteId, _) => !activeSiteIds.contains(siteId));
+  }
+
   Map<String, List<Cookie>> get allStorage => Map.from(_storage);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-/// Test harness for cookie isolation logic
+/// Test harness for cookie isolation. Delegates cookie-jar management to
+/// the REAL [CookieIsolationEngine] — the tests exercise production code,
+/// not duplicated harness code.
 class CookieIsolationTestHarness {
   final MockCookieManager cookieManager = MockCookieManager();
   final MockCookieSecureStorage storage = MockCookieSecureStorage();
+  late final CookieIsolationEngine engine = CookieIsolationEngine(
+    cookieManager: cookieManager,
+    storage: storage,
+  );
   final List<WebViewModel> sites = [];
   final Set<int> loadedIndices = {};
   int? currentIndex;
 
-  void addSite(String url, {String? name}) {
+  /// Monotonic counter mirroring `_setCurrentIndexVersion` in
+  /// `_WebSpacePageState`. Every `switchToSite` call bumps it; the engine
+  /// reads it via a closure so concurrent activations can bail.
+  int version = 0;
+
+  void addSite(String url, {String? name, bool incognito = false}) {
     sites.add(WebViewModel(
       initUrl: url,
       name: name,
+      incognito: incognito,
     ));
   }
 
-  /// Simulates switching to a site, implementing the cookie isolation logic
+  /// Mirrors `_setCurrentIndex` in main.dart: bumps the version, unloads
+  /// any same-base-domain conflicting site, then delegates cookie restore
+  /// to the real engine.
   Future<void> switchToSite(int index) async {
     if (index < 0 || index >= sites.length) return;
+    final v = ++version;
 
     final target = sites[index];
     if (!target.incognito) {
       final targetDomain = getBaseDomain(target.initUrl);
-
-      // Find and unload conflicting sites
       for (final loadedIndex in List.from(loadedIndices)) {
         if (loadedIndex == index) continue;
         final loaded = sites[loadedIndex];
         if (loaded.incognito) continue;
-
-        final loadedDomain = getBaseDomain(loaded.initUrl);
-        if (loadedDomain == targetDomain) {
-          // Domain conflict - unload
-          await _unloadSiteForDomainSwitch(loadedIndex);
+        if (getBaseDomain(loaded.initUrl) == targetDomain) {
+          await engine.unloadSiteForDomainSwitch(
+            index: loadedIndex,
+            models: sites,
+            loadedIndices: loadedIndices,
+          );
+          if (v != version) return;
           break;
         }
       }
     }
 
-    // Restore cookies for target site
-    await _restoreCookiesForSite(index);
+    await engine.restoreCookiesForSite(
+      index: index,
+      models: sites,
+      loadedIndices: loadedIndices,
+      versionAtEntry: v,
+      currentVersion: () => version,
+    );
+    if (v != version) return;
 
     currentIndex = index;
     loadedIndices.add(index);
   }
 
-  Future<void> _unloadSiteForDomainSwitch(int index) async {
-    // Capture cookies for the departing site only (its webview is about to
-    // be disposed). Other still-loaded sites are captured by
-    // _restoreCookiesForSite before it nukes the native jar.
-    final model = sites[index];
-    if (!model.incognito) {
-      final url = Uri.parse(model.currentUrl.isNotEmpty ? model.currentUrl : model.initUrl);
-      model.cookies = await cookieManager.getCookies(url: url);
-      await storage.saveCookiesForSite(model.siteId, model.cookies);
-    }
-
-    // Remove from loaded
-    loadedIndices.remove(index);
-  }
-
-  Future<void> _restoreCookiesForSite(int index) async {
-    final model = sites[index];
-    if (model.incognito) return;
-
-    // Step 1: snapshot all cookies.
-    final allCookies = await cookieManager.getAllCookies();
-
-    // Step 2: attribute to every loaded non-incognito site (including target
-    // if it's already loaded — re-activation after goHome) by base-domain.
-    final otherLoaded = <WebViewModel>[];
-    for (final loadedIndex in loadedIndices) {
-      if (loadedIndex >= sites.length) continue;
-      final loadedModel = sites[loadedIndex];
-      if (loadedModel.incognito) continue;
-
-      final base = getBaseDomain(loadedModel.initUrl);
-      final cookies = allCookies.where((c) => _matchesBase(c, base)).toList();
-      loadedModel.cookies = cookies;
-      await storage.saveCookiesForSite(loadedModel.siteId, cookies);
-      if (loadedIndex != index) otherLoaded.add(loadedModel);
-    }
-
-    // Step 3: nuke native cookie jar
-    await cookieManager.deleteAllCookies();
-
-    // Step 4a: restore target's cookies
-    final cookies = await storage.loadCookiesForSite(model.siteId);
-    model.cookies = cookies;
-
-    final url = Uri.parse(model.initUrl);
-    for (final cookie in cookies) {
-      if (cookie.value.isEmpty) continue;
-      await cookieManager.setCookie(
-        url: url,
-        name: cookie.name,
-        value: cookie.value,
-        domain: cookie.domain,
-        path: cookie.path ?? '/',
-      );
-    }
-
-    // Step 4b: restore other loaded sites' cookies
-    for (final other in otherLoaded) {
-      final otherUrl = Uri.parse(other.initUrl);
-      for (final cookie in other.cookies) {
-        if (cookie.value.isEmpty) continue;
-        await cookieManager.setCookie(
-          url: otherUrl,
-          name: cookie.name,
-          value: cookie.value,
-          domain: cookie.domain,
-          path: cookie.path ?? '/',
-        );
-      }
-    }
-  }
-
-  static bool _matchesBase(Cookie cookie, String baseDomain) {
-    var domain = (cookie.domain ?? '').trim().toLowerCase();
-    if (domain.isEmpty || baseDomain.isEmpty) return false;
-    if (domain.startsWith('.')) domain = domain.substring(1);
-    final base = baseDomain.toLowerCase();
-    return domain == base || domain.endsWith('.$base');
-  }
-
-  /// Simulates deleting a site, mirroring the cleanup logic in main.dart.
-  /// Always clears the native cookie jar for the deleted site's URL. If a
-  /// loaded same-base-domain site exists, snapshot its cookies before the
-  /// URL-scoped delete (which would otherwise wipe its live session) and
-  /// restore them after.
+  /// Mirrors `_deleteSite` cookie/storage/state bookkeeping.
   Future<void> deleteSite(int index) async {
     final deletedModel = sites[index];
-    final deletedBase = getBaseDomain(deletedModel.initUrl);
+    await engine.preDeleteCookieCleanup(
+      deletedModel: deletedModel,
+      deletedIndex: index,
+      models: sites,
+      loadedIndices: loadedIndices,
+    );
 
-    final survivingSameBase = <WebViewModel>[];
-    for (final loadedIdx in loadedIndices) {
-      if (loadedIdx == index) continue;
-      if (loadedIdx >= sites.length) continue;
-      final loaded = sites[loadedIdx];
-      if (loaded.incognito) continue;
-      if (getBaseDomain(loaded.initUrl) == deletedBase) {
-        survivingSameBase.add(loaded);
-      }
-    }
-
-    List<Cookie> survivingSnapshot = const [];
-    if (survivingSameBase.isNotEmpty) {
-      final allCookies = await cookieManager.getAllCookies();
-      survivingSnapshot = allCookies.where((c) => _matchesBase(c, deletedBase)).toList();
-    }
-
-    await cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.initUrl));
-    if (deletedModel.currentUrl.isNotEmpty && deletedModel.currentUrl != deletedModel.initUrl) {
-      await cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.currentUrl));
-    }
-
-    // Always clear secure storage for this siteId
-    await storage.saveCookiesForSite(deletedModel.siteId, []);
-
-    if (survivingSameBase.isNotEmpty && survivingSnapshot.isNotEmpty) {
-      final restoreUrl = Uri.parse(survivingSameBase.first.initUrl);
-      for (final cookie in survivingSnapshot) {
-        if (cookie.value.isEmpty) continue;
-        await cookieManager.setCookie(
-          url: restoreUrl,
-          name: cookie.name,
-          value: cookie.value,
-          domain: cookie.domain,
-          path: cookie.path ?? '/',
-        );
-      }
-    }
-
-    // Remove from sites list and loaded indices
     sites.removeAt(index);
     loadedIndices.remove(index);
-    // Shift indices down
     loadedIndices.removeWhere((i) => i >= sites.length);
-    final updatedIndices = loadedIndices.map((i) => i > index ? i - 1 : i).toSet();
-    loadedIndices.clear();
-    loadedIndices.addAll(updatedIndices);
+    final shifted = loadedIndices.map((i) => i > index ? i - 1 : i).toSet();
+    loadedIndices
+      ..clear()
+      ..addAll(shifted);
 
     if (currentIndex == index) {
       currentIndex = null;
     } else if (currentIndex != null && currentIndex! > index) {
       currentIndex = currentIndex! - 1;
     }
+
+    await storage.removeOrphanedCookies(
+      sites.map((s) => s.siteId).toSet(),
+    );
   }
 
-  /// Simulates going to the home screen (e.g., app resume or back button).
-  /// Sets currentIndex to null without touching loadedIndices or cookies.
+  /// Mirrors the startup GC in `_restoreAppState`: orphan sweep on
+  /// encrypted storage, then nuke the native cookie jar before first
+  /// activation. Call this after seeding prior-session cookies to verify
+  /// they don't leak into the next activated site.
+  Future<void> simulateAppStartupGc() async {
+    await storage.removeOrphanedCookies(
+      sites.map((s) => s.siteId).toSet(),
+    );
+    await cookieManager.deleteAllCookies();
+  }
+
+  /// Go to the home screen — `currentIndex = null` but loaded webviews
+  /// remain mounted.
   void goHome() {
     currentIndex = null;
   }
 
-  /// Simulates a cold app restart: loaded state is cleared (new process),
-  /// currentIndex starts as null (home screen), but secure storage persists.
+  /// Simulate a cold process restart: loaded state cleared, cookies
+  /// in the native jar cleared, but encrypted storage persists.
   void simulateAppRestart() {
     loadedIndices.clear();
     currentIndex = null;
@@ -298,7 +294,22 @@ class CookieIsolationTestHarness {
     }
   }
 
-  /// Simulates a site receiving cookies (e.g., after login)
+  /// Drops the site's siteId storage as if the user deleted it in a
+  /// prior session — leaves the native jar cookies in place to model the
+  /// leak scenario the fix targets.
+  Future<void> simulateSitePurgedFromPriorSession(int index) async {
+    final model = sites[index];
+    await storage.saveCookiesForSite(model.siteId, const []);
+    sites.removeAt(index);
+    loadedIndices.remove(index);
+    loadedIndices.removeWhere((i) => i >= sites.length);
+    final shifted = loadedIndices.map((i) => i > index ? i - 1 : i).toSet();
+    loadedIndices
+      ..clear()
+      ..addAll(shifted);
+  }
+
+  /// Simulate a site receiving cookies (e.g., after login).
   Future<void> simulateLogin(int index, List<Cookie> cookies) async {
     if (index < 0 || index >= sites.length) return;
     final model = sites[index];
@@ -314,6 +325,26 @@ class CookieIsolationTestHarness {
       );
     }
     model.cookies = cookies;
+  }
+
+  /// Plant a cookie scoped to a specific subdomain (for sibling-subdomain
+  /// tests). Use when the test needs a cookie whose domain isn't the
+  /// site's initUrl host — e.g. `accounts.google.com` while the loaded
+  /// site is `mail.google.com`.
+  Future<void> plantCookie({
+    required String url,
+    required String name,
+    required String value,
+    required String domain,
+    String path = '/',
+  }) async {
+    await cookieManager.setCookie(
+      url: Uri.parse(url),
+      name: name,
+      value: value,
+      domain: domain,
+      path: path,
+    );
   }
 }
 
@@ -1054,6 +1085,391 @@ void main() {
       var glCookies = await harness.cookieManager.getCookies(url: Uri.parse('https://gitlab.com'));
       expect(ghCookies.any((c) => c.value == 'gh_token'), isTrue);
       expect(glCookies.any((c) => c.value == 'gl_token'), isTrue);
+    });
+  });
+
+  // ==========================================================================
+  // Sibling-Subdomain Cookie Handling (C-2)
+  //
+  // These scenarios exercise the bug class the user originally reported:
+  // cookies scoped to a sibling subdomain (e.g. `accounts.google.com`) of
+  // a loaded site's base domain (`google.com`) must be captured across the
+  // nuke-and-restore cycle, and must not leak from a deleted site into a
+  // freshly-added site sharing the base domain.
+  // ==========================================================================
+  group('Sibling-subdomain cookies', () {
+    late CookieIsolationTestHarness harness;
+
+    setUp(() {
+      harness = CookieIsolationTestHarness();
+    });
+
+    test('Cookie on sibling subdomain (accounts.google.com) is captured for site on mail.google.com', () async {
+      harness.addSite('https://mail.google.com', name: 'Gmail');
+      harness.addSite('https://example.com', name: 'Example');
+
+      // Activate Gmail and plant a sibling-subdomain cookie AFTER
+      // activation — simulating the site's own navigation to accounts.google.com.
+      await harness.switchToSite(0);
+      await harness.plantCookie(
+        url: 'https://accounts.google.com/signin',
+        name: 'SSID',
+        value: 'google_sso_token',
+        domain: 'accounts.google.com',
+      );
+
+      // A pure URL-scoped `getCookies(mail.google.com)` wouldn't return this
+      // cookie — it's scoped to a sibling subdomain. The engine's capture
+      // uses getAllCookies() so it WILL be attributed to the Gmail site.
+
+      // Switch to Example (different base domain). This triggers the
+      // capture loop over loaded sites.
+      await harness.switchToSite(1);
+
+      // Verify: Gmail's cookies in storage include the accounts.google.com SSO.
+      final gmailSiteId = harness.sites[0].siteId;
+      final stored = await harness.storage.loadCookiesForSite(gmailSiteId);
+      expect(
+        stored.any((c) => c.name == 'SSID' && c.value == 'google_sso_token'),
+        isTrue,
+        reason: 'sibling-subdomain cookie must be captured before nuke',
+      );
+
+      // Switch back to Gmail. The engine restores from storage — the SSO
+      // cookie must be back in the native jar.
+      await harness.switchToSite(0);
+      final ssoCookies = await harness.cookieManager.getCookies(
+        url: Uri.parse('https://accounts.google.com/signin'),
+      );
+      expect(
+        ssoCookies.any((c) => c.name == 'SSID' && c.value == 'google_sso_token'),
+        isTrue,
+        reason: 'sibling-subdomain cookie must survive switch-away-and-back',
+      );
+    });
+
+    test('Cookies with Domain=.google.com are attributed to a google.com-base site', () async {
+      harness.addSite('https://mail.google.com', name: 'Gmail');
+
+      await harness.switchToSite(0);
+      // Host-agnostic domain cookie — applies to every google.com subdomain.
+      await harness.plantCookie(
+        url: 'https://mail.google.com',
+        name: 'HSID',
+        value: 'sso_hsid',
+        domain: '.google.com',
+      );
+
+      // Force a capture-and-restore cycle by switching away and back.
+      harness.addSite('https://example.com', name: 'Example');
+      await harness.switchToSite(1);
+
+      final stored = await harness.storage.loadCookiesForSite(harness.sites[0].siteId);
+      expect(stored.any((c) => c.name == 'HSID' && c.value == 'sso_hsid'), isTrue,
+          reason: '.google.com cookie must attribute to google.com base site');
+    });
+
+    test('Original bug: deleted mail.google.com leaks accounts.google.com session into new play.google.com', () async {
+      // Reproduces the exact scenario from the bug report.
+      harness.addSite('https://mail.google.com', name: 'Gmail');
+
+      await harness.switchToSite(0);
+      // Gmail logs in and picks up sibling-subdomain SSO cookies.
+      await harness.plantCookie(
+        url: 'https://accounts.google.com/signin',
+        name: 'SSID',
+        value: 'google_user_session',
+        domain: 'accounts.google.com',
+      );
+      await harness.plantCookie(
+        url: 'https://mail.google.com',
+        name: 'HSID',
+        value: 'sso_hsid',
+        domain: '.google.com',
+      );
+
+      // User deletes Gmail. The preDeleteCookieCleanup path must evict the
+      // sibling-subdomain cookies too — otherwise a fresh play.google.com
+      // site would inherit them.
+      await harness.deleteSite(0);
+
+      // Add the brand-new play.google.com site and activate it.
+      harness.addSite('https://play.google.com/console', name: 'Play Console');
+      await harness.switchToSite(0);
+
+      // No cookies should leak into the new site.
+      final accountsCookies = await harness.cookieManager.getCookies(
+        url: Uri.parse('https://accounts.google.com/signin'),
+      );
+      final playCookies = await harness.cookieManager.getCookies(
+        url: Uri.parse('https://play.google.com/console'),
+      );
+      expect(accountsCookies, isEmpty,
+          reason: 'accounts.google.com cookies from deleted Gmail must not leak');
+      expect(playCookies, isEmpty,
+          reason: '.google.com cookies from deleted Gmail must not leak');
+
+      // Encrypted storage for the new site must also be empty.
+      final newStored = await harness.storage.loadCookiesForSite(harness.sites[0].siteId);
+      expect(newStored, isEmpty);
+    });
+
+    test('Cookies on unrelated domains survive when an unrelated site is deleted', () async {
+      harness.addSite('https://mail.google.com', name: 'Gmail');
+      harness.addSite('https://github.com', name: 'GitHub');
+
+      await harness.switchToSite(0);
+      await harness.plantCookie(
+        url: 'https://accounts.google.com/signin',
+        name: 'SSID',
+        value: 'google_sso',
+        domain: 'accounts.google.com',
+      );
+
+      // Switching to GitHub captures Gmail's live cookies into storage
+      // (SSID ends up under Gmail's siteId via base-domain attribution).
+      await harness.switchToSite(1);
+
+      final gmailSiteId = harness.sites[0].siteId;
+      var gmailStored = await harness.storage.loadCookiesForSite(gmailSiteId);
+      expect(gmailStored.any((c) => c.name == 'SSID' && c.value == 'google_sso'), isTrue,
+          reason: 'precondition: Gmail\'s SSID captured on switch-away');
+
+      await harness.simulateLogin(1, [
+        Cookie(name: 'gh_session', value: 'gh_token', domain: 'github.com'),
+      ]);
+
+      // Delete GitHub. Gmail's siteId storage must NOT be touched — the
+      // deletion is for a different base domain.
+      await harness.deleteSite(1);
+
+      gmailStored = await harness.storage.loadCookiesForSite(gmailSiteId);
+      expect(gmailStored.any((c) => c.name == 'SSID' && c.value == 'google_sso'), isTrue,
+          reason: 'deleting github.com must not evict google.com sibling-subdomain cookies');
+    });
+  });
+
+  // ==========================================================================
+  // Garbage Collection: orphan sweep on delete, startup native-jar nuke,
+  // and prior-session-leak prevention.
+  // ==========================================================================
+  group('Garbage collection', () {
+    late CookieIsolationTestHarness harness;
+
+    setUp(() {
+      harness = CookieIsolationTestHarness();
+    });
+
+    test('deleteSite sweeps orphaned siteId storage', () async {
+      harness.addSite('https://example.com', name: 'Example');
+      harness.addSite('https://github.com', name: 'GitHub');
+
+      await harness.switchToSite(0);
+      await harness.simulateLogin(0, [
+        Cookie(name: 'ex', value: 'ex_val', domain: 'example.com'),
+      ]);
+      final exampleSiteId = harness.sites[0].siteId;
+
+      // Persist GitHub's login directly to storage — mirrors what the
+      // production `onCookiesChanged` handler would do on a real page load.
+      await harness.switchToSite(1);
+      await harness.simulateLogin(1, [
+        Cookie(name: 'gh', value: 'gh_val', domain: 'github.com'),
+      ]);
+      final githubSiteId = harness.sites[1].siteId;
+      await harness.storage.saveCookiesForSite(githubSiteId, harness.sites[1].cookies);
+
+      // Seed a stale entry to prove the orphan sweep actually runs on delete.
+      const stale = 'stale-from-prior-session';
+      await harness.storage.saveCookiesForSite(stale, [
+        Cookie(name: 'x', value: 'y', domain: 'deleted.example.com'),
+      ]);
+      expect(harness.storage.allStorage.keys,
+          containsAll([exampleSiteId, githubSiteId, stale]));
+
+      await harness.deleteSite(0);
+
+      // Post-delete: Example's entry is gone (explicit), the stale entry is
+      // gone (orphan sweep), GitHub's entry survives.
+      expect(harness.storage.allStorage.keys, isNot(contains(exampleSiteId)));
+      expect(harness.storage.allStorage.keys, isNot(contains(stale)));
+      expect(harness.storage.allStorage.keys, contains(githubSiteId));
+    });
+
+    test('orphan sweep removes entries whose siteId no longer corresponds to any site', () async {
+      harness.addSite('https://example.com', name: 'Example');
+      await harness.switchToSite(0);
+      final liveSiteId = harness.sites[0].siteId;
+
+      // Seed a real entry for the live site (production's onCookiesChanged
+      // handler would save after a page load).
+      await harness.storage.saveCookiesForSite(liveSiteId, [
+        Cookie(name: 'live', value: 'v', domain: 'example.com'),
+      ]);
+
+      // Seed a stale entry as if a site was deleted in a prior session
+      // without the orphan sweep ever running (pre-fix state).
+      await harness.storage.saveCookiesForSite('stale-site-id-from-prior-session', [
+        Cookie(name: 'leftover', value: 'old', domain: 'deleted.example.com'),
+      ]);
+      expect(harness.storage.allStorage.keys,
+          containsAll([liveSiteId, 'stale-site-id-from-prior-session']));
+
+      await harness.storage.removeOrphanedCookies(
+        harness.sites.map((s) => s.siteId).toSet(),
+      );
+
+      expect(harness.storage.allStorage.keys, isNot(contains('stale-site-id-from-prior-session')));
+      expect(harness.storage.allStorage.keys, contains(liveSiteId));
+    });
+
+    test('Startup GC evicts cookies from a prior-session deleted site before first activation', () async {
+      // Simulate a prior session: user had a Gmail site, logged in (cookies
+      // landed in native jar and storage), then deleted without the fix's
+      // native-jar cleanup ever running.
+      harness.addSite('https://mail.google.com', name: 'Gmail');
+      await harness.switchToSite(0);
+      await harness.plantCookie(
+        url: 'https://accounts.google.com/signin',
+        name: 'SSID',
+        value: 'prior_session_sso',
+        domain: 'accounts.google.com',
+      );
+
+      // "Prior session" ends: drop the site's storage entry but leave the
+      // cookies in the native jar (the pre-fix bug state).
+      await harness.simulateSitePurgedFromPriorSession(0);
+      expect(harness.cookieManager.all.any((c) => c.name == 'SSID'), isTrue,
+          reason: 'prior-session cookies still in native jar before startup GC');
+
+      // App launches for a new session. Startup GC runs.
+      harness.simulateAppRestart();
+      await harness.simulateAppStartupGc();
+
+      // User adds a brand-new play.google.com and activates it.
+      harness.addSite('https://play.google.com/console', name: 'Play Console');
+      await harness.switchToSite(0);
+
+      // No leak — the new site sees a pristine native jar.
+      final leak = await harness.cookieManager.getCookies(
+        url: Uri.parse('https://accounts.google.com/signin'),
+      );
+      expect(leak, isEmpty,
+          reason: 'startup GC must evict accounts.google.com cookies from prior-session Gmail');
+    });
+  });
+
+  // ==========================================================================
+  // Concurrency: the engine's version-guard mechanism must serialize
+  // rapid, overlapping activations.
+  // ==========================================================================
+  group('Concurrent activation version guard', () {
+    late CookieIsolationTestHarness harness;
+
+    setUp(() {
+      harness = CookieIsolationTestHarness();
+    });
+
+    test('stale activation bails before mutating state when a newer activation bumps the version', () async {
+      harness.addSite('https://example.com', name: 'Example');
+      harness.addSite('https://github.com', name: 'GitHub');
+
+      // Seed per-site storage so each activation has something to restore.
+      await harness.storage.saveCookiesForSite(harness.sites[0].siteId, [
+        Cookie(name: 'ex', value: 'example_persisted', domain: 'example.com'),
+      ]);
+      await harness.storage.saveCookiesForSite(harness.sites[1].siteId, [
+        Cookie(name: 'gh', value: 'github_persisted', domain: 'github.com'),
+      ]);
+
+      // Version captured at entry = 1. A "newer" caller bumps to 2 before
+      // the restore completes — the engine must abort and leave the jar
+      // untouched.
+      final staleVersion = ++harness.version; // v=1, the "stale" call
+      ++harness.version; // v=2, the "newer" call bumps it right away
+
+      await harness.engine.restoreCookiesForSite(
+        index: 0,
+        models: harness.sites,
+        loadedIndices: harness.loadedIndices,
+        versionAtEntry: staleVersion,
+        currentVersion: () => harness.version,
+      );
+
+      // Stale run bailed at the first version check — nothing was restored
+      // to the native jar from example.com's storage.
+      final ex = await harness.cookieManager.getCookies(
+        url: Uri.parse('https://example.com'),
+      );
+      expect(ex.any((c) => c.value == 'example_persisted'), isFalse,
+          reason: 'stale activation must not restore its cookies after a newer one supersedes it');
+    });
+
+    test('current activation completes when version is stable', () async {
+      harness.addSite('https://example.com', name: 'Example');
+      await harness.storage.saveCookiesForSite(harness.sites[0].siteId, [
+        Cookie(name: 'ex', value: 'example_val', domain: 'example.com'),
+      ]);
+
+      final v = ++harness.version;
+      await harness.engine.restoreCookiesForSite(
+        index: 0,
+        models: harness.sites,
+        loadedIndices: harness.loadedIndices,
+        versionAtEntry: v,
+        currentVersion: () => harness.version,
+      );
+
+      final ex = await harness.cookieManager.getCookies(
+        url: Uri.parse('https://example.com'),
+      );
+      expect(ex.any((c) => c.value == 'example_val'), isTrue);
+    });
+  });
+
+  // ==========================================================================
+  // Domain-match helper — direct unit test of the pure function.
+  // ==========================================================================
+  group('cookieMatchesBaseDomain', () {
+    Cookie c(String? domain) => Cookie(name: 'x', value: 'y', domain: domain);
+
+    test('exact match', () {
+      expect(cookieMatchesBaseDomain(c('google.com'), 'google.com'), isTrue);
+    });
+
+    test('subdomain match', () {
+      expect(cookieMatchesBaseDomain(c('mail.google.com'), 'google.com'), isTrue);
+      expect(cookieMatchesBaseDomain(c('accounts.google.com'), 'google.com'), isTrue);
+    });
+
+    test('leading-dot domain match', () {
+      expect(cookieMatchesBaseDomain(c('.google.com'), 'google.com'), isTrue);
+    });
+
+    test('case-insensitive', () {
+      expect(cookieMatchesBaseDomain(c('Mail.GOOGLE.com'), 'GOOGLE.com'), isTrue);
+    });
+
+    test('no match on unrelated domain', () {
+      expect(cookieMatchesBaseDomain(c('googlethief.com'), 'google.com'), isFalse);
+      expect(cookieMatchesBaseDomain(c('evilgoogle.com'), 'google.com'), isFalse);
+    });
+
+    test('null / empty domain never matches', () {
+      expect(cookieMatchesBaseDomain(c(null), 'google.com'), isFalse);
+      expect(cookieMatchesBaseDomain(c(''), 'google.com'), isFalse);
+      expect(cookieMatchesBaseDomain(c('google.com'), ''), isFalse);
+    });
+
+    test('multi-part TLD', () {
+      expect(cookieMatchesBaseDomain(c('bbc.co.uk'), 'bbc.co.uk'), isTrue);
+      expect(cookieMatchesBaseDomain(c('news.bbc.co.uk'), 'bbc.co.uk'), isTrue);
+      expect(cookieMatchesBaseDomain(c('bbc.co.uk'), 'amazon.co.uk'), isFalse);
+    });
+
+    test('IP address', () {
+      expect(cookieMatchesBaseDomain(c('192.168.1.1'), '192.168.1.1'), isTrue);
+      expect(cookieMatchesBaseDomain(c('192.168.1.2'), '192.168.1.1'), isFalse);
     });
   });
 }

--- a/test/cookie_isolation_integration_test.dart
+++ b/test/cookie_isolation_integration_test.dart
@@ -18,6 +18,17 @@ class MockCookieManager {
     return _cookies[domain] ?? [];
   }
 
+  /// Returns every cookie in the store regardless of URL. Mirrors the real
+  /// `CookieManager.getAllCookies()` wrapper used by the app to avoid missing
+  /// sibling-subdomain cookies.
+  Future<List<Cookie>> getAllCookies() async {
+    final out = <Cookie>[];
+    for (final list in _cookies.values) {
+      out.addAll(list);
+    }
+    return out;
+  }
+
   Future<void> setCookie({
     required Uri url,
     required String name,
@@ -127,19 +138,15 @@ class CookieIsolationTestHarness {
   }
 
   Future<void> _unloadSiteForDomainSwitch(int index) async {
-    // Capture cookies for ALL loaded sites before clearing
-    for (final loadedIndex in loadedIndices) {
-      if (loadedIndex >= sites.length) continue;
-      final model = sites[loadedIndex];
-      if (model.incognito) continue;
-
+    // Capture cookies for the departing site only (its webview is about to
+    // be disposed). Other still-loaded sites are captured by
+    // _restoreCookiesForSite before it nukes the native jar.
+    final model = sites[index];
+    if (!model.incognito) {
       final url = Uri.parse(model.currentUrl.isNotEmpty ? model.currentUrl : model.initUrl);
       model.cookies = await cookieManager.getCookies(url: url);
       await storage.saveCookiesForSite(model.siteId, model.cookies);
     }
-
-    // Clear ALL cookies from CookieManager
-    await cookieManager.deleteAllCookies();
 
     // Remove from loaded
     loadedIndices.remove(index);
@@ -149,11 +156,31 @@ class CookieIsolationTestHarness {
     final model = sites[index];
     if (model.incognito) return;
 
-    // Load persisted cookies
+    // Step 1: snapshot all cookies.
+    final allCookies = await cookieManager.getAllCookies();
+
+    // Step 2: attribute to every loaded non-incognito site (including target
+    // if it's already loaded — re-activation after goHome) by base-domain.
+    final otherLoaded = <WebViewModel>[];
+    for (final loadedIndex in loadedIndices) {
+      if (loadedIndex >= sites.length) continue;
+      final loadedModel = sites[loadedIndex];
+      if (loadedModel.incognito) continue;
+
+      final base = getBaseDomain(loadedModel.initUrl);
+      final cookies = allCookies.where((c) => _matchesBase(c, base)).toList();
+      loadedModel.cookies = cookies;
+      await storage.saveCookiesForSite(loadedModel.siteId, cookies);
+      if (loadedIndex != index) otherLoaded.add(loadedModel);
+    }
+
+    // Step 3: nuke native cookie jar
+    await cookieManager.deleteAllCookies();
+
+    // Step 4a: restore target's cookies
     final cookies = await storage.loadCookiesForSite(model.siteId);
     model.cookies = cookies;
 
-    // Restore to CookieManager
     final url = Uri.parse(model.initUrl);
     for (final cookie in cookies) {
       if (cookie.value.isEmpty) continue;
@@ -165,23 +192,78 @@ class CookieIsolationTestHarness {
         path: cookie.path ?? '/',
       );
     }
+
+    // Step 4b: restore other loaded sites' cookies
+    for (final other in otherLoaded) {
+      final otherUrl = Uri.parse(other.initUrl);
+      for (final cookie in other.cookies) {
+        if (cookie.value.isEmpty) continue;
+        await cookieManager.setCookie(
+          url: otherUrl,
+          name: cookie.name,
+          value: cookie.value,
+          domain: cookie.domain,
+          path: cookie.path ?? '/',
+        );
+      }
+    }
   }
 
-  /// Simulates deleting a site, mirroring the cleanup logic in main.dart
+  static bool _matchesBase(Cookie cookie, String baseDomain) {
+    var domain = (cookie.domain ?? '').trim().toLowerCase();
+    if (domain.isEmpty || baseDomain.isEmpty) return false;
+    if (domain.startsWith('.')) domain = domain.substring(1);
+    final base = baseDomain.toLowerCase();
+    return domain == base || domain.endsWith('.$base');
+  }
+
+  /// Simulates deleting a site, mirroring the cleanup logic in main.dart.
+  /// Always clears the native cookie jar for the deleted site's URL. If a
+  /// loaded same-base-domain site exists, snapshot its cookies before the
+  /// URL-scoped delete (which would otherwise wipe its live session) and
+  /// restore them after.
   Future<void> deleteSite(int index) async {
     final deletedModel = sites[index];
-    final deletedDomain = getBaseDomain(deletedModel.initUrl);
-    final otherSiteSameDomain = sites
-        .where((m) => m != deletedModel && getBaseDomain(m.initUrl) == deletedDomain)
-        .isNotEmpty;
+    final deletedBase = getBaseDomain(deletedModel.initUrl);
 
-    // Only clear the webview cookie jar if no other site shares this domain
-    if (!otherSiteSameDomain) {
-      await cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.initUrl));
+    final survivingSameBase = <WebViewModel>[];
+    for (final loadedIdx in loadedIndices) {
+      if (loadedIdx == index) continue;
+      if (loadedIdx >= sites.length) continue;
+      final loaded = sites[loadedIdx];
+      if (loaded.incognito) continue;
+      if (getBaseDomain(loaded.initUrl) == deletedBase) {
+        survivingSameBase.add(loaded);
+      }
+    }
+
+    List<Cookie> survivingSnapshot = const [];
+    if (survivingSameBase.isNotEmpty) {
+      final allCookies = await cookieManager.getAllCookies();
+      survivingSnapshot = allCookies.where((c) => _matchesBase(c, deletedBase)).toList();
+    }
+
+    await cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.initUrl));
+    if (deletedModel.currentUrl.isNotEmpty && deletedModel.currentUrl != deletedModel.initUrl) {
+      await cookieManager.deleteAllCookiesForUrl(Uri.parse(deletedModel.currentUrl));
     }
 
     // Always clear secure storage for this siteId
     await storage.saveCookiesForSite(deletedModel.siteId, []);
+
+    if (survivingSameBase.isNotEmpty && survivingSnapshot.isNotEmpty) {
+      final restoreUrl = Uri.parse(survivingSameBase.first.initUrl);
+      for (final cookie in survivingSnapshot) {
+        if (cookie.value.isEmpty) continue;
+        await cookieManager.setCookie(
+          url: restoreUrl,
+          name: cookie.name,
+          value: cookie.value,
+          domain: cookie.domain,
+          path: cookie.path ?? '/',
+        );
+      }
+    }
 
     // Remove from sites list and loaded indices
     sites.removeAt(index);
@@ -565,7 +647,7 @@ void main() {
       expect(stored, isEmpty);
     });
 
-    test('deleting one of multiple same-domain sites preserves cookie jar', () async {
+    test('deleting one of multiple same-domain sites preserves surviving site live session', () async {
       harness.addSite('https://github.com/personal', name: 'GitHub Personal');
       harness.addSite('https://github.com/work', name: 'GitHub Work');
 
@@ -576,7 +658,7 @@ void main() {
       ]);
       await harness.storage.saveCookiesForSite(harness.sites[0].siteId, harness.sites[0].cookies);
 
-      // Switch to work account
+      // Switch to work account (unloads personal, restores work's)
       await harness.switchToSite(1);
       await harness.simulateLogin(1, [
         Cookie(name: 'session', value: 'work_session', domain: 'github.com'),
@@ -586,18 +668,21 @@ void main() {
       final personalSiteId = harness.sites[0].siteId;
       final workSiteId = harness.sites[1].siteId;
 
-      // Delete personal account (index 0)
+      // Delete personal. Work is the active loaded site with a live
+      // github.com session in the native jar. Delete must NOT wipe that.
       await harness.deleteSite(0);
 
-      // Cookie jar should NOT be cleared (work account still exists)
+      // Work's live session preserved in native jar (snapshot+restore).
       var cookies = await harness.cookieManager.getCookies(url: Uri.parse('https://github.com'));
-      expect(cookies, isNotEmpty);
+      expect(cookies.any((c) => c.value == 'work_session'), isTrue,
+          reason: 'work\'s live session must not be wiped when deleting personal');
+      expect(cookies.any((c) => c.value == 'personal_session'), isFalse);
 
-      // Personal secure storage should be cleared
+      // Personal secure storage cleared
       var personalStored = await harness.storage.loadCookiesForSite(personalSiteId);
       expect(personalStored, isEmpty);
 
-      // Work secure storage should be intact
+      // Work secure storage intact
       var workStored = await harness.storage.loadCookiesForSite(workSiteId);
       expect(workStored, hasLength(1));
       expect(workStored[0].value, equals('work_session'));

--- a/test/cookie_isolation_test.dart
+++ b/test/cookie_isolation_test.dart
@@ -237,6 +237,18 @@ void main() {
       expect(getNormalizedDomain('https://account.google.com'), equals('google.com'));
     });
 
+    test('YouTube domains should map to google.com (SSO SetSID redirects)', () {
+      // Google Play Console / Gmail / etc. sign-in bounces through
+      // accounts.youtube.com/SetSID to sync the session cookie into the
+      // YouTube jar. Must be treated as same-family for navigation so
+      // the auth flow completes in the main webview.
+      expect(getNormalizedDomain('https://accounts.youtube.com'), equals('google.com'));
+      expect(getNormalizedDomain('https://accounts.youtube.com/accounts/SetSID'), equals('google.com'));
+      expect(getNormalizedDomain('https://www.youtube.com'), equals('google.com'));
+      expect(getNormalizedDomain('https://youtu.be/dQw4w9WgXcQ'), equals('google.com'));
+      expect(getNormalizedDomain('https://www.youtube-nocookie.com'), equals('google.com'));
+    });
+
     test('non-google subdomains extract to second-level', () {
       expect(getNormalizedDomain('https://api.github.com'), equals('github.com'));
       expect(getNormalizedDomain('https://gist.github.com'), equals('github.com'));


### PR DESCRIPTION
The native cookie jar on iOS (`WKHTTPCookieStorage`) and Android is a process-wide store that persists across app launches. When a site was deleted, cookies scoped to sibling subdomains (e.g. `accounts.google.com` when deleting `mail.google.com`) remained in the jar and leaked into any newly-added site sharing the base domain — e.g. a brand-new `play.google.com/console` showed logged-in Google accounts that were never authorized in the current webspace.

Changes:

- `_restoreCookiesForSite`: replaced URL-scoped `getCookies(url)` capture with `getAllCookies()` + base-domain attribution so sibling-subdomain cookies are preserved across the nuke. Target is included in the capture loop so re-activation (e.g. after goHome) persists its live session before the nuke. All async steps check `_setCurrentIndexVersion` to serialize concurrent activations.
- `_unloadSiteForDomainSwitch`: only captures the conflicting site (its webview is about to be disposed); the full capture-nuke-restore cycle is handled by `_restoreCookiesForSite` right after.
- `_deleteSite`: unconditionally clears native cookies for the deleted site; drops the `otherSiteSameDomain` guard. If a loaded same-base-domain site exists, snapshots its session via `getAllCookies()` before the URL-scoped delete (which would otherwise wipe the live session) and restores after. Also sweeps orphaned siteId-keyed encrypted storage and HTML cache entries.
- `_restoreAppState`: added startup GC (orphan sweep + native nuke before first activation) so cookies from sites deleted in prior sessions do not leak into the next activated site.
- `_importSettings`: removed redundant `deleteAllCookies()` that was wiping the session `_setCurrentIndex` just restored for the imported active site.
- Added `CookieManager.getAllCookies()` wrapper.
- Updated per-site-cookie-isolation spec (ISO-003, ISO-010, ISO-012) with scenarios for sibling-subdomain preservation, active-site protection on delete, concurrent-activation serialization, and the import-path rule.
- Updated mock test harness to match new semantics; all 566 tests pass.