### PR TITLE
Add "Use current location" button to per-site location picker

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Optional, requested at runtime only when the user taps "Use current location"
+         in the per-site location picker. Not used for any background/tracking. -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <application
         android:label="Webspace"
         android:name="${applicationName}"

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/LocationPlugin.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/LocationPlugin.kt
@@ -1,0 +1,192 @@
+package org.codeberg.theoden8.webspace
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.location.Location
+import android.location.LocationListener
+import android.location.LocationManager
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.PluginRegistry
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Returns a single GPS fix from Android's native LocationManager.
+ *
+ * No Google Play Services dependency — keeps the F-Droid flavor clean. Permission
+ * is requested on demand via ActivityCompat; the activity must forward
+ * onRequestPermissionsResult here (registered as a RequestPermissionsResultListener
+ * on the FlutterEngine).
+ */
+class LocationPlugin(
+    private val activity: FlutterActivity,
+    flutterEngine: FlutterEngine,
+) : MethodChannel.MethodCallHandler, PluginRegistry.RequestPermissionsResultListener {
+
+    companion object {
+        private const val CHANNEL = "org.codeberg.theoden8.webspace/location"
+        private const val REQ_PERMISSION = 0x10C
+    }
+
+    private val channel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
+    private var pendingResult: MethodChannel.Result? = null
+    private var pendingTimeoutMs: Long = 30_000
+
+    init {
+        channel.setMethodCallHandler(this)
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "getCurrentLocation" -> {
+                pendingTimeoutMs = (call.argument<Number>("timeoutMs")?.toLong() ?: 30_000)
+                handleGetCurrentLocation(result)
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun handleGetCurrentLocation(result: MethodChannel.Result) {
+        if (pendingResult != null) {
+            result.success(mapOf("status" to "error", "message" to "Another location request is already in progress."))
+            return
+        }
+        val fineGranted = ContextCompat.checkSelfPermission(
+            activity, Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+        val coarseGranted = ContextCompat.checkSelfPermission(
+            activity, Manifest.permission.ACCESS_COARSE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+
+        if (!fineGranted && !coarseGranted) {
+            pendingResult = result
+            ActivityCompat.requestPermissions(
+                activity,
+                arrayOf(
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                    Manifest.permission.ACCESS_COARSE_LOCATION,
+                ),
+                REQ_PERMISSION,
+            )
+            return
+        }
+        requestSingleLocation(result)
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray,
+    ): Boolean {
+        if (requestCode != REQ_PERMISSION) return false
+        val pending = pendingResult
+        pendingResult = null
+        if (pending == null) return true
+
+        val granted = grantResults.any { it == PackageManager.PERMISSION_GRANTED }
+        if (!granted) {
+            // shouldShowRequestPermissionRationale returns false after a "deny + don't ask again"
+            // (or on first prompt before any answer). Combined with denial, treat the
+            // false-after-denial case as "denied forever" so the UI can offer settings.
+            val canPromptAgain = permissions.any {
+                ActivityCompat.shouldShowRequestPermissionRationale(activity, it)
+            }
+            val status = if (canPromptAgain) "permission_denied" else "permission_denied_forever"
+            pending.success(mapOf(
+                "status" to status,
+                "message" to "Location permission was not granted.",
+            ))
+            return true
+        }
+        requestSingleLocation(pending)
+        return true
+    }
+
+    private fun requestSingleLocation(result: MethodChannel.Result) {
+        val lm = activity.getSystemService(Context.LOCATION_SERVICE) as? LocationManager
+        if (lm == null) {
+            result.success(mapOf("status" to "error", "message" to "LocationManager unavailable."))
+            return
+        }
+        val providers = mutableListOf<String>()
+        if (lm.isProviderEnabled(LocationManager.GPS_PROVIDER)) providers.add(LocationManager.GPS_PROVIDER)
+        if (lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER)) providers.add(LocationManager.NETWORK_PROVIDER)
+        if (providers.isEmpty()) {
+            result.success(mapOf(
+                "status" to "service_disabled",
+                "message" to "Location services are disabled.",
+            ))
+            return
+        }
+
+        val main = Handler(Looper.getMainLooper())
+        val resolved = AtomicBoolean(false)
+        val listeners = mutableListOf<LocationListener>()
+
+        fun finish(payload: Map<String, Any?>) {
+            if (!resolved.compareAndSet(false, true)) return
+            for (l in listeners) {
+                try { lm.removeUpdates(l) } catch (_: SecurityException) {}
+            }
+            main.post { result.success(payload) }
+        }
+
+        for (provider in providers) {
+            val listener = object : LocationListener {
+                override fun onLocationChanged(location: Location) {
+                    finish(mapOf(
+                        "status" to "ok",
+                        "latitude" to location.latitude,
+                        "longitude" to location.longitude,
+                        "accuracy" to (if (location.hasAccuracy()) location.accuracy.toDouble() else 0.0),
+                    ))
+                }
+
+                @Deprecated("Required for older API levels")
+                override fun onStatusChanged(provider: String?, status: Int, extras: Bundle?) {}
+                override fun onProviderEnabled(provider: String) {}
+                override fun onProviderDisabled(provider: String) {}
+            }
+            listeners.add(listener)
+            try {
+                lm.requestLocationUpdates(provider, 0L, 0f, listener, Looper.getMainLooper())
+            } catch (e: SecurityException) {
+                finish(mapOf("status" to "permission_denied", "message" to e.message))
+                return
+            }
+        }
+
+        // Seed with last known fix if available — common when Wi-Fi + GPS are off
+        // briefly but we have a recent network fix. Reduces wait from ~10s to ~0.
+        for (provider in providers) {
+            try {
+                val last = lm.getLastKnownLocation(provider) ?: continue
+                val ageMs = System.currentTimeMillis() - last.time
+                if (ageMs in 0..120_000) {
+                    finish(mapOf(
+                        "status" to "ok",
+                        "latitude" to last.latitude,
+                        "longitude" to last.longitude,
+                        "accuracy" to (if (last.hasAccuracy()) last.accuracy.toDouble() else 0.0),
+                    ))
+                    return
+                }
+            } catch (_: SecurityException) {}
+        }
+
+        main.postDelayed({
+            finish(mapOf(
+                "status" to "timeout",
+                "message" to "Timed out waiting for a location fix.",
+            ))
+        }, pendingTimeoutMs)
+    }
+}

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -15,6 +15,7 @@ import java.net.URL
 class MainActivity: FlutterActivity() {
     private val CHANNEL = "org.codeberg.theoden8.webspace/shortcuts"
     private var webInterceptPlugin: WebInterceptPlugin? = null
+    private var locationPlugin: LocationPlugin? = null
 
     override fun getFlutterShellArgs(): FlutterShellArgs {
         val args = FlutterShellArgs.fromIntent(intent)
@@ -31,6 +32,7 @@ class MainActivity: FlutterActivity() {
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
         webInterceptPlugin = WebInterceptPlugin(this, flutterEngine)
+        locationPlugin = LocationPlugin(this, flutterEngine)
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
             when (call.method) {
                 "pinShortcut" -> {
@@ -130,5 +132,16 @@ class MainActivity: FlutterActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        if (locationPlugin?.onRequestPermissionsResult(requestCode, permissions, grantResults) == true) {
+            return
+        }
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
 }

--- a/assets/licenses/openstreetmap.txt
+++ b/assets/licenses/openstreetmap.txt
@@ -1,0 +1,37 @@
+OpenStreetMap data and tiles
+============================
+
+Map data is © OpenStreetMap contributors, and is available under the
+Open Database License (ODbL).
+
+  https://www.openstreetmap.org/copyright
+  https://opendatacommons.org/licenses/odbl/
+
+The map cartography (the rendered raster tiles served from
+tile.openstreetmap.org) is licensed under the Creative Commons
+Attribution-ShareAlike 2.0 license (CC BY-SA 2.0).
+
+  https://creativecommons.org/licenses/by-sa/2.0/
+
+Webspace uses tiles from tile.openstreetmap.org as the default base map
+in the per-site location picker. This usage is subject to the
+OpenStreetMap Foundation's Tile Usage Policy:
+
+  https://operations.osmfoundation.org/policies/tiles/
+
+Webspace complies with the policy by:
+- using the canonical HTTPS URL https://tile.openstreetmap.org/{z}/{x}/{y}.png,
+- sending an identifying User-Agent of the form
+  `Webspace/<version> (+https://github.com/theoden8/webspace_app)`,
+- displaying the © OpenStreetMap contributors attribution and a link to
+  https://www.openstreetmap.org/fixthemap on every map view,
+- caching tiles per the platform HTTP cache (no Cache-Control: no-cache),
+- never bulk-downloading or pre-fetching tiles for offline use,
+- not loading any tiles until the user explicitly taps "Load map",
+- allowing the user to swap the tile URL at runtime via App Settings →
+  Location picker.
+
+Tile server access is best-effort and may be withdrawn by the OSMF at
+any time, per their policy. Users who require offline maps or guaranteed
+availability should configure a self-hosted or commercial tile provider
+in App Settings.

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		7AC100012ED2DC5600515811 /* LocationPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC100002ED2DC5600515811 /* LocationPlugin.swift */; };
 		897CA73A1B12E395D36631E0 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEB686F40D1F327FFB98EB57 /* Pods_Runner.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -50,6 +51,7 @@
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		7AC100002ED2DC5600515811 /* LocationPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationPlugin.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		8978E62AB7C1945FA3477F81 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
@@ -160,6 +162,7 @@
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
+				7AC100002ED2DC5600515811 /* LocationPlugin.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
 			path = Runner;
@@ -378,6 +381,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
+				7AC100012ED2DC5600515811 /* LocationPlugin.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -3,11 +3,16 @@ import UIKit
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
+  private var locationPlugin: LocationPlugin?
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
+    if let controller = window?.rootViewController as? FlutterViewController {
+      locationPlugin = LocationPlugin(messenger: controller.binaryMessenger)
+    }
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -8,6 +8,8 @@
 	<true/>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This app may request access to your photo library when uploading files through web pages.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Used only when you tap "Use current location" in the per-site location picker, to fill in your coordinates for the site's spoofed location.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/ios/Runner/LocationPlugin.swift
+++ b/ios/Runner/LocationPlugin.swift
@@ -1,0 +1,135 @@
+import CoreLocation
+import Flutter
+import UIKit
+
+/// Returns a single GPS fix from CLLocationManager. Permission is requested on
+/// demand (When-In-Use). The Flutter side calls "getCurrentLocation"; this plugin
+/// either resolves with a fix, or with a status describing why it could not.
+class LocationPlugin: NSObject, CLLocationManagerDelegate {
+  private let channel: FlutterMethodChannel
+  private let locationManager = CLLocationManager()
+  private var pendingResult: FlutterResult?
+  private var timeoutWorkItem: DispatchWorkItem?
+  private var pendingTimeoutSeconds: TimeInterval = 30
+
+  init(messenger: FlutterBinaryMessenger) {
+    self.channel = FlutterMethodChannel(
+      name: "org.codeberg.theoden8.webspace/location",
+      binaryMessenger: messenger
+    )
+    super.init()
+    self.locationManager.delegate = self
+    self.locationManager.desiredAccuracy = kCLLocationAccuracyBest
+    self.channel.setMethodCallHandler { [weak self] call, result in
+      self?.handle(call: call, result: result)
+    }
+  }
+
+  private func handle(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "getCurrentLocation":
+      if let args = call.arguments as? [String: Any], let ms = args["timeoutMs"] as? Int {
+        pendingTimeoutSeconds = TimeInterval(ms) / 1000.0
+      }
+      requestLocation(result: result)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func requestLocation(result: @escaping FlutterResult) {
+    if pendingResult != nil {
+      result(["status": "error", "message": "Another location request is already in progress."])
+      return
+    }
+    if !CLLocationManager.locationServicesEnabled() {
+      result(["status": "service_disabled", "message": "Location services are disabled."])
+      return
+    }
+    let status: CLAuthorizationStatus
+    if #available(iOS 14.0, *) {
+      status = locationManager.authorizationStatus
+    } else {
+      status = CLLocationManager.authorizationStatus()
+    }
+    switch status {
+    case .notDetermined:
+      pendingResult = result
+      locationManager.requestWhenInUseAuthorization()
+    case .denied:
+      result(["status": "permission_denied_forever",
+              "message": "Location permission was denied. Enable it in Settings."])
+    case .restricted:
+      result(["status": "permission_denied_forever",
+              "message": "Location access is restricted on this device."])
+    case .authorizedAlways, .authorizedWhenInUse:
+      pendingResult = result
+      startSingleFix()
+    @unknown default:
+      result(["status": "error", "message": "Unknown authorization status."])
+    }
+  }
+
+  private func startSingleFix() {
+    let work = DispatchWorkItem { [weak self] in
+      guard let self = self, let pending = self.pendingResult else { return }
+      self.pendingResult = nil
+      self.locationManager.stopUpdatingLocation()
+      pending(["status": "timeout", "message": "Timed out waiting for a location fix."])
+    }
+    timeoutWorkItem = work
+    DispatchQueue.main.asyncAfter(deadline: .now() + pendingTimeoutSeconds, execute: work)
+    locationManager.requestLocation()
+  }
+
+  // MARK: CLLocationManagerDelegate
+
+  func locationManager(_ manager: CLLocationManager,
+                       didChangeAuthorization status: CLAuthorizationStatus) {
+    handleAuthChange(status: status)
+  }
+
+  @available(iOS 14.0, *)
+  func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+    handleAuthChange(status: manager.authorizationStatus)
+  }
+
+  private func handleAuthChange(status: CLAuthorizationStatus) {
+    guard let pending = pendingResult else { return }
+    switch status {
+    case .authorizedAlways, .authorizedWhenInUse:
+      startSingleFix()
+    case .denied, .restricted:
+      pendingResult = nil
+      pending(["status": "permission_denied",
+               "message": "Location permission was not granted."])
+    case .notDetermined:
+      // System is still deciding (modal still up); wait for next callback.
+      break
+    @unknown default:
+      pendingResult = nil
+      pending(["status": "error", "message": "Unknown authorization status."])
+    }
+  }
+
+  func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+    guard let pending = pendingResult, let loc = locations.last else { return }
+    pendingResult = nil
+    timeoutWorkItem?.cancel()
+    timeoutWorkItem = nil
+    pending([
+      "status": "ok",
+      "latitude": loc.coordinate.latitude,
+      "longitude": loc.coordinate.longitude,
+      "accuracy": loc.horizontalAccuracy >= 0 ? loc.horizontalAccuracy : 0,
+    ])
+  }
+
+  func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+    guard let pending = pendingResult else { return }
+    pendingResult = nil
+    timeoutWorkItem?.cancel()
+    timeoutWorkItem = nil
+    pending(["status": "error", "message": error.localizedDescription])
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,6 +41,7 @@ import 'package:webspace/services/webspace_selection_engine.dart';
 import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
+import 'package:webspace/services/timezone_location_service.dart';
 import 'package:webspace/services/web_intercept_native.dart';
 import 'package:webspace/services/localcdn_service.dart';
 import 'package:webspace/services/connectivity_service.dart';
@@ -439,6 +440,12 @@ void main() async {
 
   // Initialize DNS block service (loads cached blocklist from disk)
   await DnsBlockService.instance.initialize();
+
+  // Load timezone-polygon dataset if previously downloaded. Lookups are
+  // synchronous so the per-site shim builder needs the data ready before
+  // it runs. Missing/empty cache is fine — the "From picked location"
+  // dropdown option just stays disabled.
+  await TimezoneLocationService.instance.loadFromCacheIfPresent();
 
   // Initialize native interceptor bridge for sub-resource DNS + ABP
   // blocking and LocalCDN serving (Android). The Dart shouldInterceptRequest
@@ -1154,6 +1161,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     double? spoofLongitude,
     double spoofAccuracy = 50.0,
     String? spoofTimezone,
+    bool spoofTimezoneFromLocation = false,
     WebRtcPolicy webRtcPolicy = WebRtcPolicy.defaultPolicy,
   }) async {
     await Navigator.push(
@@ -1175,6 +1183,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           spoofLongitude: spoofLongitude,
           spoofAccuracy: spoofAccuracy,
           spoofTimezone: spoofTimezone,
+          spoofTimezoneFromLocation: spoofTimezoneFromLocation,
           webRtcPolicy: webRtcPolicy,
         ),
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -497,6 +497,7 @@ void main() async {
     (['Hagezi DNS Blocklists (domain data)'], 'assets/licenses/hagezi.txt'),
     (['EasyList filter lists (filter data)'], 'assets/licenses/easylist.txt'),
     (['cdnjs (LocalCDN resource data)'], 'assets/licenses/cdnjs.txt'),
+    (['OpenStreetMap (map data and tiles)'], 'assets/licenses/openstreetmap.txt'),
   ];
   for (final (packages, assetPath) in customLicenses) {
     LicenseRegistry.addLicense(() async* {

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -9,6 +9,8 @@ import 'package:webspace/screens/dev_tools.dart';
 import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
+import 'package:webspace/services/timezone_location_service.dart';
+import 'package:webspace/widgets/root_messenger.dart';
 import 'package:webspace/services/web_intercept_native.dart';
 import 'package:webspace/services/localcdn_service.dart';
 import 'package:webspace/services/webview.dart';
@@ -67,6 +69,11 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
   bool _isDownloadingRules = false;
   DateTime? _rulesLastUpdated;
 
+  // Timezone polygon dataset state (per-site "From picked location" timezone option)
+  bool _isDownloadingTimezones = false;
+  DateTime? _timezonesLastUpdated;
+  int _timezoneZoneCount = 0;
+
   // DNS Blocklist state
   bool _isDownloadingBlocklist = false;
   DateTime? _blocklistLastUpdated;
@@ -100,6 +107,48 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
     _loadRulesLastUpdated();
     _loadBlocklistState();
     _loadLocalCdnState();
+    _loadTimezoneState();
+  }
+
+  Future<void> _loadTimezoneState() async {
+    final lastUpdated = await TimezoneLocationService.instance.getLastUpdated();
+    if (!mounted) return;
+    setState(() {
+      _timezonesLastUpdated = lastUpdated;
+      _timezoneZoneCount = TimezoneLocationService.instance.zoneCount;
+    });
+  }
+
+  Future<void> _downloadTimezones() async {
+    setState(() => _isDownloadingTimezones = true);
+    _spinController.repeat();
+    final success = await TimezoneLocationService.instance.download();
+    if (!mounted) return;
+    _spinController.stop();
+    _spinController.reset();
+    setState(() {
+      _isDownloadingTimezones = false;
+      _timezoneZoneCount = TimezoneLocationService.instance.zoneCount;
+    });
+    if (success) {
+      _timezonesLastUpdated =
+          await TimezoneLocationService.instance.getLastUpdated();
+      if (mounted) setState(() {});
+      rootScaffoldMessengerKey.currentState?.showSnackBar(SnackBar(
+          content: Text('Loaded $_timezoneZoneCount timezones')));
+    } else {
+      rootScaffoldMessengerKey.currentState?.showSnackBar(const SnackBar(
+          content: Text('Timezone dataset download failed (check log)')));
+    }
+  }
+
+  Future<void> _clearTimezones() async {
+    await TimezoneLocationService.instance.clear();
+    if (!mounted) return;
+    setState(() {
+      _timezonesLastUpdated = null;
+      _timezoneZoneCount = 0;
+    });
   }
 
   @override
@@ -502,6 +551,69 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
               ),
               onChanged: _saveOsmTileUrl,
             ),
+          ),
+
+          // Timezone polygon dataset — opt-in download enabling the
+          // "From picked location" timezone option in per-site settings.
+          // Modeled on the DNS blocklist pattern: status + download/refresh
+          // button, plus a clear button when data is present.
+          ListTile(
+            leading: const Icon(Icons.public),
+            title: const Row(
+              children: [
+                Text('Timezone polygons'),
+                HintButton(
+                  title: 'Timezone polygon dataset',
+                  description:
+                      'Downloads a GeoJSON dataset of IANA timezone '
+                      'boundaries (~10–60 MB) so the per-site settings can '
+                      'offer a "From picked location" timezone option that '
+                      'auto-resolves the IANA zone of your spoofed '
+                      'coordinates. Only fetched on demand (this button); '
+                      'kept in app private storage until you clear it. '
+                      'Default source: timezone-boundary-builder GitHub '
+                      'releases. Tap Clear to delete.',
+                ),
+              ],
+            ),
+            subtitle: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(_timezoneZoneCount > 0
+                    ? '${_formatNumber(_timezoneZoneCount)} zones'
+                    : 'Not downloaded'),
+                if (_timezonesLastUpdated != null)
+                  Text(
+                    'Updated: ${_timezonesLastUpdated!.toLocal().toString().split('.')[0]}',
+                    style: const TextStyle(fontSize: 12),
+                  ),
+              ],
+            ),
+            trailing: _isDownloadingTimezones
+                ? RotationTransition(
+                    turns: _spinController,
+                    child: const Icon(Icons.sync),
+                  )
+                : Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (_timezoneZoneCount > 0)
+                        IconButton(
+                          icon: const Icon(Icons.delete_outline),
+                          tooltip: 'Clear dataset',
+                          onPressed: _clearTimezones,
+                        ),
+                      IconButton(
+                        icon: Icon(_timezoneZoneCount > 0
+                            ? Icons.sync
+                            : Icons.download),
+                        tooltip: _timezoneZoneCount > 0
+                            ? 'Refresh dataset'
+                            : 'Download dataset',
+                        onPressed: _downloadTimezones,
+                      ),
+                    ],
+                  ),
           ),
 
           const Divider(height: 32),

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -28,6 +28,7 @@ class InAppWebViewScreen extends StatefulWidget {
   final double? spoofLongitude;
   final double spoofAccuracy;
   final String? spoofTimezone;
+  final bool spoofTimezoneFromLocation;
   final WebRtcPolicy webRtcPolicy;
 
   InAppWebViewScreen({
@@ -46,6 +47,7 @@ class InAppWebViewScreen extends StatefulWidget {
     this.spoofLongitude,
     this.spoofAccuracy = 50.0,
     this.spoofTimezone,
+    this.spoofTimezoneFromLocation = false,
     this.webRtcPolicy = WebRtcPolicy.defaultPolicy,
   });
 
@@ -298,6 +300,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
                 spoofLongitude: widget.spoofLongitude,
                 spoofAccuracy: widget.spoofAccuracy,
                 spoofTimezone: widget.spoofTimezone,
+                spoofTimezoneFromLocation: widget.spoofTimezoneFromLocation,
                 webRtcPolicy: widget.webRtcPolicy,
                 pullToRefreshController: _pullToRefreshController,
                 onUrlChanged: (url) {

--- a/lib/screens/location_picker.dart
+++ b/lib/screens/location_picker.dart
@@ -356,6 +356,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
   Widget _buildMap() {
     final initial = _currentLatLng() ?? const LatLng(0, 0);
     final initialZoom = _currentLatLng() == null ? 2.0 : 10.0;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
     return Stack(
       children: [
         FlutterMap(
@@ -373,6 +374,28 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
                 headers: {'User-Agent': _tileUserAgent},
               ),
               maxZoom: 19,
+              // In dark mode, post-process the standard light cartography
+              // into a dark-friendly version client-side instead of
+              // requiring a separate dark tile server. The matrix below
+              // maps each output channel to the negative luminance of
+              // the input (0.2126·R + 0.7152·G + 0.0722·B), then offsets
+              // by 255 — i.e. light → dark, dark → light, while
+              // preserving relative contrast. Roads, labels, and water
+              // stay readable; the map gets a flat dark-grey aesthetic
+              // that matches Material's dark surfaces.
+              tileBuilder: isDark
+                  ? (context, tileWidget, tile) {
+                      return ColorFiltered(
+                        colorFilter: const ColorFilter.matrix(<double>[
+                          -0.2126, -0.7152, -0.0722, 0, 255,
+                          -0.2126, -0.7152, -0.0722, 0, 255,
+                          -0.2126, -0.7152, -0.0722, 0, 255,
+                          0, 0, 0, 1, 0,
+                        ]),
+                        child: tileWidget,
+                      );
+                    }
+                  : null,
             ),
             if (_currentLatLng() != null)
               MarkerLayer(
@@ -397,21 +420,29 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
         // - 12pt is used for legibility; the guidelines reference WCAG.
         // - Always visible while the map is loaded (no auto-collapse).
         // - "Report a map issue" link is recommended by the Tile Usage Policy.
+        // - Surface and text colours adapt to dark theme so the overlay
+        //   stays legible on the dark-filtered tiles below.
         Positioned(
           bottom: 4,
           right: 4,
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
-            color: Colors.white.withValues(alpha: 0.85),
+            color: (isDark ? Colors.black : Colors.white).withValues(alpha: 0.85),
             child: Text.rich(
               TextSpan(
-                style: const TextStyle(fontSize: 12, color: Colors.black87),
+                style: TextStyle(
+                    fontSize: 12,
+                    color: isDark ? Colors.white70 : Colors.black87),
                 children: [
                   const TextSpan(text: '© '),
                   TextSpan(
                     text: 'OpenStreetMap',
-                    style: const TextStyle(
-                      color: Color(0xFF0645AD),
+                    style: TextStyle(
+                      // Wikipedia-style link blue on light, lighter cyan
+                      // on dark — both meet WCAG AA on the chosen surface.
+                      color: isDark
+                          ? const Color(0xFF6CA0DC)
+                          : const Color(0xFF0645AD),
                       decoration: TextDecoration.underline,
                     ),
                     recognizer: _osmCopyrightRecognizer,
@@ -419,8 +450,10 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
                   const TextSpan(text: ' contributors · '),
                   TextSpan(
                     text: 'Report a map issue',
-                    style: const TextStyle(
-                      color: Color(0xFF0645AD),
+                    style: TextStyle(
+                      color: isDark
+                          ? const Color(0xFF6CA0DC)
+                          : const Color(0xFF0645AD),
                       decoration: TextDecoration.underline,
                     ),
                     recognizer: _osmFixmapRecognizer,

--- a/lib/screens/location_picker.dart
+++ b/lib/screens/location_picker.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
@@ -59,6 +60,13 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
   // before the map can mount (see _loadTileUrl).
   String _tileUserAgent = 'Webspace (+https://github.com/theoden8/webspace_app)';
   final MapController _mapController = MapController();
+  // Held at field scope so the recognizers are only allocated once and
+  // disposed in [dispose]. Building them inline in [_buildMap] would leak on
+  // every rebuild (e.g. when the user types coordinates while the map is up).
+  late final TapGestureRecognizer _osmCopyrightRecognizer = TapGestureRecognizer()
+    ..onTap = () => launchUrl(Uri.parse('https://www.openstreetmap.org/copyright'));
+  late final TapGestureRecognizer _osmFixmapRecognizer = TapGestureRecognizer()
+    ..onTap = () => launchUrl(Uri.parse('https://www.openstreetmap.org/fixthemap'));
 
   @override
   void initState() {
@@ -98,6 +106,8 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
     _latController.dispose();
     _lngController.dispose();
     _accController.dispose();
+    _osmCopyrightRecognizer.dispose();
+    _osmFixmapRecognizer.dispose();
     super.dispose();
   }
 
@@ -381,38 +391,42 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
               ),
           ],
         ),
+        // Attribution per OSMF Attribution Guidelines (2021-06-25):
+        // - The word "OpenStreetMap" itself is the link to /copyright (not
+        //   the whole string) and is visually styled as a link.
+        // - 12pt is used for legibility; the guidelines reference WCAG.
+        // - Always visible while the map is loaded (no auto-collapse).
+        // - "Report a map issue" link is recommended by the Tile Usage Policy.
         Positioned(
           bottom: 4,
           right: 4,
           child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-            color: Colors.white.withValues(alpha: 0.75),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                GestureDetector(
-                  onTap: () => launchUrl(
-                      Uri.parse('https://www.openstreetmap.org/copyright')),
-                  child: const Text(
-                    '© OpenStreetMap contributors',
-                    style: TextStyle(fontSize: 10, color: Colors.black87),
-                  ),
-                ),
-                const Text(' · ',
-                    style: TextStyle(fontSize: 10, color: Colors.black54)),
-                GestureDetector(
-                  onTap: () => launchUrl(
-                      Uri.parse('https://www.openstreetmap.org/fixthemap')),
-                  child: const Text(
-                    'Report a map issue',
-                    style: TextStyle(
-                      fontSize: 10,
-                      color: Colors.black87,
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+            color: Colors.white.withValues(alpha: 0.85),
+            child: Text.rich(
+              TextSpan(
+                style: const TextStyle(fontSize: 12, color: Colors.black87),
+                children: [
+                  const TextSpan(text: '© '),
+                  TextSpan(
+                    text: 'OpenStreetMap',
+                    style: const TextStyle(
+                      color: Color(0xFF0645AD),
                       decoration: TextDecoration.underline,
                     ),
+                    recognizer: _osmCopyrightRecognizer,
                   ),
-                ),
-              ],
+                  const TextSpan(text: ' contributors · '),
+                  TextSpan(
+                    text: 'Report a map issue',
+                    style: const TextStyle(
+                      color: Color(0xFF0645AD),
+                      decoration: TextDecoration.underline,
+                    ),
+                    recognizer: _osmFixmapRecognizer,
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/screens/location_picker.dart
+++ b/lib/screens/location_picker.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -53,6 +54,10 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
   bool _mapLoaded = false;
   bool _fetchingLocation = false;
   String _tileUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+  // Compliant User-Agent per OSM Tile Usage Policy: clearly identifies the
+  // app, includes a contact URL, and avoids the library default. Populated
+  // before the map can mount (see _loadTileUrl).
+  String _tileUserAgent = 'Webspace (+https://github.com/theoden8/webspace_app)';
   final MapController _mapController = MapController();
 
   @override
@@ -73,8 +78,19 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
   Future<void> _loadTileUrl() async {
     final prefs = await SharedPreferences.getInstance();
     final url = prefs.getString('osmTileUrl') ?? _tileUrl;
+    String ua = _tileUserAgent;
+    try {
+      final info = await PackageInfo.fromPlatform();
+      final v = info.version;
+      ua = 'Webspace/$v (+https://github.com/theoden8/webspace_app)';
+    } catch (_) {
+      // Keep the static fallback if PackageInfo is unavailable.
+    }
     if (!mounted) return;
-    setState(() => _tileUrl = url);
+    setState(() {
+      _tileUrl = url;
+      _tileUserAgent = ua;
+    });
   }
 
   @override
@@ -343,6 +359,9 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
             TileLayer(
               urlTemplate: _tileUrl,
               userAgentPackageName: 'com.webspace.app',
+              tileProvider: NetworkTileProvider(
+                headers: {'User-Agent': _tileUserAgent},
+              ),
               maxZoom: 19,
             ),
             if (_currentLatLng() != null)
@@ -368,13 +387,32 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
             color: Colors.white.withValues(alpha: 0.75),
-            child: GestureDetector(
-              onTap: () =>
-                  launchUrl(Uri.parse('https://www.openstreetmap.org/copyright')),
-              child: const Text(
-                '© OpenStreetMap contributors',
-                style: TextStyle(fontSize: 10, color: Colors.black87),
-              ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                GestureDetector(
+                  onTap: () => launchUrl(
+                      Uri.parse('https://www.openstreetmap.org/copyright')),
+                  child: const Text(
+                    '© OpenStreetMap contributors',
+                    style: TextStyle(fontSize: 10, color: Colors.black87),
+                  ),
+                ),
+                const Text(' · ',
+                    style: TextStyle(fontSize: 10, color: Colors.black54)),
+                GestureDetector(
+                  onTap: () => launchUrl(
+                      Uri.parse('https://www.openstreetmap.org/fixthemap')),
+                  child: const Text(
+                    'Report a map issue',
+                    style: TextStyle(
+                      fontSize: 10,
+                      color: Colors.black87,
+                      decoration: TextDecoration.underline,
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
         ),

--- a/lib/screens/location_picker.dart
+++ b/lib/screens/location_picker.dart
@@ -4,6 +4,8 @@ import 'package:latlong2/latlong.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../services/current_location_service.dart';
+
 /// Full-screen picker for [LocationPickerResult] (lat/lng + accuracy).
 ///
 /// Two states:
@@ -49,6 +51,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
   late TextEditingController _accController;
 
   bool _mapLoaded = false;
+  bool _fetchingLocation = false;
   String _tileUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
   final MapController _mapController = MapController();
 
@@ -108,6 +111,53 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
         // Camera not attached yet — ignore; marker still rebuilds from state.
       }
     }
+  }
+
+  Future<void> _useCurrentLocation() async {
+    if (_fetchingLocation) return;
+    setState(() => _fetchingLocation = true);
+    final res = await CurrentLocationService.getCurrentLocation();
+    if (!mounted) return;
+    setState(() => _fetchingLocation = false);
+    switch (res.status) {
+      case CurrentLocationStatus.ok:
+        final fix = res.fix!;
+        setState(() {
+          _latController.text = fix.latitude.toStringAsFixed(6);
+          _lngController.text = fix.longitude.toStringAsFixed(6);
+          if (fix.accuracy > 0) {
+            _accController.text = fix.accuracy.toStringAsFixed(1);
+          }
+        });
+        if (_mapLoaded) {
+          try {
+            _mapController.move(LatLng(fix.latitude, fix.longitude), 14.0);
+          } catch (_) {}
+        }
+        break;
+      case CurrentLocationStatus.permissionDenied:
+        _showSnack('Location permission was not granted.');
+        break;
+      case CurrentLocationStatus.permissionDeniedForever:
+        _showSnack('Location permission is denied. Enable it in system Settings.');
+        break;
+      case CurrentLocationStatus.serviceDisabled:
+        _showSnack('Location services are disabled on this device.');
+        break;
+      case CurrentLocationStatus.timeout:
+        _showSnack('Could not get a location fix in time. Try again outdoors.');
+        break;
+      case CurrentLocationStatus.unsupported:
+        _showSnack('Current location is not available on this platform.');
+        break;
+      case CurrentLocationStatus.error:
+        _showSnack(res.message ?? 'Failed to get current location.');
+        break;
+    }
+  }
+
+  void _showSnack(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(message)));
   }
 
   String _hostOfTileUrl() {
@@ -210,6 +260,25 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
               isDense: true,
             ),
           ),
+          if (CurrentLocationService.isSupported) ...[
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: OutlinedButton.icon(
+                icon: _fetchingLocation
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.my_location),
+                label: Text(_fetchingLocation
+                    ? 'Getting current location…'
+                    : 'Use current location'),
+                onPressed: _fetchingLocation ? null : _useCurrentLocation,
+              ),
+            ),
+          ],
         ],
       ),
     );

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -124,7 +124,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late TextEditingController _accuracyController;
   String? _spoofTimezone;
   bool _spoofTimezoneFromLocation = false;
-  // Tracks the "live" geolocation mode. Mutually exclusive with custom
+  // Tracks the "live" geolocation mode. Mutually exclusive with static
   // coordinates: enabling live clears coords; picking coords clears live.
   bool _isLiveLocation = false;
   late WebRtcPolicy _webRtcPolicy;
@@ -421,13 +421,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   /// Build the geolocation section. A SegmentedButton at the top (Off /
-  /// Custom / Live) is always visible so all three modes are reachable
+  /// Static / Live) is always visible so all three modes are reachable
   /// regardless of current state — the previous trailing-button layout
-  /// hid Live once coords were set, leaving no way to switch from spoof
-  /// to live without clearing coords first.
+  /// hid Live once coords were set, leaving no way to switch from
+  /// static-coords mode to live without clearing coords first.
   ///
   /// Below the selector a detail row shows whatever's relevant for the
-  /// active mode: nothing for Off, coords + edit/clear for Custom,
+  /// active mode: nothing for Off, coords + edit/clear for Static,
   /// "tracking device GPS" for Live.
   ///
   /// `locationMode` is derived from this state at save time, not stored
@@ -444,7 +444,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           'Off (default): navigator.geolocation is left untouched. Sites '
           'get the platform default (typically denied unless the user '
           'grants permission to the webview).\n\n'
-          'Custom: navigator.geolocation returns the coordinates you '
+          'Static: navigator.geolocation returns the coordinates you '
           'supply. Tap "Pick location" to open the picker, where you can '
           'type coordinates, pick on a map, or use the "Use current '
           'location" button to fill them with your real device GPS once. '
@@ -458,13 +458,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
           'policy still apply, but the coordinates are real and current.',
     );
 
-    // Derive the active segment from current state. `Custom` is selected
+    // Derive the active segment from current state. `Static` is selected
     // when there are coords AND we're not in live mode; `Live` is selected
     // when the live flag is on (regardless of whether stale coords linger
     // — they're ignored on save in that branch).
     final _LocationSegment selected = _isLiveLocation
         ? _LocationSegment.live
-        : (hasCoords ? _LocationSegment.custom : _LocationSegment.off);
+        : (hasCoords ? _LocationSegment.staticCoords : _LocationSegment.off);
 
     void onSegmentChanged(Set<_LocationSegment> values) {
       final v = values.first;
@@ -476,11 +476,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
             _longitudeController.clear();
             _accuracyController.text = '50';
             break;
-          case _LocationSegment.custom:
+          case _LocationSegment.staticCoords:
             _isLiveLocation = false;
-            // If switching from off → custom with no coords yet, open the
+            // If switching from off → static with no coords yet, open the
             // picker so the user lands on something useful instead of
-            // an empty selection. From live → custom we keep whatever
+            // an empty selection. From live → static we keep whatever
             // coords were last saved (probably none) and the picker is
             // one tap away on the detail row.
             if (!hasCoords) {
@@ -503,9 +503,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
             icon: Icon(Icons.location_disabled),
             label: Text('Off')),
         ButtonSegment(
-            value: _LocationSegment.custom,
+            value: _LocationSegment.staticCoords,
             icon: Icon(Icons.map_outlined),
-            label: Text('Custom')),
+            label: Text('Static')),
         ButtonSegment(
             value: _LocationSegment.live,
             icon: Icon(Icons.my_location),
@@ -537,7 +537,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ),
         );
         break;
-      case _LocationSegment.custom:
+      case _LocationSegment.staticCoords:
         if (hasCoords) {
           detail = ListTile(
             dense: true,
@@ -1198,5 +1198,5 @@ class _SettingsScreenState extends State<SettingsScreen> {
 ///   custom -> LocationMode.spoof   (static user-supplied coords)
 ///   live   -> LocationMode.live    (real device GPS via the shim's
 ///                                   getRealLocation handler)
-enum _LocationSegment { off, custom, live }
+enum _LocationSegment { off, staticCoords, live }
 

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -640,17 +640,33 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ? _spoofTimezone
             : null);
 
+    // The "From picked location" entry is conceptually a sibling of
+    // "System default" (both auto-derive the timezone instead of taking
+    // an explicit value), so insert it right after the System default
+    // entry rather than at the bottom of the list.
     final items = <DropdownMenuItem<String?>>[];
+    var insertedFromLocation = false;
     for (final e in commonTimezones) {
       items.add(DropdownMenuItem<String?>(
         value: e.key,
         child: Text(_timezoneLabel(e)),
       ));
+      if (!insertedFromLocation && e.key == null) {
+        items.add(DropdownMenuItem<String?>(
+          value: _kFromLocationSentinel,
+          child: Text('From picked location ($preview)'),
+        ));
+        insertedFromLocation = true;
+      }
     }
-    items.add(DropdownMenuItem<String?>(
-      value: _kFromLocationSentinel,
-      child: Text('From picked location ($preview)'),
-    ));
+    // Defensive fallback: if commonTimezones ever loses the System
+    // default entry, still expose the option somewhere.
+    if (!insertedFromLocation) {
+      items.insert(0, DropdownMenuItem<String?>(
+        value: _kFromLocationSentinel,
+        child: Text('From picked location ($preview)'),
+      ));
+    }
 
     return DropdownButtonFormField<String?>(
       value: value,

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -10,6 +10,7 @@ import 'package:webspace/services/webview.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/services/localcdn_service.dart';
+import 'package:webspace/services/timezone_location_service.dart';
 import 'package:webspace/screens/location_picker.dart';
 import 'package:webspace/screens/user_scripts.dart';
 import 'package:webspace/settings/user_script.dart';
@@ -122,6 +123,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late TextEditingController _longitudeController;
   late TextEditingController _accuracyController;
   String? _spoofTimezone;
+  bool _spoofTimezoneFromLocation = false;
+  // Tracks the "live" geolocation mode. Mutually exclusive with custom
+  // coordinates: enabling live clears coords; picking coords clears live.
+  bool _isLiveLocation = false;
   late WebRtcPolicy _webRtcPolicy;
 
   String getResetUserAgent() {
@@ -181,6 +186,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
       text: widget.webViewModel.spoofAccuracy.toString(),
     );
     _spoofTimezone = widget.webViewModel.spoofTimezone;
+    _spoofTimezoneFromLocation = widget.webViewModel.spoofTimezoneFromLocation;
+    _isLiveLocation = widget.webViewModel.locationMode == LocationMode.live;
     _webRtcPolicy = widget.webViewModel.webRtcPolicy;
     // Show credentials section if credentials already exist
     _showProxyCredentials = _proxySettings.hasCredentials;
@@ -333,21 +340,34 @@ class _SettingsScreenState extends State<SettingsScreen> {
       widget.webViewModel.fullscreenMode = _fullscreenMode;
       widget.webViewModel.desktopMode = _desktopMode;
       widget.webViewModel.language = _selectedLanguage;
-      // locationMode is derived from whether a custom location is set: if
-      // the user has picked coords, mode is `spoof`; otherwise `off`. The
-      // dropdown UI was replaced with a single Pick/Clear button — see
-      // _buildLocationSection.
+      // locationMode is derived from the UI state:
+      // - `_isLiveLocation` → live (real device GPS forwarded through the shim)
+      // - else if custom coords are set → spoof (static custom coords)
+      // - else → off (no shim)
+      // Live and custom-coords are mutually exclusive in the UI: the user
+      // picks one or the other, not both. See _buildLocationTile.
       final lat = double.tryParse(_latitudeController.text.trim());
       final lng = double.tryParse(_longitudeController.text.trim());
-      widget.webViewModel.spoofLatitude = lat;
-      widget.webViewModel.spoofLongitude = lng;
-      widget.webViewModel.locationMode =
-          (lat != null && lng != null) ? LocationMode.spoof : LocationMode.off;
+      if (_isLiveLocation) {
+        widget.webViewModel.locationMode = LocationMode.live;
+        widget.webViewModel.spoofLatitude = null;
+        widget.webViewModel.spoofLongitude = null;
+      } else if (lat != null && lng != null) {
+        widget.webViewModel.locationMode = LocationMode.spoof;
+        widget.webViewModel.spoofLatitude = lat;
+        widget.webViewModel.spoofLongitude = lng;
+      } else {
+        widget.webViewModel.locationMode = LocationMode.off;
+        widget.webViewModel.spoofLatitude = null;
+        widget.webViewModel.spoofLongitude = null;
+      }
       final accuracy = double.tryParse(_accuracyController.text.trim());
       if (accuracy != null && accuracy > 0) {
         widget.webViewModel.spoofAccuracy = accuracy;
       }
       widget.webViewModel.spoofTimezone = _spoofTimezone;
+      widget.webViewModel.spoofTimezoneFromLocation =
+          _spoofTimezoneFromLocation;
       widget.webViewModel.webRtcPolicy = _webRtcPolicy;
 
       if (!mounted) return;
@@ -400,12 +420,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
     });
   }
 
-  /// Build the geolocation row. With no custom location set, shows a single
-  /// "Pick location" button. When set, shows the picked coordinates with
-  /// edit and clear actions. Picking flips `locationMode` to `spoof`;
-  /// clearing flips it back to `off`. The mode dropdown was removed because
-  /// the user cannot meaningfully be in "spoof" mode without coordinates,
-  /// and "off + coords" was never a valid combination.
+  /// Build the geolocation row. Three mutually exclusive states:
+  /// - **off**: no custom location, no live tracking. Shows "Pick" and
+  ///   "Live" buttons; tapping either flips into the corresponding state.
+  /// - **spoof**: static custom coords. Shows the coords with edit and
+  ///   clear icons.
+  /// - **live**: real device GPS forwarded through the shim. Shows
+  ///   "Tracking device location" and a button to switch back.
+  ///
+  /// `locationMode` is derived from this state at save time, not stored
+  /// explicitly here. See [_saveSettings].
   Widget _buildLocationTile() {
     final lat = double.tryParse(_latitudeController.text.trim());
     final lng = double.tryParse(_longitudeController.text.trim());
@@ -415,19 +439,37 @@ class _SettingsScreenState extends State<SettingsScreen> {
     const hint = HintButton(
       title: 'Geolocation',
       description:
-          'When no custom location is set, navigator.geolocation is left '
-          'untouched. Sites get the platform default (typically denied unless '
-          'the user grants permission to the webview).\n\n'
-          'When a custom location is set, navigator.geolocation returns those '
-          'coordinates. Tap "Pick location" to open the picker, where you can '
-          'type coordinates, pick on a map, or use the "Use current location" '
-          'button to fill them with your real device GPS. The shim overrides '
-          'Geolocation.prototype and hides the patch from '
-          'Function.prototype.toString so sites cannot trivially detect that '
-          'it is a shim. For convincing spoofing, also set a matching '
-          'timezone and use a proxy in the same country — otherwise the site '
-          'can cross-check via IP-based geolocation.',
+          'Off (default): navigator.geolocation is left untouched. Sites '
+          'get the platform default (typically denied unless the user '
+          'grants permission to the webview).\n\n'
+          'Custom location: navigator.geolocation returns the coordinates '
+          'you supply. Tap "Pick location" to open the picker, where you '
+          'can type coordinates, pick on a map, or use the "Use current '
+          'location" button to fill them with your real device GPS once. '
+          'The coordinates are then static.\n\n'
+          'Live (device GPS): navigator.geolocation calls back into the '
+          'app on every getCurrentPosition / watchPosition to fetch a '
+          'fresh fix from the platform\'s native location service, so the '
+          'reported position tracks the device as it moves. The shim '
+          'still overrides Geolocation.prototype and hides the patch from '
+          'Function.prototype.toString — so timezone override and WebRTC '
+          'policy still apply, but the coordinates are real and current.',
     );
+
+    if (_isLiveLocation) {
+      return ListTile(
+        title: Row(
+          children: const [Flexible(child: Text('Geolocation')), hint],
+        ),
+        subtitle: const Text('Live: tracks device GPS via the platform '
+            'location service'),
+        trailing: IconButton(
+          tooltip: 'Disable live tracking',
+          icon: const Icon(Icons.close),
+          onPressed: () => setState(() => _isLiveLocation = false),
+        ),
+      );
+    }
 
     if (!hasCoords) {
       return ListTile(
@@ -435,10 +477,20 @@ class _SettingsScreenState extends State<SettingsScreen> {
           children: const [Flexible(child: Text('Geolocation')), hint],
         ),
         subtitle: const Text('No custom location set'),
-        trailing: OutlinedButton.icon(
-          icon: const Icon(Icons.map_outlined),
-          label: const Text('Pick location'),
-          onPressed: _openLocationPicker,
+        trailing: Wrap(
+          spacing: 4,
+          children: [
+            OutlinedButton.icon(
+              icon: const Icon(Icons.map_outlined, size: 18),
+              label: const Text('Pick'),
+              onPressed: _openLocationPicker,
+            ),
+            OutlinedButton.icon(
+              icon: const Icon(Icons.my_location, size: 18),
+              label: const Text('Live'),
+              onPressed: () => setState(() => _isLiveLocation = true),
+            ),
+          ],
         ),
       );
     }
@@ -473,6 +525,65 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
   }
 
+  /// Sentinel value used in the timezone dropdown for the "From picked
+  /// location" entry. Not a real IANA name — translated to/from the
+  /// `spoofTimezoneFromLocation` bool when reading and writing.
+  static const String _kFromLocationSentinel = '__from_location__';
+
+  Widget _buildTimezoneDropdown() {
+    final tzReady = TimezoneLocationService.instance.isReady;
+    final lat = double.tryParse(_latitudeController.text.trim());
+    final lng = double.tryParse(_longitudeController.text.trim());
+    final hasCoords = lat != null && lng != null;
+    // Preview what the dataset would resolve to right now, so the user can
+    // see whether the lookup will succeed for their picked coords. Falls
+    // back to a hint if either prerequisite is missing.
+    final preview = (tzReady && hasCoords)
+        ? (TimezoneLocationService.instance.lookup(lat, lng) ??
+            'no match — fall through to system default')
+        : (!tzReady
+            ? 'Download polygon dataset in App Settings'
+            : 'Pick a location first');
+
+    final value = _spoofTimezoneFromLocation
+        ? _kFromLocationSentinel
+        : (commonTimezones.any((e) => e.key == _spoofTimezone)
+            ? _spoofTimezone
+            : null);
+
+    final items = <DropdownMenuItem<String?>>[];
+    for (final e in commonTimezones) {
+      items.add(DropdownMenuItem<String?>(
+        value: e.key,
+        child: Text(_timezoneLabel(e)),
+      ));
+    }
+    items.add(DropdownMenuItem<String?>(
+      value: _kFromLocationSentinel,
+      child: Text('From picked location ($preview)'),
+    ));
+
+    return DropdownButtonFormField<String?>(
+      value: value,
+      decoration: const InputDecoration(
+        labelText: 'Timezone',
+        helperText: 'Overrides Intl.DateTimeFormat and Date getters',
+        border: OutlineInputBorder(),
+      ),
+      items: items,
+      isExpanded: true,
+      onChanged: (v) => setState(() {
+        if (v == _kFromLocationSentinel) {
+          _spoofTimezoneFromLocation = true;
+          _spoofTimezone = null;
+        } else {
+          _spoofTimezoneFromLocation = false;
+          _spoofTimezone = v;
+        }
+      }),
+    );
+  }
+
   /// Render a timezone dropdown entry. The `null` (System default) entry is
   /// enriched with the device's current timezone abbreviation/offset and the
   /// current local time, so the user can see what "default" actually entails.
@@ -499,23 +610,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       _buildLocationTile(),
       Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-        child: DropdownButtonFormField<String?>(
-          value: commonTimezones.any((e) => e.key == _spoofTimezone)
-              ? _spoofTimezone
-              : null,
-          decoration: const InputDecoration(
-            labelText: 'Timezone',
-            helperText: 'Overrides Intl.DateTimeFormat and Date getters',
-            border: OutlineInputBorder(),
-          ),
-          items: commonTimezones
-              .map((e) => DropdownMenuItem<String?>(
-                    value: e.key,
-                    child: Text(_timezoneLabel(e)),
-                  ))
-              .toList(),
-          onChanged: (v) => setState(() => _spoofTimezone = v),
-        ),
+        child: _buildTimezoneDropdown(),
       ),
       ListTile(
         title: Row(

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -118,7 +118,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
   String? _selectedLanguage;
   bool _obscureProxyPassword = true;
   bool _showProxyCredentials = false;
-  late LocationMode _locationMode;
   late TextEditingController _latitudeController;
   late TextEditingController _longitudeController;
   late TextEditingController _accuracyController;
@@ -170,7 +169,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _fullscreenMode = widget.webViewModel.fullscreenMode;
     _desktopMode = widget.webViewModel.desktopMode;
     _selectedLanguage = widget.webViewModel.language;
-    _locationMode = widget.webViewModel.locationMode;
+    // locationMode is derived from whether coords are present at save time;
+    // no separate UI state needed (see _buildLocationTile).
     _latitudeController = TextEditingController(
       text: widget.webViewModel.spoofLatitude?.toString() ?? '',
     );
@@ -333,11 +333,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
       widget.webViewModel.fullscreenMode = _fullscreenMode;
       widget.webViewModel.desktopMode = _desktopMode;
       widget.webViewModel.language = _selectedLanguage;
-      widget.webViewModel.locationMode = _locationMode;
-      widget.webViewModel.spoofLatitude =
-          double.tryParse(_latitudeController.text.trim());
-      widget.webViewModel.spoofLongitude =
-          double.tryParse(_longitudeController.text.trim());
+      // locationMode is derived from whether a custom location is set: if
+      // the user has picked coords, mode is `spoof`; otherwise `off`. The
+      // dropdown UI was replaced with a single Pick/Clear button — see
+      // _buildLocationSection.
+      final lat = double.tryParse(_latitudeController.text.trim());
+      final lng = double.tryParse(_longitudeController.text.trim());
+      widget.webViewModel.spoofLatitude = lat;
+      widget.webViewModel.spoofLongitude = lng;
+      widget.webViewModel.locationMode =
+          (lat != null && lng != null) ? LocationMode.spoof : LocationMode.off;
       final accuracy = double.tryParse(_accuracyController.text.trim());
       if (accuracy != null && accuracy > 0) {
         widget.webViewModel.spoofAccuracy = accuracy;
@@ -395,6 +400,79 @@ class _SettingsScreenState extends State<SettingsScreen> {
     });
   }
 
+  /// Build the geolocation row. With no custom location set, shows a single
+  /// "Pick location" button. When set, shows the picked coordinates with
+  /// edit and clear actions. Picking flips `locationMode` to `spoof`;
+  /// clearing flips it back to `off`. The mode dropdown was removed because
+  /// the user cannot meaningfully be in "spoof" mode without coordinates,
+  /// and "off + coords" was never a valid combination.
+  Widget _buildLocationTile() {
+    final lat = double.tryParse(_latitudeController.text.trim());
+    final lng = double.tryParse(_longitudeController.text.trim());
+    final hasCoords = lat != null && lng != null;
+    final acc = double.tryParse(_accuracyController.text.trim()) ?? 50.0;
+
+    const hint = HintButton(
+      title: 'Geolocation',
+      description:
+          'When no custom location is set, navigator.geolocation is left '
+          'untouched. Sites get the platform default (typically denied unless '
+          'the user grants permission to the webview).\n\n'
+          'When a custom location is set, navigator.geolocation returns those '
+          'coordinates. Tap "Pick location" to open the picker, where you can '
+          'type coordinates, pick on a map, or use the "Use current location" '
+          'button to fill them with your real device GPS. The shim overrides '
+          'Geolocation.prototype and hides the patch from '
+          'Function.prototype.toString so sites cannot trivially detect that '
+          'it is a shim. For convincing spoofing, also set a matching '
+          'timezone and use a proxy in the same country — otherwise the site '
+          'can cross-check via IP-based geolocation.',
+    );
+
+    if (!hasCoords) {
+      return ListTile(
+        title: Row(
+          children: const [Flexible(child: Text('Geolocation')), hint],
+        ),
+        subtitle: const Text('No custom location set'),
+        trailing: OutlinedButton.icon(
+          icon: const Icon(Icons.map_outlined),
+          label: const Text('Pick location'),
+          onPressed: _openLocationPicker,
+        ),
+      );
+    }
+
+    return ListTile(
+      title: Row(
+        children: const [Flexible(child: Text('Geolocation')), hint],
+      ),
+      subtitle: Text(
+        '${lat.toStringAsFixed(6)}, ${lng.toStringAsFixed(6)}'
+        '  ±${acc.toStringAsFixed(0)}m',
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            tooltip: 'Edit location',
+            icon: const Icon(Icons.edit_location_alt_outlined),
+            onPressed: _openLocationPicker,
+          ),
+          IconButton(
+            tooltip: 'Clear custom location',
+            icon: const Icon(Icons.close),
+            onPressed: () => setState(() {
+              _latitudeController.clear();
+              _longitudeController.clear();
+              _accuracyController.text = '50';
+            }),
+          ),
+        ],
+      ),
+    );
+  }
+
   /// Render a timezone dropdown entry. The `null` (System default) entry is
   /// enriched with the device's current timezone abbreviation/offset and the
   /// current local time, so the user can see what "default" actually entails.
@@ -418,95 +496,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         child: Text('Location & timezone',
             style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
       ),
-      ListTile(
-        title: Row(
-          children: const [
-            Flexible(child: Text('Geolocation')),
-            HintButton(
-              title: 'Geolocation',
-              description:
-                  'Off: navigator.geolocation is left untouched. The webview\'s '
-                  'platform default applies.\n\n'
-                  'Custom location: navigator.geolocation returns the coordinates '
-                  'you supply below. Use the "Use current location" button in the '
-                  'picker to fill them with your real device GPS, or type any '
-                  'coordinates to spoof. The shim overrides Geolocation.prototype '
-                  'and hides the patch from Function.prototype.toString so sites '
-                  'cannot trivially detect that it is a shim. For convincing '
-                  'spoofing, also set a matching timezone and use a proxy in the '
-                  'same country — otherwise the site can cross-check via '
-                  'IP-based geolocation.',
-            ),
-          ],
-        ),
-        trailing: DropdownButton<LocationMode>(
-          value: _locationMode,
-          onChanged: (v) {
-            if (v != null) setState(() => _locationMode = v);
-          },
-          items: const [
-            DropdownMenuItem(
-                value: LocationMode.off, child: Text('Off')),
-            DropdownMenuItem(
-                value: LocationMode.spoof, child: Text('Custom location')),
-          ],
-        ),
-      ),
-      if (_locationMode == LocationMode.spoof) ...[
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
-          child: Row(
-            children: [
-              Expanded(
-                child: TextFormField(
-                  controller: _latitudeController,
-                  keyboardType: const TextInputType.numberWithOptions(
-                      signed: true, decimal: true),
-                  decoration: const InputDecoration(
-                    labelText: 'Latitude',
-                    hintText: 'e.g. 35.6762',
-                    border: OutlineInputBorder(),
-                  ),
-                ),
-              ),
-              const SizedBox(width: 8),
-              Expanded(
-                child: TextFormField(
-                  controller: _longitudeController,
-                  keyboardType: const TextInputType.numberWithOptions(
-                      signed: true, decimal: true),
-                  decoration: const InputDecoration(
-                    labelText: 'Longitude',
-                    hintText: 'e.g. 139.6503',
-                    border: OutlineInputBorder(),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
-          child: TextFormField(
-            controller: _accuracyController,
-            keyboardType:
-                const TextInputType.numberWithOptions(decimal: true),
-            decoration: const InputDecoration(
-              labelText: 'Accuracy (meters)',
-              hintText: '50',
-              border: OutlineInputBorder(),
-            ),
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
-          child: OutlinedButton.icon(
-            icon: const Icon(Icons.map_outlined),
-            label: const Text('Pick on map'),
-            onPressed: _openLocationPicker,
-          ),
-        ),
-      ],
+      _buildLocationTile(),
       Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
         child: DropdownButtonFormField<String?>(

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -420,13 +420,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
     });
   }
 
-  /// Build the geolocation row. Three mutually exclusive states:
-  /// - **off**: no custom location, no live tracking. Shows "Pick" and
-  ///   "Live" buttons; tapping either flips into the corresponding state.
-  /// - **spoof**: static custom coords. Shows the coords with edit and
-  ///   clear icons.
-  /// - **live**: real device GPS forwarded through the shim. Shows
-  ///   "Tracking device location" and a button to switch back.
+  /// Build the geolocation section. A SegmentedButton at the top (Off /
+  /// Custom / Live) is always visible so all three modes are reachable
+  /// regardless of current state — the previous trailing-button layout
+  /// hid Live once coords were set, leaving no way to switch from spoof
+  /// to live without clearing coords first.
+  ///
+  /// Below the selector a detail row shows whatever's relevant for the
+  /// active mode: nothing for Off, coords + edit/clear for Custom,
+  /// "tracking device GPS" for Live.
   ///
   /// `locationMode` is derived from this state at save time, not stored
   /// explicitly here. See [_saveSettings].
@@ -442,86 +444,173 @@ class _SettingsScreenState extends State<SettingsScreen> {
           'Off (default): navigator.geolocation is left untouched. Sites '
           'get the platform default (typically denied unless the user '
           'grants permission to the webview).\n\n'
-          'Custom location: navigator.geolocation returns the coordinates '
-          'you supply. Tap "Pick location" to open the picker, where you '
-          'can type coordinates, pick on a map, or use the "Use current '
+          'Custom: navigator.geolocation returns the coordinates you '
+          'supply. Tap "Pick location" to open the picker, where you can '
+          'type coordinates, pick on a map, or use the "Use current '
           'location" button to fill them with your real device GPS once. '
           'The coordinates are then static.\n\n'
-          'Live (device GPS): navigator.geolocation calls back into the '
-          'app on every getCurrentPosition / watchPosition to fetch a '
-          'fresh fix from the platform\'s native location service, so the '
-          'reported position tracks the device as it moves. The shim '
-          'still overrides Geolocation.prototype and hides the patch from '
+          'Live: navigator.geolocation calls back into the app on every '
+          'getCurrentPosition / watchPosition to fetch a fresh fix from '
+          'the platform\'s native location service, so the reported '
+          'position tracks the device as it moves. The shim still '
+          'overrides Geolocation.prototype and hides the patch from '
           'Function.prototype.toString — so timezone override and WebRTC '
           'policy still apply, but the coordinates are real and current.',
     );
 
-    if (_isLiveLocation) {
-      return ListTile(
-        title: Row(
-          children: const [Flexible(child: Text('Geolocation')), hint],
-        ),
-        subtitle: const Text('Live: tracks device GPS via the platform '
-            'location service'),
-        trailing: IconButton(
-          tooltip: 'Disable live tracking',
-          icon: const Icon(Icons.close),
-          onPressed: () => setState(() => _isLiveLocation = false),
-        ),
-      );
+    // Derive the active segment from current state. `Custom` is selected
+    // when there are coords AND we're not in live mode; `Live` is selected
+    // when the live flag is on (regardless of whether stale coords linger
+    // — they're ignored on save in that branch).
+    final _LocationSegment selected = _isLiveLocation
+        ? _LocationSegment.live
+        : (hasCoords ? _LocationSegment.custom : _LocationSegment.off);
+
+    void onSegmentChanged(Set<_LocationSegment> values) {
+      final v = values.first;
+      setState(() {
+        switch (v) {
+          case _LocationSegment.off:
+            _isLiveLocation = false;
+            _latitudeController.clear();
+            _longitudeController.clear();
+            _accuracyController.text = '50';
+            break;
+          case _LocationSegment.custom:
+            _isLiveLocation = false;
+            // If switching from off → custom with no coords yet, open the
+            // picker so the user lands on something useful instead of
+            // an empty selection. From live → custom we keep whatever
+            // coords were last saved (probably none) and the picker is
+            // one tap away on the detail row.
+            if (!hasCoords) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (mounted) _openLocationPicker();
+              });
+            }
+            break;
+          case _LocationSegment.live:
+            _isLiveLocation = true;
+            break;
+        }
+      });
     }
 
-    if (!hasCoords) {
-      return ListTile(
-        title: Row(
-          children: const [Flexible(child: Text('Geolocation')), hint],
-        ),
-        subtitle: const Text('No custom location set'),
-        trailing: Wrap(
-          spacing: 4,
-          children: [
-            OutlinedButton.icon(
-              icon: const Icon(Icons.map_outlined, size: 18),
-              label: const Text('Pick'),
-              onPressed: _openLocationPicker,
+    final selector = SegmentedButton<_LocationSegment>(
+      segments: const [
+        ButtonSegment(
+            value: _LocationSegment.off,
+            icon: Icon(Icons.location_disabled),
+            label: Text('Off')),
+        ButtonSegment(
+            value: _LocationSegment.custom,
+            icon: Icon(Icons.map_outlined),
+            label: Text('Custom')),
+        ButtonSegment(
+            value: _LocationSegment.live,
+            icon: Icon(Icons.my_location),
+            label: Text('Live')),
+      ],
+      selected: {selected},
+      onSelectionChanged: onSegmentChanged,
+      showSelectedIcon: false,
+    );
+
+    Widget detail;
+    switch (selected) {
+      case _LocationSegment.off:
+        detail = const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          child: Text(
+            'Sites use the webview default (typically denied).',
+            style: TextStyle(fontSize: 12),
+          ),
+        );
+        break;
+      case _LocationSegment.live:
+        detail = const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          child: Text(
+            'Tracks the device\'s real GPS via the platform location '
+            'service. Permission is requested on the first call.',
+            style: TextStyle(fontSize: 12),
+          ),
+        );
+        break;
+      case _LocationSegment.custom:
+        if (hasCoords) {
+          detail = ListTile(
+            dense: true,
+            contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+            title: Text(
+              '${lat.toStringAsFixed(6)}, ${lng.toStringAsFixed(6)}  '
+              '±${acc.toStringAsFixed(0)}m',
             ),
-            OutlinedButton.icon(
-              icon: const Icon(Icons.my_location, size: 18),
-              label: const Text('Live'),
-              onPressed: () => setState(() => _isLiveLocation = true),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconButton(
+                  tooltip: 'Edit location',
+                  icon: const Icon(Icons.edit_location_alt_outlined),
+                  onPressed: _openLocationPicker,
+                ),
+                IconButton(
+                  tooltip: 'Clear custom location',
+                  icon: const Icon(Icons.close),
+                  onPressed: () => setState(() {
+                    _latitudeController.clear();
+                    _longitudeController.clear();
+                    _accuracyController.text = '50';
+                  }),
+                ),
+              ],
             ),
-          ],
-        ),
-      );
+          );
+        } else {
+          detail = Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            child: Row(
+              children: [
+                const Expanded(child: Text(
+                  'No custom location set',
+                  style: TextStyle(fontSize: 12),
+                )),
+                OutlinedButton.icon(
+                  icon: const Icon(Icons.map_outlined, size: 18),
+                  label: const Text('Pick'),
+                  onPressed: _openLocationPicker,
+                ),
+              ],
+            ),
+          );
+        }
+        break;
     }
 
-    return ListTile(
-      title: Row(
-        children: const [Flexible(child: Text('Geolocation')), hint],
-      ),
-      subtitle: Text(
-        '${lat.toStringAsFixed(6)}, ${lng.toStringAsFixed(6)}'
-        '  ±${acc.toStringAsFixed(0)}m',
-      ),
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          IconButton(
-            tooltip: 'Edit location',
-            icon: const Icon(Icons.edit_location_alt_outlined),
-            onPressed: _openLocationPicker,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          child: Row(
+            children: const [
+              Text('Geolocation',
+                  style: TextStyle(fontWeight: FontWeight.w500)),
+              hint,
+            ],
           ),
-          IconButton(
-            tooltip: 'Clear custom location',
-            icon: const Icon(Icons.close),
-            onPressed: () => setState(() {
-              _latitudeController.clear();
-              _longitudeController.clear();
-              _accuracyController.text = '50';
-            }),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: SizedBox(
+            // SegmentedButton wants a constrained width; give it the full
+            // row so the three pills don't crowd into a corner on tablets.
+            width: double.infinity,
+            child: selector,
           ),
-        ],
-      ),
+        ),
+        detail,
+      ],
     );
   }
 
@@ -1086,3 +1175,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
   }
 }
+
+/// Three-way segmented control state for the per-site geolocation row.
+/// Maps to LocationMode at save time:
+///   off    -> LocationMode.off     (no shim)
+///   custom -> LocationMode.spoof   (static user-supplied coords)
+///   live   -> LocationMode.live    (real device GPS via the shim's
+///                                   getRealLocation handler)
+enum _LocationSegment { off, custom, live }
+

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -395,6 +395,22 @@ class _SettingsScreenState extends State<SettingsScreen> {
     });
   }
 
+  /// Render a timezone dropdown entry. The `null` (System default) entry is
+  /// enriched with the device's current timezone abbreviation/offset and the
+  /// current local time, so the user can see what "default" actually entails.
+  String _timezoneLabel(MapEntry<String?, String> entry) {
+    if (entry.key != null) return entry.value;
+    final now = DateTime.now();
+    final tzName = now.timeZoneName;
+    final offset = now.timeZoneOffset;
+    final sign = offset.isNegative ? '-' : '+';
+    final hours = offset.inHours.abs().toString().padLeft(2, '0');
+    final mins = (offset.inMinutes.abs() % 60).toString().padLeft(2, '0');
+    final hh = now.hour.toString().padLeft(2, '0');
+    final mm = now.minute.toString().padLeft(2, '0');
+    return '${entry.value} ($tzName, UTC$sign$hours:$mins, $hh:$mm)';
+  }
+
   List<Widget> _buildLocationSection() {
     return [
       const Padding(
@@ -407,14 +423,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
           children: const [
             Flexible(child: Text('Geolocation')),
             HintButton(
-              title: 'Geolocation spoofing',
+              title: 'Geolocation',
               description:
-                  'Returns user-supplied coordinates from navigator.geolocation. '
-                  'The shim overrides Geolocation.prototype and hides the patch '
-                  'from Function.prototype.toString, so sites cannot trivially '
-                  'detect the spoof. For convincing results, also set a matching '
-                  'timezone and use a proxy in the same country — otherwise the '
-                  'site can cross-check via IP-based geolocation.',
+                  'Off: navigator.geolocation is left untouched. The webview\'s '
+                  'platform default applies.\n\n'
+                  'Custom location: navigator.geolocation returns the coordinates '
+                  'you supply below. Use the "Use current location" button in the '
+                  'picker to fill them with your real device GPS, or type any '
+                  'coordinates to spoof. The shim overrides Geolocation.prototype '
+                  'and hides the patch from Function.prototype.toString so sites '
+                  'cannot trivially detect that it is a shim. For convincing '
+                  'spoofing, also set a matching timezone and use a proxy in the '
+                  'same country — otherwise the site can cross-check via '
+                  'IP-based geolocation.',
             ),
           ],
         ),
@@ -425,9 +446,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
           },
           items: const [
             DropdownMenuItem(
-                value: LocationMode.off, child: Text('Off (use real)')),
+                value: LocationMode.off, child: Text('Off')),
             DropdownMenuItem(
-                value: LocationMode.spoof, child: Text('Spoof')),
+                value: LocationMode.spoof, child: Text('Custom location')),
           ],
         ),
       ),
@@ -500,7 +521,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           items: commonTimezones
               .map((e) => DropdownMenuItem<String?>(
                     value: e.key,
-                    child: Text(e.value),
+                    child: Text(_timezoneLabel(e)),
                   ))
               .toList(),
           onChanged: (v) => setState(() => _spoofTimezone = v),

--- a/lib/services/current_location_service.dart
+++ b/lib/services/current_location_service.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+import 'package:flutter/services.dart';
+
+enum CurrentLocationStatus {
+  ok,
+  permissionDenied,
+  permissionDeniedForever,
+  serviceDisabled,
+  timeout,
+  unsupported,
+  error,
+}
+
+class CurrentLocationFix {
+  final double latitude;
+  final double longitude;
+  final double accuracy;
+
+  const CurrentLocationFix({
+    required this.latitude,
+    required this.longitude,
+    required this.accuracy,
+  });
+}
+
+class CurrentLocationResult {
+  final CurrentLocationStatus status;
+  final CurrentLocationFix? fix;
+  final String? message;
+
+  const CurrentLocationResult._(this.status, this.fix, this.message);
+
+  factory CurrentLocationResult.ok(CurrentLocationFix fix) =>
+      CurrentLocationResult._(CurrentLocationStatus.ok, fix, null);
+
+  factory CurrentLocationResult.failure(
+          CurrentLocationStatus status, String? message) =>
+      CurrentLocationResult._(status, null, message);
+}
+
+/// Thin wrapper around the platform method channel that returns a single GPS
+/// fix from the device's native location service. Uses Android's
+/// `LocationManager` (no Google Play Services) and iOS's `CLLocationManager`.
+/// Permission prompts are issued by the native side on demand.
+class CurrentLocationService {
+  static const _channel =
+      MethodChannel('org.codeberg.theoden8.webspace/location');
+
+  static bool get isSupported => Platform.isAndroid || Platform.isIOS;
+
+  static Future<CurrentLocationResult> getCurrentLocation({
+    Duration timeout = const Duration(seconds: 30),
+  }) async {
+    if (!isSupported) {
+      return CurrentLocationResult.failure(
+        CurrentLocationStatus.unsupported,
+        'Current location is not available on this platform.',
+      );
+    }
+    try {
+      final raw = await _channel.invokeMethod<dynamic>('getCurrentLocation', {
+        'timeoutMs': timeout.inMilliseconds,
+      });
+      if (raw is! Map) {
+        return CurrentLocationResult.failure(
+          CurrentLocationStatus.error,
+          'Unexpected response from platform.',
+        );
+      }
+      final status = (raw['status'] as String?) ?? 'error';
+      switch (status) {
+        case 'ok':
+          final lat = (raw['latitude'] as num?)?.toDouble();
+          final lng = (raw['longitude'] as num?)?.toDouble();
+          final acc = (raw['accuracy'] as num?)?.toDouble() ?? 0;
+          if (lat == null || lng == null) {
+            return CurrentLocationResult.failure(
+              CurrentLocationStatus.error,
+              'Missing coordinates in platform response.',
+            );
+          }
+          return CurrentLocationResult.ok(
+            CurrentLocationFix(latitude: lat, longitude: lng, accuracy: acc),
+          );
+        case 'permission_denied':
+          return CurrentLocationResult.failure(
+              CurrentLocationStatus.permissionDenied,
+              raw['message'] as String?);
+        case 'permission_denied_forever':
+          return CurrentLocationResult.failure(
+              CurrentLocationStatus.permissionDeniedForever,
+              raw['message'] as String?);
+        case 'service_disabled':
+          return CurrentLocationResult.failure(
+              CurrentLocationStatus.serviceDisabled,
+              raw['message'] as String?);
+        case 'timeout':
+          return CurrentLocationResult.failure(
+              CurrentLocationStatus.timeout, raw['message'] as String?);
+        default:
+          return CurrentLocationResult.failure(
+              CurrentLocationStatus.error, raw['message'] as String?);
+      }
+    } on PlatformException catch (e) {
+      return CurrentLocationResult.failure(
+          CurrentLocationStatus.error, e.message);
+    } catch (e) {
+      return CurrentLocationResult.failure(
+          CurrentLocationStatus.error, e.toString());
+    }
+  }
+}

--- a/lib/services/location_spoof_service.dart
+++ b/lib/services/location_spoof_service.dart
@@ -34,10 +34,13 @@ class LocationSpoofService {
     final spoofLocation = locationMode == LocationMode.spoof &&
         spoofLatitude != null &&
         spoofLongitude != null;
+    final liveLocation = locationMode == LocationMode.live;
     final hasTimezone = spoofTimezone != null && spoofTimezone.isNotEmpty;
     final hasWebRtc = webRtcPolicy != WebRtcPolicy.defaultPolicy;
 
-    if (!spoofLocation && !hasTimezone && !hasWebRtc) return null;
+    if (!spoofLocation && !liveLocation && !hasTimezone && !hasWebRtc) {
+      return null;
+    }
 
     final lat = spoofLatitude ?? 0.0;
     final lng = spoofLongitude ?? 0.0;
@@ -50,7 +53,8 @@ class LocationSpoofService {
     };
 
     return _template
-        .replaceAll('__SPOOF_LOC__', spoofLocation ? 'true' : 'false')
+        .replaceAll('__STATIC_LOC__', spoofLocation ? 'true' : 'false')
+        .replaceAll('__LIVE_LOC__', liveLocation ? 'true' : 'false')
         .replaceAll('__LAT__', lat.toString())
         .replaceAll('__LNG__', lng.toString())
         .replaceAll('__ACC__', acc.toString())
@@ -64,7 +68,8 @@ const String _template = r'''
   if (window.__wsLocShimInstalled) return;
   window.__wsLocShimInstalled = true;
 
-  var SPOOF_LOC = __SPOOF_LOC__;
+  var STATIC_LOC = __STATIC_LOC__;
+  var LIVE_LOC = __LIVE_LOC__;
   var LAT = __LAT__;
   var LNG = __LNG__;
   var ACC = __ACC__;
@@ -93,22 +98,23 @@ const String _template = r'''
     } catch (e) {}
   }
 
-  // --- Geolocation spoofing ---
-  if (SPOOF_LOC && navigator.geolocation) {
+  // --- Geolocation: spoof (static) or live (real device GPS via Dart) ---
+  if ((STATIC_LOC || LIVE_LOC) && navigator.geolocation) {
     var _coordsProto = (typeof GeolocationCoordinates !== 'undefined')
       ? GeolocationCoordinates.prototype : Object.prototype;
     var _posProto = (typeof GeolocationPosition !== 'undefined')
       ? GeolocationPosition.prototype : Object.prototype;
 
-    function makeCoords() {
-      // Sub-meter jitter so watchPosition doesn't return identical frames.
+    function makeCoordsFrom(lat, lng, acc) {
+      // Sub-meter jitter so watchPosition doesn't return identical frames
+      // when the device is stationary (also masks discretized GPS rounding).
       var jLat = (Math.random() - 0.5) * 0.00002;
       var jLng = (Math.random() - 0.5) * 0.00002;
       var c = Object.create(_coordsProto);
       Object.defineProperties(c, {
-        latitude: { value: LAT + jLat, enumerable: true },
-        longitude: { value: LNG + jLng, enumerable: true },
-        accuracy: { value: ACC, enumerable: true },
+        latitude: { value: lat + jLat, enumerable: true },
+        longitude: { value: lng + jLng, enumerable: true },
+        accuracy: { value: acc > 0 ? acc : 50, enumerable: true },
         altitude: { value: null, enumerable: true },
         altitudeAccuracy: { value: null, enumerable: true },
         heading: { value: null, enumerable: true },
@@ -116,20 +122,68 @@ const String _template = r'''
       });
       return c;
     }
-    function makePosition() {
+    function makePositionFrom(lat, lng, acc) {
       var p = Object.create(_posProto);
       Object.defineProperties(p, {
-        coords: { value: makeCoords(), enumerable: true },
+        coords: { value: makeCoordsFrom(lat, lng, acc), enumerable: true },
         timestamp: { value: Date.now(), enumerable: true },
       });
       return p;
     }
+    function makePositionStatic() {
+      return makePositionFrom(LAT, LNG, ACC);
+    }
+
+    // Map a Dart status payload to a GeolocationPositionError code:
+    //   1 = PERMISSION_DENIED, 2 = POSITION_UNAVAILABLE, 3 = TIMEOUT.
+    function geolocationErrorFor(payload) {
+      var code = 2;
+      if (payload && payload.status === 'permission_denied') code = 1;
+      else if (payload && payload.status === 'permission_denied_forever') code = 1;
+      else if (payload && payload.status === 'timeout') code = 3;
+      return {
+        code: code,
+        message: (payload && payload.message) || 'unknown',
+        PERMISSION_DENIED: 1,
+        POSITION_UNAVAILABLE: 2,
+        TIMEOUT: 3,
+      };
+    }
+
+    // Single source of truth for fetching a fresh real fix in live mode.
+    // Returns a Promise that resolves with either {ok, lat, lng, acc} or
+    // {error, payload}. The handler is registered Dart-side only when the
+    // mode is `live`; if it's missing here we still defensively fail
+    // closed so a legacy/no-handler page doesn't hang forever.
+    function getLiveFix() {
+      if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
+        return window.flutter_inappwebview.callHandler('getRealLocation').then(function(res) {
+          if (res && res.status === 'ok') {
+            return { ok: true, lat: res.latitude, lng: res.longitude, acc: res.accuracy };
+          }
+          return { ok: false, payload: res };
+        }, function() {
+          return { ok: false, payload: { status: 'error', message: 'handler_failed' } };
+        });
+      }
+      return Promise.resolve({ ok: false, payload: { status: 'error', message: 'no_handler' } });
+    }
 
     var _latency = 150 + Math.random() * 250;
     var _getCurrent = function getCurrentPosition(success, error, options) {
-      setTimeout(function() {
-        if (success) { try { success(makePosition()); } catch (e) {} }
-      }, _latency);
+      if (LIVE_LOC) {
+        getLiveFix().then(function(r) {
+          if (r.ok) {
+            if (success) { try { success(makePositionFrom(r.lat, r.lng, r.acc)); } catch (e) {} }
+          } else if (error) {
+            try { error(geolocationErrorFor(r.payload)); } catch (e) {}
+          }
+        });
+      } else {
+        setTimeout(function() {
+          if (success) { try { success(makePositionStatic()); } catch (e) {} }
+        }, _latency);
+      }
     };
     asNative(_getCurrent, 'getCurrentPosition');
 
@@ -137,12 +191,30 @@ const String _template = r'''
     var _watchTimers = {};
     var _watch = function watchPosition(success, error, options) {
       var id = ++_watchId;
-      setTimeout(function() {
-        if (success) { try { success(makePosition()); } catch (e) {} }
-      }, _latency);
-      _watchTimers[id] = setInterval(function() {
-        if (success) { try { success(makePosition()); } catch (e) {} }
-      }, 1000);
+      if (LIVE_LOC) {
+        var tick = function() {
+          getLiveFix().then(function(r) {
+            if (r.ok) {
+              if (success) { try { success(makePositionFrom(r.lat, r.lng, r.acc)); } catch (e) {} }
+            } else if (error) {
+              try { error(geolocationErrorFor(r.payload)); } catch (e) {}
+            }
+          });
+        };
+        // Fire once immediately, then poll. 5s is the same cadence used by
+        // most real GPS receivers under battery-conservative settings; the
+        // page can call clearWatch to stop. We don't expose this period to
+        // pages — `options.maximumAge` etc. are intentionally ignored.
+        setTimeout(tick, _latency);
+        _watchTimers[id] = setInterval(tick, 5000);
+      } else {
+        setTimeout(function() {
+          if (success) { try { success(makePositionStatic()); } catch (e) {} }
+        }, _latency);
+        _watchTimers[id] = setInterval(function() {
+          if (success) { try { success(makePositionStatic()); } catch (e) {} }
+        }, 1000);
+      }
       return id;
     };
     asNative(_watch, 'watchPosition');

--- a/lib/services/timezone_location_service.dart
+++ b/lib/services/timezone_location_service.dart
@@ -1,0 +1,309 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'log_service.dart';
+
+/// Default download URL: the latest `timezones-now` GeoJSON zip from
+/// `evansiroky/timezone-boundary-builder`. ~7–15 MB compressed, ~30–60 MB
+/// uncompressed. Each Feature has `properties.tzid` (IANA name) and a
+/// `geometry` of type Polygon or MultiPolygon.
+const String _defaultUrl =
+    'https://github.com/evansiroky/timezone-boundary-builder/releases/latest/download/timezones-now.geojson.zip';
+
+const String _cacheFileName = 'tz_polygons.geojson';
+const String _urlPrefKey = 'tz_polygons_url';
+const String _lastUpdatedPrefKey = 'tz_polygons_last_updated';
+
+/// One zone's polygon set, prepared for fast point-in-polygon lookup.
+class _ZoneEntry {
+  final String tzid;
+  // Each polygon is a list of rings; the first ring is the outer boundary,
+  // the rest are holes. Each ring is a flat list of [lng, lat, lng, lat,
+  // ...] for cache locality.
+  final List<List<Float64List>> polygons;
+  // Bounding box of the zone (minLng, minLat, maxLng, maxLat) — used to
+  // skip polygons whose bbox doesn't contain the query point. Without this
+  // every lookup would do PiP against ~hundreds of zones.
+  final double minLng, minLat, maxLng, maxLat;
+
+  _ZoneEntry(this.tzid, this.polygons, this.minLng, this.minLat,
+      this.maxLng, this.maxLat);
+}
+
+/// Singleton service for downloading, caching, and querying a GeoJSON
+/// timezone-polygon dataset. Used by the per-site location settings to
+/// expose a "From picked location" timezone option, which resolves the
+/// IANA zone of the user's spoofed coordinates at shim build time.
+///
+/// Pattern matches [DnsBlockService] / [ContentBlockerService] /
+/// [LocalCdnService]: the data is opt-in (the user must explicitly tap
+/// "Download timezone data" in app settings), persists across launches in
+/// app private storage, and notifies listeners on change so dependent UI
+/// (the per-site dropdown) can re-evaluate.
+class TimezoneLocationService {
+  static TimezoneLocationService? _instance;
+  static TimezoneLocationService get instance =>
+      _instance ??= TimezoneLocationService._();
+
+  TimezoneLocationService._();
+
+  List<_ZoneEntry>? _zones;
+  bool _loadAttempted = false;
+
+  /// True iff a polygon dataset is parsed and ready for lookups.
+  bool get isReady => _zones != null && _zones!.isNotEmpty;
+
+  /// Number of IANA zones in the loaded dataset (0 if not loaded).
+  int get zoneCount => _zones?.length ?? 0;
+
+  final List<VoidCallback> _listeners = [];
+
+  void addListener(VoidCallback listener) => _listeners.add(listener);
+  void removeListener(VoidCallback listener) => _listeners.remove(listener);
+
+  void _notifyListeners() {
+    for (final l in List<VoidCallback>.from(_listeners)) {
+      l();
+    }
+  }
+
+  Future<File> _cacheFile() async {
+    final dir = await getApplicationDocumentsDirectory();
+    return File('${dir.path}/$_cacheFileName');
+  }
+
+  /// Configured download URL (user-overridable in app settings).
+  Future<String> getUrl() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_urlPrefKey) ?? _defaultUrl;
+  }
+
+  /// Persist a new download URL. Does not trigger a download — the user
+  /// must press "Download" again to fetch from the new URL.
+  Future<void> setUrl(String url) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_urlPrefKey, url);
+  }
+
+  /// Last successful download timestamp, or null if never downloaded.
+  Future<DateTime?> getLastUpdated() async {
+    final prefs = await SharedPreferences.getInstance();
+    final s = prefs.getString(_lastUpdatedPrefKey);
+    if (s == null) return null;
+    return DateTime.tryParse(s);
+  }
+
+  /// Load the cached dataset from disk if present. Idempotent — subsequent
+  /// calls return the already-loaded set. Called lazily on first lookup
+  /// and eagerly at app startup so the UI knows whether the dataset is
+  /// ready before the user opens settings.
+  Future<bool> loadFromCacheIfPresent() async {
+    if (_zones != null) return true;
+    if (_loadAttempted) return false;
+    _loadAttempted = true;
+    try {
+      final file = await _cacheFile();
+      if (!await file.exists()) return false;
+      final raw = await file.readAsString();
+      _parse(raw);
+      LogService.instance
+          .log('TZ', 'Loaded ${_zones?.length ?? 0} zones from cache');
+      _notifyListeners();
+      return _zones != null;
+    } catch (e) {
+      LogService.instance
+          .log('TZ', 'Failed to load tz cache: $e', level: LogLevel.error);
+      return false;
+    }
+  }
+
+  /// Download and persist a fresh dataset from the configured URL.
+  /// Returns true on success. The download is allowed to be slow and
+  /// large (tens of megabytes); callers should show progress UI.
+  Future<bool> download({Duration timeout = const Duration(minutes: 5)}) async {
+    final url = await getUrl();
+    try {
+      LogService.instance.log('TZ', 'Downloading $url');
+      final response = await http.get(
+        Uri.parse(url),
+        headers: const {'User-Agent': 'Webspace (+https://github.com/theoden8/webspace_app)'},
+      ).timeout(timeout);
+      if (response.statusCode != 200) {
+        LogService.instance.log(
+            'TZ', 'Download failed: HTTP ${response.statusCode}',
+            level: LogLevel.error);
+        return false;
+      }
+
+      String body;
+      if (url.toLowerCase().endsWith('.zip')) {
+        // tb_builder publishes zipped GeoJSON. Pull out the first .geojson
+        // entry — releases contain exactly one.
+        final archive = ZipDecoder().decodeBytes(response.bodyBytes);
+        ArchiveFile? gj;
+        for (final f in archive.files) {
+          if (f.isFile && f.name.toLowerCase().endsWith('.geojson')) {
+            gj = f;
+            break;
+          }
+        }
+        if (gj == null) {
+          LogService.instance.log('TZ', 'Zip contains no .geojson file',
+              level: LogLevel.error);
+          return false;
+        }
+        body = utf8.decode(gj.content as List<int>);
+      } else {
+        body = response.body;
+      }
+
+      // Write through to disk first so a parse failure leaves the file
+      // recoverable (the user can edit it / re-download).
+      final file = await _cacheFile();
+      await file.writeAsString(body);
+
+      _parse(body);
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+          _lastUpdatedPrefKey, DateTime.now().toIso8601String());
+      LogService.instance.log('TZ',
+          'Downloaded and parsed ${_zones?.length ?? 0} zones from $url');
+      _notifyListeners();
+      return true;
+    } catch (e) {
+      LogService.instance
+          .log('TZ', 'Download error: $e', level: LogLevel.error);
+      return false;
+    }
+  }
+
+  /// Drop the cached dataset and any in-memory parse.
+  Future<void> clear() async {
+    _zones = null;
+    _loadAttempted = false;
+    try {
+      final file = await _cacheFile();
+      if (await file.exists()) await file.delete();
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(_lastUpdatedPrefKey);
+    } catch (e) {
+      LogService.instance
+          .log('TZ', 'Clear error: $e', level: LogLevel.error);
+    }
+    _notifyListeners();
+  }
+
+  void _parse(String body) {
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    final features = (json['features'] as List?) ?? const [];
+    final zones = <_ZoneEntry>[];
+    for (final f in features) {
+      if (f is! Map) continue;
+      final props = f['properties'] as Map?;
+      final tzid = props?['tzid'] as String?;
+      if (tzid == null || tzid.isEmpty) continue;
+      final geometry = f['geometry'] as Map?;
+      if (geometry == null) continue;
+      final type = geometry['type'] as String?;
+      final coords = geometry['coordinates'] as List?;
+      if (coords == null) continue;
+
+      final polygons = <List<Float64List>>[];
+      double minLng = double.infinity,
+          minLat = double.infinity,
+          maxLng = -double.infinity,
+          maxLat = -double.infinity;
+
+      void addPolygon(List<dynamic> rings) {
+        final ringList = <Float64List>[];
+        for (final ring in rings) {
+          if (ring is! List) continue;
+          final flat = Float64List(ring.length * 2);
+          var i = 0;
+          for (final pt in ring) {
+            if (pt is! List || pt.length < 2) continue;
+            final lng = (pt[0] as num).toDouble();
+            final lat = (pt[1] as num).toDouble();
+            flat[i++] = lng;
+            flat[i++] = lat;
+            if (lng < minLng) minLng = lng;
+            if (lat < minLat) minLat = lat;
+            if (lng > maxLng) maxLng = lng;
+            if (lat > maxLat) maxLat = lat;
+          }
+          ringList.add(flat);
+        }
+        if (ringList.isNotEmpty) polygons.add(ringList);
+      }
+
+      if (type == 'Polygon') {
+        addPolygon(coords);
+      } else if (type == 'MultiPolygon') {
+        for (final poly in coords) {
+          if (poly is List) addPolygon(poly);
+        }
+      } else {
+        continue;
+      }
+
+      if (polygons.isEmpty) continue;
+      zones.add(_ZoneEntry(tzid, polygons, minLng, minLat, maxLng, maxLat));
+    }
+    _zones = zones;
+  }
+
+  /// Look up the IANA timezone whose polygon set contains the point.
+  /// Returns null if the dataset is not ready or the point falls outside
+  /// every loaded zone (e.g. open ocean in the no-oceans dataset).
+  ///
+  /// Uses bbox prefilter + ray-cast PiP. Not blazing fast on the first
+  /// matching zone scan, but the result is stable and we only call this
+  /// once per webview creation per site, not on every JS call.
+  String? lookup(double latitude, double longitude) {
+    final zones = _zones;
+    if (zones == null || zones.isEmpty) return null;
+    for (final z in zones) {
+      if (longitude < z.minLng || longitude > z.maxLng) continue;
+      if (latitude < z.minLat || latitude > z.maxLat) continue;
+      for (final rings in z.polygons) {
+        if (rings.isEmpty) continue;
+        // Outer ring contains the point AND no hole contains it.
+        if (!_pointInRing(rings.first, longitude, latitude)) continue;
+        var inHole = false;
+        for (var i = 1; i < rings.length; i++) {
+          if (_pointInRing(rings[i], longitude, latitude)) {
+            inHole = true;
+            break;
+          }
+        }
+        if (!inHole) return z.tzid;
+      }
+    }
+    return null;
+  }
+
+  /// Even-odd ray-cast test. `ring` is a flat [lng, lat, lng, lat, ...]
+  /// closed polygon. Robust enough for IANA zone polygons; we don't
+  /// special-case the antimeridian because the dataset already splits
+  /// zones that cross it.
+  static bool _pointInRing(Float64List ring, double x, double y) {
+    var inside = false;
+    final n = ring.length;
+    if (n < 6) return false;
+    for (var i = 0, j = n - 2; i < n; j = i, i += 2) {
+      final xi = ring[i], yi = ring[i + 1];
+      final xj = ring[j], yj = ring[j + 1];
+      final intersects = ((yi > y) != (yj > y)) &&
+          (x < (xj - xi) * (y - yi) / ((yj - yi) == 0 ? 1e-30 : (yj - yi)) + xi);
+      if (intersects) inside = !inside;
+    }
+    return inside;
+  }
+}

--- a/lib/services/timezone_location_service.dart
+++ b/lib/services/timezone_location_service.dart
@@ -144,18 +144,33 @@ class TimezoneLocationService {
 
       String body;
       if (url.toLowerCase().endsWith('.zip')) {
-        // tb_builder publishes zipped GeoJSON. Pull out the first .geojson
-        // entry — releases contain exactly one.
+        // timezone-boundary-builder release zips name the inner file
+        // `combined-now.json` (or `combined.json`, `combined-with-oceans.json`)
+        // — not `.geojson` — even though the *zip* is `*.geojson.zip`.
+        // Accept either extension; fall back to the largest JSON-ish file
+        // if neither is present so the dataset doesn't fail to load when a
+        // future release renames things.
         final archive = ZipDecoder().decodeBytes(response.bodyBytes);
         ArchiveFile? gj;
+        ArchiveFile? largestJson;
+        var largestSize = 0;
         for (final f in archive.files) {
-          if (f.isFile && f.name.toLowerCase().endsWith('.geojson')) {
+          if (!f.isFile) continue;
+          final n = f.name.toLowerCase();
+          if (n.endsWith('.geojson')) {
             gj = f;
             break;
           }
+          if (n.endsWith('.json') && f.size > largestSize) {
+            largestJson = f;
+            largestSize = f.size;
+          }
         }
+        gj ??= largestJson;
         if (gj == null) {
-          LogService.instance.log('TZ', 'Zip contains no .geojson file',
+          LogService.instance.log('TZ',
+              'Zip contains no .geojson or .json file (entries: '
+              '${archive.files.where((f) => f.isFile).map((f) => f.name).join(", ")})',
               level: LogLevel.error);
           return false;
         }

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -9,7 +9,9 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
 import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
+import 'package:webspace/services/current_location_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
+import 'package:webspace/services/timezone_location_service.dart';
 import 'package:webspace/services/download_engine.dart';
 import 'package:webspace/services/download_manager.dart';
 import 'package:webspace/services/download_url_revert_engine.dart';
@@ -291,6 +293,12 @@ class WebViewConfig {
   /// IANA timezone name reported via [Intl.DateTimeFormat] and
   /// [Date.prototype.getTimezoneOffset]. Null leaves the real zone.
   final String? spoofTimezone;
+  /// When true, the effective spoof timezone is derived from
+  /// (spoofLatitude, spoofLongitude) at shim build time using
+  /// [TimezoneLocationService]. Mutually exclusive with [spoofTimezone];
+  /// if the polygon dataset is absent or the lookup misses, this falls
+  /// through to no-timezone-spoof.
+  final bool spoofTimezoneFromLocation;
   /// WebRTC policy — prevents real-IP leak that bypasses HTTP(S)/SOCKS proxies.
   final WebRtcPolicy webRtcPolicy;
 
@@ -324,6 +332,7 @@ class WebViewConfig {
     this.spoofLongitude,
     this.spoofAccuracy = 50.0,
     this.spoofTimezone,
+    this.spoofTimezoneFromLocation = false,
     this.webRtcPolicy = WebRtcPolicy.defaultPolicy,
   });
 }
@@ -829,6 +838,20 @@ class WebViewFactory {
       ));
     }
 
+    // Resolve the effective spoof timezone. If the user picked
+    // "From picked location" AND the polygon dataset is loaded AND there
+    // are coordinates, look up the IANA zone here so the JS shim sees a
+    // concrete value. If the dataset is missing or the lookup misses
+    // (e.g. open ocean in the no-oceans dataset), fall through to
+    // no-timezone-spoof rather than failing the whole shim.
+    String? effectiveSpoofTimezone = config.spoofTimezone;
+    if (config.spoofTimezoneFromLocation &&
+        config.spoofLatitude != null &&
+        config.spoofLongitude != null) {
+      effectiveSpoofTimezone = TimezoneLocationService.instance
+          .lookup(config.spoofLatitude!, config.spoofLongitude!);
+    }
+
     // Location / timezone / WebRTC shim — must run FIRST so overrides are
     // in place before any site script can capture the unpatched references.
     final locationShim = LocationSpoofService.buildScript(
@@ -836,7 +859,7 @@ class WebViewFactory {
       spoofLatitude: config.spoofLatitude,
       spoofLongitude: config.spoofLongitude,
       spoofAccuracy: config.spoofAccuracy,
-      spoofTimezone: config.spoofTimezone,
+      spoofTimezone: effectiveSpoofTimezone,
       webRtcPolicy: config.webRtcPolicy,
     );
     if (locationShim != null) {
@@ -1233,6 +1256,32 @@ class WebViewFactory {
       onWebViewCreated: (controller) async {
         final wrappedController = _WebViewController(controller);
         onControllerCreated(wrappedController);
+        // Live geolocation: forward navigator.geolocation calls from the
+        // shim into the platform's native location service. Permission is
+        // requested by the native plugin only when this handler is first
+        // invoked — i.e. only when the page actually calls
+        // getCurrentPosition / watchPosition. The handler returns a
+        // serialisable map matching CurrentLocationService's JSON shape.
+        if (config.locationMode == LocationMode.live) {
+          controller.addJavaScriptHandler(
+            handlerName: 'getRealLocation',
+            callback: (args) async {
+              final res = await CurrentLocationService.getCurrentLocation();
+              if (res.status == CurrentLocationStatus.ok && res.fix != null) {
+                return {
+                  'status': 'ok',
+                  'latitude': res.fix!.latitude,
+                  'longitude': res.fix!.longitude,
+                  'accuracy': res.fix!.accuracy,
+                };
+              }
+              return {
+                'status': res.status.name,
+                'message': res.message ?? 'unknown',
+              };
+            },
+          );
+        }
         // Register ClearURLs handler for clipboard/share URL cleaning
         if (config.clearUrlEnabled) {
           controller.addJavaScriptHandler(handlerName: 'clearUrl', callback: (args) {

--- a/lib/settings/location.dart
+++ b/lib/settings/location.dart
@@ -1,7 +1,14 @@
-/// Per-site geolocation mode. [off] leaves the Geolocation API untouched.
-/// [spoof] replaces `navigator.geolocation` with a shim that returns
-/// user-supplied coordinates.
-enum LocationMode { off, spoof }
+/// Per-site geolocation mode.
+/// - [off]: leaves the Geolocation API untouched (webview platform default).
+/// - [spoof]: replaces `navigator.geolocation` with a shim that returns
+///   user-supplied static coordinates with ~2 m jitter.
+/// - [live]: replaces `navigator.geolocation` with a shim that calls back
+///   into Dart on every `getCurrentPosition`/`watchPosition` to fetch a
+///   fresh fix from the platform's native location service. Same shim
+///   structure as `spoof` (so timezone override / WebRTC policy / sites'
+///   detection routes still apply), but the coordinates are real and
+///   change as the device moves.
+enum LocationMode { off, spoof, live }
 
 /// Per-site WebRTC policy. HTTP(S)/SOCKS5 proxies only tunnel TCP — WebRTC
 /// UDP candidates leak the real client IP even with proxy enabled. This

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -292,6 +292,13 @@ class WebViewModel {
   /// IANA timezone name to expose via [Intl.DateTimeFormat] and
   /// [Date.prototype.getTimezoneOffset]. Null leaves the real zone.
   String? spoofTimezone;
+  /// When true, the effective spoof timezone is derived from
+  /// (spoofLatitude, spoofLongitude) at shim-build time via
+  /// [TimezoneLocationService]. [spoofTimezone] is ignored in that case
+  /// (it stays null; the field is mutually exclusive). Resolution happens
+  /// in `webview.dart`, not here, because it depends on a separately-
+  /// loadable polygon dataset that may not be present.
+  bool spoofTimezoneFromLocation;
   WebRtcPolicy webRtcPolicy;
 
   final List<ConsoleLogEntry> consoleLogs = [];
@@ -335,6 +342,7 @@ class WebViewModel {
     this.spoofLongitude,
     this.spoofAccuracy = 50.0,
     this.spoofTimezone,
+    this.spoofTimezoneFromLocation = false,
     this.webRtcPolicy = WebRtcPolicy.defaultPolicy,
     this.stateSetterF,
   })  : userScripts = userScripts ?? [],
@@ -442,7 +450,7 @@ class WebViewModel {
   }
 
   Widget getWebView(
-    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required String? language, LocationMode locationMode, double? spoofLatitude, double? spoofLongitude, double spoofAccuracy, String? spoofTimezone, WebRtcPolicy webRtcPolicy}) launchUrlFunc,
+    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required String? language, LocationMode locationMode, double? spoofLatitude, double? spoofLongitude, double spoofAccuracy, String? spoofTimezone, bool spoofTimezoneFromLocation, WebRtcPolicy webRtcPolicy}) launchUrlFunc,
     CookieManager cookieManager,
     Function saveFunc, {
     Future<void> Function(int windowId, String url)? onWindowRequested,
@@ -496,6 +504,7 @@ class WebViewModel {
           spoofLongitude: spoofLongitude,
           spoofAccuracy: spoofAccuracy,
           spoofTimezone: spoofTimezone,
+          spoofTimezoneFromLocation: spoofTimezoneFromLocation,
           webRtcPolicy: webRtcPolicy,
           userScripts: [
             // Globals have no master `enabled` toggle per spec — per-site
@@ -552,7 +561,7 @@ class WebViewModel {
                 return false;
               case NavigationDecision.blockOpenNested:
                 LogService.instance.log('WebView', '  -> CANCEL (opening nested webview)');
-                launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, language: this.language, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, webRtcPolicy: webRtcPolicy);
+                launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, language: this.language, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, webRtcPolicy: webRtcPolicy);
                 return false;
             }
           },
@@ -598,7 +607,7 @@ class WebViewModel {
                     return;
                   case NavigationDecision.blockOpenNested:
                     LogService.instance.log('WebView', 'onUrlChanged: cross-domain redirect detected: $url (expected domain: $initDomain)');
-                    launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, language: this.language, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, webRtcPolicy: webRtcPolicy);
+                    launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, language: this.language, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, webRtcPolicy: webRtcPolicy);
                     return;
                   case NavigationDecision.allow:
                     break;
@@ -691,7 +700,7 @@ class WebViewModel {
   }
 
   WebViewController? getController(
-    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required String? language, LocationMode locationMode, double? spoofLatitude, double? spoofLongitude, double spoofAccuracy, String? spoofTimezone, WebRtcPolicy webRtcPolicy}) launchUrlFunc,
+    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required String? language, LocationMode locationMode, double? spoofLatitude, double? spoofLongitude, double spoofAccuracy, String? spoofTimezone, bool spoofTimezoneFromLocation, WebRtcPolicy webRtcPolicy}) launchUrlFunc,
     CookieManager cookieManager,
     Function saveFunc, {
     List<UserScriptConfig> globalUserScripts = const [],
@@ -794,6 +803,7 @@ class WebViewModel {
         if (spoofLongitude != null) 'spoofLongitude': spoofLongitude,
         'spoofAccuracy': spoofAccuracy,
         if (spoofTimezone != null) 'spoofTimezone': spoofTimezone,
+        if (spoofTimezoneFromLocation) 'spoofTimezoneFromLocation': true,
         'webRtcPolicy': webRtcPolicy.name,
       };
 
@@ -836,6 +846,8 @@ class WebViewModel {
       spoofLongitude: (json['spoofLongitude'] as num?)?.toDouble(),
       spoofAccuracy: (json['spoofAccuracy'] as num?)?.toDouble() ?? 50.0,
       spoofTimezone: json['spoofTimezone'] as String?,
+      spoofTimezoneFromLocation:
+          json['spoofTimezoneFromLocation'] as bool? ?? false,
       webRtcPolicy: WebRtcPolicy.values.firstWhere(
         (p) => p.name == json['webRtcPolicy'],
         orElse: () => WebRtcPolicy.defaultPolicy,

--- a/openspec/specs/per-site-location/spec.md
+++ b/openspec/specs/per-site-location/spec.md
@@ -29,6 +29,8 @@ A single site-level toggle set is therefore required: spoof coordinates, overrid
 
 The system SHALL expose a per-site `locationMode` with two values: `off` (default) and `spoof`. When `spoof`, user-supplied latitude/longitude/accuracy replace the real geolocation.
 
+In the UI the modes SHALL be labeled "Off" and "Custom location" respectively. "Spoof" as a label is avoided because the user-supplied coordinates can be either fake or real (the picker has a "Use current location" button — LOC-008 — that fills the inputs with the device's real GPS fix). The on-disk enum names remain `off` / `spoof` for backward compatibility with existing settings backups.
+
 #### Scenario: Off mode passes through
 
 **Given** site "Acme" has `locationMode = off`
@@ -96,6 +98,15 @@ The system SHALL expose a per-site `spoofTimezone` (IANA name, nullable). When s
 
 **Rationale:** covering `getHours`/`getMinutes`/`getDate`/... requires shifting each call into the target zone, which is invasive and has DST-boundary edge cases. Most fingerprint libraries use `Intl` or `getTimezoneOffset`.
 
+#### Scenario: System default entry shows what it entails
+
+**Given** the per-site settings timezone dropdown is open on a device whose timezone is `Europe/Helsinki` and the wall clock reads `14:32`
+**When** the user inspects the "System default" entry (the `null` option)
+**Then** its label SHALL include the device's timezone name (or abbreviation), the UTC offset, and the current local time, e.g. `"System default (EEST, UTC+03:00, 14:32)"`
+**And** all other timezone entries SHALL be displayed verbatim from `commonTimezones`
+
+This is a UI affordance only — when `spoofTimezone` is `null` the JS shim is not active for timezone, so the device's real timezone is used. The label exists so the user can see what "default" actually means before deciding whether to override.
+
 ---
 
 ### Requirement: LOC-004 - WebRTC policy
@@ -156,6 +167,21 @@ The tile URL used by the picker SHALL come from a global app pref (`osmTileUrl`,
 **Given** the user has opened the app settings and changed "Tile URL" to a self-hosted tile server
 **When** the user later opens the location picker and taps "Load map"
 **Then** tile requests go to the configured server, not to openstreetmap.org
+
+#### Scenario: OSM Tile Usage Policy compliance
+
+When the picker is configured to use the default `tile.openstreetmap.org` URL it SHALL meet the OSM Tile Usage Policy at https://operations.osmfoundation.org/policies/tiles/. Specifically:
+
+**Given** the picker has loaded the map with the default `osmTileUrl`
+**Then** every tile HTTP request SHALL carry a `User-Agent` of the form `Webspace/<version> (+https://github.com/theoden8/webspace_app)` (NOT the flutter_map library default `flutter_map (...)`)
+**And** the request SHALL NOT include `Cache-Control: no-cache` or `Pragma: no-cache`
+**And** the request SHALL go to the canonical `https://tile.openstreetmap.org/{z}/{x}/{y}.png` URL (no other subdomains, no HTTP)
+**And** the visible attribution SHALL show `© OpenStreetMap contributors` linking to https://www.openstreetmap.org/copyright
+**And** a "Report a map issue" link to https://www.openstreetmap.org/fixthemap SHALL be visible on the map view
+**And** the picker SHALL NOT pre-fetch, bulk-download, or offer "save area for offline" features
+**And** the picker SHALL NOT mount the map (issue any tile request) until the user taps "Load map" — the LOC-006 opt-in is preserved
+
+OpenStreetMap data is © OpenStreetMap contributors and licensed under ODbL; the cartography is CC BY-SA 2.0. These are compatible with commercial use as long as attribution is preserved. Tile-server access from `tile.openstreetmap.org` is best-effort and may be withdrawn by the OSMF at any time per their policy; users who require guaranteed availability or offline maps SHALL configure a self-hosted or commercial tile provider via the `osmTileUrl` app pref.
 
 ---
 

--- a/openspec/specs/per-site-location/spec.md
+++ b/openspec/specs/per-site-location/spec.md
@@ -27,14 +27,26 @@ A single site-level toggle set is therefore required: spoof coordinates, overrid
 
 ### Requirement: LOC-001 - Per-site location mode
 
-The system SHALL expose a per-site `locationMode` with two values: `off` (default) and `spoof`. When `spoof`, user-supplied latitude/longitude/accuracy replace the real geolocation.
+The system SHALL expose a per-site `locationMode` with three values:
 
-The UI SHALL NOT expose the mode as a separate dropdown. Instead, the per-site settings screen SHALL render a single "Pick location" affordance:
+- `off` (default): the JS shim does not touch `navigator.geolocation`. The webview's platform default applies.
+- `spoof`: the shim replaces `navigator.geolocation` with a static-coordinates path that returns the user-supplied `spoofLatitude` / `spoofLongitude` / `spoofAccuracy` (with sub-meter jitter so `watchPosition` doesn't return byte-identical frames).
+- `live`: the shim replaces `navigator.geolocation` with a callback path that, on every `getCurrentPosition` / `watchPosition` tick, asks the Dart side for a fresh fix from the platform's native location service (Android `LocationManager`, iOS `CLLocationManager`) and returns those real coordinates. `watchPosition` polls every 5 s.
 
-- When no coordinates are stored, a single button labeled "Pick location" is shown alongside the subtitle "No custom location set". Tapping it opens the picker (LOC-006).
-- When coordinates are stored, the row shows the coordinates and accuracy as the subtitle, plus an edit-icon button (re-opens the picker) and a clear-icon button (unsets the coordinates).
+In all three modes, `spoofTimezone` and `webRtcPolicy` apply independently — `live` does NOT bypass the timezone override or WebRTC policy. The on-disk values are `off` / `spoof` / `live`; existing settings backups round-trip without migration (older backups without a value default to `off`).
 
-`locationMode` is derived at save time: if both `spoofLatitude` and `spoofLongitude` are non-null, the mode is `spoof`; otherwise `off`. This keeps the on-disk model unchanged for backward compatibility, and removes the user-facing concept of "mode" entirely — the user only thinks in terms of "I have a custom location set" or "I don't".
+The UI SHALL NOT expose the mode as a separate dropdown. Instead, the per-site settings screen SHALL render a state-aware geolocation row with three states:
+
+- **Off** (no custom coords, live disabled): subtitle "No custom location set" with two buttons — "Pick" (opens the picker → flips to spoof) and "Live" (flips to live).
+- **Spoof** (custom coords): subtitle shows the coordinates and accuracy, with an edit-icon button (re-opens the picker) and a clear-icon button (flips to off).
+- **Live** (live tracking): subtitle "Live: tracks device GPS via the platform location service", with a clear button that flips back to off.
+
+`locationMode` is derived at save time:
+- if the user is in the live state → `live`,
+- else if both `spoofLatitude` and `spoofLongitude` are non-null → `spoof`,
+- else → `off`.
+
+The user-facing concept of "mode" is removed — the user thinks in terms of "I have a custom location", "I'm tracking my real one", or "I don't have anything set".
 
 #### Scenario: No location set shows Pick affordance
 
@@ -98,6 +110,46 @@ The spoof SHALL resist trivial detection by:
 
 ---
 
+### Requirement: LOC-009 - Live device location passthrough
+
+When `locationMode = live`, the JS shim SHALL forward `navigator.geolocation.getCurrentPosition` and `navigator.geolocation.watchPosition` calls to the platform's native location service via a `flutter_inappwebview` JavaScript handler named `getRealLocation`. Each call returns a fresh fix; coordinates change as the device moves. The same shim hardening as `spoof` mode applies (prototype overrides, toString native reporting, Permissions API → granted).
+
+The shim variable controlling the static-coordinates path SHALL be named `STATIC_LOC` (not `SPOOF_LOC`) for clarity, since both `spoof` and `live` are technically "spoofs" of `navigator.geolocation` — `STATIC_LOC` specifically gates the path that returns hardcoded coords.
+
+The Dart-side handler for `getRealLocation` SHALL be registered in `webview.dart`'s `onWebViewCreated` only when `config.locationMode == LocationMode.live`. The handler delegates to `CurrentLocationService.getCurrentLocation()` (Android `LocationManager` / iOS `CLLocationManager`, no Google Play Services). The platform permission prompt fires the first time the page actually calls `getCurrentPosition` — not at app launch, not at site activation.
+
+`watchPosition` SHALL poll every 5 s in live mode and stop when the page calls `clearWatch`. `options.maximumAge` and similar are ignored — the cadence is fixed by the shim, not exposed to pages.
+
+#### Scenario: getCurrentPosition returns a real fix
+
+**Given** site "Acme" has `locationMode = live`
+**When** the site calls `navigator.geolocation.getCurrentPosition(cb)`
+**Then** the platform permission prompt appears (first call only)
+**And** if the user grants permission, `cb` is invoked with the device's current coordinates from the native location service
+**And** the Position object has `coords.latitude`/`coords.longitude` matching the device GPS within accuracy
+
+#### Scenario: watchPosition tracks movement
+
+**Given** site "Acme" has `locationMode = live` and the user has granted permission
+**When** the site calls `navigator.geolocation.watchPosition(cb)` and the device moves between fixes
+**Then** `cb` is invoked at least every 5 s with the latest fix
+**And** `cb` continues firing until the site calls `clearWatch(id)`
+
+#### Scenario: Permission denied surfaces a GeolocationPositionError
+
+**Given** site "Acme" has `locationMode = live`
+**When** the site calls `getCurrentPosition(success, error)` and the user denies the permission prompt
+**Then** the `error` callback is invoked with a `GeolocationPositionError`-shaped object whose `code` is `1` (PERMISSION_DENIED)
+
+#### Scenario: Timezone and WebRTC apply independently
+
+**Given** site "Acme" has `locationMode = live`, `spoofTimezone = 'Asia/Tokyo'`, `webRtcPolicy = disabled`
+**When** the site reads `Intl.DateTimeFormat().resolvedOptions().timeZone` and constructs a new `RTCPeerConnection`
+**Then** `Intl` reports `'Asia/Tokyo'` (the timezone override is unaffected by live mode)
+**And** `RTCPeerConnection` is neutered per the policy
+
+---
+
 ### Requirement: LOC-003 - Timezone override
 
 The system SHALL expose a per-site `spoofTimezone` (IANA name, nullable). When set, it SHALL override:
@@ -133,6 +185,51 @@ The system SHALL expose a per-site `spoofTimezone` (IANA name, nullable). When s
 **And** all other timezone entries SHALL be displayed verbatim from `commonTimezones`
 
 This is a UI affordance only — when `spoofTimezone` is `null` the JS shim is not active for timezone, so the device's real timezone is used. The label exists so the user can see what "default" actually means before deciding whether to override.
+
+---
+
+### Requirement: LOC-010 - Timezone from picked location
+
+The per-site model SHALL expose a boolean field `spoofTimezoneFromLocation`. When true AND coordinates are set AND a polygon dataset is loaded, the effective spoof timezone is the IANA zone whose polygon contains `(spoofLatitude, spoofLongitude)`. `spoofTimezone` is ignored in that case (the two fields are mutually exclusive in the UI).
+
+If the polygon dataset is absent, or the coordinates fall in a region not covered by the dataset (e.g. open ocean in the no-oceans variant), the lookup SHALL fall through to no-timezone-spoof (system default) rather than failing the whole shim. The lookup happens once at shim build time in `webview.dart`, not on every JS call, so a slow polygon test does not affect page perf after the initial page load.
+
+The polygon dataset SHALL be downloadable on demand via App Settings → Location picker → "Timezone polygons" → Download. Default source is the `evansiroky/timezone-boundary-builder` GitHub release (zipped GeoJSON, ~7–15 MB compressed). The download URL is user-configurable so users can swap in a smaller community dataset, a self-hosted mirror, or a pre-extracted GeoJSON file. The dataset is not bundled with the app — it is opt-in. The state (loaded zone count, last-updated timestamp, configured URL) round-trips across app launches in app private storage.
+
+The per-site Timezone dropdown SHALL include a "From picked location" entry. The entry's label SHALL preview what the lookup would resolve to right now (the IANA zone for the current coords, or a hint indicating which prerequisite is missing — "Download polygon dataset in App Settings" / "Pick a location first").
+
+#### Scenario: Dataset not downloaded
+
+**Given** the user has not yet downloaded the polygon dataset
+**When** the user opens per-site settings and inspects the Timezone dropdown
+**Then** the "From picked location" entry SHALL be present but its label SHALL include "Download polygon dataset in App Settings"
+
+#### Scenario: Dataset downloaded, no coords picked
+
+**Given** the user has downloaded the dataset but the site has no `spoofLatitude` / `spoofLongitude`
+**When** the user opens the dropdown
+**Then** the "From picked location" entry SHALL include "Pick a location first"
+
+#### Scenario: Dataset downloaded and coords set
+
+**Given** the user has downloaded the dataset and picked coordinates inside a covered zone (e.g. 35.6762, 139.6503)
+**When** the user opens the dropdown
+**Then** the "From picked location" entry SHALL include the resolved zone in parentheses (e.g. "From picked location (Asia/Tokyo)")
+**And** selecting it SHALL set `spoofTimezoneFromLocation = true` and `spoofTimezone = null`
+
+#### Scenario: Lookup miss falls through
+
+**Given** `spoofTimezoneFromLocation = true` and the picked coords fall outside every polygon in the loaded dataset
+**When** a webview is built for the site
+**Then** the JS shim SHALL be built with no timezone spoof (system default applies)
+**And** no error is raised — the rest of the shim (geolocation, WebRTC) builds normally
+
+#### Scenario: Dataset is opt-in and clearable
+
+**Given** the dataset has been downloaded
+**When** the user taps the "Clear" icon next to the dataset row in App Settings
+**Then** the cache file is deleted, in-memory state is cleared, and `isReady` returns false
+**And** any per-site setting with `spoofTimezoneFromLocation = true` falls through to system default
 
 ---
 
@@ -287,7 +384,9 @@ This is a manual user action that fills inputs the user can still edit. It does 
 
 ### Requirement: LOC-007 - Settings apply to nested webviews
 
-Every per-site field on `WebViewModel` that controls privacy behavior (`locationMode`, `spoofLatitude`, `spoofLongitude`, `spoofAccuracy`, `spoofTimezone`, `webRtcPolicy`) SHALL propagate to every `InAppWebViewScreen` spawned by cross-domain navigation from the parent site via `launchUrl` in `lib/main.dart`. The JS shim SHALL be injected into cross-origin iframes as well as the top frame by setting `forMainFrameOnly: false` on the `inapp.UserScript`.
+Every per-site field on `WebViewModel` that controls privacy behavior (`locationMode`, `spoofLatitude`, `spoofLongitude`, `spoofAccuracy`, `spoofTimezone`, `spoofTimezoneFromLocation`, `webRtcPolicy`) SHALL propagate to every `InAppWebViewScreen` spawned by cross-domain navigation from the parent site via `launchUrl` in `lib/main.dart`. The JS shim SHALL be injected into cross-origin iframes as well as the top frame by setting `forMainFrameOnly: false` on the `inapp.UserScript`.
+
+When the parent's mode is `live`, nested webviews SHALL inherit the live behavior — including the `getRealLocation` JS handler registration in `webview.dart`'s `onWebViewCreated` — so that a nested browser opened from the parent site continues to read fresh device coords through the shim, not platform-default geolocation.
 
 Otherwise a site could defeat the spoof by linking to a detection page (e.g. browserleaks.com) — which opens in a nested browser — or embedding it in an iframe.
 

--- a/openspec/specs/per-site-location/spec.md
+++ b/openspec/specs/per-site-location/spec.md
@@ -159,6 +159,65 @@ The tile URL used by the picker SHALL come from a global app pref (`osmTileUrl`,
 
 ---
 
+### Requirement: LOC-008 - Use current location button
+
+The location picker SHALL expose a "Use current location" button on platforms where a native location service is wired in (Android, iOS). Tapping it SHALL request a single GPS fix from the device's native location service and populate the latitude, longitude, and accuracy inputs with the result. The implementation SHALL:
+
+- Use Android's `android.location.LocationManager` (GPS + NETWORK providers) and iOS's `CLLocationManager`. No Google Play Services dependency, so the F-Droid flavor remains GMS-free.
+- Request the runtime permission only when the user taps the button (not at app launch). On Android, request `ACCESS_FINE_LOCATION` + `ACCESS_COARSE_LOCATION`; on iOS, request `When-In-Use` authorization with `NSLocationWhenInUseUsageDescription`.
+- Make NO network requests as part of fetching the fix. The button must work even when the map is not loaded (i.e. the privacy default in LOC-006 is preserved).
+- Acquire a single fix, not a continuous stream. The native side stops listening as soon as the first fix arrives or the timeout expires.
+- Surface failure modes distinctly: permission denied, permission denied forever (offer Settings hint), location services disabled, timeout, unsupported platform.
+- Hide the button entirely on platforms where it is not supported (e.g. macOS, Linux), so it never appears as a dead control.
+
+This is a manual user action that fills inputs the user can still edit. It does not change the per-site spoof semantics — the chosen coordinates remain whatever the user accepts via "Done", whether typed, picked on the map, or imported from the device GPS.
+
+#### Scenario: Permission granted on first tap
+
+**Given** the picker is open and the user has never granted location permission to the app
+**When** the user taps "Use current location"
+**Then** the system permission prompt appears
+**And** if the user grants permission, the latitude, longitude, and accuracy inputs are populated with the device's current fix within ~30 seconds
+**And** no map tile requests are made unless the user separately taps "Load map"
+
+#### Scenario: Permission denied
+
+**Given** the picker is open
+**When** the user taps "Use current location" and denies the permission prompt
+**Then** the inputs are unchanged
+**And** a message explains that location permission was not granted
+
+#### Scenario: Permission permanently denied
+
+**Given** the user previously denied the permission with "don't ask again" (Android) or fully denied it in Settings (iOS)
+**When** the user taps "Use current location"
+**Then** no permission prompt appears
+**And** a message explains that the permission must be re-enabled in system Settings
+
+#### Scenario: Location services off
+
+**Given** location services are disabled at the OS level
+**When** the user taps "Use current location"
+**Then** a message indicates that location services are disabled
+
+#### Scenario: Timeout outdoors
+
+**Given** the user has granted permission but no fix arrives within the timeout
+**When** the timeout elapses
+**Then** the native side stops listening for updates
+**And** the picker shows a timeout message
+
+#### Scenario: Button hidden on unsupported platforms
+
+**Given** the picker is opened on a platform without a wired native location plugin (e.g. macOS, Linux)
+**Then** the "Use current location" button is not shown
+
+#### Scenario: No GMS dependency on Android
+
+**Given** the F-Droid flavor APK is installed on a device without Google Play Services
+**When** the user taps "Use current location"
+**Then** the request still succeeds (or fails with a non-GMS status), because the implementation uses `LocationManager`, not `FusedLocationProviderClient`
+
 ---
 
 ### Requirement: LOC-007 - Settings apply to nested webviews

--- a/openspec/specs/per-site-location/spec.md
+++ b/openspec/specs/per-site-location/spec.md
@@ -29,7 +29,34 @@ A single site-level toggle set is therefore required: spoof coordinates, overrid
 
 The system SHALL expose a per-site `locationMode` with two values: `off` (default) and `spoof`. When `spoof`, user-supplied latitude/longitude/accuracy replace the real geolocation.
 
-In the UI the modes SHALL be labeled "Off" and "Custom location" respectively. "Spoof" as a label is avoided because the user-supplied coordinates can be either fake or real (the picker has a "Use current location" button — LOC-008 — that fills the inputs with the device's real GPS fix). The on-disk enum names remain `off` / `spoof` for backward compatibility with existing settings backups.
+The UI SHALL NOT expose the mode as a separate dropdown. Instead, the per-site settings screen SHALL render a single "Pick location" affordance:
+
+- When no coordinates are stored, a single button labeled "Pick location" is shown alongside the subtitle "No custom location set". Tapping it opens the picker (LOC-006).
+- When coordinates are stored, the row shows the coordinates and accuracy as the subtitle, plus an edit-icon button (re-opens the picker) and a clear-icon button (unsets the coordinates).
+
+`locationMode` is derived at save time: if both `spoofLatitude` and `spoofLongitude` are non-null, the mode is `spoof`; otherwise `off`. This keeps the on-disk model unchanged for backward compatibility, and removes the user-facing concept of "mode" entirely — the user only thinks in terms of "I have a custom location set" or "I don't".
+
+#### Scenario: No location set shows Pick affordance
+
+**Given** site "Acme" has `locationMode = off` and no `spoofLatitude` / `spoofLongitude`
+**When** the user opens per-site settings for Acme
+**Then** the Geolocation row shows the subtitle "No custom location set"
+**And** a single "Pick location" button is visible
+**And** no latitude/longitude/accuracy fields are shown
+
+#### Scenario: Picking a location flips mode to spoof
+
+**Given** the user has tapped "Pick location" and chosen 35.6762, 139.6503 with accuracy 50 in the picker
+**When** the picker returns and the user saves the per-site settings
+**Then** the persisted state is `locationMode = spoof`, `spoofLatitude = 35.6762`, `spoofLongitude = 139.6503`, `spoofAccuracy = 50`
+**And** subsequent `navigator.geolocation.getCurrentPosition` calls from Acme return those coordinates
+
+#### Scenario: Clearing a location flips mode to off
+
+**Given** site "Acme" has `locationMode = spoof`, `spoofLatitude = 35.6762`, `spoofLongitude = 139.6503`
+**When** the user opens per-site settings, taps the clear (✕) icon next to the coordinates, and saves
+**Then** the persisted state is `locationMode = off` and the latitude/longitude are null
+**And** subsequent `navigator.geolocation.getCurrentPosition` calls from Acme return whatever the platform's webview default does (no shim)
 
 #### Scenario: Off mode passes through
 
@@ -168,18 +195,30 @@ The tile URL used by the picker SHALL come from a global app pref (`osmTileUrl`,
 **When** the user later opens the location picker and taps "Load map"
 **Then** tile requests go to the configured server, not to openstreetmap.org
 
-#### Scenario: OSM Tile Usage Policy compliance
+#### Scenario: OSM Tile Usage Policy and Attribution Guidelines compliance
 
-When the picker is configured to use the default `tile.openstreetmap.org` URL it SHALL meet the OSM Tile Usage Policy at https://operations.osmfoundation.org/policies/tiles/. Specifically:
+When the picker is configured to use the default `tile.openstreetmap.org` URL it SHALL meet the OSM Tile Usage Policy (https://operations.osmfoundation.org/policies/tiles/) and the OSMF Attribution Guidelines (adopted 2021-06-25). Specifically:
+
+**Tile requests:**
 
 **Given** the picker has loaded the map with the default `osmTileUrl`
 **Then** every tile HTTP request SHALL carry a `User-Agent` of the form `Webspace/<version> (+https://github.com/theoden8/webspace_app)` (NOT the flutter_map library default `flutter_map (...)`)
 **And** the request SHALL NOT include `Cache-Control: no-cache` or `Pragma: no-cache`
 **And** the request SHALL go to the canonical `https://tile.openstreetmap.org/{z}/{x}/{y}.png` URL (no other subdomains, no HTTP)
-**And** the visible attribution SHALL show `© OpenStreetMap contributors` linking to https://www.openstreetmap.org/copyright
-**And** a "Report a map issue" link to https://www.openstreetmap.org/fixthemap SHALL be visible on the map view
 **And** the picker SHALL NOT pre-fetch, bulk-download, or offer "save area for offline" features
 **And** the picker SHALL NOT mount the map (issue any tile request) until the user taps "Load map" — the LOC-006 opt-in is preserved
+
+**Attribution (Attribution Guidelines):**
+
+**And** the attribution overlay SHALL be visible on every map view, in a corner, without requiring the user to interact with the map
+**And** the text SHALL include the word `OpenStreetMap` styled visibly as a hyperlink (underlined and link-coloured), with the link target https://www.openstreetmap.org/copyright (acceptable historical form: `© OpenStreetMap contributors`)
+**And** the link SHALL be the word `OpenStreetMap` itself, not just the surrounding `©` glyph or the entire string (per the Attribution Guidelines, "by making the text 'OpenStreetMap' a link to openstreetmap.org/copyright")
+**And** the font size SHALL be at least 12 points and contrast with its background to meet WCAG legibility expectations (the guidelines reference WCAG)
+**And** a "Report a map issue" link to https://www.openstreetmap.org/fixthemap SHALL be visible adjacent to the attribution
+
+**License documentation:**
+
+**And** the in-app License screen SHALL include an entry titled "OpenStreetMap (map data and tiles)" explaining the ODbL (data) / CC BY-SA 2.0 (cartography) split, commercial-use compatibility, and the policy commitments above
 
 OpenStreetMap data is © OpenStreetMap contributors and licensed under ODbL; the cartography is CC BY-SA 2.0. These are compatible with commercial use as long as attribution is preserved. Tile-server access from `tile.openstreetmap.org` is best-effort and may be withdrawn by the OSMF at any time per their policy; users who require guaranteed availability or offline maps SHALL configure a self-hosted or commercial tile provider via the `osmTileUrl` app pref.
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2,7 +2,7 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages:
   archive:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: archive
       sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,10 @@ dependencies:
   material_design_icons_flutter: ^7.0.7296
   flutter_map: ^8.0.0
   latlong2: ^0.9.1
+  # Used to unzip the downloaded timezone-boundary-builder GeoJSON release.
+  # Already a transitive dependency of other packages; promoted to direct
+  # so it has a stable version constraint we control.
+  archive: ^4.0.0
 
 dev_dependencies:
   flutter_test:

--- a/test/location_spoof_test.dart
+++ b/test/location_spoof_test.dart
@@ -28,6 +28,24 @@ void main() {
       expect(script, isNull);
     });
 
+    test('live mode emits a shim that flips LIVE_LOC and not STATIC_LOC', () {
+      final script = LocationSpoofService.buildScript(
+        locationMode: LocationMode.live,
+        spoofLatitude: null,
+        spoofLongitude: null,
+        spoofAccuracy: 50.0,
+        spoofTimezone: null,
+        webRtcPolicy: WebRtcPolicy.defaultPolicy,
+      );
+      expect(script, isNotNull);
+      // STATIC_LOC must be false — the shim should not embed any static
+      // coords. LIVE_LOC must be true so the JS code path calls back into
+      // Dart for fresh fixes via flutter_inappwebview.callHandler.
+      expect(script, contains('var STATIC_LOC = false'));
+      expect(script, contains('var LIVE_LOC = true'));
+      expect(script, contains("callHandler('getRealLocation')"));
+    });
+
     test('geolocation shim embeds the coordinates', () {
       final script = LocationSpoofService.buildScript(
         locationMode: LocationMode.spoof,
@@ -38,7 +56,7 @@ void main() {
         webRtcPolicy: WebRtcPolicy.defaultPolicy,
       );
       expect(script, isNotNull);
-      expect(script, contains('var SPOOF_LOC = true'));
+      expect(script, contains('var STATIC_LOC = true'));
       expect(script, contains('var LAT = 35.6762'));
       expect(script, contains('var LNG = 139.6503'));
       expect(script, contains('var ACC = 25.0'));
@@ -46,7 +64,7 @@ void main() {
       expect(script, contains('var WRTC = "default"'));
     });
 
-    test('timezone-only shim still emits script without spoof_loc', () {
+    test('timezone-only shim still emits script without static_loc', () {
       final script = LocationSpoofService.buildScript(
         locationMode: LocationMode.off,
         spoofLatitude: null,
@@ -56,7 +74,7 @@ void main() {
         webRtcPolicy: WebRtcPolicy.defaultPolicy,
       );
       expect(script, isNotNull);
-      expect(script, contains('var SPOOF_LOC = false'));
+      expect(script, contains('var STATIC_LOC = false'));
       expect(script, contains('var TZ = "Asia/Tokyo"'));
     });
 

--- a/test/timezone_location_test.dart
+++ b/test/timezone_location_test.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webspace/services/timezone_location_service.dart';
+
+class _FakePathProvider extends PathProviderPlatform with MockPlatformInterfaceMixin {
+  final Directory _dir;
+  _FakePathProvider(this._dir);
+  @override
+  Future<String?> getApplicationDocumentsPath() async => _dir.path;
+  @override
+  Future<String?> getTemporaryPath() async => _dir.path;
+}
+
+/// Minimal GeoJSON FeatureCollection used as a fixture for the parser.
+/// Two zones: a square covering "Asia/Tokyo" around (35.68, 139.65) and a
+/// disjoint square covering "Europe/London" around (51.5, -0.13). Includes
+/// one MultiPolygon entry to exercise the multi-poly branch.
+const _fixture = '''
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {"tzid": "Asia/Tokyo"},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [[139.0, 35.0], [140.0, 35.0], [140.0, 36.0], [139.0, 36.0], [139.0, 35.0]]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"tzid": "Europe/London"},
+      "geometry": {
+        "type": "MultiPolygon",
+        "coordinates": [
+          [[[-1.0, 51.0], [1.0, 51.0], [1.0, 52.0], [-1.0, 52.0], [-1.0, 51.0]]]
+        ]
+      }
+    }
+  ]
+}
+''';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    final tmp = await Directory.systemTemp.createTemp('webspace_tz_test_');
+    PathProviderPlatform.instance = _FakePathProvider(tmp);
+  });
+
+  group('TimezoneLocationService', () {
+    test('lookup returns null before any data is loaded', () async {
+      // Reset the in-memory state by clearing first.
+      await TimezoneLocationService.instance.clear();
+      expect(TimezoneLocationService.instance.isReady, isFalse);
+      expect(TimezoneLocationService.instance.lookup(35.68, 139.65), isNull);
+    });
+
+    test('parses GeoJSON cache from disk and resolves polygons', () async {
+      // Write a fixture into the cache file path the service expects.
+      final dir = Directory(
+          (PathProviderPlatform.instance as _FakePathProvider)._dir.path);
+      final file = File('${dir.path}/tz_polygons.geojson');
+      await file.writeAsString(_fixture);
+
+      // Force a fresh load attempt.
+      await TimezoneLocationService.instance.clear();
+      // After clear() the service drops cache, so re-write the fixture
+      // because clear() also deletes the cache file.
+      await file.writeAsString(_fixture);
+      final ok = await TimezoneLocationService.instance.loadFromCacheIfPresent();
+      expect(ok, isTrue);
+      expect(TimezoneLocationService.instance.isReady, isTrue);
+      expect(TimezoneLocationService.instance.zoneCount, 2);
+    });
+
+    test('lookup hits the right zone for points inside each polygon', () {
+      expect(
+          TimezoneLocationService.instance.lookup(35.68, 139.65), 'Asia/Tokyo');
+      expect(TimezoneLocationService.instance.lookup(51.5, -0.13),
+          'Europe/London');
+    });
+
+    test('lookup misses for points outside both polygons', () {
+      // Open ocean somewhere — both fixture polygons exclude this point.
+      expect(TimezoneLocationService.instance.lookup(0.0, 0.0), isNull);
+      // Just outside the Tokyo bbox.
+      expect(TimezoneLocationService.instance.lookup(34.5, 139.5), isNull);
+    });
+  });
+}


### PR DESCRIPTION
Lets the user fill the spoofed lat/lng/accuracy fields from the device's real GPS instead of typing them. Permission is requested on demand only when the button is tapped.

Implementation uses native platform APIs via a method channel:
- Android: android.location.LocationManager (no Google Play Services, so the F-Droid flavor stays GMS-free).
- iOS: CLLocationManager with When-In-Use authorization.

The button is hidden on platforms without a wired plugin (macOS, Linux). No network requests happen when getting the fix; the LOC-006 privacy default of the picker (no map tiles until "Load map") is preserved.

Spec updated with new requirement LOC-008 covering button behavior, permission flow, failure modes, and the F-Droid GMS-free guarantee.