### PR TITLE
Fix per-site proxy auth wipe + apply global proxy to live webviews

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2422,6 +2422,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                       _saveGlobalUserScripts();
                       _resetAllWebViews();
                     },
+                    onOutboundProxyChanged: _resetAllWebViews,
                   ),
                 ),
               );
@@ -2588,10 +2589,10 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                         onProxySettingsChanged: (newProxySettings) {
                           setState(() {
                             for (var model in _webViewModels) {
-                              model.proxySettings = UserProxySettings(
-                                type: newProxySettings.type,
-                                address: newProxySettings.address,
-                              );
+                              // copy() preserves credentials — see its
+                              // docstring for why hand-rolling a fresh
+                              // UserProxySettings here was a footgun.
+                              model.proxySettings = newProxySettings.copy();
                             }
                           });
                           _saveWebViewModels();
@@ -2995,10 +2996,10 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                   onProxySettingsChanged: (newProxySettings) {
                     setState(() {
                       for (var model in _webViewModels) {
-                        model.proxySettings = UserProxySettings(
-                          type: newProxySettings.type,
-                          address: newProxySettings.address,
-                        );
+                        // copy() preserves credentials — see its
+                        // docstring for why hand-rolling a fresh
+                        // UserProxySettings here was a footgun.
+                        model.proxySettings = newProxySettings.copy();
                       }
                     });
                     _saveWebViewModels();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1548,12 +1548,25 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           .toList();
 
       // Hydrate per-site proxy passwords from secure storage.
+      var hydratedCount = 0;
+      var sitesWithCustomProxy = 0;
       for (final m in loadedWebViewModels) {
+        if (m.proxySettings.type != ProxyType.DEFAULT) {
+          sitesWithCustomProxy++;
+        }
         final pwd = secureProxyPasswords[m.siteId];
         if (pwd != null && pwd.isNotEmpty) {
           m.proxySettings.password = pwd;
+          hydratedCount++;
         }
       }
+      LogService.instance.log(
+        'Proxy',
+        'Hydrated proxy passwords for $hydratedCount of '
+            '${loadedWebViewModels.length} site(s); '
+            '$sitesWithCustomProxy site(s) have a non-DEFAULT per-site proxy',
+        level: LogLevel.info,
+      );
 
       // Load cookies from secure storage (keyed by siteId or legacy domain)
       final secureCookies = await _cookieSecureStorage.loadCookies();
@@ -2587,6 +2600,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                           getController()?.reload();
                         },
                         onProxySettingsChanged: (newProxySettings) {
+                          LogService.instance.log(
+                            'Proxy',
+                            'Mirroring per-site proxy across '
+                                '${_webViewModels.length} model(s): '
+                                '${newProxySettings.describeForLogs()}',
+                            level: LogLevel.info,
+                          );
                           setState(() {
                             for (var model in _webViewModels) {
                               // copy() preserves credentials — see its
@@ -2994,6 +3014,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                     getController()?.reload();
                   },
                   onProxySettingsChanged: (newProxySettings) {
+                    LogService.instance.log(
+                      'Proxy',
+                      'Mirroring per-site proxy across '
+                          '${_webViewModels.length} model(s): '
+                          '${newProxySettings.describeForLogs()}',
+                      level: LogLevel.info,
+                    );
                     setState(() {
                       for (var model in _webViewModels) {
                         // copy() preserves credentials — see its

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -9,6 +9,7 @@ import 'package:webspace/screens/dev_tools.dart';
 import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
+import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/timezone_location_service.dart';
 import 'package:webspace/widgets/root_messenger.dart';
 import 'package:webspace/services/web_intercept_native.dart';
@@ -257,7 +258,18 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
     // never modified) so we don't churn webviews while the user is
     // tabbing through.
     if (changed) {
+      LogService.instance.log(
+        'Proxy',
+        'Outbound proxy changed; resetting all loaded webviews so the new '
+            'value is applied on next render',
+        level: LogLevel.info,
+      );
       widget.onOutboundProxyChanged?.call();
+    } else {
+      LogService.instance.log(
+        'Proxy',
+        'Outbound proxy save invoked but settings unchanged; skipping webview reset',
+      );
     }
     if (mounted && changed) {
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -43,6 +43,17 @@ class AppSettingsScreen extends StatefulWidget {
   final ValueChanged<bool> onShowStatsBannerChanged;
   final List<UserScriptConfig> globalUserScripts;
   final void Function(List<UserScriptConfig>)? onGlobalUserScriptsChanged;
+  /// Fired after the global outbound proxy is updated. Parent should
+  /// dispose every loaded webview so the next render re-applies the new
+  /// proxy: on Android the singleton `inapp.ProxyController` only refreshes
+  /// when `setProxySettings` is called again (which happens in
+  /// [WebViewModel.setController]), and on iOS / macOS / Linux the proxy
+  /// is sealed into the per-site `WKWebsiteDataStore` /
+  /// `WebKitNetworkSession` at WebView construction. Without this the
+  /// "global proxy applies via DEFAULT fallthrough" contract advertised
+  /// in the UI hint silently doesn't take effect until the next app
+  /// restart.
+  final VoidCallback? onOutboundProxyChanged;
 
   const AppSettingsScreen({
     super.key,
@@ -56,6 +67,7 @@ class AppSettingsScreen extends StatefulWidget {
     required this.onShowStatsBannerChanged,
     this.globalUserScripts = const [],
     this.onGlobalUserScriptsChanged,
+    this.onOutboundProxyChanged,
   });
 
   @override
@@ -228,11 +240,26 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
           ? _outboundProxyPasswordController.text
           : null,
     );
+    final previous = GlobalOutboundProxy.current;
+    final changed = previous.type != settings.type ||
+        previous.address != settings.address ||
+        previous.username != settings.username ||
+        previous.password != settings.password;
     await GlobalOutboundProxy.update(settings);
     setState(() {
       _outboundProxy = settings;
     });
-    if (mounted) {
+    // Force every loaded webview to be rebuilt so the new global proxy
+    // takes effect immediately. Without this the change only applies to
+    // sites loaded after the next app restart — webview navigation keeps
+    // routing through the stale proxy bound at construction time.
+    // Skip the reset on no-op edits (e.g. focus leaves a field that was
+    // never modified) so we don't churn webviews while the user is
+    // tabbing through.
+    if (changed) {
+      widget.onOutboundProxyChanged?.call();
+    }
+    if (mounted && changed) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Outbound proxy updated')),
       );

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -10,6 +10,7 @@ import 'package:webspace/services/webview.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/services/localcdn_service.dart';
+import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/timezone_location_service.dart';
 import 'package:webspace/screens/location_picker.dart';
 import 'package:webspace/screens/user_scripts.dart';
@@ -310,6 +311,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
         }
 
         widget.webViewModel.proxySettings = _proxySettings;
+        LogService.instance.log(
+          'Proxy',
+          'Saving per-site proxy for siteId=${widget.webViewModel.siteId}: '
+              '${_proxySettings.describeForLogs()}',
+          level: LogLevel.info,
+        );
 
         // Apply proxy settings immediately
         await widget.webViewModel.updateProxySettings(_proxySettings);
@@ -321,12 +328,22 @@ class _SettingsScreenState extends State<SettingsScreen> {
         // `WKWebsiteDataStore.proxyConfigurations`, so per-site values
         // are independent and the sync would clobber them. See PROXY-008.
         if (Platform.isAndroid) {
+          LogService.instance.log(
+            'Proxy',
+            'Android: mirroring per-site proxy across all loaded models '
+                '(ProxyController is process-wide)',
+          );
           widget.onProxySettingsChanged?.call(_proxySettings);
         }
       } else {
         // Force DEFAULT proxy on unsupported platforms
         final defaultProxy = UserProxySettings(type: ProxyType.DEFAULT);
         widget.webViewModel.proxySettings = defaultProxy;
+        LogService.instance.log(
+          'Proxy',
+          'Per-site proxy unsupported on this platform; forcing DEFAULT for '
+              'siteId=${widget.webViewModel.siteId}',
+        );
         await widget.webViewModel.updateProxySettings(defaultProxy);
       }
 

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -226,7 +226,11 @@ class ProxyManager {
   ProxyManager._internal();
 
   Future<void> setProxySettings(UserProxySettings settings) async {
-    if (!PlatformInfo.isProxySupported) return;
+    if (!PlatformInfo.isProxySupported) {
+      LogService.instance.log('Proxy',
+          'setProxySettings: platform does not support proxy override; no-op');
+      return;
+    }
 
     // iOS / macOS: proxy travels through the fork's
     // `inapp.InAppWebViewSettings.proxySettings` field at WebView
@@ -234,7 +238,11 @@ class ProxyManager {
     // `inapp.ProxyController` is Android-only. Runtime updates of the
     // per-site proxy require the WebView to be rebuilt by the caller (see
     // [WebViewModel.updateProxySettings]).
-    if (Platform.isIOS || Platform.isMacOS) return;
+    if (Platform.isIOS || Platform.isMacOS) {
+      LogService.instance.log('Proxy',
+          'setProxySettings: iOS/macOS bind proxy at WebView construction; no-op here');
+      return;
+    }
 
     final controller = inapp.ProxyController.instance();
 
@@ -243,24 +251,49 @@ class ProxyManager {
     // honoring the same proxy precedence: explicit per-site override wins,
     // otherwise the global applies, otherwise system/direct.
     final effective = resolveEffectiveProxy(settings);
+    final fellThrough = settings.type == ProxyType.DEFAULT &&
+        effective.type != ProxyType.DEFAULT;
 
     if (effective.type == ProxyType.DEFAULT) {
+      LogService.instance.log(
+        'Proxy',
+        'Clearing proxy override (per-site=DEFAULT, no global proxy set)',
+        level: LogLevel.info,
+      );
       await controller.clearProxyOverride();
       return;
     }
 
     if (effective.address == null || effective.address!.isEmpty) {
+      LogService.instance.log(
+        'Proxy',
+        'Effective proxy missing address; aborting setProxyOverride. '
+            'Effective: ${effective.describeForLogs()}',
+        level: LogLevel.error,
+      );
       throw Exception('Proxy address is required');
     }
 
     final parts = effective.address!.split(':');
     if (parts.length != 2) {
+      LogService.instance.log(
+        'Proxy',
+        'Effective proxy address malformed (expected host:port). '
+            'Effective: ${effective.describeForLogs()}',
+        level: LogLevel.error,
+      );
       throw Exception('Proxy address must be in format host:port');
     }
 
     final host = parts[0];
     final port = int.tryParse(parts[1]);
     if (port == null) {
+      LogService.instance.log(
+        'Proxy',
+        'Effective proxy port is not numeric. '
+            'Effective: ${effective.describeForLogs()}',
+        level: LogLevel.error,
+      );
       throw Exception('Invalid port number');
     }
 
@@ -274,6 +307,13 @@ class ProxyManager {
         ? '$scheme://${Uri.encodeComponent(effective.username!)}:${Uri.encodeComponent(effective.password!)}@$host:$port'
         : '$scheme://$host:$port';
 
+    LogService.instance.log(
+      'Proxy',
+      'Applying Android proxy override (scheme=$scheme'
+          '${fellThrough ? ', via DEFAULT->global fallthrough' : ''}, '
+          'effective: ${effective.describeForLogs()})',
+      level: LogLevel.info,
+    );
     await controller.setProxyOverride(
       settings: inapp.ProxySettings(
         proxyRules: [inapp.ProxyRule(url: proxyUrl)],

--- a/lib/settings/global_outbound_proxy.dart
+++ b/lib/settings/global_outbound_proxy.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/proxy_password_secure_storage.dart';
 import 'package:webspace/settings/proxy.dart';
 
@@ -66,6 +67,11 @@ class GlobalOutboundProxy {
     if (pwd != null && pwd.isNotEmpty) {
       _current.password = pwd;
     }
+    LogService.instance.log(
+      'Proxy',
+      'GlobalOutboundProxy initialized: ${_current.describeForLogs()}',
+      level: LogLevel.info,
+    );
   }
 
   /// Update both the in-memory cache and the persisted value.
@@ -76,6 +82,11 @@ class GlobalOutboundProxy {
     await _passwordStore.savePassword(
       ProxyPasswordSecureStorage.globalProxyKey,
       settings.password,
+    );
+    LogService.instance.log(
+      'Proxy',
+      'GlobalOutboundProxy updated: ${settings.describeForLogs()}',
+      level: LogLevel.info,
     );
   }
 

--- a/lib/settings/proxy.dart
+++ b/lib/settings/proxy.dart
@@ -30,6 +30,25 @@ class UserProxySettings {
         password: json['password'],
       );
 
+  /// Deep-copy preserving credentials. Use this — not a hand-built
+  /// `UserProxySettings(type: x, address: y)` — when mirroring a per-site
+  /// proxy across other models. Android's `inapp.ProxyController` is a
+  /// process-wide singleton (PROXY-008): when the user saves a per-site
+  /// proxy, every loaded WebView ends up using it, so the data model has
+  /// to be sync'd to match. Credentials are part of "what's actually
+  /// applied" — dropping them here re-triggers 407 Proxy Authentication
+  /// Required on every navigation and, worse, makes
+  /// `_saveWebViewModels` mirror an empty password into the
+  /// `flutter_secure_storage` entry keyed by `siteId`, silently clearing
+  /// the password the user just typed. See
+  /// `openspec/specs/proxy-password-secure-storage/spec.md`.
+  UserProxySettings copy() => UserProxySettings(
+        type: type,
+        address: address,
+        username: username,
+        password: password,
+      );
+
   /// Returns true if credentials are provided
   bool get hasCredentials => username != null && username!.isNotEmpty && password != null && password!.isNotEmpty;
 }

--- a/lib/settings/proxy.dart
+++ b/lib/settings/proxy.dart
@@ -49,6 +49,18 @@ class UserProxySettings {
         password: password,
       );
 
+  /// PII-safe one-line summary suitable for [LogService] output that the
+  /// user may share publicly when debugging proxy issues. Type and address
+  /// are emitted verbatim (the address is `host:port`, not a secret), but
+  /// username and password are reported as booleans only — they may
+  /// identify the user or unlock the proxy and must never appear in logs.
+  String describeForLogs() {
+    final t = type.toString().split('.').last;
+    final a = address ?? '<none>';
+    return 'type=$t address=$a hasUsername=${username != null && username!.isNotEmpty} '
+        'hasPassword=${password != null && password!.isNotEmpty}';
+  }
+
   /// Returns true if credentials are provided
   bool get hasCredentials => username != null && username!.isNotEmpty && password != null && password!.isNotEmpty;
 }

--- a/test/proxy_test.dart
+++ b/test/proxy_test.dart
@@ -524,6 +524,49 @@ void main() {
       expect(viewModel.proxySettings.hasCredentials, true);
     });
 
+    test('copy() preserves credentials when mirroring across models', () {
+      // Regression test: the Android `onProxySettingsChanged` callback in
+      // _WebSpacePageState mirrors the just-saved per-site proxy across
+      // every loaded WebViewModel because `inapp.ProxyController` is
+      // process-wide (PROXY-008). Hand-rolling a fresh
+      // `UserProxySettings(type: x, address: y)` for the mirror silently
+      // dropped username/password, which (a) re-triggered 407 Proxy
+      // Authentication Required on the next navigation and (b) caused
+      // `_saveWebViewModels` to mirror an empty password into
+      // flutter_secure_storage, silently clearing the password the user
+      // just typed. `copy()` is the correct mirror constructor — assert
+      // that.
+      final source = UserProxySettings(
+        type: ProxyType.HTTP,
+        address: 'proxy.example.com:8080',
+        username: 'alice',
+        password: 's3cr3t',
+      );
+
+      final mirrored = source.copy();
+
+      expect(mirrored.type, ProxyType.HTTP);
+      expect(mirrored.address, 'proxy.example.com:8080');
+      expect(mirrored.username, 'alice');
+      expect(mirrored.password, 's3cr3t');
+      expect(mirrored.hasCredentials, true);
+
+      // Independent instance: mutating the copy must not affect the source.
+      mirrored.password = 'rotated';
+      expect(source.password, 's3cr3t');
+    });
+
+    test('copy() preserves null credentials for DEFAULT proxy', () {
+      final source = UserProxySettings(type: ProxyType.DEFAULT);
+      final mirrored = source.copy();
+
+      expect(mirrored.type, ProxyType.DEFAULT);
+      expect(mirrored.address, null);
+      expect(mirrored.username, null);
+      expect(mirrored.password, null);
+      expect(mirrored.hasCredentials, false);
+    });
+
     test('Proxy with special characters in credentials', () {
       final proxy = UserProxySettings(
         type: ProxyType.HTTP,

--- a/test/proxy_test.dart
+++ b/test/proxy_test.dart
@@ -567,6 +567,36 @@ void main() {
       expect(mirrored.hasCredentials, false);
     });
 
+    test('describeForLogs() never leaks username or password', () {
+      // Logs are surfaced via the Dev Tools "App Logs" screen and may be
+      // shared with maintainers (e.g. in a bug report) when proxy
+      // configuration misbehaves. The redacted summary MUST emit type and
+      // address verbatim (the user needs to see whether the right host
+      // and port reached the native layer) but never the username or
+      // password — the secret is the secret regardless of who set it.
+      final proxy = UserProxySettings(
+        type: ProxyType.SOCKS5,
+        address: '127.0.0.1:1080',
+        username: 'topsecretuser',
+        password: 'p@ssw0rd!',
+      );
+
+      final described = proxy.describeForLogs();
+
+      expect(described, contains('SOCKS5'));
+      expect(described, contains('127.0.0.1:1080'));
+      expect(described, contains('hasUsername=true'));
+      expect(described, contains('hasPassword=true'));
+      expect(described, isNot(contains('topsecretuser')));
+      expect(described, isNot(contains('p@ssw0rd!')));
+    });
+
+    test('describeForLogs() reports missing credentials as false', () {
+      final proxy = UserProxySettings(type: ProxyType.DEFAULT);
+      expect(proxy.describeForLogs(), contains('hasUsername=false'));
+      expect(proxy.describeForLogs(), contains('hasPassword=false'));
+    });
+
     test('Proxy with special characters in credentials', () {
       final proxy = UserProxySettings(
         type: ProxyType.HTTP,


### PR DESCRIPTION
Two bugs broke proxy configuration end-to-end:

1. Per-site proxy (Android): saving credentials silently cleared them.
   `onProxySettingsChanged` mirrors the just-saved proxy across every
   `WebViewModel` because `inapp.ProxyController` is process-wide
   (PROXY-008), but the mirror used
   `UserProxySettings(type: x, address: y)` and dropped username/password.
   That (a) re-triggered 407 Proxy Authentication Required on every
   navigation — pages "wouldn't load" — and (b) made `_saveWebViewModels`
   mirror an empty password into the secure-storage entry keyed by
   `siteId`, so the auth checkbox was unchecked when settings were
   reopened. Replaced with `UserProxySettings.copy()`, a new helper that
   preserves all four fields, plus a regression test.

2. Global outbound proxy: changing it via App Settings did nothing
   visible. The proxy is bound at WebView construction (iOS / macOS /
   Linux) or only refreshed when `setProxySettings` is called again
   (Android), neither of which `_saveOutboundProxy` was triggering.
   Added an `onOutboundProxyChanged` callback wired to
   `_resetAllWebViews` so the next render re-applies the new proxy via
   `WebViewModel.setController`. Guarded by a change-detect to avoid
   churning webviews when the user just tabs through unmodified fields.