### PR TITLE
Override navigator.language so SPAs honor per-site language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ Detailed feature specs are in `openspec/specs/`. Each spec uses Given/When/Then 
 | dns-blocklist | Hagezi DNS blocklist domain blocking with severity levels and per-site toggle |
 | home-shortcut | Android home screen shortcut for sites via pinned shortcuts API |
 | icon-fetching | Progressive favicon loading with fallbacks |
+| language | Per-site language: Accept-Language header + DOCUMENT_START navigator.language / Intl override |
 | lazy-webview-loading | On-demand webview creation, IndexedStack placeholders |
 | localcdn | LocalCDN - cache CDN resources locally to prevent CDN tracking (Android) |
 | navigation | Back gesture, home button, drawer swipe, pull-to-refresh, platform quirks, race condition guards |
@@ -112,7 +113,7 @@ Detailed feature specs are in `openspec/specs/`. Each spec uses Given/When/Then 
 | site-editing | Edit site URLs and custom names |
 | user-scripts | Per-site custom JavaScript injection with injection timing control |
 | webspaces | Site organization into named collections |
-| webview-hints | Webview theme and display hints |
+| webview-hints | Webview theme hints (color-scheme, matchMedia, cache theme prelude) |
 | fullscreen-mode | Full screen mode: hide app bar/tab strip/system UI, per-site auto-fullscreen setting |
 | desktop-mode | Per-site desktop-mode toggle wired to `InAppWebViewSettings.preferredContentMode` |
 

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -578,6 +579,38 @@ const String _clearUrlShareScript = r'''
 })();
 ''';
 
+/// JavaScript that overrides `navigator.language`, `navigator.languages`, and
+/// `Intl.DateTimeFormat().resolvedOptions().locale` so JS-side locale resolvers
+/// (React i18n, date formatters) see the per-site language instead of the OS
+/// locale. Must be injected at DOCUMENT_START to beat the page's own JS.
+String _languageOverrideScript(String language) {
+  // Use JSON encoding so the tag is safely escaped into the JS literal.
+  final encoded = jsonEncode(language);
+  return '''
+(function() {
+  try {
+    var lang = $encoded;
+    var langs = Object.freeze([lang]);
+    Object.defineProperty(Navigator.prototype, 'language', {
+      configurable: true, get: function() { return lang; }
+    });
+    Object.defineProperty(Navigator.prototype, 'languages', {
+      configurable: true, get: function() { return langs; }
+    });
+    if (typeof Intl !== 'undefined' && Intl.DateTimeFormat) {
+      var proto = Intl.DateTimeFormat.prototype;
+      var orig = proto.resolvedOptions;
+      proto.resolvedOptions = function() {
+        var r = orig.apply(this, arguments);
+        r.locale = lang;
+        return r;
+      };
+    }
+  } catch (e) {}
+})();
+''';
+}
+
 
 /// Factory for creating webviews
 class WebViewFactory {
@@ -699,6 +732,18 @@ class WebViewFactory {
       userScripts.add(inapp.UserScript(
         groupName: 'clearurl_share',
         source: '$_clearUrlShareScript\n;null;',
+        injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
+      ));
+    }
+
+    // Override navigator.language / navigator.languages so client-rendered
+    // SPAs (Bluesky, etc.) pick up the per-site language instead of the OS
+    // locale. The Accept-Language header alone doesn't reach JS-side locale
+    // resolvers. Must run at DOCUMENT_START before the page's JS reads it.
+    if (config.language != null) {
+      userScripts.add(inapp.UserScript(
+        groupName: 'language_override',
+        source: '${_languageOverrideScript(config.language!)}\n;null;',
         injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
       ));
     }

--- a/openspec/README.md
+++ b/openspec/README.md
@@ -19,6 +19,7 @@ openspec/
     ├── dns-blocklist/spec.md             # Hagezi DNS blocklist domain blocking
     ├── home-shortcut/spec.md             # Android home screen shortcuts
     ├── icon-fetching/spec.md             # Progressive favicon loading
+    ├── language/spec.md                  # Per-site language (Accept-Language + navigator.language override)
     ├── lazy-webview-loading/spec.md      # On-demand webview creation
     ├── localcdn/spec.md                  # Local CDN resource caching
     ├── navigation/spec.md                # Back gesture, home button, pull-to-refresh
@@ -58,6 +59,7 @@ Each spec file follows the OpenSpec format:
 | DNS Blocklist | Completed | Hagezi DNS blocklist with severity levels and per-site toggle |
 | Home Shortcut | Completed | Android home screen shortcut via pinned shortcuts API |
 | Icon Fetching | Completed | Progressive favicon loading with fallbacks |
+| Language | Completed | Per-site language via Accept-Language header and navigator.language override |
 | Lazy Webview Loading | Completed | On-demand webview creation with IndexedStack placeholders |
 | LocalCDN | Completed | Cache CDN resources locally to prevent CDN tracking (Android) |
 | Navigation | Completed | Back gesture, home button, drawer swipe, pull-to-refresh |
@@ -70,7 +72,7 @@ Each spec file follows the OpenSpec format:
 | Site Editing | Completed | Edit URLs and custom names |
 | User Scripts | Completed | Per-site custom JavaScript injection with timing control |
 | Webspaces | Completed | Organize sites into named collections |
-| Webview Hints | Completed | Webview theme and display hints |
+| Webview Hints | Completed | Webview theme hints (color-scheme, matchMedia, HTML cache theme prelude) |
 
 ## Usage
 

--- a/openspec/specs/language/spec.md
+++ b/openspec/specs/language/spec.md
@@ -1,0 +1,295 @@
+# Per-Site Language Specification
+
+## Status
+**Implemented**
+
+## Purpose
+
+Allow users to choose, per site, the language content should be served in —
+independent of the Android/iOS/macOS system locale. The app communicates the
+preference to both sides of a modern web page:
+
+1. **Server-side:** an `Accept-Language` request header for content negotiation.
+2. **Client-side:** a `DOCUMENT_START` user script that overrides
+   `navigator.language`, `navigator.languages`, and
+   `Intl.DateTimeFormat.prototype.resolvedOptions` so JS-driven locale
+   resolvers (React i18n, SPA framework detection, date/number formatters)
+   see the per-site tag instead of the OS locale.
+
+The preference is a hint. Sites are not forced into the chosen language — they
+may lack a translation, may route via URL path (`/en/`, `/es/`), or may ignore
+both the header and the JS APIs. This spec documents the hints the app sends,
+not what sites do with them.
+
+## Problem Statement
+
+Before the client-side override existed, the Accept-Language header was the
+only signal. Client-rendered SPAs (for example Bluesky) read
+`navigator.languages` at startup to pick a UI locale and ignored the header
+entirely, so the app's per-site language setting had no effect on them even
+after a full data wipe. The user's selected language on-site came from the
+Android system language instead, making the app feel dependent on system
+settings. Adding a `navigator.language` override at `DOCUMENT_START` closes
+that gap.
+
+---
+
+## Requirements
+
+### Requirement: LANG-001 - Accept-Language Header
+
+The app SHALL send the user's per-site language preference as the
+`Accept-Language` HTTP header on top-level navigations from that webview.
+
+The header format is `{tag}, *;q=0.5`, where `{tag}` is a BCP-47 /
+ISO 639-1 code (for example `en`, `es`, `fr`). The `*;q=0.5` fallback
+signals that any language is acceptable at lower priority.
+
+When the user has not chosen a language for a site, no custom header is sent
+and the platform default is used.
+
+#### Scenario: Request content in Spanish
+
+**Given** the user selects Spanish (`es`) for a site
+**When** the webview loads any top-level URL for that site
+**Then** the request includes header `Accept-Language: es, *;q=0.5`
+**And** the server may respond with Spanish content if available
+
+#### Scenario: System default language
+
+**Given** the user has not selected a specific language for a site
+**When** the webview loads any URL
+**Then** no custom `Accept-Language` header is sent
+**And** the platform's default language preference is used
+
+---
+
+### Requirement: LANG-002 - Client-Side Locale Override
+
+When a per-site language is set, the app SHALL inject a
+`UserScriptInjectionTime.AT_DOCUMENT_START` script that overrides, for the
+page and all its inline scripts:
+
+1. `Navigator.prototype.language` — returns the per-site tag
+2. `Navigator.prototype.languages` — returns a frozen single-element array
+   containing the per-site tag
+3. `Intl.DateTimeFormat.prototype.resolvedOptions` — returns the original
+   result with `locale` rewritten to the per-site tag
+
+The override MUST run before any of the page's own JavaScript so SPAs picking
+a locale at boot observe the override, not the OS value. The script is
+omitted entirely when no per-site language is set — the OS values remain
+visible.
+
+The tag is interpolated into the script via JSON encoding so that a tag
+containing quotes, backslashes, or Unicode characters cannot break out of the
+JS string literal.
+
+#### Scenario: SPA observes per-site language
+
+**Given** the user selects Spanish (`es`) for a React-based site
+**And** that site reads `navigator.languages` at boot
+**When** the page loads
+**Then** `navigator.language` is `"es"`
+**And** `navigator.languages` is `["es"]`
+**And** `new Intl.DateTimeFormat().resolvedOptions().locale` is `"es"`
+
+#### Scenario: No override when unset
+
+**Given** the user has not selected a language for a site
+**When** the page loads
+**Then** `navigator.language` returns the OS default
+**And** no override script is injected
+
+---
+
+### Requirement: LANG-003 - Language Selection UI
+
+The app SHALL provide language selection per site in site settings, offering:
+
+1. A "System default" option (no custom header, no JS override)
+2. 30+ BCP-47 / ISO 639-1 language options
+3. A per-site — not per-webspace — preference
+
+Saving a language change SHALL dispose the existing webview so it is recreated
+on next render with the new `Accept-Language` header and the new override
+script.
+
+#### Scenario: Change site language
+
+**Given** a site is displaying in English
+**When** the user selects Spanish in site settings and saves
+**Then** the existing webview is disposed
+**And** the next render creates a new webview with the Spanish
+  `Accept-Language` header
+**And** the `DOCUMENT_START` override script sees `es`
+**And** the site reloads; where supported, content appears in Spanish
+
+---
+
+### Requirement: LANG-004 - Preference Persistence
+
+Per-site language preference SHALL persist across app restarts, carried on
+`WebViewModel.toJson()` like other per-site settings, and SHALL be included
+in settings backup/import via the `sites` array.
+
+#### Scenario: Restore preference on restart
+
+**Given** the user set Spanish for a site
+**When** the app is closed and reopened
+**Then** the site's language is still Spanish
+**And** the next webview creation sends `Accept-Language: es, *;q=0.5`
+**And** injects the override script with tag `es`
+
+---
+
+### Requirement: LANG-005 - Cross-Platform Consistency
+
+The `Accept-Language` header and the client-side override SHALL be applied
+identically on all supported platforms (Android, iOS, macOS). No
+platform-specific branching is permitted for language handling.
+
+#### Scenario: Same behavior across platforms
+
+**Given** the same site with the same per-site language
+**When** the site is opened on Android, iOS, or macOS
+**Then** the `Accept-Language` header is identical on all three
+**And** `navigator.language` inside the page returns the same value on all three
+
+---
+
+## Data Model
+
+```dart
+class WebViewModel {
+  String? language; // BCP-47 tag (e.g., 'en', 'es'), null = system default
+}
+
+class WebViewConfig {
+  final String? language; // Threaded through to the webview on creation
+}
+
+abstract class WebViewController {
+  Future<void> loadUrl(String url, {String? language});
+}
+```
+
+---
+
+## Implementation Details
+
+### Accept-Language Header
+
+Emitted by:
+- `WebViewFactory.createWebView` — sets the header on the initial `URLRequest`
+  when `config.language != null`.
+- `_WebViewController.loadUrl` — sets the header on subsequent programmatic
+  navigations when a language is passed.
+
+Format: `'{language}, *;q=0.5'`, e.g. `Accept-Language: es, *;q=0.5`.
+
+### Client-Side Override Script
+
+`_languageOverrideScript(tag)` builds a small IIFE injected at
+`UserScriptInjectionTime.AT_DOCUMENT_START` via `inapp.UserScript` with
+group name `language_override`. The script:
+
+```dart
+String _languageOverrideScript(String language) {
+  final encoded = jsonEncode(language);
+  return '''
+(function() {
+  try {
+    var lang = $encoded;
+    var langs = Object.freeze([lang]);
+    Object.defineProperty(Navigator.prototype, 'language', {
+      configurable: true, get: function() { return lang; }
+    });
+    Object.defineProperty(Navigator.prototype, 'languages', {
+      configurable: true, get: function() { return langs; }
+    });
+    if (typeof Intl !== 'undefined' && Intl.DateTimeFormat) {
+      var proto = Intl.DateTimeFormat.prototype;
+      var orig = proto.resolvedOptions;
+      proto.resolvedOptions = function() {
+        var r = orig.apply(this, arguments);
+        r.locale = lang;
+        return r;
+      };
+    }
+  } catch (e) {}
+})();
+''';
+}
+```
+
+Design notes:
+
+- The properties are defined on `Navigator.prototype`, not on the `navigator`
+  instance, because some WebView builds (notably older WebKit) treat the
+  instance accessors as non-configurable.
+- The `languages` array is frozen so callers that try to push/splice into it
+  don't silently mutate shared state.
+- The function is wrapped in `try {}` so a failure in one override (for
+  example if `Intl` is absent on a stripped-down engine) does not block the
+  others.
+- The JS source is followed by `\n;null;` when attached to `UserScript` to
+  satisfy `evaluateJavascript`-style return-value handling.
+
+### Propagation on Settings Save
+
+`SettingsScreen` assigns `widget.webViewModel.language = _selectedLanguage`,
+then calls `widget.webViewModel.disposeWebView()`. The parent rebuilds the
+webview with a `UniqueKey`, so `WebViewFactory.createWebView` runs again and
+re-creates both the header and the user script with the new tag.
+
+---
+
+## Browser Compatibility
+
+**Sites that benefit from the client-side override:**
+
+- Single-page apps that call `navigator.languages` at boot (React-based
+  webapps such as Bluesky, many modern social apps)
+- Sites using `Intl.DateTimeFormat` / `Intl.NumberFormat` without an explicit
+  locale argument
+
+**Sites that benefit from the header only:**
+
+- Server-rendered multilingual sites (Wikipedia, DuckDuckGo, Google, etc.)
+- CDNs and origins that content-negotiate on `Accept-Language`
+
+**Sites unaffected by either hint:**
+
+- Sites using URL-based language selection (`/en/`, `/es/`), which typically
+  overrides the header for their internal routing
+- Sites with a single translation
+- Sites that read the language from an auth profile or a cookie
+
+---
+
+## Limitations
+
+- **Top-level requests only:** the custom `Accept-Language` header is applied
+  to the initial URL request and to `loadUrl(...)`-driven navigations. Sub-
+  resource requests (XHR, fetch, sub-iframes) go through the platform
+  networking stack with the OS `Accept-Language`. Sites that re-fetch locale
+  bundles over XHR without respecting the JS APIs may still see the OS tag
+  for those specific requests.
+- **Suggestion, not override:** the chosen language is a hint. A site may
+  lack a translation, may force a locale via its own logic, or may ignore
+  both the header and the JS APIs.
+- **Not retroactive within a session:** changing the language disposes the
+  webview so the override runs on the next creation. Existing long-lived
+  webviews would otherwise not pick up the new tag.
+
+---
+
+## Files
+
+- `lib/services/webview.dart` — `Accept-Language` header emission,
+  `_languageOverrideScript`, `UserScript` registration
+- `lib/web_view_model.dart` — `language` field and serialization
+- `lib/main.dart` — language threaded into `WebViewConfig` and `loadUrl`
+- `lib/screens/settings.dart` — language selection UI
+- `lib/demo_data.dart` — demo language defaults

--- a/openspec/specs/webview-hints/spec.md
+++ b/openspec/specs/webview-hints/spec.md
@@ -2,11 +2,18 @@
 
 ## Purpose
 
-The app provides hints to webviews about user preferences for display and content. These hints include:
-1. **Theme preference** (light/dark mode) - Suggests visual theme via JavaScript
-2. **Language preference** - Requests content in preferred language via Accept-Language header
+The app provides hints to webviews about user display preferences. Currently
+this spec covers theme preference (light/dark mode) suggested via JavaScript
+injection.
 
-These are hints/suggestions to websites, not forced overrides. Websites may choose to respect or ignore them.
+> **Note:** per-site language preference — which was previously covered here
+> as `HINTS-003` / `HINTS-004` — now lives in its own spec at
+> [`openspec/specs/language/spec.md`](../language/spec.md). That spec covers
+> both the `Accept-Language` header and the client-side
+> `navigator.language` / `Intl` override.
+
+Hints are suggestions to websites, not forced overrides. Websites may choose
+to respect or ignore them.
 
 ## Status
 
@@ -46,50 +53,13 @@ Theme preference SHALL be applied to webviews via JavaScript injection that:
 
 ---
 
-### Requirement: HINTS-003 - Language Preference via Accept-Language
+### Requirement: HINTS-003 - Theme Application Timing
 
-The app SHALL send language preferences to webviews via the Accept-Language HTTP header.
-
-#### Scenario: Request content in Spanish
-
-**Given** the user selects Spanish (es) for a site
-**When** the webview loads any URL
-**Then** the request includes header `Accept-Language: es, *;q=0.5`
-**And** the server may respond with Spanish content if available
-
-#### Scenario: System default language
-
-**Given** the user has not selected a specific language
-**When** the webview loads any URL
-**Then** no custom Accept-Language header is sent
-**And** the system's default language preference is used
-
----
-
-### Requirement: HINTS-004 - Language Selection UI
-
-The app SHALL provide language selection in site settings with:
-1. System default option (no custom header)
-2. 30+ language options
-3. Per-site language preference (not per-workspace)
-
-#### Scenario: Change site language
-
-**Given** a site is displaying in English
-**When** the user selects Spanish in site settings and saves
-**Then** the webview recreates with Spanish Accept-Language header
-**And** the site reloads showing Spanish content (if supported)
-
----
-
-### Requirement: HINTS-005 - Hint Application Timing
-
-Theme and language hints SHALL be applied:
-1. On webview creation (initial load with Accept-Language, theme on controller ready)
+The theme hint SHALL be applied:
+1. On webview creation (theme on controller ready)
 2. On page navigation (theme reapplied after each page load)
 3. On theme toggle (immediately to all existing webviews)
-4. On language change (webview recreated with new Accept-Language)
-5. On app startup (to all restored webviews)
+4. On app startup (to all restored webviews)
 
 #### Scenario: Apply theme on toggle
 
@@ -97,39 +67,30 @@ Theme and language hints SHALL be applied:
 **When** the user toggles from light to dark mode
 **Then** all webviews immediately receive the dark theme preference
 
-#### Scenario: Apply language on settings save
-
-**Given** a webview is displaying content
-**When** the user changes language and saves settings
-**Then** the webview recreates with UniqueKey
-**And** loads current URL with new Accept-Language header
-
 ---
 
-### Requirement: HINTS-006 - Preference Persistence
+### Requirement: HINTS-004 - Theme Persistence
 
-Theme and language preferences SHALL persist across app restarts.
+Theme preference SHALL persist across app restarts.
 
-#### Scenario: Restore preferences on restart
+#### Scenario: Restore theme on restart
 
-**Given** the user set dark mode and Spanish language for a site
+**Given** the user set dark mode
 **When** the app is closed and reopened
 **Then** dark mode is still active
-**And** the site's language is still Spanish
-**And** all hints are reapplied to webviews
+**And** the theme hint is reapplied to webviews
 
 ---
 
-### Requirement: HINTS-007 - Cross-Platform Consistency
+### Requirement: HINTS-005 - Cross-Platform Consistency
 
-Hint mechanisms SHALL work on all supported platforms.
+The theme hint mechanism SHALL work on all supported platforms.
 
-#### Scenario: Hints work on Android and Linux
+#### Scenario: Hints work across platforms
 
 **Given** the same webview content
-**When** hints are applied on Android
-**And** hints are applied on Linux
-**Then** both platforms inject the same preferences
+**When** the theme hint is applied on Android, iOS, and macOS
+**Then** all platforms inject the same preference
 
 ---
 
@@ -142,17 +103,8 @@ enum WebViewTheme {
   system,
 }
 
-class WebViewModel {
-  String? language; // Language code (e.g., 'en', 'es'), null = system default
-}
-
-class WebViewConfig {
-  final String? language; // Language code for Accept-Language header
-}
-
 abstract class WebViewController {
   Future<void> setThemePreference(WebViewTheme theme);
-  Future<void> loadUrl(String url, {String? language});
 }
 ```
 
@@ -172,18 +124,6 @@ abstract class WebViewController {
 - Sites with forced light theme in CSS
 - Sites that ignore color-scheme preferences
 
-### Language Hints
-
-**Websites That Support Language Hints:**
-- Multilingual sites (Wikipedia, DuckDuckGo, Google, etc.)
-- Sites that respect Accept-Language header
-- Content negotiation-aware servers
-
-**Websites That Don't Support Language Hints:**
-- Single-language sites
-- Sites using URL-based language selection (/en/, /es/)
-- Sites ignoring Accept-Language header
-
 ---
 
 ## Limitations
@@ -193,12 +133,6 @@ abstract class WebViewController {
 - **Site-dependent**: Websites must implement their own dark mode
 - **JavaScript required**: Theme application requires JavaScript enabled
 - **Best effort**: Some sites may not respond to the preference
-
-### Language Hints
-- **Server-dependent**: Sites must respect Accept-Language header
-- **Not a guarantee**: Sites may not have content in requested language
-- **Per-request**: Each navigation sends the header, but sites control response
-- **URL structure**: Some sites use URL paths for language (e.g., /en/, /es/) which overrides header
 
 ---
 
@@ -225,25 +159,11 @@ html,body{background:#111 !important;color-scheme:dark}
 
 This eliminates the white-frame flash while the cached HTML's stylesheets and user scripts re-run on the live load. The prelude is keyed on the live `WebViewModel.currentTheme` plus platform brightness (for `WebViewTheme.system`), so a theme switch takes effect on the next cache load without cache invalidation. The helper is idempotent — duplicate prelude insertion is detected via the `__ws_cache_prelude` id.
 
-### Language Header
-
-The language hint is sent via HTTP header:
-```
-Accept-Language: es, *;q=0.5
-```
-
-Format: `{language}, *;q=0.5` where:
-- `{language}` is the ISO 639-1 code (en, es, fr, etc.)
-- `*;q=0.5` indicates any language is acceptable with lower priority
-- Header is sent on all requests from that webview
-
 ---
 
 ## Files
 
 ### Modified
-- `lib/services/webview.dart` - WebViewTheme enum, Accept-Language header, theme injection
-- `lib/web_view_model.dart` - Theme state, language field, webview recreation with UniqueKey
-- `lib/main.dart` - Theme toggle, language propagation
-- `lib/screens/settings.dart` - Language selection UI
-- `lib/demo_data.dart` - Demo language defaults
+- `lib/services/webview.dart` — `WebViewTheme` enum, theme injection
+- `lib/web_view_model.dart` — theme state, webview recreation with `UniqueKey`
+- `lib/main.dart` — theme toggle


### PR DESCRIPTION
The per-site language setting only applied the Accept-Language HTTP header. Client-rendered SPAs (Bluesky, etc.) read navigator.language / navigator.languages at boot and picked up the OS locale instead. Inject a DOCUMENT_START user script that also overrides Intl.DateTimeFormat.resolvedOptions().locale to match.