### PR TITLE
Add fastlane changelog for 0.2.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,10 @@ Detailed feature specs are in `openspec/specs/`. Each spec uses Given/When/Then 
 
 Read the relevant spec before modifying a feature. Specs include file paths, data models, and manual test procedures.
 
+## Fastlane changelogs
+
+Files under `fastlane/metadata/android/en-US/changelogs/<N>.txt` (and the sibling `short_description.txt` / `full_description.txt`) are subject to Play Store / F-Droid length caps: **changelog and full description max 500 bytes, short description max 80 bytes (no trailing dot)**. Always run [scripts/validate_fastlane_metadata.sh](scripts/validate_fastlane_metadata.sh) before committing any change to those files — an oversize changelog will silently break F-Droid metadata sync. The script exits non-zero on any violation.
+
 ## Adding a new global app setting
 
 Any user-facing global toggle/preference persisted to `SharedPreferences` MUST be routed through the export/import registry, otherwise it silently drops out of user backups.

--- a/fastlane/metadata/android/en-US/changelogs/17.txt
+++ b/fastlane/metadata/android/en-US/changelogs/17.txt
@@ -2,11 +2,11 @@
 • Native per-site containers
 • Per-site HTTP/SOCKS5 proxy on all platforms except Android
 • Per-site geolocation spoof + timezone + WebRTC lockdown
-• Desktop mode via per-site UA picker
+• Convincing desktop mode: UA picker + viewport/navigator shims
 • iOS Universal Link bypass
 
 🔧 Improvements:
 • Dart-side HTTP via proxy (no IP leak); navigator.language; intent:// prompt
 
 🐛 Bug Fixes:
-• JS timer pause; cross-domain URL leak; nested-webview scripts; HTML cache no longer saves stopped pages; dark UA icons
+• JS timer pause; cross-domain URL leak; nested-webview scripts; HTML cache skips stopped pages; dark UA icons

--- a/fastlane/metadata/android/en-US/changelogs/17.txt
+++ b/fastlane/metadata/android/en-US/changelogs/17.txt
@@ -3,7 +3,7 @@
 • Per-site HTTP/SOCKS5 proxy on all platforms except Android
 • Per-site geolocation spoof + timezone + WebRTC lockdown
 • Convincing desktop mode: UA picker + viewport/navigator shims
-• Cross-app intent handling on iOS + Android
+• Cross-app intent handling
 
 🔧 Improvements:
 • Dart-side HTTP via proxy (no IP leak); navigator.language

--- a/fastlane/metadata/android/en-US/changelogs/17.txt
+++ b/fastlane/metadata/android/en-US/changelogs/17.txt
@@ -1,0 +1,18 @@
+✨ New Features:
+• Native per-site containers on Android, iOS 17+, macOS 14+ — same-domain sites coexist without cookie shuffling
+• Per-site HTTP/SOCKS5 proxy on iOS 17+, macOS 14+, Linux
+• Per-site geolocation spoofing with timezone override and WebRTC leak lockdown
+• Desktop mode via per-site UA picker (Linux/macOS/Windows)
+• iOS Universal Link bypass keeps http links in-app
+
+🔧 Improvements:
+• Dart-side outbound HTTP routed through the active proxy (no icon/HTML IP leak)
+• Override navigator.language so SPAs honor per-site language
+• Confirm prompt before launching intent:// and other external-app URLs
+• Plus: "use current location" picker button, system text scale respected, preserve chrome://, about://, file:// in URL bar, hide Home Shortcut when already pinned
+
+🐛 Bug Fixes:
+• Per-site pause no longer freezes JS timers process-globally
+• onUrlChanged no longer leaks cross-domain URLs into site state
+• User scripts now propagate into nested webviews
+• Android file chooser FileProvider declared; user-agent icons adapt to dark theme

--- a/fastlane/metadata/android/en-US/changelogs/17.txt
+++ b/fastlane/metadata/android/en-US/changelogs/17.txt
@@ -1,5 +1,5 @@
 ✨ New Features:
-• Native per-site containers (Android, iOS 17+, macOS 14+)
+• Native per-site containers
 • Per-site HTTP/SOCKS5 proxy on iOS 17+, macOS 14+, Linux
 • Per-site geolocation spoof + timezone + WebRTC lockdown
 • Desktop mode via per-site UA picker

--- a/fastlane/metadata/android/en-US/changelogs/17.txt
+++ b/fastlane/metadata/android/en-US/changelogs/17.txt
@@ -1,6 +1,6 @@
 ✨ New Features:
 • Native per-site containers
-• Per-site HTTP/SOCKS5 proxy on iOS 17+, macOS 14+, Linux
+• Per-site HTTP/SOCKS5 proxy on all platforms except Android
 • Per-site geolocation spoof + timezone + WebRTC lockdown
 • Desktop mode via per-site UA picker
 • iOS Universal Link bypass
@@ -9,4 +9,4 @@
 • Dart-side HTTP via proxy (no IP leak); navigator.language; intent:// prompt
 
 🐛 Bug Fixes:
-• JS timer pause; cross-domain URL leak; nested-webview scripts; dark UA icons
+• JS timer pause; cross-domain URL leak; nested-webview scripts; HTML cache no longer saves stopped pages; dark UA icons

--- a/fastlane/metadata/android/en-US/changelogs/17.txt
+++ b/fastlane/metadata/android/en-US/changelogs/17.txt
@@ -1,18 +1,12 @@
 ✨ New Features:
-• Native per-site containers on Android, iOS 17+, macOS 14+ — same-domain sites coexist without cookie shuffling
+• Native per-site containers (Android, iOS 17+, macOS 14+)
 • Per-site HTTP/SOCKS5 proxy on iOS 17+, macOS 14+, Linux
-• Per-site geolocation spoofing with timezone override and WebRTC leak lockdown
-• Desktop mode via per-site UA picker (Linux/macOS/Windows)
-• iOS Universal Link bypass keeps http links in-app
+• Per-site geolocation spoof + timezone + WebRTC lockdown
+• Desktop mode via per-site UA picker
+• iOS Universal Link bypass
 
 🔧 Improvements:
-• Dart-side outbound HTTP routed through the active proxy (no icon/HTML IP leak)
-• Override navigator.language so SPAs honor per-site language
-• Confirm prompt before launching intent:// and other external-app URLs
-• Plus: "use current location" picker button, system text scale respected, preserve chrome://, about://, file:// in URL bar, hide Home Shortcut when already pinned
+• Dart-side HTTP via proxy (no IP leak); navigator.language; intent:// prompt
 
 🐛 Bug Fixes:
-• Per-site pause no longer freezes JS timers process-globally
-• onUrlChanged no longer leaks cross-domain URLs into site state
-• User scripts now propagate into nested webviews
-• Android file chooser FileProvider declared; user-agent icons adapt to dark theme
+• JS timer pause; cross-domain URL leak; nested-webview scripts; dark UA icons

--- a/fastlane/metadata/android/en-US/changelogs/17.txt
+++ b/fastlane/metadata/android/en-US/changelogs/17.txt
@@ -3,10 +3,10 @@
 • Per-site HTTP/SOCKS5 proxy on all platforms except Android
 • Per-site geolocation spoof + timezone + WebRTC lockdown
 • Convincing desktop mode: UA picker + viewport/navigator shims
-• iOS Universal Link bypass
+• Cross-app intent handling on iOS + Android
 
 🔧 Improvements:
-• Dart-side HTTP via proxy (no IP leak); navigator.language; intent:// prompt
+• Dart-side HTTP via proxy (no IP leak); navigator.language
 
 🐛 Bug Fixes:
 • JS timer pause; cross-domain URL leak; nested-webview scripts; HTML cache skips stopped pages; dark UA icons

--- a/fastlane/metadata/android/en-US/changelogs/17.txt
+++ b/fastlane/metadata/android/en-US/changelogs/17.txt
@@ -6,7 +6,7 @@
 • Cross-app intent handling
 
 🔧 Improvements:
-• Dart-side HTTP via proxy (no IP leak); navigator.language
+• Dart-side HTTP routed through proxy; navigator.language
 
 🐛 Bug Fixes:
 • JS timer pause; cross-domain URL leak; nested-webview scripts; HTML cache skips stopped pages; dark UA icons

--- a/fastlane/metadata/android/en-US/changelogs/17.txt
+++ b/fastlane/metadata/android/en-US/changelogs/17.txt
@@ -2,7 +2,7 @@
 • Native per-site containers
 • Per-site HTTP/SOCKS5 proxy on all platforms except Android
 • Per-site geolocation spoof + timezone + WebRTC lockdown
-• Convincing desktop mode: UA picker + viewport/navigator shims
+• Desktop mode ships UA picker, viewport rewrite, pointer/touch shims
 • Cross-app intent handling
 
 🔧 Improvements:


### PR DESCRIPTION
Drafts `fastlane/metadata/android/en-US/changelogs/17.txt` summarizing user-facing changes since 0.2.1.

## Highlights

**New features**
- Native per-site containers on Android, iOS 17+, macOS 14+ (#250) — same-domain sites coexist without cookie shuffling
- Per-site HTTP/SOCKS5 proxy on iOS 17+, macOS 14+ (#255) and Linux (#260)
- Per-site geolocation spoofing with timezone override + WebRTC lockdown (#236)
- Desktop mode via per-site UA picker, incl. Linux/macOS/Windows (#240)
- iOS Universal Link bypass (#258)

**Improvements**
- Dart-side outbound HTTP routed through the active proxy, closing icon/HTML IP leaks (#249)
- `navigator.language` override for SPAs (#238)
- Confirm prompt before launching `intent://` and other external-app URLs (#241)
- "Use current location" picker button (#248), system text scale respected (#246), preserve `chrome://` / `about://` / `file://` in URL bar (#243), hide Home Shortcut when already pinned (#247)

**Bug fixes**
- Per-site pause no longer freezes JS timers process-globally (#252)
- `onUrlChanged` no longer leaks cross-domain URLs into site state (#239)
- User scripts now propagate into nested webviews (#242)
- Android file chooser FileProvider declared (#244); user-agent icons adapt to dark theme (#234)

## Excluded (intentionally)
Internal refactors and infra: engine extraction (#229), prefs registry (#228), `isBlocked` benchmark (#253), fork ref/tag plumbing (#259, f0e4d4e), FUNDING.yml (#257), readme/badge tweaks, the reverted desktop-mode attempt (#235 → reverted in d7aba3a; only the final picker version is mentioned).
