### PR TITLE
Declare FileProvider for flutter_inappwebview_android file chooser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ Detailed feature specs are in `openspec/specs/`. Each spec uses Given/When/Then 
 | cookie-secure-storage | Encrypted cookie persistence with flutter_secure_storage |
 | developer-tools | In-app dev tools: JS console, cookie inspector, HTML export, app logs |
 | dns-blocklist | Hagezi DNS blocklist domain blocking with severity levels and per-site toggle |
+| downloads | Webview-initiated downloads (http/https/data/blob) with streamed progress + save dialog |
 | home-shortcut | Android home screen shortcut for sites via pinned shortcuts API |
 | icon-fetching | Progressive favicon loading with fallbacks |
 | language | Per-site language: Accept-Language header + DOCUMENT_START navigator.language / Intl override |

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,5 +30,14 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.flutter_inappwebview_android.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/flutter_inappwebview_android_provider_paths" />
+        </provider>
     </application>
 </manifest>

--- a/android/app/src/main/res/xml/flutter_inappwebview_android_provider_paths.xml
+++ b/android/app/src/main/res/xml/flutter_inappwebview_android_provider_paths.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <files-path name="files" path="." />
+    <cache-path name="cache" path="." />
+    <external-path name="external_files" path="." />
+    <external-files-path name="external_files_path" path="." />
+    <external-cache-path name="external_cache_path" path="." />
+</paths>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -53,6 +53,7 @@ import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/settings/user_script.dart';
 import 'package:webspace/utils/url_utils.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:webspace/widgets/download_button.dart';
 import 'package:webspace/widgets/root_messenger.dart';
 
 // Accent color enum
@@ -1693,6 +1694,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                 ).name
               : 'No Webspace Selected'),
       actions: [
+        const DownloadButton(),
         IconButton(
           icon: Icon(_getThemeIcon()),
           tooltip: _getThemeTooltip(),

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -8,6 +8,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/settings/location.dart';
+import 'package:webspace/widgets/download_button.dart';
 import 'package:webspace/widgets/find_toolbar.dart';
 import 'package:webspace/widgets/url_bar.dart';
 
@@ -180,6 +181,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen> {
       appBar: AppBar(
         title: Text(title ?? 'In-App WebView'),
         actions: [
+          const DownloadButton(),
           PopupMenuButton<String>(
             itemBuilder: (BuildContext context) {
               return [

--- a/lib/services/download_engine.dart
+++ b/lib/services/download_engine.dart
@@ -74,6 +74,7 @@ class DownloadEngine {
     String? userAgent,
     String? suggestedFilename,
     String? mimeTypeHint,
+    void Function(int bytesDone, int? bytesTotal)? onProgress,
   }) async {
     final Uri uri;
     try {
@@ -85,30 +86,56 @@ class DownloadEngine {
       throw DownloadException('Unsupported scheme: ${uri.scheme}');
     }
 
-    final headers = <String, String>{};
+    final request = http.Request('GET', uri);
     if (cookieHeader != null && cookieHeader.isNotEmpty) {
-      headers['cookie'] = cookieHeader;
+      request.headers['cookie'] = cookieHeader;
     }
     if (userAgent != null && userAgent.isNotEmpty) {
-      headers['user-agent'] = userAgent;
+      request.headers['user-agent'] = userAgent;
     }
 
-    final http.Response response;
+    final http.StreamedResponse response;
     try {
-      response = await _client.get(uri, headers: headers);
+      response = await _client.send(request);
     } catch (e) {
       throw DownloadException('Network error: $e');
     }
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
+      // Drain the body so the connection can be returned to the pool.
+      try {
+        await response.stream.drain<void>();
+      } catch (_) {}
       throw DownloadException('HTTP ${response.statusCode}');
+    }
+
+    final total = response.contentLength;
+    onProgress?.call(0, total);
+
+    final chunks = <List<int>>[];
+    var done = 0;
+    try {
+      await for (final chunk in response.stream) {
+        chunks.add(chunk);
+        done += chunk.length;
+        onProgress?.call(done, total);
+      }
+    } catch (e) {
+      throw DownloadException('Network error: $e');
+    }
+
+    final bytes = Uint8List(done);
+    var offset = 0;
+    for (final c in chunks) {
+      bytes.setRange(offset, offset + c.length, c);
+      offset += c.length;
     }
 
     final contentType = response.headers['content-type'];
     final mime = contentType == null ? mimeTypeHint : _parseMime(contentType);
 
     return DownloadResult(
-      bytes: response.bodyBytes,
+      bytes: bytes,
       filename: deriveFilename(
         suggested: suggestedFilename,
         url: url,

--- a/lib/services/download_engine.dart
+++ b/lib/services/download_engine.dart
@@ -72,6 +72,7 @@ class DownloadEngine {
     required String url,
     String? cookieHeader,
     String? userAgent,
+    String? referer,
     String? suggestedFilename,
     String? mimeTypeHint,
     void Function(int bytesDone, int? bytesTotal)? onProgress,
@@ -92,6 +93,14 @@ class DownloadEngine {
     }
     if (userAgent != null && userAgent.isNotEmpty) {
       request.headers['user-agent'] = userAgent;
+    }
+    // Many download servers use Referer for hotlink protection; without
+    // one they may 302 to an error page or stream HTML with no
+    // Content-Length, which makes the progress ring spin indeterminately.
+    // Only forward http(s) referers so we don't leak data: / file: URLs.
+    if (referer != null &&
+        (referer.startsWith('http://') || referer.startsWith('https://'))) {
+      request.headers['referer'] = referer;
     }
 
     final http.StreamedResponse response;

--- a/lib/services/download_engine.dart
+++ b/lib/services/download_engine.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
+import 'package:http/io_client.dart';
 
 /// Result of a successful download fetch.
 class DownloadResult {
@@ -30,7 +32,19 @@ class DownloadException implements Exception {
 class DownloadEngine {
   final http.Client _client;
 
-  DownloadEngine({http.Client? client}) : _client = client ?? http.Client();
+  DownloadEngine({http.Client? client}) : _client = client ?? _defaultClient();
+
+  /// Default HTTP client with gzip auto-decompression DISABLED so the
+  /// server's Content-Length survives to the caller. When
+  /// `autoUncompress: true` (the dart:io default), the client adds
+  /// `Accept-Encoding: gzip` and then strips Content-Length from the
+  /// response headers after decompression — leaving the progress ring
+  /// indeterminate even for servers that know how big the download is.
+  static http.Client _defaultClient() {
+    final httpClient = HttpClient();
+    httpClient.autoUncompress = false;
+    return IOClient(httpClient);
+  }
 
   /// RFC 6265 `Cookie:` header value from an ordered list of name/value
   /// pairs. Returns null if no pairs were supplied.
@@ -133,11 +147,31 @@ class DownloadEngine {
       throw DownloadException('Network error: $e');
     }
 
-    final bytes = Uint8List(done);
+    final bytesReceived = Uint8List(done);
     var offset = 0;
     for (final c in chunks) {
-      bytes.setRange(offset, offset + c.length, c);
+      bytesReceived.setRange(offset, offset + c.length, c);
       offset += c.length;
+    }
+
+    // If the server compressed the response despite our not asking for
+    // it (autoUncompress: false means we don't send Accept-Encoding),
+    // decompress now. Progress tracking above is in wire bytes, which
+    // matches Content-Length; the final DownloadResult exposes the
+    // decoded body so the save-to-disk path writes usable files.
+    final encoding =
+        response.headers['content-encoding']?.trim().toLowerCase();
+    final Uint8List bytes;
+    try {
+      bytes = switch (encoding) {
+        'gzip' || 'x-gzip' =>
+          Uint8List.fromList(gzip.decode(bytesReceived)),
+        'deflate' =>
+          Uint8List.fromList(zlib.decode(bytesReceived)),
+        _ => bytesReceived,
+      };
+    } on FormatException catch (e) {
+      throw DownloadException('Decompression failed: ${e.message}');
     }
 
     final contentType = response.headers['content-type'];

--- a/lib/services/download_engine.dart
+++ b/lib/services/download_engine.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
@@ -122,6 +123,60 @@ class DownloadEngine {
         .replaceAll(RegExp(r'[/\\]'), '_')
         .replaceAll(RegExp(r'[\x00-\x1f]'), '')
         .trim();
+  }
+
+  /// Decodes a `data:` URI into bytes + filename + mime. Supports both
+  /// base64 (`data:<mime>;base64,<payload>`) and URL-encoded
+  /// (`data:<mime>,<payload>`) forms, with or without a mime.
+  static DownloadResult decodeDataUri({
+    required String url,
+    String? suggestedFilename,
+  }) {
+    final uri = Uri.parse(url);
+    if (uri.scheme != 'data') {
+      throw DownloadException('Not a data URI: $url');
+    }
+    final data = UriData.fromUri(uri);
+    final bytes = Uint8List.fromList(data.contentAsBytes());
+    final mime = data.mimeType.isEmpty ? null : data.mimeType;
+    // The data URI's "path" is the payload itself, which produces garbage
+    // when fed to deriveFilename — pass an empty URL so it falls straight
+    // through to the mime-based fallback.
+    return DownloadResult(
+      bytes: bytes,
+      filename: deriveFilename(
+        suggested: suggestedFilename,
+        url: '',
+        mimeType: mime,
+      ),
+      mimeType: mime,
+    );
+  }
+
+  /// Wraps a base64 payload (e.g. from a blob:→FileReader round-trip) in a
+  /// [DownloadResult]. The payload is the bare base64 string — no
+  /// `data:<mime>;base64,` prefix.
+  static DownloadResult fromBase64({
+    required String base64Data,
+    String? suggestedFilename,
+    String? mimeType,
+    String? sourceUrl,
+  }) {
+    final Uint8List bytes;
+    try {
+      bytes = base64.decode(base64Data.trim());
+    } on FormatException catch (e) {
+      throw DownloadException('Malformed base64: ${e.message}');
+    }
+    return DownloadResult(
+      bytes: bytes,
+      filename: deriveFilename(
+        suggested: suggestedFilename,
+        url: sourceUrl ?? '',
+        mimeType: mimeType,
+      ),
+      mimeType: mimeType,
+    );
   }
 
   static String? _parseMime(String contentType) {

--- a/lib/services/download_engine.dart
+++ b/lib/services/download_engine.dart
@@ -1,0 +1,162 @@
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+
+/// Result of a successful download fetch.
+class DownloadResult {
+  final Uint8List bytes;
+  final String filename;
+  final String? mimeType;
+
+  DownloadResult({
+    required this.bytes,
+    required this.filename,
+    this.mimeType,
+  });
+}
+
+/// Thrown when a download cannot be completed.
+class DownloadException implements Exception {
+  final String message;
+  DownloadException(this.message);
+  @override
+  String toString() => 'DownloadException: $message';
+}
+
+/// Fetches an HTTP(S) URL with optional forwarded cookies and user-agent,
+/// returning the response body as bytes plus a derived filename. I/O goes
+/// through an injectable [http.Client] so tests can supply a fake.
+class DownloadEngine {
+  final http.Client _client;
+
+  DownloadEngine({http.Client? client}) : _client = client ?? http.Client();
+
+  /// RFC 6265 `Cookie:` header value from an ordered list of name/value
+  /// pairs. Returns null if no pairs were supplied.
+  static String? buildCookieHeader(
+      Iterable<MapEntry<String, String>> cookies) {
+    final parts = cookies
+        .map((e) => '${e.key}=${e.value}')
+        .toList(growable: false);
+    return parts.isEmpty ? null : parts.join('; ');
+  }
+
+  /// Derives a filename from (in priority): [suggested] → last non-empty
+  /// URL path segment → `download` + extension guessed from [mimeType].
+  /// The result is sanitized so path separators and control chars never
+  /// escape the downloads directory.
+  static String deriveFilename({
+    String? suggested,
+    required String url,
+    String? mimeType,
+  }) {
+    final s = (suggested ?? '').trim();
+    if (s.isNotEmpty) return _sanitize(s);
+
+    try {
+      final uri = Uri.parse(url);
+      for (int i = uri.pathSegments.length - 1; i >= 0; i--) {
+        final seg = uri.pathSegments[i];
+        if (seg.trim().isEmpty) continue;
+        final decoded = Uri.decodeComponent(seg);
+        if (decoded.trim().isNotEmpty) return _sanitize(decoded);
+      }
+    } catch (_) {}
+
+    final ext = _extensionForMime(mimeType);
+    return 'download${ext ?? ''}';
+  }
+
+  Future<DownloadResult> fetch({
+    required String url,
+    String? cookieHeader,
+    String? userAgent,
+    String? suggestedFilename,
+    String? mimeTypeHint,
+  }) async {
+    final Uri uri;
+    try {
+      uri = Uri.parse(url);
+    } catch (_) {
+      throw DownloadException('Invalid URL: $url');
+    }
+    if (uri.scheme != 'http' && uri.scheme != 'https') {
+      throw DownloadException('Unsupported scheme: ${uri.scheme}');
+    }
+
+    final headers = <String, String>{};
+    if (cookieHeader != null && cookieHeader.isNotEmpty) {
+      headers['cookie'] = cookieHeader;
+    }
+    if (userAgent != null && userAgent.isNotEmpty) {
+      headers['user-agent'] = userAgent;
+    }
+
+    final http.Response response;
+    try {
+      response = await _client.get(uri, headers: headers);
+    } catch (e) {
+      throw DownloadException('Network error: $e');
+    }
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw DownloadException('HTTP ${response.statusCode}');
+    }
+
+    final contentType = response.headers['content-type'];
+    final mime = contentType == null ? mimeTypeHint : _parseMime(contentType);
+
+    return DownloadResult(
+      bytes: response.bodyBytes,
+      filename: deriveFilename(
+        suggested: suggestedFilename,
+        url: url,
+        mimeType: mime,
+      ),
+      mimeType: mime,
+    );
+  }
+
+  static String _sanitize(String name) {
+    return name
+        .replaceAll(RegExp(r'[/\\]'), '_')
+        .replaceAll(RegExp(r'[\x00-\x1f]'), '')
+        .trim();
+  }
+
+  static String? _parseMime(String contentType) {
+    final semi = contentType.indexOf(';');
+    return (semi == -1 ? contentType : contentType.substring(0, semi)).trim();
+  }
+
+  static String? _extensionForMime(String? mime) {
+    if (mime == null) return null;
+    switch (mime) {
+      case 'application/pdf':
+        return '.pdf';
+      case 'image/jpeg':
+        return '.jpg';
+      case 'image/png':
+        return '.png';
+      case 'image/gif':
+        return '.gif';
+      case 'image/webp':
+        return '.webp';
+      case 'image/svg+xml':
+        return '.svg';
+      case 'text/html':
+        return '.html';
+      case 'text/plain':
+        return '.txt';
+      case 'text/csv':
+        return '.csv';
+      case 'application/json':
+        return '.json';
+      case 'application/zip':
+        return '.zip';
+      case 'application/octet-stream':
+        return null;
+    }
+    return null;
+  }
+}

--- a/lib/services/download_manager.dart
+++ b/lib/services/download_manager.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/foundation.dart';
+
+enum DownloadState { downloading, completed, failed, cancelled }
+
+class DownloadTask {
+  final String id;
+  final String? url;
+  String filename;
+  int bytesDone;
+  int? bytesTotal;
+  DownloadState state;
+  String? errorMessage;
+  String? savedPath;
+  final DateTime startedAt;
+
+  DownloadTask({
+    required this.id,
+    required this.filename,
+    this.url,
+    this.bytesDone = 0,
+    this.bytesTotal,
+    this.state = DownloadState.downloading,
+    this.errorMessage,
+    this.savedPath,
+    DateTime? startedAt,
+  }) : startedAt = startedAt ?? DateTime.now();
+
+  /// 0.0–1.0 if [bytesTotal] is known, otherwise null (caller should render
+  /// an indeterminate indicator).
+  double? get progress {
+    final total = bytesTotal;
+    if (total == null || total <= 0) return null;
+    return (bytesDone / total).clamp(0.0, 1.0);
+  }
+
+  bool get isActive => state == DownloadState.downloading;
+}
+
+/// Tracks in-flight and recently-completed downloads for the app-bar
+/// progress button. Pure `ChangeNotifier` — no Flutter widgets, so it can
+/// be driven from any callback layer (webview handlers, blob JS handler,
+/// data-URI decode, etc.).
+class DownloadsService extends ChangeNotifier {
+  DownloadsService._();
+  static final DownloadsService instance = DownloadsService._();
+
+  final List<DownloadTask> _tasks = [];
+  int _counter = 0;
+
+  List<DownloadTask> get tasks => List.unmodifiable(_tasks);
+  bool get hasActive => _tasks.any((t) => t.isActive);
+  int get activeCount => _tasks.where((t) => t.isActive).length;
+
+  /// Creates and registers a new task. Returns the task so the caller can
+  /// mutate it directly; after any mutation call [emit] to notify
+  /// listeners.
+  DownloadTask start({
+    required String filename,
+    String? url,
+    int? bytesTotal,
+  }) {
+    final task = DownloadTask(
+      id: 'dl-${++_counter}',
+      filename: filename,
+      url: url,
+      bytesTotal: bytesTotal,
+    );
+    _tasks.insert(0, task);
+    notifyListeners();
+    return task;
+  }
+
+  /// Updates progress fields on an already-started task and notifies.
+  /// Silent if the id is unknown (task may have been cleared from history).
+  void updateProgress(String id, {int? bytesDone, int? bytesTotal}) {
+    final task = _tasks.where((t) => t.id == id).firstOrNull;
+    if (task == null) return;
+    if (bytesDone != null) task.bytesDone = bytesDone;
+    if (bytesTotal != null) task.bytesTotal = bytesTotal;
+    notifyListeners();
+  }
+
+  void complete(String id, {String? savedPath}) {
+    final task = _tasks.where((t) => t.id == id).firstOrNull;
+    if (task == null) return;
+    task.state = DownloadState.completed;
+    task.savedPath = savedPath;
+    task.bytesTotal ??= task.bytesDone;
+    notifyListeners();
+  }
+
+  void fail(String id, String message) {
+    final task = _tasks.where((t) => t.id == id).firstOrNull;
+    if (task == null) return;
+    task.state = DownloadState.failed;
+    task.errorMessage = message;
+    notifyListeners();
+  }
+
+  void cancel(String id) {
+    final task = _tasks.where((t) => t.id == id).firstOrNull;
+    if (task == null) return;
+    task.state = DownloadState.cancelled;
+    notifyListeners();
+  }
+
+  /// Remove a single finished/failed/cancelled task.
+  void dismiss(String id) {
+    _tasks.removeWhere((t) => t.id == id);
+    notifyListeners();
+  }
+
+  /// Remove all non-active tasks.
+  void clearCompleted() {
+    _tasks.removeWhere((t) => !t.isActive);
+    notifyListeners();
+  }
+
+  @visibleForTesting
+  void resetForTest() {
+    _tasks.clear();
+    _counter = 0;
+    notifyListeners();
+  }
+}

--- a/lib/services/download_manager.dart
+++ b/lib/services/download_manager.dart
@@ -123,3 +123,45 @@ class DownloadsService extends ChangeNotifier {
     notifyListeners();
   }
 }
+
+/// Pure helper for the app-bar progress ring. Given the list of tasks
+/// currently surfaced by [DownloadsService], computes what the ring
+/// should display.
+///
+/// Extracted so it's unit-testable without mounting a widget.
+class DownloadAggregateProgress {
+  /// Resulting ring value — null means "render indeterminate".
+  final double? value;
+
+  /// Whether anything is currently in flight. When false, the caller
+  /// should render the "download done" glyph without a ring.
+  final bool hasActive;
+
+  const DownloadAggregateProgress({
+    required this.value,
+    required this.hasActive,
+  });
+
+  /// Aggregate across all active tasks: [value] is done/total if every
+  /// active task has a positive known total; otherwise null so the ring
+  /// falls back to an indeterminate spin. Completed/failed/cancelled
+  /// tasks don't contribute.
+  static DownloadAggregateProgress from(Iterable<DownloadTask> tasks) {
+    final active = tasks.where((t) => t.isActive).toList(growable: false);
+    if (active.isEmpty) {
+      return const DownloadAggregateProgress(value: null, hasActive: false);
+    }
+    if (!active.every((t) => (t.bytesTotal ?? 0) > 0)) {
+      return const DownloadAggregateProgress(value: null, hasActive: true);
+    }
+    final total = active.fold<int>(0, (a, t) => a + t.bytesTotal!);
+    if (total <= 0) {
+      return const DownloadAggregateProgress(value: null, hasActive: true);
+    }
+    final done = active.fold<int>(0, (a, t) => a + t.bytesDone);
+    return DownloadAggregateProgress(
+      value: (done / total).clamp(0.0, 1.0),
+      hasActive: true,
+    );
+  }
+}

--- a/lib/services/download_url_revert_engine.dart
+++ b/lib/services/download_url_revert_engine.dart
@@ -1,0 +1,43 @@
+/// Decides which URL should be treated as "stable" (i.e. safe to persist
+/// as the site's current URL) and which URL to revert the address bar to
+/// after a download is triggered.
+///
+/// Extracted from [`WebViewFactory.createWebView`] so the scheme-based
+/// gating and revert-target selection are unit-testable without running a
+/// real webview.
+class DownloadUrlRevertEngine {
+  /// Schemes that render as a normal page and therefore represent a
+  /// reasonable state to roll back to after a download. Transient schemes
+  /// (data:, blob:, javascript:, about:blank) are deliberately excluded:
+  /// they typically arise from the download trigger itself, bookmarklets,
+  /// or chrome pages, none of which we want to overwrite the stable URL.
+  static bool isRenderable(String url) {
+    try {
+      final scheme = Uri.parse(url).scheme.toLowerCase();
+      return scheme == 'http' ||
+          scheme == 'https' ||
+          scheme == 'file' ||
+          scheme == 'about';
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Given the previously-known stable URL and a URL that just finished
+  /// loading, returns the new stable URL. Non-renderable URLs never
+  /// displace the previous value.
+  static String? updateStable(String? previous, String loadedUrl) {
+    return isRenderable(loadedUrl) ? loadedUrl : previous;
+  }
+
+  /// The URL to restore in the address bar and persisted state after a
+  /// download was triggered. Prefers the most recent stable URL, falling
+  /// back to the initial URL so downloads triggered on first load still
+  /// have somewhere to revert to. Returns null if neither is set.
+  static String? pickRevertTarget({
+    String? lastStableUrl,
+    String? initialUrl,
+  }) {
+    return lastStableUrl ?? initialUrl;
+  }
+}

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1275,6 +1275,22 @@ class WebViewFactory {
             return null;
           },
         );
+        controller.addJavaScriptHandler(
+          handlerName: '_webspaceBlobProgress',
+          callback: (args) {
+            if (args.length < 3) return null;
+            final taskId = args[0] is String ? args[0] as String : '';
+            final done = _asInt(args[1]);
+            final total = _asInt(args[2]);
+            if (taskId.isEmpty) return null;
+            DownloadsService.instance.updateProgress(
+              taskId,
+              bytesDone: done,
+              bytesTotal: total,
+            );
+            return null;
+          },
+        );
         // If we loaded cached HTML, navigate to the real URL when online
         if (usesCachedHtml) {
           final online = await ConnectivityService.instance.isOnline();
@@ -1614,10 +1630,22 @@ class WebViewFactory {
     final idJson = jsonEncode(task.id);
     final script = '''
 (function(blobUrl, suggestedFilename, taskId) {
+  function progress(done, total) {
+    window.flutter_inappwebview.callHandler(
+      '_webspaceBlobProgress', taskId, done, total);
+  }
   try {
     fetch(blobUrl).then(function(r) { return r.blob(); }).then(function(blob) {
+      var total = blob.size || 0;
+      progress(0, total);
       var reader = new FileReader();
+      reader.onprogress = function(e) {
+        if (e && e.lengthComputable) {
+          progress(e.loaded, e.total);
+        }
+      };
       reader.onload = function() {
+        progress(total, total);
         var result = reader.result || '';
         var comma = result.indexOf(',');
         var base64 = comma === -1 ? '' : result.substring(comma + 1);
@@ -1674,5 +1702,15 @@ class WebViewFactory {
     rootScaffoldMessengerKey.currentState?.showSnackBar(
       SnackBar(content: Text(message)),
     );
+  }
+
+  /// Coerce a JS handler arg to an int. Small integers come back as int
+  /// but large ones can arrive as double (JSON number serialization), so
+  /// normalize both.
+  static int? _asInt(Object? v) {
+    if (v is int) return v;
+    if (v is double) return v.toInt();
+    if (v is String) return int.tryParse(v);
+    return null;
   }
 }

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -12,6 +12,7 @@ import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/services/download_engine.dart';
 import 'package:webspace/services/download_manager.dart';
+import 'package:webspace/services/download_url_revert_engine.dart';
 import 'package:webspace/services/web_intercept_native.dart';
 import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/services/location_spoof_service.dart';
@@ -1075,12 +1076,12 @@ class WebViewFactory {
     // SPA navigations (pushState) from real page loads in onUpdateVisitedHistory.
     String? lastLoadStartUrl;
 
-    // Track the last URL that actually finished loading without being a
-    // download. When a download is triggered, the webview has already
-    // fired onUrlChanged with the download URL, so we roll the URL bar
-    // back to this value. Seeded with the initial URL so a download
-    // triggered on first load still has somewhere to revert to.
-    String? lastStableUrl = config.initialUrl;
+    // Track the last URL that actually finished loading as a renderable
+    // page. Updated via DownloadUrlRevertEngine.updateStable in
+    // onLoadStop; consumed by the onDownloadStartRequest revert so the
+    // URL bar and persisted currentUrl roll back to the referring page.
+    // Initial-load fallback is handled inside the engine.
+    String? lastStableUrl;
 
     LogService.instance.log('DnsBlock', 'Creating webview: siteId=${config.siteId} dnsBlock=${config.dnsBlockEnabled} hasBlocklist=${DnsBlockService.instance.hasBlocklist} isAndroid=${Platform.isAndroid} url=${config.initialUrl}');
 
@@ -1415,15 +1416,10 @@ class WebViewFactory {
         config.pullToRefreshController?.endRefreshing();
         if (url != null) {
           final urlStr = url.toString();
-          // Only remember as stable if the scheme is something a page can
-          // actually render — data:/blob: URLs only reach this path in
-          // rare edge cases and we don't want them persisted as the
-          // site's last URL if a download later fires.
-          final scheme = url.scheme.toLowerCase();
-          if (scheme == 'http' || scheme == 'https' ||
-              scheme == 'file' || scheme == 'about') {
-            lastStableUrl = urlStr;
-          }
+          // Only renderable schemes update the stable URL — see
+          // DownloadUrlRevertEngine.isRenderable for the rationale.
+          lastStableUrl =
+              DownloadUrlRevertEngine.updateStable(lastStableUrl, urlStr);
           config.onUrlChanged?.call(urlStr);
           if (config.onCookiesChanged != null) {
             final cookies = await cookieManager.getCookies(url: inapp.WebUri(url.toString()));
@@ -1476,13 +1472,17 @@ class WebViewFactory {
         config.onConsoleMessage?.call(consoleMessage.message, consoleMessage.messageLevel);
       },
       onDownloadStartRequest: (controller, downloadStartRequest) async {
-        final revert = lastStableUrl;
-        await _handleDownloadRequest(controller, downloadStartRequest);
         // onUrlChanged / onUpdateVisitedHistory has likely already fired
         // with the download URL (e.g. "data:application/pdf;..."), which
         // would otherwise be persisted as the site's "current URL" and
-        // tried again on next launch. Roll the URL bar back to the last
-        // page the webview actually rendered.
+        // tried again on next launch. Resolve the revert target BEFORE
+        // awaiting the download so a nested callback can't clobber it,
+        // then roll the URL bar back after stopLoading().
+        final revert = DownloadUrlRevertEngine.pickRevertTarget(
+          lastStableUrl: lastStableUrl,
+          initialUrl: config.initialUrl,
+        );
+        await _handleDownloadRequest(controller, downloadStartRequest);
         if (revert != null) {
           config.onUrlChanged?.call(revert);
         }

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1430,37 +1430,46 @@ class WebViewFactory {
       onLoadStop: (controller, url) async {
         // End pull-to-refresh animation
         config.pullToRefreshController?.endRefreshing();
-        if (url != null) {
-          final urlStr = url.toString();
-          // Only renderable schemes update the stable URL — see
-          // DownloadUrlRevertEngine.isRenderable for the rationale.
-          lastStableUrl =
-              DownloadUrlRevertEngine.updateStable(lastStableUrl, urlStr);
-          config.onUrlChanged?.call(urlStr);
-          if (config.onCookiesChanged != null) {
-            final cookies = await cookieManager.getCookies(url: inapp.WebUri(url.toString()));
-            config.onCookiesChanged!(cookies);
-          }
-          // Inject full cosmetic script: MutationObserver + text-based hiding
-          if (config.contentBlockEnabled) {
-            final script = ContentBlockerService.instance.getCosmeticScript(url.toString());
-            if (script != null) {
-              try {
-                await controller.evaluateJavascript(source: '$script\n;null;');
-              } catch (_) {} // WebKit "unsupported type" — JS still ran
-            }
-          }
-          await userScriptService.reinjectOnLoadStop(controller);
-          // Cache HTML for offline viewing
-          if (config.onHtmlLoaded != null) {
+        if (url == null) return;
+        final urlStr = url.toString();
+
+        // Downloads, javascript: bookmarklets, and other non-renderable
+        // schemes can reach here when controller.stopLoading() interrupts
+        // an in-flight navigation (the download path does this to keep
+        // the webview from rendering the attachment as a page). There's
+        // no real page to snapshot — onHtmlLoaded would end up writing
+        // either the previous page's HTML keyed under the download URL,
+        // or empty content, clobbering a legitimate offline cache entry.
+        // Skip all post-load work in that case; onDownloadStartRequest's
+        // revert handles URL bar restoration.
+        if (!DownloadUrlRevertEngine.isRenderable(urlStr)) return;
+
+        lastStableUrl =
+            DownloadUrlRevertEngine.updateStable(lastStableUrl, urlStr);
+        config.onUrlChanged?.call(urlStr);
+        if (config.onCookiesChanged != null) {
+          final cookies = await cookieManager.getCookies(url: inapp.WebUri(urlStr));
+          config.onCookiesChanged!(cookies);
+        }
+        // Inject full cosmetic script: MutationObserver + text-based hiding
+        if (config.contentBlockEnabled) {
+          final script = ContentBlockerService.instance.getCosmeticScript(urlStr);
+          if (script != null) {
             try {
-              final html = await controller.getHtml();
-              if (html != null && html.isNotEmpty) {
-                config.onHtmlLoaded!(url.toString(), html);
-              }
-            } catch (_) {
-              // Controller may have been disposed if webview was unloaded
+              await controller.evaluateJavascript(source: '$script\n;null;');
+            } catch (_) {} // WebKit "unsupported type" — JS still ran
+          }
+        }
+        await userScriptService.reinjectOnLoadStop(controller);
+        // Cache HTML for offline viewing
+        if (config.onHtmlLoaded != null) {
+          try {
+            final html = await controller.getHtml();
+            if (html != null && html.isNotEmpty) {
+              config.onHtmlLoaded!(urlStr, html);
             }
+          } catch (_) {
+            // Controller may have been disposed if webview was unloaded
           }
         }
       },

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -2,6 +2,7 @@ import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
@@ -9,6 +10,7 @@ import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
+import 'package:webspace/services/download_engine.dart';
 import 'package:webspace/services/web_intercept_native.dart';
 import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/services/location_spoof_service.dart';
@@ -16,6 +18,7 @@ import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/user_script_service.dart';
 import 'package:webspace/settings/location.dart';
 import 'package:webspace/settings/user_script.dart';
+import 'package:webspace/widgets/root_messenger.dart';
 
 // Re-export inapp.Cookie as Cookie for convenience
 typedef Cookie = inapp.Cookie;
@@ -1124,6 +1127,11 @@ class WebViewFactory {
         cacheMode: usesCachedHtml ? inapp.CacheMode.LOAD_CACHE_ELSE_NETWORK : null,
         // iOS: play videos inline instead of auto-fullscreen
         allowsInlineMediaPlayback: true,
+        // Required for onDownloadStartRequest to fire when the webview
+        // navigates to a downloadable response (Content-Disposition:
+        // attachment, or an unrecognized MIME type). Without this, the
+        // webview silently drops the navigation and the user sees nothing.
+        useOnDownloadStart: true,
         // Enable DevTools inspection in debug mode (chrome://inspect on Android)
         isInspectable: kDebugMode,
       ),
@@ -1387,6 +1395,78 @@ class WebViewFactory {
       onConsoleMessage: (controller, consoleMessage) {
         config.onConsoleMessage?.call(consoleMessage.message, consoleMessage.messageLevel);
       },
+      onDownloadStartRequest: (controller, downloadStartRequest) async {
+        await _handleDownloadRequest(downloadStartRequest);
+      },
+    );
+  }
+
+  static Future<void> _handleDownloadRequest(
+    inapp.DownloadStartRequest req,
+  ) async {
+    final urlStr = req.url.toString();
+    final scheme = req.url.scheme.toLowerCase();
+
+    if (scheme != 'http' && scheme != 'https') {
+      // blob:/data:/file: aren't reachable via a simple HTTP GET. Surface
+      // a message instead of silently dropping — blob downloads need a JS
+      // shim (FileReader → base64 → handler) which isn't wired up yet.
+      _showDownloadSnack(
+        'Can\'t download $scheme: URL yet (only http/https supported).',
+      );
+      return;
+    }
+
+    _showDownloadSnack('Downloading…');
+
+    try {
+      final cookies = await inapp.CookieManager.instance()
+          .getCookies(url: req.url);
+      final cookieHeader = DownloadEngine.buildCookieHeader(
+        cookies.map((c) => MapEntry(c.name, c.value.toString())),
+      );
+
+      final engine = DownloadEngine();
+      final result = await engine.fetch(
+        url: urlStr,
+        cookieHeader: cookieHeader,
+        userAgent: req.userAgent,
+        suggestedFilename: req.suggestedFilename,
+        mimeTypeHint: req.mimeType,
+      );
+
+      final savedPath = await _saveViaPicker(result);
+      if (savedPath == null) {
+        _showDownloadSnack('Download cancelled.');
+        return;
+      }
+      _showDownloadSnack('Saved ${result.filename}');
+    } on DownloadException catch (e) {
+      _showDownloadSnack('Download failed: ${e.message}');
+    } catch (e, stack) {
+      debugPrint('Download error: $e\n$stack');
+      _showDownloadSnack('Download failed: $e');
+    }
+  }
+
+  static Future<String?> _saveViaPicker(DownloadResult result) async {
+    final isMobile = !kIsWeb && (Platform.isIOS || Platform.isAndroid);
+    final outputPath = await FilePicker.saveFile(
+      dialogTitle: 'Save download',
+      fileName: result.filename,
+      bytes: isMobile ? result.bytes : null,
+    );
+    if (outputPath == null) return null;
+    if (!isMobile) {
+      final file = File(outputPath);
+      await file.writeAsBytes(result.bytes);
+    }
+    return outputPath;
+  }
+
+  static void _showDownloadSnack(String message) {
+    rootScaffoldMessengerKey.currentState?.showSnackBar(
+      SnackBar(content: Text(message)),
     );
   }
 }

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1204,6 +1204,46 @@ class WebViewFactory {
           }
         }
         userScriptService.registerHandlers(controller);
+        // Blob download: JS reads the blob via FileReader and hands the
+        // base64 payload back through these handlers.
+        controller.addJavaScriptHandler(
+          handlerName: '_webspaceBlobDownload',
+          callback: (args) async {
+            if (args.length < 3) return null;
+            final filename = args[0] is String ? args[0] as String : '';
+            final base64Data = args[1] is String ? args[1] as String : '';
+            final mimeType = args[2] is String ? args[2] as String : '';
+            if (base64Data.isEmpty) {
+              _showDownloadSnack('Download failed: empty payload');
+              return null;
+            }
+            try {
+              final result = DownloadEngine.fromBase64(
+                base64Data: base64Data,
+                suggestedFilename: filename.isEmpty ? null : filename,
+                mimeType: mimeType.isEmpty ? null : mimeType,
+              );
+              final saved = await _saveViaPicker(result);
+              _showDownloadSnack(saved == null
+                  ? 'Download cancelled.'
+                  : 'Saved ${result.filename}');
+            } on DownloadException catch (e) {
+              _showDownloadSnack('Download failed: ${e.message}');
+            } catch (e, stack) {
+              debugPrint('Blob download error: $e\n$stack');
+              _showDownloadSnack('Download failed: $e');
+            }
+            return null;
+          },
+        );
+        controller.addJavaScriptHandler(
+          handlerName: '_webspaceBlobDownloadError',
+          callback: (args) {
+            final msg = args.isNotEmpty ? args[0].toString() : 'unknown';
+            _showDownloadSnack('Blob download failed: $msg');
+            return null;
+          },
+        );
         // If we loaded cached HTML, navigate to the real URL when online
         if (usesCachedHtml) {
           final online = await ConnectivityService.instance.isOnline();
@@ -1416,44 +1456,116 @@ class WebViewFactory {
     final urlStr = req.url.toString();
     final scheme = req.url.scheme.toLowerCase();
 
-    if (scheme != 'http' && scheme != 'https') {
-      // blob:/data:/file: aren't reachable via a simple HTTP GET. Surface
-      // a message instead of silently dropping — blob downloads need a JS
-      // shim (FileReader → base64 → handler) which isn't wired up yet.
-      _showDownloadSnack(
-        'Can\'t download $scheme: URL yet (only http/https supported).',
-      );
-      return;
+    switch (scheme) {
+      case 'http':
+      case 'https':
+        await _handleHttpDownload(req);
+        return;
+      case 'data':
+        _handleDataDownload(req);
+        return;
+      case 'blob':
+        await _handleBlobDownload(controller, urlStr, req.suggestedFilename);
+        return;
+      default:
+        _showDownloadSnack('Can\'t download $scheme: URL.');
     }
+  }
 
+  static Future<void> _handleHttpDownload(
+      inapp.DownloadStartRequest req) async {
     _showDownloadSnack('Downloading…');
-
     try {
       final cookies = await inapp.CookieManager.instance()
           .getCookies(url: req.url);
       final cookieHeader = DownloadEngine.buildCookieHeader(
         cookies.map((c) => MapEntry(c.name, c.value.toString())),
       );
-
       final engine = DownloadEngine();
       final result = await engine.fetch(
-        url: urlStr,
+        url: req.url.toString(),
         cookieHeader: cookieHeader,
         userAgent: req.userAgent,
         suggestedFilename: req.suggestedFilename,
         mimeTypeHint: req.mimeType,
       );
-
       final savedPath = await _saveViaPicker(result);
-      if (savedPath == null) {
-        _showDownloadSnack('Download cancelled.');
-        return;
-      }
-      _showDownloadSnack('Saved ${result.filename}');
+      _showDownloadSnack(savedPath == null
+          ? 'Download cancelled.'
+          : 'Saved ${result.filename}');
     } on DownloadException catch (e) {
       _showDownloadSnack('Download failed: ${e.message}');
     } catch (e, stack) {
       debugPrint('Download error: $e\n$stack');
+      _showDownloadSnack('Download failed: $e');
+    }
+  }
+
+  static void _handleDataDownload(inapp.DownloadStartRequest req) async {
+    try {
+      final result = DownloadEngine.decodeDataUri(
+        url: req.url.toString(),
+        suggestedFilename: req.suggestedFilename,
+      );
+      final savedPath = await _saveViaPicker(result);
+      _showDownloadSnack(savedPath == null
+          ? 'Download cancelled.'
+          : 'Saved ${result.filename}');
+    } on DownloadException catch (e) {
+      _showDownloadSnack('Download failed: ${e.message}');
+    } catch (e, stack) {
+      debugPrint('Data-URI download error: $e\n$stack');
+      _showDownloadSnack('Download failed: $e');
+    }
+  }
+
+  static Future<void> _handleBlobDownload(
+    inapp.InAppWebViewController controller,
+    String blobUrl,
+    String? suggestedFilename,
+  ) async {
+    _showDownloadSnack('Downloading…');
+    // IIFE: fetch the blob, read via FileReader, hand the base64 back to
+    // Dart. Result is delivered asynchronously through
+    // _webspaceBlobDownload(filename, base64, mimeType).
+    final blobJson = jsonEncode(blobUrl);
+    final fnJson = jsonEncode(suggestedFilename ?? '');
+    final script = '''
+(function(blobUrl, suggestedFilename) {
+  try {
+    fetch(blobUrl).then(function(r) { return r.blob(); }).then(function(blob) {
+      var reader = new FileReader();
+      reader.onload = function() {
+        var result = reader.result || '';
+        var comma = result.indexOf(',');
+        var base64 = comma === -1 ? '' : result.substring(comma + 1);
+        window.flutter_inappwebview.callHandler(
+          '_webspaceBlobDownload',
+          suggestedFilename,
+          base64,
+          blob.type || ''
+        );
+      };
+      reader.onerror = function() {
+        var msg = (reader.error && reader.error.message) || 'read error';
+        window.flutter_inappwebview.callHandler(
+          '_webspaceBlobDownloadError', msg);
+      };
+      reader.readAsDataURL(blob);
+    }).catch(function(err) {
+      window.flutter_inappwebview.callHandler(
+        '_webspaceBlobDownloadError', (err && err.message) || String(err));
+    });
+  } catch (e) {
+    window.flutter_inappwebview.callHandler(
+      '_webspaceBlobDownloadError', (e && e.message) || String(e));
+  }
+})($blobJson, $fnJson);
+''';
+    try {
+      await controller.evaluateJavascript(source: script);
+    } catch (e, stack) {
+      debugPrint('Blob download eval error: $e\n$stack');
       _showDownloadSnack('Download failed: $e');
     }
   }

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1396,14 +1396,23 @@ class WebViewFactory {
         config.onConsoleMessage?.call(consoleMessage.message, consoleMessage.messageLevel);
       },
       onDownloadStartRequest: (controller, downloadStartRequest) async {
-        await _handleDownloadRequest(downloadStartRequest);
+        await _handleDownloadRequest(controller, downloadStartRequest);
       },
     );
   }
 
   static Future<void> _handleDownloadRequest(
+    inapp.InAppWebViewController controller,
     inapp.DownloadStartRequest req,
   ) async {
+    // Abort any in-flight main-frame navigation to this URL. Without this
+    // the webview tries to render the attachment response as a page and
+    // ends up on a "net::ERR_UNKNOWN_URL_SCHEME" / "invalid request" error
+    // page while the URL bar is stuck on the download URL.
+    try {
+      await controller.stopLoading();
+    } catch (_) {}
+
     final urlStr = req.url.toString();
     final scheme = req.url.scheme.toLowerCase();
 

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1075,6 +1075,13 @@ class WebViewFactory {
     // SPA navigations (pushState) from real page loads in onUpdateVisitedHistory.
     String? lastLoadStartUrl;
 
+    // Track the last URL that actually finished loading without being a
+    // download. When a download is triggered, the webview has already
+    // fired onUrlChanged with the download URL, so we roll the URL bar
+    // back to this value. Seeded with the initial URL so a download
+    // triggered on first load still has somewhere to revert to.
+    String? lastStableUrl = config.initialUrl;
+
     LogService.instance.log('DnsBlock', 'Creating webview: siteId=${config.siteId} dnsBlock=${config.dnsBlockEnabled} hasBlocklist=${DnsBlockService.instance.hasBlocklist} isAndroid=${Platform.isAndroid} url=${config.initialUrl}');
 
     return inapp.InAppWebView(
@@ -1407,7 +1414,17 @@ class WebViewFactory {
         // End pull-to-refresh animation
         config.pullToRefreshController?.endRefreshing();
         if (url != null) {
-          config.onUrlChanged?.call(url.toString());
+          final urlStr = url.toString();
+          // Only remember as stable if the scheme is something a page can
+          // actually render — data:/blob: URLs only reach this path in
+          // rare edge cases and we don't want them persisted as the
+          // site's last URL if a download later fires.
+          final scheme = url.scheme.toLowerCase();
+          if (scheme == 'http' || scheme == 'https' ||
+              scheme == 'file' || scheme == 'about') {
+            lastStableUrl = urlStr;
+          }
+          config.onUrlChanged?.call(urlStr);
           if (config.onCookiesChanged != null) {
             final cookies = await cookieManager.getCookies(url: inapp.WebUri(url.toString()));
             config.onCookiesChanged!(cookies);
@@ -1459,7 +1476,16 @@ class WebViewFactory {
         config.onConsoleMessage?.call(consoleMessage.message, consoleMessage.messageLevel);
       },
       onDownloadStartRequest: (controller, downloadStartRequest) async {
+        final revert = lastStableUrl;
         await _handleDownloadRequest(controller, downloadStartRequest);
+        // onUrlChanged / onUpdateVisitedHistory has likely already fired
+        // with the download URL (e.g. "data:application/pdf;..."), which
+        // would otherwise be persisted as the site's "current URL" and
+        // tried again on next launch. Roll the URL bar back to the last
+        // page the webview actually rendered.
+        if (revert != null) {
+          config.onUrlChanged?.call(revert);
+        }
       },
     );
   }

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1507,7 +1507,11 @@ class WebViewFactory {
           lastStableUrl: lastStableUrl,
           initialUrl: config.initialUrl,
         );
-        await _handleDownloadRequest(controller, downloadStartRequest);
+        await _handleDownloadRequest(
+          controller,
+          downloadStartRequest,
+          referer: lastStableUrl ?? config.initialUrl,
+        );
         if (revert != null) {
           config.onUrlChanged?.call(revert);
         }
@@ -1517,8 +1521,9 @@ class WebViewFactory {
 
   static Future<void> _handleDownloadRequest(
     inapp.InAppWebViewController controller,
-    inapp.DownloadStartRequest req,
-  ) async {
+    inapp.DownloadStartRequest req, {
+    String? referer,
+  }) async {
     // Abort any in-flight main-frame navigation to this URL. Without this
     // the webview tries to render the attachment response as a page and
     // ends up on a "net::ERR_UNKNOWN_URL_SCHEME" / "invalid request" error
@@ -1533,7 +1538,7 @@ class WebViewFactory {
     switch (scheme) {
       case 'http':
       case 'https':
-        await _handleHttpDownload(req);
+        await _handleHttpDownload(req, referer: referer);
         return;
       case 'data':
         _handleDataDownload(req);
@@ -1547,7 +1552,9 @@ class WebViewFactory {
   }
 
   static Future<void> _handleHttpDownload(
-      inapp.DownloadStartRequest req) async {
+    inapp.DownloadStartRequest req, {
+    String? referer,
+  }) async {
     final initialFilename = DownloadEngine.deriveFilename(
       suggested: req.suggestedFilename,
       url: req.url.toString(),
@@ -1569,6 +1576,7 @@ class WebViewFactory {
         url: req.url.toString(),
         cookieHeader: cookieHeader,
         userAgent: req.userAgent,
+        referer: referer,
         suggestedFilename: req.suggestedFilename,
         mimeTypeHint: req.mimeType,
         onProgress: (done, total) => DownloadsService.instance

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -11,6 +11,7 @@ import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/services/download_engine.dart';
+import 'package:webspace/services/download_manager.dart';
 import 'package:webspace/services/web_intercept_native.dart';
 import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/services/location_spoof_service.dart';
@@ -1209,12 +1210,15 @@ class WebViewFactory {
         controller.addJavaScriptHandler(
           handlerName: '_webspaceBlobDownload',
           callback: (args) async {
-            if (args.length < 3) return null;
+            if (args.length < 4) return null;
             final filename = args[0] is String ? args[0] as String : '';
             final base64Data = args[1] is String ? args[1] as String : '';
             final mimeType = args[2] is String ? args[2] as String : '';
+            final taskId = args[3] is String ? args[3] as String : '';
             if (base64Data.isEmpty) {
-              _showDownloadSnack('Download failed: empty payload');
+              if (taskId.isNotEmpty) {
+                DownloadsService.instance.fail(taskId, 'empty payload');
+              }
               return null;
             }
             try {
@@ -1223,15 +1227,29 @@ class WebViewFactory {
                 suggestedFilename: filename.isEmpty ? null : filename,
                 mimeType: mimeType.isEmpty ? null : mimeType,
               );
+              if (taskId.isNotEmpty) {
+                DownloadsService.instance.updateProgress(taskId,
+                    bytesDone: result.bytes.length,
+                    bytesTotal: result.bytes.length);
+              }
               final saved = await _saveViaPicker(result);
-              _showDownloadSnack(saved == null
-                  ? 'Download cancelled.'
-                  : 'Saved ${result.filename}');
+              if (taskId.isNotEmpty) {
+                if (saved == null) {
+                  DownloadsService.instance.cancel(taskId);
+                } else {
+                  DownloadsService.instance
+                      .complete(taskId, savedPath: saved);
+                }
+              }
             } on DownloadException catch (e) {
-              _showDownloadSnack('Download failed: ${e.message}');
+              if (taskId.isNotEmpty) {
+                DownloadsService.instance.fail(taskId, e.message);
+              }
             } catch (e, stack) {
               debugPrint('Blob download error: $e\n$stack');
-              _showDownloadSnack('Download failed: $e');
+              if (taskId.isNotEmpty) {
+                DownloadsService.instance.fail(taskId, e.toString());
+              }
             }
             return null;
           },
@@ -1240,7 +1258,12 @@ class WebViewFactory {
           handlerName: '_webspaceBlobDownloadError',
           callback: (args) {
             final msg = args.isNotEmpty ? args[0].toString() : 'unknown';
-            _showDownloadSnack('Blob download failed: $msg');
+            final taskId = args.length >= 2 && args[1] is String
+                ? args[1] as String
+                : '';
+            if (taskId.isNotEmpty) {
+              DownloadsService.instance.fail(taskId, msg);
+            }
             return null;
           },
         );
@@ -1474,7 +1497,16 @@ class WebViewFactory {
 
   static Future<void> _handleHttpDownload(
       inapp.DownloadStartRequest req) async {
-    _showDownloadSnack('Downloading…');
+    final initialFilename = DownloadEngine.deriveFilename(
+      suggested: req.suggestedFilename,
+      url: req.url.toString(),
+      mimeType: req.mimeType,
+    );
+    final task = DownloadsService.instance.start(
+      filename: initialFilename,
+      url: req.url.toString(),
+      bytesTotal: req.contentLength > 0 ? req.contentLength : null,
+    );
     try {
       final cookies = await inapp.CookieManager.instance()
           .getCookies(url: req.url);
@@ -1488,34 +1520,50 @@ class WebViewFactory {
         userAgent: req.userAgent,
         suggestedFilename: req.suggestedFilename,
         mimeTypeHint: req.mimeType,
+        onProgress: (done, total) => DownloadsService.instance
+            .updateProgress(task.id, bytesDone: done, bytesTotal: total),
       );
+      task.filename = result.filename;
       final savedPath = await _saveViaPicker(result);
-      _showDownloadSnack(savedPath == null
-          ? 'Download cancelled.'
-          : 'Saved ${result.filename}');
+      if (savedPath == null) {
+        DownloadsService.instance.cancel(task.id);
+      } else {
+        DownloadsService.instance.complete(task.id, savedPath: savedPath);
+      }
     } on DownloadException catch (e) {
-      _showDownloadSnack('Download failed: ${e.message}');
+      DownloadsService.instance.fail(task.id, e.message);
     } catch (e, stack) {
       debugPrint('Download error: $e\n$stack');
-      _showDownloadSnack('Download failed: $e');
+      DownloadsService.instance.fail(task.id, e.toString());
     }
   }
 
   static void _handleDataDownload(inapp.DownloadStartRequest req) async {
+    final task = DownloadsService.instance.start(
+      filename: req.suggestedFilename?.isNotEmpty == true
+          ? req.suggestedFilename!
+          : 'download',
+      url: req.url.toString(),
+    );
     try {
       final result = DownloadEngine.decodeDataUri(
         url: req.url.toString(),
         suggestedFilename: req.suggestedFilename,
       );
+      task.filename = result.filename;
+      DownloadsService.instance.updateProgress(task.id,
+          bytesDone: result.bytes.length, bytesTotal: result.bytes.length);
       final savedPath = await _saveViaPicker(result);
-      _showDownloadSnack(savedPath == null
-          ? 'Download cancelled.'
-          : 'Saved ${result.filename}');
+      if (savedPath == null) {
+        DownloadsService.instance.cancel(task.id);
+      } else {
+        DownloadsService.instance.complete(task.id, savedPath: savedPath);
+      }
     } on DownloadException catch (e) {
-      _showDownloadSnack('Download failed: ${e.message}');
+      DownloadsService.instance.fail(task.id, e.message);
     } catch (e, stack) {
       debugPrint('Data-URI download error: $e\n$stack');
-      _showDownloadSnack('Download failed: $e');
+      DownloadsService.instance.fail(task.id, e.toString());
     }
   }
 
@@ -1524,14 +1572,22 @@ class WebViewFactory {
     String blobUrl,
     String? suggestedFilename,
   ) async {
-    _showDownloadSnack('Downloading…');
+    final task = DownloadsService.instance.start(
+      filename: suggestedFilename?.isNotEmpty == true
+          ? suggestedFilename!
+          : 'download',
+      url: blobUrl,
+    );
     // IIFE: fetch the blob, read via FileReader, hand the base64 back to
     // Dart. Result is delivered asynchronously through
-    // _webspaceBlobDownload(filename, base64, mimeType).
+    // _webspaceBlobDownload(filename, base64, mimeType). The taskId is
+    // round-tripped through JS so the handler can resolve which task to
+    // complete.
     final blobJson = jsonEncode(blobUrl);
     final fnJson = jsonEncode(suggestedFilename ?? '');
+    final idJson = jsonEncode(task.id);
     final script = '''
-(function(blobUrl, suggestedFilename) {
+(function(blobUrl, suggestedFilename, taskId) {
   try {
     fetch(blobUrl).then(function(r) { return r.blob(); }).then(function(blob) {
       var reader = new FileReader();
@@ -1543,30 +1599,33 @@ class WebViewFactory {
           '_webspaceBlobDownload',
           suggestedFilename,
           base64,
-          blob.type || ''
+          blob.type || '',
+          taskId
         );
       };
       reader.onerror = function() {
         var msg = (reader.error && reader.error.message) || 'read error';
         window.flutter_inappwebview.callHandler(
-          '_webspaceBlobDownloadError', msg);
+          '_webspaceBlobDownloadError', msg, taskId);
       };
       reader.readAsDataURL(blob);
     }).catch(function(err) {
       window.flutter_inappwebview.callHandler(
-        '_webspaceBlobDownloadError', (err && err.message) || String(err));
+        '_webspaceBlobDownloadError',
+        (err && err.message) || String(err), taskId);
     });
   } catch (e) {
     window.flutter_inappwebview.callHandler(
-      '_webspaceBlobDownloadError', (e && e.message) || String(e));
+      '_webspaceBlobDownloadError',
+      (e && e.message) || String(e), taskId);
   }
-})($blobJson, $fnJson);
+})($blobJson, $fnJson, $idJson);
 ''';
     try {
       await controller.evaluateJavascript(source: script);
     } catch (e, stack) {
       debugPrint('Blob download eval error: $e\n$stack');
-      _showDownloadSnack('Download failed: $e');
+      DownloadsService.instance.fail(task.id, e.toString());
     }
   }
 

--- a/lib/widgets/download_button.dart
+++ b/lib/widgets/download_button.dart
@@ -61,7 +61,7 @@ class DownloadButton extends StatelessWidget {
                       size: 16,
                       color: iconColor,
                     ),
-                    if (tasks.length > 1)
+                    if (active.length > 1)
                       Positioned(
                         right: -4,
                         top: -4,
@@ -73,7 +73,7 @@ class DownloadButton extends StatelessWidget {
                             borderRadius: BorderRadius.circular(8),
                           ),
                           child: Text(
-                            '${tasks.length}',
+                            '${active.length}',
                             style: TextStyle(
                               color: Theme.of(context).colorScheme.onPrimary,
                               fontSize: 9,

--- a/lib/widgets/download_button.dart
+++ b/lib/widgets/download_button.dart
@@ -17,22 +17,24 @@ class DownloadButton extends StatelessWidget {
         if (tasks.isEmpty) return const SizedBox.shrink();
 
         final active = tasks.where((t) => t.isActive).toList();
-        // Aggregate progress: if every active task has a known total, show
-        // the aggregate ratio; otherwise render indeterminate.
-        double? aggregate;
-        if (active.isNotEmpty && active.every((t) => t.bytesTotal != null)) {
-          final total = active.fold<int>(0, (a, t) => a + t.bytesTotal!);
-          if (total > 0) {
-            final done = active.fold<int>(0, (a, t) => a + t.bytesDone);
-            aggregate = (done / total).clamp(0.0, 1.0);
-          }
-        }
+        final aggregate = DownloadAggregateProgress.from(tasks);
 
         final iconColor = IconTheme.of(context).color;
+        // Tooltip reports bytes-received even when the ring is
+        // indeterminate so the user can tell progress is happening when
+        // the server didn't send Content-Length.
+        final tooltip = () {
+          if (active.isEmpty) return '${tasks.length} recent downloads';
+          final doneBytes = active.fold<int>(0, (a, t) => a + t.bytesDone);
+          final doneStr = _DownloadTile._formatBytes(doneBytes);
+          if (aggregate.value != null) {
+            final pct = (aggregate.value! * 100).toStringAsFixed(0);
+            return '${active.length} downloading — $pct% ($doneStr)';
+          }
+          return '${active.length} downloading — $doneStr received';
+        }();
         return Tooltip(
-          message: active.isEmpty
-              ? '${tasks.length} recent downloads'
-              : '${active.length} downloading',
+          message: tooltip,
           child: InkWell(
             customBorder: const CircleBorder(),
             onTap: () => _openSheet(context),
@@ -44,12 +46,12 @@ class DownloadButton extends StatelessWidget {
                 child: Stack(
                   alignment: Alignment.center,
                   children: [
-                    if (active.isNotEmpty)
+                    if (aggregate.hasActive)
                       SizedBox(
                         width: 28,
                         height: 28,
                         child: CircularProgressIndicator(
-                          value: aggregate,
+                          value: aggregate.value,
                           strokeWidth: 2.5,
                           color: iconColor,
                         ),

--- a/lib/widgets/download_button.dart
+++ b/lib/widgets/download_button.dart
@@ -1,0 +1,220 @@
+import 'package:flutter/material.dart';
+import 'package:webspace/services/download_manager.dart';
+
+/// AppBar action that surfaces active downloads. Renders nothing when the
+/// queue is empty. While any task is downloading, shows a spinning progress
+/// ring (determinate if Content-Length is known). Tapping opens a bottom
+/// sheet with per-task progress + errors.
+class DownloadButton extends StatelessWidget {
+  const DownloadButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: DownloadsService.instance,
+      builder: (context, _) {
+        final tasks = DownloadsService.instance.tasks;
+        if (tasks.isEmpty) return const SizedBox.shrink();
+
+        final active = tasks.where((t) => t.isActive).toList();
+        // Aggregate progress: if every active task has a known total, show
+        // the aggregate ratio; otherwise render indeterminate.
+        double? aggregate;
+        if (active.isNotEmpty && active.every((t) => t.bytesTotal != null)) {
+          final total = active.fold<int>(0, (a, t) => a + t.bytesTotal!);
+          if (total > 0) {
+            final done = active.fold<int>(0, (a, t) => a + t.bytesDone);
+            aggregate = (done / total).clamp(0.0, 1.0);
+          }
+        }
+
+        final iconColor = IconTheme.of(context).color;
+        return Tooltip(
+          message: active.isEmpty
+              ? '${tasks.length} recent downloads'
+              : '${active.length} downloading',
+          child: InkWell(
+            customBorder: const CircleBorder(),
+            onTap: () => _openSheet(context),
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: SizedBox(
+                width: 28,
+                height: 28,
+                child: Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    if (active.isNotEmpty)
+                      SizedBox(
+                        width: 28,
+                        height: 28,
+                        child: CircularProgressIndicator(
+                          value: aggregate,
+                          strokeWidth: 2.5,
+                          color: iconColor,
+                        ),
+                      ),
+                    Icon(
+                      active.isEmpty
+                          ? Icons.download_done
+                          : Icons.download,
+                      size: 16,
+                      color: iconColor,
+                    ),
+                    if (tasks.length > 1)
+                      Positioned(
+                        right: -4,
+                        top: -4,
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 4, vertical: 1),
+                          decoration: BoxDecoration(
+                            color: Theme.of(context).colorScheme.primary,
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Text(
+                            '${tasks.length}',
+                            style: TextStyle(
+                              color: Theme.of(context).colorScheme.onPrimary,
+                              fontSize: 9,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  void _openSheet(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (_) => const _DownloadsSheet(),
+    );
+  }
+}
+
+class _DownloadsSheet extends StatelessWidget {
+  const _DownloadsSheet();
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: DownloadsService.instance,
+      builder: (context, _) {
+        final tasks = DownloadsService.instance.tasks;
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 8, 8),
+                child: Row(
+                  children: [
+                    Text('Downloads',
+                        style: Theme.of(context).textTheme.titleLarge),
+                    const Spacer(),
+                    if (tasks.any((t) => !t.isActive))
+                      TextButton(
+                        onPressed: DownloadsService.instance.clearCompleted,
+                        child: const Text('Clear finished'),
+                      ),
+                  ],
+                ),
+              ),
+              if (tasks.isEmpty)
+                const Padding(
+                  padding: EdgeInsets.all(24),
+                  child: Text('No downloads'),
+                )
+              else
+                Flexible(
+                  child: ListView.separated(
+                    shrinkWrap: true,
+                    itemCount: tasks.length,
+                    separatorBuilder: (_, _) => const Divider(height: 1),
+                    itemBuilder: (_, i) => _DownloadTile(task: tasks[i]),
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _DownloadTile extends StatelessWidget {
+  final DownloadTask task;
+  const _DownloadTile({required this.task});
+
+  @override
+  Widget build(BuildContext context) {
+    final subtitle = switch (task.state) {
+      DownloadState.downloading => _progressSubtitle(task),
+      DownloadState.completed => 'Saved${task.savedPath == null ? '' : ' • ${task.savedPath}'}',
+      DownloadState.failed => task.errorMessage ?? 'Failed',
+      DownloadState.cancelled => 'Cancelled',
+    };
+    final color = switch (task.state) {
+      DownloadState.downloading => null,
+      DownloadState.completed => Theme.of(context).colorScheme.primary,
+      DownloadState.failed => Theme.of(context).colorScheme.error,
+      DownloadState.cancelled =>
+        Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+    };
+
+    return ListTile(
+      leading: Icon(_iconFor(task), color: color),
+      title: Text(task.filename, maxLines: 1, overflow: TextOverflow.ellipsis),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(subtitle, style: TextStyle(color: color)),
+          if (task.isActive) ...[
+            const SizedBox(height: 4),
+            LinearProgressIndicator(value: task.progress),
+          ],
+        ],
+      ),
+      trailing: task.isActive
+          ? null
+          : IconButton(
+              icon: const Icon(Icons.close, size: 18),
+              tooltip: 'Dismiss',
+              onPressed: () => DownloadsService.instance.dismiss(task.id),
+            ),
+    );
+  }
+
+  IconData _iconFor(DownloadTask t) => switch (t.state) {
+        DownloadState.downloading => Icons.downloading,
+        DownloadState.completed => Icons.check_circle,
+        DownloadState.failed => Icons.error_outline,
+        DownloadState.cancelled => Icons.cancel_outlined,
+      };
+
+  static String _progressSubtitle(DownloadTask t) {
+    final done = _formatBytes(t.bytesDone);
+    final total = t.bytesTotal;
+    if (total == null || total <= 0) return '$done received';
+    return '$done / ${_formatBytes(total)}';
+  }
+
+  static String _formatBytes(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    if (bytes < 1024 * 1024 * 1024) {
+      return '${(bytes / 1024 / 1024).toStringAsFixed(1)} MB';
+    }
+    return '${(bytes / 1024 / 1024 / 1024).toStringAsFixed(2)} GB';
+  }
+}

--- a/openspec/specs/downloads/spec.md
+++ b/openspec/specs/downloads/spec.md
@@ -1,0 +1,252 @@
+# Webview Downloads
+
+## Status
+**Implemented**
+
+## Purpose
+
+Lets the user save files initiated by a webview. The underlying
+`flutter_inappwebview` exposes `onDownloadStartRequest`, but the host app
+must enable the setting, fetch/decode the bytes, run a save dialog, and
+surface progress. This spec covers the three common schemes (`http(s)`,
+`data:`, `blob:`) plus the in-app progress UI.
+
+## Problem Statement
+
+Before this spec:
+
+1. `useOnDownloadStart` defaulted to false, so `onDownloadStartRequest`
+   never fired and webview-triggered downloads silently dropped.
+2. Android also required a `FileProvider` declaration with authority
+   `${applicationId}.flutter_inappwebview_android.fileprovider` for the
+   upload-side `<input type=file>` camera/video path; without it the
+   file chooser threw `IllegalArgumentException`.
+3. For `blob:` URLs, the download URL is a JS-heap reference —
+   un-fetchable from Dart. A browser-side shim is required to read the
+   blob and hand the bytes to Dart.
+4. Even after a successful download, the main-frame navigation to the
+   download URL left the webview on a `net::ERR_UNKNOWN_URL_SCHEME`
+   page.
+
+## Solution
+
+### Upload (file chooser)
+
+`android/app/src/main/AndroidManifest.xml` declares a `FileProvider`
+with authority `${applicationId}.flutter_inappwebview_android.fileprovider`,
+pointing at
+`android/app/src/main/res/xml/flutter_inappwebview_android_provider_paths.xml`
+which whitelists `files/`, `cache/`, and the external equivalents so the
+plugin can build content URIs for camera/video temp files.
+
+### Download
+
+Three code layers:
+
+1. **Logic engine** — [`DownloadEngine`](../../../lib/services/download_engine.dart)
+   (pure Dart + injectable `http.Client`).
+   - `fetch(url, cookieHeader?, userAgent?, suggestedFilename?, mimeTypeHint?, onProgress?)`
+     — issues a streamed `GET`, accumulates chunks, reports per-chunk
+     progress; throws `DownloadException` on non-2xx / network error /
+     unsupported scheme.
+   - `decodeDataUri(url, suggestedFilename?)` — parses `data:` URIs via
+     `UriData`, returns bytes + mime + derived filename.
+   - `fromBase64(base64Data, suggestedFilename?, mimeType?)` — wraps a
+     base64 payload from the blob JS shim into a `DownloadResult`.
+   - `deriveFilename(...)` — sanitized filename from suggestion → URL
+     path segment → MIME-based fallback.
+
+2. **Render engine** —
+   [`WebViewFactory`](../../../lib/services/webview.dart)
+   wires `useOnDownloadStart: true` into the shared
+   `InAppWebViewSettings` and dispatches in
+   `_handleDownloadRequest` based on scheme.
+   - `http`/`https`: call `DownloadEngine.fetch`, stream progress into
+     `DownloadsService`.
+   - `data:`: synchronous decode, save via picker.
+   - `blob:`: register `_webspaceBlobDownload` /
+     `_webspaceBlobDownloadError` JS handlers once in
+     `onWebViewCreated`; kick off an IIFE via `evaluateJavascript` that
+     does `fetch(blobUrl) → Blob → FileReader.readAsDataURL → callHandler`.
+
+3. **UI** — [`DownloadsService`](../../../lib/services/download_manager.dart)
+   (singleton `ChangeNotifier` holding `List<DownloadTask>`),
+   rendered by [`DownloadButton`](../../../lib/widgets/download_button.dart)
+   in both the root app bar and the nested
+   [`InAppWebViewScreen`](../../../lib/screens/inappbrowser.dart) bar.
+
+## Requirements
+
+### Requirement: DL-001 — FileProvider for the file chooser
+
+The Android manifest MUST declare a `FileProvider` with authority
+`${applicationId}.flutter_inappwebview_android.fileprovider` and a
+`FILE_PROVIDER_PATHS` resource covering `files/`, `cache/`, and the
+external equivalents.
+
+#### Scenario: User taps an `<input type=file>` control that opens the camera
+**Given** the app is installed on Android
+**When** the webview invokes `InAppWebViewChromeClient.getOutputUri`
+**Then** `FileProvider.getUriForFile` finds the meta-data
+**And** the camera/video intent receives a valid content URI
+
+---
+
+### Requirement: DL-002 — Webview download callback enabled
+
+`useOnDownloadStart` MUST be set to `true` on the shared
+`InAppWebViewSettings` so `onDownloadStartRequest` fires for responses
+the webview decides to download.
+
+#### Scenario: Server returns `Content-Disposition: attachment`
+**Given** the user clicks a link whose response carries
+  `Content-Disposition: attachment`
+**When** the webview receives the response
+**Then** `onDownloadStartRequest` fires in both the root webview and
+  any nested `InAppWebViewScreen`
+**And** `controller.stopLoading()` is called so the main frame does
+  not render the response as a page
+
+---
+
+### Requirement: DL-003 — HTTP(S) downloads
+
+`DownloadEngine.fetch` MUST stream the body via `http.Client.send`,
+forwarding the webview's cookies (resolved via
+`CookieManager.getCookies(url:)`) and the request's `userAgent` so
+authenticated downloads succeed.
+
+#### Scenario: Authenticated download
+**Given** the user is logged in to a site whose download URL requires
+  session cookies
+**When** the download starts
+**Then** the `Cookie:` header is built from `CookieManager.getCookies(url:)`
+  and forwarded on the `GET`
+**And** the response body is saved via `FilePicker.saveFile` with the
+  header-derived (or URL-derived) filename
+
+#### Scenario: Server error
+**Given** the download URL returns 4xx/5xx
+**When** `fetch` completes
+**Then** a `DownloadException` with the status code is thrown
+**And** the corresponding `DownloadTask` transitions to
+  `DownloadState.failed` with the error message
+
+---
+
+### Requirement: DL-004 — `data:` URI downloads
+
+`DownloadEngine.decodeDataUri` MUST handle both base64 (`;base64,`) and
+URL-encoded forms, with or without an explicit mime (RFC 2397 default
+of `text/plain` when absent is surfaced unchanged).
+
+#### Scenario: Base64 data URI
+**Given** a link with `href="data:application/pdf;base64,..."` triggers
+  a download
+**When** `_handleDownloadRequest` runs
+**Then** the payload is decoded in Dart without a webview round-trip
+**And** the user sees a save dialog with a filename derived from the mime
+
+---
+
+### Requirement: DL-005 — `blob:` URI downloads
+
+Blob URLs MUST be read via an injected JS IIFE that calls
+`fetch(blobUrl) → Blob → FileReader.readAsDataURL` and hands the base64
+payload to a registered `JavaScriptHandler` named
+`_webspaceBlobDownload`. Errors MUST be reported via
+`_webspaceBlobDownloadError`. The `taskId` MUST be round-tripped
+through JS so the Dart handler can resolve the originating task.
+
+#### Scenario: Pairdrop WebRTC file transfer
+**Given** pairdrop.net produces an in-memory `Blob` and triggers a
+  download via `<a download href="blob:...">`
+**When** `onDownloadStartRequest` fires with scheme `blob`
+**Then** the IIFE reads the blob, ships base64 back over the handler,
+  and Dart saves the decoded bytes via `FilePicker.saveFile`
+**And** the `DownloadTask` completes with the resolved file path
+
+---
+
+### Requirement: DL-006 — In-app progress UI
+
+`DownloadsService` MUST expose the list of active and recently-finished
+tasks as a `ChangeNotifier`. A `DownloadButton` MUST live in the app
+bar of both `_WebSpacePageState` and `InAppWebViewScreen`, showing a
+spinning ring (determinate when `Content-Length` is known, indeterminate
+otherwise) while any task is active, and rendering nothing when the
+task list is empty.
+
+#### Scenario: Concurrent downloads
+**Given** two HTTP downloads are in flight
+**When** progress callbacks fire
+**Then** the app-bar icon shows an aggregate progress ratio across both
+**And** tapping the icon opens a bottom sheet listing each task with
+  its own progress bar, bytes done/total, and filename
+
+#### Scenario: Download completes
+**Given** a download finishes successfully
+**When** the save dialog resolves with a path
+**Then** the `DownloadTask` transitions to `DownloadState.completed`
+  with `savedPath` populated
+**And** the app-bar icon switches to the `download_done` glyph
+**And** the task stays in the list until `Clear finished` is tapped or
+  the task is dismissed
+
+---
+
+## Implementation
+
+### Files
+
+- `lib/services/download_engine.dart` — pure-Dart fetch/decode/filename logic.
+- `lib/services/download_manager.dart` — `DownloadsService` +
+  `DownloadTask`.
+- `lib/services/webview.dart` — wires settings, JS handlers, and
+  `_handleDownloadRequest` (HTTP/data/blob dispatch, `stopLoading()`
+  guard).
+- `lib/widgets/download_button.dart` — app-bar action + bottom sheet.
+- `lib/main.dart`, `lib/screens/inappbrowser.dart` — place the button.
+- `android/app/src/main/AndroidManifest.xml` —
+  `FileProvider` declaration.
+- `android/app/src/main/res/xml/flutter_inappwebview_android_provider_paths.xml`
+  — paths resource.
+
+### Tests
+
+- `test/download_engine_test.dart` — cookie/UA forwarding, filename
+  derivation + sanitization, scheme rejection, status/network-error
+  mapping, `data:` + base64 decoding, streamed progress with and
+  without `Content-Length`.
+- `test/download_manager_test.dart` — task lifecycle (start /
+  updateProgress / complete / fail / cancel / dismiss / clearCompleted),
+  listener notification, unknown-id no-ops.
+
+### Manual verification
+
+1. **Upload** — open a webview, tap an `<input type=file>` that offers
+   camera, confirm no `IllegalArgumentException` in logcat and the
+   camera intent opens.
+2. **HTTP** — open a site with a real download link (e.g. a GitHub
+   release `.apk`). Expect a progress ring in the top-right, a save
+   dialog, and `Saved <file>` in the downloads sheet when done.
+3. **Data URI** — trigger a `data:` download (e.g. a small PNG
+   generated by a canvas). Expect instant save dialog.
+4. **Blob** — pairdrop.net: receive a file. Expect progress + save
+   dialog + the downloads sheet showing the completed task.
+
+## Caveats / Known Limits
+
+- Blob `evaluateJavascript` runs in the top frame only. A blob created
+  inside a cross-origin iframe cannot be fetched from the top frame;
+  the shim surfaces a `TypeError` via `_webspaceBlobDownloadError`.
+- The base64 round-trip buffers the whole payload in memory (plus ~33%
+  base64 overhead). Multi-GB blob downloads will OOM; streaming is out
+  of scope.
+- `DownloadStartRequest.suggestedFilename` is often empty for
+  blob:-backed `<a download>` clicks on Android (Android WebView does
+  not parse the `download` attribute in `DownloadListener`). The engine
+  falls through to a mime-based `download.<ext>` fallback; the user can
+  rename in the save dialog.
+- Download history is in-memory and resets on app restart (matches the
+  behavior the user signed off on — no persisted stats).

--- a/test/download_engine_test.dart
+++ b/test/download_engine_test.dart
@@ -195,6 +195,89 @@ void main() {
       expect(result.filename, 'invoice.pdf');
     });
   });
+
+  group('DownloadEngine.decodeDataUri', () {
+    test('decodes base64 payload', () {
+      final result = DownloadEngine.decodeDataUri(
+        url: 'data:text/plain;base64,SGVsbG8=',
+      );
+      expect(utf8.decode(result.bytes), 'Hello');
+      expect(result.mimeType, 'text/plain');
+      expect(result.filename, 'download.txt');
+    });
+
+    test('decodes URL-encoded payload', () {
+      final result = DownloadEngine.decodeDataUri(
+        url: 'data:text/plain,Hello%20world',
+      );
+      expect(utf8.decode(result.bytes), 'Hello world');
+      expect(result.mimeType, 'text/plain');
+    });
+
+    test('handles data URI without explicit mime (RFC 2397 default)', () {
+      // Per RFC 2397, an absent mime means text/plain. Dart's UriData
+      // reports that as the mimeType, so we surface it too.
+      final result = DownloadEngine.decodeDataUri(
+        url: 'data:;base64,SGVsbG8=',
+      );
+      expect(result.bytes, utf8.encode('Hello'));
+      expect(result.mimeType, 'text/plain');
+    });
+
+    test('suggested filename wins over mime-derived fallback', () {
+      final result = DownloadEngine.decodeDataUri(
+        url: 'data:application/pdf;base64,JVBERi0=',
+        suggestedFilename: 'invoice.pdf',
+      );
+      expect(result.filename, 'invoice.pdf');
+    });
+
+    test('rejects non-data URI', () {
+      expect(
+        () => DownloadEngine.decodeDataUri(
+            url: 'https://example.com/file'),
+        throwsA(isA<DownloadException>()),
+      );
+    });
+  });
+
+  group('DownloadEngine.fromBase64', () {
+    test('decodes base64 and applies suggested filename + mime', () {
+      final bytes = Uint8List.fromList(utf8.encode('hello world'));
+      final payload = base64.encode(bytes);
+      final result = DownloadEngine.fromBase64(
+        base64Data: payload,
+        suggestedFilename: 'note.txt',
+        mimeType: 'text/plain',
+      );
+      expect(result.bytes, bytes);
+      expect(result.filename, 'note.txt');
+      expect(result.mimeType, 'text/plain');
+    });
+
+    test('derives filename from mime when no suggestion', () {
+      final payload = base64.encode([1, 2, 3]);
+      final result = DownloadEngine.fromBase64(
+        base64Data: payload,
+        mimeType: 'application/pdf',
+      );
+      expect(result.filename, 'download.pdf');
+    });
+
+    test('throws DownloadException on malformed base64', () {
+      expect(
+        () => DownloadEngine.fromBase64(base64Data: '!!!not-base64!!!'),
+        throwsA(isA<DownloadException>().having(
+            (e) => e.message, 'message', contains('Malformed base64'))),
+      );
+    });
+
+    test('tolerates surrounding whitespace in base64', () {
+      final payload = '  ${base64.encode(utf8.encode('ok'))}  ';
+      final result = DownloadEngine.fromBase64(base64Data: payload);
+      expect(utf8.decode(result.bytes), 'ok');
+    });
+  });
 }
 
 class SocketExceptionStub implements Exception {

--- a/test/download_engine_test.dart
+++ b/test/download_engine_test.dart
@@ -119,6 +119,33 @@ void main() {
       expect(capturedHeaders?['user-agent'], 'TestAgent/1.0');
     });
 
+    test('forwards http/https referer when supplied', () async {
+      Map<String, String>? capturedHeaders;
+      final client = MockClient((request) async {
+        capturedHeaders = request.headers;
+        return http.Response('ok', 200);
+      });
+      await DownloadEngine(client: client).fetch(
+        url: 'https://example.com/file',
+        referer: 'https://example.com/page',
+      );
+      expect(capturedHeaders?['referer'], 'https://example.com/page');
+    });
+
+    test('drops non-http referer to avoid leaking data:/file: URLs',
+        () async {
+      Map<String, String>? capturedHeaders;
+      final client = MockClient((request) async {
+        capturedHeaders = request.headers;
+        return http.Response('ok', 200);
+      });
+      await DownloadEngine(client: client).fetch(
+        url: 'https://example.com/file',
+        referer: 'data:text/html,hello',
+      );
+      expect(capturedHeaders?.containsKey('referer'), isFalse);
+    });
+
     test('does not send cookie header when none supplied', () async {
       Map<String, String>? capturedHeaders;
       final client = MockClient((request) async {

--- a/test/download_engine_test.dart
+++ b/test/download_engine_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -252,6 +253,51 @@ void main() {
       for (var i = 1; i < events.length; i++) {
         expect(events[i].$1 >= events[i - 1].$1, isTrue);
       }
+    });
+
+    test('decompresses gzip-encoded response bodies', () async {
+      final plain = utf8.encode('hello gzipped world');
+      final compressed = Uint8List.fromList(gzip.encode(plain));
+      final client = MockClient((request) async => http.Response.bytes(
+            compressed,
+            200,
+            headers: {
+              'content-type': 'text/plain',
+              'content-encoding': 'gzip',
+              'content-length': '${compressed.length}',
+            },
+          ));
+      final result =
+          await DownloadEngine(client: client).fetch(url: 'https://x/f.txt');
+      expect(utf8.decode(result.bytes), 'hello gzipped world');
+    });
+
+    test('decompresses deflate-encoded response bodies', () async {
+      final plain = utf8.encode('hello deflated');
+      final compressed = Uint8List.fromList(zlib.encode(plain));
+      final client = MockClient((request) async => http.Response.bytes(
+            compressed,
+            200,
+            headers: {
+              'content-type': 'text/plain',
+              'content-encoding': 'deflate',
+            },
+          ));
+      final result =
+          await DownloadEngine(client: client).fetch(url: 'https://x/f.txt');
+      expect(utf8.decode(result.bytes), 'hello deflated');
+    });
+
+    test('passes through uncompressed bodies unchanged', () async {
+      final body = Uint8List.fromList([1, 2, 3, 4, 5]);
+      final client = MockClient((request) async => http.Response.bytes(
+            body,
+            200,
+            headers: {'content-type': 'application/octet-stream'},
+          ));
+      final result =
+          await DownloadEngine(client: client).fetch(url: 'https://x/f');
+      expect(result.bytes, body);
     });
 
     test('streams progress with unknown total (no Content-Length)', () async {

--- a/test/download_engine_test.dart
+++ b/test/download_engine_test.dart
@@ -194,6 +194,58 @@ void main() {
       );
       expect(result.filename, 'invoice.pdf');
     });
+
+    test('streams progress callbacks with known total', () async {
+      final payload = Uint8List.fromList(List<int>.filled(1024, 42));
+      final client = MockClient.streaming((request, bodyStream) async {
+        Stream<List<int>> chunks() async* {
+          yield payload.sublist(0, 256);
+          yield payload.sublist(256, 512);
+          yield payload.sublist(512, 1024);
+        }
+        return http.StreamedResponse(
+          chunks(),
+          200,
+          contentLength: payload.length,
+          headers: {'content-type': 'application/octet-stream'},
+        );
+      });
+
+      final events = <(int, int?)>[];
+      final result = await DownloadEngine(client: client).fetch(
+        url: 'https://example.com/big.bin',
+        onProgress: (done, total) => events.add((done, total)),
+      );
+
+      expect(result.bytes, payload);
+      // First event is initial (0, total); last event is full.
+      expect(events.first, (0, 1024));
+      expect(events.last, (1024, 1024));
+      // Monotonic non-decreasing done.
+      for (var i = 1; i < events.length; i++) {
+        expect(events[i].$1 >= events[i - 1].$1, isTrue);
+      }
+    });
+
+    test('streams progress with unknown total (no Content-Length)', () async {
+      final client = MockClient.streaming((request, bodyStream) async {
+        Stream<List<int>> chunks() async* {
+          yield [1, 2, 3];
+          yield [4, 5];
+        }
+        return http.StreamedResponse(chunks(), 200);
+      });
+
+      final events = <(int, int?)>[];
+      final result = await DownloadEngine(client: client).fetch(
+        url: 'https://example.com/unknown',
+        onProgress: (done, total) => events.add((done, total)),
+      );
+
+      expect(result.bytes, [1, 2, 3, 4, 5]);
+      expect(events.first.$2, isNull);
+      expect(events.last.$1, 5);
+    });
   });
 
   group('DownloadEngine.decodeDataUri', () {

--- a/test/download_engine_test.dart
+++ b/test/download_engine_test.dart
@@ -1,0 +1,204 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:webspace/services/download_engine.dart';
+
+void main() {
+  group('DownloadEngine.buildCookieHeader', () {
+    test('returns null for empty input', () {
+      expect(DownloadEngine.buildCookieHeader(const []), isNull);
+    });
+
+    test('joins name=value pairs with "; "', () {
+      final header = DownloadEngine.buildCookieHeader([
+        const MapEntry('sessionid', 'abc123'),
+        const MapEntry('theme', 'dark'),
+      ]);
+      expect(header, 'sessionid=abc123; theme=dark');
+    });
+
+    test('preserves insertion order', () {
+      final header = DownloadEngine.buildCookieHeader([
+        const MapEntry('b', '2'),
+        const MapEntry('a', '1'),
+      ]);
+      expect(header, 'b=2; a=1');
+    });
+  });
+
+  group('DownloadEngine.deriveFilename', () {
+    test('suggested name wins over URL and mime', () {
+      final name = DownloadEngine.deriveFilename(
+        suggested: 'report.pdf',
+        url: 'https://example.com/path/something.bin',
+        mimeType: 'application/zip',
+      );
+      expect(name, 'report.pdf');
+    });
+
+    test('falls back to last path segment when no suggestion', () {
+      final name = DownloadEngine.deriveFilename(
+        suggested: null,
+        url: 'https://example.com/files/budget%202026.xlsx',
+      );
+      expect(name, 'budget 2026.xlsx');
+    });
+
+    test('skips trailing empty segments from trailing slash', () {
+      final name = DownloadEngine.deriveFilename(
+        suggested: '',
+        url: 'https://example.com/path/foo.txt/',
+      );
+      expect(name, 'foo.txt');
+    });
+
+    test('falls back to download.<ext> from mime when URL has no filename',
+        () {
+      final name = DownloadEngine.deriveFilename(
+        suggested: null,
+        url: 'https://example.com/',
+        mimeType: 'application/pdf',
+      );
+      expect(name, 'download.pdf');
+    });
+
+    test('generic download when nothing is known', () {
+      final name = DownloadEngine.deriveFilename(
+        suggested: null,
+        url: 'https://example.com/',
+      );
+      expect(name, 'download');
+    });
+
+    test('sanitizes path separators', () {
+      expect(
+        DownloadEngine.deriveFilename(
+          suggested: '../../etc/passwd',
+          url: 'https://example.com/',
+        ),
+        '.._.._etc_passwd',
+      );
+      expect(
+        DownloadEngine.deriveFilename(
+          suggested: r'..\..\win.ini',
+          url: 'https://example.com/',
+        ),
+        r'.._.._win.ini',
+      );
+    });
+
+    test('strips control characters', () {
+      final name = DownloadEngine.deriveFilename(
+        suggested: 'file\x00\x01.pdf',
+        url: 'https://example.com/',
+      );
+      expect(name, 'file.pdf');
+    });
+  });
+
+  group('DownloadEngine.fetch', () {
+    test('forwards cookie and user-agent headers', () async {
+      Map<String, String>? capturedHeaders;
+      final client = MockClient((request) async {
+        capturedHeaders = request.headers;
+        return http.Response('hello', 200,
+            headers: {'content-type': 'text/plain'});
+      });
+
+      final engine = DownloadEngine(client: client);
+      await engine.fetch(
+        url: 'https://example.com/f.txt',
+        cookieHeader: 'sid=xyz; theme=dark',
+        userAgent: 'TestAgent/1.0',
+      );
+
+      expect(capturedHeaders?['cookie'], 'sid=xyz; theme=dark');
+      expect(capturedHeaders?['user-agent'], 'TestAgent/1.0');
+    });
+
+    test('does not send cookie header when none supplied', () async {
+      Map<String, String>? capturedHeaders;
+      final client = MockClient((request) async {
+        capturedHeaders = request.headers;
+        return http.Response('x', 200);
+      });
+      await DownloadEngine(client: client)
+          .fetch(url: 'https://example.com/f');
+      expect(capturedHeaders, isNotNull);
+      expect(capturedHeaders!.containsKey('cookie'), isFalse);
+    });
+
+    test('returns bytes and parsed mime', () async {
+      final body = Uint8List.fromList(utf8.encode('pdf-bytes'));
+      final client = MockClient((request) async => http.Response.bytes(
+            body,
+            200,
+            headers: {'content-type': 'application/pdf; charset=binary'},
+          ));
+
+      final result = await DownloadEngine(client: client).fetch(
+        url: 'https://example.com/doc.pdf',
+      );
+
+      expect(result.bytes, body);
+      expect(result.mimeType, 'application/pdf');
+      expect(result.filename, 'doc.pdf');
+    });
+
+    test('throws on non-2xx status', () async {
+      final client = MockClient(
+          (request) async => http.Response('not found', 404));
+      expect(
+        () => DownloadEngine(client: client)
+            .fetch(url: 'https://example.com/missing'),
+        throwsA(isA<DownloadException>().having(
+            (e) => e.message, 'message', contains('404'))),
+      );
+    });
+
+    test('throws on network error', () async {
+      final client =
+          MockClient((request) async => throw const SocketExceptionStub());
+      expect(
+        () => DownloadEngine(client: client)
+            .fetch(url: 'https://example.com/x'),
+        throwsA(isA<DownloadException>().having(
+            (e) => e.message, 'message', contains('Network error'))),
+      );
+    });
+
+    test('rejects non-http schemes before any I/O', () async {
+      var called = false;
+      final client = MockClient((_) async {
+        called = true;
+        return http.Response('', 200);
+      });
+      expect(
+        () => DownloadEngine(client: client).fetch(url: 'blob:abc'),
+        throwsA(isA<DownloadException>().having(
+            (e) => e.message, 'message', contains('Unsupported scheme'))),
+      );
+      // Ensure the client was never called.
+      await Future<void>.delayed(Duration.zero);
+      expect(called, isFalse);
+    });
+
+    test('suggestedFilename wins over URL-derived name', () async {
+      final client = MockClient((_) async => http.Response('ok', 200));
+      final result = await DownloadEngine(client: client).fetch(
+        url: 'https://example.com/opaque?x=1',
+        suggestedFilename: 'invoice.pdf',
+      );
+      expect(result.filename, 'invoice.pdf');
+    });
+  });
+}
+
+class SocketExceptionStub implements Exception {
+  const SocketExceptionStub();
+  @override
+  String toString() => 'SocketException: connection refused';
+}

--- a/test/download_manager_test.dart
+++ b/test/download_manager_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/download_manager.dart';
+
+void main() {
+  setUp(() => DownloadsService.instance.resetForTest());
+
+  test('start appends a task at the front, isActive', () {
+    final s = DownloadsService.instance;
+    expect(s.tasks, isEmpty);
+    final t1 = s.start(filename: 'a.pdf');
+    final t2 = s.start(filename: 'b.pdf');
+    expect(s.tasks.first.id, t2.id);
+    expect(s.tasks.last.id, t1.id);
+    expect(s.hasActive, isTrue);
+    expect(s.activeCount, 2);
+  });
+
+  test('updateProgress mutates task and notifies listeners', () {
+    final s = DownloadsService.instance;
+    var notifyCount = 0;
+    s.addListener(() => notifyCount++);
+
+    final t = s.start(filename: 'x', bytesTotal: 1000);
+    final n0 = notifyCount;
+
+    s.updateProgress(t.id, bytesDone: 500);
+    expect(t.bytesDone, 500);
+    expect(t.progress, closeTo(0.5, 1e-9));
+    expect(notifyCount, n0 + 1);
+  });
+
+  test('complete flips state and sets savedPath', () {
+    final s = DownloadsService.instance;
+    final t = s.start(filename: 'x');
+    s.complete(t.id, savedPath: '/tmp/x');
+    expect(t.state, DownloadState.completed);
+    expect(t.savedPath, '/tmp/x');
+    expect(t.isActive, isFalse);
+    expect(s.hasActive, isFalse);
+  });
+
+  test('fail sets error message, not active', () {
+    final s = DownloadsService.instance;
+    final t = s.start(filename: 'x');
+    s.fail(t.id, 'HTTP 500');
+    expect(t.state, DownloadState.failed);
+    expect(t.errorMessage, 'HTTP 500');
+  });
+
+  test('cancel flips state', () {
+    final s = DownloadsService.instance;
+    final t = s.start(filename: 'x');
+    s.cancel(t.id);
+    expect(t.state, DownloadState.cancelled);
+    expect(t.isActive, isFalse);
+  });
+
+  test('dismiss removes the task', () {
+    final s = DownloadsService.instance;
+    final a = s.start(filename: 'a');
+    final b = s.start(filename: 'b');
+    s.complete(b.id);
+    s.dismiss(b.id);
+    expect(s.tasks, hasLength(1));
+    expect(s.tasks.first.id, a.id);
+  });
+
+  test('clearCompleted keeps active tasks', () {
+    final s = DownloadsService.instance;
+    final a = s.start(filename: 'a');
+    final b = s.start(filename: 'b');
+    s.complete(b.id);
+    s.clearCompleted();
+    expect(s.tasks, hasLength(1));
+    expect(s.tasks.first.id, a.id);
+  });
+
+  test('progress is null when total is unknown or zero', () {
+    final s = DownloadsService.instance;
+    final t = s.start(filename: 'x');
+    expect(t.progress, isNull);
+    s.updateProgress(t.id, bytesTotal: 0, bytesDone: 10);
+    expect(t.progress, isNull);
+  });
+
+  test('unknown id is a no-op', () {
+    final s = DownloadsService.instance;
+    s.updateProgress('missing', bytesDone: 100);
+    s.complete('missing');
+    s.fail('missing', 'err');
+    s.cancel('missing');
+    s.dismiss('missing');
+    expect(s.tasks, isEmpty);
+  });
+}

--- a/test/download_manager_test.dart
+++ b/test/download_manager_test.dart
@@ -92,4 +92,129 @@ void main() {
     s.dismiss('missing');
     expect(s.tasks, isEmpty);
   });
+
+  group('DownloadAggregateProgress.from', () {
+    test('no tasks → no active, null ring', () {
+      final agg = DownloadAggregateProgress.from(const []);
+      expect(agg.hasActive, isFalse);
+      expect(agg.value, isNull);
+    });
+
+    test('only finished tasks → no active', () {
+      final s = DownloadsService.instance;
+      final t = s.start(filename: 'a', bytesTotal: 100);
+      s.complete(t.id);
+      final agg = DownloadAggregateProgress.from(s.tasks);
+      expect(agg.hasActive, isFalse);
+      expect(agg.value, isNull);
+    });
+
+    test('single active task with known total → determinate', () {
+      final s = DownloadsService.instance;
+      final t = s.start(filename: 'a', bytesTotal: 1000);
+      s.updateProgress(t.id, bytesDone: 250);
+      final agg = DownloadAggregateProgress.from(s.tasks);
+      expect(agg.hasActive, isTrue);
+      expect(agg.value, closeTo(0.25, 1e-9));
+    });
+
+    test('single active task with null total → indeterminate', () {
+      final s = DownloadsService.instance;
+      s.start(filename: 'a');
+      final agg = DownloadAggregateProgress.from(s.tasks);
+      expect(agg.hasActive, isTrue);
+      expect(agg.value, isNull);
+    });
+
+    test('single active task with zero total → indeterminate', () {
+      final s = DownloadsService.instance;
+      final t = s.start(filename: 'a', bytesTotal: 1000);
+      s.updateProgress(t.id, bytesTotal: 0);
+      final agg = DownloadAggregateProgress.from(s.tasks);
+      expect(agg.hasActive, isTrue);
+      expect(agg.value, isNull);
+    });
+
+    test('multiple active tasks, all known → weighted aggregate', () {
+      final s = DownloadsService.instance;
+      final a = s.start(filename: 'a', bytesTotal: 1000);
+      final b = s.start(filename: 'b', bytesTotal: 3000);
+      s.updateProgress(a.id, bytesDone: 1000); // done
+      s.updateProgress(b.id, bytesDone: 500); // 1/6 of total
+      final agg = DownloadAggregateProgress.from(s.tasks);
+      expect(agg.hasActive, isTrue);
+      // (1000 + 500) / 4000 = 0.375
+      expect(agg.value, closeTo(0.375, 1e-9));
+    });
+
+    test('one active unknown poisons aggregate → indeterminate', () {
+      final s = DownloadsService.instance;
+      final a = s.start(filename: 'a', bytesTotal: 1000);
+      s.start(filename: 'b'); // unknown total
+      s.updateProgress(a.id, bytesDone: 500);
+      final agg = DownloadAggregateProgress.from(s.tasks);
+      expect(agg.hasActive, isTrue);
+      expect(agg.value, isNull);
+    });
+
+    test('finished tasks do not affect aggregate', () {
+      final s = DownloadsService.instance;
+      final a = s.start(filename: 'a', bytesTotal: 1000);
+      final b = s.start(filename: 'b', bytesTotal: 1000);
+      s.updateProgress(a.id, bytesDone: 500);
+      s.complete(b.id); // Finished; shouldn't enter the aggregate.
+      final agg = DownloadAggregateProgress.from(s.tasks);
+      expect(agg.hasActive, isTrue);
+      expect(agg.value, closeTo(0.5, 1e-9));
+    });
+  });
+
+  group('http download lifecycle replay', () {
+    // Reproduces the sequence a real HTTP download produces so we spot
+    // any regression where bytesTotal ends up null or the task stays
+    // stuck in "downloading" state after fetch returns.
+    test('task starts indeterminate then goes determinate on first progress',
+        () {
+      final s = DownloadsService.instance;
+      // 1. Task starts without a known total (DownloadStartRequest
+      //    contentLength was 0).
+      final task = s.start(filename: 'file.pdf', bytesTotal: null);
+      var agg = DownloadAggregateProgress.from(s.tasks);
+      expect(agg.value, isNull,
+          reason: 'no total known yet → indeterminate');
+      expect(agg.hasActive, isTrue);
+
+      // 2. Engine fires first progress with response.contentLength.
+      s.updateProgress(task.id, bytesDone: 0, bytesTotal: 10000);
+      agg = DownloadAggregateProgress.from(s.tasks);
+      expect(agg.value, 0.0, reason: 'total known, nothing done yet');
+
+      // 3. Chunks stream in.
+      s.updateProgress(task.id, bytesDone: 2500, bytesTotal: 10000);
+      expect(DownloadAggregateProgress.from(s.tasks).value,
+          closeTo(0.25, 1e-9));
+      s.updateProgress(task.id, bytesDone: 10000, bytesTotal: 10000);
+      expect(DownloadAggregateProgress.from(s.tasks).value, 1.0);
+
+      // 4. Save completes.
+      s.complete(task.id, savedPath: '/tmp/file.pdf');
+      agg = DownloadAggregateProgress.from(s.tasks);
+      expect(agg.hasActive, isFalse);
+      expect(agg.value, isNull);
+      expect(task.state, DownloadState.completed);
+    });
+
+    test('null total from engine (chunked transfer) stays indeterminate '
+        'without clobbering a known total', () {
+      final s = DownloadsService.instance;
+      final task = s.start(filename: 'f', bytesTotal: 1024);
+      expect(task.bytesTotal, 1024);
+      // Engine's onProgress for a chunked-transfer response: total is null.
+      s.updateProgress(task.id, bytesDone: 256, bytesTotal: null);
+      // bytesTotal should NOT have been overwritten to null.
+      expect(task.bytesTotal, 1024);
+      final agg = DownloadAggregateProgress.from(s.tasks);
+      expect(agg.value, closeTo(0.25, 1e-9));
+    });
+  });
 }

--- a/test/download_url_revert_engine_test.dart
+++ b/test/download_url_revert_engine_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/download_url_revert_engine.dart';
+
+void main() {
+  group('DownloadUrlRevertEngine.isRenderable', () {
+    test('true for http/https/file/about', () {
+      expect(DownloadUrlRevertEngine.isRenderable('https://example.com/'),
+          isTrue);
+      expect(DownloadUrlRevertEngine.isRenderable('http://example.com/'),
+          isTrue);
+      expect(
+          DownloadUrlRevertEngine.isRenderable('file:///tmp/x.html'), isTrue);
+      expect(DownloadUrlRevertEngine.isRenderable('about:blank'), isTrue);
+    });
+
+    test('false for data:/blob:/javascript:/chrome:', () {
+      expect(
+          DownloadUrlRevertEngine.isRenderable('data:text/plain,hello'),
+          isFalse);
+      expect(DownloadUrlRevertEngine.isRenderable('blob:https://x/abc'),
+          isFalse);
+      expect(DownloadUrlRevertEngine.isRenderable('javascript:alert(1)'),
+          isFalse);
+      expect(DownloadUrlRevertEngine.isRenderable('chrome://settings'),
+          isFalse);
+    });
+
+    test('false for empty and malformed', () {
+      expect(DownloadUrlRevertEngine.isRenderable(''), isFalse);
+      // Uri.parse is lenient; scheme is '' for bare strings.
+      expect(
+          DownloadUrlRevertEngine.isRenderable('not a url at all'), isFalse);
+    });
+
+    test('case-insensitive on scheme', () {
+      expect(DownloadUrlRevertEngine.isRenderable('HTTPS://example.com/'),
+          isTrue);
+      expect(
+          DownloadUrlRevertEngine.isRenderable('Data:text/plain,x'), isFalse);
+    });
+  });
+
+  group('DownloadUrlRevertEngine.updateStable', () {
+    test('renderable URL replaces previous', () {
+      expect(
+        DownloadUrlRevertEngine.updateStable(
+            'https://old/', 'https://new/'),
+        'https://new/',
+      );
+    });
+
+    test('non-renderable URL preserves previous', () {
+      expect(
+        DownloadUrlRevertEngine.updateStable(
+            'https://old/', 'data:text/plain,x'),
+        'https://old/',
+      );
+      expect(
+        DownloadUrlRevertEngine.updateStable(
+            'https://old/', 'blob:https://old/abc'),
+        'https://old/',
+      );
+    });
+
+    test('first renderable load seeds the stable value', () {
+      expect(
+        DownloadUrlRevertEngine.updateStable(null, 'https://x/'),
+        'https://x/',
+      );
+    });
+
+    test('non-renderable load with no previous returns null', () {
+      expect(
+        DownloadUrlRevertEngine.updateStable(null, 'data:text/plain,x'),
+        isNull,
+      );
+    });
+  });
+
+  group('DownloadUrlRevertEngine.pickRevertTarget', () {
+    test('prefers lastStableUrl over initialUrl', () {
+      expect(
+        DownloadUrlRevertEngine.pickRevertTarget(
+          lastStableUrl: 'https://stable/',
+          initialUrl: 'https://init/',
+        ),
+        'https://stable/',
+      );
+    });
+
+    test('falls back to initialUrl when stable is null', () {
+      expect(
+        DownloadUrlRevertEngine.pickRevertTarget(
+          lastStableUrl: null,
+          initialUrl: 'https://init/',
+        ),
+        'https://init/',
+      );
+    });
+
+    test('returns null when both are null', () {
+      expect(
+        DownloadUrlRevertEngine.pickRevertTarget(),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
The plugin's InAppWebViewChromeClient calls FileProvider.getUriForFile with authority "${applicationId}.flutter_inappwebview_android.fileprovider" when creating temp URIs for camera/video capture during <input type=file> uploads. Without a matching <provider> declaration the lookup throws IllegalArgumentException and the file chooser silently fails (breaks uploads on sites like pairdrop.net).

Register the FileProvider in the main AndroidManifest and supply a paths.xml covering files/cache/external locations so the plugin's temp files resolve to content URIs.