### PR TITLE
Prompt before launching intent:// and other external-app URLs

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3149,11 +3149,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                                   },
                                   onExternalSchemeUrl: (url, info) async {
                                     if (!mounted) return;
-                                    await confirmAndLaunchExternalUrl(
-                                      context,
-                                      info,
-                                      fallbackController: webViewModel.controller,
-                                    );
+                                    await confirmAndLaunchExternalUrl(context, info);
                                   },
                                 ),
                               ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,6 +54,7 @@ import 'package:webspace/settings/user_script.dart';
 import 'package:webspace/utils/url_utils.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:webspace/widgets/download_button.dart';
+import 'package:webspace/widgets/external_url_prompt.dart';
 import 'package:webspace/widgets/root_messenger.dart';
 
 // Accent color enum
@@ -3145,6 +3146,14 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                                       ),
                                     );
                                     return result ?? false;
+                                  },
+                                  onExternalSchemeUrl: (url, info) async {
+                                    if (!mounted) return;
+                                    await confirmAndLaunchExternalUrl(
+                                      context,
+                                      info,
+                                      fallbackController: webViewModel.controller,
+                                    );
                                   },
                                 ),
                               ),

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -302,11 +302,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen> {
                 onWindowRequested: _showPopupWindow,
                 onExternalSchemeUrl: (url, info) async {
                   if (!mounted) return;
-                  await confirmAndLaunchExternalUrl(
-                    context,
-                    info,
-                    fallbackController: _controller,
-                  );
+                  await confirmAndLaunchExternalUrl(context, info);
                 },
               ),
               onControllerCreated: (controller) {

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -9,6 +9,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/settings/location.dart';
 import 'package:webspace/widgets/download_button.dart';
+import 'package:webspace/widgets/external_url_prompt.dart';
 import 'package:webspace/widgets/find_toolbar.dart';
 import 'package:webspace/widgets/url_bar.dart';
 
@@ -299,6 +300,14 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen> {
                   });
                 },
                 onWindowRequested: _showPopupWindow,
+                onExternalSchemeUrl: (url, info) async {
+                  if (!mounted) return;
+                  await confirmAndLaunchExternalUrl(
+                    context,
+                    info,
+                    fallbackController: _controller,
+                  );
+                },
               ),
               onControllerCreated: (controller) {
                 _controller = controller;

--- a/lib/services/external_url_engine.dart
+++ b/lib/services/external_url_engine.dart
@@ -114,3 +114,53 @@ class ExternalUrlParser {
     );
   }
 }
+
+/// Loop-suppression for external URL prompts. After the user decides what
+/// to do with an intent (open in app / browser / cancel), pages commonly
+/// re-fire the same intent moments later (Google Maps does this every
+/// visit). The suppression list breaks that loop and lets the
+/// `onReceivedError` recovery in `webview.dart` skip reloading a URL the
+/// user already chose to leave alone.
+class ExternalUrlSuppressor {
+  ExternalUrlSuppressor._();
+
+  static final Map<String, DateTime> _suppressed = {};
+
+  static String _keyForInfo(ExternalUrlInfo info) {
+    final uri = Uri.tryParse(info.url);
+    final hostPath = uri == null ? info.url : '${uri.host}${uri.path}';
+    return '${info.scheme}|$hostPath|${info.package ?? ''}';
+  }
+
+  /// Returns true if a suppression entry exists for [info] and hasn't
+  /// expired.
+  static bool isSuppressedInfo(ExternalUrlInfo info) =>
+      _checkExpiry(_keyForInfo(info));
+
+  /// URL-keyed variant — convenience for callers that only have the raw
+  /// URL string (e.g. `onReceivedError` in webview.dart).
+  static bool isSuppressedUrl(String url) {
+    final info = ExternalUrlParser.parse(url);
+    return info == null ? false : isSuppressedInfo(info);
+  }
+
+  static void mark(
+    ExternalUrlInfo info, {
+    Duration duration = const Duration(seconds: 30),
+  }) {
+    _suppressed[_keyForInfo(info)] = DateTime.now().add(duration);
+  }
+
+  static bool _checkExpiry(String key) {
+    final expiry = _suppressed[key];
+    if (expiry == null) return false;
+    if (DateTime.now().isAfter(expiry)) {
+      _suppressed.remove(key);
+      return false;
+    }
+    return true;
+  }
+
+  /// Test hook.
+  static void clear() => _suppressed.clear();
+}

--- a/lib/services/external_url_engine.dart
+++ b/lib/services/external_url_engine.dart
@@ -1,0 +1,116 @@
+/// Parsed metadata for a non-webview URL (intent://, tel:, mailto:,
+/// market:, custom app schemes, etc.). The rendering layer turns this
+/// into a confirmation dialog and, on accept, hands it to url_launcher.
+class ExternalUrlInfo {
+  /// The original URL string as the webview saw it.
+  final String url;
+
+  /// Lowercase URI scheme (e.g. `intent`, `tel`, `mailto`, `market`).
+  final String scheme;
+
+  /// URI host when one is present. Intent URLs carry the target host
+  /// here (e.g. `www.google.com` for Google Maps intents).
+  final String? host;
+
+  /// Android package extracted from intent:// extras (`;package=...`).
+  /// Non-null only for intent URLs that name a target app.
+  final String? package;
+
+  /// `browser_fallback_url` extra from intent:// URLs — a regular web
+  /// URL that should load in the webview when the target app is absent.
+  final String? fallbackUrl;
+
+  /// Target scheme embedded in intent:// extras (`;scheme=https`).
+  /// Useful for reconstructing the intended web URL when no explicit
+  /// fallback is provided.
+  final String? targetScheme;
+
+  const ExternalUrlInfo({
+    required this.url,
+    required this.scheme,
+    this.host,
+    this.package,
+    this.fallbackUrl,
+    this.targetScheme,
+  });
+}
+
+/// Schemes handled by the webview itself — everything else is routed
+/// through the external-URL confirmation flow.
+const Set<String> _internalSchemes = {
+  'http',
+  'https',
+  'data',
+  'blob',
+  'about',
+  'file',
+  'javascript',
+  'view-source',
+};
+
+class ExternalUrlParser {
+  /// Parses a URL the webview tried to navigate to. Returns null for
+  /// normal webview navigations; a populated [ExternalUrlInfo] for
+  /// intents and custom app schemes that must be routed to the OS.
+  static ExternalUrlInfo? parse(String url) {
+    final uri = Uri.tryParse(url);
+    if (uri == null) return null;
+    final scheme = uri.scheme.toLowerCase();
+    if (scheme.isEmpty || _internalSchemes.contains(scheme)) return null;
+
+    if (scheme == 'intent') {
+      return _parseIntent(url, uri);
+    }
+    return ExternalUrlInfo(
+      url: url,
+      scheme: scheme,
+      host: uri.host.isEmpty ? null : uri.host,
+    );
+  }
+
+  /// Android intent:// URL format:
+  ///   intent://HOST/PATH?QUERY#Intent;scheme=...;package=...;S.browser_fallback_url=...;end
+  /// Extras live in the fragment, `;`-separated, with `S.` prefixing
+  /// string extras per the Chrome intent scheme spec.
+  static ExternalUrlInfo _parseIntent(String url, Uri uri) {
+    String? package;
+    String? fallbackUrl;
+    String? targetScheme;
+
+    final fragment = uri.fragment;
+    if (fragment.startsWith('Intent;')) {
+      final parts = fragment.substring('Intent;'.length).split(';');
+      for (final part in parts) {
+        if (part.isEmpty || part == 'end') continue;
+        final eq = part.indexOf('=');
+        if (eq < 0) continue;
+        final key = part.substring(0, eq);
+        final value = part.substring(eq + 1);
+        switch (key) {
+          case 'package':
+            package = value;
+            break;
+          case 'scheme':
+            targetScheme = value;
+            break;
+          case 'S.browser_fallback_url':
+            try {
+              fallbackUrl = Uri.decodeComponent(value);
+            } catch (_) {
+              fallbackUrl = value;
+            }
+            break;
+        }
+      }
+    }
+
+    return ExternalUrlInfo(
+      url: url,
+      scheme: 'intent',
+      host: uri.host.isEmpty ? null : uri.host,
+      package: package,
+      fallbackUrl: fallbackUrl,
+      targetScheme: targetScheme,
+    );
+  }
+}

--- a/lib/services/external_url_engine.dart
+++ b/lib/services/external_url_engine.dart
@@ -36,7 +36,10 @@ class ExternalUrlInfo {
 }
 
 /// Schemes handled by the webview itself — everything else is routed
-/// through the external-URL confirmation flow.
+/// through the external-URL confirmation flow. The chrome-* family is
+/// rendered by the Chromium engine that powers Android's WebView (e.g.
+/// `chrome://version`, `chrome-error://chromewebdata` from a failed
+/// load); they aren't OS app launches and shouldn't prompt.
 const Set<String> _internalSchemes = {
   'http',
   'https',
@@ -46,6 +49,11 @@ const Set<String> _internalSchemes = {
   'file',
   'javascript',
   'view-source',
+  'chrome',
+  'chrome-extension',
+  'chrome-error',
+  'chrome-search',
+  'chrome-untrusted',
 };
 
 class ExternalUrlParser {

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1559,7 +1559,20 @@ class WebViewFactory {
         if (externalInfo == null) return;
         if (ExternalUrlSuppressor.isSuppressedInfo(externalInfo)) {
           LogService.instance.log('WebView',
-              'onReceivedError: suppressed, leaving page in place — url=$reqUrl');
+              'onReceivedError: suppressed — calling goBack to drop error commit (url=$reqUrl)');
+          // The fallback page loaded successfully and got cached; the
+          // intent:// redirect that Android painted over it as
+          // chrome-error://chromewebdata is just one entry on top in the
+          // back stack. Pop it so the user lands on the fallback page
+          // they actually wanted to see. Defer to a microtask for the
+          // same chromium-bookkeeping reason as the recovery path below.
+          Future.microtask(() async {
+            try {
+              if (await controller.canGoBack()) {
+                await controller.goBack();
+              }
+            } catch (_) {}
+          });
           return;
         }
         if (config.onExternalSchemeUrl != null) {

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1559,18 +1559,20 @@ class WebViewFactory {
         if (externalInfo == null) return;
         if (ExternalUrlSuppressor.isSuppressedInfo(externalInfo)) {
           LogService.instance.log('WebView',
-              'onReceivedError: suppressed — calling goBack to drop error commit (url=$reqUrl)');
-          // The fallback page loaded successfully and got cached; the
-          // intent:// redirect that Android painted over it as
-          // chrome-error://chromewebdata is just one entry on top in the
-          // back stack. Pop it so the user lands on the fallback page
-          // they actually wanted to see. Defer to a microtask for the
-          // same chromium-bookkeeping reason as the recovery path below.
+              'onReceivedError: suppressed — loading about:blank to clear error commit (url=$reqUrl)');
+          // The fallback page actually loaded (HtmlCache shows
+          // multi-MB saves); Android then painted chrome-error://
+          // chromewebdata over it because the page's JS retried the
+          // intent we cancelled. about:blank clears the error visibly
+          // without walking back through history (controller.goBack
+          // dropped users out of the webview entirely). The
+          // suppression already prevents another dialog if the page
+          // tries again.
           Future.microtask(() async {
             try {
-              if (await controller.canGoBack()) {
-                await controller.goBack();
-              }
+              await controller.loadUrl(
+                urlRequest: inapp.URLRequest(url: inapp.WebUri('about:blank')),
+              );
             } catch (_) {}
           });
           return;

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1537,19 +1537,22 @@ class WebViewFactory {
         config.onConsoleMessage?.call(consoleMessage.message, consoleMessage.messageLevel);
       },
       onReceivedError: (controller, request, error) async {
-        // Android's WebView paints an ERR_UNKNOWN_URL_SCHEME page when an
-        // intent:// (or other non-internal scheme) navigation slips past
-        // shouldOverrideUrlLoading — typically when the URL came from a
-        // server-side redirect or a window.location assignment.
-        // Recovery: reload the last stable URL so the user isn't stuck
-        // on the error page. But ONLY if the URL isn't currently
-        // suppressed — when the user just chose Open in browser/app the
-        // page redirects right back to the same intent on its own load,
-        // and reloading would clobber whatever the fallback rendered.
-        // Defer the loadUrl to a microtask so chromium can finish its
-        // own bookkeeping for this navigation before we issue another;
-        // a previous version called loadUrl synchronously and triggered
-        // a dangling raw_ptr FATAL inside chromium.
+        // For non-internal schemes (intent://, custom app schemes) Android
+        // sometimes hands the URL straight to onReceivedError without
+        // calling shouldOverrideUrlLoading first — observed every time on
+        // Google Maps' window.location='intent://...' redirect. Without
+        // routing through the dialog path here, the user never sees the
+        // confirmation, suppression is never marked, and the previous
+        // "reload lastStableUrl" recovery looped forever (every reload
+        // re-renders the page that re-fires the same intent).
+        //
+        // New flow:
+        //   * already suppressed → silent no-op (lets the page sit on
+        //     whatever it managed to render before redirecting).
+        //   * external scheme + host UI hooked up → fire the dialog
+        //     callback; the helper guards against duplicate prompts and
+        //     marks suppression on the user's choice.
+        //   * external scheme + no host UI → best-effort reload.
         if (request.isForMainFrame != true) return;
         final reqUrl = request.url.toString();
         final externalInfo = ExternalUrlParser.parse(reqUrl);
@@ -1559,10 +1562,17 @@ class WebViewFactory {
               'onReceivedError: suppressed, leaving page in place — url=$reqUrl');
           return;
         }
+        if (config.onExternalSchemeUrl != null) {
+          LogService.instance.log('WebView',
+              'onReceivedError: type=${error.type} url=$reqUrl '
+              '— routing to external-scheme dialog');
+          config.onExternalSchemeUrl!(reqUrl, externalInfo);
+          return;
+        }
         final recovery = lastStableUrl ?? config.initialUrl;
         LogService.instance.log('WebView',
             'onReceivedError: type=${error.type} url=$reqUrl '
-            '— scheduling reload of $recovery to clear error page');
+            '— no host UI, scheduling reload of $recovery');
         Future.microtask(() async {
           try {
             await controller.loadUrl(

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1539,6 +1539,28 @@ class WebViewFactory {
       onConsoleMessage: (controller, consoleMessage) {
         config.onConsoleMessage?.call(consoleMessage.message, consoleMessage.messageLevel);
       },
+      onReceivedError: (controller, request, error) async {
+        // Android's WebView paints an ERR_UNKNOWN_URL_SCHEME page when an
+        // intent:// (or other non-internal scheme) navigation slips past
+        // shouldOverrideUrlLoading — typically when the URL came from a
+        // server-side redirect or a window.location assignment. Cancelling
+        // the navigation isn't enough; the error commit happens anyway.
+        // Detect main-frame failures whose URL has a non-internal scheme
+        // and reload the last stable URL to clear the error.
+        if (request.isForMainFrame != true) return;
+        final reqUrl = request.url.toString();
+        final externalInfo = ExternalUrlParser.parse(reqUrl);
+        if (externalInfo == null) return;
+        final recovery = lastStableUrl ?? config.initialUrl;
+        LogService.instance.log('WebView',
+            'onReceivedError: type=${error.type} url=$reqUrl '
+            '— reloading $recovery to clear error page');
+        try {
+          await controller.loadUrl(
+            urlRequest: inapp.URLRequest(url: inapp.WebUri(recovery)),
+          );
+        } catch (_) {}
+      },
       onDownloadStartRequest: (controller, downloadStartRequest) async {
         // onUrlChanged / onUpdateVisitedHistory has likely already fired
         // with the download URL (e.g. "data:application/pdf;..."), which

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1326,19 +1326,16 @@ class WebViewFactory {
         // app schemes) can't be rendered in a webview — flutter_inappwebview
         // returns ERR_UNKNOWN_URL_SCHEME. Cancel and hand the URL to the
         // host UI, which confirms with the user before calling url_launcher.
-        // We also stopLoading() because returning CANCEL alone doesn't
-        // prevent Android's WebView from painting an ERR_UNKNOWN_URL_SCHEME
-        // error page when the navigation came from a server-side redirect
-        // or a window.location assignment (same root cause the downloads
-        // path mitigates below).
+        // Don't call controller.stopLoading() here — chromium has crashed
+        // with a dangling raw_ptr when stopLoading runs concurrently with
+        // a synchronous CANCEL path. The CANCEL alone aborts the
+        // navigation; if Android still paints ERR_UNKNOWN_URL_SCHEME,
+        // onReceivedError handles recovery.
         final externalInfo = ExternalUrlParser.parse(url);
         if (externalInfo != null) {
           LogService.instance.log('WebView',
               'External scheme intercepted: scheme=${externalInfo.scheme} '
               'package=${externalInfo.package} fallback=${externalInfo.fallbackUrl} url=$url');
-          try {
-            await controller.stopLoading();
-          } catch (_) {}
           if (config.onExternalSchemeUrl != null) {
             config.onExternalSchemeUrl!(url, externalInfo);
           }
@@ -1543,23 +1540,36 @@ class WebViewFactory {
         // Android's WebView paints an ERR_UNKNOWN_URL_SCHEME page when an
         // intent:// (or other non-internal scheme) navigation slips past
         // shouldOverrideUrlLoading — typically when the URL came from a
-        // server-side redirect or a window.location assignment. Cancelling
-        // the navigation isn't enough; the error commit happens anyway.
-        // Detect main-frame failures whose URL has a non-internal scheme
-        // and reload the last stable URL to clear the error.
+        // server-side redirect or a window.location assignment.
+        // Recovery: reload the last stable URL so the user isn't stuck
+        // on the error page. But ONLY if the URL isn't currently
+        // suppressed — when the user just chose Open in browser/app the
+        // page redirects right back to the same intent on its own load,
+        // and reloading would clobber whatever the fallback rendered.
+        // Defer the loadUrl to a microtask so chromium can finish its
+        // own bookkeeping for this navigation before we issue another;
+        // a previous version called loadUrl synchronously and triggered
+        // a dangling raw_ptr FATAL inside chromium.
         if (request.isForMainFrame != true) return;
         final reqUrl = request.url.toString();
         final externalInfo = ExternalUrlParser.parse(reqUrl);
         if (externalInfo == null) return;
+        if (ExternalUrlSuppressor.isSuppressedInfo(externalInfo)) {
+          LogService.instance.log('WebView',
+              'onReceivedError: suppressed, leaving page in place — url=$reqUrl');
+          return;
+        }
         final recovery = lastStableUrl ?? config.initialUrl;
         LogService.instance.log('WebView',
             'onReceivedError: type=${error.type} url=$reqUrl '
-            '— reloading $recovery to clear error page');
-        try {
-          await controller.loadUrl(
-            urlRequest: inapp.URLRequest(url: inapp.WebUri(recovery)),
-          );
-        } catch (_) {}
+            '— scheduling reload of $recovery to clear error page');
+        Future.microtask(() async {
+          try {
+            await controller.loadUrl(
+              urlRequest: inapp.URLRequest(url: inapp.WebUri(recovery)),
+            );
+          } catch (_) {}
+        });
       },
       onDownloadStartRequest: (controller, downloadStartRequest) async {
         // onUrlChanged / onUpdateVisitedHistory has likely already fired

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -13,6 +13,7 @@ import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/services/download_engine.dart';
 import 'package:webspace/services/download_manager.dart';
 import 'package:webspace/services/download_url_revert_engine.dart';
+import 'package:webspace/services/external_url_engine.dart';
 import 'package:webspace/services/web_intercept_native.dart';
 import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/services/location_spoof_service.dart';
@@ -280,6 +281,11 @@ class WebViewConfig {
   /// Callback to confirm fetching a script from a non-whitelisted URL.
   /// Returns true if the user approves, false to block.
   final Future<bool> Function(String url)? onConfirmScriptFetch;
+  /// Callback fired when the webview tries to navigate to a non-webview
+  /// URL (`intent://`, `tel:`, `mailto:`, custom app schemes). The
+  /// webview always cancels such navigations; the host UI decides
+  /// whether to launch the target app after confirming with the user.
+  final Future<void> Function(String url, ExternalUrlInfo info)? onExternalSchemeUrl;
   /// Optional pull-to-refresh controller for enabling pull-to-refresh gesture.
   final inapp.PullToRefreshController? pullToRefreshController;
   /// Per-site geolocation mode. [LocationMode.spoof] injects a shim that
@@ -318,6 +324,7 @@ class WebViewConfig {
     this.onConsoleMessage,
     this.userScripts = const [],
     this.onConfirmScriptFetch,
+    this.onExternalSchemeUrl,
     this.pullToRefreshController,
     this.locationMode = LocationMode.off,
     this.spoofLatitude,
@@ -1315,6 +1322,17 @@ class WebViewFactory {
         final url = navigationAction.request.url.toString();
         if (_shouldBlockUrl(url)) return inapp.NavigationActionPolicy.CANCEL;
         if (isCaptchaChallenge(url)) return inapp.NavigationActionPolicy.ALLOW;
+        // External app schemes (intent://, tel:, mailto:, market:, custom
+        // app schemes) can't be rendered in a webview — flutter_inappwebview
+        // returns ERR_UNKNOWN_URL_SCHEME. Cancel and hand the URL to the
+        // host UI, which confirms with the user before calling url_launcher.
+        final externalInfo = ExternalUrlParser.parse(url);
+        if (externalInfo != null) {
+          if (config.onExternalSchemeUrl != null) {
+            config.onExternalSchemeUrl!(url, externalInfo);
+          }
+          return inapp.NavigationActionPolicy.CANCEL;
+        }
         // DNS blocklist check + record navigation for stats. Record for
         // every http navigation so the per-site log works even when no
         // blocklist is populated; isBlocked is a cheap set lookup.
@@ -1363,6 +1381,17 @@ class WebViewFactory {
           if (config.onWindowRequested != null && windowId != null) {
             await config.onWindowRequested!(windowId, url);
             return true;
+          }
+          return false;
+        }
+
+        // target="_blank" links can carry external app schemes too (e.g.
+        // a `<a target="_blank" href="intent://...">`). Route them through
+        // the same confirmation path as direct navigations.
+        final externalInfo = ExternalUrlParser.parse(url);
+        if (externalInfo != null) {
+          if (config.onExternalSchemeUrl != null) {
+            config.onExternalSchemeUrl!(url, externalInfo);
           }
           return false;
         }

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1326,8 +1326,19 @@ class WebViewFactory {
         // app schemes) can't be rendered in a webview — flutter_inappwebview
         // returns ERR_UNKNOWN_URL_SCHEME. Cancel and hand the URL to the
         // host UI, which confirms with the user before calling url_launcher.
+        // We also stopLoading() because returning CANCEL alone doesn't
+        // prevent Android's WebView from painting an ERR_UNKNOWN_URL_SCHEME
+        // error page when the navigation came from a server-side redirect
+        // or a window.location assignment (same root cause the downloads
+        // path mitigates below).
         final externalInfo = ExternalUrlParser.parse(url);
         if (externalInfo != null) {
+          LogService.instance.log('WebView',
+              'External scheme intercepted: scheme=${externalInfo.scheme} '
+              'package=${externalInfo.package} fallback=${externalInfo.fallbackUrl} url=$url');
+          try {
+            await controller.stopLoading();
+          } catch (_) {}
           if (config.onExternalSchemeUrl != null) {
             config.onExternalSchemeUrl!(url, externalInfo);
           }
@@ -1390,6 +1401,9 @@ class WebViewFactory {
         // the same confirmation path as direct navigations.
         final externalInfo = ExternalUrlParser.parse(url);
         if (externalInfo != null) {
+          LogService.instance.log('WebView',
+              'External scheme intercepted (onCreateWindow): '
+              'scheme=${externalInfo.scheme} package=${externalInfo.package} url=$url');
           if (config.onExternalSchemeUrl != null) {
             config.onExternalSchemeUrl!(url, externalInfo);
           }

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' show ConsoleMessageLevel;
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp show PullToRefreshController, PullToRefreshSettings;
+import 'package:webspace/services/external_url_engine.dart';
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/navigation_decision_engine.dart';
 import 'package:webspace/services/webview.dart';
@@ -451,6 +452,7 @@ class WebViewModel {
     String? initialHtml,
     bool Function()? isActive,
     Future<bool> Function(String url)? onConfirmScriptFetch,
+    Future<void> Function(String url, ExternalUrlInfo info)? onExternalSchemeUrl,
     List<UserScriptConfig> globalUserScripts = const [],
   }) {
     if (webview == null) {
@@ -517,6 +519,7 @@ class WebViewModel {
             ...userScripts,
           ],
           onConfirmScriptFetch: onConfirmScriptFetch,
+          onExternalSchemeUrl: onExternalSchemeUrl,
           pullToRefreshController: pullToRefreshController,
           onWindowRequested: onWindowRequested,
           shouldOverrideUrlLoading: (url, hasGesture) {

--- a/lib/widgets/external_url_prompt.dart
+++ b/lib/widgets/external_url_prompt.dart
@@ -11,37 +11,6 @@ import 'package:webspace/widgets/root_messenger.dart';
 /// webview with several intent:// bursts in a row) only surface one dialog.
 bool _isConfirming = false;
 
-/// Suppression window. After the user picks Open in browser / Open in app,
-/// any subsequent intent:// for the same target host+path+package is
-/// silently aborted for this long — the fallback URL we just loaded
-/// almost always re-fires the same intent immediately, and re-prompting
-/// the user is worse than letting them stay on a half-loaded page.
-const Duration _suppressDuration = Duration(seconds: 30);
-
-/// Per-target expiry timestamps. Key returned by [_suppressKey].
-final Map<String, DateTime> _suppressed = {};
-
-String _suppressKey(ExternalUrlInfo info) {
-  final uri = Uri.tryParse(info.url);
-  final hostPath = uri == null ? info.url : '${uri.host}${uri.path}';
-  return '${info.scheme}|$hostPath|${info.package ?? ''}';
-}
-
-bool _isSuppressed(ExternalUrlInfo info) {
-  final key = _suppressKey(info);
-  final expiry = _suppressed[key];
-  if (expiry == null) return false;
-  if (DateTime.now().isAfter(expiry)) {
-    _suppressed.remove(key);
-    return false;
-  }
-  return true;
-}
-
-void _markSuppressed(ExternalUrlInfo info) {
-  _suppressed[_suppressKey(info)] = DateTime.now().add(_suppressDuration);
-}
-
 /// Strips ClearURLs tracking query params from a URL, regardless of scheme,
 /// by reconstructing it as an https URL (which the ClearURLs ruleset
 /// recognizes), running [ClearUrlService.cleanUrl], then putting the
@@ -127,10 +96,10 @@ Future<void> confirmAndLaunchExternalUrl(
   // after we load their browser_fallback_url. Without suppression the
   // user gets re-prompted every redirect and the choice they made a
   // moment ago is meaningless.
-  if (_isSuppressed(info)) {
+  if (ExternalUrlSuppressor.isSuppressedInfo(info)) {
     LogService.instance.log(
       'ExternalUrl',
-      'suppressed (recently handled within ${_suppressDuration.inSeconds}s): ${info.url}',
+      'suppressed (recently handled): ${info.url}',
     );
     return;
   }
@@ -209,16 +178,16 @@ Future<void> confirmAndLaunchExternalUrl(
         LogService.instance.log('ExternalUrl', 'user chose: cancel');
         // Suppress so a script-driven redirect doesn't re-prompt the
         // user a second later for the choice they just declined.
-        _markSuppressed(info);
+        ExternalUrlSuppressor.mark(info);
         return;
       case _ExternalUrlChoice.openInBrowser:
         LogService.instance.log('ExternalUrl', 'user chose: open in browser → $cleanedFallback');
-        _markSuppressed(info);
+        ExternalUrlSuppressor.mark(info);
         await fallbackController!.loadUrl(cleanedFallback);
         return;
       case _ExternalUrlChoice.openInApp:
         LogService.instance.log('ExternalUrl', 'user chose: open in app → $cleanedLaunchUrl');
-        _markSuppressed(info);
+        ExternalUrlSuppressor.mark(info);
         await _launchInApp(cleanedLaunchUrl, cleanedFallback, fallbackController, info.scheme);
         return;
     }

--- a/lib/widgets/external_url_prompt.dart
+++ b/lib/widgets/external_url_prompt.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart' as url_launcher;
+
+import 'package:webspace/services/external_url_engine.dart';
+import 'package:webspace/services/webview.dart';
+import 'package:webspace/widgets/root_messenger.dart';
+
+/// Shared per-route guard so rapid-fire redirects (Google Maps can hit the
+/// webview with several intent:// bursts in a row) only surface one dialog.
+bool _isConfirming = false;
+
+/// Ask the user whether to hand [info.url] to the OS via url_launcher.
+/// If the OS has no handler (or the user declines) and the intent carried
+/// a `browser_fallback_url`, load that in [fallbackController] instead.
+Future<void> confirmAndLaunchExternalUrl(
+  BuildContext context,
+  ExternalUrlInfo info, {
+  WebViewController? fallbackController,
+}) async {
+  if (_isConfirming) return;
+  _isConfirming = true;
+  try {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Open external app?'),
+        content: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text('This site wants to open:'),
+              const SizedBox(height: 8),
+              SelectableText(
+                info.url,
+                style: const TextStyle(fontFamily: 'monospace'),
+              ),
+              if (info.package != null) ...[
+                const SizedBox(height: 8),
+                Text('Package: ${info.package}'),
+              ],
+              if (info.fallbackUrl != null) ...[
+                const SizedBox(height: 8),
+                Text('Fallback URL: ${info.fallbackUrl}'),
+              ],
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Open'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    final uri = Uri.tryParse(info.url);
+    var launched = false;
+    if (uri != null) {
+      try {
+        launched = await url_launcher.launchUrl(
+          uri,
+          mode: url_launcher.LaunchMode.externalApplication,
+        );
+      } catch (_) {
+        launched = false;
+      }
+    }
+    if (launched) return;
+
+    final fallback = info.fallbackUrl;
+    if (fallback != null && fallback.isNotEmpty && fallbackController != null) {
+      await fallbackController.loadUrl(fallback);
+      return;
+    }
+    rootScaffoldMessengerKey.currentState?.showSnackBar(
+      SnackBar(content: Text('No app available to open ${info.scheme}:')),
+    );
+  } finally {
+    _isConfirming = false;
+  }
+}

--- a/lib/widgets/external_url_prompt.dart
+++ b/lib/widgets/external_url_prompt.dart
@@ -183,7 +183,7 @@ Future<void> confirmAndLaunchExternalUrl(
       case _ExternalUrlChoice.openInBrowser:
         LogService.instance.log('ExternalUrl', 'user chose: open in browser → $cleanedFallback');
         ExternalUrlSuppressor.mark(info);
-        await fallbackController!.loadUrl(cleanedFallback);
+        await _safeLoadUrl(fallbackController, cleanedFallback, label: 'browser fallback');
         return;
       case _ExternalUrlChoice.openInApp:
         LogService.instance.log('ExternalUrl', 'user chose: open in app → $cleanedLaunchUrl');
@@ -193,6 +193,34 @@ Future<void> confirmAndLaunchExternalUrl(
     }
   } finally {
     _isConfirming = false;
+  }
+}
+
+/// loadUrl wrapper that surfaces failures in the in-app log instead of
+/// silently dropping them. The dialog is sometimes triggered while the
+/// webview is parked on `chrome-error://chromewebdata` (when the dialog
+/// came from `onReceivedError`); deferring to a microtask gives chromium
+/// a chance to settle before we issue the navigation.
+Future<void> _safeLoadUrl(
+  WebViewController? controller,
+  String url, {
+  required String label,
+}) async {
+  if (controller == null) {
+    LogService.instance.log('ExternalUrl', '$label: controller is null, dropping load $url');
+    return;
+  }
+  if (url.isEmpty) {
+    LogService.instance.log('ExternalUrl', '$label: url is empty, nothing to load');
+    return;
+  }
+  LogService.instance.log('ExternalUrl', '$label: scheduling loadUrl($url)');
+  await Future<void>.delayed(Duration.zero);
+  try {
+    await controller.loadUrl(url);
+    LogService.instance.log('ExternalUrl', '$label: loadUrl returned for $url');
+  } catch (e, st) {
+    LogService.instance.log('ExternalUrl', '$label: loadUrl threw for $url — $e\n$st');
   }
 }
 
@@ -220,7 +248,7 @@ Future<void> _launchInApp(
 
   if (cleanedFallback.isNotEmpty && fallbackController != null) {
     LogService.instance.log('ExternalUrl', 'launch failed, loading fallback: $cleanedFallback');
-    await fallbackController.loadUrl(cleanedFallback);
+    await _safeLoadUrl(fallbackController, cleanedFallback, label: 'in-app fallback');
     return;
   }
   rootScaffoldMessengerKey.currentState?.showSnackBar(

--- a/lib/widgets/external_url_prompt.dart
+++ b/lib/widgets/external_url_prompt.dart
@@ -11,24 +11,96 @@ import 'package:webspace/widgets/root_messenger.dart';
 /// webview with several intent:// bursts in a row) only surface one dialog.
 bool _isConfirming = false;
 
-/// Strips ClearURLs tracking query params from an `intent://` URL by
-/// reconstructing it as an https URL (which the ClearURLs ruleset
+/// Suppression window. After the user picks Open in browser / Open in app,
+/// any subsequent intent:// for the same target host+path+package is
+/// silently aborted for this long — the fallback URL we just loaded
+/// almost always re-fires the same intent immediately, and re-prompting
+/// the user is worse than letting them stay on a half-loaded page.
+const Duration _suppressDuration = Duration(seconds: 30);
+
+/// Per-target expiry timestamps. Key returned by [_suppressKey].
+final Map<String, DateTime> _suppressed = {};
+
+String _suppressKey(ExternalUrlInfo info) {
+  final uri = Uri.tryParse(info.url);
+  final hostPath = uri == null ? info.url : '${uri.host}${uri.path}';
+  return '${info.scheme}|$hostPath|${info.package ?? ''}';
+}
+
+bool _isSuppressed(ExternalUrlInfo info) {
+  final key = _suppressKey(info);
+  final expiry = _suppressed[key];
+  if (expiry == null) return false;
+  if (DateTime.now().isAfter(expiry)) {
+    _suppressed.remove(key);
+    return false;
+  }
+  return true;
+}
+
+void _markSuppressed(ExternalUrlInfo info) {
+  _suppressed[_suppressKey(info)] = DateTime.now().add(_suppressDuration);
+}
+
+/// Strips ClearURLs tracking query params from a URL, regardless of scheme,
+/// by reconstructing it as an https URL (which the ClearURLs ruleset
 /// recognizes), running [ClearUrlService.cleanUrl], then putting the
-/// cleaned query back. Falls back to the input on any parse failure.
-/// Non-intent URLs are returned unchanged.
+/// cleaned query back. Returns the input on any parse failure or when no
+/// rules are loaded.
+String _stripTrackingFromQuery(String url) {
+  final uri = Uri.tryParse(url);
+  if (uri == null) return url;
+  if (uri.query.isEmpty) return url;
+  if (!ClearUrlService.instance.hasRules) return url;
+
+  final asHttps = 'https://${uri.host}${uri.path}?${uri.query}';
+  final cleaned = ClearUrlService.instance.cleanUrl(asHttps);
+  if (cleaned == asHttps || cleaned.isEmpty) return url;
+  final cleanedUri = Uri.tryParse(cleaned);
+  if (cleanedUri == null) return url;
+  return uri.replace(query: cleanedUri.hasQuery ? cleanedUri.query : null).toString();
+}
+
+/// Strips ClearURLs from an intent:// URL: cleans the toplevel query AND
+/// the URL-encoded `S.browser_fallback_url` extra inside the fragment.
+/// Without the fragment-rewrite step, `utm_campaign` survives the
+/// embedded fallback URL even though it gets stripped from the toplevel.
 String _stripTrackingFromIntent(String intentUrl) {
   final uri = Uri.tryParse(intentUrl);
   if (uri == null) return intentUrl;
   if (uri.scheme.toLowerCase() != 'intent') return intentUrl;
-  if (uri.query.isEmpty) return intentUrl;
   if (!ClearUrlService.instance.hasRules) return intentUrl;
 
-  final asHttps = 'https://${uri.host}${uri.path}?${uri.query}';
-  final cleaned = ClearUrlService.instance.cleanUrl(asHttps);
-  if (cleaned == asHttps || cleaned.isEmpty) return intentUrl;
+  // Step 1: clean the toplevel query.
+  String cleaned = _stripTrackingFromQuery(intentUrl);
+
+  // Step 2: clean the embedded browser_fallback_url inside the Intent
+  // extras. Re-parse because step 1 may have changed the URL.
   final cleanedUri = Uri.tryParse(cleaned);
-  if (cleanedUri == null) return intentUrl;
-  return uri.replace(query: cleanedUri.hasQuery ? cleanedUri.query : null).toString();
+  if (cleanedUri == null) return cleaned;
+  final fragment = cleanedUri.fragment;
+  if (!fragment.startsWith('Intent;')) return cleaned;
+
+  final parts = fragment.substring('Intent;'.length).split(';');
+  var rewroteAny = false;
+  for (var i = 0; i < parts.length; i++) {
+    final part = parts[i];
+    if (!part.startsWith('S.browser_fallback_url=')) continue;
+    final rawValue = part.substring('S.browser_fallback_url='.length);
+    String decoded;
+    try {
+      decoded = Uri.decodeComponent(rawValue);
+    } catch (_) {
+      continue;
+    }
+    final cleanedFallback = ClearUrlService.instance.cleanUrl(decoded);
+    if (cleanedFallback == decoded || cleanedFallback.isEmpty) continue;
+    parts[i] = 'S.browser_fallback_url=${Uri.encodeComponent(cleanedFallback)}';
+    rewroteAny = true;
+  }
+  if (!rewroteAny) return cleaned;
+  final newFragment = 'Intent;${parts.join(';')}';
+  return cleanedUri.replace(fragment: newFragment).toString();
 }
 
 String _cleanFallback(String? fallbackUrl) {
@@ -51,6 +123,17 @@ Future<void> confirmAndLaunchExternalUrl(
   ExternalUrlInfo info, {
   WebViewController? fallbackController,
 }) async {
+  // Loop guard: pages frequently re-fire the same intent immediately
+  // after we load their browser_fallback_url. Without suppression the
+  // user gets re-prompted every redirect and the choice they made a
+  // moment ago is meaningless.
+  if (_isSuppressed(info)) {
+    LogService.instance.log(
+      'ExternalUrl',
+      'suppressed (recently handled within ${_suppressDuration.inSeconds}s): ${info.url}',
+    );
+    return;
+  }
   if (_isConfirming) return;
   _isConfirming = true;
   try {
@@ -124,13 +207,18 @@ Future<void> confirmAndLaunchExternalUrl(
     switch (choice ?? _ExternalUrlChoice.cancel) {
       case _ExternalUrlChoice.cancel:
         LogService.instance.log('ExternalUrl', 'user chose: cancel');
+        // Suppress so a script-driven redirect doesn't re-prompt the
+        // user a second later for the choice they just declined.
+        _markSuppressed(info);
         return;
       case _ExternalUrlChoice.openInBrowser:
         LogService.instance.log('ExternalUrl', 'user chose: open in browser → $cleanedFallback');
+        _markSuppressed(info);
         await fallbackController!.loadUrl(cleanedFallback);
         return;
       case _ExternalUrlChoice.openInApp:
         LogService.instance.log('ExternalUrl', 'user chose: open in app → $cleanedLaunchUrl');
+        _markSuppressed(info);
         await _launchInApp(cleanedLaunchUrl, cleanedFallback, fallbackController, info.scheme);
         return;
     }
@@ -159,10 +247,6 @@ Future<void> _launchInApp(
     }
   }
   LogService.instance.log('ExternalUrl', 'launched=$launched url=$launchUrl');
-  // Note: on Android, launchUrl can return true even when no app handles
-  // the intent (the OS shows its own "no app" toast). We can't distinguish
-  // that from a real launch — that's why the dialog offers an explicit
-  // "Open in browser" button rather than relying on this fallback.
   if (launched) return;
 
   if (cleanedFallback.isNotEmpty && fallbackController != null) {

--- a/lib/widgets/external_url_prompt.dart
+++ b/lib/widgets/external_url_prompt.dart
@@ -4,7 +4,6 @@ import 'package:url_launcher/url_launcher.dart' as url_launcher;
 import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/external_url_engine.dart';
 import 'package:webspace/services/log_service.dart';
-import 'package:webspace/services/webview.dart';
 import 'package:webspace/widgets/root_messenger.dart';
 
 /// Shared per-route guard so rapid-fire redirects (Google Maps can hit the
@@ -83,15 +82,14 @@ String _cleanFallback(String? fallbackUrl) {
 enum _ExternalUrlChoice { cancel, openInApp, openInBrowser }
 
 /// Ask the user whether to hand [info.url] to the OS via url_launcher.
-/// If the OS has no handler (or the user declines) and the intent carried
-/// a `browser_fallback_url`, load that in [fallbackController] instead.
-/// Tracking parameters are stripped from both the launched intent URL and
-/// the fallback URL via [ClearUrlService] before they leave the app.
+/// "Open in app" launches the intent URL. "Open in browser" launches
+/// the cleaned `browser_fallback_url` externally so the user's default
+/// browser handles it. Tracking params are stripped from both via
+/// [ClearUrlService] before they leave the app.
 Future<void> confirmAndLaunchExternalUrl(
   BuildContext context,
-  ExternalUrlInfo info, {
-  WebViewController? fallbackController,
-}) async {
+  ExternalUrlInfo info,
+) async {
   // Loop guard: pages frequently re-fire the same intent immediately
   // after we load their browser_fallback_url. Without suppression the
   // user gets re-prompted every redirect and the choice they made a
@@ -128,7 +126,7 @@ Future<void> confirmAndLaunchExternalUrl(
       }
     }
 
-    final hasFallback = cleanedFallback.isNotEmpty && fallbackController != null;
+    final hasFallback = cleanedFallback.isNotEmpty;
     final choice = await showDialog<_ExternalUrlChoice>(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -183,12 +181,18 @@ Future<void> confirmAndLaunchExternalUrl(
       case _ExternalUrlChoice.openInBrowser:
         LogService.instance.log('ExternalUrl', 'user chose: open in browser → $cleanedFallback');
         ExternalUrlSuppressor.mark(info);
-        await _safeLoadUrl(fallbackController, cleanedFallback, label: 'browser fallback');
+        // Hand the URL to the OS so the user's default browser opens
+        // it. Loading inside our webview was the previous behavior;
+        // for hostile sites (Google Maps mobile is the canonical
+        // example) the page just JS-redirects right back to intent://
+        // and we end up at about:blank. The external browser is what
+        // "Open in browser" means in every other app's mental model.
+        await _launchExternally(cleanedFallback, label: 'browser');
         return;
       case _ExternalUrlChoice.openInApp:
         LogService.instance.log('ExternalUrl', 'user chose: open in app → $cleanedLaunchUrl');
         ExternalUrlSuppressor.mark(info);
-        await _launchInApp(cleanedLaunchUrl, cleanedFallback, fallbackController, info.scheme);
+        await _launchInApp(cleanedLaunchUrl, cleanedFallback, info.scheme);
         return;
     }
   } finally {
@@ -196,62 +200,51 @@ Future<void> confirmAndLaunchExternalUrl(
   }
 }
 
-/// loadUrl wrapper that surfaces failures in the in-app log instead of
-/// silently dropping them. The dialog is sometimes triggered while the
-/// webview is parked on `chrome-error://chromewebdata` (when the dialog
-/// came from `onReceivedError`); deferring to a microtask gives chromium
-/// a chance to settle before we issue the navigation.
-Future<void> _safeLoadUrl(
-  WebViewController? controller,
-  String url, {
-  required String label,
-}) async {
-  if (controller == null) {
-    LogService.instance.log('ExternalUrl', '$label: controller is null, dropping load $url');
-    return;
+/// Hands [url] to the OS via url_launcher so the system browser (or
+/// whichever app handles the scheme) takes over. Used by both
+/// "Open in browser" (with the cleaned http(s) fallback) and the
+/// internal launch path inside [_launchInApp].
+Future<bool> _launchExternally(String url, {required String label}) async {
+  final uri = Uri.tryParse(url);
+  if (uri == null) {
+    LogService.instance.log('ExternalUrl', '$label: invalid URL, cannot launch — $url');
+    return false;
   }
-  if (url.isEmpty) {
-    LogService.instance.log('ExternalUrl', '$label: url is empty, nothing to load');
-    return;
-  }
-  LogService.instance.log('ExternalUrl', '$label: scheduling loadUrl($url)');
-  await Future<void>.delayed(Duration.zero);
   try {
-    await controller.loadUrl(url);
-    LogService.instance.log('ExternalUrl', '$label: loadUrl returned for $url');
-  } catch (e, st) {
-    LogService.instance.log('ExternalUrl', '$label: loadUrl threw for $url — $e\n$st');
+    final launched = await url_launcher.launchUrl(
+      uri,
+      mode: url_launcher.LaunchMode.externalApplication,
+    );
+    LogService.instance.log('ExternalUrl', '$label: external launch result=$launched url=$url');
+    if (!launched) {
+      rootScaffoldMessengerKey.currentState?.showSnackBar(
+        SnackBar(content: Text('No app available to open: $url')),
+      );
+    }
+    return launched;
+  } catch (e) {
+    LogService.instance.log('ExternalUrl', '$label: external launch threw — $e');
+    rootScaffoldMessengerKey.currentState?.showSnackBar(
+      SnackBar(content: Text('Could not open: $url')),
+    );
+    return false;
   }
 }
 
 Future<void> _launchInApp(
   String launchUrl,
   String cleanedFallback,
-  WebViewController? fallbackController,
   String scheme,
 ) async {
-  final uri = Uri.tryParse(launchUrl);
-  var launched = false;
-  if (uri != null) {
-    try {
-      launched = await url_launcher.launchUrl(
-        uri,
-        mode: url_launcher.LaunchMode.externalApplication,
-      );
-    } catch (e) {
-      LogService.instance.log('ExternalUrl', 'launchUrl threw: $e');
-      launched = false;
-    }
-  }
-  LogService.instance.log('ExternalUrl', 'launched=$launched url=$launchUrl');
+  final launched = await _launchExternally(launchUrl, label: 'app');
   if (launched) return;
-
-  if (cleanedFallback.isNotEmpty && fallbackController != null) {
-    LogService.instance.log('ExternalUrl', 'launch failed, loading fallback: $cleanedFallback');
-    await _safeLoadUrl(fallbackController, cleanedFallback, label: 'in-app fallback');
-    return;
+  // No app handler — fall back to opening the cleaned http(s) URL in
+  // the user's default browser, same as if they'd picked
+  // "Open in browser". For sites without a browser_fallback_url
+  // (tel:, custom schemes, etc.) _launchExternally already showed a
+  // "no app available" snackbar.
+  if (cleanedFallback.isNotEmpty) {
+    LogService.instance.log('ExternalUrl', 'app launch failed, opening fallback externally');
+    await _launchExternally(cleanedFallback, label: 'browser fallback after app failure');
   }
-  rootScaffoldMessengerKey.currentState?.showSnackBar(
-    SnackBar(content: Text('No app available to open $scheme:')),
-  );
 }

--- a/lib/widgets/external_url_prompt.dart
+++ b/lib/widgets/external_url_prompt.dart
@@ -38,6 +38,9 @@ String _cleanFallback(String? fallbackUrl) {
   return cleaned.isEmpty ? fallbackUrl : cleaned;
 }
 
+/// Outcome of the confirmation dialog.
+enum _ExternalUrlChoice { cancel, openInApp, openInBrowser }
+
 /// Ask the user whether to hand [info.url] to the OS via url_launcher.
 /// If the OS has no handler (or the user declines) and the intent carried
 /// a `browser_fallback_url`, load that in [fallbackController] instead.
@@ -51,16 +54,30 @@ Future<void> confirmAndLaunchExternalUrl(
   if (_isConfirming) return;
   _isConfirming = true;
   try {
+    final hasRules = ClearUrlService.instance.hasRules;
     final cleanedLaunchUrl = _stripTrackingFromIntent(info.url);
     final cleanedFallback = _cleanFallback(info.fallbackUrl);
+    final urlChanged = cleanedLaunchUrl != info.url;
+    final fallbackChanged = cleanedFallback != (info.fallbackUrl ?? '');
     LogService.instance.log(
       'ExternalUrl',
       'prompt: scheme=${info.scheme} package=${info.package} '
-      'rawUrl=${info.url} cleanedUrl=$cleanedLaunchUrl '
-      'rawFallback=${info.fallbackUrl} cleanedFallback=$cleanedFallback',
+      'clearUrlsLoaded=$hasRules urlCleaned=$urlChanged '
+      'fallbackCleaned=$fallbackChanged',
     );
+    LogService.instance.log('ExternalUrl', '  rawUrl=${info.url}');
+    if (urlChanged) {
+      LogService.instance.log('ExternalUrl', '  cleanedUrl=$cleanedLaunchUrl');
+    }
+    if (info.fallbackUrl != null) {
+      LogService.instance.log('ExternalUrl', '  rawFallback=${info.fallbackUrl}');
+      if (fallbackChanged) {
+        LogService.instance.log('ExternalUrl', '  cleanedFallback=$cleanedFallback');
+      }
+    }
 
-    final confirmed = await showDialog<bool>(
+    final hasFallback = cleanedFallback.isNotEmpty && fallbackController != null;
+    final choice = await showDialog<_ExternalUrlChoice>(
       context: context,
       builder: (ctx) => AlertDialog(
         title: const Text('Open external app?'),
@@ -79,7 +96,7 @@ Future<void> confirmAndLaunchExternalUrl(
                 const SizedBox(height: 8),
                 Text('Package: ${info.package}'),
               ],
-              if (cleanedFallback.isNotEmpty) ...[
+              if (hasFallback) ...[
                 const SizedBox(height: 8),
                 Text('Fallback URL: $cleanedFallback'),
               ],
@@ -88,55 +105,72 @@ Future<void> confirmAndLaunchExternalUrl(
         ),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
+            onPressed: () => Navigator.pop(ctx, _ExternalUrlChoice.cancel),
             child: const Text('Cancel'),
           ),
+          if (hasFallback)
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, _ExternalUrlChoice.openInBrowser),
+              child: const Text('Open in browser'),
+            ),
           TextButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Open'),
+            onPressed: () => Navigator.pop(ctx, _ExternalUrlChoice.openInApp),
+            child: const Text('Open in app'),
           ),
         ],
       ),
     );
 
-    if (confirmed != true) {
-      LogService.instance.log('ExternalUrl', 'user declined: $cleanedLaunchUrl');
-      // Even though shouldOverrideUrlLoading returned CANCEL and we called
-      // stopLoading() in the webview, Android sometimes paints an
-      // ERR_UNKNOWN_URL_SCHEME error page when the navigation was a
-      // server-side redirect. Loading the cleaned fallback URL keeps the
-      // user on a usable page; otherwise leave them where they were.
-      if (cleanedFallback.isNotEmpty && fallbackController != null) {
-        await fallbackController.loadUrl(cleanedFallback);
-      }
-      return;
+    switch (choice ?? _ExternalUrlChoice.cancel) {
+      case _ExternalUrlChoice.cancel:
+        LogService.instance.log('ExternalUrl', 'user chose: cancel');
+        return;
+      case _ExternalUrlChoice.openInBrowser:
+        LogService.instance.log('ExternalUrl', 'user chose: open in browser → $cleanedFallback');
+        await fallbackController!.loadUrl(cleanedFallback);
+        return;
+      case _ExternalUrlChoice.openInApp:
+        LogService.instance.log('ExternalUrl', 'user chose: open in app → $cleanedLaunchUrl');
+        await _launchInApp(cleanedLaunchUrl, cleanedFallback, fallbackController, info.scheme);
+        return;
     }
-
-    final uri = Uri.tryParse(cleanedLaunchUrl);
-    var launched = false;
-    if (uri != null) {
-      try {
-        launched = await url_launcher.launchUrl(
-          uri,
-          mode: url_launcher.LaunchMode.externalApplication,
-        );
-      } catch (e) {
-        LogService.instance.log('ExternalUrl', 'launchUrl threw: $e');
-        launched = false;
-      }
-    }
-    LogService.instance.log('ExternalUrl', 'launched=$launched url=$cleanedLaunchUrl');
-    if (launched) return;
-
-    if (cleanedFallback.isNotEmpty && fallbackController != null) {
-      LogService.instance.log('ExternalUrl', 'loading fallback in webview: $cleanedFallback');
-      await fallbackController.loadUrl(cleanedFallback);
-      return;
-    }
-    rootScaffoldMessengerKey.currentState?.showSnackBar(
-      SnackBar(content: Text('No app available to open ${info.scheme}:')),
-    );
   } finally {
     _isConfirming = false;
   }
+}
+
+Future<void> _launchInApp(
+  String launchUrl,
+  String cleanedFallback,
+  WebViewController? fallbackController,
+  String scheme,
+) async {
+  final uri = Uri.tryParse(launchUrl);
+  var launched = false;
+  if (uri != null) {
+    try {
+      launched = await url_launcher.launchUrl(
+        uri,
+        mode: url_launcher.LaunchMode.externalApplication,
+      );
+    } catch (e) {
+      LogService.instance.log('ExternalUrl', 'launchUrl threw: $e');
+      launched = false;
+    }
+  }
+  LogService.instance.log('ExternalUrl', 'launched=$launched url=$launchUrl');
+  // Note: on Android, launchUrl can return true even when no app handles
+  // the intent (the OS shows its own "no app" toast). We can't distinguish
+  // that from a real launch — that's why the dialog offers an explicit
+  // "Open in browser" button rather than relying on this fallback.
+  if (launched) return;
+
+  if (cleanedFallback.isNotEmpty && fallbackController != null) {
+    LogService.instance.log('ExternalUrl', 'launch failed, loading fallback: $cleanedFallback');
+    await fallbackController.loadUrl(cleanedFallback);
+    return;
+  }
+  rootScaffoldMessengerKey.currentState?.showSnackBar(
+    SnackBar(content: Text('No app available to open $scheme:')),
+  );
 }

--- a/lib/widgets/external_url_prompt.dart
+++ b/lib/widgets/external_url_prompt.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 
+import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/external_url_engine.dart';
+import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/widgets/root_messenger.dart';
 
@@ -9,9 +11,38 @@ import 'package:webspace/widgets/root_messenger.dart';
 /// webview with several intent:// bursts in a row) only surface one dialog.
 bool _isConfirming = false;
 
+/// Strips ClearURLs tracking query params from an `intent://` URL by
+/// reconstructing it as an https URL (which the ClearURLs ruleset
+/// recognizes), running [ClearUrlService.cleanUrl], then putting the
+/// cleaned query back. Falls back to the input on any parse failure.
+/// Non-intent URLs are returned unchanged.
+String _stripTrackingFromIntent(String intentUrl) {
+  final uri = Uri.tryParse(intentUrl);
+  if (uri == null) return intentUrl;
+  if (uri.scheme.toLowerCase() != 'intent') return intentUrl;
+  if (uri.query.isEmpty) return intentUrl;
+  if (!ClearUrlService.instance.hasRules) return intentUrl;
+
+  final asHttps = 'https://${uri.host}${uri.path}?${uri.query}';
+  final cleaned = ClearUrlService.instance.cleanUrl(asHttps);
+  if (cleaned == asHttps || cleaned.isEmpty) return intentUrl;
+  final cleanedUri = Uri.tryParse(cleaned);
+  if (cleanedUri == null) return intentUrl;
+  return uri.replace(query: cleanedUri.hasQuery ? cleanedUri.query : null).toString();
+}
+
+String _cleanFallback(String? fallbackUrl) {
+  if (fallbackUrl == null || fallbackUrl.isEmpty) return '';
+  if (!ClearUrlService.instance.hasRules) return fallbackUrl;
+  final cleaned = ClearUrlService.instance.cleanUrl(fallbackUrl);
+  return cleaned.isEmpty ? fallbackUrl : cleaned;
+}
+
 /// Ask the user whether to hand [info.url] to the OS via url_launcher.
 /// If the OS has no handler (or the user declines) and the intent carried
 /// a `browser_fallback_url`, load that in [fallbackController] instead.
+/// Tracking parameters are stripped from both the launched intent URL and
+/// the fallback URL via [ClearUrlService] before they leave the app.
 Future<void> confirmAndLaunchExternalUrl(
   BuildContext context,
   ExternalUrlInfo info, {
@@ -20,6 +51,15 @@ Future<void> confirmAndLaunchExternalUrl(
   if (_isConfirming) return;
   _isConfirming = true;
   try {
+    final cleanedLaunchUrl = _stripTrackingFromIntent(info.url);
+    final cleanedFallback = _cleanFallback(info.fallbackUrl);
+    LogService.instance.log(
+      'ExternalUrl',
+      'prompt: scheme=${info.scheme} package=${info.package} '
+      'rawUrl=${info.url} cleanedUrl=$cleanedLaunchUrl '
+      'rawFallback=${info.fallbackUrl} cleanedFallback=$cleanedFallback',
+    );
+
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -32,16 +72,16 @@ Future<void> confirmAndLaunchExternalUrl(
               const Text('This site wants to open:'),
               const SizedBox(height: 8),
               SelectableText(
-                info.url,
+                cleanedLaunchUrl,
                 style: const TextStyle(fontFamily: 'monospace'),
               ),
               if (info.package != null) ...[
                 const SizedBox(height: 8),
                 Text('Package: ${info.package}'),
               ],
-              if (info.fallbackUrl != null) ...[
+              if (cleanedFallback.isNotEmpty) ...[
                 const SizedBox(height: 8),
-                Text('Fallback URL: ${info.fallbackUrl}'),
+                Text('Fallback URL: $cleanedFallback'),
               ],
             ],
           ),
@@ -58,9 +98,21 @@ Future<void> confirmAndLaunchExternalUrl(
         ],
       ),
     );
-    if (confirmed != true) return;
 
-    final uri = Uri.tryParse(info.url);
+    if (confirmed != true) {
+      LogService.instance.log('ExternalUrl', 'user declined: $cleanedLaunchUrl');
+      // Even though shouldOverrideUrlLoading returned CANCEL and we called
+      // stopLoading() in the webview, Android sometimes paints an
+      // ERR_UNKNOWN_URL_SCHEME error page when the navigation was a
+      // server-side redirect. Loading the cleaned fallback URL keeps the
+      // user on a usable page; otherwise leave them where they were.
+      if (cleanedFallback.isNotEmpty && fallbackController != null) {
+        await fallbackController.loadUrl(cleanedFallback);
+      }
+      return;
+    }
+
+    final uri = Uri.tryParse(cleanedLaunchUrl);
     var launched = false;
     if (uri != null) {
       try {
@@ -68,15 +120,17 @@ Future<void> confirmAndLaunchExternalUrl(
           uri,
           mode: url_launcher.LaunchMode.externalApplication,
         );
-      } catch (_) {
+      } catch (e) {
+        LogService.instance.log('ExternalUrl', 'launchUrl threw: $e');
         launched = false;
       }
     }
+    LogService.instance.log('ExternalUrl', 'launched=$launched url=$cleanedLaunchUrl');
     if (launched) return;
 
-    final fallback = info.fallbackUrl;
-    if (fallback != null && fallback.isNotEmpty && fallbackController != null) {
-      await fallbackController.loadUrl(fallback);
+    if (cleanedFallback.isNotEmpty && fallbackController != null) {
+      LogService.instance.log('ExternalUrl', 'loading fallback in webview: $cleanedFallback');
+      await fallbackController.loadUrl(cleanedFallback);
       return;
     }
     rootScaffoldMessengerKey.currentState?.showSnackBar(

--- a/test/external_url_engine_test.dart
+++ b/test/external_url_engine_test.dart
@@ -14,6 +14,18 @@ void main() {
       expect(ExternalUrlParser.parse('blob:https://example.com/abc'), isNull);
       expect(ExternalUrlParser.parse('file:///tmp/x.html'), isNull);
       expect(ExternalUrlParser.parse('javascript:void(0)'), isNull);
+      expect(ExternalUrlParser.parse('view-source:https://example.com/'), isNull);
+    });
+
+    test('returns null for chrome-family internal schemes', () {
+      // Rendered by the Chromium engine inside Android WebView; not OS
+      // app launches.
+      expect(ExternalUrlParser.parse('chrome://version'), isNull);
+      expect(ExternalUrlParser.parse('chrome://gpu'), isNull);
+      expect(ExternalUrlParser.parse('chrome-extension://abcd/popup.html'), isNull);
+      expect(ExternalUrlParser.parse('chrome-error://chromewebdata/'), isNull);
+      expect(ExternalUrlParser.parse('chrome-search://local-ntp'), isNull);
+      expect(ExternalUrlParser.parse('chrome-untrusted://nope'), isNull);
     });
 
     test('returns null for URLs with empty scheme', () {

--- a/test/external_url_engine_test.dart
+++ b/test/external_url_engine_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/external_url_engine.dart';
+
+void main() {
+  group('ExternalUrlParser.parse', () {
+    test('returns null for http(s) URLs', () {
+      expect(ExternalUrlParser.parse('https://example.com/'), isNull);
+      expect(ExternalUrlParser.parse('http://example.com/foo?bar=1'), isNull);
+    });
+
+    test('returns null for other internal schemes', () {
+      expect(ExternalUrlParser.parse('about:blank'), isNull);
+      expect(ExternalUrlParser.parse('data:text/html,hi'), isNull);
+      expect(ExternalUrlParser.parse('blob:https://example.com/abc'), isNull);
+      expect(ExternalUrlParser.parse('file:///tmp/x.html'), isNull);
+      expect(ExternalUrlParser.parse('javascript:void(0)'), isNull);
+    });
+
+    test('returns null for URLs with empty scheme', () {
+      expect(ExternalUrlParser.parse('/relative/path'), isNull);
+      expect(ExternalUrlParser.parse(''), isNull);
+    });
+
+    test('captures scheme for tel: and mailto:', () {
+      final tel = ExternalUrlParser.parse('tel:+14155551234')!;
+      expect(tel.scheme, 'tel');
+      expect(tel.package, isNull);
+      expect(tel.fallbackUrl, isNull);
+
+      final mail = ExternalUrlParser.parse('mailto:foo@example.com?subject=hi')!;
+      expect(mail.scheme, 'mailto');
+      expect(mail.package, isNull);
+    });
+
+    test('captures scheme and host for custom app schemes', () {
+      final fb = ExternalUrlParser.parse('fb://profile/123')!;
+      expect(fb.scheme, 'fb');
+      expect(fb.host, 'profile');
+    });
+
+    test('parses Google Maps intent:// with fallback URL', () {
+      const url =
+          'intent://www.google.com/maps?entry=ml&utm_campaign=ml-ardi-wv&coh=230964'
+          '#Intent;scheme=https;package=com.google.android.apps.maps;'
+          'S.browser_fallback_url=https%3A%2F%2Fwww.google.com%2Fmaps%3Fentry%3Dml'
+          '%26utm_campaign%3Dml-ardi-wv%26coh%3D230964;end;';
+      final info = ExternalUrlParser.parse(url)!;
+      expect(info.scheme, 'intent');
+      expect(info.host, 'www.google.com');
+      expect(info.package, 'com.google.android.apps.maps');
+      expect(info.targetScheme, 'https');
+      expect(
+        info.fallbackUrl,
+        'https://www.google.com/maps?entry=ml&utm_campaign=ml-ardi-wv&coh=230964',
+      );
+    });
+
+    test('parses intent:// without fallback URL', () {
+      const url =
+          'intent://scan/#Intent;scheme=zxing;package=com.google.zxing.client.android;end';
+      final info = ExternalUrlParser.parse(url)!;
+      expect(info.scheme, 'intent');
+      expect(info.package, 'com.google.zxing.client.android');
+      expect(info.targetScheme, 'zxing');
+      expect(info.fallbackUrl, isNull);
+    });
+
+    test('intent:// with trailing semicolon before end parses cleanly', () {
+      const url = 'intent://x/#Intent;package=com.example;end;';
+      final info = ExternalUrlParser.parse(url)!;
+      expect(info.package, 'com.example');
+    });
+
+    test('scheme match is case-insensitive', () {
+      expect(ExternalUrlParser.parse('HTTPS://example.com/'), isNull);
+      final info = ExternalUrlParser.parse('INTENT://x/#Intent;end');
+      expect(info?.scheme, 'intent');
+    });
+  });
+}


### PR DESCRIPTION
Clicking a link like a Google Maps intent:// URL previously surfaced a webview error because flutter_inappwebview can't render non-webview schemes. Catch those in shouldOverrideUrlLoading / onCreateWindow, ask the user whether to hand the URL to the OS via url_launcher, and fall back to the intent's browser_fallback_url in the current webview if no handler is installed.