### PR TITLE
Stop process-globally pausing JS timers on per-site pause

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ Detailed feature specs are in `openspec/specs/`. Each spec uses Given/When/Then 
 | user-scripts | Per-site custom JavaScript injection with injection timing control |
 | webspaces | Site organization into named collections |
 | webview-hints | Webview theme hints (color-scheme, matchMedia, cache theme prelude) |
+| webview-pause-lifecycle | Per-instance vs process-global webview pause; "paused != frozen" caveat |
 | fullscreen-mode | Full screen mode: hide app bar/tab strip/system UI, per-site auto-fullscreen setting |
 
 Read the relevant spec before modifying a feature. Specs include file paths, data models, and manual test procedures.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -672,9 +672,10 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.paused || state == AppLifecycleState.inactive) {
-      // Pause the active webview when the app goes to background
+      // App is backgrounding: pause active webview AND globally freeze JS
+      // timers so loaded-but-inactive webviews stop too.
       if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
-        _lifecyclePauseFuture = _webViewModels[_currentIndex!].pauseWebView();
+        _lifecyclePauseFuture = _webViewModels[_currentIndex!].pauseForAppLifecycle();
       }
     } else if (state == AppLifecycleState.resumed) {
       // Await any in-flight pause before resuming to prevent ordering inversion
@@ -692,7 +693,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       _lifecyclePauseFuture = null;
     }
     if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
-      await _webViewModels[_currentIndex!].resumeWebView();
+      await _webViewModels[_currentIndex!].resumeFromAppLifecycle();
     }
     // Re-apply fullscreen system UI mode after resume
     if (_isFullscreen) {

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -520,11 +520,43 @@ abstract class WebViewController {
   Future<void> setTextZoom(int zoomPercent);
   Future<void> goBack();
   Future<bool> canGoBack();
-  /// Pause the webview (stop rendering and JS execution).
-  /// On Android this pauses the WebView entirely; on iOS it pauses timers.
+  /// Per-instance pause to reduce resource usage.
+  ///
+  /// On Android: calls `WebView.onPause()`, which is a best-effort pause of
+  /// animations and geolocation. **Does NOT pause JavaScript** — Android only
+  /// pauses JS via the process-global `pauseTimers()`, which we do not call
+  /// here because it would also freeze every other loaded webview.
+  ///
+  /// On iOS: calls `pauseTimers()`, which the plugin implements per-instance
+  /// via an `alert()`-deadlock hack that blocks this WebView's main JS thread.
+  ///
+  /// Activity that keeps running while paused on **both** platforms:
+  ///   - Web Workers and Service Workers
+  ///   - network requests already in flight (and any `Set-Cookie` they return)
+  ///   - media playback (`<video>` / `<audio>` decoders)
+  ///   - WebRTC peer connections, WebSocket frames over the wire
+  ///
+  /// `pause()` is for resource saving. It is **not a security boundary** — a
+  /// page can observe cookies being deleted or proxy being swapped while
+  /// paused (e.g. via a Service Worker fetch, or via `document.cookie` diff
+  /// on the next `visibilitychange`). To safely mutate global state under
+  /// a webview, dispose it instead.
   Future<void> pause();
+
   /// Resume a previously paused webview.
   Future<void> resume();
+
+  /// Pause JavaScript timers (`setTimeout`/`setInterval`/`requestAnimationFrame`)
+  /// process-globally on Android, per-instance on iOS.
+  ///
+  /// On Android, `WebView.pauseTimers()` is documented as global across all
+  /// loaded WebViews. Use this only when the whole app is going to background;
+  /// do **not** use it to pause a single site, otherwise you also freeze the
+  /// site that's about to become active.
+  Future<void> pauseAllJsTimers();
+
+  /// Inverse of [pauseAllJsTimers].
+  Future<void> resumeAllJsTimers();
 }
 
 /// InAppWebView controller wrapper
@@ -677,18 +709,30 @@ class _WebViewController implements WebViewController {
   @override
   Future<void> pause() async {
     if (Platform.isAndroid) {
+      // Android: per-instance only. pauseTimers() is process-global and would
+      // freeze every other loaded WebView too — see [pauseAllJsTimers].
       await _c.pause();
+    } else if (Platform.isIOS) {
+      // iOS has no per-instance native pause; pauseTimers() is the plugin's
+      // per-instance alert()-deadlock hack and is safe to call on one site.
+      await _c.pauseTimers();
     }
-    await _c.pauseTimers();
   }
 
   @override
   Future<void> resume() async {
     if (Platform.isAndroid) {
       await _c.resume();
+    } else if (Platform.isIOS) {
+      await _c.resumeTimers();
     }
-    await _c.resumeTimers();
   }
+
+  @override
+  Future<void> pauseAllJsTimers() => _c.pauseTimers();
+
+  @override
+  Future<void> resumeAllJsTimers() => _c.resumeTimers();
 }
 
 String _themeInjectionScript(String themeValue) => '''

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -793,9 +793,16 @@ class WebViewModel {
     cookies = await cookieManager.getCookies(url: url);
   }
 
-  /// Pause the webview to reduce resource usage when in background.
-  /// Stops rendering (Android) and JS timers. The webview remains in the
-  /// widget tree but consumes minimal resources.
+  /// Per-instance pause for site switches.
+  ///
+  /// Reduces resource usage but does NOT fully stop the page — Web Workers,
+  /// Service Workers, in-flight network requests (and the `Set-Cookie` they
+  /// return), media playback, WebRTC and WebSocket I/O all keep running. On
+  /// Android, JS timers also keep running (Android's per-instance pause does
+  /// not cover them, and the global timer pause would freeze other tabs too).
+  /// This is a resource hint, not a security boundary — see
+  /// [WebViewController.pause] for the full caveat list. To safely mutate
+  /// cookies or proxy under a webview, dispose it instead.
   Future<void> pauseWebView() async {
     if (controller == null) return;
     try {
@@ -812,6 +819,34 @@ class WebViewModel {
     try {
       await controller!.resume();
       LogService.instance.log('WebView', 'Resumed webview for "$name" (siteId: $siteId)');
+    } catch (_) {
+      // Controller may have been disposed
+    }
+  }
+
+  /// App-lifecycle pause: per-instance pause + process-global JS timer pause.
+  ///
+  /// The global timer pause is intentional here: when the whole app goes to
+  /// background we want every loaded webview's JS frozen, not just the active
+  /// one. Pair with [resumeFromAppLifecycle] on resume.
+  Future<void> pauseForAppLifecycle() async {
+    if (controller == null) return;
+    try {
+      await controller!.pause();
+      await controller!.pauseAllJsTimers();
+      LogService.instance.log('WebView', 'App-lifecycle paused webview for "$name" (siteId: $siteId)');
+    } catch (_) {
+      // Controller may have been disposed
+    }
+  }
+
+  /// Inverse of [pauseForAppLifecycle].
+  Future<void> resumeFromAppLifecycle() async {
+    if (controller == null) return;
+    try {
+      await controller!.resume();
+      await controller!.resumeAllJsTimers();
+      LogService.instance.log('WebView', 'App-lifecycle resumed webview for "$name" (siteId: $siteId)');
     } catch (_) {
       // Controller may have been disposed
     }

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -1,0 +1,202 @@
+# WebView Pause Lifecycle Specification
+
+## Status
+**Implemented**
+
+## Purpose
+
+Defines how the app pauses and resumes webviews to save resources. The split between **per-instance** pause (used on site switch) and **process-global** pause (used on app lifecycle) is load-bearing: one of them is global on Android and would freeze unrelated webviews if used at the wrong call site.
+
+## Problem Statement
+
+`flutter_inappwebview` exposes two pause primitives that look interchangeable but are not:
+
+| Primitive | Android scope | iOS scope | What it pauses |
+|---|---|---|---|
+| `WebView.onPause()` | per-instance | n/a | best-effort: animations, geolocation. **Does not pause JavaScript.** |
+| `WebView.pauseTimers()` | **process-global** | per-instance (alert() hack) | layout, parsing, JS timers (`setTimeout`/`setInterval`/`requestAnimationFrame`) |
+
+Source: Android docs verbatim — *"`onPause()` ... does not pause JavaScript. To pause JavaScript globally, use `pauseTimers`."* and *"`pauseTimers()` ... is a global request, not restricted to just this WebView."* On iOS the plugin implements `pauseTimers()` by triggering an `alert()` whose dismissal callback is withheld by the plugin's `WKUIDelegate`, blocking the page's main JS thread.
+
+Pre-fix the wrapper called `pauseTimers()` from every per-instance `pause()`, so a site-switch pause toggled the **global** Android flag for every loaded webview, and the matching resume toggled it back. Net effect on a site switch was zero useful pausing of the backgrounded site, plus a stutter on the active one.
+
+## Crucial Caveat: Pause Is Not a Security Boundary
+
+A paused webview can still:
+
+- run **Web Workers** and **Service Workers** (separate threads/processes)
+- complete **network requests already in flight** — including processing `Set-Cookie` response headers
+- continue **media playback** (`<video>`/`<audio>` decoders, `currentTime` keeps advancing)
+- run **WebRTC** peer connections; receive **WebSocket** frames over the wire
+
+Therefore, pausing a webview does **not** make it safe to mutate cookies or proxy under it. The page can detect such mutations via:
+
+- Service Worker `fetch` interception
+- Web Worker periodic XHR/fetch with cookie-bearing requests
+- `document.cookie` diff across `visibilitychange`
+- WebRTC ICE re-gather on Android proxy swap
+- media `currentTime` discontinuities
+
+The only way to truly silence a site is `disposeWebView()` — which tears down the JS engine, network sessions, workers, and media pipelines for that page.
+
+## Requirements
+
+### Requirement: PAUSE-001 — Per-Instance Pause for Site Switches
+
+The system SHALL pause the previously active webview on site switch using the per-instance API only, with no process-global side effects.
+
+#### Scenario: Site switch from A to B
+
+**Given** sites A and B are both loaded
+**And** site A is the currently active site
+**When** the user switches to site B
+**Then** `pauseWebView()` is called on A
+**And** A's controller receives `pause()` (Android: `WebView.onPause()`; iOS: per-instance `pauseTimers()` alert hack)
+**And** A's controller does NOT receive `pauseAllJsTimers()`
+**And** B's JS timers are unaffected by A's pause
+
+---
+
+### Requirement: PAUSE-002 — Process-Global Pause Only at App Lifecycle
+
+The system SHALL pause both the active webview and process-global JS timers when the app goes to background, so every loaded webview's JS halts.
+
+#### Scenario: App goes to background
+
+**Given** the app is in the foreground with N loaded webviews
+**When** `AppLifecycleState.paused` (or `inactive`) fires
+**Then** `pauseForAppLifecycle()` is called on the active webview
+**And** the controller receives `pause()` followed by `pauseAllJsTimers()`
+**And** every loaded webview's JS timers are now frozen (Android: globally; iOS: pauseTimers is per-instance, so only the active webview is timer-paused — acceptable since the OS suspends the rest)
+
+#### Scenario: App returns to foreground
+
+**Given** the app was backgrounded via `pauseForAppLifecycle`
+**When** `AppLifecycleState.resumed` fires
+**Then** `_resumeAfterLifecyclePause()` awaits the pending pause Future to prevent ordering inversion
+**And** `resumeFromAppLifecycle()` is called on the active webview
+**And** the controller receives `resume()` followed by `resumeAllJsTimers()`
+
+---
+
+### Requirement: PAUSE-003 — API Separation Is Documented at the Type Level
+
+The `WebViewController` interface SHALL expose `pause()`/`resume()` and `pauseAllJsTimers()`/`resumeAllJsTimers()` as distinct methods with doc comments stating which is per-instance and which is process-global.
+
+#### Scenario: Future contributor reads the interface
+
+**Given** a contributor adds a new pause call site
+**When** they read [lib/services/webview.dart:332-390](../../lib/services/webview.dart)
+**Then** the doc on `pause()` plainly warns it is **not a security boundary**
+**And** the doc on `pauseAllJsTimers()` plainly warns it is process-global on Android and must not be used for single-site pausing
+
+---
+
+### Requirement: PAUSE-004 — Null-Safe Controller Access
+
+`pauseWebView()`, `resumeWebView()`, `pauseForAppLifecycle()`, and `resumeFromAppLifecycle()` SHALL be no-ops when the underlying controller has not yet been initialized or has been disposed.
+
+#### Scenario: Pause called before webview attaches
+
+**Given** a `WebViewModel` whose `controller` is null (lazy loading hasn't created it yet)
+**When** `pauseWebView()` is called
+**Then** no exception is thrown
+**And** the call returns immediately
+
+#### Scenario: Pause called after dispose
+
+**Given** a `WebViewModel` whose `disposeWebView()` has been called (`controller == null`)
+**When** any of the four lifecycle methods is called
+**Then** no exception is thrown
+**And** the call returns immediately
+
+---
+
+### Requirement: PAUSE-005 — Site-Switch Pause Survives Race-Cancellation
+
+The site-switch pause SHALL respect the `_setCurrentIndexVersion` race guard so a rapid switch sequence does not invert pause/resume ordering.
+
+#### Scenario: User taps two sites in quick succession
+
+**Given** the user is on site A
+**When** they tap site B and then site C before B's switch completes
+**Then** the in-flight switch to B exits via the version-mismatch check after `pauseWebView` on A
+**And** the switch to C proceeds with the correct prior state
+**And** A is still in a valid paused state for C's restoration to operate against
+
+---
+
+## Implementation
+
+### API Surface
+
+[lib/services/webview.dart](../../lib/services/webview.dart):
+
+```dart
+abstract class WebViewController {
+  // Per-instance: site switching uses this only.
+  Future<void> pause();
+  Future<void> resume();
+
+  // Process-global on Android, per-instance on iOS.
+  // App-lifecycle uses this in addition to pause()/resume().
+  Future<void> pauseAllJsTimers();
+  Future<void> resumeAllJsTimers();
+}
+
+class _WebViewController implements WebViewController {
+  @override
+  Future<void> pause() async {
+    if (Platform.isAndroid) {
+      await _c.pause();          // WebView.onPause()
+    } else if (Platform.isIOS) {
+      await _c.pauseTimers();    // plugin's per-instance alert() hack
+    }
+  }
+
+  @override
+  Future<void> pauseAllJsTimers() => _c.pauseTimers();
+  // ... resume mirrors pause ...
+}
+```
+
+### Call Sites
+
+[lib/web_view_model.dart](../../lib/web_view_model.dart):
+
+- `pauseWebView()` / `resumeWebView()` — per-instance, used on site switch.
+- `pauseForAppLifecycle()` / `resumeFromAppLifecycle()` — calls per-instance pause **then** `pauseAllJsTimers()` (and inverse on resume).
+
+[lib/main.dart](../../lib/main.dart):
+
+- `didChangeAppLifecycleState`: calls `pauseForAppLifecycle()` / `resumeFromAppLifecycle()`.
+- `_setCurrentIndex`: calls `pauseWebView()` / `resumeWebView()`.
+
+### Tests
+
+[test/webview_pause_lifecycle_test.dart](../../test/webview_pause_lifecycle_test.dart) uses a recording fake `WebViewController` and asserts:
+
+- `pauseWebView()` invokes only `pause`, never `pauseAllJsTimers`.
+- `pauseForAppLifecycle()` invokes `pause` then `pauseAllJsTimers` in that order.
+- A site-switch round trip never touches `*AllJsTimers`.
+- A lifecycle round trip toggles each global flag exactly once.
+- All four methods are no-ops when `controller == null`.
+
+## Files
+
+### Modified
+
+- `lib/services/webview.dart` — split the `WebViewController` interface; `_WebViewController.pause()` no longer calls `pauseTimers()`.
+- `lib/web_view_model.dart` — added `pauseForAppLifecycle()` / `resumeFromAppLifecycle()`; updated docs on `pauseWebView()` / `resumeWebView()`.
+- `lib/main.dart` — `didChangeAppLifecycleState` and `_resumeAfterLifecyclePause` use the lifecycle-named methods.
+
+### Added
+
+- `test/webview_pause_lifecycle_test.dart` — contract tests for the API split.
+- `openspec/specs/webview-pause-lifecycle/spec.md` — this document.
+
+## Related Specs
+
+- [`per-site-cookie-isolation`](../per-site-cookie-isolation/spec.md) — relies on `disposeWebView()` (not pause) to safely mutate the cookie jar across domain conflicts. The "pause is not a security boundary" caveat above is why.
+- [`lazy-webview-loading`](../lazy-webview-loading/spec.md) — defines `_loadedIndices`, the set across which the app-lifecycle global pause takes effect.
+- [`navigation`](../navigation/spec.md) — defines the `_setCurrentIndexVersion` race guard referenced by PAUSE-005.

--- a/test/webview_pause_lifecycle_test.dart
+++ b/test/webview_pause_lifecycle_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/webview.dart';
+import 'package:webspace/web_view_model.dart';
+
+/// Records every controller method invocation in order.
+///
+/// We extend [Fake] so only the methods we override are exposed; any other
+/// [WebViewController] method called on this fake throws via [noSuchMethod],
+/// which is exactly what we want — the contract under test is "pause/resume
+/// touches only the pause-related controller methods, nothing else".
+class _RecordingController extends Fake implements WebViewController {
+  final List<String> calls = [];
+
+  @override
+  Future<void> pause() async {
+    calls.add('pause');
+  }
+
+  @override
+  Future<void> resume() async {
+    calls.add('resume');
+  }
+
+  @override
+  Future<void> pauseAllJsTimers() async {
+    calls.add('pauseAllJsTimers');
+  }
+
+  @override
+  Future<void> resumeAllJsTimers() async {
+    calls.add('resumeAllJsTimers');
+  }
+}
+
+WebViewModel _modelWith(WebViewController? controller) {
+  final m = WebViewModel(initUrl: 'https://example.com', name: 'Example');
+  m.controller = controller;
+  return m;
+}
+
+void main() {
+  group('WebViewModel pause/resume API split', () {
+    test('pauseWebView() invokes only the per-instance pause', () async {
+      final c = _RecordingController();
+      await _modelWith(c).pauseWebView();
+      expect(c.calls, ['pause']);
+    });
+
+    test('resumeWebView() invokes only the per-instance resume', () async {
+      final c = _RecordingController();
+      await _modelWith(c).resumeWebView();
+      expect(c.calls, ['resume']);
+    });
+
+    test('pauseWebView() does NOT invoke pauseAllJsTimers (no global timer pause on site switch)', () async {
+      final c = _RecordingController();
+      await _modelWith(c).pauseWebView();
+      expect(c.calls, isNot(contains('pauseAllJsTimers')),
+          reason: 'pauseTimers() is process-global on Android — calling it from '
+              'a per-site pauseWebView() would freeze every other loaded webview.');
+    });
+
+    test('pauseForAppLifecycle() invokes per-instance pause AND global timer pause, in order', () async {
+      final c = _RecordingController();
+      await _modelWith(c).pauseForAppLifecycle();
+      expect(c.calls, ['pause', 'pauseAllJsTimers']);
+    });
+
+    test('resumeFromAppLifecycle() invokes per-instance resume AND global timer resume, in order', () async {
+      final c = _RecordingController();
+      await _modelWith(c).resumeFromAppLifecycle();
+      expect(c.calls, ['resume', 'resumeAllJsTimers']);
+    });
+
+    test('site-switch round trip touches no global timer state', () async {
+      final c = _RecordingController();
+      final model = _modelWith(c);
+      await model.pauseWebView();
+      await model.resumeWebView();
+      expect(c.calls, ['pause', 'resume']);
+      expect(c.calls.any((s) => s.contains('AllJsTimers')), isFalse,
+          reason: 'Site switching must not toggle the process-global JS timer flag.');
+    });
+
+    test('lifecycle round trip pauses then resumes the global JS timer flag exactly once', () async {
+      final c = _RecordingController();
+      final model = _modelWith(c);
+      await model.pauseForAppLifecycle();
+      await model.resumeFromAppLifecycle();
+      expect(c.calls, ['pause', 'pauseAllJsTimers', 'resume', 'resumeAllJsTimers']);
+      expect(c.calls.where((s) => s == 'pauseAllJsTimers').length, 1);
+      expect(c.calls.where((s) => s == 'resumeAllJsTimers').length, 1);
+    });
+  });
+
+  group('WebViewModel pause/resume null-safety', () {
+    test('pauseWebView() with no controller is a no-op', () async {
+      final m = _modelWith(null);
+      await m.pauseWebView();
+    });
+
+    test('resumeWebView() with no controller is a no-op', () async {
+      final m = _modelWith(null);
+      await m.resumeWebView();
+    });
+
+    test('pauseForAppLifecycle() with no controller is a no-op', () async {
+      final m = _modelWith(null);
+      await m.pauseForAppLifecycle();
+    });
+
+    test('resumeFromAppLifecycle() with no controller is a no-op', () async {
+      final m = _modelWith(null);
+      await m.resumeFromAppLifecycle();
+    });
+  });
+}


### PR DESCRIPTION
WebView.pauseTimers() is process-global on Android — calling it from a per-instance pauseWebView() freezes JS in every other loaded webview until the next resume. The previous code did this on every site switch and on app-lifecycle pause, so the global pause/resume cycle on a site switch left no useful effect on the backgrounded site while still disturbing the active one.

Split the API:
- pause()/resume() are per-instance only (Android: WebView.onPause() which best-effort pauses animations/geolocation; iOS: the plugin's per-instance alert()-deadlock pauseTimers hack).
- pauseAllJsTimers()/resumeAllJsTimers() explicitly invoke the global Android timer pause and the per-instance iOS one. Used only at app-lifecycle, where freezing every loaded webview is the goal.

Doc comments now state plainly that paused webviews can still run Web Workers, Service Workers, in-flight network requests (and any Set-Cookie they return), media playback, WebRTC and WebSocket I/O — i.e. pause is a resource hint, not a security boundary. To safely mutate cookies/proxy under a webview, dispose it.

https://claude.ai/code/session_013MWxDXSuuiw2nLvWfWWLn6