### PR TITLE
Fix file-import URLs producing ERR_INVALID_URL when cache is missing

### DIFF
--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -414,8 +414,12 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
       final fileName = file.name;
       final nameWithoutExt = fileName.replaceAll(RegExp(r'\.(html?|htm)$', caseSensitive: false), '');
 
+      // Three slashes (empty authority) — `file://name.html` would parse
+      // with `name.html` as the host and chromium then rejects it as
+      // ERR_INVALID_URL whenever the cached HTML is unavailable
+      // (incognito, post-upgrade cache wipe, etc).
       Navigator.pop(context, {
-        'url': 'file://$fileName',
+        'url': 'file:///$fileName',
         'name': nameWithoutExt,
         'incognito': _incognito,
         'htmlContent': htmlContent,

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1041,6 +1041,60 @@ String _languageOverrideScript(String language) {
 ''';
 }
 
+/// HTML rendered when a file-import site has no cached HTML available
+/// (incognito session, post-upgrade cache wipe, …). Loaded via
+/// `InAppWebViewInitialData` so chromium never tries to fetch the synthetic
+/// `file:///<filename>` URL — that would surface as `ERR_INVALID_URL` /
+/// `ERR_FILE_NOT_FOUND` since no real file exists on disk for the import.
+String buildFileImportFallbackHtml(String initialUrl) {
+  // initialUrl is `file:///filename.html` for new imports and
+  // `file://filename.html` (or `file://filename.html/`) for legacy data
+  // that hasn't been migrated yet. Strip the scheme + leading slashes
+  // for display.
+  final stripped = initialUrl.replaceFirst(RegExp(r'^file:/+'), '');
+  final fileName = stripped.endsWith('/')
+      ? stripped.substring(0, stripped.length - 1)
+      : stripped;
+  final escapedName = htmlEscape.convert(fileName);
+  return '''
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Imported file unavailable</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    max-width: 32em;
+    margin: 3em auto;
+    padding: 0 1em;
+    line-height: 1.5;
+  }
+  h1 { font-size: 1.4em; }
+  code {
+    background: rgba(127,127,127,0.18);
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+  }
+  p { color: rgba(0,0,0,0.78); }
+  @media (prefers-color-scheme: dark) {
+    p { color: rgba(255,255,255,0.78); }
+  }
+</style>
+</head>
+<body>
+<h1>Imported file unavailable</h1>
+<p>The contents of <code>$escapedName</code> were imported as a local file
+and aren't cached on this device any more (incognito sessions don't
+persist, and the cache is cleared on app upgrade).</p>
+<p>Re-import the file from the "Add new site" screen to view it again.</p>
+</body>
+</html>
+''';
+}
+
 
 /// Factory for creating webviews
 class WebViewFactory {
@@ -1200,6 +1254,13 @@ class WebViewFactory {
     // Production users get the speed-up of cached first paint without
     // the dev-only crash.
     final isFileImport = config.initialUrl.startsWith('file://');
+    // When the cache is missing for a file import (incognito mode,
+    // post-upgrade cache wipe, …) we feed initialData with a synthetic
+    // "content unavailable" page rather than letting chromium attempt
+    // to load the synthetic file:// URL — there's no actual file on
+    // disk, so the load would surface as ERR_INVALID_URL or
+    // ERR_FILE_NOT_FOUND in the user's face.
+    final renderInitialData = config.initialHtml != null || isFileImport;
     final usesCachedHtml = config.initialHtml != null;
     // One-shot: when the cached HTML's first onLoadStop fires, do
     // exactly one controller.reload() to get a live page. Subsequent
@@ -1731,12 +1792,12 @@ class WebViewFactory {
 
     return inapp.InAppWebView(
       key: config.key,
-      initialUrlRequest: usesCachedHtml ? null : inapp.URLRequest(
+      initialUrlRequest: renderInitialData ? null : inapp.URLRequest(
         url: inapp.WebUri(config.initialUrl),
         headers: headers.isNotEmpty ? headers : null,
       ),
-      initialData: usesCachedHtml ? inapp.InAppWebViewInitialData(
-        data: config.initialHtml!,
+      initialData: renderInitialData ? inapp.InAppWebViewInitialData(
+        data: config.initialHtml ?? buildFileImportFallbackHtml(config.initialUrl),
         mimeType: 'text/html',
         encoding: 'utf-8',
         baseUrl: inapp.WebUri(config.initialUrl),

--- a/lib/utils/url_utils.dart
+++ b/lib/utils/url_utils.dart
@@ -25,3 +25,19 @@ final RegExp _authorityLessSchemeRegex =
 String ensureUrlScheme(String url) {
   return hasUrlScheme(url) ? url : 'https://$url';
 }
+
+/// Migrates legacy file-import URLs from `file://filename.html` to
+/// `file:///filename.html`. The two-slash form parses with `filename.html`
+/// as the URL host and an empty path, which chromium rejects with
+/// ERR_INVALID_URL on any direct load (incognito, post-upgrade cache wipe).
+/// The three-slash form has an empty authority and a real path, so it
+/// round-trips through Uri parsing without surprises.
+///
+/// Idempotent: a URL that already starts with `file:///` (or any non-file
+/// scheme) is returned unchanged.
+String migrateLegacyFileImportUrl(String url) {
+  if (!url.startsWith('file://') || url.startsWith('file:///')) {
+    return url;
+  }
+  return 'file:///${url.substring('file://'.length)}';
+}

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -15,6 +15,7 @@ import 'package:webspace/services/webview.dart';
 import 'package:webspace/settings/location.dart';
 import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/settings/user_script.dart';
+import 'package:webspace/utils/url_utils.dart';
 
 export 'package:webspace/settings/location.dart' show LocationMode, WebRtcPolicy;
 
@@ -1061,8 +1062,10 @@ class WebViewModel {
   factory WebViewModel.fromJson(Map<String, dynamic> json, Function? stateSetterF) {
     return WebViewModel(
       siteId: json['siteId'], // May be null for legacy data, will auto-generate
-      initUrl: json['initUrl'],
-      currentUrl: json['currentUrl'],
+      initUrl: migrateLegacyFileImportUrl(json['initUrl'] as String),
+      currentUrl: json['currentUrl'] == null
+          ? null
+          : migrateLegacyFileImportUrl(json['currentUrl'] as String),
       name: json['name'],
       cookies: (json['cookies'] as List<dynamic>)
           .map((dynamic e) => cookieFromJson(e))

--- a/openspec/specs/file-import-sites/spec.md
+++ b/openspec/specs/file-import-sites/spec.md
@@ -53,11 +53,18 @@ The imported HTML file SHALL be added as a new site.
 **When** the site is created
 **Then** the site name is `my-page` (filename without extension)
 
-#### Scenario: Site URL uses file:// scheme
+#### Scenario: Site URL uses file:/// scheme (three slashes)
 
 **Given** the user selects a file named `report.html`
 **When** the site is created
-**Then** the site's initUrl is `file://report.html`
+**Then** the site's initUrl is `file:///report.html`
+
+The three-slash form (empty authority) is required: the two-slash form
+`file://report.html` parses with `report.html` as the URL host and an
+empty path, which chromium rejects with `ERR_INVALID_URL` on any direct
+load (incognito mode, post-upgrade cache wipe, manual reload). Sites
+persisted before this fix are migrated on load via
+`migrateLegacyFileImportUrl` in [lib/utils/url_utils.dart](../../../lib/utils/url_utils.dart).
 
 #### Scenario: HTML content stored via HtmlCacheService
 
@@ -71,7 +78,10 @@ The imported HTML file SHALL be added as a new site.
 **Given** the user has incognito mode enabled
 **When** an HTML file is imported
 **Then** the HTML content is NOT persisted to HtmlCacheService
-**And** the webview still loads the content (via file:// URL or initialData)
+**And** the webview renders the "imported file unavailable" fallback
+(via `buildFileImportFallbackHtml`) instead of attempting to load the
+synthetic `file:///<filename>` URL — there's no real file on disk for
+the import, so a direct load would surface as `ERR_FILE_NOT_FOUND`.
 
 #### Scenario: No page title fetch
 
@@ -102,7 +112,8 @@ The imported HTML content SHALL render correctly in the webview.
 ## Data Model
 
 No new data models. Imported HTML sites use the existing `WebViewModel` with:
-- `initUrl`: `file://<filename>` (e.g., `file://page.html`)
+- `initUrl`: `file:///<filename>` (e.g., `file:///page.html`) — three
+  slashes; see IMPORT-003 above for why
 - `name`: Filename without extension
 - HTML content stored in `HtmlCacheService` keyed by `siteId`
 
@@ -113,6 +124,9 @@ No new data models. Imported HTML sites use the existing `WebViewModel` with:
 ### Modified
 - `lib/screens/add_site.dart` - Added `_importHtmlFile()` method and "Import HTML file" button
 - `lib/main.dart` - Updated `_addSite()` to handle `htmlContent` in result, save to `HtmlCacheService`
+- `lib/utils/url_utils.dart` - Added `migrateLegacyFileImportUrl` for legacy two-slash imports
+- `lib/web_view_model.dart` - Applies migration in `WebViewModel.fromJson` for `initUrl`/`currentUrl`
+- `lib/services/webview.dart` - Renders `buildFileImportFallbackHtml` when cache is missing for a file import
 
 ---
 

--- a/test/file_import_sites_test.dart
+++ b/test/file_import_sites_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/webview.dart';
 
 /// Tests for the file-import-sites feature.
 ///
@@ -46,13 +47,13 @@ void main() {
     test('file import result contains required keys', () {
       // Simulates the Map returned by _importHtmlFile
       final result = <String, dynamic>{
-        'url': 'file://test.html',
+        'url': 'file:///test.html',
         'name': 'test',
         'incognito': false,
         'htmlContent': '<html><body>Hello</body></html>',
       };
 
-      expect(result['url'], startsWith('file://'));
+      expect(result['url'], startsWith('file:///'));
       expect(result['name'], isNotEmpty);
       expect(result['htmlContent'], isA<String>());
       expect((result['htmlContent'] as String).isNotEmpty, isTrue);
@@ -60,7 +61,7 @@ void main() {
 
     test('file import result with incognito mode', () {
       final result = <String, dynamic>{
-        'url': 'file://test.html',
+        'url': 'file:///test.html',
         'name': 'test',
         'incognito': true,
         'htmlContent': '<html><body>Hello</body></html>',
@@ -80,25 +81,67 @@ void main() {
       expect(result['htmlContent'], isNull);
     });
 
-    test('url for imported file uses file:// scheme', () {
+    test('url for imported file uses file:/// scheme (three slashes)', () {
       final fileName = 'report.html';
-      final url = 'file://$fileName';
+      final url = 'file:///$fileName';
 
-      expect(url, 'file://report.html');
-      expect(Uri.tryParse(url)?.scheme, 'file');
+      // Three-slash form: empty authority, real path. The two-slash
+      // form `file://report.html` parses with `report.html` as the
+      // host and chromium rejects it with ERR_INVALID_URL whenever the
+      // cached HTML is unavailable (incognito, post-upgrade wipe).
+      expect(url, 'file:///report.html');
+      final parsed = Uri.tryParse(url);
+      expect(parsed?.scheme, 'file');
+      expect(parsed?.host, isEmpty);
+      expect(parsed?.path, '/report.html');
+    });
+  });
+
+  group('Fallback HTML when cache is missing', () {
+    test('renders the filename without the file:// scheme prefix', () {
+      final html = buildFileImportFallbackHtml('file:///notifs.html');
+
+      expect(html, contains('<code>notifs.html</code>'));
+      expect(html, contains('Imported file unavailable'));
+      // Don't leak the synthetic URL scheme into user-visible copy.
+      expect(html, isNot(contains('file:///notifs.html')));
+    });
+
+    test('handles legacy two-slash URLs that survived migration', () {
+      // Defensive: even if a model snuck through without migrating, the
+      // fallback shouldn't render `//notifs.html` to the user.
+      final html = buildFileImportFallbackHtml('file://notifs.html');
+
+      expect(html, contains('<code>notifs.html</code>'));
+    });
+
+    test('handles chromium-normalised URLs with trailing slash', () {
+      final html = buildFileImportFallbackHtml('file://notifs.html/');
+
+      expect(html, contains('<code>notifs.html</code>'));
+    });
+
+    test('escapes HTML metacharacters in the filename', () {
+      // FilePicker doesn't normally allow these, but be defensive — a
+      // crafted filename from a sandbox bypass shouldn't inject markup
+      // into the fallback page.
+      final html = buildFileImportFallbackHtml('file:///<script>.html');
+
+      expect(html, isNot(contains('<script>.html')));
+      expect(html, contains('&lt;script&gt;.html'));
     });
   });
 
   group('URL type detection', () {
     test('file:// URLs are distinguishable from http(s)', () {
-      expect('file://page.html'.startsWith('file://'), isTrue);
+      expect('file:///page.html'.startsWith('file://'), isTrue);
       expect('https://example.com'.startsWith('file://'), isFalse);
       expect('http://example.com'.startsWith('file://'), isFalse);
     });
 
     test('htmlContent presence indicates file import', () {
       final fileResult = <String, dynamic>{
-        'url': 'file://page.html',
+        'url': 'file:///page.html',
         'name': 'page',
         'incognito': false,
         'htmlContent': '<html></html>',

--- a/test/url_utils_test.dart
+++ b/test/url_utils_test.dart
@@ -46,4 +46,37 @@ void main() {
       expect(ensureUrlScheme('https://example.com'), 'https://example.com');
     });
   });
+
+  group('migrateLegacyFileImportUrl', () {
+    test('rewrites legacy two-slash file:// URLs to three-slash form', () {
+      // Legacy `file://name.html` parses with `name.html` as the host;
+      // chromium rejects it with ERR_INVALID_URL on direct load.
+      expect(migrateLegacyFileImportUrl('file://notifs.html'),
+          'file:///notifs.html');
+      expect(migrateLegacyFileImportUrl('file://report.html'),
+          'file:///report.html');
+    });
+
+    test('preserves trailing slash that chromium adds when normalising', () {
+      // `currentUrl` saved off chromium's onUrlChanged for a legacy
+      // import is `file://name.html/` — host=name.html, path=/.
+      expect(migrateLegacyFileImportUrl('file://notifs.html/'),
+          'file:///notifs.html/');
+    });
+
+    test('leaves already-canonical file:/// URLs alone (idempotent)', () {
+      expect(migrateLegacyFileImportUrl('file:///tmp/x.html'),
+          'file:///tmp/x.html');
+      expect(migrateLegacyFileImportUrl('file:///notifs.html'),
+          'file:///notifs.html');
+    });
+
+    test('leaves non-file URLs alone', () {
+      expect(migrateLegacyFileImportUrl('https://example.com'),
+          'https://example.com');
+      expect(migrateLegacyFileImportUrl('about:blank'), 'about:blank');
+      expect(migrateLegacyFileImportUrl('chrome://flags'), 'chrome://flags');
+      expect(migrateLegacyFileImportUrl(''), '');
+    });
+  });
 }


### PR DESCRIPTION
`file://notifs.html` parses with `notifs.html` as the URL host and an empty path, which chromium rejects as `ERR_INVALID_URL` whenever the synthetic file URL is loaded directly — incognito file imports never populate the HTML cache, and the cache is wiped on every app upgrade, so users hit this any time the cache isn't warm.

Three changes:

  - emit `file:///<filename>` (three slashes, empty authority) for new imports in add_site.dart so the URL round-trips through the parser without becoming an invalid host
  - `migrateLegacyFileImportUrl` in url_utils.dart rewrites legacy `file://name.html` to `file:///name.html` on load via WebViewModel.fromJson, covering both initUrl and currentUrl
  - `buildFileImportFallbackHtml` in webview.dart renders an "imported file unavailable" page via initialData when a file import has no cached HTML, so chromium never tries to fetch the synthetic URL and the user gets an explanation instead of an opaque ERR_INVALID_URL / ERR_FILE_NOT_FOUND error page

Spec and tests updated to match. Tests cover the migration's idempotency, the trailing-slash form chromium produces from onUrlChanged, and HTML-escaping in the fallback wording.