### PR TITLE
Add always-on Do Not Track and Global Privacy Control support

### DIFF
--- a/lib/services/do_not_track_shim.dart
+++ b/lib/services/do_not_track_shim.dart
@@ -1,0 +1,45 @@
+// Always-on Do Not Track / Global Privacy Control JS shim.
+//
+// Surfaces every common signal a site (or fingerprinting probe) checks:
+//   - navigator.doNotTrack       -> '1'   (current spec, all evergreen browsers)
+//   - window.doNotTrack          -> '1'   (legacy Safari / old Firefox)
+//   - navigator.msDoNotTrack     -> '1'   (legacy IE / pre-Chromium Edge)
+//   - navigator.globalPrivacyControl -> true  (GPC, https://globalprivacycontrol.org)
+//   - Navigator.prototype.globalPrivacyControl -> true (so prototype checks pass)
+//
+// Must be injected at DOCUMENT_START, before any site script reads the
+// property — the override sets `configurable: true` so a page can replace
+// it (rare) but defines the getter on the prototype to avoid leaking an
+// own-property a fingerprinter could look for.
+
+const String _doNotTrackShimSource = '''
+(function() {
+  try {
+    function defineGetter(obj, name, value) {
+      try {
+        Object.defineProperty(obj, name, {
+          configurable: true,
+          enumerable: true,
+          get: function() { return value; },
+        });
+      } catch (e) {}
+    }
+    var NavProto = (typeof Navigator !== 'undefined' && Navigator.prototype)
+        ? Navigator.prototype
+        : null;
+    if (NavProto) {
+      defineGetter(NavProto, 'doNotTrack', '1');
+      defineGetter(NavProto, 'msDoNotTrack', '1');
+      defineGetter(NavProto, 'globalPrivacyControl', true);
+    }
+    if (typeof window !== 'undefined') {
+      defineGetter(window, 'doNotTrack', '1');
+    }
+  } catch (e) {}
+})();
+''';
+
+/// JS source that installs the always-on DNT / GPC overrides. Pure-Dart
+/// constant so the shim string is reachable from `tool/dump_shim_js.dart`
+/// and the drift check.
+String buildDoNotTrackShim() => _doNotTrackShimSource;

--- a/lib/services/outbound_http.dart
+++ b/lib/services/outbound_http.dart
@@ -39,6 +39,28 @@ class OutboundClientReady extends OutboundClient {
   const OutboundClientReady(this.client);
 }
 
+/// Wrap [inner] so every outgoing request carries the always-on `DNT: 1`
+/// and `Sec-GPC: 1` headers. The privacy posture of this app is "do not
+/// track me": every Dart-side outbound seam (downloads, user-script
+/// fetches, blocklist updates, favicon probes, …) must advertise that
+/// preference on the wire. Existing headers win — callers that
+/// explicitly set `DNT`/`Sec-GPC` for a test or odd-server probe keep
+/// their value.
+class _DoNotTrackClient extends http.BaseClient {
+  final http.Client _inner;
+  _DoNotTrackClient(this._inner);
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    request.headers.putIfAbsent('DNT', () => '1');
+    request.headers.putIfAbsent('Sec-GPC', () => '1');
+    return _inner.send(request);
+  }
+
+  @override
+  void close() => _inner.close();
+}
+
 /// The configured proxy cannot be honored from Dart-side HTTP. The caller
 /// MUST abort the request — falling back to a direct connection would leak
 /// the user's IP, defeating the proxy the user explicitly chose.
@@ -203,9 +225,28 @@ bool _isLocalhost(String host) {
 
 OutboundHttpFactory _factory = const DefaultOutboundHttpFactory();
 
+/// Wrapping factory: forwards to [inner] for proxy/connection setup, then
+/// drapes the always-on DNT/Sec-GPC client over the result. Sandwiched
+/// between the public [outboundHttp] getter and the underlying
+/// [DefaultOutboundHttpFactory] so every caller — production or test
+/// (when not overriding the factory) — gets the privacy headers.
+class _DoNotTrackOutboundHttpFactory implements OutboundHttpFactory {
+  final OutboundHttpFactory inner;
+  const _DoNotTrackOutboundHttpFactory(this.inner);
+
+  @override
+  OutboundClient clientFor(UserProxySettings settings) {
+    final result = inner.clientFor(settings);
+    if (result is OutboundClientReady) {
+      return OutboundClientReady(_DoNotTrackClient(result.client));
+    }
+    return result;
+  }
+}
+
 /// Global outbound HTTP factory. Use this from every Dart-side HTTP call
 /// that can carry user-identifying traffic.
-OutboundHttpFactory get outboundHttp => _factory;
+OutboundHttpFactory get outboundHttp => _DoNotTrackOutboundHttpFactory(_factory);
 
 /// Replace the global factory. Intended for tests.
 @visibleForTesting

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
 import 'package:webspace/services/blob_url_capture.dart';
 import 'package:webspace/services/clearurl_service.dart';
+import 'package:webspace/services/do_not_track_shim.dart';
 import 'package:webspace/services/language_shim.dart';
 import 'package:webspace/services/theme_color_scheme_shim.dart';
 import 'package:webspace/services/connectivity_service.dart';
@@ -653,6 +654,10 @@ class _WebViewController implements WebViewController {
     // the request through the WebView's HTTP path and can get rejected as
     // "invalid URL".
     final isHttp = url.startsWith('http://') || url.startsWith('https://');
+    if (isHttp) {
+      headers['DNT'] = '1';
+      headers['Sec-GPC'] = '1';
+    }
     if (language != null && isHttp) {
       headers['Accept-Language'] = '$language, *;q=0.5';
     }
@@ -1174,8 +1179,13 @@ class WebViewFactory {
     required WebViewConfig config,
     required Function(WebViewController) onControllerCreated,
   }) {
-    // Build initial URL request with optional Accept-Language header
-    final headers = <String, String>{};
+    // Build initial URL request headers. DNT/Sec-GPC are always-on per
+    // the privacy posture of this app — every outbound nav advertises
+    // the user's no-tracking preference.
+    final headers = <String, String>{
+      'DNT': '1',
+      'Sec-GPC': '1',
+    };
     if (config.language != null) {
       headers['Accept-Language'] = '${config.language}, *;q=0.5';
     }
@@ -1246,6 +1256,17 @@ class WebViewFactory {
         forMainFrameOnly: false,
       ));
     }
+
+    // Always-on Do Not Track / Global Privacy Control. Installs the
+    // navigator.doNotTrack / navigator.globalPrivacyControl getters before
+    // any site script can read them — also covers iframes (fingerprinters
+    // routinely run inside one).
+    userScripts.add(inapp.UserScript(
+      groupName: 'do_not_track',
+      source: '${buildDoNotTrackShim()}\n;null;',
+      injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
+      forMainFrameOnly: false,
+    ));
 
     // Blob URL capture: bridge sites whose CSP `connect-src` rejects
     // fetch(blob:) — the IIFE in `_handleBlobDownload` looks the Blob

--- a/test/do_not_track_shim_test.dart
+++ b/test/do_not_track_shim_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/do_not_track_shim.dart';
+
+void main() {
+  group('buildDoNotTrackShim', () {
+    final js = buildDoNotTrackShim();
+
+    test('overrides every DNT / GPC surface fingerprinters check', () {
+      expect(js, contains("'doNotTrack'"));
+      expect(js, contains("'msDoNotTrack'"));
+      expect(js, contains("'globalPrivacyControl'"));
+    });
+
+    test('returns "1" for the DNT signals (opt-out per spec)', () {
+      expect(js, contains("'1'"));
+    });
+
+    test('binds globalPrivacyControl to the boolean true (not the string)', () {
+      // The shim funnels each surface through `defineGetter(obj, name,
+      // value)`. globalPrivacyControl must be passed as a JS boolean so
+      // `navigator.globalPrivacyControl === true` matches what real
+      // browsers report; a string would fail strict-equality probes.
+      expect(js, contains("'globalPrivacyControl', true"));
+    });
+
+    test('defines getters on Navigator.prototype, not the instance', () {
+      // Defining the property on the navigator instance would leak it as
+      // an own-property — fingerprinters can detect that. The shim must
+      // hit Navigator.prototype so the property reads exactly like a
+      // browser-native one.
+      expect(js, contains('Navigator.prototype'));
+    });
+
+    test('wraps the body in try/catch so a missing API never breaks boot', () {
+      expect(js, contains('try {'));
+      expect(js, contains('catch'));
+    });
+
+    test('runs as an IIFE so locals do not leak to the global scope', () {
+      expect(js.trim(), startsWith('(function() {'));
+      expect(js.trim(), endsWith('})();'));
+    });
+  });
+}

--- a/test/js/do_not_track_shim.test.js
+++ b/test/js/do_not_track_shim.test.js
@@ -1,0 +1,66 @@
+// Tier 1 — jsdom assertions for the always-on Do Not Track / Global
+// Privacy Control shim (lib/services/do_not_track_shim.dart, dumped to
+// test/js_fixtures/do_not_track/shim.js).
+//
+// Fingerprinting probes look at:
+//   - navigator.doNotTrack ('1' = opt out per the WHATWG draft)
+//   - navigator.msDoNotTrack (legacy IE / pre-Chromium Edge)
+//   - window.doNotTrack (legacy Safari / old Firefox)
+//   - navigator.globalPrivacyControl (modern GPC standard, true = opt out)
+// All four must read as opt-out and must not appear as own-properties of
+// `navigator` (a leak that would tell a fingerprinter the override is JS,
+// not native).
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { loadShim } = require('./helpers/load_shim');
+
+test('navigator.doNotTrack is "1"', () => {
+  const dom = loadShim('do_not_track/shim.js');
+  assert.equal(dom.window.navigator.doNotTrack, '1');
+});
+
+test('navigator.msDoNotTrack is "1"', () => {
+  const dom = loadShim('do_not_track/shim.js');
+  assert.equal(dom.window.navigator.msDoNotTrack, '1');
+});
+
+test('window.doNotTrack is "1"', () => {
+  const dom = loadShim('do_not_track/shim.js');
+  assert.equal(dom.window.doNotTrack, '1');
+});
+
+test('navigator.globalPrivacyControl is true', () => {
+  const dom = loadShim('do_not_track/shim.js');
+  assert.equal(dom.window.navigator.globalPrivacyControl, true);
+});
+
+test('overrides hit Navigator.prototype, not the navigator instance', () => {
+  // Defining `doNotTrack` directly on `navigator` would leak it as an
+  // own-property — a fingerprinter could enumerate own-properties and
+  // detect the override. The shim defines getters on Navigator.prototype.
+  const dom = loadShim('do_not_track/shim.js');
+  const own = Object.getOwnPropertyNames(dom.window.navigator);
+  assert.equal(own.includes('doNotTrack'), false,
+    `doNotTrack leaks as own-property: ${JSON.stringify(own)}`);
+  assert.equal(own.includes('msDoNotTrack'), false);
+  assert.equal(own.includes('globalPrivacyControl'), false);
+});
+
+test('shim does not throw under jsdom', () => {
+  // The body is wrapped in try/catch so a missing API can never break
+  // page boot. Sanity-check that the fixture loads cleanly.
+  assert.doesNotThrow(() => loadShim('do_not_track/shim.js'));
+});
+
+test('properties read consistently across multiple accesses', () => {
+  // A getter that returns different values on repeated access would let
+  // a fingerprinter identify the shim. Confirm the getter is stable.
+  const dom = loadShim('do_not_track/shim.js');
+  const a = dom.window.navigator.doNotTrack;
+  const b = dom.window.navigator.doNotTrack;
+  const c = dom.window.navigator.globalPrivacyControl;
+  const d = dom.window.navigator.globalPrivacyControl;
+  assert.equal(a, b);
+  assert.equal(c, d);
+});

--- a/test/js_fixtures/do_not_track/shim.js
+++ b/test/js_fixtures/do_not_track/shim.js
@@ -1,0 +1,24 @@
+(function() {
+  try {
+    function defineGetter(obj, name, value) {
+      try {
+        Object.defineProperty(obj, name, {
+          configurable: true,
+          enumerable: true,
+          get: function() { return value; },
+        });
+      } catch (e) {}
+    }
+    var NavProto = (typeof Navigator !== 'undefined' && Navigator.prototype)
+        ? Navigator.prototype
+        : null;
+    if (NavProto) {
+      defineGetter(NavProto, 'doNotTrack', '1');
+      defineGetter(NavProto, 'msDoNotTrack', '1');
+      defineGetter(NavProto, 'globalPrivacyControl', true);
+    }
+    if (typeof window !== 'undefined') {
+      defineGetter(window, 'doNotTrack', '1');
+    }
+  } catch (e) {}
+})();

--- a/test/outbound_http_test.dart
+++ b/test/outbound_http_test.dart
@@ -248,4 +248,60 @@ void main() {
       expect(fake.queries[1].type, ProxyType.HTTP);
     });
   });
+
+  group('always-on Do Not Track / Sec-GPC headers', () {
+    test('every outbound request carries DNT: 1 and Sec-GPC: 1', () async {
+      // The privacy posture of this app is "do not track me" — every
+      // Dart-side outbound call (downloads, blocklist updates, favicon
+      // probes, user-script fetches) must advertise that on the wire
+      // even when the caller didn't set the headers explicitly.
+      late http.BaseRequest captured;
+      final fake = RecordingOutboundFactory(
+        clientBuilder: () => MockClient((req) async {
+          captured = req;
+          return http.Response('', 200);
+        }),
+      );
+      outboundHttp = fake;
+      addTearDown(resetOutboundHttp);
+
+      final result = outboundHttp.clientFor(
+        UserProxySettings(type: ProxyType.DEFAULT),
+      );
+      expect(result, isA<OutboundClientReady>());
+      final client = (result as OutboundClientReady).client;
+      addTearDown(client.close);
+      await client.get(Uri.parse('https://example.com/'));
+
+      expect(captured.headers['DNT'], '1');
+      expect(captured.headers['Sec-GPC'], '1');
+    });
+
+    test('caller-supplied DNT header is preserved (no double-set)', () async {
+      // The wrapper uses putIfAbsent so a test or odd-server probe that
+      // explicitly sets a different DNT value keeps it.
+      late http.BaseRequest captured;
+      final fake = RecordingOutboundFactory(
+        clientBuilder: () => MockClient((req) async {
+          captured = req;
+          return http.Response('', 200);
+        }),
+      );
+      outboundHttp = fake;
+      addTearDown(resetOutboundHttp);
+
+      final result = outboundHttp.clientFor(
+        UserProxySettings(type: ProxyType.DEFAULT),
+      );
+      final client = (result as OutboundClientReady).client;
+      addTearDown(client.close);
+      await client.get(
+        Uri.parse('https://example.com/'),
+        headers: {'DNT': '0'},
+      );
+
+      expect(captured.headers['DNT'], '0');
+      expect(captured.headers['Sec-GPC'], '1');
+    });
+  });
 }

--- a/tool/dump_shim_js.dart
+++ b/tool/dump_shim_js.dart
@@ -21,6 +21,7 @@ import 'dart:io';
 import 'package:webspace/services/blob_url_capture.dart';
 import 'package:webspace/services/content_blocker_shim.dart';
 import 'package:webspace/services/desktop_mode_shim.dart';
+import 'package:webspace/services/do_not_track_shim.dart';
 import 'package:webspace/services/language_shim.dart';
 import 'package:webspace/services/location_spoof_service.dart';
 import 'package:webspace/services/theme_color_scheme_shim.dart';
@@ -93,6 +94,8 @@ Map<String, String> buildAllFixtures() {
     spoofTimezone: 'Europe/Paris',
     webRtcPolicy: WebRtcPolicy.relayOnly,
   )!;
+
+  fixtures['do_not_track/shim.js'] = buildDoNotTrackShim();
 
   fixtures['language/en.js'] = buildLanguageShim('en');
   fixtures['language/fr_FR.js'] = buildLanguageShim('fr-FR');


### PR DESCRIPTION
Implements always-on Do Not Track (DNT) and Global Privacy Control (GPC) headers across both the WebView and Dart-side HTTP layers to enforce the app's privacy posture.

## Summary
This change ensures that every outbound request from the app advertises the user's no-tracking preference via standard privacy headers and JavaScript APIs, preventing fingerprinting probes from detecting whether tracking protection is enabled.

## Key Changes

- **JavaScript Shim (`do_not_track_shim.dart`)**: Installs getters on `Navigator.prototype` for `doNotTrack`, `msDoNotTrack`, and `globalPrivacyControl` to cover all surfaces fingerprinters check. Defined on the prototype (not the instance) to avoid leaking as an own-property.

- **WebView Integration (`webview.dart`)**: 
  - Injects the DNT/GPC shim at `DOCUMENT_START` before any site script executes
  - Adds `DNT: 1` and `Sec-GPC: 1` headers to all HTTP navigation requests
  - Applies to both main frame and iframes

- **Dart HTTP Layer (`outbound_http.dart`)**:
  - Wraps all outbound HTTP clients with `_DoNotTrackClient` to inject `DNT: 1` and `Sec-GPC: 1` headers
  - Uses `putIfAbsent` to preserve caller-supplied headers (for tests or edge cases)
  - Applies transparently to all Dart-side requests (downloads, blocklist updates, favicon probes, user-script fetches)

- **Tests**:
  - Dart unit tests verify the shim structure and correctness
  - JavaScript integration tests confirm the shim works under jsdom and doesn't leak as own-properties
  - HTTP tests verify headers are added to all requests and caller values are preserved

## Implementation Details

- The shim wraps everything in try/catch to ensure a missing API never breaks page boot
- Runs as an IIFE to avoid polluting global scope
- `globalPrivacyControl` is set to the boolean `true` (not a string) to match real browser behavior
- The wrapping factory pattern ensures both production and test code get privacy headers unless explicitly overridden

https://claude.ai/code/session_016cVfpQMof7JaBwu7LUCuKG