### PR TITLE
Propagate user scripts into nested InAppWebViewScreen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1259,6 +1259,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     String? spoofTimezone,
     bool spoofTimezoneFromLocation = false,
     WebRtcPolicy webRtcPolicy = WebRtcPolicy.defaultPolicy,
+    required List<UserScriptConfig> userScripts,
   }) async {
     await Navigator.push(
       context,
@@ -1281,9 +1282,40 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           spoofTimezone: spoofTimezone,
           spoofTimezoneFromLocation: spoofTimezoneFromLocation,
           webRtcPolicy: webRtcPolicy,
+          userScripts: userScripts,
+          onConfirmScriptFetch: _confirmScriptFetch,
         ),
       ),
     );
+  }
+
+  /// Stable callback for the user-script fetch-from-URL confirmation prompt.
+  /// Used by both the parent webview (via `getWebView`) and the nested
+  /// `InAppWebViewScreen` so external dependency loading prompts the user
+  /// the same way regardless of where the webview was opened.
+  Future<bool> _confirmScriptFetch(String url) async {
+    if (!mounted) return false;
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Load external script?'),
+        content: Text(
+          'A user script wants to load:\n\n$url\n\n'
+          'This URL is not on the trusted CDN list. Allow?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Deny'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Allow'),
+          ),
+        ],
+      ),
+    );
+    return result ?? false;
   }
 
   void _toggleFind() {
@@ -3320,30 +3352,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                                           return HtmlCacheService.applyThemePrelude(cached, dark: isDark);
                                         }(),
                                   isActive: () => _currentIndex == index,
-                                  onConfirmScriptFetch: (url) async {
-                                    if (!mounted) return false;
-                                    final result = await showDialog<bool>(
-                                      context: context,
-                                      builder: (ctx) => AlertDialog(
-                                        title: const Text('Load external script?'),
-                                        content: Text(
-                                          'A user script wants to load:\n\n$url\n\n'
-                                          'This URL is not on the trusted CDN list. Allow?',
-                                        ),
-                                        actions: [
-                                          TextButton(
-                                            onPressed: () => Navigator.pop(ctx, false),
-                                            child: const Text('Deny'),
-                                          ),
-                                          TextButton(
-                                            onPressed: () => Navigator.pop(ctx, true),
-                                            child: const Text('Allow'),
-                                          ),
-                                        ],
-                                      ),
-                                    );
-                                    return result ?? false;
-                                  },
+                                  onConfirmScriptFetch: _confirmScriptFetch,
                                   onExternalSchemeUrl: (url, info) async {
                                     if (!mounted) return;
                                     await confirmAndLaunchExternalUrl(context, info);

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -8,6 +8,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/settings/location.dart';
+import 'package:webspace/settings/user_script.dart';
 import 'package:webspace/widgets/download_button.dart';
 import 'package:webspace/widgets/external_url_prompt.dart';
 import 'package:webspace/widgets/find_toolbar.dart';
@@ -31,6 +32,11 @@ class InAppWebViewScreen extends StatefulWidget {
   final String? spoofTimezone;
   final bool spoofTimezoneFromLocation;
   final WebRtcPolicy webRtcPolicy;
+  /// Pre-combined per-site + opted-in global user scripts to inject. Carried
+  /// over from the parent webview so cosmetic/privacy/custom scripts keep
+  /// working when the user follows an outbound link into a nested screen.
+  final List<UserScriptConfig> userScripts;
+  final Future<bool> Function(String url)? onConfirmScriptFetch;
 
   InAppWebViewScreen({
     required this.url,
@@ -50,6 +56,8 @@ class InAppWebViewScreen extends StatefulWidget {
     this.spoofTimezone,
     this.spoofTimezoneFromLocation = false,
     this.webRtcPolicy = WebRtcPolicy.defaultPolicy,
+    this.userScripts = const [],
+    this.onConfirmScriptFetch,
   });
 
   @override
@@ -114,6 +122,8 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
         spoofTimezone: widget.spoofTimezone,
         spoofTimezoneFromLocation: widget.spoofTimezoneFromLocation,
         webRtcPolicy: widget.webRtcPolicy,
+        userScripts: widget.userScripts,
+        onConfirmScriptFetch: widget.onConfirmScriptFetch,
         pullToRefreshController: _pullToRefreshController,
         onUrlChanged: (url) {
           if (mounted) {

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -446,6 +446,29 @@ class WebViewModel {
     }
   }
 
+  /// Combine this site's per-site scripts with opted-in globals into the
+  /// list to inject. Forces `enabled: true` on globals so a stale stored
+  /// flag (e.g. a disabled site script later promoted via "Make Global")
+  /// can't silently drop the script in
+  /// `UserScriptService.buildInitialUserScripts`.
+  List<UserScriptConfig> combineUserScripts(
+      List<UserScriptConfig> globalUserScripts) {
+    return [
+      ...globalUserScripts
+          .where((g) => enabledGlobalScriptIds.contains(g.id))
+          .map((g) => UserScriptConfig(
+                id: g.id,
+                name: g.name,
+                source: g.source,
+                url: g.url,
+                urlSource: g.urlSource,
+                injectionTime: g.injectionTime,
+                enabled: true,
+              )),
+      ...userScripts,
+    ];
+  }
+
   /// Apply theme preference to the webview
   Future<void> setTheme(WebViewTheme theme) async {
     _currentTheme = theme;
@@ -476,7 +499,7 @@ class WebViewModel {
   }
 
   Widget getWebView(
-    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required String? language, LocationMode locationMode, double? spoofLatitude, double? spoofLongitude, double spoofAccuracy, String? spoofTimezone, bool spoofTimezoneFromLocation, WebRtcPolicy webRtcPolicy}) launchUrlFunc,
+    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required String? language, LocationMode locationMode, double? spoofLatitude, double? spoofLongitude, double spoofAccuracy, String? spoofTimezone, bool spoofTimezoneFromLocation, WebRtcPolicy webRtcPolicy, required List<UserScriptConfig> userScripts}) launchUrlFunc,
     CookieManager cookieManager,
     ProfileCookieManager? profileCookieManager,
     Function saveFunc, {
@@ -546,25 +569,7 @@ class WebViewModel {
           // PROXY-002 / PROXY-008). Android ignores this and routes
           // through the global `ProxyController` in `_applyProxySettings`.
           proxySettings: proxySettings,
-          userScripts: [
-            // Globals have no master `enabled` toggle per spec — per-site
-            // opt-in is the only enable control. Force `enabled: true` on
-            // a copy so a stale stored flag (e.g. a disabled site script
-            // that was promoted via "Make Global") can't silently drop
-            // the script in `UserScriptService.buildInitialUserScripts`.
-            ...globalUserScripts
-                .where((g) => enabledGlobalScriptIds.contains(g.id))
-                .map((g) => UserScriptConfig(
-                      id: g.id,
-                      name: g.name,
-                      source: g.source,
-                      url: g.url,
-                      urlSource: g.urlSource,
-                      injectionTime: g.injectionTime,
-                      enabled: true,
-                    )),
-            ...userScripts,
-          ],
+          userScripts: combineUserScripts(globalUserScripts),
           onConfirmScriptFetch: onConfirmScriptFetch,
           onExternalSchemeUrl: onExternalSchemeUrl,
           pullToRefreshController: pullToRefreshController,
@@ -602,7 +607,7 @@ class WebViewModel {
                 return false;
               case NavigationDecision.blockOpenNested:
                 LogService.instance.log('WebView', '  -> CANCEL (opening nested webview)');
-                launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, language: this.language, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, webRtcPolicy: webRtcPolicy);
+                launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, language: this.language, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, webRtcPolicy: webRtcPolicy, userScripts: combineUserScripts(globalUserScripts));
                 return false;
             }
           },
@@ -672,7 +677,7 @@ class WebViewModel {
                 case NavigationDecision.blockOpenNested:
                   LogService.instance.log('WebView', 'onUrlChanged: cross-domain redirect detected: $url (expected domain: $initDomain)');
                   if (handled.launchNestedUrl != null) {
-                    launchUrlFunc(handled.launchNestedUrl!, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, language: this.language, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, webRtcPolicy: webRtcPolicy);
+                    launchUrlFunc(handled.launchNestedUrl!, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, language: this.language, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, webRtcPolicy: webRtcPolicy, userScripts: combineUserScripts(globalUserScripts));
                   }
                   return;
                 case NavigationDecision.allow:
@@ -800,7 +805,7 @@ class WebViewModel {
   }
 
   WebViewController? getController(
-    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required String? language, LocationMode locationMode, double? spoofLatitude, double? spoofLongitude, double spoofAccuracy, String? spoofTimezone, bool spoofTimezoneFromLocation, WebRtcPolicy webRtcPolicy}) launchUrlFunc,
+    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required String? language, LocationMode locationMode, double? spoofLatitude, double? spoofLongitude, double spoofAccuracy, String? spoofTimezone, bool spoofTimezoneFromLocation, WebRtcPolicy webRtcPolicy, required List<UserScriptConfig> userScripts}) launchUrlFunc,
     CookieManager cookieManager,
     ProfileCookieManager? profileCookieManager,
     Function saveFunc, {


### PR DESCRIPTION
Nested webviews opened via cross-domain navigation got an empty `WebViewConfig.userScripts`, so any per-site or opted-in global script (privacy/cosmetic shims, custom JS) silently stopped working the moment the user followed an outbound link. Same class of bug as the location shim — plug it the same way: pre-combine site + opted-in global scripts on the parent and pass the list down through `launchUrl` / `InAppWebViewScreen`.

Also extracts `_confirmScriptFetch` so the nested screen reuses the same external-dependency confirmation prompt as the parent.