### PR TITLE
Hide Home Shortcut menu item when current site is already pinned

### DIFF
--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -58,6 +58,20 @@ class MainActivity: FlutterActivity() {
                     val siteId = intent?.getStringExtra("siteId")
                     result.success(siteId)
                 }
+                "getPinnedSiteIds" -> {
+                    try {
+                        val pinned = ShortcutManagerCompat.getShortcuts(
+                            this,
+                            ShortcutManagerCompat.FLAG_MATCH_PINNED
+                        )
+                        val ids = pinned.mapNotNull { info ->
+                            info.id.takeIf { it.startsWith("site_") }?.removePrefix("site_")
+                        }
+                        result.success(ids)
+                    } catch (e: Exception) {
+                        result.success(emptyList<String>())
+                    }
+                }
                 else -> result.notImplemented()
             }
         }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -597,11 +597,28 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   // platform call complete before the pause call, leaving the webview stuck.
   Future<void>? _lifecyclePauseFuture;
 
+  // Tracks which sites already have a pinned home shortcut, so the
+  // "Home Shortcut" menu item can hide for sites that are already pinned.
+  Set<String> _pinnedSiteIds = const <String>{};
+
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     _restoreAppState();
+    _refreshPinnedSiteIds();
+  }
+
+  Future<void> _refreshPinnedSiteIds() async {
+    final ids = await ShortcutService.getPinnedSiteIds();
+    if (!mounted) return;
+    if (ids.length == _pinnedSiteIds.length &&
+        ids.containsAll(_pinnedSiteIds)) {
+      return;
+    }
+    setState(() {
+      _pinnedSiteIds = ids;
+    });
   }
 
   @override
@@ -621,6 +638,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       // Await any in-flight pause before resuming to prevent ordering inversion
       _resumeAfterLifecyclePause();
       _handleShortcutIntent();
+      // Pinned shortcuts may have been added (via the launcher's pin dialog)
+      // or removed (by the user from the launcher) while we were backgrounded.
+      _refreshPinnedSiteIds();
     }
   }
 
@@ -1875,7 +1895,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                     ],
                   ),
                 ),
-                if (Platform.isAndroid)
+                if (Platform.isAndroid &&
+                    _currentIndex != null &&
+                    !_pinnedSiteIds.contains(_webViewModels[_currentIndex!].siteId))
                   PopupMenuItem<String>(
                     value: "addToHome",
                     child: Row(
@@ -2268,7 +2290,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
               ],
             ),
           ),
-          if (Platform.isAndroid)
+          if (Platform.isAndroid &&
+              _currentIndex != null &&
+              !_pinnedSiteIds.contains(_webViewModels[_currentIndex!].siteId))
             PopupMenuItem<String>(
               value: "addToHome",
               child: Row(

--- a/lib/services/shortcut_service.dart
+++ b/lib/services/shortcut_service.dart
@@ -43,4 +43,18 @@ class ShortcutService {
       return null;
     }
   }
+
+  /// Get the set of siteIds that currently have a pinned home shortcut.
+  static Future<Set<String>> getPinnedSiteIds() async {
+    if (!Platform.isAndroid) return const <String>{};
+    try {
+      final result = await _channel.invokeMethod('getPinnedSiteIds');
+      if (result is List) {
+        return result.whereType<String>().toSet();
+      }
+      return const <String>{};
+    } on PlatformException {
+      return const <String>{};
+    }
+  }
 }

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -82,6 +82,26 @@ The feature SHALL only be available on Android. On iOS/macOS, the menu item is n
 
 ---
 
+### Requirement: HS-005 - Hide When Already Pinned
+
+Sites in WebSpace are stable, so a home shortcut is a one-time setup per site. The "Home Shortcut" menu item SHALL be hidden when the current site already has a pinned shortcut, and SHALL reappear if the user removes the shortcut from the launcher.
+
+#### Scenario: Site already has a pinned shortcut
+
+**Given** the user previously pinned a shortcut for the current site
+**When** the user opens the overflow menu
+**Then** the "Home Shortcut" option is not shown for that site
+
+#### Scenario: Shortcut removed from launcher
+
+**Given** the user removed a previously pinned shortcut from their home screen
+**When** the user backgrounds and re-foregrounds the app, then opens the overflow menu for that site
+**Then** the "Home Shortcut" option is shown again
+
+The pinned-shortcut set is queried via `ShortcutManagerCompat.getShortcuts(FLAG_MATCH_PINNED)` exposed through the platform channel as `getPinnedSiteIds`. The cached set is refreshed on `initState` and on `AppLifecycleState.resumed`, which covers both the in-app pin flow (the launcher's pin dialog backgrounds the app) and out-of-app removal.
+
+---
+
 ## Implementation
 
 ### Platform Channel
@@ -90,7 +110,9 @@ Flutter communicates with native Android code via `MethodChannel('org.codeberg.t
 
 Methods:
 - `pinShortcut({siteId, label, iconUrl})` — requests a pinned shortcut via `ShortcutManagerCompat.requestPinShortcut()`
+- `removeShortcut(siteId)` — disables and removes the dynamic+pinned shortcut for a deleted site
 - `getLaunchSiteId()` — returns the `siteId` from the launch intent extra (if launched via shortcut)
+- `getPinnedSiteIds()` — returns the set of `siteId`s currently pinned, derived from `ShortcutManagerCompat.getShortcuts(FLAG_MATCH_PINNED)` by stripping the `site_` prefix
 
 ### Shortcut Intent
 


### PR DESCRIPTION
Sites in WebSpace are stable, so a home shortcut is a one-time setup per site. Surfacing the menu item after the user has already pinned just invites duplicate-shortcut requests.

Adds a getPinnedSiteIds platform-channel method backed by ShortcutManagerCompat.getShortcuts(FLAG_MATCH_PINNED) and caches the result in _WebSpacePageState. Both overflow menus now omit the "Home Shortcut" entry when the current site's siteId is in the set. The cache refreshes on initState and on AppLifecycleState.resumed, which covers both pin success (the launcher dialog backgrounds the app) and out-of-app removal from the launcher.

https://claude.ai/code/session_016j8egcBUfcuYCerjRYmv45