### PR TITLE
Fix HTML cache eviction timing in WebSpacePage URL updates

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3370,12 +3370,18 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     }
 
     if (newUrl != null && newUrl != _webViewModels[index].initUrl) {
+      // Snapshot belongs to the old URL; deleteCache must run before the
+      // rebuild's getHtmlSync, which is why the sync in-memory eviction
+      // (inside deleteCache) is fired before setState rather than awaited.
+      final siteId = _webViewModels[index].siteId;
+      final deleteCache = HtmlCacheService.instance.deleteCache(siteId);
       setState(() {
         _webViewModels[index].initUrl = newUrl;
         _webViewModels[index].currentUrl = newUrl;
         _webViewModels[index].webview = null; // Force recreation with new URL
         _webViewModels[index].controller = null;
       });
+      await deleteCache;
     }
 
     await _saveWebViewModels();


### PR DESCRIPTION
## Summary
Fixed a race condition in the WebSpacePage URL update logic where HTML cache deletion was not properly synchronized with the view rebuild cycle.

## Key Changes
- Extracted `siteId` and initiated `deleteCache` operation before `setState()` call
- Moved the `await deleteCache` to after `setState()` completes, ensuring proper timing
- Added explanatory comments clarifying why synchronous in-memory eviction must occur before the rebuild's `getHtmlSync` call

## Implementation Details
The fix ensures that when a WebView's URL changes:
1. The cache deletion is initiated before the state update
2. The synchronous in-memory cache eviction (inside `deleteCache`) completes before `setState()` triggers the rebuild
3. The async cleanup operations are awaited after the rebuild, preventing stale cached HTML from being loaded by the new URL

This prevents a scenario where the old URL's cached snapshot could be served to the newly initialized WebView before the cache is properly cleared.

https://claude.ai/code/session_01GP6eMr7BZ363ToYj4tT2kT