### PR TITLE
Add GitHub FUNDING.yml linking to sponsor profile

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: theoden8


### PR DESCRIPTION
Surface the existing GitHub Sponsors link in the repository sidebar so visitors see the Sponsor button directly from the repo page.