### PR TITLE
Override Sec-CH-UA-* on Android to track the spoofed UA

### DIFF
--- a/lib/services/desktop_mode_shim.dart
+++ b/lib/services/desktop_mode_shim.dart
@@ -18,13 +18,13 @@
 //   * `@media (pointer: coarse)` / `(hover: none)` — match on touch.
 //   * `<meta name=viewport>` shipped by the page — defeats `useWideViewPort`.
 //
-// What the shim CANNOT fix: `Sec-CH-UA-Mobile`, `Sec-CH-UA-Platform`, and
-// `Sec-CH-UA` HTTP request headers. Chromium WebView builds these from
-// native UA-metadata that flutter_inappwebview does not expose. A site
-// that gates strictly on those headers (DDG is one) will still see mobile
-// hints. This is documented in `openspec/specs/desktop-mode/spec.md` and
-// is not fixable without a plugin patch exposing
-// `WebSettingsCompat.setUserAgentMetadata()`.
+// `Sec-CH-UA-Mobile`, `Sec-CH-UA-Platform`, and `Sec-CH-UA` HTTP request
+// headers are emitted by Chromium WebView from a separate UA-metadata
+// object — independent of the UA string and unreachable from JS. They
+// are overridden separately by `user_agent_metadata_builder.dart`, wired
+// into `InAppWebViewSettings.userAgentMetadata` on Android (fork patch
+// over `WebSettingsCompat.setUserAgentMetadata`). This shim only
+// patches the JS-side surfaces; the wire-level headers live there.
 
 import 'package:webspace/services/user_agent_classifier.dart';
 

--- a/lib/services/user_agent_metadata_builder.dart
+++ b/lib/services/user_agent_metadata_builder.dart
@@ -1,0 +1,131 @@
+/// Per-site User-Agent Client Hints metadata, derived from the spoofed
+/// `userAgent` string and wired through to androidx.webkit's
+/// `WebSettingsCompat.setUserAgentMetadata` on Android via the fork's
+/// [InAppWebViewSettings.userAgentMetadata] field.
+///
+/// Setting only [InAppWebViewSettings.userAgent] does NOT suppress the
+/// `Sec-CH-UA`, `Sec-CH-UA-Mobile`, `Sec-CH-UA-Platform` HTTP request
+/// headers or the `navigator.userAgentData` JS surface — Chromium WebView
+/// builds those from a separate UA-metadata object that this API overrides.
+/// Without an override, a per-site Firefox UA leaks
+/// `Sec-CH-UA: "Chromium";v="REAL", Sec-CH-UA-Mobile: ?1,
+/// Sec-CH-UA-Platform: "Android"` while the UA string says Firefox-desktop —
+/// sites that gate on UA-CH (DDG, anti-bot vendors) keep serving mobile and
+/// see a contradictory fingerprint. This builder makes the two consistent.
+///
+/// The setting is silently dropped on iOS / macOS / Linux: WKWebView and
+/// WPE WebKit have no equivalent native API. We still build the metadata
+/// on those platforms so backup JSON stays portable.
+library;
+
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:webspace/services/user_agent_classifier.dart';
+
+/// GREASE entry the W3C UA-CH spec recommends prepending so servers do not
+/// hard-code brand-list shape. Mirrors what real Chrome emits today.
+BrandVersion _greaseBrand() => BrandVersion(
+      brand: 'Not.A/Brand',
+      majorVersion: '99',
+      fullVersion: '99.0.0.0',
+    );
+
+/// Build [UserAgentMetadata] consistent with the spoofed [ua] string.
+/// Returns `null` for empty/null UAs (the platform default applies).
+///
+/// The shape:
+/// - `mobile` → false for desktop-shaped UAs, true otherwise.
+/// - `platform` → "Linux" / "macOS" / "Windows" / "iOS" / "Android",
+///   inferred from the UA via [isDesktopUserAgent] + [inferDesktopUaPlatform]
+///   for desktop, or substring match for mobile.
+/// - `brandVersionList` → Firefox / Chrome brand entries with the version
+///   parsed out of the UA string, plus a GREASE entry. Returns `null` when
+///   the UA matches neither (the Android default brand list survives).
+/// - `fullVersion` → the recognized brand's full version. `null` for
+///   unrecognized UAs.
+/// - `architecture` / `bitness` / `model` / `wow64` left null. The per-site
+///   anti-fingerprinting shim already covers the JS-side hardware surfaces;
+///   synthesizing wire-level values here would manufacture identifying
+///   entropy for the same site without privacy benefit.
+UserAgentMetadata? buildUserAgentMetadata(String? ua) {
+  if (ua == null || ua.isEmpty) return null;
+
+  final desktop = isDesktopUserAgent(ua);
+  final platform = _platformFor(ua, desktop);
+  final brandList = _brandVersionListFor(ua);
+
+  return UserAgentMetadata(
+    brandVersionList: brandList,
+    fullVersion: brandList?.last.fullVersion,
+    platform: platform,
+    mobile: !desktop,
+  );
+}
+
+String _platformFor(String ua, bool desktop) {
+  if (desktop) {
+    return switch (inferDesktopUaPlatform(ua)) {
+      DesktopUaPlatform.linux => 'Linux',
+      DesktopUaPlatform.macos => 'macOS',
+      DesktopUaPlatform.windows => 'Windows',
+    };
+  }
+  final lower = ua.toLowerCase();
+  if (lower.contains('iphone') ||
+      lower.contains('ipad') ||
+      lower.contains('ipod')) {
+    return 'iOS';
+  }
+  return 'Android';
+}
+
+final RegExp _firefoxVersionRe = RegExp(r'Firefox/(\d+(?:\.\d+)*)');
+final RegExp _chromeVersionRe = RegExp(r'Chrome/(\d+(?:\.\d+)*)');
+
+List<BrandVersion>? _brandVersionListFor(String ua) {
+  final firefox = _firefoxVersionRe.firstMatch(ua);
+  if (firefox != null) {
+    final full = firefox.group(1)!;
+    final major = full.split('.').first;
+    return [
+      _greaseBrand(),
+      BrandVersion(
+        brand: 'Firefox',
+        majorVersion: major,
+        fullVersion: _padFullVersion(full),
+      ),
+    ];
+  }
+
+  final chrome = _chromeVersionRe.firstMatch(ua);
+  if (chrome != null) {
+    final full = chrome.group(1)!;
+    final major = full.split('.').first;
+    final padded = _padFullVersion(full);
+    return [
+      _greaseBrand(),
+      BrandVersion(
+        brand: 'Chromium',
+        majorVersion: major,
+        fullVersion: padded,
+      ),
+      BrandVersion(
+        brand: 'Google Chrome',
+        majorVersion: major,
+        fullVersion: padded,
+      ),
+    ];
+  }
+  return null;
+}
+
+/// `Sec-CH-UA-Full-Version-List` carries 4-segment versions
+/// (e.g. `137.0.6943.137`). UA strings often only carry the major (Firefox
+/// emits `147.0`, Chrome sometimes emits `137.0.0.0`); pad to four so we
+/// don't ship a suspiciously short value.
+String _padFullVersion(String version) {
+  final parts = version.split('.');
+  while (parts.length < 4) {
+    parts.add('0');
+  }
+  return parts.join('.');
+}

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -17,6 +17,7 @@ import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/current_location_service.dart';
 import 'package:webspace/services/desktop_mode_shim.dart';
 import 'package:webspace/services/user_agent_classifier.dart';
+import 'package:webspace/services/user_agent_metadata_builder.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/services/timezone_location_service.dart';
 import 'package:webspace/services/download_engine.dart';
@@ -744,6 +745,11 @@ class _WebViewController implements WebViewController {
     settings: inapp.InAppWebViewSettings(
       javaScriptEnabled: javascriptEnabled,
       userAgent: userAgent,
+      // Keep Sec-CH-UA*/navigator.userAgentData consistent with the UA
+      // string. Webview recreation on UA edits is the primary path
+      // (DM-001), so this is a defensive parallel apply for the rare
+      // setSettings-only path.
+      userAgentMetadata: buildUserAgentMetadata(userAgent),
       thirdPartyCookiesEnabled: thirdPartyCookiesEnabled ?? false,
       incognito: incognito ?? false,
       // Preserve system-derived textZoom — the InAppWebViewSettings
@@ -1758,6 +1764,11 @@ class WebViewFactory {
     )
       ..javaScriptEnabled = config.javascriptEnabled
       ..userAgent = config.userAgent
+      // Sec-CH-UA*/navigator.userAgentData on Android come from a separate
+      // metadata object — not the UA string. Without this override the
+      // wire-level UA-CH headers contradict the spoofed UA. Silently
+      // ignored on iOS/macOS/Linux (no equivalent native API).
+      ..userAgentMetadata = buildUserAgentMetadata(config.userAgent)
       ..thirdPartyCookiesEnabled = config.thirdPartyCookiesEnabled
       ..incognito = config.incognito
       ..textZoom = textZoom

--- a/openspec/specs/desktop-mode/spec.md
+++ b/openspec/specs/desktop-mode/spec.md
@@ -164,33 +164,62 @@ underlying mobile WebView's signals.
 
 ---
 
-## Known limitation: `Sec-CH-UA-*` HTTP headers
+### Requirement: DM-003 — Sec-CH-UA-* tracks the spoofed UA on Android
 
-The `Sec-CH-UA`, `Sec-CH-UA-Mobile`, and `Sec-CH-UA-Platform` HTTP
-request headers are emitted by the native Chromium WebView (Android) /
-WebKit (iOS) from a **User-Agent metadata object** that is independent of
-the UA string. flutter_inappwebview does not expose this metadata
-object; an earlier attempt to override the headers via
-`URLRequest.headers` (Android `loadUrl(url, additionalHttpHeaders)`) was
-empirically confirmed to be discarded by Chromium's network stack —
-even on the main document, the headers reach the server as `?1` /
-`"Android"` / `"Android WebView"` regardless of the UA string we set.
+The system SHALL override the `Sec-CH-UA`, `Sec-CH-UA-Mobile`, and
+`Sec-CH-UA-Platform` HTTP request headers and the
+`navigator.userAgentData` JS surface so they stay consistent with the
+per-site User-Agent string. Chromium WebView emits these values from a
+**User-Agent metadata object** independent of the UA string; without an
+override a desktop UA leaks `Sec-CH-UA-Mobile: ?1` and
+`Sec-CH-UA-Platform: "Android"`, and sites that gate on UA-CH rather
+than the UA string (DuckDuckGo, anti-bot vendors) keep serving mobile
+layouts and observe a contradictory fingerprint.
 
-A site that gates its layout strictly on `Sec-CH-UA-Mobile` rather than
-on `navigator.userAgentData` or the UA string will continue to receive
-the mobile layout even with a desktop UA. **DuckDuckGo (`duckduckgo.com`)
-is a confirmed example**: it reads the header and serves mobile no matter
-what UA / shim we present from Dart. WhatsApp Web, Bluesky, and X read
-`navigator.userAgentData` and the UA string, so the shim + UA together
-fix them.
+The override is wired through
+[`InAppWebViewSettings.userAgentMetadata`] →
+`androidx.webkit.WebSettingsCompat.setUserAgentMetadata` (gated on
+`WebViewFeature.USER_AGENT_METADATA`), and applied for every non-empty
+per-site UA — desktop or mobile — at webview-creation time. On iOS /
+macOS / Linux there is no equivalent native API; the field is
+serialized but the platform plugin silently drops it.
 
-The only fix from the app side is exposing
-`WebSettingsCompat.setUserAgentMetadata()` (Android 13.3+, androidx.webkit
-1.5.0+; analogous WKWebView API on iOS) through a
-flutter_inappwebview plugin patch. That requires either a fork or an
-upstream PR — based on the issue history (`#1458`, `#1713`, `#682`,
-`#2132`, `#2528`, all closed without maintainer reply) the upstream
-path is dead. Not currently implemented.
+#### Scenario: Desktop UA → Sec-CH-UA-Mobile reads `?0`
+
+**Given** a site with `userAgent = "Mozilla/5.0 (X11; Linux x86_64; rv:147.0) Gecko/20100101 Firefox/147.0"`
+**When** the webview is created on Android
+**Then** `InAppWebViewSettings.userAgentMetadata.mobile` is `false`
+**And** `userAgentMetadata.platform` is `"Linux"`
+
+#### Scenario: Mobile UA → Sec-CH-UA-Mobile reads `?1`
+
+**Given** a site with `userAgent = "Mozilla/5.0 (Android 16; Mobile; rv:147.0) Gecko/20100101 Firefox/147.0"`
+**When** the webview is created on Android
+**Then** `userAgentMetadata.mobile` is `true`
+**And** `userAgentMetadata.platform` is `"Android"`
+
+#### Scenario: Brand list matches the UA family
+
+**Given** a site with a Firefox-shaped UA
+**When** the webview is created on Android
+**Then** `userAgentMetadata.brandVersionList` carries a Firefox brand
+entry whose `majorVersion` equals the UA's `Firefox/N` major
+**And** the list is prefixed with the W3C-recommended GREASE entry
+(`brand: "Not.A/Brand"`, `majorVersion: "99"`)
+
+**Given** a site with a Chrome-shaped UA
+**When** the webview is created on Android
+**Then** the brand list carries `"Chromium"` and `"Google Chrome"`
+entries with the parsed version
+**And** is prefixed with the GREASE entry
+
+#### Scenario: Empty UA → no override
+
+**Given** a site with `userAgent = ""`
+**When** the webview is created on Android
+**Then** `userAgentMetadata` is `null`
+**And** the platform default UA-CH metadata reaches the wire — we do not
+manufacture a fake brand list when the user has not chosen a UA.
 
 ---
 
@@ -200,6 +229,8 @@ path is dead. Not currently implemented.
 |------|------|
 | `lib/services/user_agent_classifier.dart` | `isDesktopUserAgent`, `inferDesktopUaPlatform`, `navigatorPlatformFor`, canonical Firefox desktop UA constants |
 | `lib/services/desktop_mode_shim.dart` | `buildDesktopModeShim(userAgent)` — JS source for AT_DOCUMENT_START injection |
-| `lib/services/webview.dart` | `createWebView`: injects shim and sets `preferredContentMode` based on `isDesktopUserAgent(config.userAgent)` |
+| `lib/services/user_agent_metadata_builder.dart` | `buildUserAgentMetadata(userAgent)` — UA-CH override mapped 1:1 with the spoofed UA. Wired through to `WebSettingsCompat.setUserAgentMetadata` on Android via the fork's `InAppWebViewSettings.userAgentMetadata`. |
+| `lib/services/webview.dart` | `createWebView`: injects shim, sets `preferredContentMode`, and assigns `userAgentMetadata` from the per-site UA |
 | `test/user_agent_classifier_test.dart` | Coverage for the inference helpers |
 | `test/desktop_mode_shim_test.dart` | Coverage for the JS shim source generation |
+| `test/user_agent_metadata_builder_test.dart` | Coverage for the UA-CH override (mobile flag, platform, brand list, GREASE entry, wire shape) |

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -247,8 +247,8 @@ packages:
     dependency: "direct main"
     description:
       path: flutter_inappwebview
-      ref: "v6.2.0-beta.3-containers-v1"
-      resolved-ref: "0abc7f00d7f44f8dd776289f2560d7d59cacc654"
+      ref: "claude/add-android-useragent-Wg5cT"
+      resolved-ref: e4f06052c0b7d0447e0210ccc522b8811d4fa641
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "6.2.0-beta.3"
@@ -256,8 +256,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_android
-      ref: "v6.2.0-beta.3-containers-v1"
-      resolved-ref: "0abc7f00d7f44f8dd776289f2560d7d59cacc654"
+      ref: "claude/add-android-useragent-Wg5cT"
+      resolved-ref: e4f06052c0b7d0447e0210ccc522b8811d4fa641
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.2.0-beta.3"
@@ -273,8 +273,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_ios
-      ref: "v6.2.0-beta.3-containers-v1"
-      resolved-ref: "0abc7f00d7f44f8dd776289f2560d7d59cacc654"
+      ref: "claude/add-android-useragent-Wg5cT"
+      resolved-ref: e4f06052c0b7d0447e0210ccc522b8811d4fa641
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.2.0-beta.3"
@@ -282,8 +282,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_linux
-      ref: "v6.2.0-beta.3-containers-v1"
-      resolved-ref: "0abc7f00d7f44f8dd776289f2560d7d59cacc654"
+      ref: "claude/add-android-useragent-Wg5cT"
+      resolved-ref: e4f06052c0b7d0447e0210ccc522b8811d4fa641
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "0.1.0-beta.2"
@@ -291,8 +291,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_macos
-      ref: "v6.2.0-beta.3-containers-v1"
-      resolved-ref: "0abc7f00d7f44f8dd776289f2560d7d59cacc654"
+      ref: "claude/add-android-useragent-Wg5cT"
+      resolved-ref: e4f06052c0b7d0447e0210ccc522b8811d4fa641
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.2.0-beta.3"
@@ -300,8 +300,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_platform_interface
-      ref: "v6.2.0-beta.3-containers-v1"
-      resolved-ref: "0abc7f00d7f44f8dd776289f2560d7d59cacc654"
+      ref: "claude/add-android-useragent-Wg5cT"
+      resolved-ref: e4f06052c0b7d0447e0210ccc522b8811d4fa641
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.4.0-beta.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -88,32 +88,32 @@ dependency_overrides:
   flutter_inappwebview:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-containers-v1
+      ref: claude/add-android-useragent-Wg5cT
       path: flutter_inappwebview
   flutter_inappwebview_android:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-containers-v1
+      ref: claude/add-android-useragent-Wg5cT
       path: flutter_inappwebview_android
   flutter_inappwebview_ios:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-containers-v1
+      ref: claude/add-android-useragent-Wg5cT
       path: flutter_inappwebview_ios
   flutter_inappwebview_macos:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-containers-v1
+      ref: claude/add-android-useragent-Wg5cT
       path: flutter_inappwebview_macos
   flutter_inappwebview_linux:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-containers-v1
+      ref: claude/add-android-useragent-Wg5cT
       path: flutter_inappwebview_linux
   flutter_inappwebview_platform_interface:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-containers-v1
+      ref: claude/add-android-useragent-Wg5cT
       path: flutter_inappwebview_platform_interface
 
 flutter:

--- a/test/user_agent_metadata_builder_test.dart
+++ b/test/user_agent_metadata_builder_test.dart
@@ -1,0 +1,176 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/user_agent_classifier.dart';
+import 'package:webspace/services/user_agent_metadata_builder.dart';
+
+void main() {
+  group('buildUserAgentMetadata', () {
+    test('returns null for empty / null UA', () {
+      // Empty UA → fall back to the platform default UA-CH metadata. We
+      // explicitly DO NOT manufacture a fake brand list when the user has
+      // not picked a UA, otherwise the wire-level UA-CH would lie about
+      // a UA the user never chose.
+      expect(buildUserAgentMetadata(null), isNull);
+      expect(buildUserAgentMetadata(''), isNull);
+    });
+
+    group('mobile flag tracks the UA shape', () {
+      test('Firefox desktop UA → mobile=false', () {
+        // The whole point: a desktop-shaped UA must emit Sec-CH-UA-Mobile:?0
+        // so DDG-style sites that gate on the header serve desktop.
+        final m = buildUserAgentMetadata(firefoxLinuxDesktopUserAgent);
+        expect(m, isNotNull);
+        expect(m!.mobile, isFalse);
+      });
+
+      test('Android Firefox UA → mobile=true', () {
+        const ua = 'Mozilla/5.0 (Android 16; Mobile; rv:147.0) '
+            'Gecko/20100101 Firefox/147.0';
+        final m = buildUserAgentMetadata(ua);
+        expect(m, isNotNull);
+        expect(m!.mobile, isTrue);
+      });
+
+      test('iPhone UA → mobile=true', () {
+        const ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) '
+            'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 '
+            'Mobile/15E148 Safari/604.1';
+        expect(buildUserAgentMetadata(ua)!.mobile, isTrue);
+      });
+    });
+
+    group('platform tracks the UA platform', () {
+      test('Linux Firefox → "Linux"', () {
+        expect(buildUserAgentMetadata(firefoxLinuxDesktopUserAgent)!.platform,
+            'Linux');
+      });
+
+      test('macOS Firefox → "macOS"', () {
+        expect(buildUserAgentMetadata(firefoxMacosDesktopUserAgent)!.platform,
+            'macOS');
+      });
+
+      test('Windows Firefox → "Windows"', () {
+        expect(buildUserAgentMetadata(firefoxWindowsDesktopUserAgent)!.platform,
+            'Windows');
+      });
+
+      test('Android Chrome → "Android"', () {
+        const ua = 'Mozilla/5.0 (Linux; Android 14; Pixel 8) '
+            'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 '
+            'Mobile Safari/537.36';
+        expect(buildUserAgentMetadata(ua)!.platform, 'Android');
+      });
+
+      test('iPhone Safari → "iOS"', () {
+        const ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) '
+            'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 '
+            'Mobile/15E148 Safari/604.1';
+        expect(buildUserAgentMetadata(ua)!.platform, 'iOS');
+      });
+
+      test('iPad Safari → "iOS"', () {
+        const ua = 'Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) '
+            'AppleWebKit/605.1.15';
+        expect(buildUserAgentMetadata(ua)!.platform, 'iOS');
+      });
+    });
+
+    group('brandVersionList is consistent with the UA string', () {
+      test('Firefox UA → GREASE + Firefox brand with parsed version', () {
+        final m = buildUserAgentMetadata(firefoxLinuxDesktopUserAgent)!;
+        final brands = m.brandVersionList!;
+        // GREASE first to keep brand list shape unstable for fingerprinters.
+        expect(brands.first.brand, 'Not.A/Brand');
+        expect(brands.first.majorVersion, '99');
+        // The actual brand entry must match the UA's Firefox version.
+        final firefoxEntry =
+            brands.firstWhere((b) => b.brand == 'Firefox');
+        expect(firefoxEntry.majorVersion, '147');
+      });
+
+      test('Chrome UA → GREASE + Chromium + Google Chrome', () {
+        const ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 '
+            '(KHTML, like Gecko) Chrome/137.0.6943.137 Safari/537.36';
+        final brands = buildUserAgentMetadata(ua)!.brandVersionList!;
+        // Both Chromium and Google Chrome are required — real Chrome
+        // emits both, and a server checking "Chromium" presence would
+        // notice if we shipped only "Google Chrome".
+        expect(brands.any((b) => b.brand == 'Chromium'), isTrue);
+        expect(brands.any((b) => b.brand == 'Google Chrome'), isTrue);
+        for (final b in brands.where((b) => b.brand != 'Not.A/Brand')) {
+          expect(b.majorVersion, '137');
+          expect(b.fullVersion, '137.0.6943.137');
+        }
+      });
+
+      test('non-Firefox/non-Chrome UA → null brand list', () {
+        // A UA we cannot parse safely falls through to the platform default
+        // brand list rather than manufacturing a fake brand identity.
+        const ua = 'Mozilla/5.0 SomeCustomBrowser/1.0';
+        expect(buildUserAgentMetadata(ua)!.brandVersionList, isNull);
+      });
+
+      test('full version is padded to four segments', () {
+        // `Sec-CH-UA-Full-Version-List` carries 4-segment versions.
+        // Firefox UAs only carry "147.0" — pad to "147.0.0.0" so we
+        // don't ship a suspiciously short value.
+        final m = buildUserAgentMetadata(firefoxLinuxDesktopUserAgent)!;
+        final firefoxEntry =
+            m.brandVersionList!.firstWhere((b) => b.brand == 'Firefox');
+        expect(firefoxEntry.fullVersion, '147.0.0.0');
+        expect(m.fullVersion, '147.0.0.0');
+      });
+    });
+
+    test('serializes through toMap', () {
+      // The wire format the platform channel consumes — must round-trip,
+      // since the Android side reads the same keys we write here.
+      final m = buildUserAgentMetadata(firefoxLinuxDesktopUserAgent)!;
+      final map = m.toMap();
+      expect(map['platform'], 'Linux');
+      expect(map['mobile'], isFalse);
+      final brands = map['brandVersionList'] as List;
+      expect(brands.length, 2);
+      final firefoxBrand = brands.firstWhere(
+        (b) => (b as Map)['brand'] == 'Firefox',
+      ) as Map;
+      expect(firefoxBrand['majorVersion'], '147');
+      expect(firefoxBrand['fullVersion'], '147.0.0.0');
+    });
+
+    test('returned UserAgentMetadata is not const-equal across calls', () {
+      // Each call constructs a fresh BrandVersion list; this guards against
+      // a refactor that swaps the GREASE entry to a singleton — caller code
+      // could mutate the list (toMap iterates it) and we don't want to
+      // share state across sites.
+      final a = buildUserAgentMetadata(firefoxLinuxDesktopUserAgent)!;
+      final b = buildUserAgentMetadata(firefoxLinuxDesktopUserAgent)!;
+      expect(identical(a, b), isFalse);
+      expect(identical(a.brandVersionList, b.brandVersionList), isFalse);
+    });
+  });
+
+  group('UserAgentMetadata wire shape', () {
+    test('matches the Android key names the fork patch reads', () {
+      // The native side (InAppWebView.java buildUserAgentMetadata) reads
+      // these exact map keys. Renaming any of them silently breaks the
+      // override. Lock the wire format here so the test fails on rename
+      // rather than at runtime on Android.
+      final m = buildUserAgentMetadata(firefoxLinuxDesktopUserAgent)!;
+      final map = m.toMap();
+      expect(map.keys, containsAll([
+        'brandVersionList',
+        'fullVersion',
+        'platform',
+        'mobile',
+      ]));
+    });
+
+    test('BrandVersion uses brand/majorVersion/fullVersion keys', () {
+      final m = buildUserAgentMetadata(firefoxLinuxDesktopUserAgent)!;
+      final firstBrand = (m.toMap()['brandVersionList'] as List).first as Map;
+      expect(firstBrand.keys,
+          containsAll(['brand', 'majorVersion', 'fullVersion']));
+    });
+  });
+}


### PR DESCRIPTION
Setting only InAppWebViewSettings.userAgent does NOT suppress Sec-CH-UA*/navigator.userAgentData on Chromium WebView — those come from a separate UA-metadata object. Without an override a desktop UA leaks Sec-CH-UA-Mobile: ?1 / Sec-CH-UA-Platform: "Android", and sites that gate on UA-CH (DDG, anti-bot vendors) keep serving mobile and observe a contradictory fingerprint.

Bump fork ref to claude/add-android-useragent-Wg5cT, which exposes WebSettingsCompat.setUserAgentMetadata via
InAppWebViewSettings.userAgentMetadata. Add user_agent_metadata_builder that derives a UserAgentMetadata 1:1 from the per-site UA string (mobile flag, platform, Firefox/Chrome brand list with parsed version, GREASE entry). Wire it through createWebView + setOptions; null on empty UA so we don't manufacture a fake brand list when the user has not chosen one. Silently dropped on iOS/macOS/Linux (no equivalent native API).

Promotes the previous DM known-limitation block to DM-003 in the desktop-mode spec.