### PR TITLE
Move imported HTML out of cache into a persistent store

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ import 'package:webspace/widgets/url_bar.dart';
 import 'package:webspace/demo_data.dart' show seedDemoData, isDemoMode;
 import 'package:webspace/services/image_cache_service.dart';
 import 'package:webspace/services/html_cache_service.dart';
+import 'package:webspace/services/html_import_storage.dart';
 import 'package:webspace/services/settings_backup.dart';
 import 'package:webspace/services/cookie_isolation.dart';
 import 'package:webspace/services/cookie_secure_storage.dart';
@@ -435,14 +436,71 @@ Future<String?> getPageTitle(String url) async {
   return null;
 }
 
+/// One-shot migration: copy file-import HTML out of [HtmlCacheService]
+/// into [HtmlImportStorage] before the cache wipes itself on app
+/// upgrade. Called from [HtmlCacheService.initialize] via the
+/// `beforeUpgradeWipe` hook — at that point the cache's encryption is
+/// initialized with the still-current key so [loadHtml] can decrypt.
+///
+/// On a fresh install the WebViewModels list is absent and this is a
+/// no-op. On every subsequent upgrade once imports stop landing in the
+/// cache (this version onward), the lookup finds nothing and returns
+/// silently — keeping the call wired keeps the path safe against
+/// future regressions without behavioral cost.
+Future<void> _migrateFileImportsToStorage() async {
+  try {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getStringList('webViewModels');
+    if (raw == null || raw.isEmpty) return;
+
+    var migrated = 0;
+    for (final entry in raw) {
+      try {
+        final m = jsonDecode(entry) as Map<String, dynamic>;
+        final initUrl = m['initUrl'] as String? ?? '';
+        if (!initUrl.startsWith('file://')) continue;
+        final siteId = m['siteId'] as String?;
+        if (siteId == null || siteId.isEmpty) continue;
+
+        if (await HtmlImportStorage.instance.hasImport(siteId)) continue;
+        final cached = await HtmlCacheService.instance.loadHtml(siteId);
+        if (cached == null) continue;
+        await HtmlImportStorage.instance.saveHtml(siteId, cached.$2, cached.$1);
+        migrated++;
+      } catch (_) {
+        // Skip malformed entries — the cache wipe is happening either way.
+      }
+    }
+    if (migrated > 0) {
+      LogService.instance.log('HtmlImport',
+          'Migrated $migrated file-import page(s) from cache to import storage',
+          level: LogLevel.info);
+    }
+  } catch (e) {
+    LogService.instance.log('HtmlImport',
+        'File-import migration failed: $e',
+        level: LogLevel.error);
+  }
+}
+
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   // Clear image cache on app upgrade
   await ImageCacheService.clearCacheOnUpgrade();
 
-  // Initialize HTML cache (clears on app upgrade)
-  await HtmlCacheService.instance.initialize();
+  // Imported HTML files are the only copy of user-supplied content,
+  // so they live in their own persistent store and survive upgrades.
+  // Cached fetched-page snapshots stay in HtmlCacheService (re-fetchable,
+  // safe to drop on upgrade).
+  await HtmlImportStorage.instance.initialize();
+
+  // Initialize HTML cache (clears on app upgrade). The pre-wipe hook
+  // copies imports left in the legacy cache (from versions before the
+  // import store existed) into HtmlImportStorage before they're nuked.
+  await HtmlCacheService.instance.initialize(
+    beforeUpgradeWipe: _migrateFileImportsToStorage,
+  );
 
   // Initialize favicon URL cache
   await FaviconUrlCache.initialize();
@@ -566,6 +624,8 @@ void main() async {
   // `InAppWebViewInitialData` requires — chromium needs the bytes
   // before navigation starts, not after an awaited disk read.
   await HtmlCacheService.instance.preloadCache();
+  // Same reasoning as the line above, for imported HTML.
+  await HtmlImportStorage.instance.preloadAll();
 
   // Load the global outbound proxy from SharedPreferences. Synchronous
   // callers (flutter_map TileProvider, per-site DEFAULT fallthrough) read
@@ -1667,6 +1727,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await _cookieSecureStorage.removeOrphanedCookies(activeSiteIdsAtStartup);
     await _proxyPasswordStorage.removeOrphaned(activeSiteIdsAtStartup);
     await HtmlCacheService.instance.removeOrphanedCaches(activeSiteIdsAtStartup);
+    await HtmlImportStorage.instance.removeOrphanedImports(activeSiteIdsAtStartup);
     await _stateStorage.removeOrphans(activeSiteIdsAtStartup);
     await _cookieManager.deleteAllCookies();
     // Sweep containers whose owning site no longer exists. No-op when
@@ -2197,6 +2258,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await _cookieSecureStorage.removeOrphanedCookies(activeSiteIds);
     await _proxyPasswordStorage.removeOrphaned(activeSiteIds);
     await HtmlCacheService.instance.removeOrphanedCaches(activeSiteIds);
+    await HtmlImportStorage.instance.removeOrphanedImports(activeSiteIds);
 
     // Apply theme to all webviews
     final webViewTheme = _themeModeToWebViewTheme(_themeSettings.themeMode);
@@ -3164,10 +3226,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       model.pageTitle = pageTitle;
     }
 
-    // For imported HTML files, store the content in HtmlCacheService
-    // so the webview loads it via initialHtml on creation
+    // Imported HTML files are the only copy of the user's data, so they
+    // go into HtmlImportStorage (persistent) rather than HtmlCacheService
+    // (cleared on app upgrade). The webview reads from the import store
+    // for `initialHtml` on creation.
     if (htmlContent != null && !incognito) {
-      await HtmlCacheService.instance.saveHtml(model.siteId, htmlContent, url);
+      await HtmlImportStorage.instance.saveHtml(model.siteId, htmlContent, url);
     }
 
     setState(() {
@@ -3406,6 +3470,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       );
     }
     await HtmlCacheService.instance.deleteCache(deletedModel.siteId);
+    await HtmlImportStorage.instance.deleteImport(deletedModel.siteId);
     if (!mounted) return;
     final currentModelIndex = _webViewModels.indexOf(deletedModel);
     if (currentModelIndex == -1) return;
@@ -3443,6 +3508,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await _cookieSecureStorage.removeOrphanedCookies(activeSiteIds);
     await _proxyPasswordStorage.removeOrphaned(activeSiteIds);
     await HtmlCacheService.instance.removeOrphanedCaches(activeSiteIds);
+    await HtmlImportStorage.instance.removeOrphanedImports(activeSiteIds);
     await _stateStorage.removeOrphans(activeSiteIds);
 
     if (!mounted) return;
@@ -3836,23 +3902,31 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                                   onWindowRequested: _showPopupWindow,
                                   language: webViewModel.language,
                                   globalUserScripts: _globalUserScripts,
-                                  onHtmlLoaded: webViewModel.incognito ? null : (url, html) {
-                                    HtmlCacheService.instance.saveHtml(webViewModel.siteId, html, url);
-                                  },
+                                  // file:// imports are user data (only copy on device), not
+                                  // a re-fetchable snapshot — the canonical bytes live in
+                                  // HtmlImportStorage and never change after import, so
+                                  // skip the live-snapshot save path entirely.
+                                  onHtmlLoaded: (webViewModel.incognito || webViewModel.initUrl.startsWith('file://'))
+                                      ? null
+                                      : (url, html) {
+                                          HtmlCacheService.instance.saveHtml(webViewModel.siteId, html, url);
+                                        },
                                   // Skip the per-onLoadStop getHtml() IPC into chromium when
                                   // a save would be debounced anyway. Drops the storm of
                                   // renderer-DOM-serializations that fired on every SPA pseudo-
                                   // navigation (8+ Saved events per page on LinkedIn) — each one
                                   // a candidate for racing chromium's frame-lifecycle teardown.
-                                  shouldFetchHtml: webViewModel.incognito
+                                  shouldFetchHtml: (webViewModel.incognito || webViewModel.initUrl.startsWith('file://'))
                                       ? null
                                       : () => HtmlCacheService.instance.shouldSave(webViewModel.siteId),
                                   initialHtml: webViewModel.incognito
                                       ? null
                                       : () {
-                                          // Always feed cached HTML when we have it (and we're not
-                                          // incognito). The webview factory uses it for instant
-                                          // first paint via `InAppWebViewInitialData` and then
+                                          // file:// imports come from HtmlImportStorage (the only
+                                          // copy of user-supplied content); URL sites come from
+                                          // HtmlCacheService (re-fetchable snapshot). The webview
+                                          // factory uses initialHtml for instant first paint via
+                                          // `InAppWebViewInitialData` and then — for URL sites —
                                           // swaps to a fresh live load via `controller.reload()`
                                           // once the cached parse settles. file:// imports skip
                                           // the swap (no live to fetch); offline cold starts skip
@@ -3870,7 +3944,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                                           // cold-start UX cost for *every* online user to
                                           // protect *userdebug developers* from a chromium
                                           // self-test, which is the wrong trade.
-                                          final cached = HtmlCacheService.instance.getHtmlSync(webViewModel.siteId);
+                                          final cached = webViewModel.initUrl.startsWith('file://')
+                                              ? HtmlImportStorage.instance.getHtmlSync(webViewModel.siteId)
+                                              : HtmlCacheService.instance.getHtmlSync(webViewModel.siteId);
                                           if (cached == null) return null;
                                           final isDark = webViewModel.currentTheme == WebViewTheme.dark ||
                                               (webViewModel.currentTheme == WebViewTheme.system &&

--- a/lib/services/html_cache_service.dart
+++ b/lib/services/html_cache_service.dart
@@ -30,12 +30,23 @@ class HtmlCacheService {
   final _secureStorage = const FlutterSecureStorage();
 
   /// Initialize the cache service. Call on app startup.
-  Future<void> initialize() async {
+  ///
+  /// [beforeUpgradeWipe] runs once if an app-version upgrade is
+  /// detected, after the existing AES key has been loaded but before
+  /// any cache file is deleted and before the key is rotated. The
+  /// callee can read existing entries (encryption is live) and copy
+  /// data that should survive the wipe — used to migrate file-import
+  /// HTML into [HtmlImportStorage] before the cache is nuked.
+  Future<void> initialize({Future<void> Function()? beforeUpgradeWipe}) async {
     final appDir = await getApplicationDocumentsDirectory();
     _cacheDirectory = Directory('${appDir.path}/$_cacheDir');
 
     // Initialize encryption
     await _initEncryption();
+
+    if (beforeUpgradeWipe != null && await _isUpgradeDetected()) {
+      await beforeUpgradeWipe();
+    }
 
     // Clear cache on version upgrade
     await _clearCacheOnUpgrade();
@@ -51,6 +62,14 @@ class HtmlCacheService {
     // it. Done this way to keep the constructor cheap; preloadCache
     // is awaited up-front because [InAppWebViewInitialData] requires
     // synchronous access to the bytes.
+  }
+
+  Future<bool> _isUpgradeDetected() async {
+    final prefs = await SharedPreferences.getInstance();
+    final packageInfo = await PackageInfo.fromPlatform();
+    final currentVersion = '${packageInfo.version}+${packageInfo.buildNumber}';
+    final lastVersion = prefs.getString(_versionKey);
+    return lastVersion != null && lastVersion != currentVersion;
   }
 
   /// Decrypt every cache file on disk into [_memoryCache]. Called from

--- a/lib/services/html_import_storage.dart
+++ b/lib/services/html_import_storage.dart
@@ -1,0 +1,227 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+import 'package:path_provider/path_provider.dart';
+import 'package:webspace/services/log_service.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:encrypt/encrypt.dart' as encrypt;
+
+/// Persistent AES-encrypted storage for user-imported HTML files.
+///
+/// Distinct from [HtmlCacheService]: imports are the only copy of the
+/// data the user picked off their device, so wiping them on app
+/// upgrade would destroy content they explicitly imported. This store
+/// survives upgrades. Cached snapshots of fetched pages stay in
+/// [HtmlCacheService] (re-fetchable, safe to drop).
+class HtmlImportStorage {
+  static const String _storageDir = 'html_imports';
+  static const String _encryptionKeyKey = 'html_import_encryption_key';
+
+  static HtmlImportStorage? _instance;
+  static HtmlImportStorage get instance => _instance ??= HtmlImportStorage();
+
+  /// Tests construct an instance directly with overrides; the production
+  /// singleton uses the default-arg path.
+  HtmlImportStorage({
+    FlutterSecureStorage? secureStorage,
+    Directory? overrideAppDir,
+  })  : _secureStorage = secureStorage ?? const FlutterSecureStorage(),
+        _overrideAppDir = overrideAppDir;
+
+  final FlutterSecureStorage _secureStorage;
+  final Directory? _overrideAppDir;
+
+  Directory? _storageDirectory;
+  encrypt.Encrypter? _encrypter;
+  encrypt.IV? _iv;
+
+  /// In-memory mirror used by [getHtmlSync] so [InAppWebViewInitialData]
+  /// can be constructed without an awaited disk read at build time.
+  final Map<String, String> _memoryStore = {};
+
+  Future<void> initialize() async {
+    final appDir = _overrideAppDir ?? await getApplicationDocumentsDirectory();
+    _storageDirectory = Directory('${appDir.path}/$_storageDir');
+
+    await _initEncryption();
+
+    if (!await _storageDirectory!.exists()) {
+      await _storageDirectory!.create(recursive: true);
+    }
+  }
+
+  /// Decrypt every file on disk into [_memoryStore]. Mirrors
+  /// [HtmlCacheService.preloadCache] so `getHtmlSync(siteId)` is
+  /// answerable synchronously during `WebSpacePage.build`.
+  Future<void> preloadAll() => _preloadAll();
+
+  Future<void> _initEncryption() async {
+    try {
+      String? keyBase64 = await _secureStorage.read(key: _encryptionKeyKey);
+
+      if (keyBase64 == null) {
+        final key = encrypt.Key.fromSecureRandom(32);
+        keyBase64 = base64.encode(key.bytes);
+        await _secureStorage.write(key: _encryptionKeyKey, value: keyBase64);
+        LogService.instance.log('HtmlImport', 'Generated new encryption key', level: LogLevel.info);
+      }
+
+      final keyBytes = base64.decode(keyBase64);
+      final key = encrypt.Key(Uint8List.fromList(keyBytes));
+      _iv = encrypt.IV(Uint8List.fromList(keyBytes.sublist(0, 16)));
+      _encrypter = encrypt.Encrypter(encrypt.AES(key, mode: encrypt.AESMode.cbc));
+
+      LogService.instance.log('HtmlImport', 'Encryption initialized');
+    } catch (e) {
+      LogService.instance.log('HtmlImport', 'Error initializing encryption: $e', level: LogLevel.error);
+    }
+  }
+
+  String? _encrypt(String plaintext) {
+    if (_encrypter == null || _iv == null) return null;
+    try {
+      return _encrypter!.encrypt(plaintext, iv: _iv).base64;
+    } catch (e) {
+      LogService.instance.log('HtmlImport', 'Encryption error: $e', level: LogLevel.error);
+      return null;
+    }
+  }
+
+  String? _decrypt(String ciphertext) {
+    if (_encrypter == null || _iv == null) return null;
+    try {
+      return _encrypter!.decrypt64(ciphertext, iv: _iv);
+    } catch (e) {
+      LogService.instance.log('HtmlImport', 'Decryption error: $e', level: LogLevel.error);
+      return null;
+    }
+  }
+
+  Future<void> _preloadAll() async {
+    if (_storageDirectory == null || !await _storageDirectory!.exists()) return;
+
+    try {
+      final files = await _storageDirectory!.list().toList();
+      for (final entity in files) {
+        if (entity is File && entity.path.endsWith('.enc')) {
+          try {
+            final encrypted = await entity.readAsString();
+            final decrypted = _decrypt(encrypted);
+            if (decrypted != null) {
+              final newlineIndex = decrypted.indexOf('\n');
+              if (newlineIndex != -1) {
+                final siteId = entity.path.split('/').last.replaceAll('.enc', '');
+                final html = decrypted.substring(newlineIndex + 1);
+                _memoryStore[siteId] = html;
+              } else {
+                LogService.instance.log('HtmlImport', 'Discarded invalid import file: ${entity.path}', level: LogLevel.warning);
+                await entity.delete();
+              }
+            } else {
+              LogService.instance.log('HtmlImport', 'Discarded undecryptable import file: ${entity.path}', level: LogLevel.warning);
+              await entity.delete();
+            }
+          } catch (e) {
+            LogService.instance.log('HtmlImport', 'Discarded corrupted import file: ${entity.path} ($e)', level: LogLevel.warning);
+            await entity.delete();
+          }
+        }
+      }
+      LogService.instance.log('HtmlImport', 'Pre-loaded ${_memoryStore.length} imported pages');
+    } catch (e) {
+      LogService.instance.log('HtmlImport', 'Error pre-loading imports: $e', level: LogLevel.error);
+    }
+  }
+
+  String? getHtmlSync(String siteId) {
+    return _memoryStore[siteId];
+  }
+
+  File _getImportFile(String siteId) {
+    return File('${_storageDirectory!.path}/$siteId.enc');
+  }
+
+  /// Per-site upper bound. Imports are user-supplied so this is a sanity
+  /// gate, not a deduplication-or-eviction policy — the legacy cache used
+  /// the same 10 MB ceiling.
+  static const int _maxHtmlSize = 10 * 1024 * 1024;
+
+  Future<void> saveHtml(String siteId, String html, String url) async {
+    if (_storageDirectory == null || _encrypter == null) return;
+
+    if (html.length > _maxHtmlSize) {
+      LogService.instance.log('HtmlImport', 'Skipping save for $siteId - HTML too large (${html.length} bytes > $_maxHtmlSize)', level: LogLevel.warning);
+      return;
+    }
+
+    try {
+      final file = _getImportFile(siteId);
+      final plaintext = '$url\n$html';
+      final encrypted = _encrypt(plaintext);
+      if (encrypted == null) return;
+
+      await file.writeAsString(encrypted);
+      _memoryStore[siteId] = html;
+
+      LogService.instance.log('HtmlImport', 'Saved ${html.length} bytes for site $siteId (encrypted)');
+    } catch (e) {
+      LogService.instance.log('HtmlImport', 'Error saving HTML for $siteId: $e', level: LogLevel.error);
+    }
+  }
+
+  Future<(String, String)?> loadHtml(String siteId) async {
+    if (_storageDirectory == null || _encrypter == null) return null;
+
+    try {
+      final file = _getImportFile(siteId);
+      if (!await file.exists()) return null;
+
+      final encrypted = await file.readAsString();
+      final decrypted = _decrypt(encrypted);
+      if (decrypted == null) return null;
+
+      final newlineIndex = decrypted.indexOf('\n');
+      if (newlineIndex == -1) return null;
+
+      final url = decrypted.substring(0, newlineIndex);
+      final html = decrypted.substring(newlineIndex + 1);
+
+      return (url, html);
+    } catch (e) {
+      LogService.instance.log('HtmlImport', 'Error loading HTML for $siteId: $e', level: LogLevel.error);
+      return null;
+    }
+  }
+
+  Future<bool> hasImport(String siteId) async {
+    if (_storageDirectory == null) return false;
+    final file = _getImportFile(siteId);
+    return file.exists();
+  }
+
+  Future<void> deleteImport(String siteId) async {
+    if (_storageDirectory == null) return;
+    final file = _getImportFile(siteId);
+    if (await file.exists()) {
+      await file.delete();
+    }
+    _memoryStore.remove(siteId);
+  }
+
+  Future<void> removeOrphanedImports(Set<String> activeSiteIds) async {
+    if (_storageDirectory == null || !await _storageDirectory!.exists()) return;
+
+    final files = await _storageDirectory!.list().toList();
+    for (final entity in files) {
+      if (entity is File && entity.path.endsWith('.enc')) {
+        final filename = entity.path.split('/').last;
+        final siteId = filename.replaceAll('.enc', '');
+        if (!activeSiteIds.contains(siteId)) {
+          await entity.delete();
+          _memoryStore.remove(siteId);
+          LogService.instance.log('HtmlImport', 'Removed orphaned import for $siteId', level: LogLevel.info);
+        }
+      }
+    }
+  }
+}

--- a/openspec/specs/file-import-sites/spec.md
+++ b/openspec/specs/file-import-sites/spec.md
@@ -6,7 +6,7 @@ Allow users to add a site by importing a local HTML file (.html/.htm) from their
 
 ## Status
 
-- **Date**: 2026-04-13
+- **Date**: 2026-04-30
 - **Status**: Completed
 
 ---
@@ -66,18 +66,41 @@ load (incognito mode, post-upgrade cache wipe, manual reload). Sites
 persisted before this fix are migrated on load via
 `migrateLegacyFileImportUrl` in [lib/utils/url_utils.dart](../../../lib/utils/url_utils.dart).
 
-#### Scenario: HTML content stored via HtmlCacheService
+#### Scenario: HTML content stored via HtmlImportStorage
 
 **Given** the user selects an HTML file
 **When** the site is created (non-incognito)
-**Then** the file content is saved to HtmlCacheService for the new site's siteId
+**Then** the file content is saved to `HtmlImportStorage` for the new site's siteId
 **And** the webview loads the content via `initialHtml` on first display
+
+The import store ([lib/services/html_import_storage.dart](../../../lib/services/html_import_storage.dart))
+is distinct from `HtmlCacheService`. Imports are the only copy of the
+user-supplied content, so the store is **not** wiped on app upgrade —
+unlike the cache, which holds re-fetchable snapshots of remote pages.
+
+#### Scenario: Imports survive app upgrade
+
+**Given** the user previously imported an HTML file
+**When** the app is upgraded to a newer version
+**Then** the imported HTML is still available — `HtmlImportStorage`
+persists across upgrades.
+
+#### Scenario: Migration from legacy HtmlCacheService
+
+**Given** an installation from before HtmlImportStorage existed where
+imported HTML was held in `HtmlCacheService`
+**When** the new version starts up after the upgrade
+**Then** prior to the cache wipe, `_migrateFileImportsToStorage` (in
+[lib/main.dart](../../../lib/main.dart)) reads each file-import
+WebViewModel's siteId from SharedPreferences, decrypts its cache entry
+with the still-current key, and writes it into HtmlImportStorage. The
+subsequent cache wipe drops the now-redundant copy.
 
 #### Scenario: Incognito mode
 
 **Given** the user has incognito mode enabled
 **When** an HTML file is imported
-**Then** the HTML content is NOT persisted to HtmlCacheService
+**Then** the HTML content is NOT persisted to HtmlImportStorage
 **And** the webview renders the "imported file unavailable" fallback
 (via `buildFileImportFallbackHtml`) instead of attempting to load the
 synthetic `file:///<filename>` URL — there's no real file on disk for
@@ -115,18 +138,25 @@ No new data models. Imported HTML sites use the existing `WebViewModel` with:
 - `initUrl`: `file:///<filename>` (e.g., `file:///page.html`) — three
   slashes; see IMPORT-003 above for why
 - `name`: Filename without extension
-- HTML content stored in `HtmlCacheService` keyed by `siteId`
+- HTML content stored in `HtmlImportStorage` keyed by `siteId`. Persistent;
+  not wiped on app upgrade (the user's only copy of the file). Distinct
+  from `HtmlCacheService`, which holds re-fetchable page snapshots and
+  *is* wiped on upgrade.
 
 ---
 
 ## Files
 
+### Added
+- `lib/services/html_import_storage.dart` - Persistent AES-encrypted store for user-imported HTML, separate from the cache so imports survive app upgrades
+
 ### Modified
 - `lib/screens/add_site.dart` - Added `_importHtmlFile()` method and "Import HTML file" button
-- `lib/main.dart` - Updated `_addSite()` to handle `htmlContent` in result, save to `HtmlCacheService`
+- `lib/main.dart` - Updated `_addSite()` to handle `htmlContent` in result and save to `HtmlImportStorage`; init/preload of the import store; `_migrateFileImportsToStorage` pre-wipe hook copies legacy entries out of `HtmlCacheService`; orphan-cleanup and per-site delete touch both stores; the webview's `initialHtml` reads from `HtmlImportStorage` for `file://` sites and the snapshot save path skips them
+- `lib/services/html_cache_service.dart` - `initialize()` accepts a `beforeUpgradeWipe` callback that runs after key load but before the wipe, used to migrate file imports out
 - `lib/utils/url_utils.dart` - Added `migrateLegacyFileImportUrl` for legacy two-slash imports
 - `lib/web_view_model.dart` - Applies migration in `WebViewModel.fromJson` for `initUrl`/`currentUrl`
-- `lib/services/webview.dart` - Renders `buildFileImportFallbackHtml` when cache is missing for a file import
+- `lib/services/webview.dart` - Renders `buildFileImportFallbackHtml` when no import is on disk for a file-import site
 
 ---
 

--- a/test/html_import_storage_test.dart
+++ b/test/html_import_storage_test.dart
@@ -1,0 +1,210 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/html_import_storage.dart';
+
+import 'helpers/mock_secure_storage.dart' show MockFlutterSecureStorage;
+
+/// Tests for [HtmlImportStorage] — the persistent store for user-imported
+/// HTML files. Exercises round-trip, persistence across instance restarts
+/// (i.e. across simulated app upgrades), orphan cleanup, and graceful
+/// handling of corrupt entries.
+///
+/// The defining property vs [HtmlCacheService]: imports survive an app
+/// upgrade. The cache wipes on version bump; this store does not.
+
+void main() {
+  late Directory tempDir;
+  late MockFlutterSecureStorage fakeStorage;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('webspace_import_test_');
+    fakeStorage = MockFlutterSecureStorage();
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  Future<HtmlImportStorage> newStorage() async {
+    final storage = HtmlImportStorage(
+      secureStorage: fakeStorage,
+      overrideAppDir: tempDir,
+    );
+    await storage.initialize();
+    return storage;
+  }
+
+  group('HtmlImportStorage save/load round-trip', () {
+    test('saveHtml + loadHtml preserves content and url', () async {
+      final s = await newStorage();
+      const html = '<html><body>hello</body></html>';
+      const url = 'file:///hello.html';
+      await s.saveHtml('site-1', html, url);
+
+      final loaded = await s.loadHtml('site-1');
+      expect(loaded, isNotNull);
+      expect(loaded!.$1, url);
+      expect(loaded.$2, html);
+    });
+
+    test('getHtmlSync returns the bytes after saveHtml', () async {
+      final s = await newStorage();
+      await s.saveHtml('site-1', '<p>hi</p>', 'file:///x.html');
+      expect(s.getHtmlSync('site-1'), '<p>hi</p>');
+    });
+
+    test('getHtmlSync returns null for unknown siteId', () async {
+      final s = await newStorage();
+      expect(s.getHtmlSync('does-not-exist'), isNull);
+    });
+
+    test('loadHtml returns null for unknown siteId', () async {
+      final s = await newStorage();
+      expect(await s.loadHtml('does-not-exist'), isNull);
+    });
+
+    test('overwrite replaces the previous bytes', () async {
+      final s = await newStorage();
+      await s.saveHtml('site-1', '<old>', 'file:///page.html');
+      await s.saveHtml('site-1', '<new>', 'file:///page.html');
+
+      final loaded = await s.loadHtml('site-1');
+      expect(loaded!.$2, '<new>');
+      expect(s.getHtmlSync('site-1'), '<new>');
+    });
+
+    test('hasImport reflects on-disk presence', () async {
+      final s = await newStorage();
+      expect(await s.hasImport('site-1'), isFalse);
+      await s.saveHtml('site-1', '<p>hi</p>', 'file:///x.html');
+      expect(await s.hasImport('site-1'), isTrue);
+      await s.deleteImport('site-1');
+      expect(await s.hasImport('site-1'), isFalse);
+    });
+  });
+
+  group('HtmlImportStorage persistence', () {
+    test('imports survive a simulated app upgrade (new instance)', () async {
+      // Save under one instance, simulate cold start by spinning a fresh
+      // instance with the SAME tempDir + SAME secure storage. This is the
+      // defining property: unlike HtmlCacheService, no version-based
+      // wipe happens.
+      final first = await newStorage();
+      await first.saveHtml('persist', '<p>kept</p>', 'file:///kept.html');
+
+      final second = await newStorage();
+      await second.preloadAll();
+
+      expect(second.getHtmlSync('persist'), '<p>kept</p>');
+      final loaded = await second.loadHtml('persist');
+      expect(loaded!.$1, 'file:///kept.html');
+      expect(loaded.$2, '<p>kept</p>');
+    });
+
+    test('preloadAll populates memory store from disk', () async {
+      final first = await newStorage();
+      await first.saveHtml('a', '<a>', 'file:///a.html');
+      await first.saveHtml('b', '<b>', 'file:///b.html');
+
+      final second = await newStorage();
+      // Before preload, memory store is empty for sites it never saw.
+      expect(second.getHtmlSync('a'), isNull);
+      expect(second.getHtmlSync('b'), isNull);
+
+      await second.preloadAll();
+      expect(second.getHtmlSync('a'), '<a>');
+      expect(second.getHtmlSync('b'), '<b>');
+    });
+  });
+
+  group('HtmlImportStorage delete + orphans', () {
+    test('deleteImport removes file and clears memory store', () async {
+      final s = await newStorage();
+      await s.saveHtml('site-1', '<p>hi</p>', 'file:///x.html');
+      expect(s.getHtmlSync('site-1'), isNotNull);
+
+      await s.deleteImport('site-1');
+      expect(s.getHtmlSync('site-1'), isNull);
+      expect(await s.loadHtml('site-1'), isNull);
+      expect(await s.hasImport('site-1'), isFalse);
+    });
+
+    test('deleteImport on missing siteId is a no-op (does not throw)',
+        () async {
+      final s = await newStorage();
+      await s.deleteImport('never-existed');
+      expect(s.getHtmlSync('never-existed'), isNull);
+    });
+
+    test('removeOrphanedImports keeps active siteIds, removes the rest',
+        () async {
+      final s = await newStorage();
+      await s.saveHtml('a', '<a>', 'file:///a.html');
+      await s.saveHtml('b', '<b>', 'file:///b.html');
+      await s.saveHtml('c', '<c>', 'file:///c.html');
+
+      await s.removeOrphanedImports({'a', 'c'});
+
+      expect(await s.hasImport('a'), isTrue);
+      expect(await s.hasImport('b'), isFalse);
+      expect(await s.hasImport('c'), isTrue);
+      expect(s.getHtmlSync('b'), isNull);
+    });
+
+    test('removeOrphanedImports with empty active set clears everything',
+        () async {
+      final s = await newStorage();
+      await s.saveHtml('a', '<a>', 'file:///a.html');
+      await s.saveHtml('b', '<b>', 'file:///b.html');
+
+      await s.removeOrphanedImports(const {});
+
+      expect(await s.hasImport('a'), isFalse);
+      expect(await s.hasImport('b'), isFalse);
+    });
+  });
+
+  group('HtmlImportStorage robustness', () {
+    test('corrupt entry on disk is reaped on preload, returns null on load',
+        () async {
+      final s = await newStorage();
+      await s.saveHtml('s', '<p>orig</p>', 'file:///s.html');
+      // Corrupt the on-disk file with garbage.
+      final filePath = '${tempDir.path}/html_imports/s.enc';
+      await File(filePath).writeAsString('not valid base64!!!');
+
+      // Fresh instance to drop in-memory state, then preload.
+      final s2 = await newStorage();
+      await s2.preloadAll();
+
+      expect(s2.getHtmlSync('s'), isNull);
+      expect(await File(filePath).exists(), isFalse);
+    });
+
+    test('files larger than 10 MB are not saved', () async {
+      final s = await newStorage();
+      // 10MB + 1 byte. Built deterministically without allocating a real
+      // 10MB string for round-trip.
+      final bigHtml = 'a' * (10 * 1024 * 1024 + 1);
+      await s.saveHtml('big', bigHtml, 'file:///big.html');
+      expect(await s.hasImport('big'), isFalse);
+      expect(s.getHtmlSync('big'), isNull);
+    });
+
+    test('different siteIds with identical bytes stay independent', () async {
+      // Sanity: fixed-IV AES means identical ciphertexts for identical
+      // plaintexts. The siteId-keyed filename is what disambiguates.
+      final s = await newStorage();
+      await s.saveHtml('a', '<same>', 'file:///x.html');
+      await s.saveHtml('b', '<same>', 'file:///x.html');
+
+      await s.deleteImport('a');
+      expect(await s.hasImport('a'), isFalse);
+      expect(await s.hasImport('b'), isTrue);
+      expect(s.getHtmlSync('b'), '<same>');
+    });
+  });
+}


### PR DESCRIPTION
HtmlCacheService wipes on app upgrade because cached page snapshots are re-fetchable. Imported HTML files are not — they're the only copy of user-supplied content, and the upgrade wipe was destroying them.

Add HtmlImportStorage (same AES-on-disk pattern, separate dir + key, no version-based wipe) for imports. Pre-wipe migration in HtmlCacheService.initialize hands off legacy entries before the cache clears, so users upgrading through this version don't lose what was previously cached.