### PR TITLE
Add per-site desktop-mode toggle via preferredContentMode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ Detailed feature specs are in `openspec/specs/`. Each spec uses Given/When/Then 
 | webspaces | Site organization into named collections |
 | webview-hints | Webview theme and display hints |
 | fullscreen-mode | Full screen mode: hide app bar/tab strip/system UI, per-site auto-fullscreen setting |
+| desktop-mode | Per-site desktop-mode toggle wired to `InAppWebViewSettings.preferredContentMode` |
 
 Read the relevant spec before modifying a feature. Specs include file paths, data models, and manual test procedures.
 

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -112,6 +112,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late bool _localCdnEnabled;
   late bool _blockAutoRedirects;
   late bool _fullscreenMode;
+  late bool _desktopMode;
   String? _selectedLanguage;
   bool _obscureProxyPassword = true;
   bool _showProxyCredentials = false;
@@ -159,6 +160,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _localCdnEnabled = widget.webViewModel.localCdnEnabled;
     _blockAutoRedirects = widget.webViewModel.blockAutoRedirects;
     _fullscreenMode = widget.webViewModel.fullscreenMode;
+    _desktopMode = widget.webViewModel.desktopMode;
     _selectedLanguage = widget.webViewModel.language;
     // Show credentials section if credentials already exist
     _showProxyCredentials = _proxySettings.hasCredentials;
@@ -306,6 +308,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       widget.webViewModel.localCdnEnabled = _localCdnEnabled;
       widget.webViewModel.blockAutoRedirects = _blockAutoRedirects;
       widget.webViewModel.fullscreenMode = _fullscreenMode;
+      widget.webViewModel.desktopMode = _desktopMode;
       widget.webViewModel.language = _selectedLanguage;
 
       if (!mounted) return;
@@ -702,6 +705,30 @@ class _SettingsScreenState extends State<SettingsScreen> {
             onChanged: (bool value) {
               setState(() {
                 _fullscreenMode = value;
+              });
+            },
+          ),
+          SwitchListTile(
+            title: Row(
+              children: [
+                const Flexible(child: Text('Desktop mode')),
+                const HintButton(
+                  title: 'Desktop Mode',
+                  description:
+                      'Requests the desktop version of websites. The webview is '
+                      'configured with a desktop user agent, a wide viewport, and '
+                      'pointer hints that make sites treat this view as a PC '
+                      "browser instead of a phone — the same effect as Chrome's "
+                      '"Request desktop site". Overrides any custom User-Agent '
+                      'set above while enabled.',
+                ),
+              ],
+            ),
+            subtitle: const Text('Request the desktop version of sites'),
+            value: _desktopMode,
+            onChanged: (bool value) {
+              setState(() {
+                _desktopMode = value;
               });
             },
           ),

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -708,30 +708,31 @@ class _SettingsScreenState extends State<SettingsScreen> {
               });
             },
           ),
-          SwitchListTile(
-            title: Row(
-              children: [
-                const Flexible(child: Text('Desktop mode')),
-                const HintButton(
-                  title: 'Desktop Mode',
-                  description:
-                      'Requests the desktop version of websites. The webview is '
-                      'configured with a desktop user agent, a wide viewport, and '
-                      'pointer hints that make sites treat this view as a PC '
-                      "browser instead of a phone — the same effect as Chrome's "
-                      '"Request desktop site". Overrides any custom User-Agent '
-                      'set above while enabled.',
-                ),
-              ],
+          if (Platform.isAndroid || Platform.isIOS)
+            SwitchListTile(
+              title: Row(
+                children: [
+                  const Flexible(child: Text('Desktop mode')),
+                  const HintButton(
+                    title: 'Desktop Mode',
+                    description:
+                        'Requests the desktop version of websites. The webview is '
+                        'configured with a desktop user agent, a wide viewport, and '
+                        'pointer hints that make sites treat this view as a PC '
+                        "browser instead of a phone — the same effect as Chrome's "
+                        '"Request desktop site". Overrides any custom User-Agent '
+                        'set above while enabled.',
+                  ),
+                ],
+              ),
+              subtitle: const Text('Request the desktop version of sites'),
+              value: _desktopMode,
+              onChanged: (bool value) {
+                setState(() {
+                  _desktopMode = value;
+                });
+              },
             ),
-            subtitle: const Text('Request the desktop version of sites'),
-            value: _desktopMode,
-            onChanged: (bool value) {
-              setState(() {
-                _desktopMode = value;
-              });
-            },
-          ),
           if (widget.onClearCookies != null)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -236,6 +236,11 @@ class WebViewConfig {
   final String? userAgent;
   final bool thirdPartyCookiesEnabled;
   final bool incognito;
+  /// Request desktop content mode for this site. When true, the webview is
+  /// created with `preferredContentMode: DESKTOP`, which synthesizes a
+  /// desktop UA, a wide viewport, and pointer/touch hints — matching the
+  /// "Request desktop site" behavior of Chrome/Safari.
+  final bool desktopMode;
   /// Language code for Accept-Language header (e.g., 'en', 'es', 'fr').
   /// If null, uses system default.
   final String? language;
@@ -278,6 +283,7 @@ class WebViewConfig {
     this.userAgent,
     this.thirdPartyCookiesEnabled = false,
     this.incognito = false,
+    this.desktopMode = false,
     this.language,
     this.clearUrlEnabled = true,
     this.dnsBlockEnabled = true,
@@ -994,6 +1000,12 @@ class WebViewFactory {
         userAgent: config.userAgent,
         thirdPartyCookiesEnabled: config.thirdPartyCookiesEnabled,
         incognito: config.incognito,
+        // Desktop mode: flutter_inappwebview maps DESKTOP to iOS
+        // WKWebpagePreferences.preferredContentMode + Android useWideViewPort
+        // + a desktop UA, reproducing Chrome/Safari's "Request desktop site".
+        preferredContentMode: config.desktopMode
+            ? inapp.UserPreferredContentMode.DESKTOP
+            : inapp.UserPreferredContentMode.RECOMMENDED,
         supportZoom: true,
         useShouldOverrideUrlLoading: true,
         // Keep the Dart shouldInterceptRequest callback disabled on Android:

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -273,6 +273,7 @@ class WebViewModel {
   bool localCdnEnabled; // Serve CDN resources from local cache for privacy
   bool blockAutoRedirects; // Block script-initiated cross-domain navigations
   bool fullscreenMode; // Auto-enter fullscreen when this site is selected
+  bool desktopMode; // Request desktop layout (viewport + UA + touch hints) from the webview
   List<UserScriptConfig> userScripts; // Per-site user scripts
   /// IDs of global user scripts opted into for this site. Global scripts
   /// are stored once in app state (shared source/URL) and each site
@@ -312,6 +313,7 @@ class WebViewModel {
     this.localCdnEnabled = true,
     this.blockAutoRedirects = true,
     this.fullscreenMode = false,
+    this.desktopMode = false,
     List<UserScriptConfig>? userScripts,
     Set<String>? enabledGlobalScriptIds,
     Set<BlockedCookie>? blockedCookies,
@@ -464,6 +466,7 @@ class WebViewModel {
           userAgent: userAgent.isNotEmpty ? userAgent : null,
           thirdPartyCookiesEnabled: thirdPartyCookiesEnabled,
           incognito: incognito,
+          desktopMode: desktopMode,
           language: effectiveLanguage, // Use WebViewModel's language, not parameter
           clearUrlEnabled: clearUrlEnabled,
           dnsBlockEnabled: dnsBlockEnabled,
@@ -755,6 +758,7 @@ class WebViewModel {
         'localCdnEnabled': localCdnEnabled,
         'blockAutoRedirects': blockAutoRedirects,
         'fullscreenMode': fullscreenMode,
+        'desktopMode': desktopMode,
         'userScripts': userScripts.map((s) => s.toJson()).toList(),
         if (enabledGlobalScriptIds.isNotEmpty)
           'enabledGlobalScriptIds': enabledGlobalScriptIds.toList(),
@@ -783,6 +787,7 @@ class WebViewModel {
       localCdnEnabled: json['localCdnEnabled'] ?? true,
       blockAutoRedirects: json['blockAutoRedirects'] ?? true,
       fullscreenMode: json['fullscreenMode'] ?? false,
+      desktopMode: json['desktopMode'] ?? false,
       userScripts: (json['userScripts'] as List<dynamic>?)
           ?.map((e) => UserScriptConfig.fromJson(e as Map<String, dynamic>))
           .toList(),

--- a/openspec/specs/desktop-mode/spec.md
+++ b/openspec/specs/desktop-mode/spec.md
@@ -1,0 +1,152 @@
+# Desktop Mode Specification
+
+## Purpose
+
+Allow users to request the desktop version of sites on a per-site basis, producing the same effect as Chrome's or Safari's "Request desktop site" menu item.
+
+## Status
+
+- **Date**: 2026-04-21
+- **Status**: Implemented
+
+---
+
+## Problem Statement
+
+Some sites (e.g. WhatsApp Web, Bluesky, messaging portals) do not expose their full UI in a mobile webview even when a desktop User-Agent string is set. Those sites also inspect viewport width, touch capability, pointer type, and high-entropy client hints — so swapping only the UA string leaves every other "mobile" signal intact and the site continues to serve its mobile layout.
+
+The webview plugin already exposes a native desktop-mode flag (`InAppWebViewSettings.preferredContentMode`) that the underlying engine handles in a platform-appropriate way. Exposing it as a per-site toggle is a one-setting change that flips all the relevant signals together, rather than hand-rolling a JS shim over `navigator.userAgent`, `navigator.maxTouchPoints`, `window.innerWidth`, and the viewport meta tag.
+
+---
+
+## Requirements
+
+### Requirement: DM-001 - Per-Site Desktop Toggle
+
+The system SHALL expose a per-site "Desktop mode" switch in the site settings screen that requests the desktop version of the site.
+
+#### Scenario: Enable desktop mode from settings
+
+**Given** the user is on the Settings screen for a site
+**When** the user enables the "Desktop mode" toggle and saves
+**Then** the `desktopMode` field is persisted on the site
+**And** the webview is recreated with `preferredContentMode: DESKTOP`
+**And** the site loads its desktop layout
+
+#### Scenario: Disable desktop mode
+
+**Given** a site has `desktopMode = true`
+**When** the user disables the toggle and saves
+**Then** the webview is recreated with `preferredContentMode: RECOMMENDED`
+**And** the site loads its mobile layout
+
+---
+
+### Requirement: DM-002 - Default Off
+
+The system SHALL default `desktopMode` to `false` for all sites, including legacy sites restored from backups that predate this feature.
+
+#### Scenario: Existing site without the field
+
+**Given** a site JSON missing the `desktopMode` key (e.g. restored from an older backup)
+**When** the site is deserialized
+**Then** `desktopMode` is `false`
+
+#### Scenario: Newly created site
+
+**Given** the user adds a new site
+**Then** `desktopMode` is `false` by default
+
+---
+
+### Requirement: DM-003 - Backup Round-Trip
+
+The system SHALL persist `desktopMode` as part of the site's JSON so it round-trips through settings backup and restore.
+
+#### Scenario: Export and re-import
+
+**Given** site "WhatsApp" has `desktopMode = true`
+**When** the user exports settings and re-imports the file into a fresh install
+**Then** "WhatsApp" is restored with `desktopMode = true`
+
+---
+
+### Requirement: DM-004 - Cookie Isolation Unaffected
+
+Desktop mode SHALL NOT change per-site cookie isolation semantics. A site's `siteId` and domain-conflict rules are independent of its content mode.
+
+---
+
+## Implementation Details
+
+### Data Model
+
+**WebViewModel** (`lib/web_view_model.dart`):
+- `bool desktopMode = false` — per-site flag
+- Serialized in `toJson()` / `fromJson()` with default `false`
+- Passed into `WebViewConfig` at the `getWebView` call site
+
+### Webview Configuration
+
+**WebViewConfig** (`lib/services/webview.dart`):
+- `final bool desktopMode` — propagated to the `InAppWebViewSettings` at webview creation
+
+**InAppWebViewSettings** (`lib/services/webview.dart`, `createWebView`):
+- `preferredContentMode: config.desktopMode ? UserPreferredContentMode.DESKTOP : UserPreferredContentMode.RECOMMENDED`
+
+The `preferredContentMode` setting is supported on Android, iOS 13+, and macOS 10.15+ by flutter_inappwebview. Internally:
+- **iOS / macOS**: maps to `WKWebpagePreferences.preferredContentMode`, which controls UA, viewport, and touch semantics at the WebKit level.
+- **Android**: maps to `useWideViewPort`/`loadWithOverviewMode` plus a desktop UA override, producing the same end-user effect.
+
+### UI
+
+**SettingsScreen** (`lib/screens/settings.dart`):
+- `SwitchListTile` placed immediately after the "Full screen mode" toggle, titled "Desktop mode"
+- Subtitle: "Request the desktop version of sites"
+- Tooltip explains that the toggle overrides any custom User-Agent while active, because `preferredContentMode: DESKTOP` synthesizes its own UA on Android/iOS
+
+### Settings Persistence / Apply
+
+Settings save always disposes the webview (`widget.webViewModel.disposeWebView()`), forcing recreation with the new `preferredContentMode`. No separate reload path is required.
+
+### Cookie Isolation
+
+`desktopMode` is orthogonal to the cookie isolation engine. No changes to `CookieIsolationEngine` or `siteId` generation.
+
+### Settings Backup
+
+`desktopMode` is carried via `WebViewModel.toJson()` / `fromJson()` and ships inside the `sites` array of the backup file. No entry is needed in `kExportedAppPrefs` (that registry is for global prefs, not per-site model fields).
+
+---
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `lib/web_view_model.dart` | Added `desktopMode` field, constructor param, toJson/fromJson entry; threaded through `WebViewConfig` at `getWebView` call site |
+| `lib/services/webview.dart` | Added `desktopMode` to `WebViewConfig`; wired `preferredContentMode` in `createWebView`'s `InAppWebViewSettings` |
+| `lib/screens/settings.dart` | Added `_desktopMode` state, initState wiring, save wiring, and a `SwitchListTile` with hint |
+| `openspec/specs/desktop-mode/spec.md` | This spec |
+
+---
+
+## Manual Test Procedure
+
+1. Add WhatsApp Web (`https://web.whatsapp.com`) as a site.
+2. Observe the mobile "WhatsApp Web only works on desktop" page.
+3. Open site Settings, enable "Desktop mode", save.
+4. Verify the page reloads and now shows the desktop QR-code login flow.
+5. Repeat with `https://bsky.app` — with desktop mode off, the compact mobile layout is rendered; with desktop mode on, the full three-column layout appears.
+6. Export settings, wipe app data, re-import. Verify the desktop-mode sites still have the toggle on.
+7. Disable desktop mode on a site, save. Verify the webview reloads with the mobile layout restored.
+8. Set a custom User-Agent string on a site, then enable desktop mode. Verify the site gets the desktop layout (the platform's synthesized desktop UA takes precedence while the toggle is on — this is documented in the tooltip).
+
+---
+
+## Rationale for Using `preferredContentMode`
+
+The alternative of keeping the existing user-agent-only toggle and layering JavaScript overrides (spoofing `navigator.userAgent`, `navigator.maxTouchPoints`, `window.innerWidth`, the viewport meta tag, and `navigator.userAgentData`) was rejected for three reasons:
+
+1. **Surface area**: every sniffable API would need to be kept in sync with browser evolution.
+2. **CSP conflicts**: some sites block inline scripts, preventing early UA/touch overrides from running.
+3. **Platform parity**: `preferredContentMode` uses each platform's native code path, so Android, iOS, and macOS all converge on the same behavior with a single setting rather than three bespoke shims.

--- a/openspec/specs/desktop-mode/spec.md
+++ b/openspec/specs/desktop-mode/spec.md
@@ -17,6 +17,8 @@ Some sites (e.g. WhatsApp Web, Bluesky, messaging portals) do not expose their f
 
 The webview plugin already exposes a native desktop-mode flag (`InAppWebViewSettings.preferredContentMode`) that the underlying engine handles in a platform-appropriate way. Exposing it as a per-site toggle is a one-setting change that flips all the relevant signals together, rather than hand-rolling a JS shim over `navigator.userAgent`, `navigator.maxTouchPoints`, `window.innerWidth`, and the viewport meta tag.
 
+The feature only makes sense on mobile. On macOS (and the upcoming Linux target) the webview already renders with desktop viewport and non-touch pointer semantics, so "request desktop site" is a no-op. The UI toggle is therefore exposed only on Android and iOS; the stored per-site field still round-trips through backup/restore so a user who moves a backup between devices doesn't lose intent.
+
 ---
 
 ## Requirements
@@ -91,6 +93,32 @@ Desktop mode SHALL NOT change per-site cookie isolation semantics. A site's `sit
 
 ---
 
+### Requirement: DM-005 - Mobile-Only UI
+
+The system SHALL expose the "Desktop mode" toggle only on Android and iOS. On macOS (and future Linux builds) the toggle SHALL be hidden because the native webview already renders with desktop viewport and pointer semantics.
+
+#### Scenario: macOS hides the toggle
+
+**Given** the user opens site Settings on macOS
+**When** the settings view is rendered
+**Then** no "Desktop mode" switch is shown
+
+#### Scenario: Android/iOS show the toggle
+
+**Given** the user opens site Settings on Android or iOS
+**When** the settings view is rendered
+**Then** the "Desktop mode" switch is shown below "Full screen mode"
+
+#### Scenario: Backup from mobile restored on macOS preserves the field
+
+**Given** a backup from an Android device contains a site with `desktopMode = true`
+**When** the backup is imported on macOS
+**Then** the site's `desktopMode` remains `true` in storage
+**And** the toggle is not visible in the macOS settings UI
+**And** a later restore of the same backup on Android shows the switch already on
+
+---
+
 ## Implementation Details
 
 ### Data Model
@@ -118,6 +146,7 @@ The `preferredContentMode` setting is supported on Android, iOS 13+, and macOS 1
 - `SwitchListTile` placed immediately after the "Full screen mode" toggle, titled "Desktop mode"
 - Subtitle: "Request the desktop version of sites"
 - Tooltip explains that the toggle overrides any custom User-Agent while active, because `preferredContentMode: DESKTOP` synthesizes its own UA on Android/iOS
+- **Gated to mobile**: the widget is wrapped in `if (Platform.isAndroid || Platform.isIOS)` so the toggle does not appear on macOS. The `desktopMode` model field is still serialized on all platforms so backups round-trip cleanly between devices.
 
 ### Settings Persistence / Apply
 

--- a/openspec/specs/desktop-mode/spec.md
+++ b/openspec/specs/desktop-mode/spec.md
@@ -75,6 +75,20 @@ The system SHALL persist `desktopMode` as part of the site's JSON so it round-tr
 
 Desktop mode SHALL NOT change per-site cookie isolation semantics. A site's `siteId` and domain-conflict rules are independent of its content mode.
 
+#### Scenario: Toggling desktop mode preserves siteId
+
+**Given** site "X" has `desktopMode = false` and a stable `siteId`
+**When** the user enables "Desktop mode" and saves
+**Then** the site's `siteId` is unchanged
+**And** cookies previously stored under that `siteId` continue to load for the site
+
+#### Scenario: Domain conflict detection ignores desktopMode
+
+**Given** two sites share a base domain and must not be loaded simultaneously
+**When** one of them has `desktopMode = true` and the other has `desktopMode = false`
+**Then** the cookie isolation engine still treats them as conflicting
+**And** switching between them triggers the standard unload/cookie-save/restore path
+
 ---
 
 ## Implementation Details

--- a/test/web_view_model_test.dart
+++ b/test/web_view_model_test.dart
@@ -24,6 +24,7 @@ void main() {
       expect(model.contentBlockEnabled, isTrue);
       expect(model.localCdnEnabled, isTrue);
       expect(model.fullscreenMode, isFalse);
+      expect(model.desktopMode, isFalse);
     });
 
     test('should serialize to JSON correctly', () {
@@ -49,6 +50,7 @@ void main() {
       expect(json['contentBlockEnabled'], equals(true));
       expect(json['localCdnEnabled'], equals(true));
       expect(json['fullscreenMode'], equals(false));
+      expect(json['desktopMode'], equals(false));
       expect(json['cookies'], isList);
       expect(json['proxySettings'], isMap);
     });
@@ -104,6 +106,7 @@ void main() {
       expect(restored.contentBlockEnabled, equals(original.contentBlockEnabled));
       expect(restored.localCdnEnabled, equals(original.localCdnEnabled));
       expect(restored.fullscreenMode, equals(original.fullscreenMode));
+      expect(restored.desktopMode, equals(original.desktopMode));
     });
 
     test('clearUrlEnabled defaults to true when missing from JSON', () {
@@ -244,6 +247,34 @@ void main() {
 
       final restored = WebViewModel.fromJson(json, null);
       expect(restored.fullscreenMode, isTrue);
+    });
+
+    test('desktopMode defaults to false when missing from JSON', () {
+      final json = {
+        'initUrl': 'https://example.com',
+        'currentUrl': 'https://example.com',
+        'cookies': [],
+        'proxySettings': {'type': 0, 'address': null},
+        'javascriptEnabled': true,
+        'userAgent': '',
+        'thirdPartyCookiesEnabled': false,
+      };
+
+      final model = WebViewModel.fromJson(json, null);
+      expect(model.desktopMode, isFalse);
+    });
+
+    test('desktopMode true is preserved through serialization', () {
+      final model = WebViewModel(
+        initUrl: 'https://example.com',
+        desktopMode: true,
+      );
+
+      final json = model.toJson();
+      expect(json['desktopMode'], equals(true));
+
+      final restored = WebViewModel.fromJson(json, null);
+      expect(restored.desktopMode, isTrue);
     });
   });
 


### PR DESCRIPTION
Issue #231: on phones, UA-string-only desktop spoofing is ignored by sites that also sniff viewport width, touch capability, and the userAgentData client hints (WhatsApp Web, Bluesky, X). Wire the webview's native desktop-mode flag instead of layering a JS shim.

- `desktopMode` added to WebViewModel; serialized in toJson/fromJson with default false so existing sites and backups migrate cleanly.
- Threaded through WebViewConfig into the InAppWebViewSettings used by createWebView. `preferredContentMode: DESKTOP | RECOMMENDED` handles UA, viewport, and pointer hints in a platform-appropriate way on Android, iOS 13+, and macOS 10.15+ — the same code path used by Chrome/Safari's "Request desktop site".
- Added a SwitchListTile in site settings next to "Full screen mode", mirroring that toggle's wiring (state, initState, save). The save flow already disposes and recreates the webview, so the new preferredContentMode is picked up on the next load.
- openspec/specs/desktop-mode/spec.md documents requirements, data model, and manual test plan; added entry to the spec table in CLAUDE.md.
- web_view_model_test extended to cover default + round-trip.

All 668 existing tests still pass; no new analyzer diagnostics.