### PR TITLE
Fix HTML cache eviction race in _goHome

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1047,20 +1047,38 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await _saveWebViewModels();
   }
 
-  /// Drop the cached HTML for a site — but only when we're online. When
-  /// offline the cached snapshot is the only content we can render, so
-  /// preserve it until a live reload can overwrite it (via the
-  /// `onHtmlLoaded` callback on the next successful `onLoadStop`).
+  /// Drop the cached HTML snapshot for a site so the next webview rebuild
+  /// boots clean — but only when we're (likely) online. When offline the
+  /// cached snapshot is the only content we can render, so preserve it
+  /// until a live reload can overwrite it (via the `onHtmlLoaded` callback
+  /// on the next successful `onLoadStop`).
   ///
-  /// Fire-and-forget so synchronous call sites (notably `_goHome`, which is
-  /// synchronous by design per navigation spec RACE-004) stay synchronous.
-  /// The connectivity probe resolves in a few ms; the worst case is a brief
-  /// window where a freshly-rebuilt webview renders the stale snapshot, and
-  /// then the next live navigation replaces it.
-  void _deleteCacheIfOnline(String siteId) {
-    ConnectivityService.instance.isOnline().then((online) {
-      if (online) HtmlCacheService.instance.deleteCache(siteId);
-    });
+  /// Synchronous in-memory eviction. Sync because callers like `_goHome`
+  /// dispose the webview and trigger a rebuild in the same event-loop turn
+  /// — `getHtmlSync(siteId)` runs during that rebuild's build phase, so an
+  /// async eviction loses the race and the rebuilt webview boots with the
+  /// stale snapshot anyway. The eviction also bumps the
+  /// [HtmlCacheService] generation, so any `saveHtml` for the same siteId
+  /// already in flight (e.g. the previous `controller.getHtml()` IPC
+  /// resolving after dispose) is rejected at write time and cannot
+  /// resurrect the stale bytes the call site just dropped.
+  ///
+  /// Online gate uses [ConnectivityService.lastKnownOnline] (primed at
+  /// startup, refreshed by every probe). Treats unknown as online so
+  /// post-startup callers get the eviction; the only cost of a wrong
+  /// guess offline is losing the cached fallback for one rebuild —
+  /// `controller.reload()` is itself online-gated in [WebViewFactory], so
+  /// nothing tries to fetch a live page we can't reach.
+  ///
+  /// Disk file is left alone. The next live `saveHtml` overwrites it; if
+  /// the app is killed before that fires, `preloadCache` reads it back at
+  /// next launch and the cached-then-live rebuild path heals it on first
+  /// webview load. Use [HtmlCacheService.deleteCache] when the disk file
+  /// must also go (orphan cleanup, explicit site deletion).
+  void _evictCacheIfOnline(String siteId) {
+    if (ConnectivityService.instance.lastKnownOnline ?? true) {
+      HtmlCacheService.instance.evictInMemory(siteId);
+    }
   }
 
   /// Dispose the current site's webview so the next render recreates it
@@ -1074,7 +1092,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   /// would render the pre-edit DOM before the new scripts re-run.
   void _resetCurrentSiteWebView() {
     if (_currentIndex == null || _currentIndex! >= _webViewModels.length) return;
-    _deleteCacheIfOnline(_webViewModels[_currentIndex!].siteId);
+    _evictCacheIfOnline(_webViewModels[_currentIndex!].siteId);
     setState(() {
       _webViewModels[_currentIndex!].disposeWebView();
     });
@@ -1087,7 +1105,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   void _resetAllWebViews() {
     for (final model in _webViewModels) {
       if (model.enabledGlobalScriptIds.isNotEmpty) {
-        _deleteCacheIfOnline(model.siteId);
+        _evictCacheIfOnline(model.siteId);
       }
     }
     setState(() {
@@ -2398,13 +2416,14 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
   /// Navigate to the site's initial URL and clear navigation history.
   /// Disposes the webview so it's recreated fresh with no back history.
-  /// Drops the HTML cache (online only) so the next load starts from the
-  /// live site rather than a stale cached frame. Offline: the cache is
+  /// Evicts the in-memory HTML cache snapshot (online only) so the
+  /// rebuilt webview boots clean and goes straight to the live home URL
+  /// rather than flashing a stale cached frame. Offline: the cache is
   /// preserved — it's the only content we can render without network.
   void _goHome() {
     if (_currentIndex == null || _currentIndex! >= _webViewModels.length) return;
     final model = _webViewModels[_currentIndex!];
-    _deleteCacheIfOnline(model.siteId);
+    _evictCacheIfOnline(model.siteId);
     model.currentUrl = model.initUrl;
     model.disposeWebView();
     _canGoBackVersion++; // Invalidate any in-flight _updateCanGoBack

--- a/lib/services/html_cache_service.dart
+++ b/lib/services/html_cache_service.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
+import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:webspace/services/log_service.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -18,6 +18,13 @@ class HtmlCacheService {
   static HtmlCacheService? _instance;
   static HtmlCacheService get instance => _instance ??= HtmlCacheService._();
 
+  /// Reset the singleton. Tests use this between cases so each starts
+  /// with empty in-memory cache and a fresh eviction-generation table.
+  @visibleForTesting
+  static void resetForTesting() {
+    _instance = null;
+  }
+
   HtmlCacheService._();
 
   Directory? _cacheDirectory;
@@ -27,7 +34,7 @@ class HtmlCacheService {
   /// In-memory cache for sync access during build
   final Map<String, String> _memoryCache = {};
 
-  final _secureStorage = const FlutterSecureStorage();
+  FlutterSecureStorage _secureStorage = const FlutterSecureStorage();
 
   /// Initialize the cache service. Call on app startup.
   ///
@@ -37,8 +44,15 @@ class HtmlCacheService {
   /// callee can read existing entries (encryption is live) and copy
   /// data that should survive the wipe — used to migrate file-import
   /// HTML into [HtmlImportStorage] before the cache is nuked.
-  Future<void> initialize({Future<void> Function()? beforeUpgradeWipe}) async {
-    final appDir = await getApplicationDocumentsDirectory();
+  Future<void> initialize({
+    Future<void> Function()? beforeUpgradeWipe,
+    @visibleForTesting Directory? overrideAppDir,
+    @visibleForTesting FlutterSecureStorage? secureStorage,
+  }) async {
+    if (secureStorage != null) {
+      _secureStorage = secureStorage;
+    }
+    final appDir = overrideAppDir ?? await getApplicationDocumentsDirectory();
     _cacheDirectory = Directory('${appDir.path}/$_cacheDir');
 
     // Initialize encryption
@@ -220,6 +234,37 @@ class HtmlCacheService {
   /// to skip saves that fire inside the [_minSaveInterval] window.
   final Map<String, DateTime> _lastSaveAt = {};
 
+  /// Per-site eviction generation. Bumped synchronously by [evictInMemory]
+  /// (and by full [deleteCache], which delegates to [evictInMemory]).
+  /// [saveHtml] captures the generation at entry and re-checks before
+  /// committing the encrypted bytes — a save that started against
+  /// generation N drops if an eviction has bumped it to N+1 in flight.
+  /// Closes the race where the disposed webview's `onLoadStop`
+  /// `getHtml()` IPC resolves after the user pressed Home and writes
+  /// the stale snapshot back over the freshly-evicted entry.
+  final Map<String, int> _evictionGen = {};
+
+  /// Synchronously drops the in-memory snapshot and debounce timestamp
+  /// for [siteId] and bumps the eviction generation so any in-flight
+  /// [saveHtml] for the same site is rejected at write time.
+  ///
+  /// Sync by design: callers (notably `_goHome`) need the next webview
+  /// rebuild's `getHtmlSync(siteId)` to return null in the same event-loop
+  /// turn, before the rebuild's build phase runs. An async eviction loses
+  /// that race.
+  ///
+  /// Disk file is left alone — the next live `saveHtml` overwrites it.
+  /// If no live save fires before app close (cold-killed mid-load), the
+  /// stale on-disk snapshot is read back into memory by `preloadCache`
+  /// at next launch and overwritten by the cached-then-live path on
+  /// first webview rebuild. Use [deleteCache] when the disk file must
+  /// also go (orphan cleanup, explicit site deletion).
+  void evictInMemory(String siteId) {
+    _evictionGen[siteId] = (_evictionGen[siteId] ?? 0) + 1;
+    _memoryCache.remove(siteId);
+    _lastSaveAt.remove(siteId);
+  }
+
   /// Returns true if a save for [siteId] should proceed right now.
   /// False means the caller should skip the save (and, in particular,
   /// skip the upstream `controller.getHtml()` IPC into the renderer
@@ -271,6 +316,8 @@ class HtmlCacheService {
       return;
     }
 
+    final genAtEntry = _evictionGen[siteId] ?? 0;
+
     try {
       final file = _getCacheFile(siteId);
 
@@ -279,7 +326,27 @@ class HtmlCacheService {
       final encrypted = _encrypt(plaintext);
       if (encrypted == null) return;
 
+      // An eviction (e.g. from `_goHome`) that lands between entry and
+      // here invalidates this save: the call site explicitly asked the
+      // cache to drop this site, and committing now would silently
+      // resurrect the stale bytes the user just told us to forget.
+      if ((_evictionGen[siteId] ?? 0) != genAtEntry) {
+        LogService.instance.log('HtmlCache', 'Skipping save for $siteId - evicted before write');
+        return;
+      }
+
       await file.writeAsString(encrypted);
+
+      // Eviction can also race the file write itself. Roll back on disk
+      // so a cold restart's `preloadCache` doesn't pick up content the
+      // call site told us to drop.
+      if ((_evictionGen[siteId] ?? 0) != genAtEntry) {
+        try {
+          if (await file.exists()) await file.delete();
+        } catch (_) {}
+        LogService.instance.log('HtmlCache', 'Rolled back save for $siteId - evicted during write');
+        return;
+      }
 
       // Update memory cache and debounce timestamp
       _memoryCache[siteId] = html;
@@ -326,15 +393,19 @@ class HtmlCacheService {
     return file.exists();
   }
 
-  /// Delete cached HTML for a site
+  /// Delete cached HTML for a site (memory + disk).
+  ///
+  /// Bumps the eviction generation synchronously via [evictInMemory]
+  /// before awaiting the file delete, so an in-flight [saveHtml] for
+  /// the same site cannot land on the cleared entry while the disk
+  /// delete is in progress.
   Future<void> deleteCache(String siteId) async {
+    evictInMemory(siteId);
     if (_cacheDirectory == null) return;
     final file = _getCacheFile(siteId);
     if (await file.exists()) {
       await file.delete();
     }
-    _memoryCache.remove(siteId);
-    _lastSaveAt.remove(siteId);
   }
 
   /// Delete cached HTML for sites not in the provided set
@@ -347,9 +418,8 @@ class HtmlCacheService {
         final filename = entity.path.split('/').last;
         final siteId = filename.replaceAll('.enc', '');
         if (!activeSiteIds.contains(siteId)) {
+          evictInMemory(siteId);
           await entity.delete();
-          _memoryCache.remove(siteId);
-    _lastSaveAt.remove(siteId);
           LogService.instance.log('HtmlCache', 'Removed orphaned cache for $siteId', level: LogLevel.info);
         }
       }

--- a/test/html_cache_service_test.dart
+++ b/test/html_cache_service_test.dart
@@ -1,0 +1,167 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webspace/services/html_cache_service.dart';
+
+import 'helpers/mock_secure_storage.dart' show MockFlutterSecureStorage;
+
+class _FakePathProvider extends PathProviderPlatform with MockPlatformInterfaceMixin {
+  final Directory _dir;
+  _FakePathProvider(this._dir);
+  @override
+  Future<String?> getApplicationDocumentsPath() async => _dir.path;
+  @override
+  Future<String?> getTemporaryPath() async => _dir.path;
+}
+
+/// Tests for the eviction race-condition fix.
+///
+/// The race: `_goHome` (and similar) used to schedule a fire-and-forget
+/// `deleteCache` after a connectivity probe. By the time the probe
+/// resolved, the rebuilt webview had often already saved a fresh
+/// snapshot — and the deletion wiped that fresh entry. Closer races
+/// also let an in-flight `saveHtml` from the disposed webview's still-
+/// resolving `getHtml()` IPC overwrite the freshly-evicted memory cache.
+///
+/// The fix: [HtmlCacheService.evictInMemory] is sync, drops the
+/// in-memory snapshot in the same event-loop turn the call site runs
+/// in, and bumps a per-site eviction generation that [saveHtml]
+/// captures at entry and re-checks before committing.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late MockFlutterSecureStorage fakeSecureStorage;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('webspace_html_cache_test_');
+    PathProviderPlatform.instance = _FakePathProvider(tempDir);
+    SharedPreferences.setMockInitialValues({});
+    PackageInfo.setMockInitialValues(
+      appName: 'webspace',
+      packageName: 'org.codeberg.theoden8.webspace',
+      version: '0.0.1',
+      buildNumber: '1',
+      buildSignature: '',
+    );
+    fakeSecureStorage = MockFlutterSecureStorage();
+    HtmlCacheService.resetForTesting();
+    await HtmlCacheService.instance.initialize(
+      overrideAppDir: tempDir,
+      secureStorage: fakeSecureStorage,
+    );
+  });
+
+  tearDown(() async {
+    HtmlCacheService.resetForTesting();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  group('evictInMemory', () {
+    test('drops in-memory snapshot synchronously', () async {
+      final svc = HtmlCacheService.instance;
+      await svc.saveHtml('site-1', '<p>cached</p>', 'https://example.com/');
+      expect(svc.getHtmlSync('site-1'), '<p>cached</p>');
+
+      svc.evictInMemory('site-1');
+
+      // No await between evict and read - this is the contract `_goHome`
+      // depends on. A rebuilt webview's `getHtmlSync` runs in the same
+      // event-loop turn; it must see the eviction.
+      expect(svc.getHtmlSync('site-1'), isNull);
+    });
+
+    test('resets the debounce window so the next save is allowed', () async {
+      final svc = HtmlCacheService.instance;
+      await svc.saveHtml('site-1', '<p>cached</p>', 'https://example.com/');
+      // Just-saved: shouldSave is false within the 10s debounce.
+      expect(svc.shouldSave('site-1'), isFalse);
+
+      svc.evictInMemory('site-1');
+
+      // After eviction the rebuilt webview's first onLoadStop must be
+      // allowed to save - the cache for this site is now empty, the
+      // debounce no longer protects useful state.
+      expect(svc.shouldSave('site-1'), isTrue);
+    });
+
+    test('bumps the eviction generation per call', () async {
+      final svc = HtmlCacheService.instance;
+      // Two evictions in a row both bump the gen, so any save that
+      // captured a gen between them is also rejected.
+      await svc.saveHtml('site-1', '<p>v1</p>', 'https://example.com/');
+      svc.evictInMemory('site-1');
+      svc.evictInMemory('site-1');
+      // The visible effect: getHtmlSync still returns null, and a
+      // saveHtml that started before either eviction would still be
+      // rejected (verified in the saveHtml race test below).
+      expect(svc.getHtmlSync('site-1'), isNull);
+    });
+  });
+
+  group('saveHtml gen check', () {
+    test('rejects a save whose gen was invalidated mid-flight', () async {
+      final svc = HtmlCacheService.instance;
+      await svc.saveHtml('site-1', '<p>baseline</p>', 'https://example.com/');
+      expect(svc.getHtmlSync('site-1'), '<p>baseline</p>');
+
+      // Race: schedule a save. Synchronously evict before the save's
+      // first await resumes - simulating `_goHome` running between when
+      // the disposed webview's onLoadStop fired its `getHtml()` IPC and
+      // when saveHtml lands.
+      final saving = svc.saveHtml(
+        'site-1',
+        '<p>stale-from-pre-home</p>',
+        'https://example.com/deep',
+      );
+      svc.evictInMemory('site-1');
+      await saving;
+
+      // saveHtml must observe the gen change and drop the write so the
+      // stale snapshot can't resurrect itself over the eviction.
+      expect(svc.getHtmlSync('site-1'), isNull);
+      // On disk: rolled back. No file should remain for site-1.
+      final cacheFile = File('${tempDir.path}/html_cache/site-1.enc');
+      expect(await cacheFile.exists(), isFalse);
+    });
+
+    test('a save started after eviction is allowed', () async {
+      final svc = HtmlCacheService.instance;
+      svc.evictInMemory('site-1');
+      await svc.saveHtml('site-1', '<p>fresh</p>', 'https://example.com/');
+      expect(svc.getHtmlSync('site-1'), '<p>fresh</p>');
+    });
+  });
+
+  group('deleteCache', () {
+    test('drops in-memory entry synchronously even before disk delete completes', () async {
+      final svc = HtmlCacheService.instance;
+      await svc.saveHtml('site-1', '<p>cached</p>', 'https://example.com/');
+      expect(svc.getHtmlSync('site-1'), '<p>cached</p>');
+
+      // Don't await - check the in-memory state in the same turn.
+      final pending = svc.deleteCache('site-1');
+      expect(svc.getHtmlSync('site-1'), isNull);
+      await pending;
+      expect(svc.getHtmlSync('site-1'), isNull);
+    });
+
+    test('rejects an in-flight save scheduled before the delete', () async {
+      final svc = HtmlCacheService.instance;
+      // Stale save in flight when delete fires - same shape as a
+      // disposed-webview onLoadStop racing an explicit deletion.
+      final saving = svc.saveHtml('site-1', '<p>stale</p>', 'https://example.com/');
+      final deleting = svc.deleteCache('site-1');
+      await Future.wait([saving, deleting]);
+      expect(svc.getHtmlSync('site-1'), isNull);
+      final cacheFile = File('${tempDir.path}/html_cache/site-1.enc');
+      expect(await cacheFile.exists(), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
_deleteCacheIfOnline was fire-and-forget over a connectivity probe; the deletion could land after the rebuilt webview had already saved fresh home content, wiping it. Replace with sync in-memory eviction gated on lastKnownOnline, plus a per-site eviction generation that saveHtml captures at entry and re-checks before commit so an in-flight stale save (e.g. from the disposed webview's still- resolving getHtml IPC) is rejected at write time.