### PR TITLE
Per-site proxy on iOS 17+ / macOS 14+ via patched WKWebsiteDataStore

### DIFF
--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -314,8 +314,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
         // Apply proxy settings immediately
         await widget.webViewModel.updateProxySettings(_proxySettings);
 
-        // Sync proxy settings to all other WebViewModels (proxy is global)
-        widget.onProxySettingsChanged?.call(_proxySettings);
+        // On Android, `inapp.ProxyController` is a process-wide singleton:
+        // changing the proxy on one site silently changes it for every
+        // currently-loaded WebView, so the data model is sync'd to match.
+        // On iOS 17+ / macOS 14+, each site has its own
+        // `WKWebsiteDataStore.proxyConfigurations`, so per-site values
+        // are independent and the sync would clobber them. See PROXY-008.
+        if (Platform.isAndroid) {
+          widget.onProxySettingsChanged?.call(_proxySettings);
+        }
       } else {
         // Force DEFAULT proxy on unsupported platforms
         final defaultProxy = UserProxySettings(type: ProxyType.DEFAULT);

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -52,14 +52,60 @@ class WebSpaceInAppWebViewSettings extends inapp.InAppWebViewSettings {
   /// profile bind. The patched native side gates on `!= null`.
   String? webspaceProfile;
 
-  WebSpaceInAppWebViewSettings({this.webspaceProfile});
+  /// Per-site proxy applied to the WebView's data store at construction.
+  /// Honored only by the patched iOS / macOS plugins on iOS 17+ / macOS 14+
+  /// (see [`WebSpaceProxy.swift`](../../third_party/PATCHES.md)). On Android
+  /// the field is silently ignored — Android proxy still flows through the
+  /// global [`inapp.ProxyController`].
+  ///
+  /// Map shape (must match `WebSpaceProxy.configurations(from:)` Swift-side):
+  /// ```
+  /// {
+  ///   'type':     'http' | 'https' | 'socks5',
+  ///   'host':     'proxy.example.com',
+  ///   'port':     8080,
+  ///   'username': 'optional',
+  ///   'password': 'optional',
+  /// }
+  /// ```
+  Map<String, dynamic>? webspaceProxy;
+
+  WebSpaceInAppWebViewSettings({this.webspaceProfile, this.webspaceProxy});
 
   @override
   Map<String, dynamic> toMap() {
     final map = super.toMap();
     map['webspaceProfile'] = webspaceProfile;
+    map['webspaceProxy'] = webspaceProxy;
     return map;
   }
+}
+
+/// Translate [UserProxySettings] into the dictionary shape consumed by the
+/// patched iOS / macOS `WebSpaceProxy.configurations(from:)`. Returns null
+/// for `ProxyType.DEFAULT` or invalid configs (so the native side clears
+/// any previously-set proxy on the data store).
+Map<String, dynamic>? _proxySettingsToWebspaceProxy(UserProxySettings settings) {
+  if (settings.type == ProxyType.DEFAULT) return null;
+  final address = settings.address;
+  if (address == null || address.isEmpty) return null;
+  final parts = address.split(':');
+  if (parts.length != 2) return null;
+  final host = parts[0];
+  final port = int.tryParse(parts[1]);
+  if (host.isEmpty || port == null || port <= 0 || port > 65535) return null;
+  final type = switch (settings.type) {
+    ProxyType.HTTPS => 'https',
+    ProxyType.SOCKS5 => 'socks5',
+    _ => 'http',
+  };
+  return <String, dynamic>{
+    'type': type,
+    'host': host,
+    'port': port,
+    if (settings.hasCredentials) 'username': settings.username,
+    if (settings.hasCredentials) 'password': settings.password,
+  };
 }
 
 /// Extension to add JSON serialization to inapp.Cookie
@@ -197,7 +243,21 @@ class FindMatchesResult {
 /// Theme preference for webviews
 enum WebViewTheme { light, dark, system }
 
-/// Proxy manager singleton
+/// Proxy manager singleton.
+///
+/// Two delivery paths coexist behind a single API:
+///
+///   * **Android.** Routes through `inapp.ProxyController` — a process-wide
+///     singleton override (`PROXY_OVERRIDE` WebViewFeature). Per-site config
+///     in the data model is fictional under profile mode: with multiple
+///     same-base-domain sites loaded concurrently, the last applied proxy
+///     wins for every WebView. See PROXY-008.
+///   * **iOS 17+ / macOS 14+.** Genuine per-site proxy via
+///     `WKWebsiteDataStore.proxyConfigurations` on the per-site data store
+///     created by the patched `preWKWebViewConfiguration` (see
+///     [`third_party/PATCHES.md`](../../third_party/PATCHES.md)). The proxy
+///     ships with the [WebSpaceInAppWebViewSettings] map at WebView
+///     construction; this class is a no-op on those platforms.
 class ProxyManager {
   static final ProxyManager _instance = ProxyManager._internal();
   factory ProxyManager() => _instance;
@@ -205,6 +265,15 @@ class ProxyManager {
 
   Future<void> setProxySettings(UserProxySettings settings) async {
     if (!PlatformInfo.isProxySupported) return;
+
+    // iOS / macOS: proxy travels through the patched
+    // `WebSpaceInAppWebViewSettings.webspaceProxy` field at WebView
+    // construction. Nothing to do at the global ProxyController level —
+    // upstream `inapp.ProxyController` doesn't even ship a non-Android
+    // implementation in our pinned plugin version. Runtime updates of the
+    // per-site proxy require the WebView to be rebuilt by the caller (see
+    // [WebViewModel.updateProxySettings]).
+    if (Platform.isIOS || Platform.isMacOS) return;
 
     final controller = inapp.ProxyController.instance();
 
@@ -248,15 +317,29 @@ class ProxyManager {
 
   Future<void> clearProxy() async {
     if (!PlatformInfo.isProxySupported) return;
+    if (Platform.isIOS || Platform.isMacOS) return;
     await inapp.ProxyController.instance().clearProxyOverride();
   }
 }
 
-/// Platform info - proxy support detection
+/// Platform info - proxy support detection.
+///
+/// Returns true on:
+/// - Android, when the System WebView reports `PROXY_OVERRIDE` support.
+/// - iOS / macOS, unconditionally — the patched
+///   `preWKWebViewConfiguration` gates internally on iOS 17+ / macOS 14+.
+///   Below that floor, the per-site proxy block silently no-ops and the
+///   site uses system default routing (matches `ProxyType.DEFAULT`).
 class PlatformInfo {
   static bool? _isProxySupportedCached;
 
   static Future<void> initialize() async {
+    if (Platform.isIOS || Platform.isMacOS) {
+      // The native side gates per-version (`#available(iOS 17.0, macOS 14.0, *)`);
+      // surface the toggle in the UI on every iOS / macOS build.
+      _isProxySupportedCached = true;
+      return;
+    }
     try {
       _isProxySupportedCached = await inapp.WebViewFeature.isFeatureSupported(
         inapp.WebViewFeature.PROXY_OVERRIDE,
@@ -348,6 +431,15 @@ class WebViewConfig {
   final bool spoofTimezoneFromLocation;
   /// WebRTC policy — prevents real-IP leak that bypasses HTTP(S)/SOCKS proxies.
   final WebRtcPolicy webRtcPolicy;
+  /// Per-site proxy. On iOS 17+ / macOS 14+ this is honored at WebView
+  /// construction via [WebSpaceInAppWebViewSettings.webspaceProxy] and
+  /// each site genuinely uses its own proxy (the patched native side
+  /// attaches it to the per-site `WKWebsiteDataStore`). On Android the
+  /// per-site config still exists in the data model but the underlying
+  /// `inapp.ProxyController` is a process-wide singleton, so the
+  /// last-applied proxy wins for every site loaded concurrently — see
+  /// PROXY-008 in [openspec/specs/proxy/spec.md] for the asymmetry.
+  final UserProxySettings? proxySettings;
 
   WebViewConfig({
     this.key,
@@ -384,6 +476,7 @@ class WebViewConfig {
     this.spoofTimezone,
     this.spoofTimezoneFromLocation = false,
     this.webRtcPolicy = WebRtcPolicy.defaultPolicy,
+    this.proxySettings,
   });
 }
 
@@ -1288,9 +1381,21 @@ class WebViewFactory {
         ? 'ws-${config.siteId}'
         : null;
 
-    LogService.instance.log('DnsBlock', 'Creating webview: siteId=${config.siteId} dnsBlock=${config.dnsBlockEnabled} hasBlocklist=${DnsBlockService.instance.hasBlocklist} isAndroid=${Platform.isAndroid} url=${config.initialUrl} webspaceProfile=$webspaceProfile');
+    // Per-site proxy delivery: only iOS / macOS honor the settings-borne
+    // map (the patched `preWKWebViewConfiguration` reads it). On Android
+    // the global `inapp.ProxyController` path runs from
+    // `WebViewModel._applyProxySettings` instead, so leave `webspaceProxy`
+    // null and avoid sending a no-op map to the native side.
+    final webspaceProxy = (Platform.isIOS || Platform.isMacOS) && config.proxySettings != null
+        ? _proxySettingsToWebspaceProxy(config.proxySettings!)
+        : null;
 
-    final settings = WebSpaceInAppWebViewSettings(webspaceProfile: webspaceProfile)
+    LogService.instance.log('DnsBlock', 'Creating webview: siteId=${config.siteId} dnsBlock=${config.dnsBlockEnabled} hasBlocklist=${DnsBlockService.instance.hasBlocklist} isAndroid=${Platform.isAndroid} url=${config.initialUrl} webspaceProfile=$webspaceProfile webspaceProxy=${webspaceProxy != null}');
+
+    final settings = WebSpaceInAppWebViewSettings(
+      webspaceProfile: webspaceProfile,
+      webspaceProxy: webspaceProxy,
+    )
       ..javaScriptEnabled = config.javascriptEnabled
       ..userAgent = config.userAgent
       ..thirdPartyCookiesEnabled = config.thirdPartyCookiesEnabled

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -421,7 +421,15 @@ class WebViewModel {
     }
   }
 
-  /// Apply proxy settings to the webview
+  /// Apply proxy settings to the webview.
+  ///
+  /// Android: routes through the global `inapp.ProxyController`. Takes
+  /// effect on next request without reload.
+  ///
+  /// iOS / macOS: no-op — the per-site proxy is bound to the per-site
+  /// `WKWebsiteDataStore` at WebView construction (via
+  /// `WebSpaceInAppWebViewSettings.webspaceProxy`). To pick up a runtime
+  /// change, the WebView must be rebuilt; see [updateProxySettings].
   Future<void> _applyProxySettings() async {
     final proxyManager = ProxyManager();
     try {
@@ -443,9 +451,20 @@ class WebViewModel {
     }
   }
 
-  /// Update proxy settings and apply them
+  /// Update proxy settings and apply them.
+  ///
+  /// On iOS / macOS, the proxy is sealed into the per-site
+  /// `WKWebsiteDataStore` at WebView construction time. To pick up the
+  /// new value, the live WebView is discarded so the next render
+  /// reconstructs it with the new `WebSpaceInAppWebViewSettings.webspaceProxy`
+  /// dictionary. The caller MUST trigger a rebuild (typically via
+  /// `setState`) so the IndexedStack actually re-creates the slot.
   Future<void> updateProxySettings(UserProxySettings newSettings) async {
     proxySettings = newSettings;
+    if (Platform.isIOS || Platform.isMacOS) {
+      disposeWebView();
+      return;
+    }
     await _applyProxySettings();
   }
 
@@ -507,6 +526,11 @@ class WebViewModel {
           spoofTimezone: spoofTimezone,
           spoofTimezoneFromLocation: spoofTimezoneFromLocation,
           webRtcPolicy: webRtcPolicy,
+          // Per-site proxy. Honored at WebView construction on iOS 17+ /
+          // macOS 14+ via the patched `preWKWebViewConfiguration` (see
+          // PROXY-002 / PROXY-008). Android ignores this and routes
+          // through the global `ProxyController` in `_applyProxySettings`.
+          proxySettings: proxySettings,
           userScripts: [
             // Globals have no master `enabled` toggle per spec — per-site
             // opt-in is the only enable control. Force `enabled: true` on

--- a/openspec/specs/proxy/spec.md
+++ b/openspec/specs/proxy/spec.md
@@ -2,12 +2,24 @@
 
 ## Purpose
 
-The proxy feature allows users to configure HTTP, HTTPS, and SOCKS5 proxies for their web views on supported platforms using Flutter InAppWebView's ProxyController.
+The proxy feature allows users to configure HTTP, HTTPS, and SOCKS5 proxies
+for their web views on supported platforms. Two delivery paths coexist:
+
+- **Android** — global override via `inapp.ProxyController` (a process-wide
+  WebView singleton).
+- **iOS 17+ / macOS 14+** — true per-site override via
+  `WKWebsiteDataStore.proxyConfigurations`, set on the per-site data store
+  created by the patched `preWKWebViewConfiguration`. See
+  [`third_party/PATCHES.md`](../../../third_party/PATCHES.md).
+
+This asymmetry is observable to the user; see
+[PROXY-008](#requirement-proxy-008---android-iOS-isolation-asymmetry-under-profile-mode).
 
 ## Status
 
 - **Status**: Completed
-- **Platforms**: Android, iOS (full support); Linux, macOS, Windows (system default)
+- **Platforms**: Android (global override), iOS 17+ / macOS 14+ (true per-site);
+  Linux, Windows (system default — UI hidden).
 
 ---
 
@@ -19,7 +31,7 @@ The system SHALL support the following proxy types:
 
 1. **DEFAULT** - Use system proxy settings (no override)
 2. **HTTP** - HTTP proxy protocol
-3. **HTTPS** - HTTPS proxy protocol
+3. **HTTPS** - HTTPS proxy protocol (HTTP CONNECT over TLS to the proxy)
 4. **SOCKS5** - SOCKS5 proxy protocol (ideal for Tor, SSH tunnels, etc.)
 
 #### Scenario: Select HTTP proxy type
@@ -34,15 +46,28 @@ The system SHALL support the following proxy types:
 
 ### Requirement: PROXY-002 - Per-Webview Proxy Configuration
 
-Each webview SHALL have its own independent proxy configuration.
+Each webview SHALL have its own proxy configuration in the data model
+(`WebViewModel.proxySettings`). The configuration is persisted per site and
+restored on app restart.
 
-#### Scenario: Configure different proxies per site
+#### Scenario: Configure different proxies per site (iOS / macOS)
 
-**Given** Site A and Site B exist
+**Given** Site A and Site B exist on iOS 17+ / macOS 14+
+**And** Site A and Site B share a base domain (so both can be loaded
+concurrently under [profile mode](../per-site-profiles/spec.md))
 **When** the user configures Site A with SOCKS5 proxy "localhost:9050"
 **And** configures Site B with HTTP proxy "proxy.company.com:8080"
 **Then** Site A routes traffic through the SOCKS5 proxy
-**And** Site B routes traffic through the HTTP proxy
+**And** Site B routes traffic through the HTTP proxy at the same time
+
+#### Scenario: Configure different proxies per site (Android)
+
+**Given** Site A and Site B exist on Android
+**When** the user configures Site A with SOCKS5 proxy "localhost:9050"
+**And** configures Site B with HTTP proxy "proxy.company.com:8080"
+**Then** the data model stores both per-site values
+**And** the implementation propagates the most recently saved value to
+every loaded site (see PROXY-008 for the underlying API constraint)
 
 ---
 
@@ -50,13 +75,31 @@ Each webview SHALL have its own independent proxy configuration.
 
 Users SHALL be able to change proxy settings without restarting the app.
 
-#### Scenario: Change proxy at runtime
+#### Scenario: Change proxy at runtime (Android)
 
-**Given** a site is currently using DEFAULT proxy
+**Given** a site is currently using DEFAULT proxy on Android
 **When** the user changes to SOCKS5 proxy "localhost:9050"
 **And** saves settings
-**Then** the proxy change takes effect immediately
+**Then** the proxy change takes effect on the next request via
+`ProxyController.setProxyOverride`
 **And** no app restart is required
+
+#### Scenario: Change proxy at runtime (iOS / macOS)
+
+**Given** a site is currently using DEFAULT proxy on iOS 17+ / macOS 14+
+**When** the user changes to SOCKS5 proxy "localhost:9050"
+**And** saves settings
+**Then** the live `WKWebView` is discarded by
+`WebViewModel.updateProxySettings` (which calls `disposeWebView`)
+**And** the next render reconstructs the WebView with the new
+`webspaceProxy` map applied to the per-site `WKWebsiteDataStore`
+**And** subsequent requests route through the new proxy
+**And** no app restart is required
+
+The `WKWebsiteDataStore.proxyConfigurations` API is bound at
+`WKWebView.init` and frozen on the live view, so swapping the proxy
+without rebuilding the WebView is not possible — the dispose-and-rebuild
+behavior is intentional.
 
 ---
 
@@ -90,6 +133,14 @@ The system SHALL validate proxy addresses before applying them.
 **Then** an error message is displayed: "Invalid port number"
 **And** the settings are not saved
 
+#### Scenario: Native side rejects malformed maps
+
+**Given** the iOS / macOS path receives a `webspaceProxy` map missing
+required keys (`type`, `host`, `port`) or with an out-of-range port
+**Then** `WebSpaceProxy.configurations(from:)` returns an empty array
+**And** the per-site data store's `proxyConfigurations` is cleared
+**And** the site falls back to system default routing
+
 ---
 
 ### Requirement: PROXY-006 - Platform-Aware UI
@@ -105,22 +156,74 @@ Proxy configuration UI SHALL only be displayed on supported platforms.
 
 #### Scenario: Show proxy UI on supported platforms
 
-**Given** the app is running on Android
+**Given** the app is running on Android, iOS, or macOS
 **When** the user opens site settings
 **Then** the proxy type dropdown and address field are displayed
+
+`PlatformInfo.isProxySupported` returns true unconditionally on iOS and
+macOS — the version gate (`#available(iOS 17.0, macOS 14.0, *)`) lives
+inside the patched native code. On older OS versions the per-site proxy
+block silently no-ops; the UI shows the controls but the site will route
+through system default.
 
 ---
 
 ### Requirement: PROXY-007 - Localhost Bypass
 
-The proxy configuration SHALL bypass localhost addresses to ensure local resources work correctly.
+The proxy configuration SHALL bypass localhost addresses to ensure local
+resources work correctly.
 
-#### Scenario: Access localhost without proxy
+#### Scenario: Access localhost without proxy (Android)
 
-**Given** a SOCKS5 proxy is configured
+**Given** a SOCKS5 proxy is configured on Android
 **When** the site accesses localhost:3000
-**Then** the request bypasses the proxy
+**Then** the request bypasses the proxy via the `<local>` bypass rule
 **And** connects directly to localhost
+
+On iOS / macOS the `Network.framework` `ProxyConfiguration` API does not
+expose a per-config bypass list; localhost routing is governed by
+Apple's defaults (loopback addresses bypass automatically for HTTP
+CONNECT and SOCKS5 proxies).
+
+---
+
+### Requirement: PROXY-008 - Android / iOS Isolation Asymmetry under Profile Mode
+
+The system SHALL behave differently on Android and iOS when multiple
+sites share a base domain and are loaded concurrently under
+[per-site profile mode](../per-site-profiles/spec.md).
+
+#### Scenario: iOS / macOS — true per-site proxy
+
+**Given** profile mode is active on iOS 17+ / macOS 14+
+**And** Site A (`accountA.example.com`) and Site B (`accountB.example.com`)
+are both loaded
+**When** Site A is configured with proxy P1 and Site B with proxy P2
+**Then** each site genuinely uses its own proxy at the same time
+**Because** the proxy is attached to the per-site `WKWebsiteDataStore`,
+which is partitioned per `siteId`
+
+#### Scenario: Android — global last-write-wins
+
+**Given** profile mode is active on Android (System WebView 110+)
+**And** Site A and Site B share a base domain and are both loaded
+**When** Site A is configured with proxy P1 and Site B with proxy P2
+**Then** the underlying `inapp.ProxyController.setProxyOverride` applies
+the most recently set proxy globally to every WebView in the process
+**And** the app's UI sync (`onProxySettingsChanged` in
+[lib/screens/settings.dart](../../../lib/screens/settings.dart)) copies
+the same proxy into every `WebViewModel.proxySettings` field on save —
+so the data model stays consistent with the runtime behavior, but the
+"per-site" promise of the UI is effectively reduced to "global".
+
+#### Scenario: Mixing platforms via settings backup
+
+**Given** a settings backup is exported on iOS with two distinct
+per-site proxies
+**When** the backup is imported on Android
+**Then** both per-site values are preserved in the data model
+**And** whichever site is opened most recently (or saved last) drives
+the global `ProxyController` state
 
 ---
 
@@ -137,9 +240,31 @@ enum ProxyType { DEFAULT, HTTP, HTTPS, SOCKS5 }
 ```dart
 class UserProxySettings {
   ProxyType type;
-  String? address;  // Format: "host:port"
+  String? address;   // Format: "host:port"
+  String? username;  // Optional credentials
+  String? password;
 }
 ```
+
+### iOS / macOS wire format
+
+When passed through `WebSpaceInAppWebViewSettings.webspaceProxy`, the
+settings are translated by `_proxySettingsToWebspaceProxy` in
+[lib/services/webview.dart](../../../lib/services/webview.dart) into:
+
+```dart
+{
+  'type':     'http' | 'https' | 'socks5',
+  'host':     'proxy.example.com',
+  'port':     8080,
+  'username': 'optional',
+  'password': 'optional',
+}
+```
+
+`ProxyType.DEFAULT`, missing addresses, or malformed entries return
+`null`, which the patched native side interprets as "clear proxy on this
+data store".
 
 ---
 
@@ -150,16 +275,24 @@ lib/settings/proxy.dart
 ├── ProxyType enum
 └── UserProxySettings class
 
-lib/platform/unified_webview.dart
-└── UnifiedProxyManager (ProxyController integration)
+lib/services/webview.dart
+├── PlatformInfo.isProxySupported          (Android: feature-flag; iOS/macOS: always true)
+├── ProxyManager.setProxySettings           (Android: ProxyController; iOS/macOS: no-op)
+├── WebSpaceInAppWebViewSettings.webspaceProxy
+└── _proxySettingsToWebspaceProxy
 
 lib/web_view_model.dart
-├── proxySettings field
-├── _applyProxySettings() method
-└── updateProxySettings() method
+├── proxySettings field                                (per-site; persisted)
+├── _applyProxySettings()                              (Android only)
+└── updateProxySettings()                              (Android: ProxyController; iOS/macOS: dispose+rebuild)
 
 lib/screens/settings.dart
-└── Proxy configuration UI with validation
+└── Proxy configuration UI; cross-site sync gated to Android only
+
+third_party/flutter_inappwebview_ios.patch
+third_party/flutter_inappwebview_macos.patch
+└── webspaceProxy field + preWKWebViewConfiguration block
+    + WebSpaceProxy.swift helper (NWEndpoint / ProxyConfiguration builder)
 ```
 
 ---
@@ -168,11 +301,11 @@ lib/screens/settings.dart
 
 | Platform | Proxy Support | UI Visibility | Behavior |
 |----------|--------------|---------------|----------|
-| Android  | Full         | Shown         | ProxyController with all options |
-| iOS      | Full         | Shown         | ProxyController with all options |
+| Android  | Full (global override) | Shown (when `PROXY_OVERRIDE` feature present) | `inapp.ProxyController` singleton; per-site config in data model is sync'd globally on save (PROXY-008) |
+| iOS      | Full (per-site, iOS 17+) | Shown unconditionally | Patched plugin attaches `proxyConfigurations` to per-site `WKWebsiteDataStore`; iOS <17 silently routes through system default |
+| macOS    | Full (per-site, macOS 14+) | Shown unconditionally | Same pattern as iOS; macOS <14 silently routes through system default |
 | Linux    | None         | Hidden        | DEFAULT proxy forced, UI hidden |
-| macOS    | Limited      | Conditional   | Shown only if PROXY_OVERRIDE supported |
-| Windows  | Limited      | Conditional   | Shown only if PROXY_OVERRIDE supported |
+| Windows  | Limited      | Conditional   | Shown only if `PROXY_OVERRIDE` supported |
 
 ---
 
@@ -180,10 +313,44 @@ lib/screens/settings.dart
 
 ### Created
 - `lib/settings/proxy.dart` - Proxy types and settings model
-- `test/proxy_test.dart` - Unit tests (23 tests)
-- `test/proxy_integration_test.dart` - Integration tests (12 tests)
+- `test/proxy_test.dart` - Unit tests
+- `test/proxy_integration_test.dart` - Integration tests
+- `third_party/flutter_inappwebview_ios.patch` - per-site `webspaceProxy` field, `WebSpaceProxy.swift`
+- `third_party/flutter_inappwebview_macos.patch` - sister copy
 
 ### Modified
-- `lib/platform/unified_webview.dart` - ProxyController integration
-- `lib/web_view_model.dart` - Proxy application in WebViewModel
-- `lib/screens/settings.dart` - Settings UI with validation and platform detection
+- `lib/services/webview.dart` - `WebSpaceInAppWebViewSettings.webspaceProxy`, ProxyManager iOS no-op, PlatformInfo iOS gate
+- `lib/web_view_model.dart` - per-site proxy passed into `WebViewConfig`; iOS rebuild on update
+- `lib/screens/settings.dart` - cross-site proxy sync gated to Android only
+
+---
+
+## Manual Test Procedure
+
+### iOS / macOS true per-site proxy
+
+1. Add two sites that share a base domain (e.g. two `github.com` accounts).
+2. Configure Site A with HTTP proxy `127.0.0.1:8080` and Site B with
+   SOCKS5 proxy `127.0.0.1:9050` (run two local proxies of different
+   shapes — `mitmproxy` and `dante`, for example).
+3. Open Site A: requests must show up in `mitmproxy` only.
+4. Switch to Site B without unloading Site A (profile mode allows both
+   to be loaded simultaneously): requests must show up in `dante` only.
+5. Both proxies should remain active for their respective sites.
+
+### Android global last-write-wins
+
+1. Same setup as above on Android.
+2. Save Site A's config, then Site B's: every WebView (including Site A)
+   now routes through Site B's proxy.
+3. The settings UI's cross-site sync should also have copied Site B's
+   proxy into Site A's `proxySettings` — the data model and the runtime
+   behavior should match.
+
+### Older OS fallback
+
+1. Configure a non-DEFAULT proxy on iOS 16 or macOS 13.
+2. Page loads should succeed and route through system default — the
+   patched `#available(iOS 17.0, macOS 14.0, *)` block silently no-ops.
+3. The UI should still allow the configuration (no crash), matching
+   `PlatformInfo.isProxySupported = true`.

--- a/third_party/PATCHES.md
+++ b/third_party/PATCHES.md
@@ -1,13 +1,24 @@
 # `third_party/` — patched flutter_inappwebview plugins
 
-WebSpace requires per-site cookie + storage isolation. The native
-primitives are:
+WebSpace requires two per-site primitives that stock
+`flutter_inappwebview` does not expose:
 
-- **Android**: `androidx.webkit.Profile` (System WebView 110+).
-  Bound via `WebViewCompat.setProfile(webView, profileName)`.
-- **iOS / macOS**: `WKWebsiteDataStore(forIdentifier: UUID)` (iOS
-  17+ / macOS 14+). Set on `WKWebViewConfiguration.websiteDataStore`
-  before `WKWebView(frame: configuration:)` runs.
+1. **Per-site cookie + storage isolation**:
+   - **Android**: `androidx.webkit.Profile` (System WebView 110+).
+     Bound via `WebViewCompat.setProfile(webView, profileName)`.
+   - **iOS / macOS**: `WKWebsiteDataStore(forIdentifier: UUID)` (iOS
+     17+ / macOS 14+). Set on `WKWebViewConfiguration.websiteDataStore`
+     before `WKWebView(frame: configuration:)` runs.
+
+2. **Per-site proxy** (iOS 17+ / macOS 14+ only):
+   `WKWebsiteDataStore.proxyConfigurations`, attached to the per-site
+   data store from item 1 inside the same `preWKWebViewConfiguration`
+   block. This is the only Apple API that scopes a proxy to a single
+   `WKWebView`. We deliberately diverge from upstream PR #2671 (which
+   would route every view through the global `nonPersistent()` store
+   and defeat per-site isolation); see
+   [`openspec/specs/proxy/spec.md`](../openspec/specs/proxy/spec.md)
+   PROXY-008 for the rationale and the Android asymmetry it documents.
 
 Stock `flutter_inappwebview` does not expose either. Worse, both
 platforms freeze the data-store decision before Dart can intercept:
@@ -155,20 +166,31 @@ per-site profile API:
 
 ## Patch contents (cheat-sheet)
 
-Each patch touches the minimum needed: a new `webspaceProfile` field
-on the plugin's settings type, the bind block at the
-construction-time injection point, and (on iOS / macOS) a small
-`WebSpaceProfile.swift` helper that derives a deterministic UUID
-from the profile name via SHA-256 — Apple's
-`WKWebsiteDataStore(forIdentifier:)` requires a UUID and our siteIds
-are opaque strings.
+Each patch touches the minimum needed:
+
+- a new `webspaceProfile` field on the plugin's settings type,
+- the bind block at the construction-time injection point,
+- (iOS / macOS) a `webspaceProxy` field on the same settings type +
+  a sibling block in `preWKWebViewConfiguration` that sets
+  `proxyConfigurations` on the per-site data store, +
+  a `WebSpaceProxy.swift` helper that builds
+  `[Network.ProxyConfiguration]` from the dict,
+- (iOS / macOS) a `WebSpaceProfile.swift` helper that derives a
+  deterministic UUID from the profile name via SHA-256 — Apple's
+  `WKWebsiteDataStore(forIdentifier:)` requires a UUID and our siteIds
+  are opaque strings,
+- (iOS / macOS) `MyCookieManager` is rerouted to look up the WebView's
+  per-site `WKHTTPCookieStore` via `webViewId` so DevTools cookie ops
+  hit the bound profile instead of the default jar.
 
 | Plugin | Files touched | Total LOC added |
 |---|---|---|
 | flutter_inappwebview_android | InAppWebView.java, InAppWebViewSettings.java | ~25 |
-| flutter_inappwebview_ios     | InAppWebView.swift, InAppWebViewSettings.swift, WebSpaceProfile.swift (new) | ~30 |
-| flutter_inappwebview_macos   | InAppWebView.swift, InAppWebViewSettings.swift, WebSpaceProfile.swift (new) | ~30 |
+| flutter_inappwebview_ios     | InAppWebView.swift, InAppWebViewSettings.swift, WebSpaceProfile.swift (new), WebSpaceProxy.swift (new), MyCookieManager.swift, lib/src/cookie_manager.dart | ~140 |
+| flutter_inappwebview_macos   | InAppWebView.swift, InAppWebViewSettings.swift, WebSpaceProfile.swift (new), WebSpaceProxy.swift (new), MyCookieManager.swift, lib/src/cookie_manager.dart | ~140 |
 
-Spec: [`openspec/specs/per-site-profiles/spec.md`](../openspec/specs/per-site-profiles/spec.md).
+Specs:
+- [`openspec/specs/per-site-profiles/spec.md`](../openspec/specs/per-site-profiles/spec.md)
+- [`openspec/specs/proxy/spec.md`](../openspec/specs/proxy/spec.md) (PROXY-008 covers the Android↔iOS asymmetry)
 
 License: upstream is Apache 2.0; our patches are also Apache 2.0.

--- a/third_party/flutter_inappwebview_ios.patch
+++ b/third_party/flutter_inappwebview_ios.patch
@@ -1,7 +1,19 @@
 diff -urN a/ios/Classes/InAppWebView/InAppWebView.swift b/ios/Classes/InAppWebView/InAppWebView.swift
---- a/ios/Classes/InAppWebView/InAppWebView.swift	2026-04-28 04:51:25.785500668 +0000
-+++ b/ios/Classes/InAppWebView/InAppWebView.swift	2026-04-28 04:51:25.921500618 +0000
-@@ -16,6 +16,39 @@
+--- a/ios/Classes/InAppWebView/InAppWebView.swift	2026-04-28 05:25:52.863677986 +0000
++++ b/ios/Classes/InAppWebView/InAppWebView.swift	2026-04-28 05:29:36.230380733 +0000
+@@ -7,6 +7,11 @@
+ 
+ import Flutter
+ import Foundation
++// [WebSpace fork patch] — `Network` provides `NWEndpoint` / `ProxyConfiguration`,
++// used by WebSpaceProxy.swift to build the per-site proxy applied to a per-site
++// WKWebsiteDataStore on iOS 17+. Adding the import unconditionally is fine —
++// `Network` ships in iOS 12+, well below our deployment target.
++import Network
+ import WebKit
+ 
+ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
+@@ -16,6 +21,39 @@
                              Disposable {
      static let METHOD_CHANNEL_NAME_PREFIX = "com.pichillilorenzo/flutter_inappwebview_"
  
@@ -41,7 +53,7 @@ diff -urN a/ios/Classes/InAppWebView/InAppWebView.swift b/ios/Classes/InAppWebVi
      var id: Any? // viewId
      var plugin: SwiftFlutterPlugin?
      var windowId: Int64?
-@@ -74,6 +107,8 @@
+@@ -74,6 +112,8 @@
          super.init(frame: frame, configuration: configuration)
          self.id = id
          self.plugin = plugin
@@ -50,7 +62,7 @@ diff -urN a/ios/Classes/InAppWebView/InAppWebView.swift b/ios/Classes/InAppWebVi
          if let id = id, let registrar = plugin?.registrar {
              let channel = FlutterMethodChannel(name: InAppWebView.METHOD_CHANNEL_NAME_PREFIX + String(describing: id),
                                                 binaryMessenger: registrar.messenger())
-@@ -617,6 +652,19 @@
+@@ -617,6 +657,37 @@
                  } else if settings.cacheEnabled {
                      configuration.websiteDataStore = WKWebsiteDataStore.default()
                  }
@@ -67,13 +79,31 @@ diff -urN a/ios/Classes/InAppWebView/InAppWebView.swift b/ios/Classes/InAppWebVi
 +                    configuration.websiteDataStore =
 +                        WKWebsiteDataStore(forIdentifier: WebSpaceProfile.uuid(for: profile))
 +                }
++                // [WebSpace fork patch] — see third_party/PATCHES.md in the WebSpace repo.
++                // Per-site proxy. Apple's `WKWebsiteDataStore.proxyConfigurations`
++                // (iOS 17+ / macOS 14+) is the only API that scopes a proxy to a
++                // single WKWebView, by attaching the config to the view's data
++                // store. We intentionally diverge from upstream PR #2671 here:
++                // that PR routes proxy through the GLOBAL `default()` /
++                // `nonPersistent()` stores, defeating per-site isolation when
++                // multiple sites are loaded concurrently. We attach the proxy
++                // to whichever store this WebView ended up with — typically the
++                // per-site `WKWebsiteDataStore(forIdentifier:)` set above, so
++                // each site genuinely uses its own proxy. On <iOS 17 / <macOS 14
++                // there is no per-store proxy API, so the block is no-op and the
++                // site falls back to system default routing.
++                if let proxy = settings.webspaceProxy,
++                   #available(iOS 17.0, macOS 14.0, *) {
++                    configuration.websiteDataStore.proxyConfigurations =
++                        WebSpaceProxy.configurations(from: proxy)
++                }
                  if !settings.applicationNameForUserAgent.isEmpty {
                      if let applicationNameForUserAgent = configuration.applicationNameForUserAgent {
                          configuration.applicationNameForUserAgent = applicationNameForUserAgent + " " + settings.applicationNameForUserAgent
 diff -urN a/ios/Classes/InAppWebView/InAppWebViewSettings.swift b/ios/Classes/InAppWebView/InAppWebViewSettings.swift
---- a/ios/Classes/InAppWebView/InAppWebViewSettings.swift	2026-04-28 04:51:25.787500667 +0000
-+++ b/ios/Classes/InAppWebView/InAppWebViewSettings.swift	2026-04-28 04:51:25.924500617 +0000
-@@ -30,6 +30,16 @@
+--- a/ios/Classes/InAppWebView/InAppWebViewSettings.swift	2026-04-28 05:25:52.863658569 +0000
++++ b/ios/Classes/InAppWebView/InAppWebViewSettings.swift	2026-04-28 05:29:50.530381583 +0000
+@@ -30,6 +30,24 @@
      var interceptOnlyAsyncAjaxRequests = true
      var useShouldInterceptFetchRequest = false
      var incognito = false
@@ -87,12 +117,20 @@ diff -urN a/ios/Classes/InAppWebView/InAppWebViewSettings.swift b/ios/Classes/In
 +    // before `WKWebView(frame:configuration:)` runs — the data store
 +    // is frozen at construction.
 +    var webspaceProfile: String? = nil
++    // [WebSpace fork patch] — see third_party/PATCHES.md in the WebSpace repo.
++    // Per-site proxy applied to the per-site WKWebsiteDataStore in
++    // preWKWebViewConfiguration. Map keys: `type` ("http"|"https"|"socks5"),
++    // `host` (String), `port` (Int 1..65535), and optional `username` /
++    // `password` (Strings). Nil means "no proxy override" — the site uses
++    // system default routing. Honored only on iOS 17+ / macOS 14+; ignored
++    // on older OSes (no API to scope a proxy to one data store there).
++    var webspaceProxy: [String: Any]? = nil
      var cacheEnabled = true
      var transparentBackground = false
      var disableVerticalScroll = false
 diff -urN a/ios/Classes/InAppWebView/WebSpaceProfile.swift b/ios/Classes/InAppWebView/WebSpaceProfile.swift
 --- a/ios/Classes/InAppWebView/WebSpaceProfile.swift	1970-01-01 00:00:00.000000000 +0000
-+++ b/ios/Classes/InAppWebView/WebSpaceProfile.swift	2026-04-28 04:51:25.929500615 +0000
++++ b/ios/Classes/InAppWebView/WebSpaceProfile.swift	2026-04-28 05:25:52.884789988 +0000
 @@ -0,0 +1,51 @@
 +//
 +// WebSpaceProfile.swift
@@ -145,9 +183,86 @@ diff -urN a/ios/Classes/InAppWebView/WebSpaceProfile.swift b/ios/Classes/InAppWe
 +        return UUID(uuid: bytes)
 +    }
 +}
+diff -urN a/ios/Classes/InAppWebView/WebSpaceProxy.swift b/ios/Classes/InAppWebView/WebSpaceProxy.swift
+--- a/ios/Classes/InAppWebView/WebSpaceProxy.swift	1970-01-01 00:00:00.000000000 +0000
++++ b/ios/Classes/InAppWebView/WebSpaceProxy.swift	2026-04-28 05:30:44.662384801 +0000
+@@ -0,0 +1,73 @@
++//
++// WebSpaceProxy.swift
++//
++// [WebSpace fork patch] — see third_party/PATCHES.md in the WebSpace repo
++//
++// Per-site proxy helper. Apple's `WKWebsiteDataStore.proxyConfigurations`
++// (iOS 17+ / macOS 14+) takes an array of `Network.ProxyConfiguration`,
++// which is the only API that scopes a proxy to a single WKWebView's data
++// store. Upstream `flutter_inappwebview` doesn't expose this; we pass
++// the proxy through a new `webspaceProxy` settings field and translate
++// it here.
++//
++// Why we don't reuse upstream PR #2671's design:
++//   - PR #2671 routes proxy via the GLOBAL `WKWebsiteDataStore.default()`
++//     and a swap to `nonPersistent()`, defeating per-site isolation.
++//   - We attach proxy to whichever store the WebView ended up with —
++//     for a profile-bound site, that's the per-site
++//     `WKWebsiteDataStore(forIdentifier:)` set in
++//     `preWKWebViewConfiguration`. So each site genuinely uses its own
++//     proxy, even when multiple sites are loaded concurrently.
++//
++// Map shape (passed from Dart through the settings dictionary):
++//   {
++//     "type":     "http" | "https" | "socks5",   // required
++//     "host":     "proxy.example.com",            // required
++//     "port":     8080,                           // required, 1..65535
++//     "username": "user",                         // optional
++//     "password": "pass"                          // optional
++//   }
++//
++// Invalid maps return an empty array, which clears any previously-set
++// proxy on the store (matches the documented "no override" behavior).
++
++import Foundation
++import Network
++
++@available(iOS 17.0, macOS 14.0, *)
++public enum WebSpaceProxy {
++    /// Build a `[ProxyConfiguration]` from the Dart-provided dictionary.
++    /// Returns an empty array on invalid input (caller should treat that
++    /// as "clear proxy").
++    public static func configurations(from map: [String: Any]) -> [ProxyConfiguration] {
++        guard let type = map["type"] as? String,
++              let host = map["host"] as? String, !host.isEmpty,
++              let portInt = map["port"] as? Int,
++              portInt > 0, portInt <= 65535,
++              let port = NWEndpoint.Port(rawValue: UInt16(portInt)) else {
++            return []
++        }
++
++        let endpoint = NWEndpoint.hostPort(host: NWEndpoint.Host(host), port: port)
++
++        var config: ProxyConfiguration
++        switch type.lowercased() {
++        case "https":
++            // HTTPS proxy = HTTP CONNECT over TLS to the proxy itself.
++            config = ProxyConfiguration(httpCONNECTProxy: endpoint, tlsOptions: NWProtocolTLS.Options())
++        case "http":
++            config = ProxyConfiguration(httpCONNECTProxy: endpoint, tlsOptions: nil)
++        case "socks5":
++            config = ProxyConfiguration(socksv5Proxy: endpoint)
++        default:
++            return []
++        }
++
++        if let username = map["username"] as? String, !username.isEmpty,
++           let password = map["password"] as? String, !password.isEmpty {
++            config.applyCredential(username: username, password: password)
++        }
++
++        return [config]
++    }
++}
 diff -urN a/ios/Classes/MyCookieManager.swift b/ios/Classes/MyCookieManager.swift
---- a/ios/Classes/MyCookieManager.swift	2026-04-28 04:51:25.797500664 +0000
-+++ b/ios/Classes/MyCookieManager.swift	2026-04-28 04:51:25.931500615 +0000
+--- a/ios/Classes/MyCookieManager.swift	2026-04-28 05:25:52.864194206 +0000
++++ b/ios/Classes/MyCookieManager.swift	2026-04-28 05:25:52.884938486 +0000
 @@ -6,6 +6,7 @@
  //
  
@@ -260,8 +375,8 @@ diff -urN a/ios/Classes/MyCookieManager.swift b/ios/Classes/MyCookieManager.swif
                      })
                      return
 diff -urN a/lib/src/cookie_manager.dart b/lib/src/cookie_manager.dart
---- a/lib/src/cookie_manager.dart	2026-04-28 04:51:25.885500631 +0000
-+++ b/lib/src/cookie_manager.dart	2026-04-28 04:51:26.025500580 +0000
+--- a/lib/src/cookie_manager.dart	2026-04-28 05:25:52.862086498 +0000
++++ b/lib/src/cookie_manager.dart	2026-04-28 05:25:52.885085689 +0000
 @@ -183,6 +183,14 @@
  
      Map<String, dynamic> args = <String, dynamic>{};

--- a/third_party/flutter_inappwebview_macos.patch
+++ b/third_party/flutter_inappwebview_macos.patch
@@ -1,6 +1,6 @@
 diff -urN a/lib/src/cookie_manager.dart b/lib/src/cookie_manager.dart
---- a/lib/src/cookie_manager.dart	2026-04-28 04:51:37.604496334 +0000
-+++ b/lib/src/cookie_manager.dart	2026-04-28 04:51:37.816496257 +0000
+--- a/lib/src/cookie_manager.dart	2026-04-28 05:25:58.506949888 +0000
++++ b/lib/src/cookie_manager.dart	2026-04-28 05:25:58.525143347 +0000
 @@ -183,6 +183,10 @@
  
      Map<String, dynamic> args = <String, dynamic>{};
@@ -24,9 +24,21 @@ diff -urN a/lib/src/cookie_manager.dart b/lib/src/cookie_manager.dart
    }
  
 diff -urN a/macos/Classes/InAppWebView/InAppWebView.swift b/macos/Classes/InAppWebView/InAppWebView.swift
---- a/macos/Classes/InAppWebView/InAppWebView.swift	2026-04-28 04:51:37.635496323 +0000
-+++ b/macos/Classes/InAppWebView/InAppWebView.swift	2026-04-28 04:51:37.716496293 +0000
-@@ -15,6 +15,42 @@
+--- a/macos/Classes/InAppWebView/InAppWebView.swift	2026-04-28 05:25:58.510235898 +0000
++++ b/macos/Classes/InAppWebView/InAppWebView.swift	2026-04-28 05:31:22.906387074 +0000
+@@ -7,6 +7,11 @@
+ 
+ import FlutterMacOS
+ import Foundation
++// [WebSpace fork patch] — `Network` provides `NWEndpoint` / `ProxyConfiguration`,
++// used by WebSpaceProxy.swift to build the per-site proxy applied to a per-site
++// WKWebsiteDataStore on macOS 14+. The framework ships in macOS 10.14+, well
++// below our deployment target, so importing it unconditionally is fine.
++import Network
+ import WebKit
+ 
+ public class InAppWebView: WKWebView, WKUIDelegate,
+@@ -15,6 +20,42 @@
                              Disposable {
      static var METHOD_CHANNEL_NAME_PREFIX = "com.pichillilorenzo/flutter_inappwebview_"
  
@@ -69,7 +81,7 @@ diff -urN a/macos/Classes/InAppWebView/InAppWebView.swift b/macos/Classes/InAppW
      var id: Any? // viewId
      var plugin: InAppWebViewFlutterPlugin?
      var windowId: Int64?
-@@ -63,8 +99,20 @@
+@@ -63,8 +104,20 @@
          self.initialUserScripts = userScripts
          uiDelegate = self
          navigationDelegate = self
@@ -91,7 +103,7 @@ diff -urN a/macos/Classes/InAppWebView/InAppWebView.swift b/macos/Classes/InAppW
      required public init(coder aDecoder: NSCoder) {
          super.init(coder: aDecoder)!
      }
-@@ -261,6 +309,16 @@
+@@ -261,6 +314,29 @@
              } else if settings.cacheEnabled {
                  configuration.websiteDataStore = WKWebsiteDataStore.default()
              }
@@ -105,13 +117,26 @@ diff -urN a/macos/Classes/InAppWebView/InAppWebView.swift b/macos/Classes/InAppW
 +                configuration.websiteDataStore =
 +                    WKWebsiteDataStore(forIdentifier: WebSpaceProfile.uuid(for: profile))
 +            }
++            // [WebSpace fork patch] — see third_party/PATCHES.md in the WebSpace repo.
++            // Per-site proxy on macOS 14+. Same shape and rationale as the iOS
++            // fork's block (see PROF-005 + the proxy spec): we attach the proxy
++            // to whichever store this WebView ended up with — typically the
++            // per-site `WKWebsiteDataStore(forIdentifier:)` set above, so each
++            // site genuinely uses its own proxy. Diverges from upstream PR #2671,
++            // which forces every view through the GLOBAL nonPersistent store and
++            // would defeat per-site isolation.
++            if let proxy = settings.webspaceProxy,
++               #available(macOS 14.0, *) {
++                configuration.websiteDataStore.proxyConfigurations =
++                    WebSpaceProxy.configurations(from: proxy)
++            }
              if !settings.applicationNameForUserAgent.isEmpty {
                  if let applicationNameForUserAgent = configuration.applicationNameForUserAgent {
                      configuration.applicationNameForUserAgent = applicationNameForUserAgent + " " + settings.applicationNameForUserAgent
 diff -urN a/macos/Classes/InAppWebView/InAppWebViewSettings.swift b/macos/Classes/InAppWebView/InAppWebViewSettings.swift
---- a/macos/Classes/InAppWebView/InAppWebViewSettings.swift	2026-04-28 04:51:37.637496322 +0000
-+++ b/macos/Classes/InAppWebView/InAppWebViewSettings.swift	2026-04-28 04:51:37.720496292 +0000
-@@ -28,6 +28,11 @@
+--- a/macos/Classes/InAppWebView/InAppWebViewSettings.swift	2026-04-28 05:25:58.510217734 +0000
++++ b/macos/Classes/InAppWebView/InAppWebViewSettings.swift	2026-04-28 05:31:29.962387493 +0000
+@@ -28,6 +28,16 @@
      var interceptOnlyAsyncAjaxRequests = true
      var useShouldInterceptFetchRequest = false
      var incognito = false
@@ -120,12 +145,17 @@ diff -urN a/macos/Classes/InAppWebView/InAppWebViewSettings.swift b/macos/Classe
 +    // shares the same `WKWebsiteDataStore(forIdentifier:)` API. See
 +    // PROF-005 in openspec/specs/per-site-profiles/spec.md.
 +    var webspaceProfile: String? = nil
++    // [WebSpace fork patch] — see third_party/PATCHES.md in the WebSpace repo.
++    // Same shape as the iOS fork's webspaceProxy field; macOS 14+ shares the
++    // same `WKWebsiteDataStore.proxyConfigurations` API. Honored only on
++    // macOS 14+; ignored on older OSes.
++    var webspaceProxy: [String: Any]? = nil
      var cacheEnabled = true
      var transparentBackground = false
      var supportZoom = true
 diff -urN a/macos/Classes/InAppWebView/WebSpaceProfile.swift b/macos/Classes/InAppWebView/WebSpaceProfile.swift
 --- a/macos/Classes/InAppWebView/WebSpaceProfile.swift	1970-01-01 00:00:00.000000000 +0000
-+++ b/macos/Classes/InAppWebView/WebSpaceProfile.swift	2026-04-28 04:51:37.724496290 +0000
++++ b/macos/Classes/InAppWebView/WebSpaceProfile.swift	2026-04-28 05:25:58.526674942 +0000
 @@ -0,0 +1,36 @@
 +//
 +// WebSpaceProfile.swift
@@ -163,9 +193,62 @@ diff -urN a/macos/Classes/InAppWebView/WebSpaceProfile.swift b/macos/Classes/InA
 +        return UUID(uuid: bytes)
 +    }
 +}
+diff -urN a/macos/Classes/InAppWebView/WebSpaceProxy.swift b/macos/Classes/InAppWebView/WebSpaceProxy.swift
+--- a/macos/Classes/InAppWebView/WebSpaceProxy.swift	1970-01-01 00:00:00.000000000 +0000
++++ b/macos/Classes/InAppWebView/WebSpaceProxy.swift	2026-04-28 05:31:40.190388101 +0000
+@@ -0,0 +1,49 @@
++//
++// WebSpaceProxy.swift
++//
++// [WebSpace fork patch] — see third_party/PATCHES.md in the WebSpace repo
++//
++// Sister copy of the iOS fork's WebSpaceProxy helper. The two platform
++// packages don't share a Swift module so the helper is duplicated; the
++// byte-level definition stays identical so a given proxy dictionary
++// produces the same configuration on both platforms.
++//
++// Keep the body byte-identical to
++// third_party/flutter_inappwebview_ios/ios/Classes/InAppWebView/WebSpaceProxy.swift.
++
++import Foundation
++import Network
++
++@available(macOS 14.0, *)
++public enum WebSpaceProxy {
++    public static func configurations(from map: [String: Any]) -> [ProxyConfiguration] {
++        guard let type = map["type"] as? String,
++              let host = map["host"] as? String, !host.isEmpty,
++              let portInt = map["port"] as? Int,
++              portInt > 0, portInt <= 65535,
++              let port = NWEndpoint.Port(rawValue: UInt16(portInt)) else {
++            return []
++        }
++
++        let endpoint = NWEndpoint.hostPort(host: NWEndpoint.Host(host), port: port)
++
++        var config: ProxyConfiguration
++        switch type.lowercased() {
++        case "https":
++            config = ProxyConfiguration(httpCONNECTProxy: endpoint, tlsOptions: NWProtocolTLS.Options())
++        case "http":
++            config = ProxyConfiguration(httpCONNECTProxy: endpoint, tlsOptions: nil)
++        case "socks5":
++            config = ProxyConfiguration(socksv5Proxy: endpoint)
++        default:
++            return []
++        }
++
++        if let username = map["username"] as? String, !username.isEmpty,
++           let password = map["password"] as? String, !password.isEmpty {
++            config.applyCredential(username: username, password: password)
++        }
++
++        return [config]
++    }
++}
 diff -urN a/macos/Classes/MyCookieManager.swift b/macos/Classes/MyCookieManager.swift
---- a/macos/Classes/MyCookieManager.swift	2026-04-28 04:51:37.642496320 +0000
-+++ b/macos/Classes/MyCookieManager.swift	2026-04-28 04:51:37.726496290 +0000
+--- a/macos/Classes/MyCookieManager.swift	2026-04-28 05:25:58.510567047 +0000
++++ b/macos/Classes/MyCookieManager.swift	2026-04-28 05:25:58.526786888 +0000
 @@ -5,6 +5,7 @@
  //  Created by Lorenzo on 26/10/18.
  //


### PR DESCRIPTION
Extends the iOS / macOS plugin patches with a `webspaceProxy` field on
`InAppWebViewSettings` and a sibling `proxyConfigurations` block in
`preWKWebViewConfiguration` that attaches the proxy to whichever data
store this WebView ended up with — typically the per-site
`WKWebsiteDataStore(forIdentifier:)` already created by the profile
patch. Two same-base-domain sites loaded concurrently can now use
different proxies on iOS 17+ / macOS 14+.

Diverges from upstream PR #2671 (which routes proxy through the global
`nonPersistent()` store and would defeat per-site isolation under
profile mode); see PROXY-008 in `openspec/specs/proxy/spec.md` for the
Android↔iOS asymmetry: Android's `inapp.ProxyController` is a
process-wide singleton, so per-site config in the data model is
effectively last-write-wins. The settings-screen sync that copied the
proxy across all sites is now Android-only.

`PlatformInfo.isProxySupported` returns true unconditionally on iOS /
macOS; the version gate (`#available(iOS 17.0, macOS 14.0, *)`) lives
in the patched native code. Older OS versions silently fall through to
system default routing. `WebViewModel.updateProxySettings` discards the
live WebView on iOS / macOS so the next render rebuilds it with the new
proxy (the data store is frozen at `WKWebView.init`).

https://claude.ai/code/session_012Q7N2ibBMKssYZCCy4i53t