### PR TITLE
Preserve non-http URL schemes (chrome://, about:, file://) in URL input

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -51,6 +51,7 @@ import 'package:webspace/screens/dev_tools.dart';
 import 'package:webspace/settings/app_prefs.dart';
 import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/settings/user_script.dart';
+import 'package:webspace/utils/url_utils.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:webspace/widgets/root_messenger.dart';
 
@@ -2531,9 +2532,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
               var url = urlController.text.trim();
 
               // Infer protocol if not specified
-              if (!url.startsWith('http://') && !url.startsWith('https://')) {
-                url = 'https://$url';
-              }
+              url = ensureUrlScheme(url);
 
               Navigator.pop(context, {'name': name, 'url': url});
             },

--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -9,6 +9,7 @@ import 'package:material_design_icons_flutter/material_design_icons_flutter.dart
 import 'package:shared_preferences/shared_preferences.dart';
 import '../main.dart' show extractDomain;
 import '../services/icon_service.dart' show getFaviconUrlStream, getSvgContent, onSvgContentCached, invalidateFaviconFor, IconUpdate;
+import '../utils/url_utils.dart';
 
 /// Persistent cache for favicon URLs and SVG content
 class FaviconUrlCache {
@@ -339,10 +340,7 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
       return;
     }
 
-    String url = text;
-    if (!url.startsWith('http://') && !url.startsWith('https://')) {
-      url = 'https://$url';
-    }
+    String url = ensureUrlScheme(text);
 
     final uri = Uri.tryParse(url);
     if (uri == null || uri.host.isEmpty ||
@@ -470,9 +468,7 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
                 final name = nameController.text.trim();
                 var url = urlController.text.trim();
                 if (name.isEmpty || url.isEmpty) return;
-                if (!url.startsWith('http://') && !url.startsWith('https://')) {
-                  url = 'https://$url';
-                }
+                url = ensureUrlScheme(url);
                 final uri = Uri.tryParse(url);
                 if (uri == null || uri.host.isEmpty) return;
                 final suggestion = SiteSuggestion(
@@ -543,9 +539,7 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
                   onPressed: () {
                     String url = urlController.text.trim();
                     // If no protocol specified, default to https
-                    if (!url.startsWith('http://') && !url.startsWith('https://')) {
-                      url = 'https://$url';
-                    }
+                    url = ensureUrlScheme(url);
                     Navigator.of(context).pop();
                     Navigator.of(context).pop({'url': url, 'name': '', 'incognito': incognito});
                   },
@@ -666,9 +660,7 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
                               onPressed: () {
                                 String url = _urlController.text.trim();
                                 // If no protocol specified, default to https
-                                if (!url.startsWith('http://') && !url.startsWith('https://')) {
-                                  url = 'https://$url';
-                                }
+                                url = ensureUrlScheme(url);
                                 Navigator.pop(context, {'url': url, 'name': '', 'incognito': _incognito});
                               },
                               child: Text('Add Site'),

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -360,7 +360,12 @@ class _WebViewController implements WebViewController {
   @override
   Future<void> loadUrl(String url, {String? language}) {
     final headers = <String, String>{};
-    if (language != null) {
+    // HTTP headers are only meaningful for http(s) schemes. Attaching them to
+    // non-HTTP URLs (chrome://, about:, file://, data:, javascript:) routes
+    // the request through the WebView's HTTP path and can get rejected as
+    // "invalid URL".
+    final isHttp = url.startsWith('http://') || url.startsWith('https://');
+    if (language != null && isHttp) {
       headers['Accept-Language'] = '$language, *;q=0.5';
     }
     return _c.loadUrl(

--- a/lib/utils/url_utils.dart
+++ b/lib/utils/url_utils.dart
@@ -1,0 +1,19 @@
+/// Returns true if [url] already starts with a URL scheme such as
+/// `http://`, `https://`, `chrome://`, `about:`, `file://`, `javascript:`,
+/// `data:`, `mailto:`, etc. Used to avoid prepending `https://` to URLs the
+/// user already qualified with a scheme.
+///
+/// The scheme is `[a-zA-Z][a-zA-Z0-9+-]*` followed by `:`. Dots are excluded
+/// from the scheme to keep `example.com:8080` classified as a host:port, not a
+/// scheme.
+bool hasUrlScheme(String url) {
+  return _schemeRegex.hasMatch(url);
+}
+
+final RegExp _schemeRegex = RegExp(r'^[a-zA-Z][a-zA-Z0-9+\-]*:');
+
+/// If [url] has no scheme, prepends `https://`. Otherwise returns [url]
+/// unchanged so schemes like `chrome://` are preserved.
+String ensureUrlScheme(String url) {
+  return hasUrlScheme(url) ? url : 'https://$url';
+}

--- a/lib/utils/url_utils.dart
+++ b/lib/utils/url_utils.dart
@@ -1,16 +1,24 @@
 /// Returns true if [url] already starts with a URL scheme such as
 /// `http://`, `https://`, `chrome://`, `about:`, `file://`, `javascript:`,
-/// `data:`, `mailto:`, etc. Used to avoid prepending `https://` to URLs the
+/// `data:`, or `mailto:`. Used to avoid prepending `https://` to URLs the
 /// user already qualified with a scheme.
 ///
-/// The scheme is `[a-zA-Z][a-zA-Z0-9+-]*` followed by `:`. Dots are excluded
-/// from the scheme to keep `example.com:8080` classified as a host:port, not a
-/// scheme.
+/// A URL has a scheme if:
+///   - it contains `://` after a leading alpha/digit/+/- scheme identifier, OR
+///   - it starts with a known authority-less scheme followed by `:`
+///     (`about:`, `javascript:`, `data:`, `mailto:`, `tel:`, `view-source:`).
+///
+/// This deliberately excludes bare `host:port` strings like `localhost:8080`
+/// or `192.168.1.1:3000` so they still get `https://` prepended.
 bool hasUrlScheme(String url) {
-  return _schemeRegex.hasMatch(url);
+  if (_authoritySchemeRegex.hasMatch(url)) return true;
+  return _authorityLessSchemeRegex.hasMatch(url);
 }
 
-final RegExp _schemeRegex = RegExp(r'^[a-zA-Z][a-zA-Z0-9+\-]*:');
+final RegExp _authoritySchemeRegex =
+    RegExp(r'^[a-zA-Z][a-zA-Z0-9+\-]*://');
+final RegExp _authorityLessSchemeRegex =
+    RegExp(r'^(about|javascript|data|mailto|tel|view-source):');
 
 /// If [url] has no scheme, prepends `https://`. Otherwise returns [url]
 /// unchanged so schemes like `chrome://` are preserved.

--- a/lib/widgets/url_bar.dart
+++ b/lib/widgets/url_bar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../utils/url_utils.dart';
 
 class UrlBar extends StatefulWidget {
   final String currentUrl;
@@ -55,9 +56,7 @@ class _UrlBarState extends State<UrlBar> {
     String url = _urlController.text.trim();
 
     // Infer protocol if not specified
-    if (!url.startsWith('http://') && !url.startsWith('https://')) {
-      url = 'https://$url';
-    }
+    url = ensureUrlScheme(url);
 
     widget.onUrlSubmitted(url);
     _focusNode.unfocus();

--- a/test/url_utils_test.dart
+++ b/test/url_utils_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/utils/url_utils.dart';
+
+void main() {
+  group('hasUrlScheme', () {
+    test('detects http/https schemes', () {
+      expect(hasUrlScheme('http://example.com'), isTrue);
+      expect(hasUrlScheme('https://example.com'), isTrue);
+    });
+
+    test('detects chrome:// and other browser-internal schemes', () {
+      expect(hasUrlScheme('chrome://flags'), isTrue);
+      expect(hasUrlScheme('chrome://version'), isTrue);
+      expect(hasUrlScheme('about:blank'), isTrue);
+      expect(hasUrlScheme('file:///tmp/index.html'), isTrue);
+      expect(hasUrlScheme('javascript:alert(1)'), isTrue);
+      expect(hasUrlScheme('data:text/html,<h1>hi</h1>'), isTrue);
+      expect(hasUrlScheme('mailto:foo@example.com'), isTrue);
+    });
+
+    test('bare hostnames have no scheme', () {
+      expect(hasUrlScheme('example.com'), isFalse);
+      expect(hasUrlScheme('www.example.com'), isFalse);
+      expect(hasUrlScheme('localhost'), isFalse);
+    });
+
+    test('host:port is not classified as a scheme', () {
+      expect(hasUrlScheme('example.com:8080'), isFalse);
+      expect(hasUrlScheme('192.168.1.1:3000'), isFalse);
+      expect(hasUrlScheme('localhost:8080'), isFalse);
+    });
+  });
+
+  group('ensureUrlScheme', () {
+    test('prepends https:// to bare hostnames', () {
+      expect(ensureUrlScheme('example.com'), 'https://example.com');
+      expect(ensureUrlScheme('example.com:8080'), 'https://example.com:8080');
+      expect(ensureUrlScheme('localhost'), 'https://localhost');
+    });
+
+    test('preserves chrome:// and other schemes', () {
+      expect(ensureUrlScheme('chrome://flags'), 'chrome://flags');
+      expect(ensureUrlScheme('about:blank'), 'about:blank');
+      expect(ensureUrlScheme('file:///tmp/x.html'), 'file:///tmp/x.html');
+      expect(ensureUrlScheme('http://example.com'), 'http://example.com');
+      expect(ensureUrlScheme('https://example.com'), 'https://example.com');
+    });
+  });
+}


### PR DESCRIPTION
The URL normalization at 6 entry points (URL bar, add-site flows, edit-site dialog) only recognized `http://` and `https://` as schemes, so typing `chrome://flags` or `about:blank` was rewritten to `https://chrome://flags`. Extract the scheme check into `ensureUrlScheme` in `lib/utils/url_utils.dart` so any `scheme:` prefix (no dots, per RFC 3986) is preserved, while `example.com:8080` still gets `https://` prepended.