### PR TITLE
Add per-site location spoofing with timezone override and WebRTC lock…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ Detailed feature specs are in `openspec/specs/`. Each spec uses Given/When/Then 
 | navigation | Back gesture, home button, drawer swipe, pull-to-refresh, platform quirks, race condition guards |
 | nested-url-blocking | Cross-domain navigation control: nested InAppBrowser, gesture-based auto-redirect blocking |
 | per-site-cookie-isolation | Cookie isolation via domain conflict detection, siteId storage |
+| per-site-location | Per-site geolocation spoofing, IANA timezone override, WebRTC leak lockdown |
 | platform-support | Platform abstraction layer for iOS, Android, macOS |
 | proxy | Per-site HTTP/HTTPS/SOCKS5 proxy (Android only) |
 | screenshots | Automated screenshot generation via integration tests |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,20 @@ Some features (DNS blocklist, content blocker, LocalCDN) require a downloaded bl
 - Update the subtitle to hint the user to populate the data first when the service is not ready.
 - Examples in [lib/screens/settings.dart](lib/screens/settings.dart): DNS blocklist gates on `DnsBlockService.instance.hasBlocklist`; content blocker gates on `ContentBlockerService.instance.hasRules`; LocalCDN gates on `LocalCdnService.instance.hasCache`.
 
+## Per-site settings MUST apply to nested webviews
+
+Per-site settings (cookie isolation flags, language, geolocation/timezone spoof, WebRTC policy, user scripts, content blocking, ClearURLs, DNS blocklist, desktop mode, etc.) apply to the parent webview *and* every nested webview spawned from it. Cross-domain navigations open a new `InAppWebViewScreen` via `launchUrl` in [lib/main.dart](lib/main.dart), which constructs its own `WebViewConfig` — that config MUST carry the parent site's per-site fields, otherwise the nested webview runs as a plain browser and any privacy property the user configured silently breaks in the one place a hostile site is most likely to test it (e.g. opening `browserleaks.com/webrtc` after following an outbound link).
+
+When you add a new per-site field:
+
+1. Add it to `WebViewModel.toJson`/`fromJson`.
+2. Pass it into `WebViewConfig` at the main call site in `WebViewModel.getWebView` ([lib/web_view_model.dart](lib/web_view_model.dart)).
+3. Add it to `launchUrl`'s signature in [lib/main.dart](lib/main.dart).
+4. Add it to the `InAppWebViewScreen` constructor in [lib/screens/inappbrowser.dart](lib/screens/inappbrowser.dart) and pass it into that screen's `WebViewConfig` as well.
+5. Update the `launchUrlFunc` typedef and both call sites in [lib/web_view_model.dart](lib/web_view_model.dart) that invoke it.
+
+If a field controls JavaScript injected via `initialUserScripts`, also set `forMainFrameOnly: false` on the `inapp.UserScript` so the shim reaches cross-origin iframes (on iOS the default is main-frame-only). Otherwise a site can embed the detection logic in an iframe and bypass the shim.
+
 ## Logic engine vs. rendering engine
 
 Orchestration logic — "which sites to unload on a webspace switch", "how do indices shift after a deletion", "what cookies move where during site activation" — belongs in a pure-Dart **logic engine** under `lib/services/*_engine.dart`, not inlined in `_WebSpacePageState`. The template is [lib/services/cookie_isolation.dart](lib/services/cookie_isolation.dart): the engine takes mutable state as parameters, depends only on abstract I/O interfaces (`CookieManager`, `CookieSecureStorage`), and is invoked from `main.dart` as a thin call site. The **rendering engine** (native webview, platform channels, UI setState) stays at the call site. "Logic" is literal — it's the same code path in production and tests; the split is strictly about separating orchestration from rendering so the former can run without a display.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1116,6 +1116,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     required bool dnsBlockEnabled,
     required bool contentBlockEnabled,
     required String? language,
+    LocationMode locationMode = LocationMode.off,
+    double? spoofLatitude,
+    double? spoofLongitude,
+    double spoofAccuracy = 50.0,
+    String? spoofTimezone,
+    WebRtcPolicy webRtcPolicy = WebRtcPolicy.defaultPolicy,
   }) async {
     await Navigator.push(
       context,
@@ -1131,6 +1137,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           contentBlockEnabled: contentBlockEnabled,
           language: language,
           showUrlBar: _showUrlBar,
+          locationMode: locationMode,
+          spoofLatitude: spoofLatitude,
+          spoofLongitude: spoofLongitude,
+          spoofAccuracy: spoofAccuracy,
+          spoofTimezone: spoofTimezone,
+          webRtcPolicy: webRtcPolicy,
         ),
       ),
     );

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:webspace/main.dart' show AppThemeSettings, AccentColor;
 import 'package:webspace/screens/dev_tools.dart';
@@ -62,6 +63,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
   late AppThemeSettings _settings;
   late bool _showTabStrip;
   late bool _showStatsBanner;
+  late TextEditingController _osmTileUrlController;
   bool _isDownloadingRules = false;
   DateTime? _rulesLastUpdated;
 
@@ -89,6 +91,8 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
     _settings = widget.currentSettings;
     _showTabStrip = widget.showTabStrip;
     _showStatsBanner = widget.showStatsBanner;
+    _osmTileUrlController = TextEditingController();
+    _loadOsmTileUrl();
     _spinController = AnimationController(
       vsync: this,
       duration: const Duration(seconds: 1),
@@ -100,6 +104,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
 
   @override
   void dispose() {
+    _osmTileUrlController.dispose();
     _spinController.dispose();
     super.dispose();
   }
@@ -267,6 +272,24 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
       return '${(n / 1000).toStringAsFixed(n % 1000 == 0 ? 0 : 1)}K';
     }
     return n.toString();
+  }
+
+  Future<void> _loadOsmTileUrl() async {
+    final prefs = await SharedPreferences.getInstance();
+    final url = prefs.getString('osmTileUrl') ??
+        'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+    if (!mounted) return;
+    _osmTileUrlController.text = url;
+  }
+
+  Future<void> _saveOsmTileUrl(String value) async {
+    final prefs = await SharedPreferences.getInstance();
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      await prefs.remove('osmTileUrl');
+    } else {
+      await prefs.setString('osmTileUrl', trimmed);
+    }
   }
 
   Future<void> _loadRulesLastUpdated() async {
@@ -443,6 +466,42 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
               });
               widget.onShowStatsBannerChanged(value);
             },
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+            child: Row(
+              children: [
+                Text(
+                  'Location picker',
+                  style: Theme.of(context).textTheme.labelLarge,
+                ),
+                const HintButton(
+                  title: 'Location picker tile provider',
+                  description:
+                      'The tile URL used by the per-site location picker. '
+                      'No tiles are fetched unless the user taps "Load map" on '
+                      'the picker itself — the app never makes background '
+                      'requests to this provider. The {z}/{x}/{y} placeholders '
+                      'are substituted with OSM tile coordinates. '
+                      'Defaults to OpenStreetMap; swap for any '
+                      'OSM-compatible provider (MapTiler, CartoDB, a self-'
+                      'hosted server, etc.).',
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
+            child: TextFormField(
+              controller: _osmTileUrlController,
+              decoration: const InputDecoration(
+                labelText: 'Tile URL',
+                hintText: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                border: OutlineInputBorder(),
+                isDense: true,
+              ),
+              onChanged: _saveOsmTileUrl,
+            ),
           ),
 
           const Divider(height: 32),

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -7,6 +7,7 @@ import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:webspace/services/webview.dart';
+import 'package:webspace/settings/location.dart';
 import 'package:webspace/widgets/find_toolbar.dart';
 import 'package:webspace/widgets/url_bar.dart';
 
@@ -21,6 +22,12 @@ class InAppWebViewScreen extends StatefulWidget {
   final bool contentBlockEnabled;
   final String? language;
   final bool showUrlBar;
+  final LocationMode locationMode;
+  final double? spoofLatitude;
+  final double? spoofLongitude;
+  final double spoofAccuracy;
+  final String? spoofTimezone;
+  final WebRtcPolicy webRtcPolicy;
 
   InAppWebViewScreen({
     required this.url,
@@ -33,6 +40,12 @@ class InAppWebViewScreen extends StatefulWidget {
     required this.contentBlockEnabled,
     required this.language,
     this.showUrlBar = false,
+    this.locationMode = LocationMode.off,
+    this.spoofLatitude,
+    this.spoofLongitude,
+    this.spoofAccuracy = 50.0,
+    this.spoofTimezone,
+    this.webRtcPolicy = WebRtcPolicy.defaultPolicy,
   });
 
   @override
@@ -265,6 +278,12 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen> {
                 dnsBlockEnabled: widget.dnsBlockEnabled,
                 contentBlockEnabled: widget.contentBlockEnabled,
                 language: widget.language,
+                locationMode: widget.locationMode,
+                spoofLatitude: widget.spoofLatitude,
+                spoofLongitude: widget.spoofLongitude,
+                spoofAccuracy: widget.spoofAccuracy,
+                spoofTimezone: widget.spoofTimezone,
+                webRtcPolicy: widget.webRtcPolicy,
                 pullToRefreshController: _pullToRefreshController,
                 onUrlChanged: (url) {
                   setState(() {

--- a/lib/screens/location_picker.dart
+++ b/lib/screens/location_picker.dart
@@ -1,20 +1,21 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_map/flutter_map.dart';
-import 'package:latlong2/latlong.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher/url_launcher.dart' as launcher;
+
+import 'package:webspace/settings/location.dart';
 
 /// Full-screen picker for [LocationPickerResult] (lat/lng + accuracy).
 ///
-/// Two states:
-/// - **Placeholder** (default): manual lat/lng/accuracy text fields plus a
-///   "Load map" button. No network requests are made — [flutter_map] is not
-///   mounted until the user explicitly opts in. This is the privacy-default
-///   for a browser that tries to avoid leaking user intent to third parties.
-/// - **Map mounted**: after "Load map" is tapped, the map fetches tiles from
-///   the URL configured in the `osmTileUrl` global pref (default OSM). Tap
-///   anywhere on the map to move the pin, which in turn updates the text
-///   fields. The text fields remain editable and keep the pin in sync.
+/// Privacy-first design — there is NO embedded map. Typing or choosing a
+/// preset city makes zero network requests. If the user needs to visually
+/// pick a coordinate they can tap "Open in OpenStreetMap" which hands off
+/// to the platform browser via `url_launcher`, and they paste the result
+/// back in. Keeping the map out-of-process means the webspace app itself
+/// never calls a tile server and never leaks the user's IP or inspection
+/// target to OSM from inside our webview/network stack.
+///
+/// The tile URL in the "Open in…" button is derived from the `osmTileUrl`
+/// global pref so self-hosters can point it at their own provider.
 class LocationPickerScreen extends StatefulWidget {
   final double? initialLatitude;
   final double? initialLongitude;
@@ -43,14 +44,43 @@ class LocationPickerResult {
   });
 }
 
+/// Popular cities for one-tap selection. Intentionally short — the point is
+/// quick access to recognizable anchors, not a gazetteer.
+const List<_PresetCity> _presetCities = [
+  _PresetCity('Tokyo', 35.6762, 139.6503),
+  _PresetCity('London', 51.5074, -0.1278),
+  _PresetCity('New York', 40.7128, -74.0060),
+  _PresetCity('Paris', 48.8566, 2.3522),
+  _PresetCity('Berlin', 52.5200, 13.4050),
+  _PresetCity('Los Angeles', 34.0522, -118.2437),
+  _PresetCity('Sydney', -33.8688, 151.2093),
+  _PresetCity('São Paulo', -23.5505, -46.6333),
+  _PresetCity('Moscow', 55.7558, 37.6173),
+  _PresetCity('Dubai', 25.2048, 55.2708),
+  _PresetCity('Singapore', 1.3521, 103.8198),
+  _PresetCity('Hong Kong', 22.3193, 114.1694),
+  _PresetCity('Seoul', 37.5665, 126.9780),
+  _PresetCity('Mumbai', 19.0760, 72.8777),
+  _PresetCity('Mexico City', 19.4326, -99.1332),
+  _PresetCity('Cairo', 30.0444, 31.2357),
+  _PresetCity('Istanbul', 41.0082, 28.9784),
+  _PresetCity('Toronto', 43.6532, -79.3832),
+  _PresetCity('Amsterdam', 52.3676, 4.9041),
+  _PresetCity('Reykjavík', 64.1466, -21.9426),
+];
+
+class _PresetCity {
+  final String name;
+  final double lat;
+  final double lng;
+  const _PresetCity(this.name, this.lat, this.lng);
+}
+
 class _LocationPickerScreenState extends State<LocationPickerScreen> {
   late TextEditingController _latController;
   late TextEditingController _lngController;
   late TextEditingController _accController;
-
-  bool _mapLoaded = false;
   String _tileUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
-  final MapController _mapController = MapController();
 
   @override
   void initState() {
@@ -82,32 +112,18 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
     super.dispose();
   }
 
-  LatLng? _currentLatLng() {
+  bool _coordsValid() {
     final lat = double.tryParse(_latController.text.trim());
     final lng = double.tryParse(_lngController.text.trim());
-    if (lat == null || lng == null) return null;
-    if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return null;
-    return LatLng(lat, lng);
+    if (lat == null || lng == null) return false;
+    return lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180;
   }
 
-  void _setPin(LatLng p) {
+  void _applyPreset(_PresetCity city) {
     setState(() {
-      _latController.text = p.latitude.toStringAsFixed(6);
-      _lngController.text = p.longitude.toStringAsFixed(6);
+      _latController.text = city.lat.toString();
+      _lngController.text = city.lng.toString();
     });
-  }
-
-  void _onCoordTyped(String _) {
-    setState(() {});
-    if (_mapLoaded) {
-      final p = _currentLatLng();
-      if (p == null) return;
-      try {
-        _mapController.move(p, _mapController.camera.zoom);
-      } catch (_) {
-        // Camera not attached yet — ignore; marker still rebuilds from state.
-      }
-    }
   }
 
   String _hostOfTileUrl() {
@@ -123,6 +139,18 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
     }
   }
 
+  Future<void> _openExternalMap() async {
+    // Seed the external map at the currently typed coords if valid,
+    // otherwise at the world view.
+    final lat = double.tryParse(_latController.text.trim()) ?? 0.0;
+    final lng = double.tryParse(_lngController.text.trim()) ?? 0.0;
+    final zoom = _coordsValid() ? 10 : 2;
+    final url = Uri.parse(
+      'https://www.openstreetmap.org/?mlat=$lat&mlon=$lng#map=$zoom/$lat/$lng',
+    );
+    await launcher.launchUrl(url, mode: launcher.LaunchMode.externalApplication);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -131,8 +159,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
         actions: [
           TextButton(
             onPressed: () {
-              final p = _currentLatLng();
-              if (p == null) {
+              if (!_coordsValid()) {
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(content: Text('Enter valid coordinates first')),
                 );
@@ -142,8 +169,8 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
               Navigator.pop(
                 context,
                 LocationPickerResult(
-                  latitude: p.latitude,
-                  longitude: p.longitude,
+                  latitude: double.parse(_latController.text.trim()),
+                  longitude: double.parse(_lngController.text.trim()),
                   accuracy: acc > 0 ? acc : 50.0,
                 ),
               );
@@ -152,21 +179,8 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
           ),
         ],
       ),
-      body: Column(
-        children: [
-          _buildCoordinateInputs(),
-          Expanded(
-            child: _mapLoaded ? _buildMap() : _buildPlaceholder(),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildCoordinateInputs() {
-    return Padding(
-      padding: const EdgeInsets.all(12.0),
-      child: Column(
+      body: ListView(
+        padding: const EdgeInsets.all(16),
         children: [
           Row(
             children: [
@@ -180,7 +194,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
                     border: OutlineInputBorder(),
                     isDense: true,
                   ),
-                  onChanged: _onCoordTyped,
+                  onChanged: (_) => setState(() {}),
                 ),
               ),
               const SizedBox(width: 8),
@@ -194,122 +208,55 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
                     border: OutlineInputBorder(),
                     isDense: true,
                   ),
-                  onChanged: _onCoordTyped,
+                  onChanged: (_) => setState(() {}),
                 ),
               ),
             ],
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: 12),
           TextFormField(
             controller: _accController,
-            keyboardType:
-                const TextInputType.numberWithOptions(decimal: true),
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
             decoration: const InputDecoration(
               labelText: 'Accuracy (meters)',
               border: OutlineInputBorder(),
               isDense: true,
             ),
           ),
+          const SizedBox(height: 24),
+          Text('Preset cities',
+              style: Theme.of(context).textTheme.labelLarge),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: _presetCities
+                .map((c) => ActionChip(
+                      label: Text(c.name),
+                      onPressed: () => _applyPreset(c),
+                    ))
+                .toList(),
+          ),
+          const SizedBox(height: 24),
+          Text('Pick visually',
+              style: Theme.of(context).textTheme.labelLarge),
+          const SizedBox(height: 8),
+          Text(
+            'Opens ${_hostOfTileUrl()} in your device browser — no requests '
+            'are made from inside WebSpace. Copy coordinates back into the '
+            'fields above when you have a spot.',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 8),
+          OutlinedButton.icon(
+            icon: const Icon(Icons.open_in_new),
+            label: const Text('Open in OpenStreetMap'),
+            onPressed: _openExternalMap,
+          ),
         ],
       ),
-    );
-  }
-
-  Widget _buildPlaceholder() {
-    return Padding(
-      padding: const EdgeInsets.all(16.0),
-      child: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(Icons.map_outlined,
-                size: 64,
-                color: Theme.of(context).colorScheme.onSurfaceVariant),
-            const SizedBox(height: 16),
-            const Text(
-              'Map is not loaded.',
-              style: TextStyle(fontWeight: FontWeight.w600),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Loading the map will fetch tiles from ${_hostOfTileUrl()}, '
-              'revealing the area you view to the tile server. '
-              'You can also just type coordinates above and tap Done.',
-              textAlign: TextAlign.center,
-              style: TextStyle(
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
-              ),
-            ),
-            const SizedBox(height: 20),
-            FilledButton.icon(
-              icon: const Icon(Icons.download_outlined),
-              label: const Text('Load map'),
-              onPressed: () => setState(() => _mapLoaded = true),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Change provider in App Settings → Location picker',
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildMap() {
-    final initial = _currentLatLng() ?? const LatLng(0, 0);
-    final initialZoom = _currentLatLng() == null ? 2.0 : 10.0;
-    return Stack(
-      children: [
-        FlutterMap(
-          mapController: _mapController,
-          options: MapOptions(
-            initialCenter: initial,
-            initialZoom: initialZoom,
-            onTap: (_, p) => _setPin(p),
-          ),
-          children: [
-            TileLayer(
-              urlTemplate: _tileUrl,
-              userAgentPackageName: 'com.webspace.app',
-              maxZoom: 19,
-            ),
-            if (_currentLatLng() != null)
-              MarkerLayer(
-                markers: [
-                  Marker(
-                    point: _currentLatLng()!,
-                    width: 40,
-                    height: 40,
-                    child: Icon(
-                      Icons.location_pin,
-                      color: Theme.of(context).colorScheme.error,
-                      size: 40,
-                    ),
-                  ),
-                ],
-              ),
-          ],
-        ),
-        Positioned(
-          bottom: 4,
-          right: 4,
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-            color: Colors.white.withValues(alpha: 0.75),
-            child: GestureDetector(
-              onTap: () =>
-                  launchUrl(Uri.parse('https://www.openstreetmap.org/copyright')),
-              child: const Text(
-                '© OpenStreetMap contributors',
-                style: TextStyle(fontSize: 10, color: Colors.black87),
-              ),
-            ),
-          ),
-        ),
-      ],
     );
   }
 }

--- a/lib/screens/location_picker.dart
+++ b/lib/screens/location_picker.dart
@@ -1,21 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:url_launcher/url_launcher.dart' as launcher;
-
-import 'package:webspace/settings/location.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 /// Full-screen picker for [LocationPickerResult] (lat/lng + accuracy).
 ///
-/// Privacy-first design — there is NO embedded map. Typing or choosing a
-/// preset city makes zero network requests. If the user needs to visually
-/// pick a coordinate they can tap "Open in OpenStreetMap" which hands off
-/// to the platform browser via `url_launcher`, and they paste the result
-/// back in. Keeping the map out-of-process means the webspace app itself
-/// never calls a tile server and never leaks the user's IP or inspection
-/// target to OSM from inside our webview/network stack.
-///
-/// The tile URL in the "Open in…" button is derived from the `osmTileUrl`
-/// global pref so self-hosters can point it at their own provider.
+/// Two states:
+/// - **Placeholder** (default): manual lat/lng/accuracy text fields plus a
+///   "Load map" button. No network requests are made — [flutter_map] is not
+///   mounted until the user explicitly opts in. This is the privacy-default
+///   for a browser that tries to avoid leaking user intent to third parties.
+/// - **Map mounted**: after "Load map" is tapped, the map fetches tiles from
+///   the URL configured in the `osmTileUrl` global pref (default OSM). Tap
+///   anywhere on the map to move the pin, which in turn updates the text
+///   fields. The text fields remain editable and keep the pin in sync.
 class LocationPickerScreen extends StatefulWidget {
   final double? initialLatitude;
   final double? initialLongitude;
@@ -44,43 +43,14 @@ class LocationPickerResult {
   });
 }
 
-/// Popular cities for one-tap selection. Intentionally short — the point is
-/// quick access to recognizable anchors, not a gazetteer.
-const List<_PresetCity> _presetCities = [
-  _PresetCity('Tokyo', 35.6762, 139.6503),
-  _PresetCity('London', 51.5074, -0.1278),
-  _PresetCity('New York', 40.7128, -74.0060),
-  _PresetCity('Paris', 48.8566, 2.3522),
-  _PresetCity('Berlin', 52.5200, 13.4050),
-  _PresetCity('Los Angeles', 34.0522, -118.2437),
-  _PresetCity('Sydney', -33.8688, 151.2093),
-  _PresetCity('São Paulo', -23.5505, -46.6333),
-  _PresetCity('Moscow', 55.7558, 37.6173),
-  _PresetCity('Dubai', 25.2048, 55.2708),
-  _PresetCity('Singapore', 1.3521, 103.8198),
-  _PresetCity('Hong Kong', 22.3193, 114.1694),
-  _PresetCity('Seoul', 37.5665, 126.9780),
-  _PresetCity('Mumbai', 19.0760, 72.8777),
-  _PresetCity('Mexico City', 19.4326, -99.1332),
-  _PresetCity('Cairo', 30.0444, 31.2357),
-  _PresetCity('Istanbul', 41.0082, 28.9784),
-  _PresetCity('Toronto', 43.6532, -79.3832),
-  _PresetCity('Amsterdam', 52.3676, 4.9041),
-  _PresetCity('Reykjavík', 64.1466, -21.9426),
-];
-
-class _PresetCity {
-  final String name;
-  final double lat;
-  final double lng;
-  const _PresetCity(this.name, this.lat, this.lng);
-}
-
 class _LocationPickerScreenState extends State<LocationPickerScreen> {
   late TextEditingController _latController;
   late TextEditingController _lngController;
   late TextEditingController _accController;
+
+  bool _mapLoaded = false;
   String _tileUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+  final MapController _mapController = MapController();
 
   @override
   void initState() {
@@ -112,18 +82,32 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
     super.dispose();
   }
 
-  bool _coordsValid() {
+  LatLng? _currentLatLng() {
     final lat = double.tryParse(_latController.text.trim());
     final lng = double.tryParse(_lngController.text.trim());
-    if (lat == null || lng == null) return false;
-    return lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180;
+    if (lat == null || lng == null) return null;
+    if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return null;
+    return LatLng(lat, lng);
   }
 
-  void _applyPreset(_PresetCity city) {
+  void _setPin(LatLng p) {
     setState(() {
-      _latController.text = city.lat.toString();
-      _lngController.text = city.lng.toString();
+      _latController.text = p.latitude.toStringAsFixed(6);
+      _lngController.text = p.longitude.toStringAsFixed(6);
     });
+  }
+
+  void _onCoordTyped(String _) {
+    setState(() {});
+    if (_mapLoaded) {
+      final p = _currentLatLng();
+      if (p == null) return;
+      try {
+        _mapController.move(p, _mapController.camera.zoom);
+      } catch (_) {
+        // Camera not attached yet — ignore; marker still rebuilds from state.
+      }
+    }
   }
 
   String _hostOfTileUrl() {
@@ -139,18 +123,6 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
     }
   }
 
-  Future<void> _openExternalMap() async {
-    // Seed the external map at the currently typed coords if valid,
-    // otherwise at the world view.
-    final lat = double.tryParse(_latController.text.trim()) ?? 0.0;
-    final lng = double.tryParse(_lngController.text.trim()) ?? 0.0;
-    final zoom = _coordsValid() ? 10 : 2;
-    final url = Uri.parse(
-      'https://www.openstreetmap.org/?mlat=$lat&mlon=$lng#map=$zoom/$lat/$lng',
-    );
-    await launcher.launchUrl(url, mode: launcher.LaunchMode.externalApplication);
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -159,7 +131,8 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
         actions: [
           TextButton(
             onPressed: () {
-              if (!_coordsValid()) {
+              final p = _currentLatLng();
+              if (p == null) {
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(content: Text('Enter valid coordinates first')),
                 );
@@ -169,8 +142,8 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
               Navigator.pop(
                 context,
                 LocationPickerResult(
-                  latitude: double.parse(_latController.text.trim()),
-                  longitude: double.parse(_lngController.text.trim()),
+                  latitude: p.latitude,
+                  longitude: p.longitude,
                   accuracy: acc > 0 ? acc : 50.0,
                 ),
               );
@@ -179,8 +152,21 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
           ),
         ],
       ),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
+      body: Column(
+        children: [
+          _buildCoordinateInputs(),
+          Expanded(
+            child: _mapLoaded ? _buildMap() : _buildPlaceholder(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCoordinateInputs() {
+    return Padding(
+      padding: const EdgeInsets.all(12.0),
+      child: Column(
         children: [
           Row(
             children: [
@@ -194,7 +180,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
                     border: OutlineInputBorder(),
                     isDense: true,
                   ),
-                  onChanged: (_) => setState(() {}),
+                  onChanged: _onCoordTyped,
                 ),
               ),
               const SizedBox(width: 8),
@@ -208,55 +194,122 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
                     border: OutlineInputBorder(),
                     isDense: true,
                   ),
-                  onChanged: (_) => setState(() {}),
+                  onChanged: _onCoordTyped,
                 ),
               ),
             ],
           ),
-          const SizedBox(height: 12),
+          const SizedBox(height: 8),
           TextFormField(
             controller: _accController,
-            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            keyboardType:
+                const TextInputType.numberWithOptions(decimal: true),
             decoration: const InputDecoration(
               labelText: 'Accuracy (meters)',
               border: OutlineInputBorder(),
               isDense: true,
             ),
           ),
-          const SizedBox(height: 24),
-          Text('Preset cities',
-              style: Theme.of(context).textTheme.labelLarge),
-          const SizedBox(height: 8),
-          Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            children: _presetCities
-                .map((c) => ActionChip(
-                      label: Text(c.name),
-                      onPressed: () => _applyPreset(c),
-                    ))
-                .toList(),
-          ),
-          const SizedBox(height: 24),
-          Text('Pick visually',
-              style: Theme.of(context).textTheme.labelLarge),
-          const SizedBox(height: 8),
-          Text(
-            'Opens ${_hostOfTileUrl()} in your device browser — no requests '
-            'are made from inside WebSpace. Copy coordinates back into the '
-            'fields above when you have a spot.',
-            style: TextStyle(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
-          ),
-          const SizedBox(height: 8),
-          OutlinedButton.icon(
-            icon: const Icon(Icons.open_in_new),
-            label: const Text('Open in OpenStreetMap'),
-            onPressed: _openExternalMap,
-          ),
         ],
       ),
+    );
+  }
+
+  Widget _buildPlaceholder() {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.map_outlined,
+                size: 64,
+                color: Theme.of(context).colorScheme.onSurfaceVariant),
+            const SizedBox(height: 16),
+            const Text(
+              'Map is not loaded.',
+              style: TextStyle(fontWeight: FontWeight.w600),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Loading the map will fetch tiles from ${_hostOfTileUrl()}, '
+              'revealing the area you view to the tile server. '
+              'You can also just type coordinates above and tap Done.',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 20),
+            FilledButton.icon(
+              icon: const Icon(Icons.download_outlined),
+              label: const Text('Load map'),
+              onPressed: () => setState(() => _mapLoaded = true),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Change provider in App Settings → Location picker',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMap() {
+    final initial = _currentLatLng() ?? const LatLng(0, 0);
+    final initialZoom = _currentLatLng() == null ? 2.0 : 10.0;
+    return Stack(
+      children: [
+        FlutterMap(
+          mapController: _mapController,
+          options: MapOptions(
+            initialCenter: initial,
+            initialZoom: initialZoom,
+            onTap: (_, p) => _setPin(p),
+          ),
+          children: [
+            TileLayer(
+              urlTemplate: _tileUrl,
+              userAgentPackageName: 'com.webspace.app',
+              maxZoom: 19,
+            ),
+            if (_currentLatLng() != null)
+              MarkerLayer(
+                markers: [
+                  Marker(
+                    point: _currentLatLng()!,
+                    width: 40,
+                    height: 40,
+                    child: Icon(
+                      Icons.location_pin,
+                      color: Theme.of(context).colorScheme.error,
+                      size: 40,
+                    ),
+                  ),
+                ],
+              ),
+          ],
+        ),
+        Positioned(
+          bottom: 4,
+          right: 4,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            color: Colors.white.withValues(alpha: 0.75),
+            child: GestureDetector(
+              onTap: () =>
+                  launchUrl(Uri.parse('https://www.openstreetmap.org/copyright')),
+              child: const Text(
+                '© OpenStreetMap contributors',
+                style: TextStyle(fontSize: 10, color: Colors.black87),
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/location_picker.dart
+++ b/lib/screens/location_picker.dart
@@ -1,0 +1,315 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Full-screen picker for [LocationPickerResult] (lat/lng + accuracy).
+///
+/// Two states:
+/// - **Placeholder** (default): manual lat/lng/accuracy text fields plus a
+///   "Load map" button. No network requests are made — [flutter_map] is not
+///   mounted until the user explicitly opts in. This is the privacy-default
+///   for a browser that tries to avoid leaking user intent to third parties.
+/// - **Map mounted**: after "Load map" is tapped, the map fetches tiles from
+///   the URL configured in the `osmTileUrl` global pref (default OSM). Tap
+///   anywhere on the map to move the pin, which in turn updates the text
+///   fields. The text fields remain editable and keep the pin in sync.
+class LocationPickerScreen extends StatefulWidget {
+  final double? initialLatitude;
+  final double? initialLongitude;
+  final double initialAccuracy;
+
+  const LocationPickerScreen({
+    super.key,
+    this.initialLatitude,
+    this.initialLongitude,
+    this.initialAccuracy = 50.0,
+  });
+
+  @override
+  State<LocationPickerScreen> createState() => _LocationPickerScreenState();
+}
+
+class LocationPickerResult {
+  final double latitude;
+  final double longitude;
+  final double accuracy;
+
+  const LocationPickerResult({
+    required this.latitude,
+    required this.longitude,
+    required this.accuracy,
+  });
+}
+
+class _LocationPickerScreenState extends State<LocationPickerScreen> {
+  late TextEditingController _latController;
+  late TextEditingController _lngController;
+  late TextEditingController _accController;
+
+  bool _mapLoaded = false;
+  String _tileUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+  final MapController _mapController = MapController();
+
+  @override
+  void initState() {
+    super.initState();
+    _latController = TextEditingController(
+      text: widget.initialLatitude?.toString() ?? '',
+    );
+    _lngController = TextEditingController(
+      text: widget.initialLongitude?.toString() ?? '',
+    );
+    _accController = TextEditingController(
+      text: widget.initialAccuracy.toString(),
+    );
+    _loadTileUrl();
+  }
+
+  Future<void> _loadTileUrl() async {
+    final prefs = await SharedPreferences.getInstance();
+    final url = prefs.getString('osmTileUrl') ?? _tileUrl;
+    if (!mounted) return;
+    setState(() => _tileUrl = url);
+  }
+
+  @override
+  void dispose() {
+    _latController.dispose();
+    _lngController.dispose();
+    _accController.dispose();
+    super.dispose();
+  }
+
+  LatLng? _currentLatLng() {
+    final lat = double.tryParse(_latController.text.trim());
+    final lng = double.tryParse(_lngController.text.trim());
+    if (lat == null || lng == null) return null;
+    if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return null;
+    return LatLng(lat, lng);
+  }
+
+  void _setPin(LatLng p) {
+    setState(() {
+      _latController.text = p.latitude.toStringAsFixed(6);
+      _lngController.text = p.longitude.toStringAsFixed(6);
+    });
+  }
+
+  void _onCoordTyped(String _) {
+    setState(() {});
+    if (_mapLoaded) {
+      final p = _currentLatLng();
+      if (p == null) return;
+      try {
+        _mapController.move(p, _mapController.camera.zoom);
+      } catch (_) {
+        // Camera not attached yet — ignore; marker still rebuilds from state.
+      }
+    }
+  }
+
+  String _hostOfTileUrl() {
+    try {
+      final clean = _tileUrl
+          .replaceAll('{z}', '0')
+          .replaceAll('{x}', '0')
+          .replaceAll('{y}', '0')
+          .replaceAll('{s}', 'a');
+      return Uri.parse(clean).host;
+    } catch (_) {
+      return _tileUrl;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Pick location'),
+        actions: [
+          TextButton(
+            onPressed: () {
+              final p = _currentLatLng();
+              if (p == null) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Enter valid coordinates first')),
+                );
+                return;
+              }
+              final acc = double.tryParse(_accController.text.trim()) ?? 50.0;
+              Navigator.pop(
+                context,
+                LocationPickerResult(
+                  latitude: p.latitude,
+                  longitude: p.longitude,
+                  accuracy: acc > 0 ? acc : 50.0,
+                ),
+              );
+            },
+            child: const Text('Done'),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          _buildCoordinateInputs(),
+          Expanded(
+            child: _mapLoaded ? _buildMap() : _buildPlaceholder(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCoordinateInputs() {
+    return Padding(
+      padding: const EdgeInsets.all(12.0),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: TextFormField(
+                  controller: _latController,
+                  keyboardType: const TextInputType.numberWithOptions(
+                      signed: true, decimal: true),
+                  decoration: const InputDecoration(
+                    labelText: 'Latitude',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                  onChanged: _onCoordTyped,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: TextFormField(
+                  controller: _lngController,
+                  keyboardType: const TextInputType.numberWithOptions(
+                      signed: true, decimal: true),
+                  decoration: const InputDecoration(
+                    labelText: 'Longitude',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                  onChanged: _onCoordTyped,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          TextFormField(
+            controller: _accController,
+            keyboardType:
+                const TextInputType.numberWithOptions(decimal: true),
+            decoration: const InputDecoration(
+              labelText: 'Accuracy (meters)',
+              border: OutlineInputBorder(),
+              isDense: true,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPlaceholder() {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.map_outlined,
+                size: 64,
+                color: Theme.of(context).colorScheme.onSurfaceVariant),
+            const SizedBox(height: 16),
+            const Text(
+              'Map is not loaded.',
+              style: TextStyle(fontWeight: FontWeight.w600),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Loading the map will fetch tiles from ${_hostOfTileUrl()}, '
+              'revealing the area you view to the tile server. '
+              'You can also just type coordinates above and tap Done.',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 20),
+            FilledButton.icon(
+              icon: const Icon(Icons.download_outlined),
+              label: const Text('Load map'),
+              onPressed: () => setState(() => _mapLoaded = true),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Change provider in App Settings → Location picker',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMap() {
+    final initial = _currentLatLng() ?? const LatLng(0, 0);
+    final initialZoom = _currentLatLng() == null ? 2.0 : 10.0;
+    return Stack(
+      children: [
+        FlutterMap(
+          mapController: _mapController,
+          options: MapOptions(
+            initialCenter: initial,
+            initialZoom: initialZoom,
+            onTap: (_, p) => _setPin(p),
+          ),
+          children: [
+            TileLayer(
+              urlTemplate: _tileUrl,
+              userAgentPackageName: 'com.webspace.app',
+              maxZoom: 19,
+            ),
+            if (_currentLatLng() != null)
+              MarkerLayer(
+                markers: [
+                  Marker(
+                    point: _currentLatLng()!,
+                    width: 40,
+                    height: 40,
+                    child: Icon(
+                      Icons.location_pin,
+                      color: Theme.of(context).colorScheme.error,
+                      size: 40,
+                    ),
+                  ),
+                ],
+              ),
+          ],
+        ),
+        Positioned(
+          bottom: 4,
+          right: 4,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            color: Colors.white.withValues(alpha: 0.75),
+            child: GestureDetector(
+              onTap: () =>
+                  launchUrl(Uri.parse('https://www.openstreetmap.org/copyright')),
+              child: const Text(
+                '© OpenStreetMap contributors',
+                style: TextStyle(fontSize: 10, color: Colors.black87),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -10,6 +10,7 @@ import 'package:webspace/services/webview.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/services/localcdn_service.dart';
+import 'package:webspace/screens/location_picker.dart';
 import 'package:webspace/screens/user_scripts.dart';
 import 'package:webspace/settings/user_script.dart';
 import 'package:webspace/widgets/hint_button.dart';
@@ -375,6 +376,25 @@ class _SettingsScreenState extends State<SettingsScreen> {
     }
   }
 
+  Future<void> _openLocationPicker() async {
+    final result = await Navigator.push<LocationPickerResult>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => LocationPickerScreen(
+          initialLatitude: double.tryParse(_latitudeController.text.trim()),
+          initialLongitude: double.tryParse(_longitudeController.text.trim()),
+          initialAccuracy: double.tryParse(_accuracyController.text.trim()) ?? 50.0,
+        ),
+      ),
+    );
+    if (result == null || !mounted) return;
+    setState(() {
+      _latitudeController.text = result.latitude.toStringAsFixed(6);
+      _longitudeController.text = result.longitude.toStringAsFixed(6);
+      _accuracyController.text = result.accuracy.toString();
+    });
+  }
+
   List<Widget> _buildLocationSection() {
     return [
       const Padding(
@@ -455,6 +475,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
               hintText: '50',
               border: OutlineInputBorder(),
             ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
+          child: OutlinedButton.icon(
+            icon: const Icon(Icons.map_outlined),
+            label: const Text('Pick on map'),
+            onPressed: _openLocationPicker,
           ),
         ),
       ],

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 
 import 'package:webspace/web_view_model.dart';
+import 'package:webspace/settings/location.dart';
 import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/services/content_blocker_service.dart';
@@ -116,6 +117,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
   String? _selectedLanguage;
   bool _obscureProxyPassword = true;
   bool _showProxyCredentials = false;
+  late LocationMode _locationMode;
+  late TextEditingController _latitudeController;
+  late TextEditingController _longitudeController;
+  late TextEditingController _accuracyController;
+  String? _spoofTimezone;
+  late WebRtcPolicy _webRtcPolicy;
 
   String getResetUserAgent() {
     return (widget.webViewModel.userAgent == '') ? (widget.webViewModel.defaultUserAgent ?? '') : widget.webViewModel.userAgent;
@@ -162,6 +169,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _fullscreenMode = widget.webViewModel.fullscreenMode;
     _desktopMode = widget.webViewModel.desktopMode;
     _selectedLanguage = widget.webViewModel.language;
+    _locationMode = widget.webViewModel.locationMode;
+    _latitudeController = TextEditingController(
+      text: widget.webViewModel.spoofLatitude?.toString() ?? '',
+    );
+    _longitudeController = TextEditingController(
+      text: widget.webViewModel.spoofLongitude?.toString() ?? '',
+    );
+    _accuracyController = TextEditingController(
+      text: widget.webViewModel.spoofAccuracy.toString(),
+    );
+    _spoofTimezone = widget.webViewModel.spoofTimezone;
+    _webRtcPolicy = widget.webViewModel.webRtcPolicy;
     // Show credentials section if credentials already exist
     _showProxyCredentials = _proxySettings.hasCredentials;
   }
@@ -172,6 +191,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _proxyAddressController.dispose();
     _proxyUsernameController.dispose();
     _proxyPasswordController.dispose();
+    _latitudeController.dispose();
+    _longitudeController.dispose();
+    _accuracyController.dispose();
     super.dispose();
   }
 
@@ -310,6 +332,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
       widget.webViewModel.fullscreenMode = _fullscreenMode;
       widget.webViewModel.desktopMode = _desktopMode;
       widget.webViewModel.language = _selectedLanguage;
+      widget.webViewModel.locationMode = _locationMode;
+      widget.webViewModel.spoofLatitude =
+          double.tryParse(_latitudeController.text.trim());
+      widget.webViewModel.spoofLongitude =
+          double.tryParse(_longitudeController.text.trim());
+      final accuracy = double.tryParse(_accuracyController.text.trim());
+      if (accuracy != null && accuracy > 0) {
+        widget.webViewModel.spoofAccuracy = accuracy;
+      }
+      widget.webViewModel.spoofTimezone = _spoofTimezone;
+      widget.webViewModel.webRtcPolicy = _webRtcPolicy;
 
       if (!mounted) return;
 
@@ -340,6 +373,143 @@ class _SettingsScreenState extends State<SettingsScreen> {
         SnackBar(content: Text('Error saving settings: $e')),
       );
     }
+  }
+
+  List<Widget> _buildLocationSection() {
+    return [
+      const Padding(
+        padding: EdgeInsets.fromLTRB(16, 16, 16, 0),
+        child: Text('Location & timezone',
+            style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+      ),
+      ListTile(
+        title: Row(
+          children: const [
+            Flexible(child: Text('Geolocation')),
+            HintButton(
+              title: 'Geolocation spoofing',
+              description:
+                  'Returns user-supplied coordinates from navigator.geolocation. '
+                  'The shim overrides Geolocation.prototype and hides the patch '
+                  'from Function.prototype.toString, so sites cannot trivially '
+                  'detect the spoof. For convincing results, also set a matching '
+                  'timezone and use a proxy in the same country — otherwise the '
+                  'site can cross-check via IP-based geolocation.',
+            ),
+          ],
+        ),
+        trailing: DropdownButton<LocationMode>(
+          value: _locationMode,
+          onChanged: (v) {
+            if (v != null) setState(() => _locationMode = v);
+          },
+          items: const [
+            DropdownMenuItem(
+                value: LocationMode.off, child: Text('Off (use real)')),
+            DropdownMenuItem(
+                value: LocationMode.spoof, child: Text('Spoof')),
+          ],
+        ),
+      ),
+      if (_locationMode == LocationMode.spoof) ...[
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
+          child: Row(
+            children: [
+              Expanded(
+                child: TextFormField(
+                  controller: _latitudeController,
+                  keyboardType: const TextInputType.numberWithOptions(
+                      signed: true, decimal: true),
+                  decoration: const InputDecoration(
+                    labelText: 'Latitude',
+                    hintText: 'e.g. 35.6762',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: TextFormField(
+                  controller: _longitudeController,
+                  keyboardType: const TextInputType.numberWithOptions(
+                      signed: true, decimal: true),
+                  decoration: const InputDecoration(
+                    labelText: 'Longitude',
+                    hintText: 'e.g. 139.6503',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
+          child: TextFormField(
+            controller: _accuracyController,
+            keyboardType:
+                const TextInputType.numberWithOptions(decimal: true),
+            decoration: const InputDecoration(
+              labelText: 'Accuracy (meters)',
+              hintText: '50',
+              border: OutlineInputBorder(),
+            ),
+          ),
+        ),
+      ],
+      Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+        child: DropdownButtonFormField<String?>(
+          value: commonTimezones.any((e) => e.key == _spoofTimezone)
+              ? _spoofTimezone
+              : null,
+          decoration: const InputDecoration(
+            labelText: 'Timezone',
+            helperText: 'Overrides Intl.DateTimeFormat and Date getters',
+            border: OutlineInputBorder(),
+          ),
+          items: commonTimezones
+              .map((e) => DropdownMenuItem<String?>(
+                    value: e.key,
+                    child: Text(e.value),
+                  ))
+              .toList(),
+          onChanged: (v) => setState(() => _spoofTimezone = v),
+        ),
+      ),
+      ListTile(
+        title: Row(
+          children: const [
+            Flexible(child: Text('WebRTC policy')),
+            HintButton(
+              title: 'WebRTC leak protection',
+              description:
+                  'HTTP(S) and SOCKS5 proxies only carry TCP. WebRTC uses UDP '
+                  'and leaks your real IP around the proxy. '
+                  '"Relay only" forces iceTransportPolicy=relay and strips '
+                  'non-relay ICE candidates; video calls that rely on direct '
+                  'peer-to-peer connections will break. '
+                  '"Disabled" blocks RTCPeerConnection entirely.',
+            ),
+          ],
+        ),
+        trailing: DropdownButton<WebRtcPolicy>(
+          value: _webRtcPolicy,
+          onChanged: (v) {
+            if (v != null) setState(() => _webRtcPolicy = v);
+          },
+          items: const [
+            DropdownMenuItem(
+                value: WebRtcPolicy.defaultPolicy, child: Text('Default')),
+            DropdownMenuItem(
+                value: WebRtcPolicy.relayOnly, child: Text('Relay only')),
+            DropdownMenuItem(
+                value: WebRtcPolicy.disabled, child: Text('Disabled')),
+          ],
+        ),
+      ),
+    ];
   }
 
   @override
@@ -733,6 +903,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 });
               },
             ),
+          ..._buildLocationSection(),
           if (widget.onClearCookies != null)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),

--- a/lib/services/location_spoof_service.dart
+++ b/lib/services/location_spoof_service.dart
@@ -1,0 +1,311 @@
+import 'dart:convert';
+
+import 'package:webspace/settings/location.dart';
+
+/// Builds a JavaScript shim injected at DOCUMENT_START that:
+/// - spoofs [navigator.geolocation] with user-supplied coordinates,
+/// - overrides [Intl.DateTimeFormat] + [Date.prototype.getTimezoneOffset]
+///   + [Date.prototype.toString] to report a chosen IANA timezone, and
+/// - applies a WebRTC policy (relay-only or disabled) to prevent the
+///   real-IP leak that bypasses HTTP(S)/SOCKS proxies.
+///
+/// Detection hardening:
+/// - Overrides live on the class prototype (Geolocation, RTCPeerConnection)
+///   so sites cannot grab the unpatched method via
+///   `Geolocation.prototype.getCurrentPosition`.
+/// - `Function.prototype.toString` is patched once, keyed by a [WeakMap],
+///   so overridden methods still report `"function name() { [native code] }"`
+///   when stringified. The toString override itself reports native too.
+/// - Spoofed [GeolocationPosition] / [GeolocationCoordinates] are created
+///   with the real class prototypes so `position instanceof
+///   GeolocationPosition` holds.
+/// - Coordinates are jittered per-call (~2m) so [watchPosition] does not
+///   return byte-identical frames.
+class LocationSpoofService {
+  /// Build the shim. Returns null when the site has every spoof feature off.
+  static String? buildScript({
+    required LocationMode locationMode,
+    required double? spoofLatitude,
+    required double? spoofLongitude,
+    required double spoofAccuracy,
+    required String? spoofTimezone,
+    required WebRtcPolicy webRtcPolicy,
+  }) {
+    final spoofLocation = locationMode == LocationMode.spoof &&
+        spoofLatitude != null &&
+        spoofLongitude != null;
+    final hasTimezone = spoofTimezone != null && spoofTimezone.isNotEmpty;
+    final hasWebRtc = webRtcPolicy != WebRtcPolicy.defaultPolicy;
+
+    if (!spoofLocation && !hasTimezone && !hasWebRtc) return null;
+
+    final lat = spoofLatitude ?? 0.0;
+    final lng = spoofLongitude ?? 0.0;
+    final acc = spoofAccuracy > 0 ? spoofAccuracy : 50.0;
+    final tzJson = hasTimezone ? jsonEncode(spoofTimezone) : 'null';
+    final wrtcJson = switch (webRtcPolicy) {
+      WebRtcPolicy.relayOnly => '"relay"',
+      WebRtcPolicy.disabled => '"off"',
+      WebRtcPolicy.defaultPolicy => '"default"',
+    };
+
+    return _template
+        .replaceAll('__SPOOF_LOC__', spoofLocation ? 'true' : 'false')
+        .replaceAll('__LAT__', lat.toString())
+        .replaceAll('__LNG__', lng.toString())
+        .replaceAll('__ACC__', acc.toString())
+        .replaceAll('__TZ__', tzJson)
+        .replaceAll('__WRTC__', wrtcJson);
+  }
+}
+
+const String _template = r'''
+(function() {
+  if (window.__wsLocShimInstalled) return;
+  window.__wsLocShimInstalled = true;
+
+  var SPOOF_LOC = __SPOOF_LOC__;
+  var LAT = __LAT__;
+  var LNG = __LNG__;
+  var ACC = __ACC__;
+  var TZ = __TZ__;
+  var WRTC = __WRTC__;
+
+  // --- Function.prototype.toString hardening ---
+  // Keyed by WeakMap so overridden functions stringify as native. Patched
+  // exactly once — subsequent reloads via evaluateJavascript are no-ops.
+  var _origFnToString = Function.prototype.toString;
+  var _stubs = window.__wsFnStubs || new WeakMap();
+  window.__wsFnStubs = _stubs;
+  function asNative(fn, name) {
+    _stubs.set(fn, 'function ' + name + '() { [native code] }');
+    return fn;
+  }
+  if (!window.__wsFnToStringPatched) {
+    window.__wsFnToStringPatched = true;
+    var patched = function toString() {
+      var stub = _stubs.get(this);
+      return stub !== undefined ? stub : _origFnToString.call(this);
+    };
+    _stubs.set(patched, 'function toString() { [native code] }');
+    try {
+      Function.prototype.toString = patched;
+    } catch (e) {}
+  }
+
+  // --- Geolocation spoofing ---
+  if (SPOOF_LOC && navigator.geolocation) {
+    var _coordsProto = (typeof GeolocationCoordinates !== 'undefined')
+      ? GeolocationCoordinates.prototype : Object.prototype;
+    var _posProto = (typeof GeolocationPosition !== 'undefined')
+      ? GeolocationPosition.prototype : Object.prototype;
+
+    function makeCoords() {
+      // Sub-meter jitter so watchPosition doesn't return identical frames.
+      var jLat = (Math.random() - 0.5) * 0.00002;
+      var jLng = (Math.random() - 0.5) * 0.00002;
+      var c = Object.create(_coordsProto);
+      Object.defineProperties(c, {
+        latitude: { value: LAT + jLat, enumerable: true },
+        longitude: { value: LNG + jLng, enumerable: true },
+        accuracy: { value: ACC, enumerable: true },
+        altitude: { value: null, enumerable: true },
+        altitudeAccuracy: { value: null, enumerable: true },
+        heading: { value: null, enumerable: true },
+        speed: { value: null, enumerable: true },
+      });
+      return c;
+    }
+    function makePosition() {
+      var p = Object.create(_posProto);
+      Object.defineProperties(p, {
+        coords: { value: makeCoords(), enumerable: true },
+        timestamp: { value: Date.now(), enumerable: true },
+      });
+      return p;
+    }
+
+    var _latency = 150 + Math.random() * 250;
+    var _getCurrent = function getCurrentPosition(success, error, options) {
+      setTimeout(function() {
+        if (success) { try { success(makePosition()); } catch (e) {} }
+      }, _latency);
+    };
+    asNative(_getCurrent, 'getCurrentPosition');
+
+    var _watchId = 0;
+    var _watchTimers = {};
+    var _watch = function watchPosition(success, error, options) {
+      var id = ++_watchId;
+      setTimeout(function() {
+        if (success) { try { success(makePosition()); } catch (e) {} }
+      }, _latency);
+      _watchTimers[id] = setInterval(function() {
+        if (success) { try { success(makePosition()); } catch (e) {} }
+      }, 1000);
+      return id;
+    };
+    asNative(_watch, 'watchPosition');
+
+    var _clear = function clearWatch(id) {
+      var t = _watchTimers[id];
+      if (t) { clearInterval(t); delete _watchTimers[id]; }
+    };
+    asNative(_clear, 'clearWatch');
+
+    // Override on the prototype so `Geolocation.prototype.getCurrentPosition`
+    // is the patched version — sites cannot capture the unpatched reference.
+    if (typeof Geolocation !== 'undefined') {
+      try {
+        Object.defineProperty(Geolocation.prototype, 'getCurrentPosition',
+          { value: _getCurrent, configurable: true, writable: true });
+        Object.defineProperty(Geolocation.prototype, 'watchPosition',
+          { value: _watch, configurable: true, writable: true });
+        Object.defineProperty(Geolocation.prototype, 'clearWatch',
+          { value: _clear, configurable: true, writable: true });
+      } catch (e) {}
+    }
+
+    // Permissions API: geolocation should report 'granted' since
+    // getCurrentPosition resolves without prompting.
+    if (navigator.permissions && navigator.permissions.query) {
+      var _origQuery = navigator.permissions.query.bind(navigator.permissions);
+      var _query = function query(p) {
+        if (p && p.name === 'geolocation') {
+          var status = {};
+          Object.defineProperties(status, {
+            state: { value: 'granted', enumerable: true },
+            status: { value: 'granted', enumerable: true },
+            onchange: { value: null, writable: true, enumerable: true },
+          });
+          status.addEventListener = function() {};
+          status.removeEventListener = function() {};
+          status.dispatchEvent = function() { return true; };
+          return Promise.resolve(status);
+        }
+        return _origQuery(p);
+      };
+      asNative(_query, 'query');
+      try { navigator.permissions.query = _query; } catch (e) {}
+    }
+  }
+
+  // --- Timezone spoofing ---
+  if (TZ) {
+    var _nativeDTF = Intl.DateTimeFormat;
+
+    // Compute the target zone's UTC offset (minutes, sign flipped to match
+    // Date.prototype.getTimezoneOffset: positive when local is behind UTC)
+    // at the given Date instant. Respects DST by going through Intl.
+    function targetOffsetMinutes(date) {
+      var t = date.getTime();
+      if (isNaN(t)) return NaN;
+      try {
+        var parts = {};
+        new _nativeDTF('en-US', {
+          timeZone: TZ,
+          hourCycle: 'h23',
+          year: 'numeric', month: '2-digit', day: '2-digit',
+          hour: '2-digit', minute: '2-digit', second: '2-digit',
+        }).formatToParts(date).forEach(function(p) { parts[p.type] = p.value; });
+        var asUtc = Date.UTC(
+          +parts.year, +parts.month - 1, +parts.day,
+          +parts.hour, +parts.minute, +parts.second);
+        return -Math.round((asUtc - t) / 60000);
+      } catch (e) {
+        return date.getTimezoneOffset();
+      }
+    }
+
+    var _origGetTZO = Date.prototype.getTimezoneOffset;
+    var _getTZO = function getTimezoneOffset() {
+      return targetOffsetMinutes(this);
+    };
+    asNative(_getTZO, 'getTimezoneOffset');
+    try { Date.prototype.getTimezoneOffset = _getTZO; } catch (e) {}
+
+    // Date.prototype.toString: real-browser format is
+    //   "Tue Apr 21 2026 10:30:00 GMT+0900 (Japan Standard Time)"
+    // We rebuild it with the spoofed zone. Sites that regex the tz
+    // abbreviation or offset will see the spoofed values.
+    function pad2(n) { n = String(n); return n.length < 2 ? '0' + n : n; }
+    var _toString = function toString() {
+      var t = this.getTime();
+      if (isNaN(t)) return 'Invalid Date';
+      var parts = {};
+      try {
+        new _nativeDTF('en-US', {
+          timeZone: TZ, hourCycle: 'h23',
+          weekday: 'short', month: 'short', day: '2-digit', year: 'numeric',
+          hour: '2-digit', minute: '2-digit', second: '2-digit',
+          timeZoneName: 'long',
+        }).formatToParts(this).forEach(function(p) { parts[p.type] = p.value; });
+      } catch (e) {
+        try { return Date.prototype.toISOString.call(this); } catch (_) { return ''; }
+      }
+      var off = targetOffsetMinutes(this);
+      var sign = off <= 0 ? '+' : '-';
+      var abs = Math.abs(off);
+      var offStr = 'GMT' + sign + pad2(Math.floor(abs / 60)) + pad2(abs % 60);
+      return parts.weekday + ' ' + parts.month + ' ' + parts.day + ' ' +
+        parts.year + ' ' + parts.hour + ':' + parts.minute + ':' +
+        parts.second + ' ' + offStr + ' (' + (parts.timeZoneName || TZ) + ')';
+    };
+    asNative(_toString, 'toString');
+    try { Date.prototype.toString = _toString; } catch (e) {}
+
+    // Intl.DateTimeFormat: inject TZ when no explicit timeZone provided,
+    // so `resolvedOptions().timeZone` reports the spoofed zone.
+    function PatchedDTF(locales, options) {
+      options = options || {};
+      if (!options.timeZone) {
+        options = Object.assign({}, options, { timeZone: TZ });
+      }
+      // Support being called without `new` per spec.
+      if (!(this instanceof PatchedDTF)) {
+        return new _nativeDTF(locales, options);
+      }
+      return new _nativeDTF(locales, options);
+    }
+    PatchedDTF.prototype = _nativeDTF.prototype;
+    PatchedDTF.supportedLocalesOf = _nativeDTF.supportedLocalesOf
+      ? _nativeDTF.supportedLocalesOf.bind(_nativeDTF) : undefined;
+    asNative(PatchedDTF, 'DateTimeFormat');
+    try { Intl.DateTimeFormat = PatchedDTF; } catch (e) {}
+  }
+
+  // --- WebRTC policy ---
+  if (WRTC === 'off') {
+    var _blocked = function RTCPeerConnection() {
+      throw new Error('WebRTC disabled');
+    };
+    asNative(_blocked, 'RTCPeerConnection');
+    try { window.RTCPeerConnection = _blocked; } catch (e) {}
+    try { window.webkitRTCPeerConnection = _blocked; } catch (e) {}
+  } else if (WRTC === 'relay') {
+    var _RealRTC = window.RTCPeerConnection || window.webkitRTCPeerConnection;
+    if (_RealRTC) {
+      var _Patched = function RTCPeerConnection(config) {
+        config = config || {};
+        config.iceTransportPolicy = 'relay';
+        var pc = new _RealRTC(config);
+        var _origSetLocal = pc.setLocalDescription.bind(pc);
+        pc.setLocalDescription = function(desc) {
+          if (desc && typeof desc.sdp === 'string') {
+            desc.sdp = desc.sdp.split('\r\n').filter(function(line) {
+              if (line.indexOf('a=candidate:') !== 0) return true;
+              return line.indexOf(' typ relay') !== -1;
+            }).join('\r\n');
+          }
+          return _origSetLocal(desc);
+        };
+        return pc;
+      };
+      _Patched.prototype = _RealRTC.prototype;
+      asNative(_Patched, 'RTCPeerConnection');
+      try { window.RTCPeerConnection = _Patched; } catch (e) {}
+      try { window.webkitRTCPeerConnection = _Patched; } catch (e) {}
+    }
+  }
+})();
+''';

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -749,6 +749,10 @@ class WebViewFactory {
         groupName: 'location_spoof',
         source: '$locationShim\n;null;',
         injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
+        // Inject into every frame (iOS WKUserScript defaults to main-frame
+        // only). Without this a site could embed browserleaks.com in an
+        // iframe and bypass the spoof.
+        forMainFrameOnly: false,
       ));
     }
 

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -11,8 +11,10 @@ import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/services/web_intercept_native.dart';
 import 'package:webspace/settings/proxy.dart';
+import 'package:webspace/services/location_spoof_service.dart';
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/user_script_service.dart';
+import 'package:webspace/settings/location.dart';
 import 'package:webspace/settings/user_script.dart';
 
 // Re-export inapp.Cookie as Cookie for convenience
@@ -275,6 +277,17 @@ class WebViewConfig {
   final Future<bool> Function(String url)? onConfirmScriptFetch;
   /// Optional pull-to-refresh controller for enabling pull-to-refresh gesture.
   final inapp.PullToRefreshController? pullToRefreshController;
+  /// Per-site geolocation mode. [LocationMode.spoof] injects a shim that
+  /// overrides `navigator.geolocation` with [spoofLatitude]/[spoofLongitude].
+  final LocationMode locationMode;
+  final double? spoofLatitude;
+  final double? spoofLongitude;
+  final double spoofAccuracy;
+  /// IANA timezone name reported via [Intl.DateTimeFormat] and
+  /// [Date.prototype.getTimezoneOffset]. Null leaves the real zone.
+  final String? spoofTimezone;
+  /// WebRTC policy — prevents real-IP leak that bypasses HTTP(S)/SOCKS proxies.
+  final WebRtcPolicy webRtcPolicy;
 
   WebViewConfig({
     this.key,
@@ -301,6 +314,12 @@ class WebViewConfig {
     this.userScripts = const [],
     this.onConfirmScriptFetch,
     this.pullToRefreshController,
+    this.locationMode = LocationMode.off,
+    this.spoofLatitude,
+    this.spoofLongitude,
+    this.spoofAccuracy = 50.0,
+    this.spoofTimezone,
+    this.webRtcPolicy = WebRtcPolicy.defaultPolicy,
   });
 }
 
@@ -713,9 +732,28 @@ class WebViewFactory {
     // so sub-resources (CSS/JS/images) resolve from browser HTTP cache.
     final usesCachedHtml = config.initialHtml != null;
 
+    final userScripts = <inapp.UserScript>[];
+
+    // Location / timezone / WebRTC shim — must run FIRST so overrides are
+    // in place before any site script can capture the unpatched references.
+    final locationShim = LocationSpoofService.buildScript(
+      locationMode: config.locationMode,
+      spoofLatitude: config.spoofLatitude,
+      spoofLongitude: config.spoofLongitude,
+      spoofAccuracy: config.spoofAccuracy,
+      spoofTimezone: config.spoofTimezone,
+      webRtcPolicy: config.webRtcPolicy,
+    );
+    if (locationShim != null) {
+      userScripts.add(inapp.UserScript(
+        groupName: 'location_spoof',
+        source: '$locationShim\n;null;',
+        injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
+      ));
+    }
+
     // Inject content blocker CSS at DOCUMENT_START so elements are hidden
     // before they ever render, eliminating the flash of unstyled content.
-    final userScripts = <inapp.UserScript>[];
     if (config.contentBlockEnabled) {
       final earlyScript = ContentBlockerService.instance.getEarlyCssScript(config.initialUrl);
       if (earlyScript != null) {

--- a/lib/settings/app_prefs.dart
+++ b/lib/settings/app_prefs.dart
@@ -21,6 +21,10 @@ const Map<String, Object> kExportedAppPrefs = <String, Object>{
   'showUrlBar': false,
   'showTabStrip': false,
   'showStatsBanner': true,
+  // Tile URL used by the optional location picker map. Only queried after
+  // the user explicitly taps "Load map" on the picker — no requests happen
+  // from normal app use.
+  'osmTileUrl': 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 };
 
 /// Read every registered pref from [prefs] into a map suitable for embedding

--- a/lib/settings/location.dart
+++ b/lib/settings/location.dart
@@ -1,0 +1,73 @@
+/// Per-site geolocation mode. [off] leaves the Geolocation API untouched.
+/// [spoof] replaces `navigator.geolocation` with a shim that returns
+/// user-supplied coordinates.
+enum LocationMode { off, spoof }
+
+/// Per-site WebRTC policy. HTTP(S)/SOCKS5 proxies only tunnel TCP — WebRTC
+/// UDP candidates leak the real client IP even with proxy enabled. This
+/// policy controls how the app neutralizes that leak.
+///
+/// [defaultPolicy] — no restriction.
+/// [relayOnly] — force `iceTransportPolicy: 'relay'` on every
+/// [RTCPeerConnection] and strip non-relay ICE candidates from local SDP.
+/// Real IP does not leak but WebRTC breaks unless a TURN server is reachable.
+/// [disabled] — neutralize `RTCPeerConnection` entirely.
+enum WebRtcPolicy { defaultPolicy, relayOnly, disabled }
+
+/// Common IANA timezone names shown in the per-site settings picker.
+/// The list is intentionally curated — `Intl.supportedValuesOf('timeZone')`
+/// returns ~430 zones, which is unwieldy in a dropdown.
+const List<MapEntry<String?, String>> commonTimezones = [
+  MapEntry(null, 'System default'),
+  MapEntry('UTC', 'UTC'),
+  MapEntry('Europe/London', 'Europe/London (GMT/BST)'),
+  MapEntry('Europe/Dublin', 'Europe/Dublin'),
+  MapEntry('Europe/Lisbon', 'Europe/Lisbon'),
+  MapEntry('Europe/Paris', 'Europe/Paris (CET/CEST)'),
+  MapEntry('Europe/Berlin', 'Europe/Berlin'),
+  MapEntry('Europe/Madrid', 'Europe/Madrid'),
+  MapEntry('Europe/Rome', 'Europe/Rome'),
+  MapEntry('Europe/Amsterdam', 'Europe/Amsterdam'),
+  MapEntry('Europe/Brussels', 'Europe/Brussels'),
+  MapEntry('Europe/Zurich', 'Europe/Zurich'),
+  MapEntry('Europe/Vienna', 'Europe/Vienna'),
+  MapEntry('Europe/Warsaw', 'Europe/Warsaw'),
+  MapEntry('Europe/Prague', 'Europe/Prague'),
+  MapEntry('Europe/Athens', 'Europe/Athens'),
+  MapEntry('Europe/Helsinki', 'Europe/Helsinki'),
+  MapEntry('Europe/Stockholm', 'Europe/Stockholm'),
+  MapEntry('Europe/Oslo', 'Europe/Oslo'),
+  MapEntry('Europe/Copenhagen', 'Europe/Copenhagen'),
+  MapEntry('Europe/Kyiv', 'Europe/Kyiv'),
+  MapEntry('Europe/Moscow', 'Europe/Moscow'),
+  MapEntry('Europe/Istanbul', 'Europe/Istanbul'),
+  MapEntry('Africa/Cairo', 'Africa/Cairo'),
+  MapEntry('Africa/Johannesburg', 'Africa/Johannesburg'),
+  MapEntry('Africa/Lagos', 'Africa/Lagos'),
+  MapEntry('Asia/Dubai', 'Asia/Dubai'),
+  MapEntry('Asia/Tehran', 'Asia/Tehran'),
+  MapEntry('Asia/Jerusalem', 'Asia/Jerusalem'),
+  MapEntry('Asia/Karachi', 'Asia/Karachi'),
+  MapEntry('Asia/Kolkata', 'Asia/Kolkata (IST)'),
+  MapEntry('Asia/Bangkok', 'Asia/Bangkok'),
+  MapEntry('Asia/Singapore', 'Asia/Singapore'),
+  MapEntry('Asia/Hong_Kong', 'Asia/Hong Kong'),
+  MapEntry('Asia/Shanghai', 'Asia/Shanghai'),
+  MapEntry('Asia/Taipei', 'Asia/Taipei'),
+  MapEntry('Asia/Seoul', 'Asia/Seoul'),
+  MapEntry('Asia/Tokyo', 'Asia/Tokyo (JST)'),
+  MapEntry('Australia/Perth', 'Australia/Perth'),
+  MapEntry('Australia/Sydney', 'Australia/Sydney'),
+  MapEntry('Pacific/Auckland', 'Pacific/Auckland'),
+  MapEntry('Pacific/Honolulu', 'Pacific/Honolulu'),
+  MapEntry('America/Anchorage', 'America/Anchorage'),
+  MapEntry('America/Los_Angeles', 'America/Los Angeles (PT)'),
+  MapEntry('America/Denver', 'America/Denver (MT)'),
+  MapEntry('America/Phoenix', 'America/Phoenix'),
+  MapEntry('America/Chicago', 'America/Chicago (CT)'),
+  MapEntry('America/New_York', 'America/New York (ET)'),
+  MapEntry('America/Toronto', 'America/Toronto'),
+  MapEntry('America/Mexico_City', 'America/Mexico City'),
+  MapEntry('America/Sao_Paulo', 'America/Sao Paulo'),
+  MapEntry('America/Buenos_Aires', 'America/Buenos Aires'),
+];

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -442,7 +442,7 @@ class WebViewModel {
   }
 
   Widget getWebView(
-    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required String? language}) launchUrlFunc,
+    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required String? language, LocationMode locationMode, double? spoofLatitude, double? spoofLongitude, double spoofAccuracy, String? spoofTimezone, WebRtcPolicy webRtcPolicy}) launchUrlFunc,
     CookieManager cookieManager,
     Function saveFunc, {
     Future<void> Function(int windowId, String url)? onWindowRequested,
@@ -552,7 +552,7 @@ class WebViewModel {
                 return false;
               case NavigationDecision.blockOpenNested:
                 LogService.instance.log('WebView', '  -> CANCEL (opening nested webview)');
-                launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, language: this.language);
+                launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, language: this.language, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, webRtcPolicy: webRtcPolicy);
                 return false;
             }
           },
@@ -598,7 +598,7 @@ class WebViewModel {
                     return;
                   case NavigationDecision.blockOpenNested:
                     LogService.instance.log('WebView', 'onUrlChanged: cross-domain redirect detected: $url (expected domain: $initDomain)');
-                    launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, language: this.language);
+                    launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, language: this.language, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, webRtcPolicy: webRtcPolicy);
                     return;
                   case NavigationDecision.allow:
                     break;
@@ -691,7 +691,7 @@ class WebViewModel {
   }
 
   WebViewController? getController(
-    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required String? language}) launchUrlFunc,
+    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required String? language, LocationMode locationMode, double? spoofLatitude, double? spoofLongitude, double spoofAccuracy, String? spoofTimezone, WebRtcPolicy webRtcPolicy}) launchUrlFunc,
     CookieManager cookieManager,
     Function saveFunc, {
     List<UserScriptConfig> globalUserScripts = const [],

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -7,8 +7,11 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp show Pu
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/navigation_decision_engine.dart';
 import 'package:webspace/services/webview.dart';
+import 'package:webspace/settings/location.dart';
 import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/settings/user_script.dart';
+
+export 'package:webspace/settings/location.dart' show LocationMode, WebRtcPolicy;
 
 class ConsoleLogEntry {
   final DateTime timestamp;
@@ -23,6 +26,7 @@ class ConsoleLogEntry {
     this.isEvalInput = false,
   });
 }
+
 
 /// Generates a unique site ID for per-site cookie isolation.
 String _generateSiteId() {
@@ -280,6 +284,15 @@ class WebViewModel {
   /// independently enables which ones to inject.
   Set<String> enabledGlobalScriptIds;
   Set<BlockedCookie> blockedCookies; // Per-site blocked cookies (name + domain)
+  LocationMode locationMode;
+  double? spoofLatitude;
+  double? spoofLongitude;
+  /// Coordinate accuracy in meters reported to the spoofed Position.
+  double spoofAccuracy;
+  /// IANA timezone name to expose via [Intl.DateTimeFormat] and
+  /// [Date.prototype.getTimezoneOffset]. Null leaves the real zone.
+  String? spoofTimezone;
+  WebRtcPolicy webRtcPolicy;
 
   final List<ConsoleLogEntry> consoleLogs = [];
   static const _maxConsoleLogs = 500;
@@ -317,6 +330,12 @@ class WebViewModel {
     List<UserScriptConfig>? userScripts,
     Set<String>? enabledGlobalScriptIds,
     Set<BlockedCookie>? blockedCookies,
+    this.locationMode = LocationMode.off,
+    this.spoofLatitude,
+    this.spoofLongitude,
+    this.spoofAccuracy = 50.0,
+    this.spoofTimezone,
+    this.webRtcPolicy = WebRtcPolicy.defaultPolicy,
     this.stateSetterF,
   })  : userScripts = userScripts ?? [],
         enabledGlobalScriptIds = enabledGlobalScriptIds ?? {},
@@ -472,6 +491,12 @@ class WebViewModel {
           dnsBlockEnabled: dnsBlockEnabled,
           contentBlockEnabled: contentBlockEnabled,
           localCdnEnabled: localCdnEnabled,
+          locationMode: locationMode,
+          spoofLatitude: spoofLatitude,
+          spoofLongitude: spoofLongitude,
+          spoofAccuracy: spoofAccuracy,
+          spoofTimezone: spoofTimezone,
+          webRtcPolicy: webRtcPolicy,
           userScripts: [
             // Globals have no master `enabled` toggle per spec — per-site
             // opt-in is the only enable control. Force `enabled: true` on
@@ -764,6 +789,12 @@ class WebViewModel {
           'enabledGlobalScriptIds': enabledGlobalScriptIds.toList(),
         if (blockedCookies.isNotEmpty)
           'blockedCookies': blockedCookies.map((b) => b.toJson()).toList(),
+        'locationMode': locationMode.name,
+        if (spoofLatitude != null) 'spoofLatitude': spoofLatitude,
+        if (spoofLongitude != null) 'spoofLongitude': spoofLongitude,
+        'spoofAccuracy': spoofAccuracy,
+        if (spoofTimezone != null) 'spoofTimezone': spoofTimezone,
+        'webRtcPolicy': webRtcPolicy.name,
       };
 
   factory WebViewModel.fromJson(Map<String, dynamic> json, Function? stateSetterF) {
@@ -797,6 +828,18 @@ class WebViewModel {
       blockedCookies: (json['blockedCookies'] as List<dynamic>?)
           ?.map((e) => BlockedCookie.fromJson(e as Map<String, dynamic>))
           .toSet(),
+      locationMode: LocationMode.values.firstWhere(
+        (m) => m.name == json['locationMode'],
+        orElse: () => LocationMode.off,
+      ),
+      spoofLatitude: (json['spoofLatitude'] as num?)?.toDouble(),
+      spoofLongitude: (json['spoofLongitude'] as num?)?.toDouble(),
+      spoofAccuracy: (json['spoofAccuracy'] as num?)?.toDouble() ?? 50.0,
+      spoofTimezone: json['spoofTimezone'] as String?,
+      webRtcPolicy: WebRtcPolicy.values.firstWhere(
+        (p) => p.name == json['webRtcPolicy'],
+        orElse: () => WebRtcPolicy.defaultPolicy,
+      ),
       stateSetterF: stateSetterF,
     )..pageTitle = json['pageTitle'];
   }

--- a/openspec/specs/per-site-location/spec.md
+++ b/openspec/specs/per-site-location/spec.md
@@ -122,6 +122,43 @@ The system SHALL expose a per-site `webRtcPolicy` with three values: `defaultPol
 
 ---
 
+### Requirement: LOC-006 - Map picker with explicit opt-in
+
+The per-site location settings SHALL provide a "Pick on map" button that opens a full-screen picker. The picker SHALL NOT make any network requests (map tile fetches) until the user explicitly taps a "Load map" button on the picker's placeholder state. Manual coordinate entry SHALL remain available without ever loading the map.
+
+The tile URL used by the picker SHALL come from a global app pref (`osmTileUrl`, default `https://tile.openstreetmap.org/{z}/{x}/{y}.png`). The pref SHALL be editable from the app-level settings and SHALL round-trip through settings backup/restore via the existing registry in `lib/settings/app_prefs.dart`.
+
+#### Scenario: Opening the picker makes no requests
+
+**Given** the user has tapped "Pick on map" on the per-site location settings
+**When** the picker opens
+**Then** no tile requests have been made
+**And** the placeholder view is shown with the configured tile host name
+**And** latitude, longitude, and accuracy inputs are already editable
+
+#### Scenario: User enters coordinates without loading the map
+
+**Given** the picker is showing the placeholder
+**When** the user types coordinates into the inputs and taps "Done"
+**Then** still no tile requests have been made
+**And** the picker returns the typed coordinates to the caller
+
+#### Scenario: User loads the map
+
+**Given** the picker is showing the placeholder
+**When** the user taps "Load map"
+**Then** the map is mounted
+**And** tile requests begin to the URL configured in `osmTileUrl`
+**And** tapping anywhere on the map updates the coordinate inputs and moves the pin
+
+#### Scenario: Tile URL is swappable
+
+**Given** the user has opened the app settings and changed "Tile URL" to a self-hosted tile server
+**When** the user later opens the location picker and taps "Load map"
+**Then** tile requests go to the configured server, not to openstreetmap.org
+
+---
+
 ### Requirement: LOC-005 - Persistence and backup
 
 All six fields (`locationMode`, `spoofLatitude`, `spoofLongitude`, `spoofAccuracy`, `spoofTimezone`, `webRtcPolicy`) SHALL round-trip through `WebViewModel.toJson` / `fromJson` with sensible defaults when absent. They ride along in the `sites` array of settings backups automatically.

--- a/openspec/specs/per-site-location/spec.md
+++ b/openspec/specs/per-site-location/spec.md
@@ -1,0 +1,148 @@
+# Per-Site Location & Timezone Spoofing Specification
+
+## Purpose
+
+Allow users to return fake geolocation coordinates and a chosen IANA timezone to each site independently, and to prevent the WebRTC real-IP leak that bypasses HTTP(S)/SOCKS proxies.
+
+## Status
+
+- **Date**: 2026-04-21
+- **Status**: Implemented
+
+---
+
+## Problem Statement
+
+A privacy-focused browser should let users control what a site learns about their physical location. Three signals leak it today:
+
+1. `navigator.geolocation.getCurrentPosition` / `watchPosition` — exposes real GPS / IP-derived coordinates.
+2. `Intl.DateTimeFormat().resolvedOptions().timeZone`, `Date.prototype.getTimezoneOffset`, `Date.prototype.toString` — reveal the device's timezone, which cross-checks against any coordinate spoof.
+3. WebRTC — `RTCPeerConnection` + STUN exposes the device's public IP even through an HTTP(S) or SOCKS5 proxy, because Android WebView's proxy API only tunnels TCP and Chromium's WebRTC UDP stack does not honor the proxy.
+
+A single site-level toggle set is therefore required: spoof coordinates, override timezone, and lock down WebRTC.
+
+---
+
+## Requirements
+
+### Requirement: LOC-001 - Per-site location mode
+
+The system SHALL expose a per-site `locationMode` with two values: `off` (default) and `spoof`. When `spoof`, user-supplied latitude/longitude/accuracy replace the real geolocation.
+
+#### Scenario: Off mode passes through
+
+**Given** site "Acme" has `locationMode = off`
+**When** the site calls `navigator.geolocation.getCurrentPosition(cb)`
+**Then** the webview returns the platform's real geolocation (or prompts for permission)
+
+#### Scenario: Spoof mode returns fake coords
+
+**Given** site "Acme" has `locationMode = spoof`, `spoofLatitude = 35.6762`, `spoofLongitude = 139.6503`, `spoofAccuracy = 50`
+**When** the site calls `navigator.geolocation.getCurrentPosition(cb)`
+**Then** `cb` is invoked (after ~150–400ms) with a `GeolocationPosition` whose `coords.latitude ≈ 35.6762`, `coords.longitude ≈ 139.6503`, `coords.accuracy = 50`
+**And** `position instanceof GeolocationPosition` is true
+
+---
+
+### Requirement: LOC-002 - Spoof hardening
+
+The spoof SHALL resist trivial detection by:
+- overriding `Geolocation.prototype.getCurrentPosition/watchPosition/clearWatch` (not just the instance),
+- patching `Function.prototype.toString` via a `WeakMap` keyed by overridden functions so stringifying them returns `"function <name>() { [native code] }"`,
+- constructing the returned `GeolocationPosition` and `GeolocationCoordinates` with the real class prototypes,
+- returning `'granted'` from `navigator.permissions.query({name:'geolocation'})` so the reported permission state matches the resolved call,
+- jittering coordinates by up to ~2 meters per call so `watchPosition` does not return byte-identical frames,
+- introducing a 150–400ms latency so `getCurrentPosition` does not resolve synchronously-fast.
+
+#### Scenario: Prototype method is patched
+
+**Given** `locationMode = spoof`
+**When** a site calls `Geolocation.prototype.getCurrentPosition.call(navigator.geolocation, cb)`
+**Then** `cb` receives the spoofed coordinates (the prototype reference is not the unpatched native)
+
+#### Scenario: toString reports native
+
+**Given** `locationMode = spoof`
+**When** a site evaluates `navigator.geolocation.getCurrentPosition.toString()`
+**Then** the result is `"function getCurrentPosition() { [native code] }"`
+**And** `Function.prototype.toString.toString()` likewise returns `"function toString() { [native code] }"`
+
+---
+
+### Requirement: LOC-003 - Timezone override
+
+The system SHALL expose a per-site `spoofTimezone` (IANA name, nullable). When set, it SHALL override:
+- `Intl.DateTimeFormat(locales, options)` — when `options.timeZone` is absent, the configured zone is injected so `resolvedOptions().timeZone` reports it,
+- `Date.prototype.getTimezoneOffset` — returns the offset in the configured zone at the given Date instant (DST-correct via Intl),
+- `Date.prototype.toString` — returns a well-formed browser-style string with the spoofed GMT offset and long timezone name.
+
+#### Scenario: Intl reports spoofed zone
+
+**Given** `spoofTimezone = 'Asia/Tokyo'`
+**When** a site reads `new Intl.DateTimeFormat().resolvedOptions().timeZone`
+**Then** the value is `'Asia/Tokyo'`
+
+#### Scenario: getTimezoneOffset returns spoofed offset
+
+**Given** `spoofTimezone = 'Asia/Tokyo'`
+**When** a site calls `new Date().getTimezoneOffset()` at a moment when JST is UTC+9
+**Then** the result is `-540`
+
+#### Scenario: Known detection gap
+
+**Given** `spoofTimezone = 'Asia/Tokyo'` and device real zone is `UTC`
+**When** a site calls `new Date().getHours()` and compares to `Intl.DateTimeFormat('en', { hour: 'numeric', timeZone: 'Asia/Tokyo' }).format(new Date())`
+**Then** the values disagree (real local vs spoofed). This is a known gap — the implementation deliberately does not override `Date` getters to keep the shim small; cross-referencing callers can detect the spoof.
+
+**Rationale:** covering `getHours`/`getMinutes`/`getDate`/... requires shifting each call into the target zone, which is invasive and has DST-boundary edge cases. Most fingerprint libraries use `Intl` or `getTimezoneOffset`.
+
+---
+
+### Requirement: LOC-004 - WebRTC policy
+
+The system SHALL expose a per-site `webRtcPolicy` with three values: `defaultPolicy` (no change), `relayOnly`, and `disabled`.
+
+#### Scenario: Relay-only strips local candidates
+
+**Given** `webRtcPolicy = relayOnly`
+**When** a site creates a new `RTCPeerConnection(config)` and calls `setLocalDescription(offer)`
+**Then** the effective config has `iceTransportPolicy = 'relay'`
+**And** the SDP passed to `setLocalDescription` has all non-`typ relay` candidate lines stripped
+
+#### Scenario: Disabled throws
+
+**Given** `webRtcPolicy = disabled`
+**When** a site evaluates `new RTCPeerConnection()`
+**Then** the constructor throws `Error('WebRTC disabled')`
+
+#### Scenario: Default policy is untouched
+
+**Given** `webRtcPolicy = defaultPolicy`
+**Then** `RTCPeerConnection` behaves exactly as the platform default
+
+---
+
+### Requirement: LOC-005 - Persistence and backup
+
+All six fields (`locationMode`, `spoofLatitude`, `spoofLongitude`, `spoofAccuracy`, `spoofTimezone`, `webRtcPolicy`) SHALL round-trip through `WebViewModel.toJson` / `fromJson` with sensible defaults when absent. They ride along in the `sites` array of settings backups automatically.
+
+---
+
+## Implementation Notes
+
+- Shim source: [lib/services/location_spoof_service.dart](../../lib/services/location_spoof_service.dart)
+- Shim injection: [lib/services/webview.dart](../../lib/services/webview.dart) `createWebView`, added to `initialUserScripts` at `DOCUMENT_START` — **before** any other content script, content-blocker early CSS, or user-scripts shim, so overrides are in place before any site code runs.
+- Model: [lib/web_view_model.dart](../../lib/web_view_model.dart)
+- UI: [lib/screens/settings.dart](../../lib/screens/settings.dart) — "Location & timezone" section with mode dropdown, lat/long/accuracy inputs, timezone dropdown, WebRTC policy dropdown.
+- Enum and timezone list: [lib/settings/location.dart](../../lib/settings/location.dart)
+- Tests: [test/location_spoof_test.dart](../../test/location_spoof_test.dart), [test/web_view_model_test.dart](../../test/web_view_model_test.dart)
+
+## Threat Model
+
+The shim targets **passive detection** — sites that read Geolocation/Intl/WebRTC once and trust the result. It does NOT defend against:
+
+- **IP-based geolocation**: a site's server can reverse-resolve your IP. Pair with a per-site proxy in the spoofed country.
+- **Coordinated cross-checks**: a site that compares `getHours()` vs `Intl.DateTimeFormat` results in the target zone will notice the disagreement (see LOC-003 scenario).
+- **Sensor-based location**: DeviceOrientation / magnetometer can give coarse location if granted; the shim does not intercept them.
+
+For higher-confidence spoofing, enable all three: location spoof + matching timezone + WebRTC `relayOnly` or `disabled` + a proxy in the same country.

--- a/openspec/specs/per-site-location/spec.md
+++ b/openspec/specs/per-site-location/spec.md
@@ -122,43 +122,42 @@ The system SHALL expose a per-site `webRtcPolicy` with three values: `defaultPol
 
 ---
 
-### Requirement: LOC-006 - Picker with no in-app map
+### Requirement: LOC-006 - Map picker with explicit opt-in
 
-The per-site location settings SHALL provide a "Pick on map" button that opens a full-screen picker. The picker SHALL NOT embed a map widget inside the app and SHALL NOT make any tile requests from the WebSpace process — so the user's act of *choosing* a spoof location never leaks the area of interest through our network stack. Selection methods offered:
+The per-site location settings SHALL provide a "Pick on map" button that opens a full-screen picker. The picker SHALL NOT make any network requests (map tile fetches) until the user explicitly taps a "Load map" button on the picker's placeholder state. Manual coordinate entry SHALL remain available without ever loading the map.
 
-- Typed latitude / longitude / accuracy.
-- A preset-city chip list for one-tap common anchors.
-- An "Open in OpenStreetMap" button that hands off to the OS browser via `url_launcher`, preseeded with the currently typed coordinates. The tile provider used by the handoff URL comes from the `osmTileUrl` global pref (default `https://tile.openstreetmap.org/{z}/{x}/{y}.png`). The pref is editable from app-level settings and round-trips through settings backup via `lib/settings/app_prefs.dart`.
+The tile URL used by the picker SHALL come from a global app pref (`osmTileUrl`, default `https://tile.openstreetmap.org/{z}/{x}/{y}.png`). The pref SHALL be editable from the app-level settings and SHALL round-trip through settings backup/restore via the existing registry in `lib/settings/app_prefs.dart`.
 
 #### Scenario: Opening the picker makes no requests
 
 **Given** the user has tapped "Pick on map" on the per-site location settings
 **When** the picker opens
-**Then** no network requests have been made from the WebSpace process
-**And** latitude, longitude, and accuracy inputs are editable
-**And** a preset city chip list is visible
+**Then** no tile requests have been made
+**And** the placeholder view is shown with the configured tile host name
+**And** latitude, longitude, and accuracy inputs are already editable
 
-#### Scenario: Preset city sets coordinates without network
+#### Scenario: User enters coordinates without loading the map
 
-**Given** the picker is open
-**When** the user taps the "Tokyo" preset chip
-**Then** still no network requests have been made
-**And** the latitude / longitude inputs now contain Tokyo's coordinates
+**Given** the picker is showing the placeholder
+**When** the user types coordinates into the inputs and taps "Done"
+**Then** still no tile requests have been made
+**And** the picker returns the typed coordinates to the caller
 
-#### Scenario: External handoff opens device browser
+#### Scenario: User loads the map
 
-**Given** the picker is open
-**When** the user taps "Open in OpenStreetMap"
-**Then** the device's OS browser opens `https://www.openstreetmap.org/?mlat=...&mlon=...#map=...` seeded at the currently typed coordinates
-**And** WebSpace's webview/networking never touches the tile server
+**Given** the picker is showing the placeholder
+**When** the user taps "Load map"
+**Then** the map is mounted
+**And** tile requests begin to the URL configured in `osmTileUrl`
+**And** tapping anywhere on the map updates the coordinate inputs and moves the pin
 
-#### Scenario: Tile URL pref persists through backup
+#### Scenario: Tile URL is swappable
 
-**Given** the user has opened app settings and changed "Tile URL" under "Location picker" to a self-hosted value
-**When** they export and re-import their settings
-**Then** the configured tile URL is restored from the backup
+**Given** the user has opened the app settings and changed "Tile URL" to a self-hosted tile server
+**When** the user later opens the location picker and taps "Load map"
+**Then** tile requests go to the configured server, not to openstreetmap.org
 
-**Note:** the external handoff currently targets `https://www.openstreetmap.org/?mlat=…&mlon=…`. The tile URL pref is surfaced so users can still see and configure which provider the "Pick visually" button references, but the OSM website URL is hardcoded — Leaflet-style tile URLs are not necessarily browser-viewable maps. Self-hosters who point the tile URL at their own server should type coordinates directly or use their own map UI.
+---
 
 ---
 

--- a/openspec/specs/per-site-location/spec.md
+++ b/openspec/specs/per-site-location/spec.md
@@ -122,40 +122,65 @@ The system SHALL expose a per-site `webRtcPolicy` with three values: `defaultPol
 
 ---
 
-### Requirement: LOC-006 - Map picker with explicit opt-in
+### Requirement: LOC-006 - Picker with no in-app map
 
-The per-site location settings SHALL provide a "Pick on map" button that opens a full-screen picker. The picker SHALL NOT make any network requests (map tile fetches) until the user explicitly taps a "Load map" button on the picker's placeholder state. Manual coordinate entry SHALL remain available without ever loading the map.
+The per-site location settings SHALL provide a "Pick on map" button that opens a full-screen picker. The picker SHALL NOT embed a map widget inside the app and SHALL NOT make any tile requests from the WebSpace process — so the user's act of *choosing* a spoof location never leaks the area of interest through our network stack. Selection methods offered:
 
-The tile URL used by the picker SHALL come from a global app pref (`osmTileUrl`, default `https://tile.openstreetmap.org/{z}/{x}/{y}.png`). The pref SHALL be editable from the app-level settings and SHALL round-trip through settings backup/restore via the existing registry in `lib/settings/app_prefs.dart`.
+- Typed latitude / longitude / accuracy.
+- A preset-city chip list for one-tap common anchors.
+- An "Open in OpenStreetMap" button that hands off to the OS browser via `url_launcher`, preseeded with the currently typed coordinates. The tile provider used by the handoff URL comes from the `osmTileUrl` global pref (default `https://tile.openstreetmap.org/{z}/{x}/{y}.png`). The pref is editable from app-level settings and round-trips through settings backup via `lib/settings/app_prefs.dart`.
 
 #### Scenario: Opening the picker makes no requests
 
 **Given** the user has tapped "Pick on map" on the per-site location settings
 **When** the picker opens
-**Then** no tile requests have been made
-**And** the placeholder view is shown with the configured tile host name
-**And** latitude, longitude, and accuracy inputs are already editable
+**Then** no network requests have been made from the WebSpace process
+**And** latitude, longitude, and accuracy inputs are editable
+**And** a preset city chip list is visible
 
-#### Scenario: User enters coordinates without loading the map
+#### Scenario: Preset city sets coordinates without network
 
-**Given** the picker is showing the placeholder
-**When** the user types coordinates into the inputs and taps "Done"
-**Then** still no tile requests have been made
-**And** the picker returns the typed coordinates to the caller
+**Given** the picker is open
+**When** the user taps the "Tokyo" preset chip
+**Then** still no network requests have been made
+**And** the latitude / longitude inputs now contain Tokyo's coordinates
 
-#### Scenario: User loads the map
+#### Scenario: External handoff opens device browser
 
-**Given** the picker is showing the placeholder
-**When** the user taps "Load map"
-**Then** the map is mounted
-**And** tile requests begin to the URL configured in `osmTileUrl`
-**And** tapping anywhere on the map updates the coordinate inputs and moves the pin
+**Given** the picker is open
+**When** the user taps "Open in OpenStreetMap"
+**Then** the device's OS browser opens `https://www.openstreetmap.org/?mlat=...&mlon=...#map=...` seeded at the currently typed coordinates
+**And** WebSpace's webview/networking never touches the tile server
 
-#### Scenario: Tile URL is swappable
+#### Scenario: Tile URL pref persists through backup
 
-**Given** the user has opened the app settings and changed "Tile URL" to a self-hosted tile server
-**When** the user later opens the location picker and taps "Load map"
-**Then** tile requests go to the configured server, not to openstreetmap.org
+**Given** the user has opened app settings and changed "Tile URL" under "Location picker" to a self-hosted value
+**When** they export and re-import their settings
+**Then** the configured tile URL is restored from the backup
+
+**Note:** the external handoff currently targets `https://www.openstreetmap.org/?mlat=…&mlon=…`. The tile URL pref is surfaced so users can still see and configure which provider the "Pick visually" button references, but the OSM website URL is hardcoded — Leaflet-style tile URLs are not necessarily browser-viewable maps. Self-hosters who point the tile URL at their own server should type coordinates directly or use their own map UI.
+
+---
+
+### Requirement: LOC-007 - Settings apply to nested webviews
+
+Every per-site field on `WebViewModel` that controls privacy behavior (`locationMode`, `spoofLatitude`, `spoofLongitude`, `spoofAccuracy`, `spoofTimezone`, `webRtcPolicy`) SHALL propagate to every `InAppWebViewScreen` spawned by cross-domain navigation from the parent site via `launchUrl` in `lib/main.dart`. The JS shim SHALL be injected into cross-origin iframes as well as the top frame by setting `forMainFrameOnly: false` on the `inapp.UserScript`.
+
+Otherwise a site could defeat the spoof by linking to a detection page (e.g. browserleaks.com) — which opens in a nested browser — or embedding it in an iframe.
+
+#### Scenario: Nested browser inherits the spoof
+
+**Given** site "Acme" has `locationMode = spoof`, `spoofLatitude = 35.6762`, `spoofLongitude = 139.6503`, and `webRtcPolicy = disabled`
+**When** the user follows a cross-domain link from Acme that opens a nested `InAppWebViewScreen` at browserleaks.com/webrtc
+**Then** the nested webview reports the spoofed coordinates
+**And** `RTCPeerConnection` is neutered in the nested webview too
+
+#### Scenario: Iframe sees the spoof
+
+**Given** a page embeds `https://browserleaks.com/webrtc` inside a cross-origin iframe
+**When** the iframe runs its detection script
+**Then** `navigator.geolocation` returns the spoofed coordinates
+**And** `RTCPeerConnection` is either neutered or relay-only per the parent site's policy
 
 ---
 

--- a/openspec/specs/per-site-location/spec.md
+++ b/openspec/specs/per-site-location/spec.md
@@ -126,6 +126,18 @@ The system SHALL expose a per-site `webRtcPolicy` with three values: `defaultPol
 
 All six fields (`locationMode`, `spoofLatitude`, `spoofLongitude`, `spoofAccuracy`, `spoofTimezone`, `webRtcPolicy`) SHALL round-trip through `WebViewModel.toJson` / `fromJson` with sensible defaults when absent. They ride along in the `sites` array of settings backups automatically.
 
+#### Scenario: Round-trip through JSON
+
+**Given** a `WebViewModel` with `locationMode = spoof`, `spoofLatitude = 35.6762`, `spoofLongitude = 139.6503`, `spoofAccuracy = 25`, `spoofTimezone = 'Asia/Tokyo'`, `webRtcPolicy = relayOnly`
+**When** the model is serialized via `toJson` and re-hydrated via `fromJson`
+**Then** all six fields equal their original values
+
+#### Scenario: Defaults when absent from JSON
+
+**Given** a JSON blob from an older backup that has none of the six fields
+**When** the model is hydrated via `fromJson`
+**Then** `locationMode = off`, coordinates are `null`, `spoofAccuracy = 50`, `spoofTimezone = null`, and `webRtcPolicy = defaultPolicy`
+
 ---
 
 ## Implementation Notes

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -153,6 +153,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  dart_earcut:
+    dependency: transitive
+    description:
+      name: dart_earcut
+      sha256: e485001bfc05dcbc437d7bfb666316182e3522d4c3f9668048e004d0eb2ce43b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
+  dart_polylabel2:
+    dependency: transitive
+    description:
+      name: dart_polylabel2
+      sha256: "7eeab15ce72894e4bdba6a8765712231fc81be0bd95247de4ad9966abc57adc6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   dbus:
     dependency: transitive
     description:
@@ -307,6 +323,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_map:
+    dependency: "direct main"
+    description:
+      name: flutter_map
+      sha256: "03b71c02806ff20c3718d108cbbb3638142ebafe368d8ce2dd22a33344bcb02b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -439,6 +463,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   jni:
     dependency: transitive
     description:
@@ -471,6 +503,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.11.0"
+  latlong2:
+    dependency: "direct main"
+    description:
+      name: latlong2
+      sha256: "98227922caf49e6056f91b6c56945ea1c7b166f28ffcd5fb8e72fc0b453cc8fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -543,6 +583,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  mgrs_dart:
+    dependency: transitive
+    description:
+      name: mgrs_dart
+      sha256: "385e7168ecc77eb545220223c49eef8ab249da7bf57f22781c40a04d23fb196f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   mime:
     dependency: transitive
     description:
@@ -711,6 +759,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.5"
+  proj4dart:
+    dependency: transitive
+    description:
+      name: proj4dart
+      sha256: ddcedc1f7876e62717de43ab3491e2829bdad0b028261805f94aa080967e5859
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   pub_semver:
     dependency: transitive
     description:
@@ -799,6 +855,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  simple_sparse_list:
+    dependency: transitive
+    description:
+      name: simple_sparse_list
+      sha256: aa648fd240fa39b49dcd11c19c266990006006de6699a412de485695910fbc1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -916,6 +980,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  unicode:
+    dependency: transitive
+    description:
+      name: unicode
+      sha256: a6f7bcfc8ea1d5ce1f6c0b1c39117a9919f4953edd9fd7a64090a9796c499b57
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.9"
   url_launcher:
     dependency: "direct main"
     description:
@@ -1052,6 +1124,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
+  wkt_parser:
+    dependency: transitive
+    description:
+      name: wkt_parser
+      sha256: "8a555fc60de3116c00aad67891bcab20f81a958e4219cc106e3c037aa3937f13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,8 @@ dependencies:
   encrypt: ^5.0.3
   share_plus: ^12.0.0
   material_design_icons_flutter: ^7.0.7296
+  flutter_map: ^8.0.0
+  latlong2: ^0.9.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,8 +56,6 @@ dependencies:
   encrypt: ^5.0.3
   share_plus: ^12.0.0
   material_design_icons_flutter: ^7.0.7296
-  flutter_map: ^8.0.0
-  latlong2: ^0.9.1
 
 dev_dependencies:
   flutter_test:

--- a/test/location_spoof_test.dart
+++ b/test/location_spoof_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/location_spoof_service.dart';
+import 'package:webspace/settings/location.dart';
+
+void main() {
+  group('LocationSpoofService', () {
+    test('returns null when everything is default', () {
+      final script = LocationSpoofService.buildScript(
+        locationMode: LocationMode.off,
+        spoofLatitude: null,
+        spoofLongitude: null,
+        spoofAccuracy: 50.0,
+        spoofTimezone: null,
+        webRtcPolicy: WebRtcPolicy.defaultPolicy,
+      );
+      expect(script, isNull);
+    });
+
+    test('returns null when spoof mode is on but coordinates are missing', () {
+      final script = LocationSpoofService.buildScript(
+        locationMode: LocationMode.spoof,
+        spoofLatitude: null,
+        spoofLongitude: null,
+        spoofAccuracy: 50.0,
+        spoofTimezone: null,
+        webRtcPolicy: WebRtcPolicy.defaultPolicy,
+      );
+      expect(script, isNull);
+    });
+
+    test('geolocation shim embeds the coordinates', () {
+      final script = LocationSpoofService.buildScript(
+        locationMode: LocationMode.spoof,
+        spoofLatitude: 35.6762,
+        spoofLongitude: 139.6503,
+        spoofAccuracy: 25.0,
+        spoofTimezone: null,
+        webRtcPolicy: WebRtcPolicy.defaultPolicy,
+      );
+      expect(script, isNotNull);
+      expect(script, contains('var SPOOF_LOC = true'));
+      expect(script, contains('var LAT = 35.6762'));
+      expect(script, contains('var LNG = 139.6503'));
+      expect(script, contains('var ACC = 25.0'));
+      expect(script, contains('var TZ = null'));
+      expect(script, contains('var WRTC = "default"'));
+    });
+
+    test('timezone-only shim still emits script without spoof_loc', () {
+      final script = LocationSpoofService.buildScript(
+        locationMode: LocationMode.off,
+        spoofLatitude: null,
+        spoofLongitude: null,
+        spoofAccuracy: 50.0,
+        spoofTimezone: 'Asia/Tokyo',
+        webRtcPolicy: WebRtcPolicy.defaultPolicy,
+      );
+      expect(script, isNotNull);
+      expect(script, contains('var SPOOF_LOC = false'));
+      expect(script, contains('var TZ = "Asia/Tokyo"'));
+    });
+
+    test('webrtc relay-only shim sets WRTC=relay', () {
+      final script = LocationSpoofService.buildScript(
+        locationMode: LocationMode.off,
+        spoofLatitude: null,
+        spoofLongitude: null,
+        spoofAccuracy: 50.0,
+        spoofTimezone: null,
+        webRtcPolicy: WebRtcPolicy.relayOnly,
+      );
+      expect(script, isNotNull);
+      expect(script, contains('var WRTC = "relay"'));
+      expect(script, contains("iceTransportPolicy = 'relay'"));
+      expect(script, contains('typ relay'));
+    });
+
+    test('webrtc disabled shim sets WRTC=off and neuters RTCPeerConnection', () {
+      final script = LocationSpoofService.buildScript(
+        locationMode: LocationMode.off,
+        spoofLatitude: null,
+        spoofLongitude: null,
+        spoofAccuracy: 50.0,
+        spoofTimezone: null,
+        webRtcPolicy: WebRtcPolicy.disabled,
+      );
+      expect(script, isNotNull);
+      expect(script, contains('var WRTC = "off"'));
+      expect(script, contains('WebRTC disabled'));
+    });
+
+    test('shim patches prototype methods not just instance', () {
+      final script = LocationSpoofService.buildScript(
+        locationMode: LocationMode.spoof,
+        spoofLatitude: 0.0,
+        spoofLongitude: 0.0,
+        spoofAccuracy: 50.0,
+        spoofTimezone: 'UTC',
+        webRtcPolicy: WebRtcPolicy.defaultPolicy,
+      );
+      expect(script, contains('Geolocation.prototype'));
+      expect(script, contains('Date.prototype.getTimezoneOffset'));
+      expect(script, contains('Date.prototype.toString'));
+      expect(script, contains('Intl.DateTimeFormat'));
+    });
+
+    test('shim hardens Function.prototype.toString', () {
+      final script = LocationSpoofService.buildScript(
+        locationMode: LocationMode.spoof,
+        spoofLatitude: 0.0,
+        spoofLongitude: 0.0,
+        spoofAccuracy: 50.0,
+        spoofTimezone: null,
+        webRtcPolicy: WebRtcPolicy.defaultPolicy,
+      );
+      expect(script, contains('Function.prototype.toString'));
+      expect(script, contains('[native code]'));
+    });
+
+    test('shim fakes permissions.query for geolocation', () {
+      final script = LocationSpoofService.buildScript(
+        locationMode: LocationMode.spoof,
+        spoofLatitude: 0.0,
+        spoofLongitude: 0.0,
+        spoofAccuracy: 50.0,
+        spoofTimezone: null,
+        webRtcPolicy: WebRtcPolicy.defaultPolicy,
+      );
+      expect(script, contains('navigator.permissions'));
+      expect(script, contains("name === 'geolocation'"));
+      expect(script, contains("'granted'"));
+    });
+
+    test('installs only once via window flag', () {
+      final script = LocationSpoofService.buildScript(
+        locationMode: LocationMode.spoof,
+        spoofLatitude: 1.0,
+        spoofLongitude: 2.0,
+        spoofAccuracy: 50.0,
+        spoofTimezone: null,
+        webRtcPolicy: WebRtcPolicy.defaultPolicy,
+      );
+      expect(script, contains('__wsLocShimInstalled'));
+    });
+  });
+}

--- a/test/web_view_model_test.dart
+++ b/test/web_view_model_test.dart
@@ -276,6 +276,64 @@ void main() {
       final restored = WebViewModel.fromJson(json, null);
       expect(restored.desktopMode, isTrue);
     });
+
+    test('location spoof fields default to off and null', () {
+      final model = WebViewModel(initUrl: 'https://example.com');
+      expect(model.locationMode, equals(LocationMode.off));
+      expect(model.spoofLatitude, isNull);
+      expect(model.spoofLongitude, isNull);
+      expect(model.spoofAccuracy, equals(50.0));
+      expect(model.spoofTimezone, isNull);
+      expect(model.webRtcPolicy, equals(WebRtcPolicy.defaultPolicy));
+    });
+
+    test('location spoof fields round-trip through JSON', () {
+      final original = WebViewModel(
+        initUrl: 'https://example.com',
+        locationMode: LocationMode.spoof,
+        spoofLatitude: 35.6762,
+        spoofLongitude: 139.6503,
+        spoofAccuracy: 25.0,
+        spoofTimezone: 'Asia/Tokyo',
+        webRtcPolicy: WebRtcPolicy.relayOnly,
+      );
+
+      final json = original.toJson();
+      expect(json['locationMode'], equals('spoof'));
+      expect(json['spoofLatitude'], equals(35.6762));
+      expect(json['spoofLongitude'], equals(139.6503));
+      expect(json['spoofAccuracy'], equals(25.0));
+      expect(json['spoofTimezone'], equals('Asia/Tokyo'));
+      expect(json['webRtcPolicy'], equals('relayOnly'));
+
+      final restored = WebViewModel.fromJson(json, null);
+      expect(restored.locationMode, equals(LocationMode.spoof));
+      expect(restored.spoofLatitude, equals(35.6762));
+      expect(restored.spoofLongitude, equals(139.6503));
+      expect(restored.spoofAccuracy, equals(25.0));
+      expect(restored.spoofTimezone, equals('Asia/Tokyo'));
+      expect(restored.webRtcPolicy, equals(WebRtcPolicy.relayOnly));
+    });
+
+    test('location spoof fields default when missing from JSON', () {
+      final json = {
+        'initUrl': 'https://example.com',
+        'currentUrl': 'https://example.com',
+        'cookies': [],
+        'proxySettings': {'type': 0, 'address': null},
+        'javascriptEnabled': true,
+        'userAgent': '',
+        'thirdPartyCookiesEnabled': false,
+      };
+
+      final model = WebViewModel.fromJson(json, null);
+      expect(model.locationMode, equals(LocationMode.off));
+      expect(model.spoofLatitude, isNull);
+      expect(model.spoofLongitude, isNull);
+      expect(model.spoofAccuracy, equals(50.0));
+      expect(model.spoofTimezone, isNull);
+      expect(model.webRtcPolicy, equals(WebRtcPolicy.defaultPolicy));
+    });
   });
 
   group('extractDomain', () {


### PR DESCRIPTION
…down

Each site now has four independent privacy settings:

- `locationMode` (off / spoof) with lat/long/accuracy — replaces `navigator.geolocation` with a shim that returns user-supplied coordinates. Overrides live on `Geolocation.prototype` (not just the instance) and `Function.prototype.toString` is patched via WeakMap so stringifying the patched methods still reports `[native code]`. The returned `GeolocationPosition`/`Coordinates` use the real class prototypes so `instanceof` holds. Coordinates jitter ~2m per call and resolve after ~150-400ms so `watchPosition` and `getCurrentPosition` look organic.
- `spoofTimezone` (IANA name) — overrides `Intl.DateTimeFormat` so `resolvedOptions().timeZone` reports the configured zone, `Date.prototype.getTimezoneOffset` returns the DST-correct offset at the Date's instant (computed via Intl), and `Date.prototype.toString` rebuilds the browser-style `"... GMT+0900 (Japan Standard Time)"` output with the spoofed offset and zone name. Known gap: `Date.get*` methods still return real local time; cross-referencing callers can detect the spoof.
- `webRtcPolicy` (default / relayOnly / disabled) — closes the real-IP leak through HTTP(S)/SOCKS proxies (Android WebView's proxy API only tunnels TCP, and Chromium's WebRTC UDP stack does not honor it). `relayOnly` forces `iceTransportPolicy: 'relay'` on every `RTCPeerConnection` and strips non-relay ICE candidates from local SDP. `disabled` neuters `RTCPeerConnection` entirely.
- `navigator.permissions.query({name:'geolocation'})` returns `'granted'` so the reported permission state agrees with the resolving `getCurrentPosition` call.

The shim is built once per webview from `LocationSpoofService` and injected at `DOCUMENT_START` via `initialUserScripts` — before any content-blocker CSS or user-scripts shim — so overrides are in place before any site script can capture the unpatched references. Returns null (no injection) when every feature is off.

Per-site UI is a new "Location & timezone" section in the settings screen with a mode dropdown, lat/long/accuracy inputs, IANA timezone dropdown (curated ~50-entry list), and WebRTC policy dropdown.

All six fields round-trip through `WebViewModel.toJson`/`fromJson` with backwards-compatible defaults when missing, so existing sites and backup files keep working.

Spec: openspec/specs/per-site-location/spec.md