### PR TITLE
Fix user-agent icon colors not adapting to dark theme

### DIFF
--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -453,7 +453,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   });
                 },
                 icon: Icon(Icons.home), // Use an appropriate icon for generating user-agent
-                color: Theme.of(context).primaryColor,
+                color: Theme.of(context).colorScheme.primary,
                 iconSize: 24, // Adjust the icon size as needed
               ),
               Expanded(
@@ -471,7 +471,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   });
                 },
                 icon: Icon(Icons.autorenew), // Use an appropriate icon for generating user-agent
-                color: Theme.of(context).primaryColor,
+                color: Theme.of(context).colorScheme.primary,
                 iconSize: 24, // Adjust the icon size as needed
               ),
             ],


### PR DESCRIPTION
The reset and regenerate IconButtons in the per-site settings screen used Theme.of(context).primaryColor, which on a ThemeData built from only a colorScheme falls back to colorScheme.surface in dark mode — rendering the icons nearly invisible on a near-black background. Switch both to colorScheme.primary so they stay readable in both light and dark themes.