### PR TITLE
Handle intent:// URLs with web fallbacks in-app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ Specs live under `openspec/specs/<slug>/spec.md` (Given/When/Then). **Read the r
 | developer-tools | JS console, cookie inspector, HTML export, app logs |
 | dns-blocklist | Hagezi list, severity levels, per-site toggle |
 | downloads | http/https/data/blob, streamed progress + save dialog |
+| external-scheme-handling | intent:// auto-resolves to http(s) fallback (silent route); prompt only when no web equivalent |
 | file-import-sites | local HTML via HtmlCacheService |
 | fullscreen-mode | hide app bar/tab strip/system UI; per-site auto |
 | home-shortcut | Android pinned shortcuts |

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3992,7 +3992,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                                   onConfirmScriptFetch: _confirmScriptFetch,
                                   onExternalSchemeUrl: (url, info) async {
                                     if (!mounted) return;
-                                    await confirmAndLaunchExternalUrl(context, info);
+                                    await confirmAndLaunchExternalUrl(
+                                      context,
+                                      info,
+                                      loadInWebView: webViewModel.controller,
+                                    );
                                   },
                                 ),
                               ),

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -155,7 +155,11 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
         onWindowRequested: _showPopupWindow,
         onExternalSchemeUrl: (url, info) async {
           if (!mounted) return;
-          await confirmAndLaunchExternalUrl(context, info);
+          await confirmAndLaunchExternalUrl(
+            context,
+            info,
+            loadInWebView: _controller,
+          );
         },
       ),
       onControllerCreated: (controller) {

--- a/lib/services/external_url_engine.dart
+++ b/lib/services/external_url_engine.dart
@@ -121,6 +121,34 @@ class ExternalUrlParser {
       targetScheme: targetScheme,
     );
   }
+
+  /// Resolves an [ExternalUrlInfo] for an intent:// URL to an equivalent
+  /// http(s) URL the webview can load: prefers the explicit
+  /// `S.browser_fallback_url` extra; otherwise reconstructs from
+  /// `targetScheme` + the intent's host/path/query when the target scheme
+  /// is http(s). Returns null when no equivalent web URL can be produced
+  /// (e.g. zxing scanner intent with no fallback).
+  static String? intentToWebUrl(ExternalUrlInfo info) {
+    if (info.scheme != 'intent') return null;
+    final fallback = info.fallbackUrl;
+    if (fallback != null && fallback.isNotEmpty) {
+      final parsed = Uri.tryParse(fallback);
+      if (parsed != null && (parsed.scheme == 'http' || parsed.scheme == 'https')) {
+        return fallback;
+      }
+    }
+    final scheme = info.targetScheme;
+    if (scheme != 'http' && scheme != 'https') return null;
+    final original = Uri.tryParse(info.url);
+    if (original == null || original.host.isEmpty) return null;
+    return Uri(
+      scheme: scheme,
+      host: original.host,
+      port: original.hasPort ? original.port : null,
+      path: original.path,
+      query: original.query.isEmpty ? null : original.query,
+    ).toString();
+  }
 }
 
 /// Loop-suppression for external URL prompts. After the user decides what

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -2024,6 +2024,31 @@ class WebViewFactory {
           LogService.instance.log('WebView',
               'External scheme intercepted: scheme=${externalInfo.scheme} '
               'package=${externalInfo.package} fallback=${externalInfo.fallbackUrl} url=$url');
+          // intent:// with a resolvable web URL: route the fallback
+          // through the standard same-domain / cross-domain path, no
+          // confirmation prompt. We are the browser; handing the user
+          // off to a different app for a URL they clicked inside us is
+          // hostile behavior (and Google Maps fires these constantly).
+          // Same base domain → load in this webview; cross-domain →
+          // nested via shouldOverrideUrlLoading. Intents *without* a
+          // web fallback (zxing scanner, custom-app deep links) still
+          // hit the confirmation dialog so the user can choose.
+          if (externalInfo.scheme == 'intent') {
+            final resolved = ExternalUrlParser.intentToWebUrl(externalInfo);
+            if (resolved != null) {
+              LogService.instance.log('WebView',
+                  'intent fallback resolved → $resolved (from $url)');
+              bool allow = true;
+              if (config.shouldOverrideUrlLoading != null) {
+                final hasGesture = _hasUserGesture(navigationAction);
+                allow = config.shouldOverrideUrlLoading!(resolved, hasGesture);
+              }
+              if (allow) {
+                controller.loadUrl(urlRequest: inapp.URLRequest(url: inapp.WebUri(resolved)));
+              }
+              return inapp.NavigationActionPolicy.CANCEL;
+            }
+          }
           if (config.onExternalSchemeUrl != null) {
             config.onExternalSchemeUrl!(url, externalInfo);
           }
@@ -2153,6 +2178,22 @@ class WebViewFactory {
           LogService.instance.log('WebView',
               'External scheme intercepted (onCreateWindow): '
               'scheme=${externalInfo.scheme} package=${externalInfo.package} url=$url');
+          if (externalInfo.scheme == 'intent') {
+            final resolved = ExternalUrlParser.intentToWebUrl(externalInfo);
+            if (resolved != null) {
+              LogService.instance.log('WebView',
+                  'intent fallback resolved (onCreateWindow) → $resolved (from $url)');
+              bool allow = true;
+              if (config.shouldOverrideUrlLoading != null) {
+                final hasGesture = _hasUserGesture(createWindowAction);
+                allow = config.shouldOverrideUrlLoading!(resolved, hasGesture);
+              }
+              if (allow) {
+                controller.loadUrl(urlRequest: inapp.URLRequest(url: inapp.WebUri(resolved)));
+              }
+              return false;
+            }
+          }
           if (config.onExternalSchemeUrl != null) {
             config.onExternalSchemeUrl!(url, externalInfo);
           }
@@ -2403,6 +2444,34 @@ class WebViewFactory {
             } catch (_) {}
           });
           return;
+        }
+        if (externalInfo.scheme == 'intent') {
+          final resolved = ExternalUrlParser.intentToWebUrl(externalInfo);
+          if (resolved != null) {
+            ExternalUrlSuppressor.mark(externalInfo);
+            LogService.instance.log('WebView',
+                'onReceivedError: intent fallback resolved → $resolved (from $reqUrl)');
+            Future.microtask(() async {
+              try {
+                bool allow = true;
+                if (config.shouldOverrideUrlLoading != null) {
+                  allow = config.shouldOverrideUrlLoading!(resolved, false);
+                }
+                if (allow) {
+                  await controller.loadUrl(
+                    urlRequest: inapp.URLRequest(url: inapp.WebUri(resolved)),
+                  );
+                } else {
+                  await controller.loadUrl(
+                    urlRequest: inapp.URLRequest(url: inapp.WebUri('about:blank')),
+                  );
+                }
+              } catch (_) {}
+            });
+            return;
+          }
+          // No web fallback — fall through to the dialog path so the
+          // user can still choose to launch the target app.
         }
         if (config.onExternalSchemeUrl != null) {
           LogService.instance.log('WebView',

--- a/lib/widgets/external_url_prompt.dart
+++ b/lib/widgets/external_url_prompt.dart
@@ -4,6 +4,7 @@ import 'package:url_launcher/url_launcher.dart' as url_launcher;
 import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/external_url_engine.dart';
 import 'package:webspace/services/log_service.dart';
+import 'package:webspace/services/webview.dart' show WebViewController;
 import 'package:webspace/widgets/root_messenger.dart';
 
 /// Shared per-route guard so rapid-fire redirects (Google Maps can hit the
@@ -82,14 +83,18 @@ String _cleanFallback(String? fallbackUrl) {
 enum _ExternalUrlChoice { cancel, openInApp, openInBrowser }
 
 /// Ask the user whether to hand [info.url] to the OS via url_launcher.
-/// "Open in app" launches the intent URL. "Open in browser" launches
-/// the cleaned `browser_fallback_url` externally so the user's default
-/// browser handles it. Tracking params are stripped from both via
-/// [ClearUrlService] before they leave the app.
+/// "Open in app" launches the intent URL. "Open in browser" loads the
+/// cleaned `browser_fallback_url` inside our own webview — we are the
+/// browser; handing the URL to a different one would lose per-site
+/// settings and confuse the user. When [loadInWebView] is null (no
+/// controller available), it falls back to launching the URL via the OS.
+/// Tracking params are stripped from both via [ClearUrlService] before
+/// they leave the app.
 Future<void> confirmAndLaunchExternalUrl(
   BuildContext context,
-  ExternalUrlInfo info,
-) async {
+  ExternalUrlInfo info, {
+  WebViewController? loadInWebView,
+}) async {
   // Loop guard: pages frequently re-fire the same intent immediately
   // after we load their browser_fallback_url. Without suppression the
   // user gets re-prompted every redirect and the choice they made a
@@ -181,13 +186,23 @@ Future<void> confirmAndLaunchExternalUrl(
       case _ExternalUrlChoice.openInBrowser:
         LogService.instance.log('ExternalUrl', 'user chose: open in browser → $cleanedFallback');
         ExternalUrlSuppressor.mark(info);
-        // Hand the URL to the OS so the user's default browser opens
-        // it. Loading inside our webview was the previous behavior;
-        // for hostile sites (Google Maps mobile is the canonical
-        // example) the page just JS-redirects right back to intent://
-        // and we end up at about:blank. The external browser is what
-        // "Open in browser" means in every other app's mental model.
-        await _launchExternally(cleanedFallback, label: 'browser');
+        // We are the browser. Load the fallback inside our own webview
+        // so per-site settings (cookie isolation, proxy, content blocker
+        // etc.) still apply. shouldOverrideUrlLoading then decides
+        // same-domain vs cross-domain (nested webview). When no
+        // controller is available — e.g. tel:/mailto: with no fallback —
+        // fall back to handing the URL to the OS.
+        if (loadInWebView != null && cleanedFallback.isNotEmpty) {
+          try {
+            await loadInWebView.loadUrl(cleanedFallback);
+          } catch (e) {
+            LogService.instance.log('ExternalUrl',
+                'in-app loadUrl failed ($e), falling back to external launch');
+            await _launchExternally(cleanedFallback, label: 'browser fallback');
+          }
+        } else {
+          await _launchExternally(cleanedFallback, label: 'browser');
+        }
         return;
       case _ExternalUrlChoice.openInApp:
         LogService.instance.log('ExternalUrl', 'user chose: open in app → $cleanedLaunchUrl');

--- a/openspec/README.md
+++ b/openspec/README.md
@@ -17,6 +17,7 @@ openspec/
     ├── cookie-secure-storage/spec.md     # Encrypted cookie storage
     ├── developer-tools/spec.md           # In-app dev tools (JS console, cookie inspector)
     ├── dns-blocklist/spec.md             # Hagezi DNS blocklist domain blocking
+    ├── external-scheme-handling/spec.md  # intent:// auto-resolve to http(s) fallback; prompt unresolvable schemes
     ├── home-shortcut/spec.md             # Android home screen shortcuts
     ├── icon-fetching/spec.md             # Progressive favicon loading
     ├── language/spec.md                  # Per-site language (Accept-Language + navigator.language override)
@@ -58,6 +59,7 @@ Each spec file follows the OpenSpec format:
 | Cookie Secure Storage | Completed | Encrypted cookie persistence with flutter_secure_storage |
 | Developer Tools | Completed | JS console, cookie inspector, HTML export, app logs |
 | DNS Blocklist | Completed | Hagezi DNS blocklist with severity levels and per-site toggle |
+| External Scheme Handling | Completed | intent:// fallback URLs route through standard navigation; prompt only when no http(s) equivalent exists |
 | Home Shortcut | Completed | Android home screen shortcut via pinned shortcuts API |
 | Icon Fetching | Completed | Progressive favicon loading with fallbacks |
 | Language | Completed | Per-site language via Accept-Language header and navigator.language override |

--- a/openspec/specs/external-scheme-handling/spec.md
+++ b/openspec/specs/external-scheme-handling/spec.md
@@ -1,0 +1,324 @@
+# External Scheme Handling Specification
+
+## Status
+
+- **Date**: 2026-05-01
+- **Status**: Implemented
+- **Scope**: All platforms
+
+## Purpose
+
+Decide what happens when a webview tries to navigate to a URL whose scheme the webview itself cannot render: `intent://`, `tel:`, `mailto:`, `market:`, `fb://`, custom-app deep links, etc. Two competing concerns:
+
+1. **We are the browser.** When a site fires `intent://www.google.com/maps?…#Intent;scheme=https;…;S.browser_fallback_url=https://www.google.com/maps?…;end`, the user is *already* inside their chosen browser. Punting them out to the native Maps app contradicts what they configured WebSpace to do, loses per-site cookies/proxy/blockers, and (Google Maps does this every visit) spams a confirmation prompt the user keeps cancelling.
+2. **Some intents really ARE for an unsupported scheme.** A QR-code page firing `intent://scan/#Intent;scheme=zxing;package=com.google.zxing.client.android;end` legitimately wants the scanner app — there is no http(s) equivalent the webview could load instead. The user must still be able to pick "open in app".
+
+The split is "is there a resolvable web URL?". If yes → silent route through the standard navigation path. If no → existing confirmation dialog.
+
+---
+
+## Problem Statement
+
+Pre-existing behavior: every `intent://` (and every other non-internal scheme) opened the same `_ExternalUrlChoice` dialog with three buttons — Cancel / Open in browser / Open in app. Two failure modes:
+
+- **Google Maps spam.** Mobile Google Maps fires its `intent://www.google.com/maps?…` redirect on every page view. Even with `ExternalUrlSuppressor` damping repeats, the user sees the prompt the first time on every visit. The fallback URL is always `https://www.google.com/maps?…` — a URL the webview *is already showing* — so the prompt is asking "do you want to open this app you don't have for a URL you're already on?".
+- **"Open in browser" lied.** The button called `url_launcher.launchUrl(…, mode: externalApplication)`, handing the URL to the system default browser. WebSpace *is* the browser the user picked. The handoff lost per-site settings (cookie isolation, proxy, content blocker) and dropped the user into a different app for no reason.
+
+---
+
+## Solution
+
+Two changes in `lib/services/webview.dart` and one in `lib/widgets/external_url_prompt.dart`:
+
+1. **Resolve `intent://` to its web equivalent** via `ExternalUrlParser.intentToWebUrl(info)`:
+   - Prefer the explicit `S.browser_fallback_url` extra (must parse as `http`/`https`).
+   - Otherwise reconstruct from `targetScheme://host[:port]/path?query` when `targetScheme` is `http` or `https`.
+   - Return `null` for everything else (zxing, custom app schemes, file://, etc.).
+2. **At every intent intercept point** (`shouldOverrideUrlLoading`, `onCreateWindow`, `onReceivedError`):
+   - If `intentToWebUrl` returns non-null → call back into `config.shouldOverrideUrlLoading(resolved, hasGesture)`. Same base domain → `controller.loadUrl(resolved)` here. Cross-domain → the callback already issued `launchUrl(resolved)` for a nested webview. No prompt.
+   - If `intentToWebUrl` returns null → fall through to `config.onExternalSchemeUrl(url, info)`, the existing prompt flow.
+3. **"Open in browser" loads in this webview.** `confirmAndLaunchExternalUrl` accepts an optional `WebViewController? loadInWebView`. When non-null and the cleaned fallback is non-empty, the button calls `loadInWebView.loadUrl(cleanedFallback)`; on failure (or when no controller is available, e.g. tel:/mailto: with no fallback), it falls back to `url_launcher.launchUrl(…, externalApplication)`.
+
+### Why route through the existing `shouldOverrideUrlLoading` callback
+
+The host already wires that callback to a same-domain / cross-domain decision: same domain → `ALLOW`, cross-domain → `CANCEL` plus an inline `launchUrlFunc(url, …)` that opens a nested `InAppWebViewScreen` with all per-site fields propagated. Re-entering that callback with the resolved URL means an intent fallback inherits the exact same routing rules as a regular `<a href="https://…">` click — no parallel decision tree to keep in sync.
+
+### Why `onReceivedError` needs the same treatment
+
+On Android, intent navigations sometimes skip `shouldOverrideUrlLoading` entirely and surface as an `ERR_UNKNOWN_URL_SCHEME` in `onReceivedError` (every Google Maps `window.location='intent://…'` JS redirect, observed). Without the same intent-resolve step, the user would see the chrome error page until the page re-fired the intent and finally got intercepted at the `shouldOverrideUrlLoading` layer.
+
+### Why file:// is excluded from the fallback allowlist
+
+A web origin must not be able to convince the webview to load a `file://` URL via the intent dance: classic local-file disclosure. `intentToWebUrl` only accepts `http` and `https` for both the explicit `browser_fallback_url` and the reconstructed URL. Intents with `scheme=file` or a `file://` fallback drop into the prompt path; the user can still launch externally if they really want to.
+
+---
+
+## Requirements
+
+### Requirement: EXT-001 - Intent URL Parsing
+
+The system SHALL parse `intent://` URLs into structured `ExternalUrlInfo` records exposing `host`, `package`, `fallbackUrl`, and `targetScheme` per the Chrome intent scheme spec.
+
+#### Scenario: Google Maps intent with fallback URL
+
+**Given** the URL `intent://www.google.com/maps?entry=ml#Intent;scheme=https;package=com.google.android.apps.maps;S.browser_fallback_url=https%3A%2F%2Fwww.google.com%2Fmaps%3Fentry%3Dml;end;`
+**When** `ExternalUrlParser.parse` is called
+**Then** the returned info has `scheme=intent`, `host=www.google.com`, `package=com.google.android.apps.maps`, `targetScheme=https`, `fallbackUrl=https://www.google.com/maps?entry=ml`
+
+#### Scenario: Scanner intent without web fallback
+
+**Given** the URL `intent://scan/#Intent;scheme=zxing;package=com.google.zxing.client.android;end`
+**When** `ExternalUrlParser.parse` is called
+**Then** the info has `targetScheme=zxing`, `fallbackUrl=null`
+
+---
+
+### Requirement: EXT-002 - Intent Resolution to Web URL
+
+The system SHALL provide `ExternalUrlParser.intentToWebUrl(info)` that returns an `http`/`https` equivalent of an intent, or `null` when none exists.
+
+#### Scenario: Prefer explicit browser_fallback_url
+
+**Given** an `ExternalUrlInfo` with `scheme=intent`, `targetScheme=https`, `fallbackUrl=https://www.google.com/maps?entry=ml`
+**When** `intentToWebUrl(info)` is called
+**Then** it returns `https://www.google.com/maps?entry=ml`
+
+#### Scenario: Reconstruct from targetScheme + host + path + query
+
+**Given** an `ExternalUrlInfo` parsed from `intent://www.google.com/maps?entry=ml#Intent;scheme=https;package=x;end` (no explicit fallback)
+**When** `intentToWebUrl(info)` is called
+**Then** it returns `https://www.google.com/maps?entry=ml`
+
+#### Scenario: Non-http target scheme returns null
+
+**Given** an `ExternalUrlInfo` with `targetScheme=zxing` and no `fallbackUrl`
+**When** `intentToWebUrl(info)` is called
+**Then** it returns `null`
+
+#### Scenario: Non-http fallback URL returns null
+
+**Given** an `ExternalUrlInfo` with `targetScheme=zxing` and `fallbackUrl=zxing://scan/`
+**When** `intentToWebUrl(info)` is called
+**Then** it returns `null`
+
+#### Scenario: Non-intent input returns null
+
+**Given** an `ExternalUrlInfo` with `scheme=tel`
+**When** `intentToWebUrl(info)` is called
+**Then** it returns `null`
+
+#### Scenario: file:// fallback rejected
+
+**Given** an `ExternalUrlInfo` with `targetScheme=file` and `fallbackUrl=file:///etc/passwd`
+**When** `intentToWebUrl(info)` is called
+**Then** it returns `null` (security: web origins must not steer the webview to local-file URLs)
+
+---
+
+### Requirement: EXT-003 - Silent Routing of Resolvable Intents
+
+The webview SHALL silently route resolvable intent fallbacks through the standard same-domain / cross-domain navigation path, without showing the confirmation dialog.
+
+#### Scenario: Same-domain intent fallback loads in current webview
+
+**Given** the current site is `https://www.google.com/maps`
+**And** the webview intercepts `intent://www.google.com/maps?entry=ml#Intent;scheme=https;…;S.browser_fallback_url=https%3A%2F%2Fwww.google.com%2Fmaps%3Fentry%3Dml;end`
+**When** `shouldOverrideUrlLoading` resolves the intent to `https://www.google.com/maps?entry=ml`
+**Then** the existing `shouldOverrideUrlLoading` callback returns `true` for the same-domain URL
+**And** the webview calls `controller.loadUrl(https://www.google.com/maps?entry=ml)`
+**And** no confirmation dialog is shown
+**And** the original `intent://` navigation is `CANCEL`led
+
+#### Scenario: Cross-domain intent fallback opens nested webview
+
+**Given** the current site is `https://example.com`
+**And** the webview intercepts `intent://www.google.com/maps#Intent;scheme=https;S.browser_fallback_url=https%3A%2F%2Fwww.google.com%2Fmaps;end`
+**When** `shouldOverrideUrlLoading` resolves the intent to `https://www.google.com/maps`
+**Then** the existing callback decides cross-domain → `blockOpenNested` → `launchUrlFunc(https://www.google.com/maps, …)` opens a nested `InAppWebViewScreen`
+**And** the callback returns `false`, so the webview does NOT also call `loadUrl`
+**And** no confirmation dialog is shown
+**And** the original `intent://` navigation is `CANCEL`led
+
+#### Scenario: target=_blank intent routes the same way
+
+**Given** the user clicks `<a target="_blank" href="intent://…;S.browser_fallback_url=https://example.com;end">`
+**When** `onCreateWindow` parses the intent and resolves it to `https://example.com`
+**Then** the same routing applies: same-domain → `controller.loadUrl`; cross-domain → nested webview; no prompt
+
+#### Scenario: Android onReceivedError path
+
+**Given** an Android navigation to `intent://…;S.browser_fallback_url=https://example.com;end` skips `shouldOverrideUrlLoading` and surfaces in `onReceivedError`
+**When** the suppression cache is cold
+**Then** `onReceivedError` resolves the intent, marks the suppression entry, and posts a microtask that loads the resolved URL via the standard callback path
+
+---
+
+### Requirement: EXT-004 - Prompt Path Preserved for Unresolvable Intents
+
+When `intentToWebUrl` returns `null`, the webview SHALL fall through to the existing `config.onExternalSchemeUrl` callback so the host can show the confirmation dialog and let the user pick an action.
+
+#### Scenario: Scanner intent prompts the user
+
+**Given** the webview intercepts `intent://scan/#Intent;scheme=zxing;package=com.google.zxing.client.android;end`
+**When** `intentToWebUrl` returns `null`
+**Then** the webview calls `config.onExternalSchemeUrl(url, info)`
+**And** the host shows the Cancel / Open in browser / Open in app dialog
+**And** the original navigation is `CANCEL`led
+
+#### Scenario: tel:/mailto:/custom schemes still prompt
+
+**Given** the webview intercepts `tel:+14155551234`
+**When** `ExternalUrlParser.parse` returns a non-intent `ExternalUrlInfo`
+**Then** the webview skips the intent-resolve branch and calls `config.onExternalSchemeUrl(url, info)`
+**And** the existing dialog is shown
+
+---
+
+### Requirement: EXT-005 - "Open in Browser" Loads in This Webview
+
+The "Open in browser" choice in the confirmation dialog SHALL load the cleaned fallback URL inside the WebSpace webview that originated the navigation, not via `url_launcher`.
+
+#### Scenario: Loads in the originating webview
+
+**Given** the user is on a tel:/custom-scheme prompt with a non-empty cleaned fallback URL
+**And** `confirmAndLaunchExternalUrl` was called with a non-null `loadInWebView` controller
+**When** the user picks "Open in browser"
+**Then** `loadInWebView.loadUrl(cleanedFallback)` is invoked
+**And** `url_launcher.launchUrl` is NOT invoked
+**And** the suppression cache is marked so the next identical fire is silenced
+
+#### Scenario: Falls back to external launch when no controller available
+
+**Given** `confirmAndLaunchExternalUrl` was called with `loadInWebView == null`
+**Or** the in-app `loadUrl` call throws
+**When** the user picks "Open in browser"
+**Then** `_launchExternally(cleanedFallback, label: 'browser')` is invoked
+**And** url_launcher hands the URL to the system default browser
+
+---
+
+### Requirement: EXT-006 - ClearURLs Stripping Survives Resolution
+
+Tracking parameters SHALL be stripped from intent fallback URLs before they leave the app or load in the webview.
+
+#### Scenario: Resolved fallback runs through ClearURLs
+
+**Given** ClearURLs rules are loaded
+**And** the resolved intent fallback is `https://www.google.com/maps?entry=ml&utm_campaign=ml-ardi-wv`
+**When** `controller.loadUrl(resolved)` triggers a fresh `shouldOverrideUrlLoading` for the http(s) URL
+**Then** the ClearURLs branch in `shouldOverrideUrlLoading` rewrites the URL to `https://www.google.com/maps?entry=ml`
+**And** the webview loads the cleaned URL
+
+#### Scenario: Confirmation-dialog path also strips tracking
+
+**Given** an unresolvable intent (no http fallback) still hits the prompt
+**When** `confirmAndLaunchExternalUrl` builds the dialog
+**Then** `_stripTrackingFromIntent` rewrites both the toplevel query and the embedded `S.browser_fallback_url` extra
+**And** the dialog displays the cleaned URLs to the user
+
+---
+
+### Requirement: EXT-007 - Suppression Loop Guard
+
+After a navigation resolves through the silent intent path or the user makes a choice in the dialog, the system SHALL mark `ExternalUrlSuppressor` so a script-driven re-fire of the same intent does not re-trigger work or re-prompt the user.
+
+#### Scenario: onReceivedError marks suppression on silent route
+
+**Given** `onReceivedError` resolved an intent silently
+**When** the page's JS re-fires the same intent moments later
+**Then** the suppression cache returns true for the same intent key
+**And** the second fire short-circuits to about:blank rather than re-loading the fallback
+
+#### Scenario: Dialog choices mark suppression
+
+**Given** the user picks Cancel / Open in browser / Open in app in the dialog
+**Then** `ExternalUrlSuppressor.mark(info)` is called for that info
+**And** a re-fire within the suppression window is silenced
+
+---
+
+## Data Models
+
+### `ExternalUrlInfo`
+
+```dart
+class ExternalUrlInfo {
+  final String url;          // raw URL string
+  final String scheme;       // lowercase scheme (intent, tel, mailto, …)
+  final String? host;        // intent target host or URI host
+  final String? package;     // ;package= extra (intent only)
+  final String? fallbackUrl; // S.browser_fallback_url extra (intent only)
+  final String? targetScheme;// ;scheme= extra (intent only)
+}
+```
+
+### Intent fragment grammar
+
+```
+intent://HOST/PATH?QUERY#Intent;scheme=...;package=...;S.browser_fallback_url=...;end
+```
+
+Extras live in the URL fragment, `;`-separated. `S.` prefix marks string extras per the [Chrome intent scheme spec](https://developer.chrome.com/docs/multidevice/android/intents).
+
+---
+
+## Files
+
+### Modified
+
+- `lib/services/external_url_engine.dart` — added `ExternalUrlParser.intentToWebUrl`.
+- `lib/services/webview.dart` — intent-resolve branch in `shouldOverrideUrlLoading`, `onCreateWindow`, `onReceivedError`.
+- `lib/widgets/external_url_prompt.dart` — `confirmAndLaunchExternalUrl` accepts `loadInWebView`; "Open in browser" loads inside the webview.
+- `lib/main.dart` and `lib/screens/inappbrowser.dart` — pass the active controller as `loadInWebView` when invoking the prompt.
+
+### Test coverage
+
+- `test/external_url_engine_test.dart` — unit tests for `ExternalUrlParser.intentToWebUrl` covering: non-intent input, explicit fallback, scheme+host+path+query reconstruction, non-http target scheme, non-http fallback.
+
+---
+
+## Testing
+
+### Manual: Google Maps no longer prompts
+
+1. Add `https://maps.google.com` as a WebSpace site (Android device, no Google Maps app installed is fine).
+2. Open the site, navigate within Maps.
+3. The intent-confirmation dialog MUST NOT appear.
+4. Navigation stays inside the webview throughout.
+
+### Manual: Scanner intent still prompts
+
+1. Visit a page that fires `intent://scan/#Intent;scheme=zxing;…;end` (e.g. a QR-code embed).
+2. The dialog MUST appear with Cancel / Open in browser (disabled, no fallback) / Open in app buttons.
+3. "Open in app" launches the scanner if installed; otherwise the snackbar reports "no app available".
+
+### Manual: tel: / mailto: still prompt
+
+1. Tap a `tel:+1…` link.
+2. The dialog MUST appear.
+3. "Open in app" launches the dialer.
+
+### Manual: "Open in browser" loads in the webview
+
+1. Visit a page that fires a custom-scheme intent with an http fallback (or any intent the silent path doesn't catch).
+2. Pick "Open in browser".
+3. The fallback URL MUST load inside the same webview (or open in a nested screen if cross-domain), NOT in Chrome/Safari.
+
+### Automated
+
+`fvm flutter test test/external_url_engine_test.dart`
+
+---
+
+## Related
+
+- [`navigation`](../navigation/spec.md) — main navigation orchestration; `shouldOverrideUrlLoading` is the entry point this spec hooks into.
+- [`nested-url-blocking`](../nested-url-blocking/spec.md) — the same-domain / cross-domain decision used to route resolved intents.
+- [`clearurls`](../clearurls/spec.md) — tracking-parameter stripping that intent fallbacks inherit.
+- [`ios-universal-link-bypass`](../ios-universal-link-bypass/spec.md) — sibling concern: keeping iOS user-tap navigations inside the webview when AASA would otherwise route them to a native app.
+
+## Future Work
+
+- A per-site **"never prompt for external schemes"** toggle for users who want even tel:/mailto:/custom-scheme links suppressed.
+- A long-press affordance to launch the native app deliberately (currently the only escape hatch is the OS-level "open with" menu).
+- Suppression cache persistence across app restarts.

--- a/test/external_url_engine_test.dart
+++ b/test/external_url_engine_test.dart
@@ -89,4 +89,50 @@ void main() {
       expect(info?.scheme, 'intent');
     });
   });
+
+  group('ExternalUrlParser.intentToWebUrl', () {
+    test('returns null for non-intent schemes', () {
+      final tel = ExternalUrlParser.parse('tel:+14155551234')!;
+      expect(ExternalUrlParser.intentToWebUrl(tel), isNull);
+    });
+
+    test('prefers explicit browser_fallback_url', () {
+      const url =
+          'intent://www.google.com/maps?entry=ml&utm_campaign=ml-ardi-wv&coh=230964'
+          '#Intent;scheme=https;package=com.google.android.apps.maps;'
+          'S.browser_fallback_url=https%3A%2F%2Fwww.google.com%2Fmaps%3Fentry%3Dml'
+          '%26utm_campaign%3Dml-ardi-wv%26coh%3D230964;end;';
+      final info = ExternalUrlParser.parse(url)!;
+      expect(
+        ExternalUrlParser.intentToWebUrl(info),
+        'https://www.google.com/maps?entry=ml&utm_campaign=ml-ardi-wv&coh=230964',
+      );
+    });
+
+    test('reconstructs from targetScheme + host + path + query when no fallback', () {
+      const url =
+          'intent://www.google.com/maps?entry=ml#Intent;scheme=https;package=x;end';
+      final info = ExternalUrlParser.parse(url)!;
+      expect(info.fallbackUrl, isNull);
+      expect(
+        ExternalUrlParser.intentToWebUrl(info),
+        'https://www.google.com/maps?entry=ml',
+      );
+    });
+
+    test('returns null when targetScheme is non-http (e.g. zxing) and no fallback', () {
+      const url =
+          'intent://scan/#Intent;scheme=zxing;package=com.google.zxing.client.android;end';
+      final info = ExternalUrlParser.parse(url)!;
+      expect(ExternalUrlParser.intentToWebUrl(info), isNull);
+    });
+
+    test('returns null when fallback is non-http and no http target scheme', () {
+      const url =
+          'intent://scan/#Intent;scheme=zxing;'
+          'S.browser_fallback_url=zxing%3A%2F%2Fscan%2F;end';
+      final info = ExternalUrlParser.parse(url)!;
+      expect(ExternalUrlParser.intentToWebUrl(info), isNull);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
This PR improves handling of Android `intent://` URLs by automatically loading their web fallbacks inside the webview instead of always prompting the user or launching externally. This prevents hostile redirect loops (e.g., Google Maps) while maintaining user choice for app-only intents.

## Key Changes

- **Auto-resolve intent:// URLs with web fallbacks**: Added `ExternalUrlParser.intentToWebUrl()` method that:
  - Prefers explicit `S.browser_fallback_url` extras
  - Falls back to reconstructing URLs from `targetScheme` + host/path/query when target is http(s)
  - Returns null for app-only intents (e.g., zxing scanner) to preserve user confirmation dialog

- **Intercept intent:// URLs at three points in the webview lifecycle**:
  - `shouldOverrideUrlLoading`: Route resolved fallbacks through standard same-domain/cross-domain path
  - `onCreateWindow`: Handle popup-triggered intents
  - `onReceivedError`: Resolve fallbacks when intent scheme fails to load

- **Updated external URL confirmation dialog**:
  - "Open in browser" now loads the fallback inside our webview (we are the browser)
  - Respects per-site settings (cookies, proxy, content blockers)
  - Falls back to external launch when no controller available
  - Updated documentation to explain the behavior change

- **Pass webview controller to confirmation dialog**: Modified `confirmAndLaunchExternalUrl()` to accept optional `loadInWebView` parameter in `main.dart` and `inappbrowser.dart`

## Implementation Details

- Intent URLs without web fallbacks still trigger the user confirmation dialog, preserving choice for app-only deep links
- Uses `shouldOverrideUrlLoading` callback to determine same-domain vs cross-domain loading
- Logs all intent resolution attempts for debugging
- Handles errors gracefully with fallback to external launch when in-app loading fails

https://claude.ai/code/session_017MpxrS5F6hZf6yqujx2J88