### PR TITLE
Replace blanket webspace-switch unload with container-aware policy

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1136,6 +1136,34 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await _webViewModels[index].resumeWebView();
     _updateCanGoBack();
 
+    // Defensive sweep: pause every other loaded webview so background
+    // sites don't run animations / GPS listeners / non-throttled
+    // raf callbacks when the user isn't looking at them. Steady state
+    // already has them paused (each becomes paused when it last lost
+    // active status above), but a path that adds to _loadedIndices
+    // without going through the previous-active pause would leave
+    // it unpaused. pauseWebView() is idempotent.
+    //
+    // unawaited: subsequent activation logic (fullscreen, logging)
+    // doesn't depend on these completing. Race-wise this is safe in
+    // Dart's single-threaded model: each pauseWebView dispatches on
+    // the platform channel synchronously up to its first await, and
+    // the channel preserves FIFO order — so the resumeWebView above
+    // is dispatched before any of these pauses. A subsequent
+    // _setCurrentIndex would also do its own resume after these
+    // pauses, so the latest target always ends up resumed.
+    //
+    // (Per-instance pause() doesn't stop JavaScript — see
+    // openspec/specs/webview-pause-lifecycle/spec.md. This is a
+    // CPU/battery optimization, not RAM. The LRU cap and OS memory
+    // pressure handler cover RAM.)
+    final loadedSnapshot = _loadedIndices.toList();
+    for (final i in loadedSnapshot) {
+      if (i == index) continue;
+      if (i < 0 || i >= _webViewModels.length) continue;
+      unawaited(_webViewModels[i].pauseWebView());
+    }
+
     // Auto-enter fullscreen if the site has fullscreenMode enabled
     if (target.fullscreenMode) {
       _enterFullscreen();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -721,6 +721,34 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   }
 
   @override
+  void didHaveMemoryPressure() {
+    // OS is signaling memory pressure. Trim one loaded site per
+    // event so the system controls the curve — if pressure persists
+    // the callback fires again and we evict the next victim. The
+    // active site is hard-protected; sites in the active webspace
+    // are soft-keep (evicted only after every other candidate).
+    unawaited(_handleMemoryPressure());
+  }
+
+  Future<void> _handleMemoryPressure() async {
+    final victim = SiteUnloadEngine.indexToEvictForMemoryPressure(
+      loadedIndices: _loadedIndices,
+      protectedIndices:
+          _currentIndex != null ? <int>{_currentIndex!} : const <int>{},
+      preferKeepIndices: _getFilteredSiteIndices().toSet(),
+    );
+    if (victim == null) return;
+    LogService.instance.log(
+      'SiteUnload',
+      'Memory pressure — unloading site $victim: '
+          '"${_webViewModels[victim].name}"',
+      level: LogLevel.warning,
+    );
+    await _unloadSiteForOtherReason(victim);
+    if (mounted) setState(() {});
+  }
+
+  @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.paused || state == AppLifecycleState.inactive) {
       // App is backgrounding: pause active webview AND globally freeze JS

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1004,12 +1004,19 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     // without a cap a heavy user could pile up dozens of live webviews.
     // _loadedIndices is treated as access-ordered (re-added on each
     // activation below), so iteration order is least-recently-used first.
+    //
+    // Sites in the currently-selected webspace are passed as soft-keep:
+    // membership in the user's active workspace is treated as "context
+    // relevance" and beats raw access recency, so a stale site in the
+    // active webspace stays loaded over a fresher site from a different
+    // webspace if both are eligible for eviction.
     final lruEvict = SiteUnloadEngine.indicesToEvictForLruCap(
       targetIndex: index,
       loadedIndices: _loadedIndices,
       maxLoadedSites: kMaxLoadedSites,
       protectedIndices:
           _currentIndex != null ? <int>{_currentIndex!} : const <int>{},
+      preferKeepIndices: _getFilteredSiteIndices().toSet(),
     );
     for (final i in lruEvict) {
       LogService.instance.log(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,6 +44,7 @@ import 'package:webspace/services/site_activation_engine.dart';
 import 'package:webspace/services/site_lifecycle_engine.dart';
 import 'package:webspace/services/site_lifecycle_promotion_engine.dart';
 import 'package:webspace/services/site_unload_engine.dart';
+import 'package:webspace/services/webview_state_secure_storage.dart';
 import 'package:webspace/services/webview_state_storage.dart';
 import 'package:webspace/services/startup_restore_engine.dart';
 import 'package:webspace/services/webspace_selection_engine.dart';
@@ -683,14 +684,18 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   // victim and double-write its captured cookies to storage.
   bool _isHandlingMemoryPressure = false;
 
-  // In-memory storage for per-site `controller.saveState()` bytes.
-  // Bytes survive webspace switches, LRU evictions, and memory-
-  // pressure disposals within a single app run; lost on cold start.
+  // AES-encrypted on-disk storage for per-site `controller.saveState()`
+  // bytes. The same encryption pattern as the HTML cache: a 256-bit
+  // AES key in `FlutterSecureStorage`, per-site files under
+  // `<docs>/webview_state/<siteId>.enc`. Bytes survive webspace
+  // switches, LRU evictions, memory-pressure disposals, AND cold
+  // starts (cleared on app-version upgrade alongside the key).
+  //
   // Sites in [SiteLifecycleState.savedForRestore] have an entry here
   // keyed by siteId; re-activation reads it and pre-populates the
   // model's `_pendingRestoreState` so onControllerCreated can apply
   // it to the freshly-built controller.
-  final WebViewStateStorage _stateStorage = InMemoryWebViewStateStorage();
+  final WebViewStateStorage _stateStorage = SecureWebViewStateStorage();
 
   // Track which webview indices have been loaded (for lazy loading)
   // Only webviews in this set will be created - others remain as placeholders
@@ -839,6 +844,15 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       // timers so loaded-but-inactive webviews stop too.
       if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
         _lifecyclePauseFuture = _webViewModels[_currentIndex!].pauseForAppLifecycle();
+        // Capture state for the active site so an OS-induced kill
+        // while we're backgrounded doesn't lose the back/forward
+        // stack and (Apple) form data. Best-effort, fire-and-forget;
+        // the webview stays loaded — disk capture is just defense
+        // in depth in case the OS reaps the app entirely. Bytes-
+        // only capture — lifecycleState stays `live` because the
+        // webview is not disposed.
+        final activeIdx = _currentIndex!;
+        unawaited(_captureStateBytes(_webViewModels[activeIdx]));
       }
     } else if (state == AppLifecycleState.resumed) {
       // Await any in-flight pause before resuming to prevent ordering inversion
@@ -1052,8 +1066,17 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     final version = ++_setCurrentIndexVersion;
 
     if (index == null || index < 0 || index >= _webViewModels.length) {
-      // Pause the previously active webview when navigating away
+      // Going home: opportunistically capture state for the
+      // previously-active site so a later cold start (or
+      // OS-killed-while-backgrounded scenario) can re-hydrate its
+      // back/forward stack and form data on re-activation. The
+      // webview stays loaded (pause-only, not disposed) so a
+      // near-immediate return to the same site keeps its in-memory
+      // tab. Bytes-only capture — `lifecycleState` stays `live`
+      // because the webview is not actually disposed.
       if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
+        await _captureStateBytes(_webViewModels[_currentIndex!]);
+        if (version != _setCurrentIndexVersion) return;
         await _webViewModels[_currentIndex!].pauseWebView();
         if (version != _setCurrentIndexVersion) return;
       }
@@ -1289,20 +1312,37 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     );
   }
 
-  /// Capture [model]'s navigation state to in-memory storage so
-  /// re-activation can apply it. Updates `model.lifecycleState` to
-  /// [SiteLifecycleState.savedForRestore] on success. No-op for
+  /// Capture [model]'s navigation state to encrypted on-disk storage.
+  /// Returns true if bytes were captured and persisted. No-op for
   /// incognito sites or when there's nothing to save.
-  Future<void> _captureStateForRestore(WebViewModel model) async {
-    if (model.incognito) return;
+  ///
+  /// Does NOT mutate `model.lifecycleState` — callers that are
+  /// disposing the webview should do that themselves (typically
+  /// flipping to [SiteLifecycleState.savedForRestore]); callers that
+  /// are *only* opportunistically persisting (go-home,
+  /// app-background) should leave the state at [SiteLifecycleState.live]
+  /// since the webview is still in memory.
+  Future<bool> _captureStateBytes(WebViewModel model) async {
+    if (model.incognito) return false;
     final bytes = await model.captureNavigationState();
-    if (bytes == null) return;
+    if (bytes == null) return false;
     await _stateStorage.saveState(model.siteId, bytes);
-    model.lifecycleState = SiteLifecycleState.savedForRestore;
     LogService.instance.log(
       'WebViewState',
       'Captured ${bytes.length} bytes for "${model.name}" (siteId: ${model.siteId})',
     );
+    return true;
+  }
+
+  /// Capture state and flip the lifecycle to [SiteLifecycleState.savedForRestore].
+  /// Used by dispose paths (LRU eviction, memory-pressure cascade,
+  /// legacy webspace-switch unload) where the webview is about to be
+  /// torn down.
+  Future<void> _captureStateForRestore(WebViewModel model) async {
+    final ok = await _captureStateBytes(model);
+    if (ok) {
+      model.lifecycleState = SiteLifecycleState.savedForRestore;
+    }
   }
 
   /// Restores cookies for a site before activation. Delegates to the engine.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,6 +42,7 @@ import 'package:webspace/services/container_cookie_manager.dart';
 import 'package:webspace/services/navigation_engine.dart';
 import 'package:webspace/services/site_activation_engine.dart';
 import 'package:webspace/services/site_lifecycle_engine.dart';
+import 'package:webspace/services/site_unload_engine.dart';
 import 'package:webspace/services/startup_restore_engine.dart';
 import 'package:webspace/services/webspace_selection_engine.dart';
 import 'package:webspace/services/clearurl_service.dart';
@@ -977,6 +978,48 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       }
     }
 
+    // Proxy-mismatch unload (Android only). The WebView proxy is
+    // process-global on Android (`inapp.ProxyController` last-write-wins);
+    // activating a site whose effective proxy differs from a currently-
+    // loaded site would silently re-route that site's next request through
+    // the new proxy. Unload conflicting sites so they can't leak.
+    final proxyMismatch = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+      targetIndex: index,
+      models: _webViewModels,
+      loadedIndices: _loadedIndices,
+      proxyIsGlobal: Platform.isAndroid,
+    );
+    for (final i in proxyMismatch) {
+      LogService.instance.log(
+        'SiteUnload',
+        'Proxy mismatch — unloading site $i: "${_webViewModels[i].name}"',
+        level: LogLevel.warning,
+      );
+      await _unloadSiteForOtherReason(i);
+      if (version != _setCurrentIndexVersion) return;
+    }
+
+    // LRU cap. Bound the number of concurrently loaded webviews; under
+    // container mode the unload-on-webspace-switch step is skipped, so
+    // without a cap a heavy user could pile up dozens of live webviews.
+    // _loadedIndices is treated as access-ordered (re-added on each
+    // activation below), so iteration order is least-recently-used first.
+    final lruEvict = SiteUnloadEngine.indicesToEvictForLruCap(
+      targetIndex: index,
+      loadedIndices: _loadedIndices,
+      maxLoadedSites: kMaxLoadedSites,
+      protectedIndices:
+          _currentIndex != null ? <int>{_currentIndex!} : const <int>{},
+    );
+    for (final i in lruEvict) {
+      LogService.instance.log(
+        'SiteUnload',
+        'LRU cap (>$kMaxLoadedSites) — unloading site $i: "${_webViewModels[i].name}"',
+      );
+      await _unloadSiteForOtherReason(i);
+      if (version != _setCurrentIndexVersion) return;
+    }
+
     // Pause the previously active webview to save resources
     if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
       await _webViewModels[_currentIndex!].pauseWebView();
@@ -999,6 +1042,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     if (index >= _webViewModels.length) return;
 
     _currentIndex = index;
+    // Bump to end of insertion order so iteration over _loadedIndices is
+    // least-recently-used first (consumed by the LRU eviction above).
+    _loadedIndices.remove(index);
     _loadedIndices.add(index);
     _canGoBackVersion++; // Invalidate any in-flight _updateCanGoBack
     _canGoBack = false; // Reset until async check completes
@@ -1020,6 +1066,27 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   /// Unloads a site due to domain conflict with another site. Delegates to
   /// the isolation engine so the orchestration is shared with tests.
   Future<void> _unloadSiteForDomainSwitch(int index) async {
+    await _cookieIsolation.unloadSiteForDomainSwitch(
+      index: index,
+      models: _webViewModels,
+      loadedIndices: _loadedIndices,
+    );
+  }
+
+  /// Unloads a site for non-domain-conflict reasons (proxy mismatch,
+  /// LRU cap). Under container mode the per-site container partitions
+  /// cookies/localStorage/IDB/etc., so disposing the webview is enough.
+  /// Under legacy mode, the cookie jar is shared, so we run the same
+  /// capture-then-dispose cycle the engine uses for domain conflicts —
+  /// otherwise the soon-to-run capture-nuke-restore on activation of
+  /// the target would wipe the unloaded site's session out of the jar.
+  Future<void> _unloadSiteForOtherReason(int index) async {
+    if (index < 0 || index >= _webViewModels.length) return;
+    if (_useContainers) {
+      _webViewModels[index].disposeWebView();
+      _loadedIndices.remove(index);
+      return;
+    }
     await _cookieIsolation.unloadSiteForDomainSwitch(
       index: index,
       models: _webViewModels,
@@ -1569,7 +1636,14 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       if (!mounted || version != _selectWebspaceVersion) return;
 
       if (online) {
-        final indicesToUnload = WebspaceSelectionEngine.indicesToUnloadOnWebspaceSwitch(
+        // Under container mode, sites are isolated by their per-site
+        // container (cookies, localStorage, IDB, ServiceWorkers, HTTP
+        // cache) and stay resident across webspace switches — keeping
+        // them loaded is harmless and avoids the cost of re-creating the
+        // webview when the user switches back. The unload-on-switch only
+        // runs in legacy mode where the cookie jar is shared.
+        final indicesToUnload = SiteUnloadEngine.indicesToUnloadOnWebspaceSwitch(
+          useContainers: _useContainers,
           loadedIndices: _loadedIndices,
           previousWebspaceIndices: previousIndices,
           newWebspaceIndices: newIndices,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -826,7 +826,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           // _captureStateForRestore inside that helper is what
           // updates the lifecycleState to savedForRestore.
           await _unloadSiteForOtherReason(victim);
-        case SiteLifecycleState.live:
+        case SiteLifecycleState.resident:
           // Promotion can never go back to live — defensive.
           break;
       }
@@ -1116,12 +1116,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
               '(siteId: ${target.siteId})',
         );
       }
-      target.lifecycleState = SiteLifecycleState.live;
-    } else if (target.lifecycleState != SiteLifecycleState.live) {
+      target.lifecycleState = SiteLifecycleState.resident;
+    } else if (target.lifecycleState != SiteLifecycleState.resident) {
       // cacheCleared promoted back to live on activation — the user
       // is interacting with it again, so any subsequent memory
       // pressure starts the cascade fresh from the live tier.
-      target.lifecycleState = SiteLifecycleState.live;
+      target.lifecycleState = SiteLifecycleState.resident;
     }
 
     // Domain-conflict unload + capture-nuke-restore is only needed when
@@ -1192,6 +1192,50 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       );
       await _unloadSiteForOtherReason(i);
       if (version != _setCurrentIndexVersion) return;
+    }
+
+    // Proactive `resident → cacheCleared` promotion. Backstop for
+    // platforms where the OS doesn't reliably fire memory pressure
+    // (Linux/desktop), and for iOS where Jetsam is reactive (after
+    // memory is already tight). Once more than [kMaxResidentSites]
+    // sites are at the resident tier, the oldest excess get
+    // clearCache called eagerly. This is the proactive complement
+    // to the reactive _handleMemoryPressure cascade and uses the
+    // same priority hierarchy. The active site is hard-protected;
+    // sites in the active webspace are soft-keep.
+    final cacheClearStates = <int, SiteLifecycleState>{
+      for (final i in _loadedIndices)
+        if (i >= 0 && i < _webViewModels.length) i: _webViewModels[i].lifecycleState,
+    };
+    final cacheClearTargets =
+        SiteLifecyclePromotionEngine.pickProactiveCacheClearTargets(
+      loadedIndices: _loadedIndices,
+      states: cacheClearStates,
+      maxResidentSites: kMaxResidentSites,
+      protectedIndices: _activationInFlightIndex != null
+          ? <int>{_activationInFlightIndex!}
+          : const <int>{},
+      preferKeepIndices: _getFilteredSiteIndices().toSet(),
+    );
+    for (final i in cacheClearTargets) {
+      // Defensive bounds check after the await below in case site
+      // deletion shifted indices.
+      if (i < 0 || i >= _webViewModels.length) continue;
+      LogService.instance.log(
+        'SiteUnload',
+        'Proactive cacheClear (>$kMaxResidentSites resident) — '
+            'clearing cache for site $i: "${_webViewModels[i].name}"',
+      );
+      await _webViewModels[i].clearWebViewCache();
+      if (version != _setCurrentIndexVersion) return;
+      // Re-check membership in case a concurrent path (memory
+      // pressure handler, deletion) already promoted or evicted this
+      // index between the engine pick and the await resume.
+      if (i < _webViewModels.length &&
+          _loadedIndices.contains(i) &&
+          _webViewModels[i].lifecycleState == SiteLifecycleState.resident) {
+        _webViewModels[i].lifecycleState = SiteLifecycleState.cacheCleared;
+      }
     }
 
     // Pause the previously active webview to save resources
@@ -1320,7 +1364,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   /// disposing the webview should do that themselves (typically
   /// flipping to [SiteLifecycleState.savedForRestore]); callers that
   /// are *only* opportunistically persisting (go-home,
-  /// app-background) should leave the state at [SiteLifecycleState.live]
+  /// app-background) should leave the state at [SiteLifecycleState.resident]
   /// since the webview is still in memory.
   Future<bool> _captureStateBytes(WebViewModel model) async {
     if (model.incognito) return false;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,7 +42,9 @@ import 'package:webspace/services/container_cookie_manager.dart';
 import 'package:webspace/services/navigation_engine.dart';
 import 'package:webspace/services/site_activation_engine.dart';
 import 'package:webspace/services/site_lifecycle_engine.dart';
+import 'package:webspace/services/site_lifecycle_promotion_engine.dart';
 import 'package:webspace/services/site_unload_engine.dart';
+import 'package:webspace/services/webview_state_storage.dart';
 import 'package:webspace/services/startup_restore_engine.dart';
 import 'package:webspace/services/webspace_selection_engine.dart';
 import 'package:webspace/services/clearurl_service.dart';
@@ -681,6 +683,15 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   // victim and double-write its captured cookies to storage.
   bool _isHandlingMemoryPressure = false;
 
+  // In-memory storage for per-site `controller.saveState()` bytes.
+  // Bytes survive webspace switches, LRU evictions, and memory-
+  // pressure disposals within a single app run; lost on cold start.
+  // Sites in [SiteLifecycleState.savedForRestore] have an entry here
+  // keyed by siteId; re-activation reads it and pre-populates the
+  // model's `_pendingRestoreState` so onControllerCreated can apply
+  // it to the freshly-built controller.
+  final WebViewStateStorage _stateStorage = InMemoryWebViewStateStorage();
+
   // Track which webview indices have been loaded (for lazy loading)
   // Only webviews in this set will be created - others remain as placeholders
   final Set<int> _loadedIndices = {};
@@ -748,9 +759,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
   Future<void> _handleMemoryPressure() async {
     // Drop concurrent invocations: if the OS fires repeatedly while
-    // we're still capturing cookies for the previous victim (legacy
-    // mode), we'd otherwise pick the same site twice and double-write
-    // the same cookies to storage.
+    // we're still applying the previous promotion's transition
+    // (clearCache, or saveState+dispose), we'd otherwise pick the
+    // same victim twice and re-apply the same transition.
     if (_isHandlingMemoryPressure) return;
     _isHandlingMemoryPressure = true;
     try {
@@ -763,25 +774,57 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         if (_currentIndex != null) _currentIndex!,
         if (_activationInFlightIndex != null) _activationInFlightIndex!,
       };
-      final victim = SiteUnloadEngine.indexToEvictForMemoryPressure(
+      // Build the per-site state map snapshot for the cascade engine.
+      // Iterate _loadedIndices defensively in case _webViewModels
+      // shifted under us.
+      final states = <int, SiteLifecycleState>{};
+      for (final i in _loadedIndices) {
+        if (i < 0 || i >= _webViewModels.length) continue;
+        states[i] = _webViewModels[i].lifecycleState;
+      }
+      final victim = SiteLifecyclePromotionEngine.pickPromotionTarget(
         loadedIndices: _loadedIndices,
+        states: states,
         protectedIndices: protected,
         preferKeepIndices: _getFilteredSiteIndices().toSet(),
       );
       if (victim == null) return;
-      // Race guard: the model array may have shifted between picking
-      // and the eventual await (rare, but possible if site deletion
-      // happened to interleave). The engine's own bounds check inside
-      // `_unloadSiteForOtherReason` would catch this too, but we want
-      // to avoid logging a stale name.
       if (victim < 0 || victim >= _webViewModels.length) return;
+      final model = _webViewModels[victim];
+      final from = model.lifecycleState;
+      final to = SiteLifecyclePromotionEngine.nextState(from);
+      if (to == null) return;
+
       LogService.instance.log(
         'SiteUnload',
-        'Memory pressure — unloading site $victim: '
-            '"${_webViewModels[victim].name}"',
+        'Memory pressure — promoting site $victim "${model.name}": '
+            '${from.name} → ${to.name}',
         level: LogLevel.warning,
       );
-      await _unloadSiteForOtherReason(victim);
+
+      switch (to) {
+        case SiteLifecycleState.cacheCleared:
+          // live → cacheCleared: drop the in-memory cache. Webview
+          // stays loaded; tab state intact. Frees decoded image
+          // cache + HTTP response cache.
+          await model.clearWebViewCache();
+          if (!mounted) return;
+          model.lifecycleState = SiteLifecycleState.cacheCleared;
+        case SiteLifecycleState.savedForRestore:
+          // cacheCleared → savedForRestore: capture state, dispose
+          // webview, drop from _loadedIndices. Frees the renderer
+          // process. Re-activation hydrates from storage via the
+          // model's _pendingRestoreState hook.
+          //
+          // Routes through _unloadSiteForOtherReason so the legacy
+          // cookie capture (when not in container mode) runs too;
+          // _captureStateForRestore inside that helper is what
+          // updates the lifecycleState to savedForRestore.
+          await _unloadSiteForOtherReason(victim);
+        case SiteLifecycleState.live:
+          // Promotion can never go back to live — defensive.
+          break;
+      }
       if (!mounted) return;
       setState(() {});
     } finally {
@@ -1033,6 +1076,31 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     _activationInFlightIndex = index;
     try {
 
+    // If the target was disposed under memory pressure (lifecycleState
+    // == savedForRestore), fetch its captured navigation state and
+    // hand it to the model so the soon-to-be-built controller's
+    // onControllerCreated handler can apply restoreState. Resets the
+    // tier to live regardless — the about-to-be-resumed webview
+    // is back at the lowest tier.
+    if (target.lifecycleState == SiteLifecycleState.savedForRestore) {
+      final bytes = await _stateStorage.loadState(target.siteId);
+      if (version != _setCurrentIndexVersion) return;
+      if (bytes != null) {
+        target.schedulePendingRestoreState(bytes);
+        LogService.instance.log(
+          'WebViewState',
+          'Queued ${bytes.length} restore bytes for "${target.name}" '
+              '(siteId: ${target.siteId})',
+        );
+      }
+      target.lifecycleState = SiteLifecycleState.live;
+    } else if (target.lifecycleState != SiteLifecycleState.live) {
+      // cacheCleared promoted back to live on activation — the user
+      // is interacting with it again, so any subsequent memory
+      // pressure starts the cascade fresh from the live tier.
+      target.lifecycleState = SiteLifecycleState.live;
+    }
+
     // Domain-conflict unload + capture-nuke-restore is only needed when
     // the native cookie jar is shared between sites. With the Container
     // API, each site has its own jar; concurrent same-base-domain sites
@@ -1193,16 +1261,24 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   }
 
   /// Unloads a site for non-domain-conflict reasons (proxy mismatch,
-  /// LRU cap). Under container mode the per-site container partitions
-  /// cookies/localStorage/IDB/etc., so disposing the webview is enough.
-  /// Under legacy mode, the cookie jar is shared, so we run the same
-  /// capture-then-dispose cycle the engine uses for domain conflicts —
-  /// otherwise the soon-to-run capture-nuke-restore on activation of
-  /// the target would wipe the unloaded site's session out of the jar.
+  /// LRU cap, memory pressure). Under container mode the per-site
+  /// container partitions cookies/localStorage/IDB/etc., so disposing
+  /// the webview is enough. Under legacy mode, the cookie jar is
+  /// shared, so we run the same capture-then-dispose cycle the engine
+  /// uses for domain conflicts — otherwise the soon-to-run capture-
+  /// nuke-restore on activation of the target would wipe the unloaded
+  /// site's session out of the jar.
+  ///
+  /// Before disposing, captures `controller.saveState()` to the in-
+  /// memory state storage so re-activation can restore the back/
+  /// forward stack and (Apple) form data via `restoreState`. Skipped
+  /// for incognito sites (state is meant to be ephemeral).
   Future<void> _unloadSiteForOtherReason(int index) async {
     if (index < 0 || index >= _webViewModels.length) return;
+    final model = _webViewModels[index];
+    await _captureStateForRestore(model);
     if (_useContainers) {
-      _webViewModels[index].disposeWebView();
+      model.disposeWebView();
       _loadedIndices.remove(index);
       return;
     }
@@ -1210,6 +1286,22 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       index: index,
       models: _webViewModels,
       loadedIndices: _loadedIndices,
+    );
+  }
+
+  /// Capture [model]'s navigation state to in-memory storage so
+  /// re-activation can apply it. Updates `model.lifecycleState` to
+  /// [SiteLifecycleState.savedForRestore] on success. No-op for
+  /// incognito sites or when there's nothing to save.
+  Future<void> _captureStateForRestore(WebViewModel model) async {
+    if (model.incognito) return;
+    final bytes = await model.captureNavigationState();
+    if (bytes == null) return;
+    await _stateStorage.saveState(model.siteId, bytes);
+    model.lifecycleState = SiteLifecycleState.savedForRestore;
+    LogService.instance.log(
+      'WebViewState',
+      'Captured ${bytes.length} bytes for "${model.name}" (siteId: ${model.siteId})',
     );
   }
 
@@ -1478,6 +1570,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await _cookieSecureStorage.removeOrphanedCookies(activeSiteIdsAtStartup);
     await _proxyPasswordStorage.removeOrphaned(activeSiteIdsAtStartup);
     await HtmlCacheService.instance.removeOrphanedCaches(activeSiteIdsAtStartup);
+    await _stateStorage.removeOrphans(activeSiteIdsAtStartup);
     await _cookieManager.deleteAllCookies();
     // Sweep containers whose owning site no longer exists. No-op when
     // the Container API is unsupported.
@@ -1770,6 +1863,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
         for (final index in indicesToUnload) {
           if (index >= 0 && index < _webViewModels.length) {
+            // Capture state before dispose so re-activation can
+            // restore the back/forward stack and (Apple) form data.
+            // Skipped for incognito sites inside the helper.
+            await _captureStateForRestore(_webViewModels[index]);
+            if (!mounted || version != _selectWebspaceVersion) return;
             _webViewModels[index].disposeWebView();
             _loadedIndices.remove(index);
             LogService.instance.log('WebspaceSwitch', 'Unloaded site $index: "${_webViewModels[index].name}"');
@@ -3233,6 +3331,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await _cookieSecureStorage.removeOrphanedCookies(activeSiteIds);
     await _proxyPasswordStorage.removeOrphaned(activeSiteIds);
     await HtmlCacheService.instance.removeOrphanedCaches(activeSiteIds);
+    await _stateStorage.removeOrphans(activeSiteIds);
 
     if (!mounted) return;
     Navigator.pop(context);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -665,6 +665,22 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   int _setCurrentIndexVersion = 0;
   Completer<void>? _webspaceSwitchCompleter;
 
+  // Index currently being activated by an in-flight `_setCurrentIndex`
+  // call, or null when no activation is in progress. Read by
+  // `_handleMemoryPressure` so an OS pressure event during a
+  // re-activation can't dispose the soon-to-be-active site (which
+  // would silently wipe its state — the IndexedStack would re-create
+  // a fresh webview on next paint, losing scroll/URL/session).
+  int? _activationInFlightIndex;
+
+  // Drops concurrent `_handleMemoryPressure` invocations. The OS may
+  // fire `didHaveMemoryPressure` repeatedly under sustained pressure;
+  // the first handler runs to completion, then the next event picks up
+  // the new state. Without this, in legacy (non-container) mode the
+  // capture-then-dispose await window lets two handlers pick the same
+  // victim and double-write its captured cookies to storage.
+  bool _isHandlingMemoryPressure = false;
+
   // Track which webview indices have been loaded (for lazy loading)
   // Only webviews in this set will be created - others remain as placeholders
   final Set<int> _loadedIndices = {};
@@ -731,21 +747,46 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   }
 
   Future<void> _handleMemoryPressure() async {
-    final victim = SiteUnloadEngine.indexToEvictForMemoryPressure(
-      loadedIndices: _loadedIndices,
-      protectedIndices:
-          _currentIndex != null ? <int>{_currentIndex!} : const <int>{},
-      preferKeepIndices: _getFilteredSiteIndices().toSet(),
-    );
-    if (victim == null) return;
-    LogService.instance.log(
-      'SiteUnload',
-      'Memory pressure — unloading site $victim: '
-          '"${_webViewModels[victim].name}"',
-      level: LogLevel.warning,
-    );
-    await _unloadSiteForOtherReason(victim);
-    if (mounted) setState(() {});
+    // Drop concurrent invocations: if the OS fires repeatedly while
+    // we're still capturing cookies for the previous victim (legacy
+    // mode), we'd otherwise pick the same site twice and double-write
+    // the same cookies to storage.
+    if (_isHandlingMemoryPressure) return;
+    _isHandlingMemoryPressure = true;
+    try {
+      // Protect both the currently-active site and any site in the
+      // middle of being activated by an in-flight `_setCurrentIndex`.
+      // Without the in-flight guard, a re-activation of an already-
+      // loaded site could be racing with this handler — disposing the
+      // soon-to-be-active webview silently wipes its state.
+      final protected = <int>{
+        if (_currentIndex != null) _currentIndex!,
+        if (_activationInFlightIndex != null) _activationInFlightIndex!,
+      };
+      final victim = SiteUnloadEngine.indexToEvictForMemoryPressure(
+        loadedIndices: _loadedIndices,
+        protectedIndices: protected,
+        preferKeepIndices: _getFilteredSiteIndices().toSet(),
+      );
+      if (victim == null) return;
+      // Race guard: the model array may have shifted between picking
+      // and the eventual await (rare, but possible if site deletion
+      // happened to interleave). The engine's own bounds check inside
+      // `_unloadSiteForOtherReason` would catch this too, but we want
+      // to avoid logging a stale name.
+      if (victim < 0 || victim >= _webViewModels.length) return;
+      LogService.instance.log(
+        'SiteUnload',
+        'Memory pressure — unloading site $victim: '
+            '"${_webViewModels[victim].name}"',
+        level: LogLevel.warning,
+      );
+      await _unloadSiteForOtherReason(victim);
+      if (!mounted) return;
+      setState(() {});
+    } finally {
+      _isHandlingMemoryPressure = false;
+    }
   }
 
   @override
@@ -985,6 +1026,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     LogService.instance.log('CookieIsolation', 'Target domain: ${getBaseDomain(target.initUrl)}');
     LogService.instance.log('CookieIsolation', 'Currently loaded indices: $_loadedIndices');
 
+    // Mark this site as activation-in-flight so concurrent OS memory
+    // pressure events can't pick it as a victim before _currentIndex
+    // is updated below — disposing the webview mid-activation would
+    // silently wipe its state from under the user.
+    _activationInFlightIndex = index;
+    try {
+
     // Domain-conflict unload + capture-nuke-restore is only needed when
     // the native cookie jar is shared between sites. With the Container
     // API, each site has its own jar; concurrent same-base-domain sites
@@ -1096,6 +1144,14 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     }
 
     LogService.instance.log('CookieIsolation', 'After switch, loaded indices: $_loadedIndices');
+    } finally {
+      // Clear the in-flight marker only if we still own it; a newer
+      // _setCurrentIndex caller will have already overwritten it with
+      // its own target.
+      if (_activationInFlightIndex == index) {
+        _activationInFlightIndex = null;
+      }
+    }
   }
 
   /// Unloads a site due to domain conflict with another site. Delegates to

--- a/lib/services/site_lifecycle_promotion_engine.dart
+++ b/lib/services/site_lifecycle_promotion_engine.dart
@@ -1,0 +1,200 @@
+/// Tiered lifecycle for loaded webviews under memory pressure.
+///
+/// As OS memory pressure escalates, each `didHaveMemoryPressure` event
+/// promotes one loaded site one tier deeper. The active site is
+/// excluded (via `protectedIndices`); within a tier, the LRU site is
+/// picked, with out-of-active-webspace candidates evicted before
+/// in-webspace candidates (`preferKeepIndices`).
+///
+/// Tier order (least → most aggressive):
+///
+///   1. **live** — webview in memory, may be resumed (active) or paused
+///      (inactive). Default state for any loaded site.
+///   2. **cacheCleared** — webview still in memory, but `clearCache()`
+///      has been called. Frees decoded image cache + in-memory disk
+///      cache (~10-50 MB per webview) without losing tab state. The
+///      page transparently re-caches on the next interaction.
+///   3. **savedForRestore** — `saveState()` captured the navigation
+///      state to [WebViewStateStorage]; webview is disposed. Frees the
+///      whole renderer process (~100s MB). On re-activation, a new
+///      webview is built and `restoreState()` re-hydrates the
+///      back/forward stack and (on iOS 15+ / macOS 12+) form data.
+///      Live JS heap is gone.
+///
+/// Future work: a `suspended` tier slots between `cacheCleared` and
+/// `savedForRestore` once we wire native suspend (WKWebView's `suspend`
+/// SPI on Apple, Chromium tab discarding on Android — neither is
+/// exposed by the current plugin).
+///
+/// The engine is pure-Dart; the caller (typically `_handleMemoryPressure`
+/// in `_WebSpacePageState`) is responsible for the actual platform
+/// channel calls (`clearCache`, `saveState`, `disposeWebView`) and for
+/// updating the per-site state map after each promotion.
+enum SiteLifecycleState {
+  /// Webview is loaded in memory. Includes both the user-visible active
+  /// site (resumed) and any backgrounded loaded site (paused). The
+  /// distinction between resumed/paused is orthogonal to memory tier
+  /// and tracked via the controller's pause/resume state, not here.
+  live,
+
+  /// Webview is loaded in memory and has had its in-memory cache
+  /// cleared. The page is functional; cache will refill on next
+  /// interaction.
+  cacheCleared,
+
+  /// Webview is disposed; its navigation state is captured to
+  /// [WebViewStateStorage] keyed by `siteId`. Re-activation rebuilds
+  /// the webview and applies `restoreState`. This is the terminal tier
+  /// — sites in this state are NOT in `_loadedIndices` (their
+  /// controllers are null).
+  savedForRestore,
+}
+
+/// Counts of loaded sites broken down by lifecycle tier. Used by
+/// debug surfaces and tests to assert the cascade is progressing.
+class SiteTierCounts {
+  /// Sites at the active position (typically 0 or 1).
+  final int active;
+
+  /// Sites at [SiteLifecycleState.live] minus the active one.
+  final int live;
+
+  /// Sites at [SiteLifecycleState.cacheCleared].
+  final int cacheCleared;
+
+  /// Sites at [SiteLifecycleState.savedForRestore]. Includes sites
+  /// that have been disposed (not in `loadedIndices`); the count is
+  /// taken from the state map.
+  final int savedForRestore;
+
+  const SiteTierCounts({
+    required this.active,
+    required this.live,
+    required this.cacheCleared,
+    required this.savedForRestore,
+  });
+
+  @override
+  String toString() => 'SiteTierCounts(active=$active, live=$live, '
+      'cacheCleared=$cacheCleared, savedForRestore=$savedForRestore)';
+}
+
+class SiteLifecyclePromotionEngine {
+  /// State machine for memory-pressure escalation. Returns the next
+  /// more-aggressive tier, or null when [current] is terminal.
+  static SiteLifecycleState? nextState(SiteLifecycleState current) {
+    switch (current) {
+      case SiteLifecycleState.live:
+        return SiteLifecycleState.cacheCleared;
+      case SiteLifecycleState.cacheCleared:
+        return SiteLifecycleState.savedForRestore;
+      case SiteLifecycleState.savedForRestore:
+        return null;
+    }
+  }
+
+  /// Picks the next loaded site to promote one tier under memory
+  /// pressure, or null when nothing is safely promotable (everything
+  /// in [loadedIndices] is in [protectedIndices], or the loaded set is
+  /// empty).
+  ///
+  /// Selection rules, applied in order:
+  ///
+  ///   1. **Tier dominates LRU.** Walks tiers from least-aggressive
+  ///      ([SiteLifecycleState.live]) to most-aggressive non-terminal
+  ///      ([SiteLifecycleState.cacheCleared]). All `live` sites are
+  ///      promoted to `cacheCleared` before any `cacheCleared` site is
+  ///      promoted to `savedForRestore`. This gives the OS gradual
+  ///      relief — clearing cache on every loaded site (~10-50 MB
+  ///      each) often satisfies pressure without disposing anything.
+  ///   2. **Within a tier, out-of-keep before in-keep.** A site
+  ///      outside `preferKeepIndices` (typically the active webspace)
+  ///      gets promoted before a site inside, so the user's current
+  ///      workspace stays at the freshest tier.
+  ///   3. **Within a (tier, keep) bucket, oldest LRU first.** Caller
+  ///      treats [loadedIndices] as access-ordered (newest at end);
+  ///      iteration picks the oldest first.
+  ///   4. **Always exclude `protectedIndices`** (the active site, plus
+  ///      the in-flight activation target). [SiteLifecycleState.savedForRestore]
+  ///      sites are also skipped defensively (they shouldn't be in
+  ///      `loadedIndices` anyway, since the webview is disposed).
+  static int? pickPromotionTarget({
+    required Set<int> loadedIndices,
+    required Map<int, SiteLifecycleState> states,
+    Set<int> protectedIndices = const <int>{},
+    Set<int> preferKeepIndices = const <int>{},
+  }) {
+    // Walk tiers from least to most aggressive (excluding terminal).
+    for (final tier in [
+      SiteLifecycleState.live,
+      SiteLifecycleState.cacheCleared,
+    ]) {
+      // Within a tier, partition into out-of-keep then in-keep so
+      // out-of-keep is exhausted first. Both lists preserve LRU order
+      // (iteration order of loadedIndices).
+      int? outOfKeepCandidate;
+      int? inKeepCandidate;
+      for (final i in loadedIndices) {
+        if (protectedIndices.contains(i)) continue;
+        final s = states[i] ?? SiteLifecycleState.live;
+        if (s != tier) continue;
+        if (preferKeepIndices.contains(i)) {
+          inKeepCandidate ??= i;
+        } else {
+          outOfKeepCandidate ??= i;
+          // Out-of-keep is the highest priority within this tier;
+          // can't beat the oldest one we already found.
+          break;
+        }
+      }
+      if (outOfKeepCandidate != null) return outOfKeepCandidate;
+      if (inKeepCandidate != null) return inKeepCandidate;
+    }
+    return null;
+  }
+
+  /// Tier-count snapshot. The `active` count is whichever loaded
+  /// index matches `activeIndex` (0 or 1); other live loaded sites
+  /// land in `live`. `savedForRestore` is read from the state map
+  /// directly (those sites aren't in `loadedIndices`).
+  static SiteTierCounts tierCounts({
+    required Set<int> loadedIndices,
+    required Map<int, SiteLifecycleState> states,
+    required int? activeIndex,
+  }) {
+    var active = 0;
+    var live = 0;
+    var cacheCleared = 0;
+    var savedForRestore = 0;
+    for (final i in loadedIndices) {
+      final s = states[i] ?? SiteLifecycleState.live;
+      if (i == activeIndex && s == SiteLifecycleState.live) {
+        active++;
+        continue;
+      }
+      switch (s) {
+        case SiteLifecycleState.live:
+          live++;
+        case SiteLifecycleState.cacheCleared:
+          cacheCleared++;
+        case SiteLifecycleState.savedForRestore:
+          // Defensive: shouldn't appear in loadedIndices.
+          savedForRestore++;
+      }
+    }
+    // Count savedForRestore from the state map (those sites are
+    // disposed, so not in loadedIndices).
+    for (final entry in states.entries) {
+      if (loadedIndices.contains(entry.key)) continue;
+      if (entry.value == SiteLifecycleState.savedForRestore) {
+        savedForRestore++;
+      }
+    }
+    return SiteTierCounts(
+      active: active,
+      live: live,
+      cacheCleared: cacheCleared,
+      savedForRestore: savedForRestore,
+    );
+  }
+}

--- a/lib/services/site_lifecycle_promotion_engine.dart
+++ b/lib/services/site_lifecycle_promotion_engine.dart
@@ -8,8 +8,11 @@
 ///
 /// Tier order (least → most aggressive):
 ///
-///   1. **live** — webview in memory, may be resumed (active) or paused
-///      (inactive). Default state for any loaded site.
+///   1. **resident** — webview is in memory with full cache. May be
+///      resumed (the active site) or paused (a backgrounded loaded
+///      site after the pause-all-inactive sweep). The resumed/paused
+///      distinction is orthogonal to memory tier — both share the
+///      same renderer-process and decoded-image-cache footprint.
 ///   2. **cacheCleared** — webview still in memory, but `clearCache()`
 ///      has been called. Frees decoded image cache + in-memory disk
 ///      cache (~10-50 MB per webview) without losing tab state. The
@@ -30,16 +33,31 @@
 /// in `_WebSpacePageState`) is responsible for the actual platform
 /// channel calls (`clearCache`, `saveState`, `disposeWebView`) and for
 /// updating the per-site state map after each promotion.
-enum SiteLifecycleState {
-  /// Webview is loaded in memory. Includes both the user-visible active
-  /// site (resumed) and any backgrounded loaded site (paused). The
-  /// distinction between resumed/paused is orthogonal to memory tier
-  /// and tracked via the controller's pause/resume state, not here.
-  live,
 
-  /// Webview is loaded in memory and has had its in-memory cache
-  /// cleared. The page is functional; cache will refill on next
-  /// interaction.
+/// Proactive `resident → cacheCleared` threshold. When more than this
+/// number of loaded sites are at the [SiteLifecycleState.resident] tier,
+/// activation eagerly promotes the oldest excess to `cacheCleared`
+/// (running `controller.clearCache()`) without waiting for an OS
+/// memory-pressure event. Backstop for platforms where memory
+/// pressure isn't reliably signaled (Linux/desktop) or where Jetsam
+/// is reactive after the fact (iOS). Sized for "comfortable working
+/// set" — well below [kMaxLoadedSites] so eviction (resident →
+/// cacheCleared → savedForRestore) has runway to operate before the
+/// LRU cap kicks in.
+const int kMaxResidentSites = 10;
+
+enum SiteLifecycleState {
+  /// Webview is in memory with full cache. Includes both the user-
+  /// visible active site (controller resumed) and any backgrounded
+  /// loaded site (controller paused). The distinction between
+  /// resumed/paused is orthogonal to memory tier and tracked via the
+  /// controller's pause/resume state, not here. Renamed from `live`
+  /// because backgrounded loaded sites are paused — "live" implied
+  /// activity that doesn't apply.
+  resident,
+
+  /// Webview is in memory but `clearCache()` has been called. The
+  /// page is functional; cache refills on next interaction.
   cacheCleared,
 
   /// Webview is disposed; its navigation state is captured to
@@ -56,8 +74,8 @@ class SiteTierCounts {
   /// Sites at the active position (typically 0 or 1).
   final int active;
 
-  /// Sites at [SiteLifecycleState.live] minus the active one.
-  final int live;
+  /// Sites at [SiteLifecycleState.resident] minus the active one.
+  final int resident;
 
   /// Sites at [SiteLifecycleState.cacheCleared].
   final int cacheCleared;
@@ -69,13 +87,13 @@ class SiteTierCounts {
 
   const SiteTierCounts({
     required this.active,
-    required this.live,
+    required this.resident,
     required this.cacheCleared,
     required this.savedForRestore,
   });
 
   @override
-  String toString() => 'SiteTierCounts(active=$active, live=$live, '
+  String toString() => 'SiteTierCounts(active=$active, resident=$resident, '
       'cacheCleared=$cacheCleared, savedForRestore=$savedForRestore)';
 }
 
@@ -84,7 +102,7 @@ class SiteLifecyclePromotionEngine {
   /// more-aggressive tier, or null when [current] is terminal.
   static SiteLifecycleState? nextState(SiteLifecycleState current) {
     switch (current) {
-      case SiteLifecycleState.live:
+      case SiteLifecycleState.resident:
         return SiteLifecycleState.cacheCleared;
       case SiteLifecycleState.cacheCleared:
         return SiteLifecycleState.savedForRestore;
@@ -101,8 +119,8 @@ class SiteLifecyclePromotionEngine {
   /// Selection rules, applied in order:
   ///
   ///   1. **Tier dominates LRU.** Walks tiers from least-aggressive
-  ///      ([SiteLifecycleState.live]) to most-aggressive non-terminal
-  ///      ([SiteLifecycleState.cacheCleared]). All `live` sites are
+  ///      ([SiteLifecycleState.resident]) to most-aggressive non-terminal
+  ///      ([SiteLifecycleState.cacheCleared]). All `resident` sites are
   ///      promoted to `cacheCleared` before any `cacheCleared` site is
   ///      promoted to `savedForRestore`. This gives the OS gradual
   ///      relief — clearing cache on every loaded site (~10-50 MB
@@ -126,7 +144,7 @@ class SiteLifecyclePromotionEngine {
   }) {
     // Walk tiers from least to most aggressive (excluding terminal).
     for (final tier in [
-      SiteLifecycleState.live,
+      SiteLifecycleState.resident,
       SiteLifecycleState.cacheCleared,
     ]) {
       // Within a tier, partition into out-of-keep then in-keep so
@@ -136,7 +154,7 @@ class SiteLifecyclePromotionEngine {
       int? inKeepCandidate;
       for (final i in loadedIndices) {
         if (protectedIndices.contains(i)) continue;
-        final s = states[i] ?? SiteLifecycleState.live;
+        final s = states[i] ?? SiteLifecycleState.resident;
         if (s != tier) continue;
         if (preferKeepIndices.contains(i)) {
           inKeepCandidate ??= i;
@@ -153,6 +171,64 @@ class SiteLifecyclePromotionEngine {
     return null;
   }
 
+  /// Returns the list of indices to proactively promote from
+  /// [SiteLifecycleState.resident] to [SiteLifecycleState.cacheCleared]
+  /// so that no more than [maxResidentSites] sites remain at the `live`
+  /// tier. Selection uses the same priority hierarchy as
+  /// [pickPromotionTarget]: out-of-`preferKeepIndices` sites are
+  /// promoted before in-keep sites, oldest-LRU-first within each
+  /// bucket. [protectedIndices] (active + activation-in-flight) are
+  /// excluded entirely.
+  ///
+  /// Caller invokes after each activation so the threshold is
+  /// enforced eagerly — this is the proactive complement to the
+  /// reactive memory-pressure cascade. Returns an empty list when
+  /// the count is already at or below the threshold.
+  ///
+  /// Order matters: the returned list is in the order the caller
+  /// should apply transitions (oldest-first within priority).
+  /// Already-`cacheCleared` and `savedForRestore` sites are not
+  /// counted toward the live total and not in the result.
+  static List<int> pickProactiveCacheClearTargets({
+    required Set<int> loadedIndices,
+    required Map<int, SiteLifecycleState> states,
+    required int maxResidentSites,
+    Set<int> protectedIndices = const <int>{},
+    Set<int> preferKeepIndices = const <int>{},
+  }) {
+    var residentCount = 0;
+    for (final i in loadedIndices) {
+      final s = states[i] ?? SiteLifecycleState.resident;
+      if (s == SiteLifecycleState.resident) residentCount++;
+    }
+    if (residentCount <= maxResidentSites) return const [];
+    final excess = residentCount - maxResidentSites;
+
+    final outOfKeep = <int>[];
+    final inKeep = <int>[];
+    for (final i in loadedIndices) {
+      if (protectedIndices.contains(i)) continue;
+      final s = states[i] ?? SiteLifecycleState.resident;
+      if (s != SiteLifecycleState.resident) continue;
+      if (preferKeepIndices.contains(i)) {
+        inKeep.add(i);
+      } else {
+        outOfKeep.add(i);
+      }
+    }
+
+    final result = <int>[];
+    for (final i in outOfKeep) {
+      if (result.length >= excess) return result;
+      result.add(i);
+    }
+    for (final i in inKeep) {
+      if (result.length >= excess) return result;
+      result.add(i);
+    }
+    return result;
+  }
+
   /// Tier-count snapshot. The `active` count is whichever loaded
   /// index matches `activeIndex` (0 or 1); other live loaded sites
   /// land in `live`. `savedForRestore` is read from the state map
@@ -163,18 +239,18 @@ class SiteLifecyclePromotionEngine {
     required int? activeIndex,
   }) {
     var active = 0;
-    var live = 0;
+    var resident = 0;
     var cacheCleared = 0;
     var savedForRestore = 0;
     for (final i in loadedIndices) {
-      final s = states[i] ?? SiteLifecycleState.live;
-      if (i == activeIndex && s == SiteLifecycleState.live) {
+      final s = states[i] ?? SiteLifecycleState.resident;
+      if (i == activeIndex && s == SiteLifecycleState.resident) {
         active++;
         continue;
       }
       switch (s) {
-        case SiteLifecycleState.live:
-          live++;
+        case SiteLifecycleState.resident:
+          resident++;
         case SiteLifecycleState.cacheCleared:
           cacheCleared++;
         case SiteLifecycleState.savedForRestore:
@@ -192,7 +268,7 @@ class SiteLifecyclePromotionEngine {
     }
     return SiteTierCounts(
       active: active,
-      live: live,
+      resident: resident,
       cacheCleared: cacheCleared,
       savedForRestore: savedForRestore,
     );

--- a/lib/services/site_unload_engine.dart
+++ b/lib/services/site_unload_engine.dart
@@ -1,0 +1,136 @@
+import 'package:webspace/services/outbound_http.dart';
+import 'package:webspace/services/webspace_selection_engine.dart';
+import 'package:webspace/settings/proxy.dart';
+import 'package:webspace/web_view_model.dart';
+
+/// Default cap on concurrently loaded webviews. Keeps memory bounded when
+/// container mode lets sites stay resident across webspace switches; without
+/// it, a heavy user could accumulate dozens of live native webviews.
+///
+/// Sized for "more than the user is likely actively juggling, but well under
+/// what an OOM-prone device can carry". Loaded webviews each consume native
+/// resources (renderer process, decoded images, JS heap). 16 is comfortably
+/// above typical working sets and well below the point where mid-range
+/// Android devices start swapping.
+const int kMaxLoadedSites = 16;
+
+/// Pure-Dart unload policy engine.
+///
+/// Owns the three orthogonal "should this site be unloaded?" rules:
+///
+///   1. Webspace switch — under legacy isolation only, sites visible only in
+///      the previous webspace are unloaded so the shared cookie jar stays
+///      clean. Under container isolation, sites stay resident across
+///      switches.
+///   2. Proxy mismatch — on Android, the WebView proxy is process-global
+///      (`inapp.ProxyController` last-write-wins). Activating a site with a
+///      different effective proxy would silently re-route any other loaded
+///      site's next request through the new proxy, defeating the user's
+///      per-site proxy choice. Force-unload conflicting sites so they can't
+///      leak.
+///   3. LRU cap — bound the number of concurrently loaded webviews so memory
+///      stays under control. The least-recently-used loaded site is evicted
+///      when the cap is exceeded. Caller treats [loadedIndices] as an
+///      access-ordered `LinkedHashSet` (bump on activation).
+///
+/// No rendering, no `setState`, no I/O — every method is a pure function over
+/// plain collections. Call sites in `_WebSpacePageState` translate the
+/// returned indices into webview disposal + isolation cleanup.
+class SiteUnloadEngine {
+  /// Webspace-switch unload set. Returns the indices to dispose.
+  ///
+  /// In container mode, returns an empty set: each site has its own native
+  /// container (cookies, localStorage, IDB, ServiceWorkers, HTTP cache), so
+  /// keeping a site loaded outside the active webspace is harmless and
+  /// avoids the cost of re-creating the webview when the user switches back.
+  ///
+  /// In legacy mode, falls through to the previous "anything visible only in
+  /// the old webspace gets unloaded" rule — same as the pre-container
+  /// behavior preserved by [WebspaceSelectionEngine].
+  static Set<int> indicesToUnloadOnWebspaceSwitch({
+    required bool useContainers,
+    required Set<int> loadedIndices,
+    required Set<int> previousWebspaceIndices,
+    required Set<int> newWebspaceIndices,
+  }) {
+    if (useContainers) return const <int>{};
+    return WebspaceSelectionEngine.indicesToUnloadOnWebspaceSwitch(
+      loadedIndices: loadedIndices,
+      previousWebspaceIndices: previousWebspaceIndices,
+      newWebspaceIndices: newWebspaceIndices,
+    );
+  }
+
+  /// Sites that must be unloaded because activating [targetIndex] would
+  /// repoint a process-global proxy override out from under them.
+  ///
+  /// Only applies on platforms where the WebView proxy is process-global
+  /// (Android). On platforms with true per-site proxies (iOS 17+ /
+  /// macOS 14+), pass `proxyIsGlobal: false` and this returns an empty set.
+  ///
+  /// "Different effective proxy" is computed via
+  /// [resolveEffectiveProxy] — a per-site `DEFAULT` resolves through the
+  /// app-global outbound proxy, so two sites both set to `DEFAULT` are
+  /// considered equivalent regardless of the global value (it's the same
+  /// for both).
+  static Set<int> indicesToUnloadForProxyMismatch({
+    required int targetIndex,
+    required List<WebViewModel> models,
+    required Set<int> loadedIndices,
+    required bool proxyIsGlobal,
+  }) {
+    if (!proxyIsGlobal) return const <int>{};
+    if (targetIndex < 0 || targetIndex >= models.length) return const <int>{};
+    final targetEffective =
+        resolveEffectiveProxy(models[targetIndex].proxySettings);
+    final result = <int>{};
+    for (final i in loadedIndices) {
+      if (i == targetIndex) continue;
+      if (i < 0 || i >= models.length) continue;
+      final effective = resolveEffectiveProxy(models[i].proxySettings);
+      if (!_proxyEquivalent(targetEffective, effective)) {
+        result.add(i);
+      }
+    }
+    return result;
+  }
+
+  /// LRU eviction set. Returns the indices to evict (oldest first) so that
+  /// [loadedIndices] plus [targetIndex] fits within [maxLoadedSites].
+  ///
+  /// Treats [loadedIndices] as an access-ordered set: iteration order is
+  /// least-recently-used first. The caller is responsible for bumping a
+  /// site to the end of [loadedIndices] each time it becomes active (via
+  /// remove-then-add on a `LinkedHashSet`). [targetIndex] itself is never
+  /// evicted, and indices in [protectedIndices] (typically the currently-
+  /// active site, if not yet the target) are also kept resident.
+  ///
+  /// Returns an empty list when the cap would not be exceeded.
+  static List<int> indicesToEvictForLruCap({
+    required int targetIndex,
+    required Set<int> loadedIndices,
+    required int maxLoadedSites,
+    Set<int> protectedIndices = const <int>{},
+  }) {
+    final projected = loadedIndices.contains(targetIndex)
+        ? loadedIndices.length
+        : loadedIndices.length + 1;
+    if (projected <= maxLoadedSites) return const [];
+    final overflow = projected - maxLoadedSites;
+    final evict = <int>[];
+    for (final i in loadedIndices) {
+      if (i == targetIndex) continue;
+      if (protectedIndices.contains(i)) continue;
+      evict.add(i);
+      if (evict.length >= overflow) break;
+    }
+    return evict;
+  }
+
+  static bool _proxyEquivalent(UserProxySettings a, UserProxySettings b) {
+    return a.type == b.type &&
+        a.address == b.address &&
+        a.username == b.username &&
+        a.password == b.password;
+  }
+}

--- a/lib/services/site_unload_engine.dart
+++ b/lib/services/site_unload_engine.dart
@@ -14,7 +14,7 @@ import 'package:webspace/web_view_model.dart';
 /// [SiteUnloadEngine.indexToEvictForMemoryPressure] — so this cap can
 /// be generous. Per-event one-at-a-time eviction lets the OS clamp us
 /// down to whatever the device can carry.
-const int kMaxLoadedSites = 50;
+const int kMaxLoadedSites = 20;
 
 /// Pure-Dart unload policy engine.
 ///

--- a/lib/services/site_unload_engine.dart
+++ b/lib/services/site_unload_engine.dart
@@ -7,12 +7,14 @@ import 'package:webspace/web_view_model.dart';
 /// container mode lets sites stay resident across webspace switches; without
 /// it, a heavy user could accumulate dozens of live native webviews.
 ///
-/// Sized for "more than the user is likely actively juggling, but well under
-/// what an OOM-prone device can carry". Loaded webviews each consume native
-/// resources (renderer process, decoded images, JS heap). 16 is comfortably
-/// above typical working sets and well below the point where mid-range
-/// Android devices start swapping.
-const int kMaxLoadedSites = 16;
+/// Sized for "more than the user is likely actively juggling, on a device
+/// with healthy headroom". Loaded webviews each consume native resources
+/// (renderer process, decoded images, JS heap), but the OS's own memory
+/// pressure signal is the real backstop — see
+/// [SiteUnloadEngine.indexToEvictForMemoryPressure] — so this cap can
+/// be generous. Per-event one-at-a-time eviction lets the OS clamp us
+/// down to whatever the device can carry.
+const int kMaxLoadedSites = 50;
 
 /// Pure-Dart unload policy engine.
 ///
@@ -155,6 +157,41 @@ class SiteUnloadEngine {
       evict.add(i);
     }
     return evict;
+  }
+
+  /// Picks one loaded site to unload in response to an OS memory pressure
+  /// signal. Returns null when there's nothing safe to evict (everything
+  /// loaded is in [protectedIndices], typically just the currently-active
+  /// site).
+  ///
+  /// Same two-tier policy as [indicesToEvictForLruCap]: out-of-preferKeep
+  /// candidates (oldest first), then in-preferKeep (oldest first). The
+  /// caller invokes this on each `didHaveMemoryPressure()` event — if
+  /// pressure persists, the OS fires the callback again and the next
+  /// victim is picked. This lets the device clamp us down to whatever
+  /// it can carry, instead of guessing a target up front.
+  ///
+  /// One-per-event matches the OS's signaling cadence. Trimming
+  /// aggressively in a single shot would over-evict on transient
+  /// pressure (e.g. another foregrounded app); trimming gradually lets
+  /// the system stabilize.
+  static int? indexToEvictForMemoryPressure({
+    required Set<int> loadedIndices,
+    Set<int> protectedIndices = const <int>{},
+    Set<int> preferKeepIndices = const <int>{},
+  }) {
+    // Tier 1: out-of-preferKeep candidates, in LRU order.
+    for (final i in loadedIndices) {
+      if (protectedIndices.contains(i)) continue;
+      if (preferKeepIndices.contains(i)) continue;
+      return i;
+    }
+    // Tier 2: in-preferKeep candidates, in LRU order.
+    for (final i in loadedIndices) {
+      if (protectedIndices.contains(i)) continue;
+      return i;
+    }
+    return null;
   }
 
   static bool _proxyEquivalent(UserProxySettings a, UserProxySettings b) {

--- a/lib/services/site_unload_engine.dart
+++ b/lib/services/site_unload_engine.dart
@@ -101,28 +101,58 @@ class SiteUnloadEngine {
   /// Treats [loadedIndices] as an access-ordered set: iteration order is
   /// least-recently-used first. The caller is responsible for bumping a
   /// site to the end of [loadedIndices] each time it becomes active (via
-  /// remove-then-add on a `LinkedHashSet`). [targetIndex] itself is never
-  /// evicted, and indices in [protectedIndices] (typically the currently-
-  /// active site, if not yet the target) are also kept resident.
+  /// remove-then-add on a `LinkedHashSet`).
   ///
-  /// Returns an empty list when the cap would not be exceeded.
+  /// Eviction priority is two-tier:
+  ///
+  ///   1. **Hard protected.** Indices in [protectedIndices] (typically the
+  ///      currently-active site, if not yet the target) are never evicted.
+  ///      [targetIndex] itself is also never evicted.
+  ///   2. **Soft kept.** Indices in [preferKeepIndices] (typically the
+  ///      sites in the active webspace) are evicted only after every
+  ///      out-of-set candidate is exhausted. This treats webspace
+  ///      membership as "context relevance" — a site in the user's
+  ///      current workspace that they haven't touched in five
+  ///      activations is still more likely to be needed soon than a
+  ///      stale site from a different workspace.
+  ///
+  /// Within each tier, oldest-accessed comes first. Returns an empty list
+  /// when the cap would not be exceeded.
   static List<int> indicesToEvictForLruCap({
     required int targetIndex,
     required Set<int> loadedIndices,
     required int maxLoadedSites,
     Set<int> protectedIndices = const <int>{},
+    Set<int> preferKeepIndices = const <int>{},
   }) {
     final projected = loadedIndices.contains(targetIndex)
         ? loadedIndices.length
         : loadedIndices.length + 1;
     if (projected <= maxLoadedSites) return const [];
     final overflow = projected - maxLoadedSites;
-    final evict = <int>[];
+
+    // Tier 1: out-of-preferKeep candidates, in LRU order.
+    final outOfKeep = <int>[];
+    final inKeep = <int>[];
     for (final i in loadedIndices) {
       if (i == targetIndex) continue;
       if (protectedIndices.contains(i)) continue;
+      if (preferKeepIndices.contains(i)) {
+        inKeep.add(i);
+      } else {
+        outOfKeep.add(i);
+      }
+    }
+
+    final evict = <int>[];
+    for (final i in outOfKeep) {
+      if (evict.length >= overflow) return evict;
       evict.add(i);
-      if (evict.length >= overflow) break;
+    }
+    // Tier 2: only used if tier 1 didn't supply enough overflow.
+    for (final i in inKeep) {
+      if (evict.length >= overflow) return evict;
+      evict.add(i);
     }
     return evict;
   }

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -558,6 +558,35 @@ abstract class WebViewController {
   /// before queuing a follow-up navigation, shrinking the overlap
   /// between in-flight teardown and the next loadUrl.
   Future<void> stopLoading();
+
+  /// Drop the WebView's in-memory cache (decoded image cache + the
+  /// HTTP response cache). Tab state stays — the page keeps running,
+  /// the back/forward stack is intact. Idempotent: a second call
+  /// is a near no-op (the cache is already empty).
+  ///
+  /// Used by the [SiteLifecyclePromotionEngine] cacheCleared tier to
+  /// reclaim memory under OS pressure without losing tab state. Frees
+  /// roughly 10-50 MB per webview depending on what was cached.
+  Future<void> clearCache();
+
+  /// Capture the WebView's navigation state into a serializable byte
+  /// blob. Pair with [restoreState] on a freshly-created controller
+  /// to re-hydrate the back/forward stack and (on iOS 15+ / macOS
+  /// 12+) form-field values. Live JS heap and DOM are NOT preserved.
+  ///
+  /// Returns null when there's nothing to save (e.g. a webview that
+  /// never navigated).
+  ///
+  /// Platform mapping:
+  ///   - Android: `WebView.saveState(Bundle)` — back/forward + scroll.
+  ///   - iOS 15+ / macOS 12+: `WKWebView.interactionState` — back/
+  ///     forward + form-field values + scroll.
+  ///   - Linux (fork): equivalent navigation snapshot.
+  Future<Uint8List?> saveState();
+
+  /// Apply [state] (previously returned by [saveState] on the same
+  /// site) to this controller. Returns true on success.
+  Future<bool> restoreState(Uint8List state);
 }
 
 /// InAppWebView controller wrapper
@@ -738,6 +767,35 @@ class _WebViewController implements WebViewController {
   @override
   Future<void> stopLoading() async {
     await _c.stopLoading();
+  }
+
+  @override
+  Future<void> clearCache() async {
+    try {
+      await _c.clearCache();
+    } catch (_) {
+      // Controller may have been disposed during memory pressure.
+    }
+  }
+
+  @override
+  Future<Uint8List?> saveState() async {
+    try {
+      return await _c.saveState();
+    } catch (_) {
+      // Disposed mid-call, or platform refused. Treat as "nothing
+      // to save" — re-activation will fall back to a fresh load.
+      return null;
+    }
+  }
+
+  @override
+  Future<bool> restoreState(Uint8List state) async {
+    try {
+      return await _c.restoreState(state);
+    } catch (_) {
+      return false;
+    }
   }
 }
 

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -581,7 +581,9 @@ abstract class WebViewController {
   ///   - Android: `WebView.saveState(Bundle)` — back/forward + scroll.
   ///   - iOS 15+ / macOS 12+: `WKWebView.interactionState` — back/
   ///     forward + form-field values + scroll.
-  ///   - Linux (fork): equivalent navigation snapshot.
+  ///   - Linux (WebKitGTK / WPE): `webkit_web_view_get_session_state`
+  ///     + `webkit_web_view_session_state_serialize` — back/forward
+  ///     + scroll. Form-field values are NOT preserved (Apple-only).
   Future<Uint8List?> saveState();
 
   /// Apply [state] (previously returned by [saveState] on the same

--- a/lib/services/webview_state_secure_storage.dart
+++ b/lib/services/webview_state_secure_storage.dart
@@ -1,0 +1,286 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:encrypt/encrypt.dart' as encrypt;
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:webspace/services/log_service.dart';
+import 'package:webspace/services/webview_state_storage.dart';
+
+/// AES-encrypted, on-disk implementation of [WebViewStateStorage].
+///
+/// Models the [HtmlCacheService] pattern: a 256-bit AES-CBC key lives
+/// in [FlutterSecureStorage] (platform keychain / keystore), the
+/// per-site state bytes are encrypted with a fixed IV derived from
+/// that key and written to `<docs>/webview_state/<siteId>.enc`.
+///
+/// State survives cold starts. On app upgrade the cache directory is
+/// nuked (key is rotated alongside it) — the back/forward stack from
+/// a previous app version is unlikely to re-hydrate cleanly anyway.
+///
+/// Why on-disk instead of straight `flutter_secure_storage`:
+/// `saveState()` returns a `Uint8List` that's typically 1-50 KB but
+/// can grow with deep history. iOS Keychain caps individual items at
+/// ~4 KB, and Android EncryptedSharedPreferences degrades with size.
+/// AES-on-disk handles arbitrary sizes; the keychain only holds the
+/// 32-byte AES key.
+///
+/// File format: base64(AES-CBC(state-bytes)). Reads decrypt to
+/// `Uint8List`; the IV is fixed (per-key) so identical bytes encrypt
+/// to identical ciphertext — fine, the threat model is "device
+/// compromise" not "ciphertext analysis", and matches the HTML cache
+/// shape so future contributors don't have to learn two patterns.
+class SecureWebViewStateStorage implements WebViewStateStorage {
+  static const String _versionKey = 'webview_state_cache_version';
+  static const String _cacheDir = 'webview_state';
+  static const String _encryptionKeyKey = 'webview_state_encryption_key';
+
+  final FlutterSecureStorage _secureStorage;
+  /// Optional override for the cache parent directory. When null,
+  /// `getApplicationDocumentsDirectory()` is queried at init. Tests
+  /// inject a temp dir to avoid the path_provider plugin.
+  final Directory? _overrideAppDir;
+  /// Optional override for the version-tracking SharedPreferences-
+  /// equivalent. When null, [SharedPreferences] is queried.
+  /// Tests inject a stub to avoid plugin setup.
+  final String Function()? _versionProvider;
+
+  Directory? _cacheDirectory;
+  encrypt.Encrypter? _encrypter;
+  encrypt.IV? _iv;
+  bool _initialized = false;
+
+  SecureWebViewStateStorage({
+    FlutterSecureStorage? secureStorage,
+    Directory? overrideAppDir,
+    String Function()? versionProvider,
+  })  : _secureStorage = secureStorage ?? const FlutterSecureStorage(),
+        _overrideAppDir = overrideAppDir,
+        _versionProvider = versionProvider;
+
+  /// Initialize the storage. Idempotent. Must complete before any
+  /// save/load — the AES key is provisioned here (or rotated on app
+  /// upgrade) and the cache directory is created if missing.
+  Future<void> initialize() async {
+    if (_initialized) return;
+    final appDir = _overrideAppDir ?? await getApplicationDocumentsDirectory();
+    _cacheDirectory = Directory('${appDir.path}/$_cacheDir');
+    await _initEncryption();
+    await _clearCacheOnUpgrade();
+    if (!await _cacheDirectory!.exists()) {
+      await _cacheDirectory!.create(recursive: true);
+    }
+    _initialized = true;
+  }
+
+  Future<void> _initEncryption() async {
+    try {
+      String? keyBase64 = await _secureStorage.read(key: _encryptionKeyKey);
+      if (keyBase64 == null) {
+        final key = encrypt.Key.fromSecureRandom(32);
+        keyBase64 = base64.encode(key.bytes);
+        await _secureStorage.write(key: _encryptionKeyKey, value: keyBase64);
+        LogService.instance.log(
+          'WebViewState',
+          'Generated new encryption key',
+        );
+      }
+      final keyBytes = base64.decode(keyBase64);
+      final key = encrypt.Key(Uint8List.fromList(keyBytes));
+      _iv = encrypt.IV(Uint8List.fromList(keyBytes.sublist(0, 16)));
+      _encrypter = encrypt.Encrypter(
+        encrypt.AES(key, mode: encrypt.AESMode.cbc),
+      );
+    } catch (e) {
+      LogService.instance.log(
+        'WebViewState',
+        'Error initializing encryption: $e',
+        level: LogLevel.error,
+      );
+    }
+  }
+
+  Future<void> _clearCacheOnUpgrade() async {
+    final String currentVersion;
+    final String? lastVersion;
+    final SharedPreferences? prefs;
+    if (_versionProvider != null) {
+      currentVersion = _versionProvider();
+      // Test path: persist version via the injected secure storage so
+      // the next instance with a different versionProvider triggers
+      // rotation. Returns null on first run, just like the production
+      // SharedPreferences path.
+      prefs = null;
+      lastVersion = await _secureStorage.read(key: '$_versionKey.test');
+    } else {
+      prefs = await SharedPreferences.getInstance();
+      final info = await PackageInfo.fromPlatform();
+      currentVersion = '${info.version}+${info.buildNumber}';
+      lastVersion = prefs.getString(_versionKey);
+    }
+    if (lastVersion != currentVersion) {
+      if (lastVersion != null && _cacheDirectory != null) {
+        try {
+          if (await _cacheDirectory!.exists()) {
+            await _cacheDirectory!.delete(recursive: true);
+          }
+        } catch (e) {
+          LogService.instance.log(
+            'WebViewState',
+            'Error clearing cache on upgrade: $e',
+            level: LogLevel.error,
+          );
+        }
+        // Rotate the AES key alongside the bytes — old ciphertext
+        // wouldn't decrypt with the new key anyway, but explicit
+        // rotation matches the HTML cache pattern.
+        try {
+          await _secureStorage.delete(key: _encryptionKeyKey);
+          await _initEncryption();
+        } catch (_) {
+          // Best effort.
+        }
+      }
+      if (prefs != null) {
+        await prefs.setString(_versionKey, currentVersion);
+      } else {
+        await _secureStorage.write(
+          key: '$_versionKey.test',
+          value: currentVersion,
+        );
+      }
+    }
+  }
+
+  File _fileFor(String siteId) {
+    return File('${_cacheDirectory!.path}/$siteId.enc');
+  }
+
+  @override
+  Future<void> saveState(String siteId, Uint8List state) async {
+    if (state.isEmpty) return;
+    if (!_initialized) await initialize();
+    if (_cacheDirectory == null || _encrypter == null || _iv == null) return;
+    try {
+      final encoded = base64.encode(state);
+      final cipher = _encrypter!.encrypt(encoded, iv: _iv).base64;
+      await _fileFor(siteId).writeAsString(cipher);
+      LogService.instance.log(
+        'WebViewState',
+        'Saved ${state.length} bytes for site $siteId (encrypted)',
+      );
+    } catch (e) {
+      LogService.instance.log(
+        'WebViewState',
+        'Error saving state for $siteId: $e',
+        level: LogLevel.error,
+      );
+    }
+  }
+
+  @override
+  Future<Uint8List?> loadState(String siteId) async {
+    if (!_initialized) await initialize();
+    if (_cacheDirectory == null || _encrypter == null || _iv == null) {
+      return null;
+    }
+    try {
+      final f = _fileFor(siteId);
+      if (!await f.exists()) return null;
+      final cipher = await f.readAsString();
+      final decoded = _encrypter!.decrypt64(cipher, iv: _iv);
+      final bytes = base64.decode(decoded);
+      return Uint8List.fromList(bytes);
+    } catch (e) {
+      LogService.instance.log(
+        'WebViewState',
+        'Error loading state for $siteId: $e',
+        level: LogLevel.error,
+      );
+      // Corrupt entry — defensive: remove so a re-save can succeed
+      // and we don't keep failing loads in a hot loop.
+      try {
+        await _fileFor(siteId).delete();
+      } catch (_) {}
+      return null;
+    }
+  }
+
+  @override
+  Future<void> removeState(String siteId) async {
+    if (!_initialized) await initialize();
+    if (_cacheDirectory == null) return;
+    try {
+      final f = _fileFor(siteId);
+      if (await f.exists()) {
+        await f.delete();
+      }
+    } catch (e) {
+      LogService.instance.log(
+        'WebViewState',
+        'Error deleting state for $siteId: $e',
+        level: LogLevel.error,
+      );
+    }
+  }
+
+  @override
+  Future<int> removeOrphans(Set<String> activeSiteIds) async {
+    if (!_initialized) await initialize();
+    if (_cacheDirectory == null || !await _cacheDirectory!.exists()) {
+      return 0;
+    }
+    var removed = 0;
+    try {
+      final entries = await _cacheDirectory!.list().toList();
+      for (final entity in entries) {
+        if (entity is! File) continue;
+        if (!entity.path.endsWith('.enc')) continue;
+        final filename = entity.path.split('/').last;
+        final siteId = filename.replaceAll('.enc', '');
+        if (!activeSiteIds.contains(siteId)) {
+          await entity.delete();
+          removed++;
+        }
+      }
+      if (removed > 0) {
+        LogService.instance.log(
+          'WebViewState',
+          'Removed $removed orphan state file(s)',
+        );
+      }
+    } catch (e) {
+      LogService.instance.log(
+        'WebViewState',
+        'Error sweeping orphan state files: $e',
+        level: LogLevel.error,
+      );
+    }
+    return removed;
+  }
+
+  @override
+  Future<Set<String>> siteIds() async {
+    if (!_initialized) await initialize();
+    if (_cacheDirectory == null || !await _cacheDirectory!.exists()) {
+      return const <String>{};
+    }
+    final result = <String>{};
+    try {
+      final entries = await _cacheDirectory!.list().toList();
+      for (final entity in entries) {
+        if (entity is! File) continue;
+        if (!entity.path.endsWith('.enc')) continue;
+        final filename = entity.path.split('/').last;
+        result.add(filename.replaceAll('.enc', ''));
+      }
+    } catch (_) {
+      // Best effort.
+    }
+    return result;
+  }
+}

--- a/lib/services/webview_state_storage.dart
+++ b/lib/services/webview_state_storage.dart
@@ -1,0 +1,85 @@
+import 'dart:typed_data';
+
+/// Storage abstraction for `WKWebView.interactionState` /
+/// `WebView.saveState` bytes, keyed by site ID. Used by the
+/// memory-pressure cascade ([SiteLifecyclePromotionEngine]) to persist
+/// a webview's navigation state before its renderer is torn down so
+/// re-activation can re-hydrate the back/forward stack and (on
+/// iOS 15+ / macOS 12+) form-field values via `restoreState`.
+///
+/// The current default implementation is in-memory only — saved bytes
+/// survive webspace switches, LRU evictions, and memory-pressure
+/// disposals within a single app run, but are lost on cold start. A
+/// future on-disk implementation can drop in here without changes to
+/// callers.
+///
+/// Implementations are expected to be idempotent for both
+/// [removeState] and [saveState] (overwrite semantics), and to treat
+/// empty / null bytes as "nothing to save" so a webview that never
+/// navigated doesn't leave a dangling empty entry that a later
+/// `restoreState` would then attempt to apply.
+abstract class WebViewStateStorage {
+  /// Persist [state] under [siteId]. If [state] is empty, the call
+  /// is treated as a no-op (any previously-saved entry is left
+  /// untouched).
+  Future<void> saveState(String siteId, Uint8List state);
+
+  /// Returns the bytes previously stored for [siteId], or null if
+  /// none exist.
+  Future<Uint8List?> loadState(String siteId);
+
+  /// Removes any saved bytes for [siteId]. No-op when nothing is
+  /// stored.
+  Future<void> removeState(String siteId);
+
+  /// Removes every entry whose siteId is not in [activeSiteIds].
+  /// Returns the count removed. Run on app startup to reap state
+  /// belonging to sites the user deleted in a previous session.
+  Future<int> removeOrphans(Set<String> activeSiteIds);
+
+  /// Returns the set of siteIds currently holding state. Used by the
+  /// counters in [SiteLifecyclePromotionEngine.tierCounts] and by
+  /// debug surfaces.
+  Future<Set<String>> siteIds();
+}
+
+/// In-memory implementation of [WebViewStateStorage]. State is
+/// preserved across webspace switches and memory-pressure disposals
+/// within a single app run, and lost on cold start.
+class InMemoryWebViewStateStorage implements WebViewStateStorage {
+  final Map<String, Uint8List> _store = <String, Uint8List>{};
+
+  @override
+  Future<void> saveState(String siteId, Uint8List state) async {
+    if (state.isEmpty) return;
+    _store[siteId] = state;
+  }
+
+  @override
+  Future<Uint8List?> loadState(String siteId) async {
+    return _store[siteId];
+  }
+
+  @override
+  Future<void> removeState(String siteId) async {
+    _store.remove(siteId);
+  }
+
+  @override
+  Future<int> removeOrphans(Set<String> activeSiteIds) async {
+    var removed = 0;
+    final keys = _store.keys.toList();
+    for (final k in keys) {
+      if (!activeSiteIds.contains(k)) {
+        _store.remove(k);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
+  @override
+  Future<Set<String>> siteIds() async {
+    return _store.keys.toSet();
+  }
+}

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' show ConsoleMessageLevel;
@@ -8,6 +10,7 @@ import 'package:webspace/services/external_url_engine.dart';
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/navigation_decision_engine.dart';
 import 'package:webspace/services/container_cookie_manager.dart';
+import 'package:webspace/services/site_lifecycle_promotion_engine.dart';
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/settings/location.dart';
 import 'package:webspace/settings/proxy.dart';
@@ -798,6 +801,34 @@ class WebViewModel {
           LogService.instance.log('WebView', 'onControllerCreated for "$name" (siteId: $siteId)');
           controller = ctrl;
           setController();
+          // Apply any state queued by the activation flow when this
+          // model came back from SavedForRestore. The InAppWebView's
+          // `initialUrlRequest` already kicked off a navigation to
+          // `currentUrl` (which matches the most-recent saved URL);
+          // restoreState restores the back/forward stack on Android
+          // and (Apple 15+/12+) form-field values. The brief
+          // redundant initial-nav-then-restore on Apple is acceptable
+          // for the much-better re-activation UX.
+          //
+          // unawaited: subsequent webview-creation logic doesn't
+          // depend on the restore completing. Clear the field
+          // *before* awaiting so a back-to-back rebuild doesn't
+          // re-apply the same bytes.
+          final pending = _pendingRestoreState;
+          if (pending != null) {
+            _pendingRestoreState = null;
+            unawaited(() async {
+              try {
+                final ok = await ctrl.restoreState(pending);
+                LogService.instance.log('WebView',
+                    'restoreState for "$name" (siteId: $siteId): $ok');
+              } catch (_) {
+                // Restore is best-effort; on failure the page is
+                // already loading from `currentUrl` — user just loses
+                // the back/forward stack and form data.
+              }
+            }());
+          }
         },
       );
     }
@@ -919,6 +950,69 @@ class WebViewModel {
     LogService.instance.log('WebView', 'disposeWebView called for "$name" (siteId: $siteId)');
     webview = null;
     controller = null;
+  }
+
+  /// Drop the in-memory cache (decoded image cache + HTTP response
+  /// cache) without disposing the webview. Tab state stays. Used by
+  /// the [SiteLifecyclePromotionEngine] cacheCleared tier under OS
+  /// memory pressure. Idempotent. No-op when controller is null
+  /// (already disposed).
+  Future<void> clearWebViewCache() async {
+    if (controller == null) return;
+    try {
+      await controller!.clearCache();
+      LogService.instance.log('WebView',
+          'Cleared in-memory cache for "$name" (siteId: $siteId)');
+    } catch (_) {
+      // Controller may have been disposed mid-call.
+    }
+  }
+
+  /// Capture the WebView's navigation state as bytes. Returns null
+  /// when there's nothing to save (controller is null, page never
+  /// navigated, or the platform refused). Pair with the matching
+  /// `restoreState` on a freshly-created controller in
+  /// [getWebView]'s `onControllerCreated` handler to re-hydrate
+  /// the back/forward stack and (Apple only) form-field values.
+  ///
+  /// Live JS heap and DOM are NOT preserved.
+  Future<Uint8List?> captureNavigationState() async {
+    if (controller == null) return null;
+    if (incognito) return null;
+    try {
+      final state = await controller!.saveState();
+      if (state == null || state.isEmpty) return null;
+      return state;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Current memory-tier state. Drives the
+  /// [SiteLifecyclePromotionEngine] cascade. Default [SiteLifecycleState.live]
+  /// — active and paused-but-loaded sites both sit at this tier
+  /// (the resume/pause distinction is orthogonal to memory tier).
+  /// Promoted on memory pressure events; reset to `live` on
+  /// re-activation when the webview is rebuilt.
+  SiteLifecycleState lifecycleState = SiteLifecycleState.live;
+
+  /// Bytes from a prior `controller.saveState()`, queued by the
+  /// activation flow when re-activating a [SiteLifecycleState.savedForRestore]
+  /// site. Consumed once by [getWebView]'s `onControllerCreated`
+  /// handler and then cleared, so subsequent activations don't
+  /// re-apply stale state.
+  ///
+  /// Caller (typically `_setCurrentIndex` in `_WebSpacePageState`)
+  /// fetches bytes from [WebViewStateStorage] before letting the
+  /// webview rebuild, so the IndexedStack repaint and the
+  /// `restoreState` call land in the same render cycle.
+  Uint8List? _pendingRestoreState;
+
+  /// Schedule [state] to be applied to the next freshly-created
+  /// controller for this model. Cleared automatically once the
+  /// `onControllerCreated` callback consumes it.
+  void schedulePendingRestoreState(Uint8List state) {
+    _pendingRestoreState = state;
   }
 
   /// Get display name - uses the name field (which auto-updates from page title)

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -989,12 +989,12 @@ class WebViewModel {
   }
 
   /// Current memory-tier state. Drives the
-  /// [SiteLifecyclePromotionEngine] cascade. Default [SiteLifecycleState.live]
+  /// [SiteLifecyclePromotionEngine] cascade. Default [SiteLifecycleState.resident]
   /// — active and paused-but-loaded sites both sit at this tier
   /// (the resume/pause distinction is orthogonal to memory tier).
   /// Promoted on memory pressure events; reset to `live` on
   /// re-activation when the webview is rebuilt.
-  SiteLifecycleState lifecycleState = SiteLifecycleState.live;
+  SiteLifecycleState lifecycleState = SiteLifecycleState.resident;
 
   /// Bytes from a prior `controller.saveState()`, queued by the
   /// activation flow when re-activating a [SiteLifecycleState.savedForRestore]

--- a/openspec/specs/per-site-containers/spec.md
+++ b/openspec/specs/per-site-containers/spec.md
@@ -259,11 +259,41 @@ The orchestration lives in
 [`SiteUnloadEngine.indicesToUnloadOnWebspaceSwitch`](../../../lib/services/site_unload_engine.dart),
 which returns `{}` when `useContainers == true` and delegates to the
 legacy `WebspaceSelectionEngine` otherwise. To prevent unbounded growth
-under this policy, the same engine enforces an LRU cap
-([`kMaxLoadedSites`](../../../lib/services/site_unload_engine.dart)) on
-activation: when adding a site would exceed the cap, the
-least-recently-used loaded site (other than the currently-active one)
-is evicted.
+under this policy, two backstops apply:
+
+1. **LRU cap**
+   ([`kMaxLoadedSites`](../../../lib/services/site_unload_engine.dart),
+   currently 50). Activation evicts least-recently-used loaded sites
+   when adding the new site would exceed the cap. The two-tier
+   priority keeps the active site (hard-protected) and active-webspace
+   sites (soft-keep) loaded in preference to stale sites from other
+   webspaces.
+2. **OS memory pressure**
+   (`WidgetsBindingObserver.didHaveMemoryPressure`). Each event
+   evicts one site via
+   [`SiteUnloadEngine.indexToEvictForMemoryPressure`](../../../lib/services/site_unload_engine.dart).
+   The OS controls the curve: if pressure persists, the callback
+   fires again and the next victim is picked. One-per-event matches
+   the OS signaling cadence and avoids over-evicting on transient
+   pressure (e.g. another foregrounded app spike). Mirrors
+   Flutter's own `ImageCache` reactivity pattern.
+
+#### Scenario: Memory pressure during re-activation does not strand state
+
+**Given** profile mode is active
+**And** site A is loaded but not the currently-active site
+**When** the user activates A and the OS fires
+  `didHaveMemoryPressure` between the version bump and the eventual
+  webview resume
+**Then** A is NOT picked as the eviction victim
+**Because** `_setCurrentIndex` records its target in
+  `_activationInFlightIndex` (set in the try block, cleared in
+  finally); `_handleMemoryPressure` includes that index in its
+  hard-protected set alongside `_currentIndex`. Without the in-flight
+  guard, mid-activation eviction would dispose A's webview, leaving
+  `_setCurrentIndex` to call `resumeWebView()` on a null controller
+  (no-op) — the IndexedStack would re-create a fresh webview on next
+  paint, silently wiping the user's URL/scroll/session.
 
 ### Requirement: CONT-004 — Orphan Garbage Collection
 

--- a/openspec/specs/per-site-containers/spec.md
+++ b/openspec/specs/per-site-containers/spec.md
@@ -242,6 +242,29 @@ load and run concurrently with fully isolated cookies, `localStorage`,
 **Then** site A's session is intact — no re-login, no reload, no
   capture-nuke-restore cycle ran
 
+#### Scenario: Sites stay loaded across webspace switches
+
+**Given** profile mode is active
+**And** site A is in webspace `Work` and site B is in webspace `Personal`
+**And** both A and B have been loaded
+**When** the user switches webspace from `Work` to `Personal`
+**Then** site A is NOT unloaded (it remains in `_loadedIndices` and its
+  webview stays in the IndexedStack), even though it isn't part of the
+  newly-active webspace
+**Because** the per-site container isolates A's state from B's, so
+  keeping A resident is harmless and avoids the cost of re-creating
+  the webview if the user switches back
+
+The orchestration lives in
+[`SiteUnloadEngine.indicesToUnloadOnWebspaceSwitch`](../../../lib/services/site_unload_engine.dart),
+which returns `{}` when `useContainers == true` and delegates to the
+legacy `WebspaceSelectionEngine` otherwise. To prevent unbounded growth
+under this policy, the same engine enforces an LRU cap
+([`kMaxLoadedSites`](../../../lib/services/site_unload_engine.dart)) on
+activation: when adding a site would exceed the cap, the
+least-recently-used loaded site (other than the currently-active one)
+is evicted.
+
 ### Requirement: CONT-004 — Orphan Garbage Collection
 
 The system SHALL sweep profiles whose owning site no longer exists.

--- a/openspec/specs/per-site-containers/spec.md
+++ b/openspec/specs/per-site-containers/spec.md
@@ -263,7 +263,7 @@ under this policy, two backstops apply:
 
 1. **LRU cap**
    ([`kMaxLoadedSites`](../../../lib/services/site_unload_engine.dart),
-   currently 50). Activation evicts least-recently-used loaded sites
+   currently 20). Activation evicts least-recently-used loaded sites
    when adding the new site would exceed the cap. The two-tier
    priority keeps the active site (hard-protected) and active-webspace
    sites (soft-keep) loaded in preference to stale sites from other

--- a/openspec/specs/proxy/spec.md
+++ b/openspec/specs/proxy/spec.md
@@ -231,6 +231,24 @@ the same proxy into every `WebViewModel.proxySettings` field on save —
 so the data model stays consistent with the runtime behavior, but the
 "per-site" promise of the UI is effectively reduced to "global".
 
+#### Scenario: Android — proxy-mismatch unload on activation
+
+**Given** Site A is loaded on Android with HTTP proxy P1
+**And** Site B is configured with SOCKS5 proxy P2
+**When** the user activates Site B
+**Then** Site A is unloaded *before* `ProxyController.setProxyOverride`
+applies P2 globally
+**Because** if A stayed loaded, its next outbound request (XHR, image
+fetch, ServiceWorker poll, …) would silently route through P2 — exactly
+the leak the user's per-site proxy choice was meant to prevent
+
+The mismatch detection lives in
+[`SiteUnloadEngine.indicesToUnloadForProxyMismatch`](../../../lib/services/site_unload_engine.dart);
+"different proxy" is computed via [`resolveEffectiveProxy`] so two sites
+both set to `DEFAULT` are equivalent (they share the global proxy).
+This is gated on `Platform.isAndroid` — iOS / macOS (true per-site
+proxy) and platforms without proxy support skip it.
+
 #### Scenario: Mixing platforms via settings backup
 
 **Given** a settings backup is exported on iOS with two distinct

--- a/openspec/specs/webspaces/spec.md
+++ b/openspec/specs/webspaces/spec.md
@@ -188,16 +188,38 @@ production):
     newWebspaceIndices})` — returns the loaded sites that leave the
     visible set on a webspace switch. The offline short-circuit
     (preserve-all-loaded when disconnected) is a policy decision owned
-    by the caller, not the engine.
+    by the caller, not the engine. The container-mode short-circuit
+    (sites stay resident across switches when isolated by their own
+    native container) lives in [`SiteUnloadEngine`](../../../lib/services/site_unload_engine.dart),
+    which delegates here in legacy mode.
   - `cleanupWebspaceIndices({webspaces, siteCount})` — strips
     out-of-bounds entries in place.
+- [`SiteUnloadEngine`](../../../lib/services/site_unload_engine.dart):
+  - `indicesToUnloadOnWebspaceSwitch({useContainers, ...})` — returns
+    `{}` under container mode (sites are isolated and stay loaded);
+    delegates to `WebspaceSelectionEngine` in legacy mode.
+  - `indicesToUnloadForProxyMismatch({targetIndex, models, loadedIndices,
+    proxyIsGlobal})` — on Android (process-global proxy), returns the
+    loaded sites whose effective proxy differs from the activating
+    site's. Their next request would silently route through the new
+    proxy (last-write-wins on `inapp.ProxyController`), so they are
+    force-unloaded on activation. Per-site DEFAULT resolves through the
+    app-global outbound proxy via `resolveEffectiveProxy`, so two
+    DEFAULT sites are equivalent regardless of the global value. Returns
+    `{}` on platforms with true per-site proxy (iOS 17+ / macOS 14+).
+  - `indicesToEvictForLruCap({targetIndex, loadedIndices, maxLoadedSites,
+    protectedIndices})` — bounds the number of concurrently loaded
+    webviews at [`kMaxLoadedSites`](../../../lib/services/site_unload_engine.dart);
+    treats `loadedIndices` as access-ordered (caller bumps to end on
+    activation) and returns the least-recently-used overflow.
 - [`SiteLifecycleEngine.computeDeletionPatch`](../../../lib/services/site_lifecycle_engine.dart)
   — returns the rewritten `siteIndices` for every affected webspace
   when a site is removed from `_webViewModels`, implementing
   WEBSPACE-010. The rewrite drops the deleted index and shifts every
   `i > deletedIndex` down by one.
 
-Tests live in [test/webspace_selection_engine_test.dart](../../../test/webspace_selection_engine_test.dart)
+Tests live in [test/webspace_selection_engine_test.dart](../../../test/webspace_selection_engine_test.dart),
+[test/site_unload_engine_test.dart](../../../test/site_unload_engine_test.dart),
 and [test/site_lifecycle_engine_test.dart](../../../test/site_lifecycle_engine_test.dart).
 
 ---

--- a/openspec/specs/webspaces/spec.md
+++ b/openspec/specs/webspaces/spec.md
@@ -211,7 +211,7 @@ production):
     protectedIndices, preferKeepIndices})` — bounds the number of
     concurrently loaded webviews at
     [`kMaxLoadedSites`](../../../lib/services/site_unload_engine.dart)
-    (currently 50); treats `loadedIndices` as access-ordered (caller
+    (currently 20); treats `loadedIndices` as access-ordered (caller
     bumps to end on activation). Two-tier eviction: out-of-keep
     candidates first (oldest first), then in-keep candidates (oldest
     first), with `protectedIndices` (typically the active site)

--- a/openspec/specs/webspaces/spec.md
+++ b/openspec/specs/webspaces/spec.md
@@ -208,10 +208,23 @@ production):
     DEFAULT sites are equivalent regardless of the global value. Returns
     `{}` on platforms with true per-site proxy (iOS 17+ / macOS 14+).
   - `indicesToEvictForLruCap({targetIndex, loadedIndices, maxLoadedSites,
-    protectedIndices})` — bounds the number of concurrently loaded
-    webviews at [`kMaxLoadedSites`](../../../lib/services/site_unload_engine.dart);
-    treats `loadedIndices` as access-ordered (caller bumps to end on
-    activation) and returns the least-recently-used overflow.
+    protectedIndices, preferKeepIndices})` — bounds the number of
+    concurrently loaded webviews at
+    [`kMaxLoadedSites`](../../../lib/services/site_unload_engine.dart)
+    (currently 50); treats `loadedIndices` as access-ordered (caller
+    bumps to end on activation). Two-tier eviction: out-of-keep
+    candidates first (oldest first), then in-keep candidates (oldest
+    first), with `protectedIndices` (typically the active site)
+    excluded entirely. The caller passes the active webspace's site
+    indices as `preferKeepIndices`, so context-relevant sites are
+    evicted last.
+  - `indexToEvictForMemoryPressure({loadedIndices, protectedIndices,
+    preferKeepIndices})` — picks one site to evict in response to an
+    OS memory pressure signal (`didHaveMemoryPressure`). Same two-tier
+    policy as `indicesToEvictForLruCap`. One victim per event lets the
+    OS clamp the loaded count to whatever the device can carry,
+    instead of guessing a target up front; if pressure persists the
+    callback fires again and the next victim is picked.
 - [`SiteLifecycleEngine.computeDeletionPatch`](../../../lib/services/site_lifecycle_engine.dart)
   — returns the rewritten `siteIndices` for every affected webspace
   when a site is removed from `_webViewModels`, implementing

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -110,6 +110,129 @@ The `WebViewController` interface SHALL expose `pause()`/`resume()` and `pauseAl
 
 ---
 
+### Requirement: PAUSE-005 — Cascading Memory-Pressure Lifecycle
+
+When the OS signals memory pressure via `WidgetsBindingObserver.didHaveMemoryPressure`, the system SHALL promote one loaded site by one tier per event, cascading through three states from least to most aggressive: `live` → `cacheCleared` → `savedForRestore`.
+
+The cascade is owned by [`SiteLifecyclePromotionEngine`](../../../lib/services/site_lifecycle_promotion_engine.dart), a pure-Dart picker that:
+
+- Walks tiers from least to most aggressive (`live` first, then `cacheCleared`).
+- Within a tier, evicts out-of-active-webspace sites before in-webspace sites.
+- Within a (tier, keep) bucket, picks the LRU oldest first.
+- Never picks the active site (`_currentIndex`) or the in-flight activation target (`_activationInFlightIndex`).
+- Treats `savedForRestore` as terminal — those sites are no longer in `_loadedIndices`, but their state lives in [`WebViewStateStorage`](../../../lib/services/webview_state_storage.dart) keyed by `siteId`.
+
+The OS controls the curve: if pressure persists, the callback fires again and the next victim is promoted. One-per-event matches the OS signaling cadence and avoids over-evicting on transient pressure (e.g. another app's foreground spike).
+
+#### Scenario: First memory pressure event clears cache without losing state
+
+**Given** the app has 5 loaded sites — one active and four backgrounded `live`
+**When** `didHaveMemoryPressure` fires for the first time
+**Then** the LRU oldest non-active site is promoted from `live` to `cacheCleared`
+**And** `controller.clearCache()` is called on it (frees ~10-50 MB without disposing)
+**And** the user's tab state, back/forward stack, and active site remain untouched
+
+#### Scenario: Sustained pressure cascades all loaded sites through clearCache before disposing any
+
+**Given** every loaded site is at the `live` tier
+**When** `didHaveMemoryPressure` fires N times in succession (where N is the number of non-active loaded sites)
+**Then** every non-active loaded site reaches `cacheCleared` before any reaches `savedForRestore`
+**Because** the picker walks tiers from lowest to highest — `live` is exhausted first, regardless of LRU age within other tiers
+
+#### Scenario: cacheCleared site disposes with state captured
+
+**Given** every non-active loaded site is at `cacheCleared`
+**When** `didHaveMemoryPressure` fires again
+**Then** the LRU oldest cacheCleared site is promoted to `savedForRestore`
+**And** `controller.saveState()` captures the navigation state to `WebViewStateStorage` keyed by siteId
+**And** `disposeWebView()` tears down the webview (and in legacy mode, `CookieIsolationEngine.unloadSiteForDomainSwitch` captures cookies first)
+**And** the site is removed from `_loadedIndices`
+**Because** the cascade reaches its terminal tier — the renderer process is torn down (~100s MB freed); state is preserved for re-activation
+
+#### Scenario: Re-activating a savedForRestore site rehydrates the back/forward stack
+
+**Given** site A is in `savedForRestore` (disposed, but its bytes are in `WebViewStateStorage`)
+**When** the user activates site A
+**Then** `_setCurrentIndex` reads the bytes from storage and queues them on the model via `schedulePendingRestoreState`
+**And** the model's `lifecycleState` is reset to `live`
+**And** the webview is rebuilt — `getWebView`'s `onControllerCreated` consumes the pending bytes and calls `controller.restoreState(bytes)`
+**And** the back/forward stack is restored
+**And** on iOS 15+ / macOS 12+, form-field values are restored too (via `WKWebView.interactionState`)
+
+The `initialUrlRequest` (set to `currentUrl` on the model) kicks off a navigation that lands at the most-recent saved URL; on Apple, `restoreState` may trigger a brief redundant nav (acceptable for the much-better re-activation UX). Live JS heap and DOM are not preserved — re-execution starts fresh.
+
+#### Scenario: Active webspace tier is preserved over stale workspace
+
+**Given** the user is on webspace `Work` with sites {A, B, active=A} and webspace `Personal` has loaded site C
+**When** `didHaveMemoryPressure` fires
+**Then** site C (out-of-active-webspace) is promoted before site B (in-active-webspace) at every tier transition
+**Because** within a tier, the picker partitions by `preferKeepIndices` (which is the active webspace) and exhausts out-of-keep first
+
+#### Scenario: Concurrent didHaveMemoryPressure events do not double-promote
+
+**Given** a memory pressure event is mid-flight (capturing state, awaiting `saveState()`)
+**When** the OS fires `didHaveMemoryPressure` again before the first handler completes
+**Then** the second invocation drops out at the `_isHandlingMemoryPressure` guard
+**And** no site is double-promoted
+**Because** the OS will fire again if pressure persists, and the next picker run sees the updated state map
+
+#### Scenario: Memory pressure during re-activation does not strand state
+
+**Given** site A is in `savedForRestore`
+**And** the user has just activated A — `_setCurrentIndex` is mid-flight, awaiting `_stateStorage.loadState`
+**When** `didHaveMemoryPressure` fires
+**Then** the picker excludes A from the candidate iteration
+**Because** `_setCurrentIndex` records its target in `_activationInFlightIndex` (set synchronously before any await), and `_handleMemoryPressure` includes that index in its hard-protected set alongside `_currentIndex`. Without the in-flight guard, mid-activation eviction would dispose A's about-to-be-built webview, leaving `restoreState` to no-op against a null controller.
+
+### Requirement: PAUSE-006 — State Capture on All Dispose Paths
+
+The system SHALL capture `controller.saveState()` bytes before disposing any non-incognito loaded site, regardless of which path triggered the disposal:
+
+- LRU cap eviction in `_setCurrentIndex` (proxy mismatch + cap overflow)
+- Domain-conflict unload in legacy (non-container) cookie isolation
+- Webspace switch unload in legacy mode
+- Memory pressure cascade `cacheCleared → savedForRestore`
+
+Site deletion is the only path that does NOT save state — it removes the entry from `WebViewStateStorage` instead, since the site is being thrown away entirely.
+
+#### Scenario: Webspace switch in legacy mode preserves restorable state
+
+**Given** legacy isolation mode is active (no per-site containers)
+**And** site A is loaded in webspace `Work`, the user is now switching to `Personal` which doesn't include A
+**When** `_selectWebspace(Personal)` runs the unload step
+**Then** A's `saveState()` bytes are captured to `WebViewStateStorage`
+**And** A's webview is disposed
+**And** A's `lifecycleState` becomes `savedForRestore`
+**And** later switching back to `Work` and activating A re-hydrates from the stored bytes
+
+#### Scenario: Site deletion removes state, doesn't save
+
+**Given** site A is in `savedForRestore` with bytes in storage
+**When** the user deletes A from the site list
+**Then** the orphan sweep at the end of `_deleteSite` calls `_stateStorage.removeOrphans(activeSiteIds)`
+**And** A's state bytes are reaped (siteId no longer in active set)
+
+### Requirement: PAUSE-007 — Cold-Start State Storage Defaults to In-Memory
+
+The current default `WebViewStateStorage` implementation is in-memory (`InMemoryWebViewStateStorage`). State bytes survive webspace switches, LRU evictions, and memory-pressure disposals within a single app run, but are lost on cold start. A future on-disk implementation SHALL drop in without callers changing — the abstraction is documented at the `WebViewStateStorage` interface.
+
+#### Scenario: App restart loses captured state
+
+**Given** site A reached `savedForRestore` during the previous session
+**When** the app cold-starts
+**Then** `WebViewStateStorage` is empty
+**And** activating A loads from `currentUrl` as before, without `restoreState`
+**Because** in-memory storage doesn't persist across runs
+
+#### Scenario: Startup orphan sweep keeps state aligned with active sites
+
+**Given** the previous session had state for sites {A, B, C}, and B was deleted before app exit (but the deletion's removeOrphans race didn't reach state storage in time, or the storage was disk-backed)
+**When** the app starts and `_restoreAppState` runs the orphan sweep
+**Then** `_stateStorage.removeOrphans({A, C})` is called
+**And** any orphaned B entry is reaped
+
+---
+
 ### Requirement: PAUSE-004 — Null-Safe Controller Access
 
 `pauseWebView()`, `resumeWebView()`, `pauseForAppLifecycle()`, and `resumeFromAppLifecycle()` SHALL be no-ops when the underlying controller has not yet been initialized or has been disposed.

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -112,11 +112,11 @@ The `WebViewController` interface SHALL expose `pause()`/`resume()` and `pauseAl
 
 ### Requirement: PAUSE-006 — Cascading Memory-Pressure Lifecycle
 
-When the OS signals memory pressure via `WidgetsBindingObserver.didHaveMemoryPressure`, the system SHALL promote one loaded site by one tier per event, cascading through three states from least to most aggressive: `live` → `cacheCleared` → `savedForRestore`.
+When the OS signals memory pressure via `WidgetsBindingObserver.didHaveMemoryPressure`, the system SHALL promote one loaded site by one tier per event, cascading through three states from least to most aggressive: `resident` → `cacheCleared` → `savedForRestore`.
 
 The cascade is owned by [`SiteLifecyclePromotionEngine`](../../../lib/services/site_lifecycle_promotion_engine.dart), a pure-Dart picker that:
 
-- Walks tiers from least to most aggressive (`live` first, then `cacheCleared`).
+- Walks tiers from least to most aggressive (`resident` first, then `cacheCleared`).
 - Within a tier, evicts out-of-active-webspace sites before in-webspace sites.
 - Within a (tier, keep) bucket, picks the LRU oldest first.
 - Never picks the active site (`_currentIndex`) or the in-flight activation target (`_activationInFlightIndex`).
@@ -126,18 +126,18 @@ The OS controls the curve: if pressure persists, the callback fires again and th
 
 #### Scenario: First memory pressure event clears cache without losing state
 
-**Given** the app has 5 loaded sites — one active and four backgrounded `live`
+**Given** the app has 5 loaded sites — one active and four backgrounded `resident`
 **When** `didHaveMemoryPressure` fires for the first time
-**Then** the LRU oldest non-active site is promoted from `live` to `cacheCleared`
+**Then** the LRU oldest non-active site is promoted from `resident` to `cacheCleared`
 **And** `controller.clearCache()` is called on it (frees ~10-50 MB without disposing)
 **And** the user's tab state, back/forward stack, and active site remain untouched
 
 #### Scenario: Sustained pressure cascades all loaded sites through clearCache before disposing any
 
-**Given** every loaded site is at the `live` tier
+**Given** every loaded site is at the `resident` tier
 **When** `didHaveMemoryPressure` fires N times in succession (where N is the number of non-active loaded sites)
 **Then** every non-active loaded site reaches `cacheCleared` before any reaches `savedForRestore`
-**Because** the picker walks tiers from lowest to highest — `live` is exhausted first, regardless of LRU age within other tiers
+**Because** the picker walks tiers from lowest to highest — `resident` is exhausted first, regardless of LRU age within other tiers
 
 #### Scenario: cacheCleared site disposes with state captured
 
@@ -154,7 +154,7 @@ The OS controls the curve: if pressure persists, the callback fires again and th
 **Given** site A is in `savedForRestore` (disposed, but its bytes are in `WebViewStateStorage`)
 **When** the user activates site A
 **Then** `_setCurrentIndex` reads the bytes from storage and queues them on the model via `schedulePendingRestoreState`
-**And** the model's `lifecycleState` is reset to `live`
+**And** the model's `lifecycleState` is reset to `resident`
 **And** the webview is rebuilt — `getWebView`'s `onControllerCreated` consumes the pending bytes and calls `controller.restoreState(bytes)`
 **And** the back/forward stack is restored on every supported platform:
   - **Android** via `WebView.restoreState(Bundle)`
@@ -186,6 +186,56 @@ The `initialUrlRequest` (set to `currentUrl` on the model) kicks off a navigatio
 **When** `didHaveMemoryPressure` fires
 **Then** the picker excludes A from the candidate iteration
 **Because** `_setCurrentIndex` records its target in `_activationInFlightIndex` (set synchronously before any await), and `_handleMemoryPressure` includes that index in its hard-protected set alongside `_currentIndex`. Without the in-flight guard, mid-activation eviction would dispose A's about-to-be-built webview, leaving `restoreState` to no-op against a null controller.
+
+### Requirement: PAUSE-012 — Proactive Cache-Clear Threshold
+
+The system SHALL proactively promote the oldest sites from `resident` to `cacheCleared` once the count of `resident`-tier sites exceeds [`kMaxResidentSites`](../../../lib/services/site_lifecycle_promotion_engine.dart) (currently 10), without waiting for an OS memory-pressure event. This is the proactive complement to the reactive `_handleMemoryPressure` cascade — both call into the same priority hierarchy ([`SiteLifecyclePromotionEngine.pickProactiveCacheClearTargets`](../../../lib/services/site_lifecycle_promotion_engine.dart) for proactive picks; the same out-of-keep ↦ in-keep, oldest-LRU-first rule).
+
+Why proactive: `didHaveMemoryPressure` doesn't fire reliably on Linux/desktop (no equivalent OS signal in WebKitGTK / WPE), and on iOS Jetsam is reactive — by the time pressure is signaled the OS may already be reclaiming. The threshold ensures every platform sees consistent memory hygiene regardless of OS signaling fidelity.
+
+The proactive pass runs at the tail of `_setCurrentIndex` (after the LRU eviction step, before the resume), so a single user activation can both lift the new target into `resident` and demote stale residents to `cacheCleared` in the same race-protected window.
+
+#### Scenario: 11th loaded resident site triggers proactive clearCache on the oldest
+
+**Given** 10 sites are loaded at the `resident` tier (under the `kMaxResidentSites = 10` threshold)
+**When** the user activates an 11th site
+**Then** during the activation tail, the engine identifies that resident count would be 11 (one over)
+**And** the LRU oldest non-active resident site is promoted to `cacheCleared`
+**And** `controller.clearCache()` runs on it
+**And** the user's tab state is intact — only the in-memory cache was dropped
+
+#### Scenario: Active webspace soft-keep applies to proactive promotion
+
+**Given** the user is on webspace `Work` with 6 loaded sites in it (active=A) plus 5 loaded sites in `Personal`
+**And** all 11 are at the `resident` tier
+**When** activation runs the proactive cache-clear pass with threshold 10
+**Then** the LRU oldest *out-of-active-webspace* site (one of the `Personal` sites) is promoted first
+**Because** `preferKeepIndices` (= active webspace) is exhausted last within the same tier — same priority as the reactive memory-pressure cascade
+
+#### Scenario: Already-cacheCleared sites don't count toward threshold
+
+**Given** 8 sites at `resident` and 5 sites at `cacheCleared`
+**When** activation runs the proactive cache-clear pass with threshold 10
+**Then** the engine sees 8 resident (under threshold), returns empty
+**And** no clearCache call is made
+**Because** the threshold gates resident-tier sites; sites already at `cacheCleared` are accounted as "already mitigated"
+
+#### Scenario: Concurrent proactive pass and memory-pressure handler
+
+**Given** activation is mid-flight, awaiting `controller.clearCache()` on a proactive target
+**When** an OS `didHaveMemoryPressure` event fires
+**Then** the memory-pressure handler enters and reads the current state map (which may already show the in-flight target as still `resident` until the await resumes)
+**And** the handler picks a different victim (the next-oldest, since the in-flight target is in `_activationInFlightIndex` and therefore in protected)
+**And** both transitions complete without double-promoting any single site
+**Because** `_isHandlingMemoryPressure` and `_activationInFlightIndex` together ensure: (1) no concurrent memory-pressure invocations; (2) the current activation target is hard-protected from external promotion.
+
+#### Scenario: Activation race protects newly-cleared candidate
+
+**Given** activation is awaiting `controller.clearCache()` on site X (proactive promotion mid-flight)
+**When** a newer `_setCurrentIndex` call starts and bumps the version counter
+**Then** the in-flight activation aborts after the await via the version-mismatch check
+**And** site X's `lifecycleState` is NOT flipped to `cacheCleared` by the aborted activation
+**Because** the post-await guard re-checks `_loadedIndices.contains(i)` and `lifecycleState == resident` before mutating — a newer activation may have demoted, evicted, or promoted X by then
 
 ### Requirement: PAUSE-007 — State Capture on All Dispose Paths
 
@@ -266,7 +316,7 @@ The system SHALL capture `controller.saveState()` bytes opportunistically — wi
 1. **Go-home** (`_setCurrentIndex(null)`): when the user navigates to the home screen, the previously-active site's state is captured before its webview is paused. The webview stays loaded for fast resume; state is captured defensively in case the OS later reaps the app or the user comes back after a long delay.
 2. **App-background** (`didChangeAppLifecycleState(paused | inactive)`): the active site's state is captured fire-and-forget alongside the existing `pauseForAppLifecycle` call, so an OS-induced kill while we're backgrounded preserves restorable state.
 
-Neither path mutates the model's `lifecycleState` — the field stays at `live` because the webview is not actually disposed. Capture goes through `_captureStateBytes` (bytes-only) rather than `_captureStateForRestore` (bytes + flip-to-savedForRestore).
+Neither path mutates the model's `lifecycleState` — the field stays at `resident` because the webview is not actually disposed. Capture goes through `_captureStateBytes` (bytes-only) rather than `_captureStateForRestore` (bytes + flip-to-savedForRestore).
 
 #### Scenario: Go-home captures state for the previously-active site
 
@@ -275,7 +325,7 @@ Neither path mutates the model's `lifecycleState` — the field stays at `live` 
 **Then** `_captureStateBytes(A)` runs before A is paused
 **And** A's bytes are persisted to `WebViewStateStorage`
 **And** A's webview is NOT disposed — `_loadedIndices` still contains A
-**And** A's `lifecycleState` stays `live`
+**And** A's `lifecycleState` stays `resident`
 **And** later cold-starting the app and re-activating A re-hydrates from the bytes
 
 #### Scenario: App-background captures the active site asynchronously

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -55,6 +55,24 @@ The system SHALL pause the previously active webview on site switch using the pe
 **And** A's controller does NOT receive `pauseAllJsTimers()`
 **And** B's JS timers are unaffected by A's pause
 
+#### Scenario: Sites loaded but never previously active also get paused
+
+**Given** sites A, B, C are all loaded under container mode (which lets sites stay
+  resident across webspace switches)
+**And** the user activates site B
+**When** the activation completes
+**Then** `pauseWebView()` is called on every loaded site that is NOT B
+**Because** steady state should already have them paused (each becomes paused
+  when it last lost active status), but a pause-all-inactive sweep guarantees
+  consistency even if a path adds to `_loadedIndices` without going through
+  the previous-active pause. `pauseWebView()` is idempotent — already-paused
+  or disposed-controller sites no-op.
+
+The sweep uses `unawaited` so subsequent activation logic doesn't block on it.
+This is race-safe because Dart's platform channel preserves FIFO order: the
+`resume()` for the new active site is dispatched before the loop's `pause()`
+calls, so the active site is never left paused.
+
 ---
 
 ### Requirement: PAUSE-002 — Process-Global Pause Only at App Lifecycle

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -110,7 +110,7 @@ The `WebViewController` interface SHALL expose `pause()`/`resume()` and `pauseAl
 
 ---
 
-### Requirement: PAUSE-005 — Cascading Memory-Pressure Lifecycle
+### Requirement: PAUSE-006 — Cascading Memory-Pressure Lifecycle
 
 When the OS signals memory pressure via `WidgetsBindingObserver.didHaveMemoryPressure`, the system SHALL promote one loaded site by one tier per event, cascading through three states from least to most aggressive: `live` → `cacheCleared` → `savedForRestore`.
 
@@ -184,7 +184,7 @@ The `initialUrlRequest` (set to `currentUrl` on the model) kicks off a navigatio
 **Then** the picker excludes A from the candidate iteration
 **Because** `_setCurrentIndex` records its target in `_activationInFlightIndex` (set synchronously before any await), and `_handleMemoryPressure` includes that index in its hard-protected set alongside `_currentIndex`. Without the in-flight guard, mid-activation eviction would dispose A's about-to-be-built webview, leaving `restoreState` to no-op against a null controller.
 
-### Requirement: PAUSE-006 — State Capture on All Dispose Paths
+### Requirement: PAUSE-007 — State Capture on All Dispose Paths
 
 The system SHALL capture `controller.saveState()` bytes before disposing any non-incognito loaded site, regardless of which path triggered the disposal:
 
@@ -212,9 +212,9 @@ Site deletion is the only path that does NOT save state — it removes the entry
 **Then** the orphan sweep at the end of `_deleteSite` calls `_stateStorage.removeOrphans(activeSiteIds)`
 **And** A's state bytes are reaped (siteId no longer in active set)
 
-### Requirement: PAUSE-007 — State Storage Persists in Encrypted On-Disk Cache
+### Requirement: PAUSE-008 — State Storage Persists in Encrypted On-Disk Cache
 
-The default `WebViewStateStorage` implementation in production is `SecureWebViewStateStorage`, an AES-256 CBC on-disk cache modeled after `HtmlCacheService`:
+State bytes captured by `WebViewStateStorage` SHALL persist across cold starts and SHALL be encrypted at rest. The default production implementation is `SecureWebViewStateStorage`, an AES-256 CBC on-disk cache modeled after `HtmlCacheService`:
 
 - Encryption key (32-byte, base64-encoded) lives in `FlutterSecureStorage` (platform keychain on iOS/macOS, encrypted SharedPreferences on Android).
 - Per-site bytes live under `<documents>/webview_state/<siteId>.enc`, written via `writeAsString` of the base64-encoded ciphertext.
@@ -256,7 +256,7 @@ State bytes survive cold starts (unlike the in-memory `InMemoryWebViewStateStora
 **Then** `_stateStorage.removeOrphans({A, C})` is called
 **And** the file `B.enc` is deleted from disk
 
-### Requirement: PAUSE-008 — State Capture on Go-Home and App-Background
+### Requirement: PAUSE-009 — State Capture on Go-Home and App-Background
 
 The system SHALL capture `controller.saveState()` bytes opportunistically — without disposing the webview — at two additional lifecycle points beyond the dispose paths:
 
@@ -292,7 +292,7 @@ Neither path mutates the model's `lifecycleState` — the field stays at `live` 
 **And** `restoreState` re-populates the back/forward stack
 **And** the user can press the back gesture to return to `page2` and `home`
 
-### Requirement: PAUSE-009 — State Storage Garbage Collection
+### Requirement: PAUSE-010 — State Storage Garbage Collection
 
 State files SHALL be reaped when their owning site is deleted, not when the user merely navigates away. Leaving state for sites that still exist (via go-home, app-background, memory-pressure disposal) is the entire point of save/restore.
 
@@ -306,7 +306,7 @@ State files SHALL be reaped when their owning site is deleted, not when the user
 **Then** the orphan sweep at the end of `_deleteSite` calls `_stateStorage.removeOrphans(activeSiteIds)`
 **And** A's state file is reaped (siteId no longer in active set)
 
-### Requirement: PAUSE-010 — Race Protections for State Capture
+### Requirement: PAUSE-011 — Race Protections for State Capture
 
 Concurrent paths that may capture state for the same site SHALL coexist without corruption:
 

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -212,24 +212,125 @@ Site deletion is the only path that does NOT save state — it removes the entry
 **Then** the orphan sweep at the end of `_deleteSite` calls `_stateStorage.removeOrphans(activeSiteIds)`
 **And** A's state bytes are reaped (siteId no longer in active set)
 
-### Requirement: PAUSE-007 — Cold-Start State Storage Defaults to In-Memory
+### Requirement: PAUSE-007 — State Storage Persists in Encrypted On-Disk Cache
 
-The current default `WebViewStateStorage` implementation is in-memory (`InMemoryWebViewStateStorage`). State bytes survive webspace switches, LRU evictions, and memory-pressure disposals within a single app run, but are lost on cold start. A future on-disk implementation SHALL drop in without callers changing — the abstraction is documented at the `WebViewStateStorage` interface.
+The default `WebViewStateStorage` implementation in production is `SecureWebViewStateStorage`, an AES-256 CBC on-disk cache modeled after `HtmlCacheService`:
 
-#### Scenario: App restart loses captured state
+- Encryption key (32-byte, base64-encoded) lives in `FlutterSecureStorage` (platform keychain on iOS/macOS, encrypted SharedPreferences on Android).
+- Per-site bytes live under `<documents>/webview_state/<siteId>.enc`, written via `writeAsString` of the base64-encoded ciphertext.
+- IV is derived from the first 16 bytes of the AES key (deterministic per-key) — matches the HTML cache shape, threat model is "device compromise" not "ciphertext analysis".
+- App-version upgrades nuke the cache directory and rotate the AES key; old ciphertext wouldn't decrypt anyway.
 
-**Given** site A reached `savedForRestore` during the previous session
-**When** the app cold-starts
-**Then** `WebViewStateStorage` is empty
-**And** activating A loads from `currentUrl` as before, without `restoreState`
-**Because** in-memory storage doesn't persist across runs
+State bytes survive cold starts (unlike the in-memory `InMemoryWebViewStateStorage` which remains for tests). Re-activation after a kill or reboot can restore the back/forward stack and (Apple) form-field values.
+
+#### Scenario: State persists across cold starts
+
+**Given** site A is in `savedForRestore` with bytes in the encrypted cache
+**When** the user force-quits the app and reopens it
+**Then** the encrypted file at `<documents>/webview_state/<A.siteId>.enc` survives
+**And** activating A reads the bytes, decrypts them, and applies `restoreState` — back/forward stack and (Apple) form data are intact
+
+#### Scenario: App-version upgrade rotates the key and clears the cache
+
+**Given** state was written under app version `1.2.3`
+**When** the user installs version `1.2.4` and the new app starts
+**Then** `_clearCacheOnUpgrade` detects the version mismatch
+**And** the `<documents>/webview_state/` directory is deleted recursively
+**And** the AES key in `FlutterSecureStorage` is regenerated
+**Because** state captured by an older WebView build may not re-hydrate cleanly into the new build, and rotating the key prevents the new app from decrypting any stale leftovers
+
+#### Scenario: Corrupt entry on disk is reaped on load
+
+**Given** a state file at `<documents>/webview_state/foo.enc` has been corrupted (truncated, key mismatch, etc.)
+**When** the user activates site `foo` and `loadState` runs
+**Then** decryption fails
+**And** the corrupt file is deleted
+**And** `loadState` returns null
+**And** the activation falls back to a fresh load from `currentUrl`
 
 #### Scenario: Startup orphan sweep keeps state aligned with active sites
 
-**Given** the previous session had state for sites {A, B, C}, and B was deleted before app exit (but the deletion's removeOrphans race didn't reach state storage in time, or the storage was disk-backed)
+**Given** the previous session left state files for siteIds {A, B, C}
+**And** the user deleted site B before app exit (state file lingered)
 **When** the app starts and `_restoreAppState` runs the orphan sweep
 **Then** `_stateStorage.removeOrphans({A, C})` is called
-**And** any orphaned B entry is reaped
+**And** the file `B.enc` is deleted from disk
+
+### Requirement: PAUSE-008 — State Capture on Go-Home and App-Background
+
+The system SHALL capture `controller.saveState()` bytes opportunistically — without disposing the webview — at two additional lifecycle points beyond the dispose paths:
+
+1. **Go-home** (`_setCurrentIndex(null)`): when the user navigates to the home screen, the previously-active site's state is captured before its webview is paused. The webview stays loaded for fast resume; state is captured defensively in case the OS later reaps the app or the user comes back after a long delay.
+2. **App-background** (`didChangeAppLifecycleState(paused | inactive)`): the active site's state is captured fire-and-forget alongside the existing `pauseForAppLifecycle` call, so an OS-induced kill while we're backgrounded preserves restorable state.
+
+Neither path mutates the model's `lifecycleState` — the field stays at `live` because the webview is not actually disposed. Capture goes through `_captureStateBytes` (bytes-only) rather than `_captureStateForRestore` (bytes + flip-to-savedForRestore).
+
+#### Scenario: Go-home captures state for the previously-active site
+
+**Given** site A is the active site
+**When** the user taps the home / drawer button (triggering `_setCurrentIndex(null)`)
+**Then** `_captureStateBytes(A)` runs before A is paused
+**And** A's bytes are persisted to `WebViewStateStorage`
+**And** A's webview is NOT disposed — `_loadedIndices` still contains A
+**And** A's `lifecycleState` stays `live`
+**And** later cold-starting the app and re-activating A re-hydrates from the bytes
+
+#### Scenario: App-background captures the active site asynchronously
+
+**Given** site A is the active site
+**When** the app goes to background (`AppLifecycleState.paused`)
+**Then** `pauseForAppLifecycle(A)` is invoked synchronously
+**And** `_captureStateBytes(A)` runs fire-and-forget (`unawaited`) so the lifecycle handler returns promptly
+**And** the encrypted state file is updated in the background
+**Because** the OS may grant only a brief window before suspending the process; capture races against that deadline but is best-effort
+
+#### Scenario: Save and restore preserve back/forward across reopen
+
+**Given** the user navigated within site A from `home → page2 → page3`, then went home and force-quit the app
+**When** the app cold-starts and the user activates A
+**Then** A loads at `currentUrl` (= `page3`)
+**And** `restoreState` re-populates the back/forward stack
+**And** the user can press the back gesture to return to `page2` and `home`
+
+### Requirement: PAUSE-009 — State Storage Garbage Collection
+
+State files SHALL be reaped when their owning site is deleted, not when the user merely navigates away. Leaving state for sites that still exist (via go-home, app-background, memory-pressure disposal) is the entire point of save/restore.
+
+#### Scenario: Site deletion removes state, go-home does not
+
+**Given** site A is in storage
+**When** the user goes home (`_setCurrentIndex(null)`)
+**Then** A's state is *added* to storage (defensively captured) — not removed
+
+**When** the user later deletes site A from the site list
+**Then** the orphan sweep at the end of `_deleteSite` calls `_stateStorage.removeOrphans(activeSiteIds)`
+**And** A's state file is reaped (siteId no longer in active set)
+
+### Requirement: PAUSE-010 — Race Protections for State Capture
+
+Concurrent paths that may capture state for the same site SHALL coexist without corruption:
+
+- Two `_handleMemoryPressure` events firing rapidly: dropped via `_isHandlingMemoryPressure` flag (the first runs to completion, the next event picks up the new state).
+- App-background `unawaited(_captureStateBytes)` racing with `_setCurrentIndex`: each path operates on per-site state independently; storage writes are last-writer-wins per siteId, both produce valid bytes.
+- Re-activation of a `savedForRestore` site mid-fetch: the in-flight target is in `_activationInFlightIndex` (set sync before any await in `_setCurrentIndex`, cleared in finally); memory pressure includes that index in `protectedIndices`, so the picker excludes it.
+- Storage initialization concurrency: `if (!_initialized) await initialize()` may run twice on a cold race, but each invocation produces the same key from `FlutterSecureStorage` (existing key on read, generated once on first miss); the second call's redundant writes are no-ops.
+
+#### Scenario: Concurrent didHaveMemoryPressure events do not double-capture
+
+**Given** a memory pressure cascade is mid-flight (capturing state, awaiting `saveState()` on the target site)
+**When** the OS fires `didHaveMemoryPressure` again before the first handler completes
+**Then** the second invocation drops out at the `_isHandlingMemoryPressure` guard
+**And** no site is double-captured
+
+#### Scenario: HTML cache and state storage cover orthogonal concerns
+
+**Given** site A is loaded
+**When** A's `onLoadStop` fires after a navigation
+**Then** `HtmlCacheService.saveHtml` may run (debounced 10s, captures the rendered DOM for offline / fast-paint)
+**And** `WebViewStateStorage.saveState` does NOT run on `onLoadStop` — state capture is scoped to dispose paths + go-home + app-background
+**Because** state bytes can be tens of KB and capturing on every page load would generate platform-channel pressure for marginal benefit; the strategic capture points (going-to-be-evicted-or-killed) cover the realistic loss scenarios
+
+The two systems are complementary: HTML cache provides instant first-paint of the last rendered DOM; state storage restores the back/forward stack and (Apple) form data on top.
 
 ---
 

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -156,10 +156,13 @@ The OS controls the curve: if pressure persists, the callback fires again and th
 **Then** `_setCurrentIndex` reads the bytes from storage and queues them on the model via `schedulePendingRestoreState`
 **And** the model's `lifecycleState` is reset to `live`
 **And** the webview is rebuilt — `getWebView`'s `onControllerCreated` consumes the pending bytes and calls `controller.restoreState(bytes)`
-**And** the back/forward stack is restored
-**And** on iOS 15+ / macOS 12+, form-field values are restored too (via `WKWebView.interactionState`)
+**And** the back/forward stack is restored on every supported platform:
+  - **Android** via `WebView.restoreState(Bundle)`
+  - **iOS 15+ / macOS 12+** via `WKWebView.interactionState` (also restores form-field values + scroll)
+  - **Linux** (WebKitGTK / WPE) via `webkit_web_view_restore_session_state`
+**And** on iOS 15+ / macOS 12+ form-field values are restored too — Linux and Android only carry history + scroll
 
-The `initialUrlRequest` (set to `currentUrl` on the model) kicks off a navigation that lands at the most-recent saved URL; on Apple, `restoreState` may trigger a brief redundant nav (acceptable for the much-better re-activation UX). Live JS heap and DOM are not preserved — re-execution starts fresh.
+The `initialUrlRequest` (set to `currentUrl` on the model) kicks off a navigation that lands at the most-recent saved URL; on Apple, assigning `interactionState` may trigger a brief redundant nav (acceptable for the much-better re-activation UX). Live JS heap and DOM are not preserved on any platform — re-execution starts fresh.
 
 #### Scenario: Active webspace tier is preserved over stale workspace
 

--- a/test/site_lifecycle_promotion_engine_test.dart
+++ b/test/site_lifecycle_promotion_engine_test.dart
@@ -1,0 +1,322 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/site_lifecycle_promotion_engine.dart';
+
+void main() {
+  group('SiteLifecyclePromotionEngine.nextState', () {
+    test('live → cacheCleared', () {
+      expect(
+        SiteLifecyclePromotionEngine.nextState(SiteLifecycleState.live),
+        SiteLifecycleState.cacheCleared,
+      );
+    });
+
+    test('cacheCleared → savedForRestore', () {
+      expect(
+        SiteLifecyclePromotionEngine.nextState(
+            SiteLifecycleState.cacheCleared),
+        SiteLifecycleState.savedForRestore,
+      );
+    });
+
+    test('savedForRestore is terminal', () {
+      expect(
+        SiteLifecyclePromotionEngine.nextState(
+            SiteLifecycleState.savedForRestore),
+        isNull,
+      );
+    });
+  });
+
+  group('SiteLifecyclePromotionEngine.pickPromotionTarget', () {
+    test('returns null when nothing is loaded', () {
+      final result = SiteLifecyclePromotionEngine.pickPromotionTarget(
+        loadedIndices: const {},
+        states: const {},
+      );
+      expect(result, isNull);
+    });
+
+    test('returns oldest live site when all loaded are live', () {
+      final loaded = <int>{};
+      for (final i in [0, 1, 2]) {
+        loaded.add(i);
+      }
+      final result = SiteLifecyclePromotionEngine.pickPromotionTarget(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.live,
+          1: SiteLifecycleState.live,
+          2: SiteLifecycleState.live,
+        },
+      );
+      expect(result, 0);
+    });
+
+    test('treats missing state-map entries as live (default)', () {
+      // Robustness: a site that hasn't had its state explicitly set
+      // should default to live (not crash, not be skipped).
+      final loaded = <int>{};
+      loaded.add(0);
+      final result = SiteLifecyclePromotionEngine.pickPromotionTarget(
+        loadedIndices: loaded,
+        states: const {},
+      );
+      expect(result, 0);
+    });
+
+    test('prefers live tier over cacheCleared (tier dominates LRU)', () {
+      // Order: 0 (cacheCleared, oldest), 1 (cacheCleared), 2 (live, newest).
+      // Engine returns 2 — even though it's the newest, it's at the
+      // lowest non-terminal tier and gets promoted first. All live
+      // sites become cacheCleared before any cacheCleared sites are
+      // saved-for-restore.
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      loaded.add(2);
+      final result = SiteLifecyclePromotionEngine.pickPromotionTarget(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.cacheCleared,
+          1: SiteLifecycleState.cacheCleared,
+          2: SiteLifecycleState.live,
+        },
+      );
+      expect(result, 2);
+    });
+
+    test('falls through to cacheCleared when no live candidate', () {
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      final result = SiteLifecyclePromotionEngine.pickPromotionTarget(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.cacheCleared,
+          1: SiteLifecycleState.cacheCleared,
+        },
+      );
+      expect(result, 0);
+    });
+
+    test('skips protected indices (e.g. active site)', () {
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      final result = SiteLifecyclePromotionEngine.pickPromotionTarget(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.live,
+          1: SiteLifecycleState.live,
+        },
+        protectedIndices: {0},
+      );
+      expect(result, 1);
+    });
+
+    test('returns null when every loaded site is protected', () {
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      final result = SiteLifecyclePromotionEngine.pickPromotionTarget(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.live,
+          1: SiteLifecycleState.live,
+        },
+        protectedIndices: {0, 1},
+      );
+      expect(result, isNull);
+    });
+
+    test('within a tier, prefers out-of-preferKeep over in-keep', () {
+      final loaded = <int>{};
+      loaded.add(0); // in-keep, oldest
+      loaded.add(1); // out-of-keep, newer
+      final result = SiteLifecyclePromotionEngine.pickPromotionTarget(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.live,
+          1: SiteLifecycleState.live,
+        },
+        preferKeepIndices: {0},
+      );
+      // out-of-keep wins within tier, even though newer.
+      expect(result, 1);
+    });
+
+    test('tier dominates over preferKeep', () {
+      // Out-of-keep cacheCleared vs in-keep live: live tier promotes
+      // first, even though in-keep would normally be evicted later.
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      final result = SiteLifecyclePromotionEngine.pickPromotionTarget(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.cacheCleared,
+          1: SiteLifecycleState.live,
+        },
+        preferKeepIndices: {1},
+      );
+      expect(result, 1);
+    });
+
+    test('skips savedForRestore (terminal — should not be in loaded)', () {
+      // Defensive: if a savedForRestore site somehow appears in the
+      // loadedIndices snapshot (caller error), the engine skips it.
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      final result = SiteLifecyclePromotionEngine.pickPromotionTarget(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.savedForRestore,
+          1: SiteLifecycleState.live,
+        },
+      );
+      expect(result, 1);
+    });
+
+    test('cascade walks the full hierarchy across successive promotions', () {
+      // 4 loaded sites in LRU order [0, 1, 2, 3]. Active (3) is
+      // protected. Active webspace = {1, 2, 3}; site 0 is out-of-keep.
+      // Initial state: all live.
+      //
+      // Cascade steps the caller would observe:
+      //   1. Pick 0 (out-of-keep live, oldest at lowest tier).
+      //      Caller promotes: state[0] = cacheCleared.
+      //   2. Pick 1 (in-keep live, oldest live remaining).
+      //      state[1] = cacheCleared.
+      //   3. Pick 2 (in-keep live, oldest live remaining).
+      //      state[2] = cacheCleared.
+      //   4. Pick 0 (out-of-keep cacheCleared, oldest at next tier).
+      //      state[0] = savedForRestore. Caller would also remove
+      //      from loadedIndices at this point.
+      //   ...
+      final loaded = <int>{};
+      for (final i in [0, 1, 2, 3]) {
+        loaded.add(i);
+      }
+      final states = <int, SiteLifecycleState>{
+        0: SiteLifecycleState.live,
+        1: SiteLifecycleState.live,
+        2: SiteLifecycleState.live,
+        3: SiteLifecycleState.live,
+      };
+      const protected = <int>{3};
+      const preferKeep = <int>{1, 2, 3};
+
+      var result = SiteLifecyclePromotionEngine.pickPromotionTarget(
+        loadedIndices: loaded,
+        states: states,
+        protectedIndices: protected,
+        preferKeepIndices: preferKeep,
+      );
+      expect(result, 0);
+      states[0] = SiteLifecycleState.cacheCleared;
+
+      result = SiteLifecyclePromotionEngine.pickPromotionTarget(
+        loadedIndices: loaded,
+        states: states,
+        protectedIndices: protected,
+        preferKeepIndices: preferKeep,
+      );
+      expect(result, 1);
+      states[1] = SiteLifecycleState.cacheCleared;
+
+      result = SiteLifecyclePromotionEngine.pickPromotionTarget(
+        loadedIndices: loaded,
+        states: states,
+        protectedIndices: protected,
+        preferKeepIndices: preferKeep,
+      );
+      expect(result, 2);
+      states[2] = SiteLifecycleState.cacheCleared;
+
+      // No more live sites. Engine should now pick at cacheCleared
+      // tier — out-of-keep first, so 0.
+      result = SiteLifecyclePromotionEngine.pickPromotionTarget(
+        loadedIndices: loaded,
+        states: states,
+        protectedIndices: protected,
+        preferKeepIndices: preferKeep,
+      );
+      expect(result, 0);
+      states[0] = SiteLifecycleState.savedForRestore;
+      // Caller also removes 0 from loadedIndices when it transitions
+      // to savedForRestore (the webview is disposed at that point).
+      loaded.remove(0);
+
+      // Now {1, 2}, both in-keep cacheCleared.
+      result = SiteLifecyclePromotionEngine.pickPromotionTarget(
+        loadedIndices: loaded,
+        states: states,
+        protectedIndices: protected,
+        preferKeepIndices: preferKeep,
+      );
+      expect(result, 1);
+    });
+  });
+
+  group('SiteLifecyclePromotionEngine.tierCounts', () {
+    test('counts sites by tier with active accounted separately', () {
+      final loaded = <int>{};
+      for (final i in [0, 1, 2, 3, 4]) {
+        loaded.add(i);
+      }
+      final counts = SiteLifecyclePromotionEngine.tierCounts(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.live,
+          1: SiteLifecycleState.live,
+          2: SiteLifecycleState.cacheCleared,
+          3: SiteLifecycleState.cacheCleared,
+          4: SiteLifecycleState.live,
+        },
+        activeIndex: 4,
+      );
+      expect(counts.active, 1);
+      expect(counts.live, 2); // 0 and 1; 4 is active and excluded
+      expect(counts.cacheCleared, 2);
+      expect(counts.savedForRestore, 0);
+    });
+
+    test('savedForRestore tracked per-state-map regardless of loaded set',
+        () {
+      // savedForRestore sites are NOT in loadedIndices (their webviews
+      // are disposed). The counter inspects the state map directly so
+      // callers can monitor pressure-induced disposal.
+      final loaded = <int>{};
+      for (final i in [0, 1]) {
+        loaded.add(i);
+      }
+      final counts = SiteLifecyclePromotionEngine.tierCounts(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.live,
+          1: SiteLifecycleState.live,
+          2: SiteLifecycleState.savedForRestore,
+          3: SiteLifecycleState.savedForRestore,
+        },
+        activeIndex: null,
+      );
+      expect(counts.active, 0);
+      expect(counts.live, 2);
+      expect(counts.cacheCleared, 0);
+      expect(counts.savedForRestore, 2);
+    });
+
+    test('handles null activeIndex', () {
+      final loaded = <int>{};
+      loaded.add(0);
+      final counts = SiteLifecyclePromotionEngine.tierCounts(
+        loadedIndices: loaded,
+        states: {0: SiteLifecycleState.live},
+        activeIndex: null,
+      );
+      expect(counts.active, 0);
+      expect(counts.live, 1);
+    });
+  });
+}

--- a/test/site_lifecycle_promotion_engine_test.dart
+++ b/test/site_lifecycle_promotion_engine_test.dart
@@ -5,7 +5,7 @@ void main() {
   group('SiteLifecyclePromotionEngine.nextState', () {
     test('live → cacheCleared', () {
       expect(
-        SiteLifecyclePromotionEngine.nextState(SiteLifecycleState.live),
+        SiteLifecyclePromotionEngine.nextState(SiteLifecycleState.resident),
         SiteLifecycleState.cacheCleared,
       );
     });
@@ -44,9 +44,9 @@ void main() {
       final result = SiteLifecyclePromotionEngine.pickPromotionTarget(
         loadedIndices: loaded,
         states: {
-          0: SiteLifecycleState.live,
-          1: SiteLifecycleState.live,
-          2: SiteLifecycleState.live,
+          0: SiteLifecycleState.resident,
+          1: SiteLifecycleState.resident,
+          2: SiteLifecycleState.resident,
         },
       );
       expect(result, 0);
@@ -79,7 +79,7 @@ void main() {
         states: {
           0: SiteLifecycleState.cacheCleared,
           1: SiteLifecycleState.cacheCleared,
-          2: SiteLifecycleState.live,
+          2: SiteLifecycleState.resident,
         },
       );
       expect(result, 2);
@@ -106,8 +106,8 @@ void main() {
       final result = SiteLifecyclePromotionEngine.pickPromotionTarget(
         loadedIndices: loaded,
         states: {
-          0: SiteLifecycleState.live,
-          1: SiteLifecycleState.live,
+          0: SiteLifecycleState.resident,
+          1: SiteLifecycleState.resident,
         },
         protectedIndices: {0},
       );
@@ -121,8 +121,8 @@ void main() {
       final result = SiteLifecyclePromotionEngine.pickPromotionTarget(
         loadedIndices: loaded,
         states: {
-          0: SiteLifecycleState.live,
-          1: SiteLifecycleState.live,
+          0: SiteLifecycleState.resident,
+          1: SiteLifecycleState.resident,
         },
         protectedIndices: {0, 1},
       );
@@ -136,8 +136,8 @@ void main() {
       final result = SiteLifecyclePromotionEngine.pickPromotionTarget(
         loadedIndices: loaded,
         states: {
-          0: SiteLifecycleState.live,
-          1: SiteLifecycleState.live,
+          0: SiteLifecycleState.resident,
+          1: SiteLifecycleState.resident,
         },
         preferKeepIndices: {0},
       );
@@ -155,7 +155,7 @@ void main() {
         loadedIndices: loaded,
         states: {
           0: SiteLifecycleState.cacheCleared,
-          1: SiteLifecycleState.live,
+          1: SiteLifecycleState.resident,
         },
         preferKeepIndices: {1},
       );
@@ -172,7 +172,7 @@ void main() {
         loadedIndices: loaded,
         states: {
           0: SiteLifecycleState.savedForRestore,
-          1: SiteLifecycleState.live,
+          1: SiteLifecycleState.resident,
         },
       );
       expect(result, 1);
@@ -199,10 +199,10 @@ void main() {
         loaded.add(i);
       }
       final states = <int, SiteLifecycleState>{
-        0: SiteLifecycleState.live,
-        1: SiteLifecycleState.live,
-        2: SiteLifecycleState.live,
-        3: SiteLifecycleState.live,
+        0: SiteLifecycleState.resident,
+        1: SiteLifecycleState.resident,
+        2: SiteLifecycleState.resident,
+        3: SiteLifecycleState.resident,
       };
       const protected = <int>{3};
       const preferKeep = <int>{1, 2, 3};
@@ -259,6 +259,223 @@ void main() {
     });
   });
 
+  group('SiteLifecyclePromotionEngine.pickProactiveCacheClearTargets', () {
+    test('returns empty when count is at threshold', () {
+      final loaded = <int>{};
+      for (final i in [0, 1, 2]) {
+        loaded.add(i);
+      }
+      final result = SiteLifecyclePromotionEngine.pickProactiveCacheClearTargets(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.resident,
+          1: SiteLifecycleState.resident,
+          2: SiteLifecycleState.resident,
+        },
+        maxResidentSites: 3,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('returns empty when count is below threshold', () {
+      final loaded = <int>{};
+      for (final i in [0, 1]) {
+        loaded.add(i);
+      }
+      final result = SiteLifecyclePromotionEngine.pickProactiveCacheClearTargets(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.resident,
+          1: SiteLifecycleState.resident,
+        },
+        maxResidentSites: 5,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('picks oldest excess to bring count back to threshold', () {
+      // 5 resident sites, threshold 3 → excess 2, evict oldest 2.
+      final loaded = <int>{};
+      for (final i in [0, 1, 2, 3, 4]) {
+        loaded.add(i);
+      }
+      final result = SiteLifecyclePromotionEngine.pickProactiveCacheClearTargets(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.resident,
+          1: SiteLifecycleState.resident,
+          2: SiteLifecycleState.resident,
+          3: SiteLifecycleState.resident,
+          4: SiteLifecycleState.resident,
+        },
+        maxResidentSites: 3,
+      );
+      expect(result, [0, 1]);
+    });
+
+    test('only counts resident-tier sites against the threshold', () {
+      // 3 resident + 2 cacheCleared, threshold 3 → resident count is
+      // 3, no excess. Returns empty.
+      final loaded = <int>{};
+      for (final i in [0, 1, 2, 3, 4]) {
+        loaded.add(i);
+      }
+      final result = SiteLifecyclePromotionEngine.pickProactiveCacheClearTargets(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.cacheCleared,
+          1: SiteLifecycleState.cacheCleared,
+          2: SiteLifecycleState.resident,
+          3: SiteLifecycleState.resident,
+          4: SiteLifecycleState.resident,
+        },
+        maxResidentSites: 3,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('skips already-cacheCleared sites in the result', () {
+      // 4 resident + 1 cacheCleared, threshold 2 → resident excess 2.
+      // Result picks 2 resident sites, never the already-cacheCleared.
+      final loaded = <int>{};
+      for (final i in [0, 1, 2, 3, 4]) {
+        loaded.add(i);
+      }
+      final result = SiteLifecyclePromotionEngine.pickProactiveCacheClearTargets(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.cacheCleared, // already cleared
+          1: SiteLifecycleState.resident,
+          2: SiteLifecycleState.resident,
+          3: SiteLifecycleState.resident,
+          4: SiteLifecycleState.resident,
+        },
+        maxResidentSites: 2,
+      );
+      expect(result, [1, 2]);
+    });
+
+    test('skips protected indices', () {
+      final loaded = <int>{};
+      for (final i in [0, 1, 2, 3]) {
+        loaded.add(i);
+      }
+      final result = SiteLifecyclePromotionEngine.pickProactiveCacheClearTargets(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.resident,
+          1: SiteLifecycleState.resident,
+          2: SiteLifecycleState.resident,
+          3: SiteLifecycleState.resident,
+        },
+        maxResidentSites: 2,
+        protectedIndices: {0},
+      );
+      // Protected (0) excluded; pick oldest 2 of {1, 2, 3} → [1, 2].
+      expect(result, [1, 2]);
+    });
+
+    test('prefers out-of-keep over in-keep within excess budget', () {
+      // 4 resident, threshold 2 → excess 2.
+      // Active webspace = {0, 2}. Out-of-keep: [1, 3]. In-keep:
+      // [0, 2]. Take 2 from out-of-keep → [1, 3].
+      final loaded = <int>{};
+      for (final i in [0, 1, 2, 3]) {
+        loaded.add(i);
+      }
+      final result = SiteLifecyclePromotionEngine.pickProactiveCacheClearTargets(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.resident,
+          1: SiteLifecycleState.resident,
+          2: SiteLifecycleState.resident,
+          3: SiteLifecycleState.resident,
+        },
+        maxResidentSites: 2,
+        preferKeepIndices: {0, 2},
+      );
+      expect(result, [1, 3]);
+    });
+
+    test('falls through to in-keep when out-of-keep is exhausted', () {
+      // 4 resident, threshold 1 → excess 3.
+      // Active webspace = {1, 2, 3}. Out-of-keep: [0]. In-keep:
+      // [1, 2, 3]. Take 0, then 1, 2.
+      final loaded = <int>{};
+      for (final i in [0, 1, 2, 3]) {
+        loaded.add(i);
+      }
+      final result = SiteLifecyclePromotionEngine.pickProactiveCacheClearTargets(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.resident,
+          1: SiteLifecycleState.resident,
+          2: SiteLifecycleState.resident,
+          3: SiteLifecycleState.resident,
+        },
+        maxResidentSites: 1,
+        preferKeepIndices: {1, 2, 3},
+      );
+      expect(result, [0, 1, 2]);
+    });
+
+    test('respects LRU access-order bumps', () {
+      // Loaded [0, 1, 2, 3]; bump 0 → [1, 2, 3, 0].
+      // Threshold 2 → excess 2. Picks oldest in post-bump order:
+      // [1, 2].
+      final loaded = <int>{};
+      for (final i in [0, 1, 2, 3]) {
+        loaded.add(i);
+      }
+      loaded.remove(0);
+      loaded.add(0);
+      final result = SiteLifecyclePromotionEngine.pickProactiveCacheClearTargets(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.resident,
+          1: SiteLifecycleState.resident,
+          2: SiteLifecycleState.resident,
+          3: SiteLifecycleState.resident,
+        },
+        maxResidentSites: 2,
+      );
+      expect(result, [1, 2]);
+    });
+
+    test('treats missing state-map entries as resident', () {
+      // No state map provided — defaults to resident.
+      // Threshold 1, 3 loaded → excess 2 → pick oldest [0, 1].
+      final loaded = <int>{};
+      for (final i in [0, 1, 2]) {
+        loaded.add(i);
+      }
+      final result = SiteLifecyclePromotionEngine.pickProactiveCacheClearTargets(
+        loadedIndices: loaded,
+        states: const {},
+        maxResidentSites: 1,
+      );
+      expect(result, [0, 1]);
+    });
+
+    test('all resident protected returns empty', () {
+      final loaded = <int>{};
+      for (final i in [0, 1, 2]) {
+        loaded.add(i);
+      }
+      final result = SiteLifecyclePromotionEngine.pickProactiveCacheClearTargets(
+        loadedIndices: loaded,
+        states: {
+          0: SiteLifecycleState.resident,
+          1: SiteLifecycleState.resident,
+          2: SiteLifecycleState.resident,
+        },
+        maxResidentSites: 1,
+        protectedIndices: {0, 1, 2},
+      );
+      expect(result, isEmpty);
+    });
+  });
+
   group('SiteLifecyclePromotionEngine.tierCounts', () {
     test('counts sites by tier with active accounted separately', () {
       final loaded = <int>{};
@@ -268,16 +485,16 @@ void main() {
       final counts = SiteLifecyclePromotionEngine.tierCounts(
         loadedIndices: loaded,
         states: {
-          0: SiteLifecycleState.live,
-          1: SiteLifecycleState.live,
+          0: SiteLifecycleState.resident,
+          1: SiteLifecycleState.resident,
           2: SiteLifecycleState.cacheCleared,
           3: SiteLifecycleState.cacheCleared,
-          4: SiteLifecycleState.live,
+          4: SiteLifecycleState.resident,
         },
         activeIndex: 4,
       );
       expect(counts.active, 1);
-      expect(counts.live, 2); // 0 and 1; 4 is active and excluded
+      expect(counts.resident, 2); // 0 and 1; 4 is active and excluded
       expect(counts.cacheCleared, 2);
       expect(counts.savedForRestore, 0);
     });
@@ -294,15 +511,15 @@ void main() {
       final counts = SiteLifecyclePromotionEngine.tierCounts(
         loadedIndices: loaded,
         states: {
-          0: SiteLifecycleState.live,
-          1: SiteLifecycleState.live,
+          0: SiteLifecycleState.resident,
+          1: SiteLifecycleState.resident,
           2: SiteLifecycleState.savedForRestore,
           3: SiteLifecycleState.savedForRestore,
         },
         activeIndex: null,
       );
       expect(counts.active, 0);
-      expect(counts.live, 2);
+      expect(counts.resident, 2);
       expect(counts.cacheCleared, 0);
       expect(counts.savedForRestore, 2);
     });
@@ -312,11 +529,11 @@ void main() {
       loaded.add(0);
       final counts = SiteLifecyclePromotionEngine.tierCounts(
         loadedIndices: loaded,
-        states: {0: SiteLifecycleState.live},
+        states: {0: SiteLifecycleState.resident},
         activeIndex: null,
       );
       expect(counts.active, 0);
-      expect(counts.live, 1);
+      expect(counts.resident, 1);
     });
   });
 }

--- a/test/site_unload_engine_test.dart
+++ b/test/site_unload_engine_test.dart
@@ -1,0 +1,282 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/site_unload_engine.dart';
+import 'package:webspace/settings/global_outbound_proxy.dart';
+import 'package:webspace/settings/proxy.dart';
+import 'package:webspace/web_view_model.dart';
+
+WebViewModel _site(String url, {UserProxySettings? proxy}) =>
+    WebViewModel(initUrl: url, proxySettings: proxy);
+
+void main() {
+  setUp(() {
+    GlobalOutboundProxy.resetForTest();
+  });
+
+  group('SiteUnloadEngine.indicesToUnloadOnWebspaceSwitch', () {
+    test('returns empty under container mode (sites stay resident)', () {
+      final result = SiteUnloadEngine.indicesToUnloadOnWebspaceSwitch(
+        useContainers: true,
+        loadedIndices: {0, 1, 2},
+        previousWebspaceIndices: {0, 1},
+        newWebspaceIndices: {2, 3},
+      );
+      expect(result, isEmpty);
+    });
+
+    test('legacy mode unloads sites visible only in previous webspace', () {
+      final result = SiteUnloadEngine.indicesToUnloadOnWebspaceSwitch(
+        useContainers: false,
+        loadedIndices: {0, 1, 2},
+        previousWebspaceIndices: {0, 1},
+        newWebspaceIndices: {2, 3},
+      );
+      expect(result, {0, 1});
+    });
+
+    test('legacy mode preserves sites visible in both webspaces', () {
+      final result = SiteUnloadEngine.indicesToUnloadOnWebspaceSwitch(
+        useContainers: false,
+        loadedIndices: {0, 1, 2},
+        previousWebspaceIndices: {0, 1, 2},
+        newWebspaceIndices: {1, 2, 3},
+      );
+      expect(result, {0});
+    });
+  });
+
+  group('SiteUnloadEngine.indicesToUnloadForProxyMismatch', () {
+    test('returns empty when proxy is per-site (iOS/macOS)', () {
+      final models = [
+        _site('https://a.example.com',
+            proxy: UserProxySettings(type: ProxyType.HTTP, address: 'p1:8080')),
+        _site('https://b.example.com',
+            proxy: UserProxySettings(type: ProxyType.SOCKS5, address: 'p2:9050')),
+      ];
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: 1,
+        models: models,
+        loadedIndices: {0, 1},
+        proxyIsGlobal: false,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('flags loaded sites with a different proxy on Android', () {
+      final models = [
+        _site('https://a.example.com',
+            proxy: UserProxySettings(type: ProxyType.HTTP, address: 'p1:8080')),
+        _site('https://b.example.com',
+            proxy: UserProxySettings(type: ProxyType.SOCKS5, address: 'p2:9050')),
+        _site('https://c.example.com',
+            proxy: UserProxySettings(type: ProxyType.HTTP, address: 'p1:8080')),
+      ];
+      // Activating index 1 (SOCKS5) — index 0 (HTTP p1) and index 2 (HTTP p1)
+      // must be unloaded; their next request would silently route through
+      // p2 once `ProxyController.setProxyOverride` lands the new override.
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: 1,
+        models: models,
+        loadedIndices: {0, 1, 2},
+        proxyIsGlobal: true,
+      );
+      expect(result, {0, 2});
+    });
+
+    test('does not flag the activating site itself', () {
+      final models = [
+        _site('https://a.example.com',
+            proxy: UserProxySettings(type: ProxyType.HTTP, address: 'p1:8080')),
+      ];
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: 0,
+        models: models,
+        loadedIndices: {0},
+        proxyIsGlobal: true,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('does not flag sites with the same proxy', () {
+      final models = [
+        _site('https://a.example.com',
+            proxy: UserProxySettings(type: ProxyType.HTTP, address: 'p1:8080')),
+        _site('https://b.example.com',
+            proxy: UserProxySettings(type: ProxyType.HTTP, address: 'p1:8080')),
+      ];
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: 0,
+        models: models,
+        loadedIndices: {0, 1},
+        proxyIsGlobal: true,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('two DEFAULT sites are equivalent regardless of global proxy', () {
+      // Both fall through resolveEffectiveProxy to the global outbound
+      // proxy, so they resolve to the same effective value.
+      GlobalOutboundProxy.setForTest(
+        UserProxySettings(type: ProxyType.SOCKS5, address: 'tor:9050'),
+      );
+      final models = [
+        _site('https://a.example.com',
+            proxy: UserProxySettings(type: ProxyType.DEFAULT)),
+        _site('https://b.example.com',
+            proxy: UserProxySettings(type: ProxyType.DEFAULT)),
+      ];
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: 1,
+        models: models,
+        loadedIndices: {0, 1},
+        proxyIsGlobal: true,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('DEFAULT vs explicit-matching-global is equivalent', () {
+      GlobalOutboundProxy.setForTest(
+        UserProxySettings(type: ProxyType.HTTP, address: 'gp:1234'),
+      );
+      final models = [
+        // Resolves through the global proxy.
+        _site('https://a.example.com',
+            proxy: UserProxySettings(type: ProxyType.DEFAULT)),
+        // Set explicitly to the same value the global proxy provides.
+        _site('https://b.example.com',
+            proxy: UserProxySettings(type: ProxyType.HTTP, address: 'gp:1234')),
+      ];
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: 0,
+        models: models,
+        loadedIndices: {0, 1},
+        proxyIsGlobal: true,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('flags credential-only differences', () {
+      final models = [
+        _site('https://a.example.com',
+            proxy: UserProxySettings(
+                type: ProxyType.HTTP,
+                address: 'p:8080',
+                username: 'alice',
+                password: 'a-pw')),
+        _site('https://b.example.com',
+            proxy: UserProxySettings(
+                type: ProxyType.HTTP,
+                address: 'p:8080',
+                username: 'bob',
+                password: 'b-pw')),
+      ];
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: 1,
+        models: models,
+        loadedIndices: {0, 1},
+        proxyIsGlobal: true,
+      );
+      expect(result, {0});
+    });
+
+    test('out-of-bounds target returns empty', () {
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: 5,
+        models: const [],
+        loadedIndices: const {},
+        proxyIsGlobal: true,
+      );
+      expect(result, isEmpty);
+    });
+  });
+
+  group('SiteUnloadEngine.indicesToEvictForLruCap', () {
+    test('returns empty when within cap', () {
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 3,
+        loadedIndices: {0, 1, 2},
+        maxLoadedSites: 5,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('evicts oldest when adding target overflows cap', () {
+      // LinkedHashSet preserves insertion order; iteration is LRU-first.
+      // Loaded order: 0 (oldest), 1, 2. Activating index 3 would make 4
+      // loaded; cap is 3, so the oldest (0) is evicted.
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      loaded.add(2);
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 3,
+        loadedIndices: loaded,
+        maxLoadedSites: 3,
+      );
+      expect(result, [0]);
+    });
+
+    test('evicts multiple when overflow > 1', () {
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      loaded.add(2);
+      loaded.add(3);
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 4,
+        loadedIndices: loaded,
+        maxLoadedSites: 2,
+      );
+      expect(result, [0, 1, 2]);
+    });
+
+    test('skips the target index even at the front of loaded order', () {
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      loaded.add(2);
+      // Re-activating index 0 doesn't add a new slot — projected count is
+      // still 3, so no eviction needed at cap=3.
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 0,
+        loadedIndices: loaded,
+        maxLoadedSites: 3,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('skips protected indices (e.g. currently active site)', () {
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      loaded.add(2);
+      // Cap is 2, projected is 4 with new index 3 → overflow 2. With
+      // index 0 protected, the engine should evict 1 and 2 instead.
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 3,
+        loadedIndices: loaded,
+        maxLoadedSites: 2,
+        protectedIndices: {0},
+      );
+      expect(result, [1, 2]);
+    });
+
+    test('respects access-order updates (LRU semantics)', () {
+      // Caller bumps re-activated sites to the end. After visiting 0, 1,
+      // 2, then re-visiting 0, the order becomes 1, 2, 0 — so the next
+      // overflow evicts 1, not 0.
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      loaded.add(2);
+      // Bump 0 (re-activation).
+      loaded.remove(0);
+      loaded.add(0);
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 3,
+        loadedIndices: loaded,
+        maxLoadedSites: 3,
+      );
+      expect(result, [1]);
+    });
+  });
+}

--- a/test/site_unload_engine_test.dart
+++ b/test/site_unload_engine_test.dart
@@ -664,5 +664,155 @@ void main() {
       // sites are evictable.
       expect(result, [0, 1]);
     });
+
+    group('preferKeepIndices (active-webspace soft-keep)', () {
+      test('out-of-set candidates are evicted before in-set candidates', () {
+        // Loaded LRU order: 0 (oldest), 1, 2, 3 (newest).
+        // Active webspace = {0, 2}; sites 1 and 3 are outside.
+        // Cap=4 with target=4 → overflow 1. Naive LRU would evict 0;
+        // soft-keep prefers to evict 1 (the oldest out-of-set).
+        final loaded = <int>{};
+        for (final i in [0, 1, 2, 3]) {
+          loaded.add(i);
+        }
+        final result = SiteUnloadEngine.indicesToEvictForLruCap(
+          targetIndex: 4,
+          loadedIndices: loaded,
+          maxLoadedSites: 4,
+          preferKeepIndices: {0, 2},
+        );
+        expect(result, [1]);
+      });
+
+      test('falls back to in-set when out-of-set is exhausted', () {
+        // Loaded: 0, 1, 2, 3. Active webspace = {0, 1, 2, 3} (everything).
+        // Cap=2 with target=4 → overflow 3. Out-of-set is empty, so the
+        // engine falls through to in-set in LRU order: evict 0, 1, 2.
+        final loaded = <int>{};
+        for (final i in [0, 1, 2, 3]) {
+          loaded.add(i);
+        }
+        final result = SiteUnloadEngine.indicesToEvictForLruCap(
+          targetIndex: 4,
+          loadedIndices: loaded,
+          maxLoadedSites: 2,
+          preferKeepIndices: {0, 1, 2, 3},
+        );
+        expect(result, [0, 1, 2]);
+      });
+
+      test('mixes tiers when out-of-set is too small', () {
+        // Loaded: 0 (out), 1 (in), 2 (out), 3 (in), 4 (in), 5 (in).
+        // Cap=3 with target=6 → overflow 4. Out-of-set = [0, 2] (2
+        // candidates), in-set = [1, 3, 4, 5]. Need 4 → take 0, 2,
+        // then 1, 3 from in-set.
+        final loaded = <int>{};
+        for (final i in [0, 1, 2, 3, 4, 5]) {
+          loaded.add(i);
+        }
+        final result = SiteUnloadEngine.indicesToEvictForLruCap(
+          targetIndex: 6,
+          loadedIndices: loaded,
+          maxLoadedSites: 3,
+          preferKeepIndices: {1, 3, 4, 5},
+        );
+        expect(result, [0, 2, 1, 3]);
+      });
+
+      test('protectedIndices wins over preferKeepIndices', () {
+        // Site 0 is hard-protected; site 1 is in soft-keep; sites 2, 3
+        // are out-of-set. Cap=3 with target=4 → overflow 2.
+        // Eviction: out-of-set first ([2, 3]) — exhausts overflow.
+        // Site 0 (protected) and site 1 (soft-keep) both stay.
+        final loaded = <int>{};
+        for (final i in [0, 1, 2, 3]) {
+          loaded.add(i);
+        }
+        final result = SiteUnloadEngine.indicesToEvictForLruCap(
+          targetIndex: 4,
+          loadedIndices: loaded,
+          maxLoadedSites: 3,
+          protectedIndices: {0},
+          preferKeepIndices: {1},
+        );
+        expect(result, [2, 3]);
+      });
+
+      test('a soft-keep site can still be evicted if hard-protected covers '
+          'the keep room', () {
+        // Loaded: 0 (out), 1 (in), 2 (out, hard-protected), 3 (in,
+        // hard-protected). Cap=2 with target=4 → overflow 2.
+        // Non-protected eligible: 0 (out), 1 (in). Out tier supplies
+        // [0]; need one more → in tier supplies [1].
+        final loaded = <int>{};
+        for (final i in [0, 1, 2, 3]) {
+          loaded.add(i);
+        }
+        final result = SiteUnloadEngine.indicesToEvictForLruCap(
+          targetIndex: 4,
+          loadedIndices: loaded,
+          maxLoadedSites: 2,
+          protectedIndices: {2, 3},
+          preferKeepIndices: {1, 3},
+        );
+        expect(result, [0, 1]);
+      });
+
+      test('empty preferKeepIndices == old single-tier behavior', () {
+        // Sanity check: when no soft-keep is provided, eviction order
+        // is pure LRU (oldest first) — backwards-compatible default.
+        // Cap=3 with target=3 (new) → overflow 1 → evict [0].
+        final loaded = <int>{};
+        for (final i in [0, 1, 2]) {
+          loaded.add(i);
+        }
+        final result = SiteUnloadEngine.indicesToEvictForLruCap(
+          targetIndex: 3,
+          loadedIndices: loaded,
+          maxLoadedSites: 3,
+        );
+        expect(result, [0]);
+      });
+
+      test('preferKeepIndices may include unloaded sites without effect', () {
+        // The active webspace can list site indices that aren't loaded
+        // yet (haven't been visited). Those don't affect eviction
+        // because the engine only iterates loadedIndices.
+        // Cap=3 with target=3 (new) → overflow 1.
+        final loaded = <int>{};
+        for (final i in [0, 1, 2]) {
+          loaded.add(i);
+        }
+        final result = SiteUnloadEngine.indicesToEvictForLruCap(
+          targetIndex: 3,
+          loadedIndices: loaded,
+          maxLoadedSites: 3,
+          preferKeepIndices: {0, 4, 5, 99},
+        );
+        // Site 0 is in soft-keep; sites 4/5/99 are noise. Out-of-set
+        // candidates: [1, 2]. Evict oldest: [1].
+        expect(result, [1]);
+      });
+
+      test('respects access-order within each tier', () {
+        // Loaded in order: 0 (out), 1 (in), 2 (out), 3 (in). Then 0
+        // gets bumped (re-activation) → order becomes 1, 2, 3, 0.
+        // Cap=2 with target=4 → overflow 3. Out-of-set in LRU order:
+        // [2, 0]. In-set in LRU order: [1, 3]. Need 3 → [2, 0, 1].
+        final loaded = <int>{};
+        for (final i in [0, 1, 2, 3]) {
+          loaded.add(i);
+        }
+        loaded.remove(0);
+        loaded.add(0);
+        final result = SiteUnloadEngine.indicesToEvictForLruCap(
+          targetIndex: 4,
+          loadedIndices: loaded,
+          maxLoadedSites: 2,
+          preferKeepIndices: {1, 3},
+        );
+        expect(result, [2, 0, 1]);
+      });
+    });
   });
 }

--- a/test/site_unload_engine_test.dart
+++ b/test/site_unload_engine_test.dart
@@ -937,4 +937,142 @@ void main() {
       expect(result, 0);
     });
   });
+
+  group('SiteUnloadEngine eviction priority — full hierarchy', () {
+    // Canonical scenario for documenting and locking down the priority
+    // ordering. Five loaded sites in LRU order [0, 1, 2, 3, 4]:
+    //
+    //   index 0 → in soft-keep (active webspace), oldest
+    //   index 1 → standard, no flags
+    //   index 2 → hard-protected (currently-active site)
+    //   index 3 → standard, no flags
+    //   index 4 → in soft-keep, newest
+    //
+    // From most-likely-to-be-evicted to least:
+    //   tier A: standard, oldest first   → 1, 3
+    //   tier B: soft-keep, oldest first  → 0, 4
+    //   never:  hard-protected, target   → 2 (and any targetIndex)
+    Set<int> _baseLoaded() {
+      final s = <int>{};
+      for (final i in [0, 1, 2, 3, 4]) {
+        s.add(i);
+      }
+      return s;
+    }
+
+    const protected = <int>{2};
+    const softKeep = <int>{0, 2, 4};
+
+    test('LruCap evicts strictly in tier order (1, 3, 0, 4)', () {
+      // Cap=1 with target=5 → projected 6, overflow 5. The engine
+      // exhausts tier A (1, 3) then tier B (0, 4). Site 2 is
+      // hard-protected so it's never evicted, even though we'd need
+      // to drop more sites to actually fit the cap. Returns the four
+      // safely-evictable indices in the documented order.
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 5,
+        loadedIndices: _baseLoaded(),
+        maxLoadedSites: 1,
+        protectedIndices: protected,
+        preferKeepIndices: softKeep,
+      );
+      expect(result, [1, 3, 0, 4]);
+    });
+
+    test('LruCap with overflow=1 takes the oldest tier-A site', () {
+      // Cap=4 with target=5 → projected 6, overflow 1. Pick index 1
+      // (oldest in tier A). Sites 3, 0, 4 stay; 2 is protected.
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 5,
+        loadedIndices: _baseLoaded(),
+        maxLoadedSites: 5,
+        protectedIndices: protected,
+        preferKeepIndices: softKeep,
+      );
+      expect(result, [1]);
+    });
+
+    test('LruCap with overflow=3 reaches into tier B', () {
+      // Cap=2 with target=5 → projected 6, overflow 4 (need 4
+      // candidates). Tier A supplies [1, 3]; tier B supplies [0, 4].
+      // Result: [1, 3, 0, 4]. Same as the cap=1 case because tier A
+      // had only 2 candidates and protection takes the rest.
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 5,
+        loadedIndices: _baseLoaded(),
+        maxLoadedSites: 2,
+        protectedIndices: protected,
+        preferKeepIndices: softKeep,
+      );
+      expect(result, [1, 3, 0, 4]);
+    });
+
+    test('MemoryPressure picks the same first victim as LruCap', () {
+      // Cross-method consistency: both methods derive the next victim
+      // from the same priority hierarchy, so on identical inputs the
+      // first index from indicesToEvictForLruCap should match the
+      // single index from indexToEvictForMemoryPressure.
+      final lruVictim = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 5,
+        loadedIndices: _baseLoaded(),
+        maxLoadedSites: 5,
+        protectedIndices: protected,
+        preferKeepIndices: softKeep,
+      ).first;
+      final memVictim = SiteUnloadEngine.indexToEvictForMemoryPressure(
+        loadedIndices: _baseLoaded(),
+        protectedIndices: protected,
+        preferKeepIndices: softKeep,
+      );
+      expect(memVictim, equals(lruVictim));
+      expect(memVictim, 1);
+    });
+
+    test('MemoryPressure walks the full hierarchy across successive events',
+        () {
+      // Each call picks one victim, caller mutates loaded, repeat
+      // until null. The sequence must equal the LruCap exhaust order
+      // [1, 3, 0, 4]; site 2 stays protected.
+      final loaded = _baseLoaded();
+      final picked = <int>[];
+      while (true) {
+        final v = SiteUnloadEngine.indexToEvictForMemoryPressure(
+          loadedIndices: loaded,
+          protectedIndices: protected,
+          preferKeepIndices: softKeep,
+        );
+        if (v == null) break;
+        picked.add(v);
+        loaded.remove(v);
+      }
+      expect(picked, [1, 3, 0, 4]);
+      expect(loaded, {2});
+    });
+
+    test('protected ∩ softKeep is the production case (active site is both)',
+        () {
+      // In production, _setCurrentIndex passes _currentIndex as
+      // protectedIndices and _getFilteredSiteIndices() as
+      // preferKeepIndices. The active site is typically in the active
+      // webspace, so the intersection is non-empty by design. The
+      // overlap must NOT cause double-counting or skip the site
+      // entirely from soft-keep semantics for *other* sites.
+      // Loaded LRU: [0, 1, 2]. Active = 1 (in active webspace).
+      // Active webspace = {0, 1}. Cap=2 with target=3 → overflow 2.
+      // Tier A: [2]; tier B: [0]; protected: 1. Take [2, 0] → 0 is
+      // demoted to last because it's in soft-keep.
+      final loaded = <int>{};
+      for (final i in [0, 1, 2]) {
+        loaded.add(i);
+      }
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 3,
+        loadedIndices: loaded,
+        maxLoadedSites: 2,
+        protectedIndices: {1},
+        preferKeepIndices: {0, 1},
+      );
+      expect(result, [2, 0]);
+    });
+  });
 }

--- a/test/site_unload_engine_test.dart
+++ b/test/site_unload_engine_test.dart
@@ -794,7 +794,7 @@ void main() {
         expect(result, [1]);
       });
 
-      test('respects access-order within each tier', () {
+      test('respects access-order within each tier with target', () {
         // Loaded in order: 0 (out), 1 (in), 2 (out), 3 (in). Then 0
         // gets bumped (re-activation) → order becomes 1, 2, 3, 0.
         // Cap=2 with target=4 → overflow 3. Out-of-set in LRU order:
@@ -813,6 +813,128 @@ void main() {
         );
         expect(result, [2, 0, 1]);
       });
+    });
+  });
+
+  group('SiteUnloadEngine.indexToEvictForMemoryPressure', () {
+    test('returns null when nothing is loaded', () {
+      final result = SiteUnloadEngine.indexToEvictForMemoryPressure(
+        loadedIndices: const {},
+      );
+      expect(result, isNull);
+    });
+
+    test('returns null when every loaded site is protected', () {
+      // Pathological: only the active site is loaded, can't evict it.
+      final loaded = <int>{};
+      loaded.add(0);
+      final result = SiteUnloadEngine.indexToEvictForMemoryPressure(
+        loadedIndices: loaded,
+        protectedIndices: {0},
+      );
+      expect(result, isNull);
+    });
+
+    test('picks oldest non-protected site (single tier)', () {
+      // Loaded order: 0 (oldest), 1, 2 (newest, active). Pick 0.
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      loaded.add(2);
+      final result = SiteUnloadEngine.indexToEvictForMemoryPressure(
+        loadedIndices: loaded,
+        protectedIndices: {2},
+      );
+      expect(result, 0);
+    });
+
+    test('prefers out-of-keep over in-keep', () {
+      // Order: 0 (in), 1 (out), 2 (in, active). Active is protected.
+      // Out-of-keep candidate exists → pick 1, not the older 0.
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      loaded.add(2);
+      final result = SiteUnloadEngine.indexToEvictForMemoryPressure(
+        loadedIndices: loaded,
+        protectedIndices: {2},
+        preferKeepIndices: {0, 2},
+      );
+      expect(result, 1);
+    });
+
+    test('falls through to in-keep when no out-of-keep candidate', () {
+      // Order: 0, 1, 2. Active=2. Soft-keep covers everything left.
+      // Pick the oldest in-keep: 0.
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      loaded.add(2);
+      final result = SiteUnloadEngine.indexToEvictForMemoryPressure(
+        loadedIndices: loaded,
+        protectedIndices: {2},
+        preferKeepIndices: {0, 1, 2},
+      );
+      expect(result, 0);
+    });
+
+    test('respects LRU access order after re-activation bumps', () {
+      // Activations 0, 1, 2 then re-activate 0 → order is 1, 2, 0.
+      // Active = 2 (most recent of {1, 2}). Out-of-keep: {1}; pick 1.
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      loaded.add(2);
+      // Re-activate 0.
+      loaded.remove(0);
+      loaded.add(0);
+      final result = SiteUnloadEngine.indexToEvictForMemoryPressure(
+        loadedIndices: loaded,
+        protectedIndices: {0},
+        preferKeepIndices: {0, 2},
+      );
+      expect(result, 1);
+    });
+
+    test('successive calls evict one-by-one without re-evicting', () {
+      // Caller mutates loadedIndices on each evict. After three OS
+      // memory-pressure events, three different sites get picked, in
+      // LRU order. The fourth event has only the active site left;
+      // returns null.
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      loaded.add(2);
+      loaded.add(3);
+      final picked = <int>[];
+      while (true) {
+        final v = SiteUnloadEngine.indexToEvictForMemoryPressure(
+          loadedIndices: loaded,
+          protectedIndices: {3},
+        );
+        if (v == null) break;
+        picked.add(v);
+        loaded.remove(v);
+      }
+      expect(picked, [0, 1, 2]);
+      expect(loaded, {3});
+    });
+
+    test('stable when activeIndex is also in preferKeep', () {
+      // Common production case: the active site is part of the
+      // currently-selected webspace (so it's in both protectedIndices
+      // and preferKeepIndices). Tier-2 fall-through must not double-
+      // count the protected site.
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      final result = SiteUnloadEngine.indexToEvictForMemoryPressure(
+        loadedIndices: loaded,
+        protectedIndices: {1},
+        preferKeepIndices: {0, 1},
+      );
+      // Only candidate is 0 (in-keep), since 1 is protected.
+      expect(result, 0);
     });
   });
 }

--- a/test/site_unload_engine_test.dart
+++ b/test/site_unload_engine_test.dart
@@ -1049,6 +1049,63 @@ void main() {
       expect(loaded, {2});
     });
 
+    test('user re-activates the site that would otherwise be next to evict',
+        () {
+      // Production scenario the user asked about: site 0 is the LRU
+      // front (oldest, would be next out under the cap) AND the user
+      // re-activates it. The engine excludes targetIndex from the
+      // candidate iteration, so 0 is never picked even though it's
+      // both the oldest AND in the soft-keep tier. Cap=3 with
+      // target=0 (re-activation) → projected stays at 4, overflow 1
+      // (we're already over cap). Eviction must spare target.
+      final loaded = <int>{};
+      for (final i in [0, 1, 2, 3]) {
+        loaded.add(i);
+      }
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 0,
+        loadedIndices: loaded,
+        maxLoadedSites: 3,
+        // Previous active was 2 (different from target — common case
+        // when the user is switching sites, not just re-tapping the
+        // already-active one).
+        protectedIndices: {2},
+        // Active webspace contains the target plus one more.
+        preferKeepIndices: {0, 1},
+      );
+      // outOfKeep = [3] (1 in keep, 2 protected, 0 is target).
+      // inKeep = [1] (0 is target).
+      // overflow=1, take outOfKeep first → [3]. Target survives.
+      expect(result, [3]);
+    });
+
+    test('memory pressure during re-activation: in-flight target is protected',
+        () {
+      // Production scenario: _setCurrentIndex(target) is mid-flight
+      // (_activationInFlightIndex = target). User has the OLD active
+      // site in _currentIndex. _handleMemoryPressure passes both as
+      // protectedIndices. Target is the LRU front (oldest) and IS in
+      // the active webspace. Without the in-flight guard the engine
+      // would pick target and dispose its webview — silently wiping
+      // the user's state from the IndexedStack on next paint.
+      final loaded = <int>{};
+      for (final i in [0, 1, 2]) {
+        loaded.add(i);
+      }
+      // _currentIndex = 2 (active, oldest gets bumped to back on
+      // every activation, so 2 is most recent). Target = 0 (oldest).
+      // Both go in protected.
+      final result = SiteUnloadEngine.indexToEvictForMemoryPressure(
+        loadedIndices: loaded,
+        protectedIndices: {0, 2},
+        preferKeepIndices: {0, 1, 2},
+      );
+      // Only candidate left is 1 (out-of-keep is empty since
+      // everything's in active webspace; in-keep with 0 and 2
+      // protected leaves just 1).
+      expect(result, 1);
+    });
+
     test('protected ∩ softKeep is the production case (active site is both)',
         () {
       // In production, _setCurrentIndex passes _currentIndex as

--- a/test/site_unload_engine_test.dart
+++ b/test/site_unload_engine_test.dart
@@ -23,6 +23,18 @@ void main() {
       expect(result, isEmpty);
     });
 
+    test('container mode short-circuits even with no overlap', () {
+      // Worst case for legacy (every loaded site leaves the visible set);
+      // container mode still keeps them all.
+      final result = SiteUnloadEngine.indicesToUnloadOnWebspaceSwitch(
+        useContainers: true,
+        loadedIndices: {0, 1, 2},
+        previousWebspaceIndices: {0, 1, 2},
+        newWebspaceIndices: {3, 4, 5},
+      );
+      expect(result, isEmpty);
+    });
+
     test('legacy mode unloads sites visible only in previous webspace', () {
       final result = SiteUnloadEngine.indicesToUnloadOnWebspaceSwitch(
         useContainers: false,
@@ -41,6 +53,26 @@ void main() {
         newWebspaceIndices: {1, 2, 3},
       );
       expect(result, {0});
+    });
+
+    test('legacy mode no-op when no loaded sites in previous webspace', () {
+      final result = SiteUnloadEngine.indicesToUnloadOnWebspaceSwitch(
+        useContainers: false,
+        loadedIndices: {5, 6},
+        previousWebspaceIndices: {0, 1},
+        newWebspaceIndices: {2, 3},
+      );
+      expect(result, isEmpty);
+    });
+
+    test('legacy mode no-op on empty loadedIndices', () {
+      final result = SiteUnloadEngine.indicesToUnloadOnWebspaceSwitch(
+        useContainers: false,
+        loadedIndices: const {},
+        previousWebspaceIndices: {0, 1, 2},
+        newWebspaceIndices: {3, 4},
+      );
+      expect(result, isEmpty);
     });
   });
 
@@ -178,11 +210,227 @@ void main() {
       expect(result, {0});
     });
 
+    test('flags type-only differences (HTTP vs SOCKS5, same address)', () {
+      // Same host:port string but different protocol — the wire format
+      // is fundamentally different (CONNECT tunnel vs SOCKS handshake),
+      // so a request that thinks it's going to one will fail on the
+      // other. Must be treated as a mismatch.
+      final models = [
+        _site('https://a.example.com',
+            proxy: UserProxySettings(type: ProxyType.HTTP, address: 'p:9050')),
+        _site('https://b.example.com',
+            proxy: UserProxySettings(
+                type: ProxyType.SOCKS5, address: 'p:9050')),
+      ];
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: 1,
+        models: models,
+        loadedIndices: {0, 1},
+        proxyIsGlobal: true,
+      );
+      expect(result, {0});
+    });
+
+    test('flags HTTP vs HTTPS (different schemes)', () {
+      final models = [
+        _site('https://a.example.com',
+            proxy: UserProxySettings(type: ProxyType.HTTP, address: 'p:8080')),
+        _site('https://b.example.com',
+            proxy: UserProxySettings(type: ProxyType.HTTPS, address: 'p:8080')),
+      ];
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: 1,
+        models: models,
+        loadedIndices: {0, 1},
+        proxyIsGlobal: true,
+      );
+      expect(result, {0});
+    });
+
+    test('flags address-only differences (host)', () {
+      final models = [
+        _site('https://a.example.com',
+            proxy: UserProxySettings(type: ProxyType.HTTP, address: 'p1:8080')),
+        _site('https://b.example.com',
+            proxy: UserProxySettings(type: ProxyType.HTTP, address: 'p2:8080')),
+      ];
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: 1,
+        models: models,
+        loadedIndices: {0, 1},
+        proxyIsGlobal: true,
+      );
+      expect(result, {0});
+    });
+
+    test('flags address-only differences (port)', () {
+      final models = [
+        _site('https://a.example.com',
+            proxy: UserProxySettings(type: ProxyType.HTTP, address: 'p:8080')),
+        _site('https://b.example.com',
+            proxy: UserProxySettings(type: ProxyType.HTTP, address: 'p:9090')),
+      ];
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: 1,
+        models: models,
+        loadedIndices: {0, 1},
+        proxyIsGlobal: true,
+      );
+      expect(result, {0});
+    });
+
+    test('flags username-only differences', () {
+      final models = [
+        _site('https://a.example.com',
+            proxy: UserProxySettings(
+                type: ProxyType.HTTP,
+                address: 'p:8080',
+                username: 'alice',
+                password: 'shared-pw')),
+        _site('https://b.example.com',
+            proxy: UserProxySettings(
+                type: ProxyType.HTTP,
+                address: 'p:8080',
+                username: 'bob',
+                password: 'shared-pw')),
+      ];
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: 1,
+        models: models,
+        loadedIndices: {0, 1},
+        proxyIsGlobal: true,
+      );
+      expect(result, {0});
+    });
+
+    test('flags password-only differences', () {
+      final models = [
+        _site('https://a.example.com',
+            proxy: UserProxySettings(
+                type: ProxyType.HTTP,
+                address: 'p:8080',
+                username: 'shared',
+                password: 'pw1')),
+        _site('https://b.example.com',
+            proxy: UserProxySettings(
+                type: ProxyType.HTTP,
+                address: 'p:8080',
+                username: 'shared',
+                password: 'pw2')),
+      ];
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: 1,
+        models: models,
+        loadedIndices: {0, 1},
+        proxyIsGlobal: true,
+      );
+      expect(result, {0});
+    });
+
+    test('null and absent credentials are equivalent', () {
+      // Both sites: same type/address, no credentials. Different
+      // construction paths (UserProxySettings(...) vs default ctor) but
+      // the field values match.
+      final models = [
+        _site('https://a.example.com',
+            proxy: UserProxySettings(
+                type: ProxyType.HTTP,
+                address: 'p:8080',
+                username: null,
+                password: null)),
+        _site('https://b.example.com',
+            proxy: UserProxySettings(
+                type: ProxyType.HTTP, address: 'p:8080')),
+      ];
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: 1,
+        models: models,
+        loadedIndices: {0, 1},
+        proxyIsGlobal: true,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('flags DEFAULT vs explicit-non-matching-global', () {
+      // Site 0 = DEFAULT → resolves through global (HTTP gp:1234).
+      // Site 1 = explicit SOCKS5. Different effective proxy.
+      GlobalOutboundProxy.setForTest(
+        UserProxySettings(type: ProxyType.HTTP, address: 'gp:1234'),
+      );
+      final models = [
+        _site('https://a.example.com',
+            proxy: UserProxySettings(type: ProxyType.DEFAULT)),
+        _site('https://b.example.com',
+            proxy: UserProxySettings(
+                type: ProxyType.SOCKS5, address: 'tor:9050')),
+      ];
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: 1,
+        models: models,
+        loadedIndices: {0, 1},
+        proxyIsGlobal: true,
+      );
+      expect(result, {0});
+    });
+
+    test('only conflicting indices are returned, not all loaded', () {
+      // Mix: site 0 matches target, site 2 differs. Activating target
+      // (index 1) should unload only 2, not 0.
+      GlobalOutboundProxy.resetForTest();
+      final models = [
+        _site('https://a.example.com',
+            proxy: UserProxySettings(type: ProxyType.HTTP, address: 'p:8080')),
+        _site('https://b.example.com',
+            proxy: UserProxySettings(type: ProxyType.HTTP, address: 'p:8080')),
+        _site('https://c.example.com',
+            proxy: UserProxySettings(
+                type: ProxyType.SOCKS5, address: 'tor:9050')),
+      ];
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: 1,
+        models: models,
+        loadedIndices: {0, 1, 2},
+        proxyIsGlobal: true,
+      );
+      expect(result, {2});
+    });
+
+    test('skips out-of-bounds entries in loadedIndices', () {
+      // Mock state where _loadedIndices contains a stale index past
+      // the end of models (e.g. mid-deletion race). Engine must not
+      // throw a RangeError.
+      final models = [
+        _site('https://a.example.com',
+            proxy: UserProxySettings(type: ProxyType.HTTP, address: 'p:8080')),
+      ];
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: 0,
+        models: models,
+        loadedIndices: {0, 99, -1},
+        proxyIsGlobal: true,
+      );
+      expect(result, isEmpty);
+    });
+
     test('out-of-bounds target returns empty', () {
       final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
         targetIndex: 5,
         models: const [],
         loadedIndices: const {},
+        proxyIsGlobal: true,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('negative target returns empty', () {
+      final models = [
+        _site('https://a.example.com',
+            proxy: UserProxySettings(type: ProxyType.HTTP, address: 'p:8080')),
+      ];
+      final result = SiteUnloadEngine.indicesToUnloadForProxyMismatch(
+        targetIndex: -1,
+        models: models,
+        loadedIndices: {0},
         proxyIsGlobal: true,
       );
       expect(result, isEmpty);
@@ -277,6 +525,144 @@ void main() {
         maxLoadedSites: 3,
       );
       expect(result, [1]);
+    });
+
+    test('eviction order respects multiple bumps', () {
+      // Activations in order: 0, 1, 2, 3 — then 1 bumped, then 0 bumped.
+      // Final order: 2, 3, 1, 0. Cap=2 with new index 4 → overflow 3,
+      // evict 2, 3, 1 (oldest three) and keep 0 + new 4.
+      final loaded = <int>{};
+      for (final i in [0, 1, 2, 3]) {
+        loaded.add(i);
+      }
+      loaded.remove(1);
+      loaded.add(1);
+      loaded.remove(0);
+      loaded.add(0);
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 4,
+        loadedIndices: loaded,
+        maxLoadedSites: 2,
+      );
+      expect(result, [2, 3, 1]);
+    });
+
+    test('empty loadedIndices needs no eviction', () {
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 0,
+        loadedIndices: const {},
+        maxLoadedSites: 5,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('cap of 1 evicts every prior site', () {
+      final loaded = <int>{};
+      loaded.add(0);
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 1,
+        loadedIndices: loaded,
+        maxLoadedSites: 1,
+      );
+      expect(result, [0]);
+    });
+
+    test('exactly-at-cap re-activation does not evict', () {
+      // Loaded = {0, 1, 2}, cap=3, target=2 (already loaded). Projected
+      // count stays at 3, no eviction.
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      loaded.add(2);
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 2,
+        loadedIndices: loaded,
+        maxLoadedSites: 3,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('all loaded sites protected — overflow is unavoidable, returns []',
+        () {
+      // Pathological: every loaded site is protected and target adds
+      // one more. There's nothing to evict. Engine returns [] rather
+      // than evicting a protected site.
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 2,
+        loadedIndices: loaded,
+        maxLoadedSites: 1,
+        protectedIndices: {0, 1},
+      );
+      expect(result, isEmpty);
+    });
+
+    test('protected indices kept even when oldest', () {
+      // Order: 0 (oldest), 1, 2. Cap=2 with target=3 → overflow 2,
+      // evict 0 and 1 normally. Protect 0 → evict 1 and 2 instead.
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      loaded.add(2);
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 3,
+        loadedIndices: loaded,
+        maxLoadedSites: 2,
+        protectedIndices: {0},
+      );
+      expect(result, [1, 2]);
+    });
+
+    test('re-activation at cap is a no-op (target already loaded)', () {
+      // Loaded = {0, 1}, cap=2, target=0. Projected stays at 2 (target
+      // is already loaded), so no eviction. protectedIndices is the
+      // currently-active site, which may or may not equal target.
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 0,
+        loadedIndices: loaded,
+        maxLoadedSites: 2,
+        protectedIndices: {0},
+      );
+      expect(result, isEmpty);
+    });
+
+    test('over-cap state recovers via eviction even on target re-activation',
+        () {
+      // Loaded = {0, 1}, cap=1 (already over cap from a prior config
+      // change or settings import). Re-activating the protected target
+      // doesn't change the count, but the engine still pulls back to
+      // cap by evicting the non-target non-protected entry.
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 0,
+        loadedIndices: loaded,
+        maxLoadedSites: 1,
+        protectedIndices: {0},
+      );
+      expect(result, [1]);
+    });
+
+    test('cap of 0 evicts every non-target non-protected entry', () {
+      // Degenerate but well-defined: cap=0 with target → projected 1,
+      // overflow 1, evict the oldest non-target site.
+      final loaded = <int>{};
+      loaded.add(0);
+      loaded.add(1);
+      final result = SiteUnloadEngine.indicesToEvictForLruCap(
+        targetIndex: 2,
+        loadedIndices: loaded,
+        maxLoadedSites: 0,
+      );
+      // Overflow = 3 (projected 3 - cap 0). All non-target loaded
+      // sites are evictable.
+      expect(result, [0, 1]);
     });
   });
 }

--- a/test/webview_state_secure_storage_test.dart
+++ b/test/webview_state_secure_storage_test.dart
@@ -1,0 +1,305 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/webview_state_secure_storage.dart';
+
+/// In-memory FlutterSecureStorage for unit tests. The real one binds
+/// to platform keychain/keystore and isn't usable from `flutter test`.
+class _FakeSecureStorage implements FlutterSecureStorage {
+  final Map<String, String> _store = {};
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AndroidOptions? aOptions,
+    AppleOptions? iOptions,
+    AppleOptions? mOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (value == null) {
+      _store.remove(key);
+    } else {
+      _store[key] = value;
+    }
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    AndroidOptions? aOptions,
+    AppleOptions? iOptions,
+    AppleOptions? mOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    return _store[key];
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AndroidOptions? aOptions,
+    AppleOptions? iOptions,
+    AppleOptions? mOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    _store.remove(key);
+  }
+
+  @override
+  Future<bool> containsKey({
+    required String key,
+    AndroidOptions? aOptions,
+    AppleOptions? iOptions,
+    AppleOptions? mOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    WindowsOptions? wOptions,
+  }) async =>
+      _store.containsKey(key);
+
+  @override
+  Future<Map<String, String>> readAll({
+    AndroidOptions? aOptions,
+    AppleOptions? iOptions,
+    AppleOptions? mOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    WindowsOptions? wOptions,
+  }) async =>
+      Map<String, String>.from(_store);
+
+  @override
+  Future<void> deleteAll({
+    AndroidOptions? aOptions,
+    AppleOptions? iOptions,
+    AppleOptions? mOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    WindowsOptions? wOptions,
+  }) async =>
+      _store.clear();
+
+  // Unused in tests but required by the interface. Default to no-op.
+  @override
+  AndroidOptions get aOptions => AndroidOptions.defaultOptions;
+
+  @override
+  IOSOptions get iOptions => IOSOptions.defaultOptions;
+
+  @override
+  MacOsOptions get mOptions => MacOsOptions.defaultOptions;
+
+  @override
+  LinuxOptions get lOptions => LinuxOptions.defaultOptions;
+
+  @override
+  WebOptions get webOptions => WebOptions.defaultOptions;
+
+  @override
+  WindowsOptions get wOptions => WindowsOptions.defaultOptions;
+
+  @override
+  void registerListener({
+    required String key,
+    required ValueChanged<String?> listener,
+  }) {}
+
+  @override
+  void unregisterListener({
+    required String key,
+    required ValueChanged<String?> listener,
+  }) {}
+
+  @override
+  void unregisterAllListeners() {}
+
+  @override
+  void unregisterAllListenersForKey({required String key}) {}
+
+  @override
+  Map<String, List<ValueChanged<String?>>> get getListeners => const {};
+
+  @override
+  Future<bool?> isCupertinoProtectedDataAvailable() async => true;
+
+  @override
+  Stream<bool> get onCupertinoProtectedDataAvailabilityChanged =>
+      const Stream.empty();
+}
+
+typedef ValueChanged<T> = void Function(T);
+
+void main() {
+  late Directory tempDir;
+  late _FakeSecureStorage fakeStorage;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('webspace_state_test_');
+    fakeStorage = _FakeSecureStorage();
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  SecureWebViewStateStorage newStorage({String version = 'v1'}) {
+    return SecureWebViewStateStorage(
+      secureStorage: fakeStorage,
+      overrideAppDir: tempDir,
+      versionProvider: () => version,
+    );
+  }
+
+  group('SecureWebViewStateStorage', () {
+    test('save and load round-trip preserves bytes', () async {
+      final storage = newStorage();
+      final bytes = Uint8List.fromList(List.generate(256, (i) => i));
+      await storage.saveState('alpha', bytes);
+      final loaded = await storage.loadState('alpha');
+      expect(loaded, bytes);
+    });
+
+    test('round-trip preserves exact byte content for binary blob', () async {
+      final storage = newStorage();
+      // Pseudo-random binary, not just incrementing — covers padding /
+      // alignment / null-byte edges in the AES-CBC path.
+      final raw = List<int>.generate(
+        1234,
+        (i) => (i * 31 + 7) & 0xFF,
+      );
+      final bytes = Uint8List.fromList(raw);
+      await storage.saveState('binary', bytes);
+      final loaded = await storage.loadState('binary');
+      expect(loaded, bytes);
+    });
+
+    test('load returns null for unknown siteId', () async {
+      final storage = newStorage();
+      expect(await storage.loadState('does-not-exist'), isNull);
+    });
+
+    test('saving empty bytes is a no-op (no file written)', () async {
+      final storage = newStorage();
+      await storage.saveState('empty', Uint8List(0));
+      expect(await storage.loadState('empty'), isNull);
+      expect(await storage.siteIds(), isEmpty);
+    });
+
+    test('overwrite replaces previous bytes', () async {
+      final storage = newStorage();
+      await storage.saveState('s', Uint8List.fromList([1, 2, 3]));
+      await storage.saveState('s', Uint8List.fromList([10, 20, 30, 40]));
+      expect(await storage.loadState('s'), Uint8List.fromList([10, 20, 30, 40]));
+    });
+
+    test('removeState deletes the entry from disk', () async {
+      final storage = newStorage();
+      await storage.saveState('s', Uint8List.fromList([1]));
+      expect(await storage.loadState('s'), isNotNull);
+      await storage.removeState('s');
+      expect(await storage.loadState('s'), isNull);
+      expect(await storage.siteIds(), isEmpty);
+    });
+
+    test('removeOrphans keeps active siteIds, removes the rest', () async {
+      final storage = newStorage();
+      await storage.saveState('a', Uint8List.fromList([1]));
+      await storage.saveState('b', Uint8List.fromList([2]));
+      await storage.saveState('c', Uint8List.fromList([3]));
+
+      final removed = await storage.removeOrphans({'a', 'c'});
+      expect(removed, 1);
+      expect(await storage.loadState('a'), isNotNull);
+      expect(await storage.loadState('b'), isNull);
+      expect(await storage.loadState('c'), isNotNull);
+    });
+
+    test('siteIds reflects what is currently saved', () async {
+      final storage = newStorage();
+      await storage.saveState('a', Uint8List.fromList([1]));
+      await storage.saveState('b', Uint8List.fromList([2]));
+      expect(await storage.siteIds(), {'a', 'b'});
+      await storage.removeState('a');
+      expect(await storage.siteIds(), {'b'});
+    });
+
+    test('persists across instance restarts (same key)', () async {
+      // Same encryption key in fakeStorage → same instance can decrypt
+      // what a previous instance encrypted, modeling app cold-start
+      // with persistent key.
+      final s1 = newStorage();
+      final bytes = Uint8List.fromList([42, 13, 7, 3, 1]);
+      await s1.saveState('persist', bytes);
+
+      final s2 = newStorage();
+      final loaded = await s2.loadState('persist');
+      expect(loaded, bytes);
+    });
+
+    test('app-version upgrade rotates the key and clears state', () async {
+      // Save under v1.
+      final s1 = newStorage(version: 'v1');
+      await s1.saveState('versioned', Uint8List.fromList([99, 88, 77]));
+      expect(await s1.loadState('versioned'), isNotNull);
+
+      // Simulate cold start with v2 — the cache dir + key are nuked,
+      // previously-stored state is gone.
+      final s2 = newStorage(version: 'v2');
+      // Trigger init.
+      expect(await s2.loadState('versioned'), isNull);
+      expect(await s2.siteIds(), isEmpty);
+    });
+
+    test('corrupt entry on disk is reaped and load returns null', () async {
+      final storage = newStorage();
+      await storage.saveState('s', Uint8List.fromList([1, 2, 3]));
+      // Corrupt the file by overwriting with garbage.
+      final filePath = '${tempDir.path}/webview_state/s.enc';
+      await File(filePath).writeAsString('not valid base64!!!');
+      // Loading should fail gracefully and clean up the corrupt file.
+      expect(await storage.loadState('s'), isNull);
+      expect(await File(filePath).exists(), isFalse);
+    });
+
+    test('removeState on missing siteId is a no-op (does not throw)',
+        () async {
+      final storage = newStorage();
+      // Reach this without exception.
+      await storage.removeState('does-not-exist');
+      expect(await storage.loadState('does-not-exist'), isNull);
+    });
+
+    test('removeOrphans with empty active set clears everything', () async {
+      final storage = newStorage();
+      await storage.saveState('a', Uint8List.fromList([1]));
+      await storage.saveState('b', Uint8List.fromList([2]));
+      final removed = await storage.removeOrphans(const {});
+      expect(removed, 2);
+      expect(await storage.siteIds(), isEmpty);
+    });
+
+    test('different siteIds produce independent entries', () async {
+      // Sanity: encrypted-with-fixed-IV doesn't accidentally collide
+      // distinct ciphertexts under different filenames.
+      final storage = newStorage();
+      await storage.saveState('a', Uint8List.fromList([1, 2, 3]));
+      await storage.saveState('b', Uint8List.fromList([1, 2, 3])); // same bytes
+      expect(await storage.loadState('a'), Uint8List.fromList([1, 2, 3]));
+      expect(await storage.loadState('b'), Uint8List.fromList([1, 2, 3]));
+      await storage.removeState('a');
+      expect(await storage.loadState('a'), isNull);
+      expect(await storage.loadState('b'), Uint8List.fromList([1, 2, 3]));
+    });
+  });
+}

--- a/test/webview_state_storage_test.dart
+++ b/test/webview_state_storage_test.dart
@@ -1,0 +1,93 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/webview_state_storage.dart';
+
+void main() {
+  group('InMemoryWebViewStateStorage', () {
+    late InMemoryWebViewStateStorage storage;
+
+    setUp(() {
+      storage = InMemoryWebViewStateStorage();
+    });
+
+    test('save and load round-trip', () async {
+      final bytes = Uint8List.fromList([1, 2, 3, 42]);
+      await storage.saveState('site-a', bytes);
+      final loaded = await storage.loadState('site-a');
+      expect(loaded, bytes);
+    });
+
+    test('load returns null for unknown siteId', () async {
+      final loaded = await storage.loadState('does-not-exist');
+      expect(loaded, isNull);
+    });
+
+    test('overwriting saves replaces the previous bytes', () async {
+      await storage.saveState('s', Uint8List.fromList([1]));
+      await storage.saveState('s', Uint8List.fromList([2, 3]));
+      final loaded = await storage.loadState('s');
+      expect(loaded, Uint8List.fromList([2, 3]));
+    });
+
+    test('removeState deletes the entry', () async {
+      await storage.saveState('s', Uint8List.fromList([1]));
+      await storage.removeState('s');
+      expect(await storage.loadState('s'), isNull);
+    });
+
+    test('removeState on missing siteId is a no-op (does not throw)',
+        () async {
+      await storage.removeState('does-not-exist');
+      // Reach here = no throw.
+      expect(await storage.loadState('does-not-exist'), isNull);
+    });
+
+    test('removeOrphans keeps active siteIds, removes the rest',
+        () async {
+      await storage.saveState('a', Uint8List.fromList([1]));
+      await storage.saveState('b', Uint8List.fromList([2]));
+      await storage.saveState('c', Uint8List.fromList([3]));
+
+      final removed = await storage.removeOrphans({'a', 'c'});
+      expect(removed, 1);
+      expect(await storage.loadState('a'), isNotNull);
+      expect(await storage.loadState('b'), isNull);
+      expect(await storage.loadState('c'), isNotNull);
+    });
+
+    test('removeOrphans returns 0 when everything is active', () async {
+      await storage.saveState('a', Uint8List.fromList([1]));
+      final removed = await storage.removeOrphans({'a'});
+      expect(removed, 0);
+      expect(await storage.loadState('a'), isNotNull);
+    });
+
+    test('removeOrphans clears all when activeSiteIds is empty', () async {
+      await storage.saveState('a', Uint8List.fromList([1]));
+      await storage.saveState('b', Uint8List.fromList([2]));
+      final removed = await storage.removeOrphans(const {});
+      expect(removed, 2);
+      expect(await storage.loadState('a'), isNull);
+      expect(await storage.loadState('b'), isNull);
+    });
+
+    test('siteIds returns the current set of saved sites', () async {
+      await storage.saveState('a', Uint8List.fromList([1]));
+      await storage.saveState('b', Uint8List.fromList([2]));
+      expect(await storage.siteIds(), {'a', 'b'});
+      await storage.removeState('a');
+      expect(await storage.siteIds(), {'b'});
+    });
+
+    test('saving empty bytes is treated as no-op', () async {
+      // Defensive: the platform's saveState() can return null or empty
+      // bytes when there's nothing meaningful to save (e.g. a webview
+      // that never navigated). We don't store empty entries, so a
+      // subsequent load returns null and re-activation falls back to
+      // a fresh load instead of attempting an empty restoreState.
+      await storage.saveState('s', Uint8List(0));
+      expect(await storage.loadState('s'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
Under per-site container mode, sites are isolated by their own native container (cookies, localStorage, IDB, ServiceWorkers, HTTP cache), so unloading them on every webspace switch is wasted work — they can stay resident and be re-shown instantly when the user comes back.

Introduce SiteUnloadEngine with three orthogonal rules:

  1. Webspace switch — under containers, return {} (sites stay loaded); legacy mode still unloads sites that leave the visible set so the shared cookie jar stays clean.
  2. Proxy mismatch — on Android the WebView proxy is process-global (ProxyController last-write-wins), so activating a site whose effective proxy differs from a currently-loaded site would silently re-route that site's next request through the new proxy. Force-unload conflicting sites on activation. Per-site DEFAULT resolves through the app-global outbound proxy via resolveEffectiveProxy, so two DEFAULT sites are equivalent.
  3. LRU cap — bound concurrent webviews at kMaxLoadedSites=16 so the container-mode "stay resident" policy doesn't accumulate dozens of live native webviews. _loadedIndices is treated as access-ordered (bumped on activation); evict least-recently-used when adding a new site overflows the cap, never the active one.

Legacy-mode unloads (proxy mismatch, LRU) route through the existing CookieIsolationEngine.unloadSiteForDomainSwitch so cookies are captured to siteId-keyed storage before the webview is disposed; otherwise the soon-to-run capture-nuke-restore on the new site's activation would wipe the unloaded site's session out of the shared jar.

Specs updated: webspaces (engine table + tests), per-site-containers (new CONT-003 scenario for cross-webspace residency + LRU rationale), proxy (new PROXY-008 scenario for the Android mismatch unload).