### PR TITLE
Speed up DNS + ABP blocking on iOS and Android

### DIFF
--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/WebInterceptPlugin.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/WebInterceptPlugin.kt
@@ -15,7 +15,6 @@ import io.flutter.plugin.common.MethodChannel
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.FileInputStream
-import java.net.URI
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
@@ -38,11 +37,14 @@ class WebInterceptPlugin(private val activity: Activity, flutterEngine: FlutterE
     // LocalCDN: cacheKey ("lib/ver/file") -> absolute file path on disk.
     private val cdnCacheIndex = mutableMapOf<String, String>()
 
-    // Per-site pending block events (DNS + ABP + allowed). Java is the
-    // source of truth; Dart pulls on demand. Each event carries a
-    // "source" string identifying which blocklist matched ("dns", "abp")
-    // or null/absent for allowed requests.
-    private val pendingBlockEvents = ConcurrentHashMap<String, MutableList<Map<String, Any>>>()
+    // Per-site pending block events. Stored as a per-host map keyed by
+    // host so repeated requests for the same host (the dominant pattern
+    // on real pages — a CDN domain serving 30+ assets) collapse into one
+    // log entry with a `count` aggregate. Without this dedup, a typical
+    // page enqueued 200+ HashMap allocations on the WebView thread per
+    // load, pinned the synchronized list contention, and pumped 200+
+    // events through the Flutter MethodChannel codec on each drain.
+    private val pendingBlockEvents = ConcurrentHashMap<String, MutableMap<String, BlockEventEntry>>()
     private val blockSignalPending = ConcurrentHashMap<String, AtomicBoolean>()
 
     // Per-site pending LocalCDN replacement events. Events carry the cache key
@@ -128,7 +130,7 @@ class WebInterceptPlugin(private val activity: Activity, flutterEngine: FlutterE
                     if (siteId == null) {
                         result.error("INVALID_ARGS", "siteId required", null)
                     } else {
-                        result.success(drainEvents(pendingBlockEvents, siteId))
+                        result.success(drainBlockEvents(siteId))
                     }
                 }
                 "fetchCdnEvents" -> {
@@ -136,7 +138,7 @@ class WebInterceptPlugin(private val activity: Activity, flutterEngine: FlutterE
                     if (siteId == null) {
                         result.error("INVALID_ARGS", "siteId required", null)
                     } else {
-                        result.success(drainEvents(pendingCdnEvents, siteId))
+                        result.success(drainCdnEvents(siteId))
                     }
                 }
                 else -> result.notImplemented()
@@ -144,11 +146,8 @@ class WebInterceptPlugin(private val activity: Activity, flutterEngine: FlutterE
         }
     }
 
-    private fun drainEvents(
-        store: ConcurrentHashMap<String, MutableList<Map<String, Any>>>,
-        siteId: String
-    ): List<Map<String, Any>> {
-        val list = store[siteId] ?: return emptyList()
+    private fun drainCdnEvents(siteId: String): List<Map<String, Any>> {
+        val list = pendingCdnEvents[siteId] ?: return emptyList()
         synchronized(list) {
             val snapshot = ArrayList(list)
             list.clear()
@@ -156,19 +155,54 @@ class WebInterceptPlugin(private val activity: Activity, flutterEngine: FlutterE
         }
     }
 
-    /// Records a block event (allowed or blocked, source-tagged) and
-    /// signals Dart once per batch. If Dart is already processing an
-    /// earlier signal for this site, subsequent events just accumulate —
-    /// no duplicate signals.
-    private fun recordBlockEvent(siteId: String, host: String, blocked: Boolean, source: String?) {
-        val list = pendingBlockEvents.computeIfAbsent(siteId) {
-            Collections.synchronizedList(mutableListOf())
+    /// Drain all pending block events for a site. The map is consumed
+    /// (cleared) under lock and returned as a list of `{host, blocked,
+    /// source, count}` records. A repeat host that fired N times since
+    /// the previous drain shows up as a single record with `count = N`.
+    /// Dart applies the counts to the per-site totals while only adding
+    /// one DnsLogEntry per record.
+    private fun drainBlockEvents(siteId: String): List<Map<String, Any>> {
+        val map = pendingBlockEvents[siteId] ?: return emptyList()
+        synchronized(map) {
+            if (map.isEmpty()) return emptyList()
+            val snapshot = ArrayList<Map<String, Any>>(map.size)
+            for ((host, entry) in map) {
+                val event = HashMap<String, Any>(4)
+                event["host"] = host
+                event["blocked"] = entry.blocked
+                if (entry.source != null) event["source"] = entry.source!!
+                event["count"] = entry.count
+                snapshot.add(event)
+            }
+            map.clear()
+            return snapshot
         }
-        val event = HashMap<String, Any>(3)
-        event["host"] = host
-        event["blocked"] = blocked
-        if (source != null) event["source"] = source
-        list.add(event)
+    }
+
+    /// Records a block event (allowed or blocked, source-tagged) and
+    /// signals Dart once per batch. Repeat hosts in the same drain
+    /// window only bump the `count` field on the existing entry — no
+    /// new HashMap allocation, no extra mainHandler.post.
+    private fun recordBlockEvent(siteId: String, host: String, blocked: Boolean, source: String?) {
+        val map = pendingBlockEvents.computeIfAbsent(siteId) {
+            Collections.synchronizedMap(LinkedHashMap())
+        }
+        val isNew: Boolean
+        synchronized(map) {
+            val existing = map[host]
+            if (existing != null) {
+                existing.count++
+                isNew = false
+            } else {
+                map[host] = BlockEventEntry(blocked, source, 1)
+                isNew = true
+            }
+        }
+
+        // Signal Dart only when a new host appears, OR when no signal is
+        // pending (Dart will eventually drain). Bumping a count on an
+        // already-pending host doesn't need a fresh wakeup.
+        if (!isNew) return
 
         val signaled = blockSignalPending.computeIfAbsent(siteId) { AtomicBoolean(false) }
         if (signaled.compareAndSet(false, true)) {
@@ -181,6 +215,11 @@ class WebInterceptPlugin(private val activity: Activity, flutterEngine: FlutterE
             }
         }
     }
+
+    /// Mutable count carrier. The map of these is the source of truth
+    /// while events are pending; on drain we atomically swap the map
+    /// contents and translate each entry to a serializable `Map<String, Any>`.
+    private class BlockEventEntry(val blocked: Boolean, val source: String?, var count: Int)
 
     /// Records that a CDN request was replaced with a cached resource for
     /// this site. Signal batching mirrors the DNS path.
@@ -291,6 +330,27 @@ class WebInterceptPlugin(private val activity: Activity, flutterEngine: FlutterE
 /// DNS is checked before ABP so that requests which appear in both lists
 /// are attributed to DNS (the user-facing blocklist with the tighter
 /// severity settings). Stats downstream can be disentangled by source.
+///
+/// Hot-path notes:
+/// * Host extraction avoids `java.net.URI`. Java's URI ctor is strict
+///   about RFC 3986 and throws on perfectly valid web URLs (spaces,
+///   curly braces in query strings, etc.); each throw allocates a stack
+///   trace. The substring-based [extractHost] handles every form
+///   chromium delivers without throwing.
+/// * [isInSet] walks the suffix hierarchy without `host.split(".")` /
+///   `parts.subList(...).joinToString(".")` per level. Hundreds of
+///   sub-resources per page x 4–6 levels of suffix walk ≈ thousands of
+///   list/string allocations on the WebView thread; the substring walk
+///   keeps that down to one substring per parent label visited.
+/// * [hostDecision] caches the (DNS+ABP+allowed) classification per
+///   host so a page that loads 50 resources from `cdn.example.com`
+///   walks the suffix lookup once, not 50 times. The cache is also
+///   used to dedupe block-event reporting back to Dart: only the
+///   first request per (siteId, host) is enqueued, repeats just bump
+///   atomic counters that Dart reconciles on each drain. Without
+///   dedup, a single page load enqueued one event per allowed
+///   sub-resource — hundreds of HashMap allocations + synchronizedList
+///   adds per page on the critical request path.
 class FastSubresourceInterceptor(
     private val dnsBlockedDomains: HashSet<String>,
     private val abpBlockedDomains: HashSet<String>,
@@ -306,6 +366,14 @@ class FastSubresourceInterceptor(
     private var loggedNoCache = false
     private var loggedLocalCdnDisabled = false
 
+    /// Per-instance host classification cache. Capacity 1024 covers a
+    /// typical busy page (≤ a few hundred unique hosts) plus headroom;
+    /// once full, FIFO eviction keeps memory bounded. Storing
+    /// `Decision` (an enum) instead of raw `String?` for the source
+    /// avoids re-classifying on dedup'd repeats.
+    private val hostDecision = LinkedHashMap<String, Decision>(256, 0.75f, false)
+    private val hostDecisionCap = 1024
+
     init {
         // Dummy rule so the Java guard `ruleList.size() > 0` passes
         val trigger = ContentBlockerTrigger(".*", null, null, null, null, null, null, null)
@@ -313,60 +381,62 @@ class FastSubresourceInterceptor(
         ruleList.add(ContentBlocker(trigger, action))
     }
 
+    private enum class Decision { ALLOWED, BLOCKED_DNS, BLOCKED_ABP }
+
     override fun checkUrl(
         webView: InAppWebView,
         request: WebResourceRequestExt
     ): WebResourceResponse? {
         val url = request.url ?: return null
-        val host = try {
-            URI(url).host?.lowercase() ?: return null
-        } catch (_: Exception) {
-            return null
-        }
+        val host = extractHost(url) ?: return null
         if (host.isEmpty()) return null
 
         checkCount++
-        // Log the first handful of sub-resource intercepts so you can
-        // confirm the native path is firing at all, plus periodic samples.
         if (checkCount <= 10 || checkCount % 100 == 0) {
             onLog("WebIntercept", "checkUrl #$checkCount host=$host url=$url")
         }
 
-        // 1. Domain blocking (DNS first, then ABP) with source attribution.
-        // ALWAYS runs, regardless of the LocalCDN kill-switch.
-        //
-        // Use an EMPTY ByteArrayInputStream for the response body, NOT
-        // null. Returning a `WebResourceResponse(_, _, null)` is a
-        // documented edge case: per the chromium WebView source the
-        // null body is treated as "request blocked" but the response
-        // object is still routed across the IPC boundary to chromium's
-        // IO thread, which on some builds dereferences the InputStream
-        // during cleanup of cross-origin redirects. That's the candidate
-        // for the dangling-raw_ptr SIGTRAP at
-        // `partition_alloc_support.cc:770` we keep hitting on the
-        // LinkedIn safety/go → reddit redirect path: the previous
-        // origin's blocked sub-resource responses are still cleaning up
-        // when chromium swaps SiteInstance, and a null InputStream
-        // there nulls a raw_ptr held against the old RenderFrameHost.
-        // An empty stream gives chromium a real (zero-byte) object to
-        // route through the same code path with no null dereference.
-        when {
-            isInSet(host, dnsBlockedDomains) -> {
-                onBlockChecked(host, true, "dns")
-                return WebResourceResponse(
-                    "text/plain", "utf-8", ByteArrayInputStream(EMPTY_BODY))
+        // 1. Look up the cached classification for this host. On miss,
+        // walk the DNS + ABP sets and cache. The dominant cost the cache
+        // saves is the suffix walk — `tracker.example.com` resolved
+        // once doesn't need to look up `tracker.example.com`,
+        // `example.com`, then fail again on every subsequent fetch.
+        var decision = hostDecision[host]
+        if (decision == null) {
+            decision = when {
+                isInSet(host, dnsBlockedDomains) -> Decision.BLOCKED_DNS
+                isInSet(host, abpBlockedDomains) -> Decision.BLOCKED_ABP
+                else -> Decision.ALLOWED
             }
-            isInSet(host, abpBlockedDomains) -> {
-                onBlockChecked(host, true, "abp")
-                return WebResourceResponse(
-                    "text/plain", "utf-8", ByteArrayInputStream(EMPTY_BODY))
-            }
-            else -> {
-                onBlockChecked(host, false, null)
-            }
+            putHostDecision(host, decision)
         }
 
-        // 2. LocalCDN — gated by the diagnostic kill-switch. Builds a
+        // Always report — the WebInterceptPlugin layer dedupes at the
+        // pending-drain level, collapsing repeat requests for the same
+        // host into a single Dart-side log entry while still summing
+        // the count toward the per-site totals.
+        when (decision) {
+            Decision.BLOCKED_DNS -> onBlockChecked(host, true, "dns")
+            Decision.BLOCKED_ABP -> onBlockChecked(host, true, "abp")
+            Decision.ALLOWED -> onBlockChecked(host, false, null)
+        }
+
+        // 2. Domain blocking response. Use an EMPTY ByteArrayInputStream
+        // for the response body, NOT null. Returning a `WebResourceResponse(
+        // _, _, null)` is a documented edge case: per the chromium WebView
+        // source the null body is treated as "request blocked" but the
+        // response object is still routed across the IPC boundary to
+        // chromium's IO thread, which on some builds dereferences the
+        // InputStream during cleanup of cross-origin redirects. That's the
+        // candidate for the dangling-raw_ptr SIGTRAP at
+        // `partition_alloc_support.cc:770`. An empty stream gives chromium
+        // a real (zero-byte) object with no null dereference.
+        if (decision == Decision.BLOCKED_DNS || decision == Decision.BLOCKED_ABP) {
+            return WebResourceResponse(
+                "text/plain", "utf-8", ByteArrayInputStream(EMPTY_BODY))
+        }
+
+        // 3. LocalCDN — gated by the diagnostic kill-switch. Builds a
         // WebResourceResponse with a FileInputStream that chromium's IO
         // thread reads async; if the request lifecycle ends before
         // chromium consumes the stream, that's the candidate origin
@@ -390,6 +460,17 @@ class FastSubresourceInterceptor(
         }
 
         return null
+    }
+
+    private fun putHostDecision(host: String, decision: Decision) {
+        if (hostDecision.size >= hostDecisionCap) {
+            val it = hostDecision.entries.iterator()
+            if (it.hasNext()) {
+                it.next()
+                it.remove()
+            }
+        }
+        hostDecision[host] = decision
     }
 
     private fun tryServeCdn(url: String): WebResourceResponse? {
@@ -425,14 +506,23 @@ class FastSubresourceInterceptor(
         return null
     }
 
+    /// Allocation-free suffix-walk lookup. Same semantics as the previous
+    /// `host.split(".")` + `parts.subList(i, parts.size).joinToString(".")`
+    /// pattern, but uses `String.indexOf` against `host` to derive each
+    /// parent label without allocating a fresh `List<String>` or composing
+    /// strings via `joinToString`. The single substring per parent is
+    /// the key for `set.contains(...)` — `HashSet.contains` accepts that
+    /// substring directly without further allocation. Stops before the
+    /// final eTLD label (`com` alone is never matched).
     private fun isInSet(host: String, set: HashSet<String>): Boolean {
         if (set.isEmpty()) return false
         if (set.contains(host)) return true
-        val parts = host.split(".")
-        for (i in 1 until parts.size - 1) {
-            if (set.contains(parts.subList(i, parts.size).joinToString("."))) {
-                return true
-            }
+        var dot = host.indexOf('.')
+        while (dot in 0 until host.length - 1) {
+            val parent = host.substring(dot + 1)
+            if (parent.indexOf('.') < 0) return false
+            if (set.contains(parent)) return true
+            dot = host.indexOf('.', dot + 1)
         }
         return false
     }
@@ -465,6 +555,67 @@ class FastSubresourceInterceptor(
                 if (path.endsWith(ext)) return mime
             }
             return "application/octet-stream"
+        }
+
+        /// Extract the lowercase host from `scheme://host[:port]/...`.
+        /// Mirrors `host_lookup.dart#extractHost` so Dart and Kotlin
+        /// agree on what counts as a host. Avoids `java.net.URI` which
+        /// throws on URLs chromium accepts (spaces / `{` `}` in query
+        /// strings, malformed userinfo, etc.) — each throw allocates a
+        /// stack trace and pays for `Throwable.fillInStackTrace`. This
+        /// hand-rolled extractor uses three index scans + one substring,
+        /// no exceptions.
+        @JvmStatic
+        fun extractHost(url: String): String? {
+            val schemeEnd = url.indexOf("://")
+            if (schemeEnd < 0) return null
+            val start = schemeEnd + 3
+            val len = url.length
+            var end = len
+            for (j in start until len) {
+                val c = url[j].code
+                if (c == 0x2F || c == 0x3F || c == 0x23) {
+                    end = j
+                    break
+                }
+            }
+            // Strip userinfo: last '@' before authority terminator.
+            var hostStart = start
+            for (j in start until end) {
+                if (url[j].code == 0x40) hostStart = j + 1
+            }
+            // IPv6 literal: bracketed.
+            if (hostStart < end && url[hostStart].code == 0x5B) {
+                for (j in hostStart until end) {
+                    if (url[j].code == 0x5D) {
+                        return slice(url, hostStart, j + 1)
+                    }
+                }
+                return null
+            }
+            // Strip :port — first ':' between hostStart and end.
+            var hostEnd = end
+            for (j in hostStart until end) {
+                if (url[j].code == 0x3A) {
+                    hostEnd = j
+                    break
+                }
+            }
+            return slice(url, hostStart, hostEnd)
+        }
+
+        private fun slice(url: String, start: Int, end: Int): String {
+            if (start >= end) return ""
+            var hasUpper = false
+            for (j in start until end) {
+                val c = url[j].code
+                if (c in 0x41..0x5A) {
+                    hasUpper = true
+                    break
+                }
+            }
+            val s = url.substring(start, end)
+            return if (hasUpper) s.lowercase() else s
         }
     }
 }

--- a/lib/services/content_blocker_service.dart
+++ b/lib/services/content_blocker_service.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:webspace/services/content_blocker_shim.dart';
+import 'package:webspace/services/host_lookup.dart';
 import 'package:webspace/services/outbound_http.dart';
 import 'package:webspace/settings/global_outbound_proxy.dart';
 import 'package:webspace/services/log_service.dart';
@@ -140,22 +141,36 @@ class ContentBlockerService {
     }
   }
 
+  /// Per-host decision cache for [isBlocked]. The DNS path uses the same
+  /// pattern in [DnsBlockService._dnsBlockCache]; without a cache here,
+  /// every sub-resource roundtrip (iOS JS-bridge `blockCheck` /
+  /// `blockResourceLoaded`) re-walks the suffix hierarchy even for hosts
+  /// already known good. Cleared in [_rebuildRules].
+  final HostFifoCache _isBlockedCache = HostFifoCache(2048);
+
   /// Check if a URL's domain (or any parent domain) is blocked.
+  ///
+  /// Hot path. Avoids `Uri.parse` (full RFC 3986 validation, allocates a
+  /// `Uri` object) by using [extractHost] and short-circuits via
+  /// [_isBlockedCache] on repeated hosts. The suffix walk is allocation-
+  /// free aside from the parent substring per level. Mirrors the
+  /// optimisation already in place on [DnsBlockService.isBlocked].
   bool isBlocked(String url) {
     if (_blockedDomains.isEmpty) return false;
-    try {
-      final host = Uri.parse(url).host.toLowerCase();
-      if (host.isEmpty) return false;
-      // Check exact and parent domains: a.b.example.com -> b.example.com -> example.com
-      String domain = host;
-      while (domain.isNotEmpty) {
-        if (_blockedDomains.contains(domain)) return true;
-        final dotIdx = domain.indexOf('.');
-        if (dotIdx < 0) break;
-        domain = domain.substring(dotIdx + 1);
-      }
-    } catch (_) {}
-    return false;
+    final host = extractHost(url);
+    if (host == null || host.isEmpty) return false;
+    return isHostBlocked(host);
+  }
+
+  /// Like [isBlocked] but the caller already has the host. Skips the
+  /// URL-parse step.
+  bool isHostBlocked(String host) {
+    if (_blockedDomains.isEmpty || host.isEmpty) return false;
+    final cached = _isBlockedCache[host];
+    if (cached != null) return cached;
+    final result = hostInSet(host, _blockedDomains);
+    _isBlockedCache.put(host, result);
+    return result;
   }
 
   /// Collect applicable selectors and text rules for a page URL.
@@ -168,8 +183,8 @@ class ContentBlockerService {
     final globalText = _textHideRules[''];
     if (globalText != null) textRules.addAll(globalText);
 
-    try {
-      final host = Uri.parse(pageUrl).host.toLowerCase();
+    final host = extractHost(pageUrl);
+    if (host != null && host.isNotEmpty) {
       String domain = host;
       while (domain.isNotEmpty) {
         final ds = _cosmeticSelectors[domain];
@@ -180,7 +195,7 @@ class ContentBlockerService {
         if (dotIdx < 0) break;
         domain = domain.substring(dotIdx + 1);
       }
-    } catch (_) {}
+    }
 
     return (selectors: selectors, textRules: textRules);
   }
@@ -375,6 +390,7 @@ class ContentBlockerService {
     _blockedDomains = allDomains;
     _cosmeticSelectors = allSelectors;
     _textHideRules = allTextRules;
+    _isBlockedCache.clear();
     _notifyRulesChanged();
   }
 
@@ -396,6 +412,7 @@ class ContentBlockerService {
     _blockedDomains = {};
     _cosmeticSelectors = {};
     _textHideRules = {};
+    _isBlockedCache.clear();
   }
 
   /// Exposed for testing: set lists directly.

--- a/lib/services/content_blocker_service.dart
+++ b/lib/services/content_blocker_service.dart
@@ -420,4 +420,14 @@ class ContentBlockerService {
   void setLists(List<FilterList> lists) {
     _lists = lists;
   }
+
+  /// Exposed for testing: seed the aggregated blocked domains directly,
+  /// bypassing the file I/O / parser path. Mirrors the shape produced
+  /// by [_rebuildRules] so the [isBlocked] hot path can be exercised
+  /// without staging cached filter files on disk.
+  @visibleForTesting
+  void setBlockedDomainsForTest(Set<String> domains) {
+    _blockedDomains = domains;
+    _isBlockedCache.clear();
+  }
 }

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -7,6 +7,7 @@ import 'package:webspace/services/outbound_http.dart';
 import 'package:webspace/settings/global_outbound_proxy.dart';
 import 'package:webspace/services/bloom_filter.dart';
 import 'package:webspace/services/content_blocker_service.dart';
+import 'package:webspace/services/host_lookup.dart';
 import 'package:webspace/services/log_service.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -35,26 +36,55 @@ class DnsLogEntry {
 ///
 /// `blocked`/`allowed` are merged totals; `blockedByDns`/`blockedByAbp` let
 /// callers break it down without iterating the log.
+///
+/// The log is backed by a fixed-size ring buffer so high-volume pages
+/// (hundreds of sub-resources per load) don't pay an O(n) shift on every
+/// overflow — `List.removeAt(0)` on a 500-element list copies all 499
+/// remaining elements per insert past the cap.
 class DnsStats {
   int allowed = 0;
   int blocked = 0;
   int blockedByDns = 0;
   int blockedByAbp = 0;
-  final List<DnsLogEntry> log = [];
   static const int _maxLogEntries = 500;
+
+  final List<DnsLogEntry?> _ring =
+      List<DnsLogEntry?>.filled(_maxLogEntries, null);
+  int _head = 0;
+  int _size = 0;
 
   int get total => allowed + blocked;
   double get blockRate => total > 0 ? blocked / total * 100 : 0;
 
-  void record(String domain, bool wasBlocked, {BlockSource? source}) {
+  /// Snapshot of the log, oldest-first. Allocates a new list per call —
+  /// the dev tools UI consumes this once per visible refresh, not per
+  /// recorded request.
+  List<DnsLogEntry> get log {
+    if (_size == 0) return const <DnsLogEntry>[];
+    final out = List<DnsLogEntry>.filled(_size, _ring[0]!, growable: false);
+    final start = _size < _maxLogEntries ? 0 : _head;
+    for (var i = 0; i < _size; i++) {
+      out[i] = _ring[(start + i) % _maxLogEntries]!;
+    }
+    return out;
+  }
+
+  /// Record a request decision against this site's stats. [count] lets
+  /// callers fold in `N` repeated requests for the same host without
+  /// allocating `N` log entries — the log only ever grows by one per
+  /// call, but the per-site total and source-attributed counters
+  /// increment by [count]. Used by the Android native interceptor's
+  /// per-host dedup batching.
+  void record(String domain, bool wasBlocked, {BlockSource? source, int count = 1}) {
+    if (count < 1) count = 1;
     if (wasBlocked) {
-      blocked++;
+      blocked += count;
       switch (source) {
         case BlockSource.dns:
-          blockedByDns++;
+          blockedByDns += count;
           break;
         case BlockSource.abp:
-          blockedByAbp++;
+          blockedByAbp += count;
           break;
         case null:
           // Unsourced block — count toward the total only. Callers should
@@ -63,16 +93,20 @@ class DnsStats {
           break;
       }
     } else {
-      allowed++;
+      allowed += count;
     }
-    log.add(DnsLogEntry(
+    final entry = DnsLogEntry(
       timestamp: DateTime.now(),
       domain: domain,
       blocked: wasBlocked,
       source: wasBlocked ? source : null,
-    ));
-    if (log.length > _maxLogEntries) {
-      log.removeAt(0);
+    );
+    if (_size < _maxLogEntries) {
+      _ring[(_head + _size) % _maxLogEntries] = entry;
+      _size++;
+    } else {
+      _ring[_head] = entry;
+      _head = (_head + 1) % _maxLogEntries;
     }
   }
 
@@ -81,7 +115,11 @@ class DnsStats {
     blocked = 0;
     blockedByDns = 0;
     blockedByAbp = 0;
-    log.clear();
+    for (var i = 0; i < _maxLogEntries; i++) {
+      _ring[i] = null;
+    }
+    _head = 0;
+    _size = 0;
   }
 }
 
@@ -211,7 +249,7 @@ class DnsBlockService {
   /// — no allocation per evict. On the realistic single-page workload this
   /// shaves ~50% off per-call cost; on cache-thrash workloads it
   /// eliminates the regression entirely.
-  final _HostFifoCache _dnsBlockCache = _HostFifoCache(_maxDomainCacheEntries);
+  final HostFifoCache _dnsBlockCache = HostFifoCache(_maxDomainCacheEntries);
 
   static const _domainCacheKey = 'dns_domain_cache';
   static const _maxDomainCacheEntries = 5000;
@@ -343,17 +381,28 @@ class DnsBlockService {
   /// next request because both services can answer independently.
   void recordRequest(String siteId, String url, bool wasBlocked,
       {BlockSource? source}) {
-    final uri = Uri.tryParse(url);
-    if (uri == null || uri.host.isEmpty) return;
-    statsForSite(siteId).record(uri.host, wasBlocked, source: source);
-    recordDomainDecision(uri.host, wasBlocked);
-    _notifyDnsLogListeners();
+    final host = extractHost(url);
+    if (host == null || host.isEmpty) return;
+    recordHostRequest(siteId, host, wasBlocked, source: source);
+  }
+
+  /// Like [recordRequest] but the caller already has a host (e.g. the
+  /// Android native interceptor reports `host` directly). Skips
+  /// `Uri.tryParse` and the URL synthesis roundtrip. [count] folds
+  /// dedup'd repeat requests into the per-site totals without growing
+  /// the log by [count].
+  void recordHostRequest(String siteId, String host, bool wasBlocked,
+      {BlockSource? source, int count = 1}) {
+    if (host.isEmpty) return;
+    statsForSite(siteId).record(host, wasBlocked, source: source, count: count);
+    recordDomainDecision(host, wasBlocked);
+    _scheduleNotifyDnsLogListeners();
   }
 
   /// Clear stats for a specific site.
   void clearStatsForSite(String siteId) {
     _siteStats[siteId]?.clear();
-    _notifyDnsLogListeners();
+    _scheduleNotifyDnsLogListeners();
   }
 
   /// Add a listener for DNS log changes (live UI updates).
@@ -366,8 +415,24 @@ class DnsBlockService {
     _dnsLogListeners.remove(listener);
   }
 
-  void _notifyDnsLogListeners() {
-    for (final listener in _dnsLogListeners) {
+  /// Coalesce listener notifications across a microtask. The dev-tools UI
+  /// only needs one rebuild per batch of recorded requests — without
+  /// coalescing, a page load that records hundreds of sub-resources kicks
+  /// off hundreds of `setState` calls in <1s, each rebuilding the entire
+  /// log `ListView`. The microtask runs before the next frame, so the UI
+  /// still updates "live". When no listener is registered the post is a
+  /// no-op (early return).
+  bool _notifyScheduled = false;
+  void _scheduleNotifyDnsLogListeners() {
+    if (_dnsLogListeners.isEmpty) return;
+    if (_notifyScheduled) return;
+    _notifyScheduled = true;
+    scheduleMicrotask(_flushDnsLogListeners);
+  }
+
+  void _flushDnsLogListeners() {
+    _notifyScheduled = false;
+    for (final listener in List<VoidCallback>.from(_dnsLogListeners)) {
       listener();
     }
   }
@@ -488,113 +553,32 @@ class DnsBlockService {
   /// roundtrip. Backed by [_dnsBlockCache] so a domain repeated dozens of
   /// times within a single page (the common case) only walks once.
   ///
-  /// Host extraction uses the hand-rolled [_fastHost] rather than
-  /// `Uri.tryParse`. Full RFC 3986 validation is unnecessary for our
-  /// purposes: we only need scheme://host[:port], and `_fastHost` handles
-  /// userinfo, IPv6 brackets, and case-folding without allocating
-  /// intermediate `Uri` objects. The scenarios `Uri.tryParse` rejects
-  /// (relative URLs, opaque schemes like `data:` / `about:`) are also
-  /// rejected here, with the same observable behavior: return false.
+  /// Host extraction uses [extractHost] rather than `Uri.tryParse`: full
+  /// RFC 3986 validation is unnecessary, we only need scheme://host[:port],
+  /// and [extractHost] handles userinfo, IPv6 brackets, and case-folding
+  /// without allocating intermediate `Uri` objects. The scenarios
+  /// `Uri.tryParse` rejects (relative URLs, opaque schemes like `data:` /
+  /// `about:`) are also rejected here, with the same observable behavior:
+  /// return false.
   bool isBlocked(String url) {
     if (_blockedDomains.isEmpty) return false;
 
-    final host = _fastHost(url);
+    final host = extractHost(url);
     if (host == null || host.isEmpty) return false;
+    return isHostBlocked(host);
+  }
 
+  /// Like [isBlocked] but skips URL parsing — caller already has the host
+  /// (e.g. native interceptor bridge passing `host` directly). Hot-path
+  /// callers should prefer this over `recordRequest('https://$host/', ...)`
+  /// which round-trips through `Uri.tryParse` just to recover the host.
+  bool isHostBlocked(String host) {
+    if (_blockedDomains.isEmpty || host.isEmpty) return false;
     final cached = _dnsBlockCache[host];
     if (cached != null) return cached;
-
-    final result = _hostIsBlocked(host);
+    final result = hostInSet(host, _blockedDomains);
     _dnsBlockCache.put(host, result);
     return result;
-  }
-
-  /// Extract the lowercase host from `scheme://host[:port]/...` without
-  /// `Uri.parse`-style RFC validation. Handles userinfo (`user:pass@host`)
-  /// and IPv6 literals (`[2001:db8::1]`). Returns null when no `://` is
-  /// present (relative URLs, `data:` / `about:` / `javascript:` etc.) so
-  /// the caller treats them as not-blockable, matching the previous
-  /// `Uri.tryParse` behavior.
-  ///
-  /// Case-folds only when the host actually contains uppercase ASCII.
-  /// `String.toLowerCase()` always allocates a new string, so for the
-  /// common case of already-lowercase hosts we return the substring
-  /// directly. The uppercase scan piggybacks on the existing authority
-  /// scan loop — zero added work in the no-uppercase fast path.
-  static String? _fastHost(String url) {
-    final i = url.indexOf('://');
-    if (i < 0) return null;
-    final start = i + 3;
-    int end = url.length;
-    for (var j = start; j < url.length; j++) {
-      final c = url.codeUnitAt(j);
-      // '/', '?', '#' all terminate the authority.
-      if (c == 0x2F || c == 0x3F || c == 0x23) {
-        end = j;
-        break;
-      }
-    }
-    // Strip userinfo. The LAST '@' before '/' delimits userinfo from host
-    // (per RFC 3986); intermediate '@'s would be percent-encoded.
-    int hostStart = start;
-    for (var j = start; j < end; j++) {
-      if (url.codeUnitAt(j) == 0x40 /* @ */) hostStart = j + 1;
-    }
-    // IPv6 literal: host is bracketed, port (if any) follows the ']'.
-    if (hostStart < end && url.codeUnitAt(hostStart) == 0x5B /* [ */) {
-      for (var j = hostStart; j < end; j++) {
-        if (url.codeUnitAt(j) == 0x5D /* ] */) {
-          // IPv6 literals are hex digits + ':' — already case-insensitive
-          // but we lowercase for canonical-form match. Most real hosts
-          // are lowercase already.
-          return _slice(url, hostStart, j + 1);
-        }
-      }
-      return null; // unterminated [
-    }
-    // Strip :port — first ':' between hostStart and end terminates the host.
-    int hostEnd = end;
-    for (var j = hostStart; j < end; j++) {
-      if (url.codeUnitAt(j) == 0x3A /* : */) {
-        hostEnd = j;
-        break;
-      }
-    }
-    return _slice(url, hostStart, hostEnd);
-  }
-
-  /// Substring + conditional lowercase. Scans for any uppercase ASCII in
-  /// `url[start..end)` and only allocates a lowercased copy if found.
-  /// In the common case (already-lowercase host) this returns the bare
-  /// substring — one allocation instead of two.
-  static String _slice(String url, int start, int end) {
-    bool hasUpper = false;
-    for (var j = start; j < end; j++) {
-      final c = url.codeUnitAt(j);
-      if (c >= 0x41 && c <= 0x5A) {
-        hasUpper = true;
-        break;
-      }
-    }
-    final s = url.substring(start, end);
-    return hasUpper ? s.toLowerCase() : s;
-  }
-
-  /// Substring-based hierarchy walk. Avoids the per-step `parts.sublist(i)
-  /// .join('.')` allocation pattern of the previous implementation. Same
-  /// matching semantics: exact match, then walk parents until the final
-  /// label (eTLD) — `mytracker.net` is NOT blocked by `tracker.net`.
-  bool _hostIsBlocked(String host) {
-    if (_blockedDomains.contains(host)) return true;
-    int dot = host.indexOf('.');
-    while (dot >= 0 && dot < host.length - 1) {
-      final parent = host.substring(dot + 1);
-      // Stop at the eTLD level — never check a single-label string like "com".
-      if (!parent.contains('.')) break;
-      if (_blockedDomains.contains(parent)) return true;
-      dot = host.indexOf('.', dot + 1);
-    }
-    return false;
   }
 
   /// Get the last time the blocklist was downloaded, or null if never.
@@ -632,53 +616,4 @@ class DnsBlockService {
     final appDir = await getApplicationDocumentsDirectory();
     return File('${appDir.path}/$_cacheFileName');
   }
-}
-
-/// Bounded host->bool cache with FIFO eviction, designed for the
-/// [DnsBlockService.isBlocked] hot path. Eviction is O(1) without
-/// allocating an iterator: insertion order is tracked in a fixed-size
-/// `List<String?>` ring, and the oldest entry is evicted via
-/// `_ring[head++ % cap]`. Hits never reorder the ring — read path is a
-/// single `Map` lookup.
-class _HostFifoCache {
-  final int capacity;
-  final List<String?> _ring;
-  int _head = 0;
-  int _size = 0;
-  final Map<String, bool> _map = <String, bool>{};
-
-  _HostFifoCache(this.capacity)
-      : _ring = List<String?>.filled(capacity, null);
-
-  bool? operator [](String key) => _map[key];
-
-  void put(String key, bool value) {
-    if (_map.containsKey(key)) {
-      // Update in place; keep original insertion position so a hot host
-      // doesn't keep evicting itself by being repeatedly re-inserted.
-      _map[key] = value;
-      return;
-    }
-    if (_size >= capacity) {
-      final evicted = _ring[_head];
-      if (evicted != null) _map.remove(evicted);
-      _ring[_head] = key;
-      _head = (_head + 1) % capacity;
-    } else {
-      _ring[(_head + _size) % capacity] = key;
-      _size++;
-    }
-    _map[key] = value;
-  }
-
-  void clear() {
-    _map.clear();
-    _head = 0;
-    _size = 0;
-    for (var i = 0; i < _ring.length; i++) {
-      _ring[i] = null;
-    }
-  }
-
-  int get length => _map.length;
 }

--- a/lib/services/host_lookup.dart
+++ b/lib/services/host_lookup.dart
@@ -1,0 +1,141 @@
+/// Hot-path helpers shared by [DnsBlockService] and [ContentBlockerService].
+/// Both services do per-request URL → host extraction + suffix-walk lookups
+/// against a `Set<String>` of blocked domains. Centralising the helpers
+/// keeps the two services on the same fast implementation:
+///
+/// * [extractHost] avoids `Uri.parse` (full RFC 3986 validation, allocates
+///   a `Uri` object) and conditionally lowercases — no allocation when the
+///   host is already lowercase.
+/// * [hostInSet] walks the suffix hierarchy with `String.indexOf` instead
+///   of allocating a new substring per level.
+library;
+
+/// Extract the lowercase host from `scheme://host[:port]/...` without
+/// `Uri.parse`-style RFC validation. Handles userinfo (`user:pass@host`)
+/// and IPv6 literals (`[2001:db8::1]`). Returns null when no `://` is
+/// present (relative URLs, `data:` / `about:` / `javascript:` etc.).
+///
+/// Case-folds only when the host actually contains uppercase ASCII —
+/// `String.toLowerCase()` always allocates a new string, so for the
+/// common case of already-lowercase hosts we return the substring
+/// directly.
+String? extractHost(String url) {
+  final i = url.indexOf('://');
+  if (i < 0) return null;
+  final start = i + 3;
+  int end = url.length;
+  for (var j = start; j < url.length; j++) {
+    final c = url.codeUnitAt(j);
+    // '/', '?', '#' all terminate the authority.
+    if (c == 0x2F || c == 0x3F || c == 0x23) {
+      end = j;
+      break;
+    }
+  }
+  // Strip userinfo. The LAST '@' before '/' delimits userinfo from host
+  // (per RFC 3986); intermediate '@'s would be percent-encoded.
+  int hostStart = start;
+  for (var j = start; j < end; j++) {
+    if (url.codeUnitAt(j) == 0x40 /* @ */) hostStart = j + 1;
+  }
+  // IPv6 literal: host is bracketed, port (if any) follows the ']'.
+  if (hostStart < end && url.codeUnitAt(hostStart) == 0x5B /* [ */) {
+    for (var j = hostStart; j < end; j++) {
+      if (url.codeUnitAt(j) == 0x5D /* ] */) {
+        return _slice(url, hostStart, j + 1);
+      }
+    }
+    return null;
+  }
+  // Strip :port — first ':' between hostStart and end terminates the host.
+  int hostEnd = end;
+  for (var j = hostStart; j < end; j++) {
+    if (url.codeUnitAt(j) == 0x3A /* : */) {
+      hostEnd = j;
+      break;
+    }
+  }
+  return _slice(url, hostStart, hostEnd);
+}
+
+String _slice(String url, int start, int end) {
+  bool hasUpper = false;
+  for (var j = start; j < end; j++) {
+    final c = url.codeUnitAt(j);
+    if (c >= 0x41 && c <= 0x5A) {
+      hasUpper = true;
+      break;
+    }
+  }
+  final s = url.substring(start, end);
+  return hasUpper ? s.toLowerCase() : s;
+}
+
+/// Substring-based suffix-walk lookup. Same semantics as
+/// `set.contains(host)` then walking parents (`a.b.c` → `b.c` → ...) via
+/// `host.indexOf('.', from)` — never allocates an intermediate substring
+/// for the comparison since `Set<String>.contains` accepts a key built
+/// directly from `String.substring(start)`. Stops before the eTLD label
+/// (`com` alone is never matched).
+bool hostInSet(String host, Set<String> set) {
+  if (set.isEmpty) return false;
+  if (set.contains(host)) return true;
+  int dot = host.indexOf('.');
+  while (dot >= 0 && dot < host.length - 1) {
+    final parent = host.substring(dot + 1);
+    if (!parent.contains('.')) break;
+    if (set.contains(parent)) return true;
+    dot = host.indexOf('.', dot + 1);
+  }
+  return false;
+}
+
+/// Bounded host->bool cache with FIFO eviction. Designed for the per-URL
+/// hot path in [DnsBlockService.isBlocked] / [ContentBlockerService.isBlocked]
+/// where the same host repeats dozens of times per page.
+///
+/// Eviction is O(1) without allocating an iterator: insertion order is
+/// tracked in a fixed-size `List<String?>` ring, and the oldest entry is
+/// evicted via `_ring[head++ % cap]`. Hits never reorder the ring — read
+/// path is a single `Map` lookup. Re-inserting an existing key keeps its
+/// original position so a hot host doesn't keep evicting itself.
+class HostFifoCache {
+  final int capacity;
+  final List<String?> _ring;
+  int _head = 0;
+  int _size = 0;
+  final Map<String, bool> _map = <String, bool>{};
+
+  HostFifoCache(this.capacity)
+      : _ring = List<String?>.filled(capacity, null);
+
+  bool? operator [](String key) => _map[key];
+
+  void put(String key, bool value) {
+    if (_map.containsKey(key)) {
+      _map[key] = value;
+      return;
+    }
+    if (_size >= capacity) {
+      final evicted = _ring[_head];
+      if (evicted != null) _map.remove(evicted);
+      _ring[_head] = key;
+      _head = (_head + 1) % capacity;
+    } else {
+      _ring[(_head + _size) % capacity] = key;
+      _size++;
+    }
+    _map[key] = value;
+  }
+
+  void clear() {
+    _map.clear();
+    _head = 0;
+    _size = 0;
+    for (var i = 0; i < _ring.length; i++) {
+      _ring[i] = null;
+    }
+  }
+
+  int get length => _map.length;
+}

--- a/lib/services/web_intercept_native.dart
+++ b/lib/services/web_intercept_native.dart
@@ -61,8 +61,15 @@ class WebInterceptNative {
             'abp' => BlockSource.abp,
             _ => null,
           };
+          // Native dedupes by host across the drain window. `count` is
+          // the number of repeat requests since the last drain; default
+          // 1 if absent (older codec / no dedup). Pass it straight to
+          // the host-level recorder so the per-site Total/Allowed/
+          // Blocked counts stay accurate while the log keeps a single
+          // entry per host.
+          final count = (entry['count'] as int?) ?? 1;
           DnsBlockService.instance
-              .recordRequest(siteId, 'https://$host/', blocked, source: source);
+              .recordHostRequest(siteId, host, blocked, source: source, count: count);
         }
       }
     } catch (_) {}

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1433,36 +1433,49 @@ class WebViewFactory {
         groupName: 'block_resource_observer',
         source: '''
 (function() {
-  var seen = {};
-  var pending = [];
-  function send(url) {
-    if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
-      window.flutter_inappwebview.callHandler('blockResourceLoaded', url);
-    } else {
-      pending.push(url);
-    }
-  }
-  function report(url) {
-    if (!url || seen[url] || !url.startsWith('http')) return;
-    seen[url] = 1;
-    send(url);
-  }
-  var po = new PerformanceObserver(function(list) {
-    list.getEntries().forEach(function(e) { report(e.name); });
-  });
-  po.observe({type: 'resource', buffered: true});
-  po.observe({type: 'navigation', buffered: true});
+  // Per-host dedup. PerformanceObserver fires once per loaded resource;
+  // a typical news page is hundreds of entries across ~30 hosts. We
+  // record one host per Dart roundtrip and dedup the rest in JS — same
+  // semantics as the native Android interceptor, but driven from the
+  // performance timeline because WebKit doesn't expose a sub-resource
+  // intercept hook.
+  var seenHost = Object.create(null);
+  var pending = [];           // batched hosts not yet sent
+  var pendingTimer = null;
+  var BATCH_MS = 250;
+  var BATCH_MAX = 64;
+
   function flush() {
-    if (!window.flutter_inappwebview || !window.flutter_inappwebview.callHandler) {
+    pendingTimer = null;
+    if (!pending.length) return;
+    if (!(window.flutter_inappwebview && window.flutter_inappwebview.callHandler)) {
       setTimeout(flush, 50);
       return;
     }
-    pending.forEach(function(url) {
-      window.flutter_inappwebview.callHandler('blockResourceLoaded', url);
-    });
+    var batch = pending;
     pending = [];
+    window.flutter_inappwebview.callHandler('blockResourceLoadedBatch', batch);
   }
-  flush();
+  function schedule() {
+    if (pending.length >= BATCH_MAX) { flush(); return; }
+    if (pendingTimer == null) pendingTimer = setTimeout(flush, BATCH_MS);
+  }
+  function report(url) {
+    if (!url || url.charCodeAt(0) === 100 /* d */) return; // data:
+    if (url.indexOf('http') !== 0) return;
+    var host;
+    try { host = new URL(url).hostname; } catch (e) { return; }
+    if (!host || seenHost[host]) return;
+    seenHost[host] = 1;
+    pending.push(host);
+    schedule();
+  }
+  var po = new PerformanceObserver(function(list) {
+    var entries = list.getEntries();
+    for (var i = 0; i < entries.length; i++) report(entries[i].name);
+  });
+  po.observe({type: 'resource', buffered: true});
+  po.observe({type: 'navigation', buffered: true});
 })();
 ;null;''',
         injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
@@ -1470,9 +1483,20 @@ class WebViewFactory {
     }
 
     // iOS sub-resource blocking: JS interceptor with merged DNS+ABP
-    // Bloom-filter prefilter. Bloom check is pure JS (microseconds).
-    // Only ~0.1% of allowed URLs trigger a Dart roundtrip; Dart's
-    // blockCheck handler decides DNS vs ABP and records the source.
+    // Bloom-filter prefilter. The hot path is allocation-light and
+    // SYNCHRONOUS for bloom misses (the dominant case): no Promise
+    // wrapping, no microtask delay. That matters for property setters
+    // — wrapping `Image.src = url` in `Promise.resolve().then(set)`
+    // delays every image load by a microtask, which on a page with
+    // hundreds of `<img>` elements adds up to a visible stall. Only
+    // the rare bloom-hit path goes through Dart, where the actual DNS
+    // vs ABP attribution happens.
+    //
+    // We don't fire `blockResourceLoaded` from this script anymore.
+    // The block_resource_observer (PerformanceObserver) above batches
+    // unique hosts and reports them via `blockResourceLoadedBatch` —
+    // having both fire was double-counting hundreds of entries per
+    // page.
     if (!Platform.isAndroid
         && config.siteId != null
         && ((config.dnsBlockEnabled && hasDnsRules) ||
@@ -1486,7 +1510,6 @@ class WebViewFactory {
   var bloomBitCount = 0;
   var bloomK = 0;
 
-  // FNV-1a 32-bit hash, matching Dart implementation
   function fnv1a(s, seed) {
     var h = seed >>> 0;
     for (var i = 0; i < s.length; i++) {
@@ -1497,7 +1520,7 @@ class WebViewFactory {
   }
 
   function bloomContains(s) {
-    if (!bloomReady) return true; // safe default while loading: ask Dart
+    if (!bloomReady) return true;
     var h1 = fnv1a(s, 0x811C9DC5);
     var h2 = fnv1a(s, 0xCBF29CE4);
     for (var i = 0; i < bloomK; i++) {
@@ -1507,65 +1530,84 @@ class WebViewFactory {
     return true;
   }
 
-  // Hierarchy walk-up: check host, then each parent suffix
   function maybeBlocked(host) {
     if (bloomContains(host)) return true;
-    var parts = host.split('.');
-    for (var i = 1; i < parts.length - 1; i++) {
-      if (bloomContains(parts.slice(i).join('.'))) return true;
+    // Suffix walk without parts.slice().join() per level — peel labels
+    // from the left by tracking a single dot index.
+    var dot = host.indexOf('.');
+    while (dot >= 0 && dot < host.length - 1) {
+      var parent = host.substring(dot + 1);
+      if (parent.indexOf('.') < 0) break;
+      if (bloomContains(parent)) return true;
+      dot = host.indexOf('.', dot + 1);
     }
     return false;
   }
 
-  // Per-site domain result cache (LRU-ish: evict oldest when full).
-  // Restored from Dart persistence on startup, sent back on page load.
-  var allowedCache = {};
-  var blockedCache = {};
-  var cacheKeys = [];
+  // Cache. Capacity 500 covers the typical page header set; FIFO eviction
+  // when full. Map-of-bools instead of two parallel objects so we keep
+  // per-host RAM at one entry not two — important on iOS where every
+  // long-running tab keeps this state alive.
+  var hostCache = Object.create(null);     // host -> true (blocked) | false (allowed)
+  var hostOrder = [];                       // FIFO order
   var MAX_CACHE = 500;
-
-  function cacheResult(host, blocked) {
-    if (blocked) { blockedCache[host] = 1; }
-    else { allowedCache[host] = 1; }
-    cacheKeys.push(host);
-    if (cacheKeys.length > MAX_CACHE) {
-      var old = cacheKeys.shift();
-      delete allowedCache[old];
-      delete blockedCache[old];
+  function cacheGet(host) { return hostCache[host]; }
+  function cachePut(host, blocked) {
+    if (host in hostCache) { hostCache[host] = blocked; return; }
+    hostCache[host] = blocked;
+    hostOrder.push(host);
+    if (hostOrder.length > MAX_CACHE) {
+      var old = hostOrder.shift();
+      delete hostCache[old];
     }
   }
 
-
-  function check(url) {
-    if (!url || typeof url !== 'string' || !url.startsWith('http')) {
-      return Promise.resolve(false);
-    }
-    if (!window.flutter_inappwebview || !window.flutter_inappwebview.callHandler) {
-      return Promise.resolve(false);
-    }
+  // Sync-only check. Returns:
+  //   true  → known blocked (skip request)
+  //   false → known allowed (proceed synchronously)
+  //   undefined → decision needs async Dart confirmation
+  // The caller is responsible for handling the undefined case via
+  // checkAsync. Keeping the sync path branchless and microtask-free is
+  // what makes property-setter patches not stall image loads.
+  function checkSync(url) {
+    if (!url || typeof url !== 'string' || url.charCodeAt(0) !== 104) return false; // 'h'
+    if (url.indexOf('http') !== 0) return false;
     var host;
-    try { host = new URL(url).hostname; } catch (e) { return Promise.resolve(false); }
-    // Check per-site cache first (instant)
-    if (allowedCache[host]) return Promise.resolve(false);
-    if (blockedCache[host]) return Promise.resolve(true);
-    // Bloom prefilter: if definitely not in set, allow without roundtrip
+    try { host = new URL(url).hostname; } catch (e) { return false; }
+    if (!host) return false;
+    var cached = cacheGet(host);
+    if (cached === false) return false;
+    if (cached === true) return true;
+    if (!bloomReady) return undefined; // Dart roundtrip while bloom warms up
     if (!maybeBlocked(host)) {
-      cacheResult(host, false);
-      window.flutter_inappwebview.callHandler('blockResourceLoaded', url);
+      cachePut(host, false);
+      return false;
+    }
+    return undefined; // bloom hit — Dart must adjudicate
+  }
+
+  function checkAsync(url) {
+    if (!(window.flutter_inappwebview && window.flutter_inappwebview.callHandler)) {
       return Promise.resolve(false);
     }
-    // Possibly blocked — confirm via Dart, then cache result. Dart
-    // decides DNS vs ABP and records the source in per-site stats.
     return window.flutter_inappwebview.callHandler('blockCheck', url).then(function(blocked) {
-      cacheResult(host, blocked);
-      return blocked;
+      try {
+        var host = new URL(url).hostname;
+        if (host) cachePut(host, !!blocked);
+      } catch (e) {}
+      return !!blocked;
     });
   }
 
-  // Fetch merged DNS+ABP Bloom filter + persisted per-site cache from
-  // Dart at startup.
+  // Promise-returning wrapper for callers that always go through .then.
+  function check(url) {
+    var sync = checkSync(url);
+    if (sync !== undefined) return Promise.resolve(sync);
+    return checkAsync(url);
+  }
+
   function loadBloom() {
-    if (!window.flutter_inappwebview || !window.flutter_inappwebview.callHandler) {
+    if (!(window.flutter_inappwebview && window.flutter_inappwebview.callHandler)) {
       setTimeout(loadBloom, 50);
       return;
     }
@@ -1575,13 +1617,17 @@ class WebViewFactory {
       bloomBits = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
       bloomBitCount = map.bitCount;
       bloomK = map.k;
-      // Restore persisted per-site cache
       var persisted = map.cache;
       if (persisted) {
         for (var h in persisted) {
-          if (persisted[h]) blockedCache[h] = 1;
-          else allowedCache[h] = 1;
-          cacheKeys.push(h);
+          if (!(h in hostCache)) {
+            hostCache[h] = !!persisted[h];
+            hostOrder.push(h);
+            if (hostOrder.length > MAX_CACHE) {
+              var old = hostOrder.shift();
+              delete hostCache[old];
+            }
+          }
         }
       }
       bloomReady = true;
@@ -1589,15 +1635,19 @@ class WebViewFactory {
   }
   loadBloom();
 
-  // fetch
+  // fetch — sync fast-path on misses, async only on bloom hits.
   var origFetch = window.fetch;
   if (origFetch) {
     window.fetch = function(input, init) {
       var url = typeof input === 'string' ? input : (input && input.url);
-      return check(url).then(function(blocked) {
-        if (blocked) return Promise.reject(new TypeError('Blocked by DNS blocklist: ' + url));
-        return origFetch.call(this, input, init);
-      }.bind(this));
+      var sync = checkSync(url);
+      if (sync === false) return origFetch.call(this, input, init);
+      if (sync === true) return Promise.reject(new TypeError('Blocked: ' + url));
+      var self = this;
+      return checkAsync(url).then(function(blocked) {
+        if (blocked) return Promise.reject(new TypeError('Blocked: ' + url));
+        return origFetch.call(self, input, init);
+      });
     };
   }
 
@@ -1609,15 +1659,23 @@ class WebViewFactory {
   };
   var origSend = XMLHttpRequest.prototype.send;
   XMLHttpRequest.prototype.send = function(body) {
+    var url = this.__dnsBlockUrl;
+    var sync = checkSync(url);
+    if (sync === false) return origSend.apply(this, arguments);
+    if (sync === true) { try { this.abort(); } catch (e) {} return; }
     var self = this;
     var args = arguments;
-    check(self.__dnsBlockUrl).then(function(blocked) {
-      if (blocked) { try { self.abort(); } catch(e) {} return; }
+    checkAsync(url).then(function(blocked) {
+      if (blocked) { try { self.abort(); } catch (e) {} return; }
       origSend.apply(self, args);
     });
   };
 
-  // Property setters for src/href on resource elements
+  // Property setters for src/href. CRITICAL that the bloom-miss path is
+  // synchronous: wrapping `el.src = url` in `Promise.resolve().then(set)`
+  // delays every image load by one microtask. On a typical e-commerce
+  // page with 200 product images that's 200 microtasks — visible
+  // jitter and dropped scroll frames.
   function patchSetter(proto, attr) {
     var desc = Object.getOwnPropertyDescriptor(proto, attr);
     if (!desc || !desc.set) return;
@@ -1627,8 +1685,11 @@ class WebViewFactory {
       enumerable: desc.enumerable,
       get: desc.get,
       set: function(value) {
+        var sync = checkSync(value);
+        if (sync === false) { origSet.call(this, value); return; }
+        if (sync === true) { return; }
         var el = this;
-        check(value).then(function(blocked) {
+        checkAsync(value).then(function(blocked) {
           if (!blocked) origSet.call(el, value);
         });
       }
@@ -1639,22 +1700,29 @@ class WebViewFactory {
   patchSetter(HTMLLinkElement.prototype, 'href');
   patchSetter(HTMLIFrameElement.prototype, 'src');
 
-  // MutationObserver for statically-parsed HTML elements
+  // MutationObserver for statically-parsed HTML elements. Bloom-miss
+  // path is a no-op (the element is allowed to keep the attribute);
+  // only confirmed-blocked elements are stripped.
   function checkElement(el) {
     var attr = null;
     if (el.tagName === 'IMG' || el.tagName === 'SCRIPT' || el.tagName === 'IFRAME') attr = 'src';
     else if (el.tagName === 'LINK') attr = 'href';
-    if (attr) {
-      var url = el.getAttribute(attr);
-      if (url && url.indexOf('http') === 0) {
-        check(url).then(function(blocked) {
-          if (blocked) {
-            el.removeAttribute(attr);
-            if (el.parentNode) el.parentNode.removeChild(el);
-          }
-        });
-      }
+    if (!attr) return;
+    var url = el.getAttribute(attr);
+    if (!url || url.indexOf('http') !== 0) return;
+    var sync = checkSync(url);
+    if (sync === false) return; // allowed, leave element alone
+    if (sync === true) {
+      el.removeAttribute(attr);
+      if (el.parentNode) el.parentNode.removeChild(el);
+      return;
     }
+    checkAsync(url).then(function(blocked) {
+      if (blocked) {
+        el.removeAttribute(attr);
+        if (el.parentNode) el.parentNode.removeChild(el);
+      }
+    });
   }
   var mo = new MutationObserver(function(mutations) {
     for (var i = 0; i < mutations.length; i++) {
@@ -1873,45 +1941,70 @@ class WebViewFactory {
         // checks below decide how to attribute a block, and a request
         // with neither list matching is simply recorded as allowed.
         if (config.siteId != null) {
-          controller.addJavaScriptHandler(handlerName: 'blockResourceLoaded', callback: (args) {
-            if (args.isNotEmpty && args[0] is String) {
-              final url = args[0] as String;
-              final dnsBlocked = config.dnsBlockEnabled &&
-                  DnsBlockService.instance.isBlocked(url);
+          // Batched per-host allowed/blocked report from
+          // PerformanceObserver. JS dedupes by host across the entire
+          // page lifetime and flushes batches every 250ms (or 64 hosts).
+          // Each host walks the blocklists once and gets a single log
+          // entry — no per-URL Dart roundtrip.
+          controller.addJavaScriptHandler(handlerName: 'blockResourceLoadedBatch', callback: (args) {
+            if (args.isEmpty || args[0] is! List) return null;
+            final hosts = args[0] as List;
+            final dnsSvc = DnsBlockService.instance;
+            final abpSvc = ContentBlockerService.instance;
+            for (final h in hosts) {
+              if (h is! String || h.isEmpty) continue;
+              final dnsBlocked =
+                  config.dnsBlockEnabled && dnsSvc.isHostBlocked(h);
               final abpBlocked = !dnsBlocked &&
                   config.contentBlockEnabled &&
-                  ContentBlockerService.instance.isBlocked(url);
+                  abpSvc.isHostBlocked(h);
               final blocked = dnsBlocked || abpBlocked;
               final source = dnsBlocked
                   ? BlockSource.dns
                   : (abpBlocked ? BlockSource.abp : null);
-              DnsBlockService.instance
-                  .recordRequest(config.siteId!, url, blocked, source: source);
+              dnsSvc.recordHostRequest(config.siteId!, h, blocked, source: source);
             }
             return null;
           });
+          // Backwards-compat: legacy single-URL report path. The JS
+          // interceptor no longer fires this, but stale injected scripts
+          // (cached service workers, in-page bookmarklets) might. Treat
+          // it the same as a one-host batch.
+          controller.addJavaScriptHandler(handlerName: 'blockResourceLoaded', callback: (args) {
+            if (args.isEmpty || args[0] is! String) return null;
+            final url = args[0] as String;
+            final dnsBlocked = config.dnsBlockEnabled &&
+                DnsBlockService.instance.isBlocked(url);
+            final abpBlocked = !dnsBlocked &&
+                config.contentBlockEnabled &&
+                ContentBlockerService.instance.isBlocked(url);
+            final blocked = dnsBlocked || abpBlocked;
+            final source = dnsBlocked
+                ? BlockSource.dns
+                : (abpBlocked ? BlockSource.abp : null);
+            DnsBlockService.instance
+                .recordRequest(config.siteId!, url, blocked, source: source);
+            return null;
+          });
           // iOS sub-resource blocking: per-URL check from JS interceptor.
-          // Merged Bloom prefilter runs in JS; Dart resolves DNS vs ABP.
+          // Only the bloom-hit minority of requests hits this path.
           if (!Platform.isAndroid) {
             controller.addJavaScriptHandler(handlerName: 'blockCheck', callback: (args) {
               if (args.isEmpty || args[0] is! String) return false;
               final url = args[0] as String;
-              if (config.dnsBlockEnabled &&
-                  DnsBlockService.instance.isBlocked(url)) {
-                DnsBlockService.instance.recordRequest(
-                    config.siteId!, url, true,
+              final dnsSvc = DnsBlockService.instance;
+              final abpSvc = ContentBlockerService.instance;
+              if (config.dnsBlockEnabled && dnsSvc.isBlocked(url)) {
+                dnsSvc.recordRequest(config.siteId!, url, true,
                     source: BlockSource.dns);
                 return true;
               }
-              if (config.contentBlockEnabled &&
-                  ContentBlockerService.instance.isBlocked(url)) {
-                DnsBlockService.instance.recordRequest(
-                    config.siteId!, url, true,
+              if (config.contentBlockEnabled && abpSvc.isBlocked(url)) {
+                dnsSvc.recordRequest(config.siteId!, url, true,
                     source: BlockSource.abp);
                 return true;
               }
-              DnsBlockService.instance
-                  .recordRequest(config.siteId!, url, false);
+              dnsSvc.recordRequest(config.siteId!, url, false);
               return false;
             });
             // One-shot merged Bloom filter + global domain cache delivery to JS
@@ -2111,9 +2204,11 @@ class WebViewFactory {
         }
         // DNS blocklist check + record navigation for stats. Record for
         // every http navigation so the per-site log works even when no
-        // blocklist is populated; isBlocked is a cheap set lookup.
+        // blocklist is populated; isBlocked is a cheap set lookup. The
+        // verbose `[Navigation] $url` log was dropped — `LogService.log`
+        // calls `notifyListeners()` which triggers a setState rebuild
+        // on the dev tools log tab for every single navigation.
         if (config.siteId != null && url.startsWith('http')) {
-          LogService.instance.log('DnsBlock', '[Navigation] $url');
           final blocked = DnsBlockService.instance.hasBlocklist &&
               DnsBlockService.instance.isBlocked(url);
           DnsBlockService.instance.recordRequest(config.siteId!, url, blocked,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "WebSpace app development tools",
   "scripts": {
     "test:js": "node --test --test-reporter=spec 'test/js/**/*.test.js'",
-    "test:browser": "node --test --test-reporter=spec --test-timeout=30000 'test/browser/**/*.test.js'"
+    "test:browser": "node --test --test-reporter=spec --test-timeout=30000 'test/browser/**/*.test.js'",
+    "bench:js": "node test/js/perf/blocking.bench.js"
   },
   "devDependencies": {
     "@fingerprintjs/fingerprintjs": "^5.2.0",

--- a/test/content_blocker_service_isblocked_test.dart
+++ b/test/content_blocker_service_isblocked_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/content_blocker_service.dart';
+
+/// Direct tests for [ContentBlockerService.isBlocked] / `isHostBlocked`
+/// after the Uri.parse → extractHost + per-host FIFO cache rewrite. The
+/// existing content_blocker_service_test.dart only covers FilterList
+/// JSON serialization; the hot-path matching had no real coverage.
+void main() {
+  late ContentBlockerService service;
+
+  setUp(() {
+    service = ContentBlockerService.instance;
+    service.reset();
+  });
+
+  group('ContentBlockerService.isBlocked', () {
+    test('returns false when no rules loaded', () {
+      expect(service.isBlocked('https://example.com/path'), isFalse);
+    });
+
+    test('exact host match', () {
+      service.setBlockedDomainsForTest({'tracker.net'});
+      expect(service.isBlocked('https://tracker.net/'), isTrue);
+    });
+
+    test('subdomain matches blocked parent', () {
+      service.setBlockedDomainsForTest({'tracker.net'});
+      expect(service.isBlocked('https://ads.tracker.net/path'), isTrue);
+      expect(service.isBlocked('https://a.b.c.tracker.net/'), isTrue);
+    });
+
+    test('unrelated host with same suffix does NOT match', () {
+      service.setBlockedDomainsForTest({'tracker.net'});
+      expect(service.isBlocked('https://mytracker.net/'), isFalse,
+          reason: 'partial string match must not cross label boundary');
+    });
+
+    test('host extraction strips port and userinfo', () {
+      service.setBlockedDomainsForTest({'tracker.net'});
+      expect(service.isBlocked('https://tracker.net:8443/'), isTrue);
+      expect(service.isBlocked('https://user:pass@tracker.net/'), isTrue);
+    });
+
+    test('case-insensitive', () {
+      service.setBlockedDomainsForTest({'tracker.net'});
+      expect(service.isBlocked('https://Tracker.NET/'), isTrue);
+      expect(service.isBlocked('HTTPS://SUB.TRACKER.NET/'), isTrue);
+    });
+
+    test('returns false for non-http schemes', () {
+      service.setBlockedDomainsForTest({'tracker.net'});
+      expect(service.isBlocked('about:blank'), isFalse);
+      expect(service.isBlocked('data:text/html,hi'), isFalse);
+      expect(service.isBlocked('javascript:0'), isFalse);
+    });
+
+    test('eTLD-only entry does not block everything', () {
+      service.setBlockedDomainsForTest({'com'});
+      expect(service.isBlocked('https://example.com/'), isFalse,
+          reason: 'walk must stop above eTLD');
+    });
+
+    test('cache is invalidated when domain set changes', () {
+      service.setBlockedDomainsForTest({'tracker.net'});
+      expect(service.isBlocked('https://tracker.net/'), isTrue);
+      // Cache now holds tracker.net→true. Swap the set; the cached
+      // decision must be discarded.
+      service.setBlockedDomainsForTest({'other.com'});
+      expect(service.isBlocked('https://tracker.net/'), isFalse,
+          reason: 'cache must clear when blocked-domain set is replaced');
+      expect(service.isBlocked('https://other.com/'), isTrue);
+    });
+
+    test('cache holds bounded distinct hosts under load', () {
+      service.setBlockedDomainsForTest({'tracker.net'});
+      final sw = Stopwatch()..start();
+      for (int i = 0; i < 20000; i++) {
+        service.isBlocked('https://host$i.example.test/');
+      }
+      sw.stop();
+      // Sanity: still answers correctly after the churn.
+      expect(service.isBlocked('https://tracker.net/'), isTrue);
+      expect(service.isBlocked('https://host999999.example.test/'), isFalse);
+      // 20K bounded-cache lookups must finish well under a second.
+      expect(sw.elapsedMilliseconds, lessThan(2000));
+    });
+
+    test('reset clears the cache', () {
+      service.setBlockedDomainsForTest({'tracker.net'});
+      expect(service.isBlocked('https://tracker.net/'), isTrue);
+      service.reset();
+      // After reset the domain set is empty; even a previously-cached
+      // "true" must not survive.
+      expect(service.isBlocked('https://tracker.net/'), isFalse);
+    });
+  });
+
+  group('ContentBlockerService.isHostBlocked', () {
+    test('skips URL parsing — host is the input', () {
+      service.setBlockedDomainsForTest({'tracker.net'});
+      expect(service.isHostBlocked('tracker.net'), isTrue);
+      expect(service.isHostBlocked('sub.tracker.net'), isTrue);
+      expect(service.isHostBlocked('mytracker.net'), isFalse);
+    });
+
+    test('returns false on empty host', () {
+      service.setBlockedDomainsForTest({'tracker.net'});
+      expect(service.isHostBlocked(''), isFalse);
+    });
+
+    test('returns false when no rules loaded', () {
+      expect(service.isHostBlocked('tracker.net'), isFalse);
+    });
+  });
+}

--- a/test/dns_stats_test.dart
+++ b/test/dns_stats_test.dart
@@ -1,0 +1,224 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/dns_block_service.dart';
+
+/// Tests for [DnsStats] after switching the log to a fixed-size ring
+/// buffer and adding the `count` parameter to [DnsStats.record]. The
+/// previous test surface didn't exercise the log directly because the
+/// behaviour was an obvious `List.add` — now that log/counter semantics
+/// can diverge (count > 1 keeps log size at +1 but bumps totals by N),
+/// pin them down.
+void main() {
+  group('DnsStats counters', () {
+    test('records allowed with default count=1', () {
+      final s = DnsStats();
+      s.record('a.com', false);
+      expect(s.allowed, equals(1));
+      expect(s.blocked, equals(0));
+      expect(s.total, equals(1));
+    });
+
+    test('records blocked with source attribution', () {
+      final s = DnsStats();
+      s.record('ad.com', true, source: BlockSource.dns);
+      s.record('tr.com', true, source: BlockSource.abp);
+      expect(s.blockedByDns, equals(1));
+      expect(s.blockedByAbp, equals(1));
+      expect(s.blocked, equals(2));
+      expect(s.allowed, equals(0));
+    });
+
+    test('count > 1 increments totals by count but log grows by one', () {
+      final s = DnsStats();
+      s.record('cdn.example.com', false, count: 47);
+      expect(s.allowed, equals(47),
+          reason: 'count must fold into the total');
+      expect(s.log, hasLength(1),
+          reason: 'log entry stays at +1 regardless of count');
+      expect(s.log.single.domain, equals('cdn.example.com'));
+      expect(s.log.single.blocked, isFalse);
+    });
+
+    test('count > 1 with blocked + source attributes correctly', () {
+      final s = DnsStats();
+      s.record('ad.example.com', true, source: BlockSource.dns, count: 12);
+      s.record('tr.example.com', true, source: BlockSource.abp, count: 5);
+      expect(s.blocked, equals(17));
+      expect(s.blockedByDns, equals(12));
+      expect(s.blockedByAbp, equals(5));
+      expect(s.log, hasLength(2));
+    });
+
+    test('count below 1 is clamped to 1', () {
+      final s = DnsStats();
+      s.record('a.com', false, count: 0);
+      s.record('b.com', false, count: -3);
+      expect(s.allowed, equals(2));
+      expect(s.log, hasLength(2));
+    });
+
+    test('blockRate computes correctly', () {
+      final s = DnsStats();
+      s.record('a.com', false);
+      s.record('a.com', false);
+      s.record('a.com', false);
+      s.record('ad.com', true, source: BlockSource.dns);
+      expect(s.blockRate, equals(25.0));
+    });
+
+    test('clear resets everything', () {
+      final s = DnsStats();
+      s.record('a.com', false, count: 10);
+      s.record('ad.com', true, source: BlockSource.dns, count: 5);
+      s.clear();
+      expect(s.allowed, equals(0));
+      expect(s.blocked, equals(0));
+      expect(s.blockedByDns, equals(0));
+      expect(s.log, isEmpty);
+    });
+  });
+
+  group('DnsStats log ring buffer', () {
+    test('log grows from empty in insertion order', () {
+      final s = DnsStats();
+      for (var i = 0; i < 5; i++) {
+        s.record('host$i.com', false);
+      }
+      final entries = s.log;
+      expect(entries, hasLength(5));
+      for (var i = 0; i < 5; i++) {
+        expect(entries[i].domain, equals('host$i.com'),
+            reason: 'oldest-first iteration order');
+      }
+    });
+
+    test('log caps at 500 entries with FIFO eviction', () {
+      final s = DnsStats();
+      // Fill past the cap. The oldest 100 must be dropped.
+      for (var i = 0; i < 600; i++) {
+        s.record('host$i.com', false);
+      }
+      final entries = s.log;
+      expect(entries, hasLength(500));
+      // Oldest surviving entry should be host100 (host0..host99 evicted).
+      expect(entries.first.domain, equals('host100.com'));
+      expect(entries.last.domain, equals('host599.com'));
+    });
+
+    test('log ordering survives wrap-around', () {
+      final s = DnsStats();
+      // Insert exactly cap + 1 to cross the boundary by one.
+      for (var i = 0; i < 501; i++) {
+        s.record('h$i', false);
+      }
+      final entries = s.log;
+      expect(entries, hasLength(500));
+      expect(entries.first.domain, equals('h1'));
+      expect(entries.last.domain, equals('h500'));
+    });
+
+    test('clear empties the ring and accepts new entries', () {
+      final s = DnsStats();
+      for (var i = 0; i < 600; i++) {
+        s.record('h$i', false);
+      }
+      s.clear();
+      expect(s.log, isEmpty);
+      s.record('fresh.com', false);
+      expect(s.log, hasLength(1));
+      expect(s.log.single.domain, equals('fresh.com'));
+    });
+
+    test('blocked entries retain source in log', () {
+      final s = DnsStats();
+      s.record('a.com', true, source: BlockSource.dns);
+      s.record('b.com', true, source: BlockSource.abp);
+      s.record('c.com', false);
+      final entries = s.log;
+      expect(entries[0].source, equals(BlockSource.dns));
+      expect(entries[1].source, equals(BlockSource.abp));
+      expect(entries[2].source, isNull, reason: 'allowed entries have no source');
+    });
+  });
+
+  group('DnsBlockService.recordHostRequest', () {
+    setUp(() {
+      DnsBlockService.instance.loadDomainsFromString('');
+      DnsBlockService.instance.clearStatsForSite('site-A');
+    });
+
+    test('skips empty host', () {
+      DnsBlockService.instance.recordHostRequest('site-A', '', false);
+      final stats = DnsBlockService.instance.statsForSite('site-A');
+      expect(stats.total, equals(0));
+    });
+
+    test('records with count', () {
+      DnsBlockService.instance.recordHostRequest(
+          'site-A', 'cdn.example.com', false,
+          count: 25);
+      final stats = DnsBlockService.instance.statsForSite('site-A');
+      expect(stats.allowed, equals(25));
+      expect(stats.log, hasLength(1));
+    });
+
+    test('records source-attributed block with count', () {
+      DnsBlockService.instance.recordHostRequest(
+          'site-A', 'ad.example.com', true,
+          source: BlockSource.abp, count: 7);
+      final stats = DnsBlockService.instance.statsForSite('site-A');
+      expect(stats.blocked, equals(7));
+      expect(stats.blockedByAbp, equals(7));
+    });
+  });
+
+  group('DnsBlockService coalesced log listener notification', () {
+    setUp(() {
+      DnsBlockService.instance.loadDomainsFromString('');
+      DnsBlockService.instance.clearStatsForSite('site-N');
+    });
+
+    test('many recordHostRequest calls fire one listener per microtask', () async {
+      var notifications = 0;
+      void listener() {
+        notifications++;
+      }
+
+      DnsBlockService.instance.addDnsLogListener(listener);
+      try {
+        // Burst of recordings — the listener must fire exactly once per
+        // microtask flush, not once per recorded request.
+        for (var i = 0; i < 50; i++) {
+          DnsBlockService.instance
+              .recordHostRequest('site-N', 'h$i.com', false);
+        }
+        expect(notifications, equals(0),
+            reason: 'notification deferred to next microtask');
+        // Flush the microtask queue.
+        await Future<void>.delayed(Duration.zero);
+        expect(notifications, equals(1),
+            reason: 'one coalesced flush, not 50');
+
+        // A second burst after the flush goes into a fresh microtask.
+        for (var i = 0; i < 10; i++) {
+          DnsBlockService.instance
+              .recordHostRequest('site-N', 'x$i.com', false);
+        }
+        await Future<void>.delayed(Duration.zero);
+        expect(notifications, equals(2));
+      } finally {
+        DnsBlockService.instance.removeDnsLogListener(listener);
+      }
+    });
+
+    test('listener registration with no prior listener does not retroactively notify', () async {
+      // Record before any listener is attached — these should not fire.
+      for (var i = 0; i < 5; i++) {
+        DnsBlockService.instance.recordHostRequest('site-N', 'pre$i.com', false);
+      }
+      var notifications = 0;
+      DnsBlockService.instance.addDnsLogListener(() => notifications++);
+      await Future<void>.delayed(Duration.zero);
+      expect(notifications, equals(0));
+    });
+  });
+}

--- a/test/host_lookup_test.dart
+++ b/test/host_lookup_test.dart
@@ -1,0 +1,183 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/host_lookup.dart';
+
+void main() {
+  group('extractHost', () {
+    test('extracts host from https URL with path', () {
+      expect(extractHost('https://example.com/path'), equals('example.com'));
+    });
+
+    test('extracts host from URL with no path', () {
+      expect(extractHost('https://example.com'), equals('example.com'));
+      expect(extractHost('https://example.com?q=1'), equals('example.com'));
+      expect(extractHost('https://example.com#frag'), equals('example.com'));
+    });
+
+    test('strips port', () {
+      expect(extractHost('https://example.com:443'), equals('example.com'));
+      expect(extractHost('https://example.com:8080/path'), equals('example.com'));
+    });
+
+    test('strips userinfo', () {
+      expect(extractHost('https://user:pass@example.com/'), equals('example.com'));
+      expect(extractHost('https://user@example.com:8080/'), equals('example.com'));
+      expect(extractHost('https://a:b@c:d@example.com/'), equals('example.com'),
+          reason: 'last @ delimits userinfo');
+    });
+
+    test('handles IPv6 literals', () {
+      expect(extractHost('https://[2001:db8::1]/'), equals('[2001:db8::1]'));
+      expect(extractHost('https://[2001:db8::1]:443/'), equals('[2001:db8::1]'));
+      expect(extractHost('https://[::1]/'), equals('[::1]'));
+    });
+
+    test('returns null for unterminated IPv6 literal', () {
+      expect(extractHost('https://[2001:db8/path'), isNull);
+    });
+
+    test('lowercases uppercase hosts', () {
+      expect(extractHost('https://Example.COM/'), equals('example.com'));
+      expect(extractHost('HTTPS://EXAMPLE.COM/'), equals('example.com'));
+    });
+
+    test('returns same string when host is already lowercase', () {
+      // Identity isn't guaranteed by the API, but the no-uppercase fast
+      // path is the realistic case worth covering: the result is an
+      // unmodified substring of the input.
+      const url = 'https://example.com/path';
+      expect(extractHost(url), equals('example.com'));
+    });
+
+    test('returns null for non-scheme URLs', () {
+      expect(extractHost('about:blank'), isNull);
+      expect(extractHost('data:text/html,<p>hi</p>'), isNull);
+      expect(extractHost('javascript:void(0)'), isNull);
+      expect(extractHost('relative/path'), isNull);
+      expect(extractHost(''), isNull);
+    });
+
+    test('handles file:// (scheme present, empty host)', () {
+      expect(extractHost('file:///etc/hosts'), equals(''));
+    });
+
+    test('IPv6 in URL with port and path', () {
+      expect(extractHost('https://[2001:db8::1]:8443/foo?q=1#frag'),
+          equals('[2001:db8::1]'));
+    });
+  });
+
+  group('hostInSet', () {
+    test('exact match', () {
+      expect(hostInSet('tracker.net', {'tracker.net'}), isTrue);
+    });
+
+    test('subdomain match via parent walk', () {
+      final set = {'tracker.net'};
+      expect(hostInSet('sub.tracker.net', set), isTrue);
+      expect(hostInSet('a.b.c.tracker.net', set), isTrue);
+    });
+
+    test('does not match unrelated domain that ends in same string', () {
+      // mytracker.net should NOT be matched by tracker.net
+      expect(hostInSet('mytracker.net', {'tracker.net'}), isFalse);
+    });
+
+    test('never matches a single-label string (eTLD safety)', () {
+      // Even if someone mistakenly added "com" to the set, walking up
+      // foo.example.com must not return true on the bare "com" suffix.
+      expect(hostInSet('foo.example.com', {'com'}), isFalse,
+          reason: 'eTLD-only entries must never block everything');
+    });
+
+    test('returns false on empty set', () {
+      expect(hostInSet('anything.com', <String>{}), isFalse);
+    });
+
+    test('hierarchy walk hits intermediate ancestor', () {
+      final set = {'ads.example.com'};
+      expect(hostInSet('ads.example.com', set), isTrue);
+      expect(hostInSet('foo.ads.example.com', set), isTrue);
+      expect(hostInSet('example.com', set), isFalse);
+      expect(hostInSet('other.example.com', set), isFalse);
+    });
+
+    test('exact-match-on-eTLD parent does not match', () {
+      // The implementation specifically does NOT check the bare eTLD,
+      // even when reached via walk-up. Document that.
+      expect(hostInSet('example.com', {'com'}), isFalse);
+    });
+  });
+
+  group('HostFifoCache', () {
+    test('stores and retrieves entries', () {
+      final c = HostFifoCache(4);
+      c.put('a', true);
+      c.put('b', false);
+      expect(c['a'], isTrue);
+      expect(c['b'], isFalse);
+      expect(c['unknown'], isNull);
+    });
+
+    test('FIFO evicts oldest when full', () {
+      final c = HostFifoCache(3);
+      c.put('a', true);
+      c.put('b', true);
+      c.put('c', true);
+      c.put('d', true); // evicts 'a'
+      expect(c['a'], isNull);
+      expect(c['b'], isTrue);
+      expect(c['c'], isTrue);
+      expect(c['d'], isTrue);
+    });
+
+    test('updates in place do not change FIFO order', () {
+      final c = HostFifoCache(3);
+      c.put('a', true);
+      c.put('b', true);
+      c.put('c', true);
+      c.put('a', false); // update; 'a' must still be the oldest
+      c.put('d', true); // evicts 'a' (still oldest)
+      expect(c['a'], isNull);
+      expect(c['b'], isTrue);
+      expect(c['c'], isTrue);
+      expect(c['d'], isTrue);
+    });
+
+    test('clear empties the cache', () {
+      final c = HostFifoCache(3);
+      c.put('a', true);
+      c.put('b', true);
+      c.clear();
+      expect(c.length, equals(0));
+      expect(c['a'], isNull);
+      // Reuse after clear works.
+      c.put('x', true);
+      expect(c['x'], isTrue);
+    });
+
+    test('length tracks size up to cap', () {
+      final c = HostFifoCache(3);
+      expect(c.length, equals(0));
+      c.put('a', true);
+      c.put('b', true);
+      expect(c.length, equals(2));
+      c.put('c', true);
+      c.put('d', true); // evicts 'a'
+      expect(c.length, equals(3));
+    });
+
+    test('hammering many distinct keys stays bounded and fast', () {
+      // The DNS hot path benchmark also covers this, but exercise the
+      // cache directly here so a regression in the FIFO path surfaces
+      // without needing a 522K-domain build.
+      final c = HostFifoCache(100);
+      final sw = Stopwatch()..start();
+      for (var i = 0; i < 50000; i++) {
+        c.put('host$i', i.isEven);
+      }
+      sw.stop();
+      expect(c.length, equals(100));
+      expect(sw.elapsedMilliseconds, lessThan(2000));
+    });
+  });
+}

--- a/test/js/perf/blocking.bench.js
+++ b/test/js/perf/blocking.bench.js
@@ -1,0 +1,421 @@
+// Benchmark for the JS interceptor rewrite. Compares the old
+// (Promise-everywhere, split-based suffix walk) vs new (sync fast-path,
+// substring-based suffix walk) implementations on synthetic but
+// realistic workloads.
+//
+// Run via `npm run bench:js`. Output is human-readable text — no
+// assertions. The numbers are useful as a relative comparison; absolute
+// throughput depends heavily on the host machine.
+//
+// Workload assumptions (from real-world measurements on news/social
+// pages):
+//   * 200 sub-resource requests per page
+//   * ~30 unique hosts per page
+//   * blocklist: 100K domains (Hagezi "Pro" tier ≈ 392K — we use 100K
+//     to keep the benchmark fast on CI; the bloom shape is the same)
+//   * 5% of sub-resources hit the bloom (need Dart roundtrip)
+//   * 95% of sub-resources are bloom misses (sync fast-path candidates)
+
+'use strict';
+
+const { performance } = require('node:perf_hooks');
+const { makeOldInterceptor } = require('./old_interceptor');
+const { makeNewInterceptor } = require('./new_interceptor');
+const { buildBloom } = require('./bloom_build');
+
+// ---------------- Synthetic data ----------------
+
+function rng(seed) {
+  // Mulberry32 — small, deterministic, good enough for benchmark data.
+  let s = seed >>> 0;
+  return function next() {
+    s = (s + 0x6D2B79F5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function makeBlocklist(count, seed = 42) {
+  const next = rng(seed);
+  const tlds = ['com', 'net', 'org', 'io', 'co', 'info', 'biz', 'xyz'];
+  const out = [];
+  for (let i = 0; i < count; i++) {
+    const tld = tlds[Math.floor(next() * tlds.length)];
+    const nameLen = 4 + Math.floor(next() * 12);
+    let name = '';
+    for (let j = 0; j < nameLen; j++) {
+      name += String.fromCharCode(97 + Math.floor(next() * 26));
+    }
+    if (Math.floor(next() * 5) === 0) {
+      const subLen = 3 + Math.floor(next() * 6);
+      let sub = '';
+      for (let j = 0; j < subLen; j++) {
+        sub += String.fromCharCode(97 + Math.floor(next() * 26));
+      }
+      out.push(`${sub}.${name}.${tld}`);
+    } else {
+      out.push(`${name}.${tld}`);
+    }
+  }
+  return out;
+}
+
+// Generate a request stream: `pageCount` synthetic pages, each with
+// `requestsPerPage` sub-resource URLs spread across `uniqueHostsPerPage`
+// hosts. Of those hosts, `bloomHitFrac` are guaranteed bloom hits
+// (drawn from the blocklist) — the rest are non-blocked synthetic hosts.
+function makeRequestStream({
+  blocklist,
+  pageCount,
+  requestsPerPage,
+  uniqueHostsPerPage,
+  bloomHitFrac,
+  seed = 99,
+}) {
+  const next = rng(seed);
+  const stream = [];
+  for (let p = 0; p < pageCount; p++) {
+    const hosts = [];
+    const hitCount = Math.round(uniqueHostsPerPage * bloomHitFrac);
+    for (let h = 0; h < hitCount; h++) {
+      hosts.push(blocklist[Math.floor(next() * blocklist.length)]);
+    }
+    for (let h = hitCount; h < uniqueHostsPerPage; h++) {
+      let nm = '';
+      const len = 6 + Math.floor(next() * 6);
+      for (let j = 0; j < len; j++) {
+        nm += String.fromCharCode(97 + Math.floor(next() * 26));
+      }
+      hosts.push(`${nm}.example.test`);
+    }
+    for (let r = 0; r < requestsPerPage; r++) {
+      const host = hosts[Math.floor(next() * hosts.length)];
+      const path = '/' + Math.floor(next() * 1e9).toString(36);
+      stream.push(`https://${host}${path}`);
+    }
+  }
+  return stream;
+}
+
+// ---------------- Bench helpers ----------------
+
+function format(ms) {
+  if (ms < 0.01) return `${(ms * 1000).toFixed(2)}µs`;
+  if (ms < 1) return `${ms.toFixed(3)}ms`;
+  return `${ms.toFixed(2)}ms`;
+}
+
+function ratio(a, b) {
+  if (a === 0 || b === 0) return '∞';
+  const r = b / a;
+  if (r >= 1) return `${r.toFixed(2)}× faster`;
+  return `${(1 / r).toFixed(2)}× slower`;
+}
+
+function bench(label, fn, { warmup = 1, iters = 5 } = {}) {
+  for (let i = 0; i < warmup; i++) fn();
+  const samples = [];
+  for (let i = 0; i < iters; i++) {
+    const t0 = performance.now();
+    fn();
+    samples.push(performance.now() - t0);
+  }
+  samples.sort((a, b) => a - b);
+  const median = samples[Math.floor(samples.length / 2)];
+  return { label, median, min: samples[0], max: samples[samples.length - 1] };
+}
+
+async function benchAsync(label, fn, { warmup = 1, iters = 5 } = {}) {
+  for (let i = 0; i < warmup; i++) await fn();
+  const samples = [];
+  for (let i = 0; i < iters; i++) {
+    const t0 = performance.now();
+    await fn();
+    samples.push(performance.now() - t0);
+  }
+  samples.sort((a, b) => a - b);
+  return {
+    label,
+    median: samples[Math.floor(samples.length / 2)],
+    min: samples[0],
+    max: samples[samples.length - 1],
+  };
+}
+
+function printRow(label, value) {
+  console.log(`  ${label.padEnd(46)} ${value}`);
+}
+
+function printResult(r) {
+  printRow(r.label, `${format(r.median)}  (min ${format(r.min)})`);
+}
+
+function compare(label, oldRes, newRes) {
+  console.log('');
+  console.log(label);
+  printResult(oldRes);
+  printResult(newRes);
+  const speedup = oldRes.median / newRes.median;
+  printRow(
+    'speedup',
+    speedup >= 1
+      ? `${speedup.toFixed(2)}× faster`
+      : `${(1 / speedup).toFixed(2)}× slower`,
+  );
+}
+
+// ---------------- Benchmarks ----------------
+
+async function correctnessCheck(blocklist, bloom) {
+  // Confirm old and new agree on bloom decisions for a representative
+  // sample. If they disagree the speedup is meaningless — we'd just be
+  // doing less work.
+  const old = makeOldInterceptor({
+    bloomBits: bloom.bits,
+    bloomBitCount: bloom.bitCount,
+    bloomK: bloom.k,
+    callHandler: () => Promise.resolve(false),
+  });
+  const next = makeNewInterceptor({
+    bloomBits: bloom.bits,
+    bloomBitCount: bloom.bitCount,
+    bloomK: bloom.k,
+    callHandler: () => Promise.resolve(false),
+  });
+  const sample = [];
+  // 100 known-blocked hosts (drawn from the blocklist) + 100 known-safe.
+  for (let i = 0; i < 100; i++) sample.push(blocklist[i * 17 % blocklist.length]);
+  for (let i = 0; i < 100; i++) sample.push(`safe${i}.example.test`);
+  // Sub-domain forms of each.
+  for (let i = 0; i < 100; i++) sample.push(`a.b.${blocklist[i * 23 % blocklist.length]}`);
+  let mismatches = 0;
+  for (const host of sample) {
+    if (old.maybeBlocked(host) !== next.maybeBlocked(host)) mismatches++;
+  }
+  if (mismatches > 0) {
+    throw new Error(
+      `Correctness check FAILED: ${mismatches}/${sample.length} bloom decisions differ between old and new`,
+    );
+  }
+  console.log(
+    `  correctness: ${sample.length}/${sample.length} bloom decisions match between old and new`,
+  );
+}
+
+async function main() {
+  console.log('Building synthetic 100K-domain blocklist + bloom...');
+  const blocklist = makeBlocklist(100_000);
+  const bloom = buildBloom(blocklist, 0.05);
+  console.log(
+    `  bloom: ${bloom.bits.length} bytes, k=${bloom.k}, bitCount=${bloom.bitCount}`,
+  );
+  await correctnessCheck(blocklist, bloom);
+
+  // ---------------- 1. Suffix walk (pure CPU) ----------------
+  // 50K hosts × ~3 average levels of walk-up. Pre-warm cache disabled —
+  // we want the actual walk cost. Use bloom-miss hosts so every query
+  // walks the full hierarchy.
+  const walkHosts = [];
+  for (let i = 0; i < 50_000; i++) {
+    walkHosts.push(`a.b.c.d.host${i}.example.test`);
+  }
+  const oldI1 = makeOldInterceptor({
+    bloomBits: bloom.bits,
+    bloomBitCount: bloom.bitCount,
+    bloomK: bloom.k,
+    callHandler: () => Promise.resolve(false),
+  });
+  const newI1 = makeNewInterceptor({
+    bloomBits: bloom.bits,
+    bloomBitCount: bloom.bitCount,
+    bloomK: bloom.k,
+    callHandler: () => Promise.resolve(false),
+  });
+  const oldWalk = bench(
+    'old (split + slice + join)',
+    () => {
+      for (const h of walkHosts) oldI1.maybeBlocked(h);
+    },
+    { iters: 7 },
+  );
+  const newWalk = bench(
+    'new (substring + indexOf)',
+    () => {
+      for (const h of walkHosts) newI1.maybeBlocked(h);
+    },
+    { iters: 7 },
+  );
+  compare('Suffix walk: 50K hosts × 5 levels', oldWalk, newWalk);
+
+  // ---------------- 2. Property-setter microtask delay ----------------
+  // Simulate `el.src = url` 1000 times. Old wraps in Promise.then, new
+  // runs origSet synchronously on bloom miss. The cost worth tracking
+  // is split into two phases:
+  //   * `sync_ms` — wall-clock time spent on the main JS thread issuing
+  //     the work. This is what blocks the UI / scrolling. In the new
+  //     code, ~95% of sets COMPLETE in this phase (origSet runs sync);
+  //     in the old code, every set just enqueues a microtask.
+  //   * `drain_ms` — time spent in the microtask queue after the loop
+  //     exits, until all pending decisions have run their `.then`
+  //     callbacks.
+  // Real-world hit: while the `sync_ms` phase is running the UI thread
+  // is unresponsive — each microtask delay there means an image load
+  // doesn't kick off until later.
+  const setterStream = makeRequestStream({
+    blocklist,
+    pageCount: 1,
+    requestsPerPage: 1000,
+    uniqueHostsPerPage: 50,
+    bloomHitFrac: 0.05,
+  });
+
+  const oldI3 = makeOldInterceptor({
+    bloomBits: bloom.bits,
+    bloomBitCount: bloom.bitCount,
+    bloomK: bloom.k,
+    callHandler: () => Promise.resolve(true),
+  });
+  const newI3 = makeNewInterceptor({
+    bloomBits: bloom.bits,
+    bloomBitCount: bloom.bitCount,
+    bloomK: bloom.k,
+    callHandler: () => Promise.resolve(true),
+  });
+
+  async function setterPhasesOld() {
+    let counter = 0;
+    const settled = [];
+    const tSync = performance.now();
+    for (const url of setterStream) {
+      settled.push(
+        oldI3.check(url).then((blocked) => {
+          if (!blocked) counter++;
+        }),
+      );
+    }
+    const sync = performance.now() - tSync;
+    const tDrain = performance.now();
+    await Promise.all(settled);
+    const drain = performance.now() - tDrain;
+    return { sync, drain };
+  }
+  async function setterPhasesNew() {
+    let counter = 0;
+    const settled = [];
+    const tSync = performance.now();
+    for (const url of setterStream) {
+      const sync = newI3.checkSync(url);
+      if (sync === false) {
+        counter++; // synchronous — origSet would have run here
+        continue;
+      }
+      if (sync === true) continue;
+      settled.push(
+        newI3.checkAsync(url).then((blocked) => {
+          if (!blocked) counter++;
+        }),
+      );
+    }
+    const sync = performance.now() - tSync;
+    const tDrain = performance.now();
+    await Promise.all(settled);
+    const drain = performance.now() - tDrain;
+    return { sync, drain };
+  }
+
+  // Warm up.
+  for (let i = 0; i < 2; i++) {
+    await setterPhasesOld();
+    await setterPhasesNew();
+  }
+  const oldPhases = [];
+  const newPhases = [];
+  for (let i = 0; i < 7; i++) {
+    oldPhases.push(await setterPhasesOld());
+    newPhases.push(await setterPhasesNew());
+  }
+  function median(values) {
+    const sorted = [...values].sort((a, b) => a - b);
+    return sorted[Math.floor(sorted.length / 2)];
+  }
+  const oldSync = median(oldPhases.map((p) => p.sync));
+  const oldDrain = median(oldPhases.map((p) => p.drain));
+  const newSync = median(newPhases.map((p) => p.sync));
+  const newDrain = median(newPhases.map((p) => p.drain));
+  console.log('');
+  console.log(
+    'Property setter phases (1000 sets, 95% bloom miss; UI thread blocked during sync)',
+  );
+  printRow('old sync (UI-thread)', format(oldSync));
+  printRow('new sync (UI-thread)', `${format(newSync)}  (${ratio(newSync, oldSync)})`);
+  printRow('old drain (microtask queue)', format(oldDrain));
+  printRow('new drain (microtask queue)', `${format(newDrain)}  (${ratio(newDrain, oldDrain)})`);
+  printRow(
+    'old total',
+    format(oldSync + oldDrain),
+  );
+  printRow(
+    'new total',
+    `${format(newSync + newDrain)}  (${ratio(newSync + newDrain, oldSync + oldDrain)})`,
+  );
+
+  // ---------------- 3. Pure-sync: hot-cache lookup throughput ----------------
+  // After warmup the cache holds every host. Old still creates a Promise
+  // per call; new returns sync directly. This bounds the steady-state
+  // cost on a long-lived page.
+  const hotStream = makeRequestStream({
+    blocklist,
+    pageCount: 1,
+    requestsPerPage: 10_000,
+    uniqueHostsPerPage: 50,
+    bloomHitFrac: 0.05,
+  });
+  // Warm both caches.
+  const ps = [];
+  for (const url of hotStream) ps.push(oldI3.check(url));
+  await Promise.all(ps);
+  for (const url of hotStream) newI3.checkSync(url);
+
+  const oldHot = await benchAsync(
+    'old hot-cache: 10K cached lookups',
+    async () => {
+      const ps = [];
+      for (const url of hotStream) ps.push(oldI3.check(url));
+      await Promise.all(ps);
+    },
+    { iters: 5 },
+  );
+  const newHot = bench(
+    'new hot-cache: 10K sync lookups',
+    () => {
+      for (const url of hotStream) newI3.checkSync(url);
+    },
+    { iters: 5 },
+  );
+  compare('Hot-cache throughput (10K cached lookups)', oldHot, newHot);
+
+  console.log('');
+  console.log('Notes:');
+  console.log('  * Times are wall-clock medians across 5–7 runs (after warmup).');
+  console.log('  * Workload uses a 100K-domain bloom; production "Pro" tier is');
+  console.log('    ~390K. Bloom miss cost scales with `k` (4 in both cases) so');
+  console.log('    the relative speedup is stable across blocklist sizes.');
+  console.log('  * Suffix-walk: pure CPU. No async, no DOM. The 1.4–1.5×');
+  console.log('    speedup comes from substring/indexOf in place of');
+  console.log('    parts.split + parts.slice(i).join — no per-level array');
+  console.log('    allocation.');
+  console.log('  * Property setter: most important number. The "drain" line');
+  console.log('    is microtask-queue time before all 1000 callbacks resolve.');
+  console.log('    On a real iOS WebView this drain blocks the render loop —');
+  console.log('    image loads queued behind 1000 microtasks vs 50 microtasks');
+  console.log('    is the perceptible UX win.');
+  console.log('  * Hot-cache throughput: steady-state cost on a long-lived');
+  console.log('    page after every host has been seen once.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/js/perf/bloom_build.js
+++ b/test/js/perf/bloom_build.js
@@ -1,0 +1,29 @@
+// JS-side bloom builder, mirroring `lib/services/bloom_filter.dart`.
+// Used to seed the benchmark filter from a synthetic blocklist so we
+// don't have to ship a real Hagezi list in the repo just to run perf.
+
+'use strict';
+
+const { fnv1a } = require('./old_interceptor');
+
+function buildBloom(items, fpRate = 0.05) {
+  const n = items.length;
+  if (n === 0) return { bits: new Uint8Array(8), bitCount: 64, k: 1 };
+  const ln2 = Math.LN2;
+  const m = Math.ceil((-n * Math.log(fpRate)) / (ln2 * ln2));
+  const byteCount = Math.ceil(m / 8);
+  const bitCount = byteCount * 8;
+  const k = Math.max(1, Math.min(16, Math.round((m / n) * ln2)));
+  const bits = new Uint8Array(byteCount);
+  for (const item of items) {
+    const h1 = fnv1a(item, 0x811C9DC5);
+    const h2 = fnv1a(item, 0xCBF29CE4);
+    for (let i = 0; i < k; i++) {
+      const pos = ((h1 + i * h2) >>> 0) % bitCount;
+      bits[pos >> 3] |= 1 << (pos & 7);
+    }
+  }
+  return { bits, bitCount, k };
+}
+
+module.exports = { buildBloom };

--- a/test/js/perf/new_interceptor.js
+++ b/test/js/perf/new_interceptor.js
@@ -1,0 +1,95 @@
+// New iOS JS interceptor logic, mirroring the rewrite in
+// `lib/services/webview.dart` (the `block_js_interceptor` user script).
+//
+//   * `checkSync(url)` returns true / false / undefined — no Promise
+//     wrapping on the bloom-miss / cache-hit fast path.
+//   * Suffix walk uses `host.indexOf('.', dot+1)` + `substring`, no
+//     `split('.')` array allocation per level.
+//   * Cache is one map keyed by host (not two parallel objects), with
+//     FIFO eviction.
+//
+// Standalone for benching — kept in sync with webview.dart manually.
+
+'use strict';
+
+const { fnv1a } = require('./old_interceptor');
+
+function makeNewInterceptor({ bloomBits, bloomBitCount, bloomK, callHandler }) {
+  let bloomReady = bloomBits != null;
+
+  function bloomContains(s) {
+    if (!bloomReady) return true;
+    const h1 = fnv1a(s, 0x811C9DC5);
+    const h2 = fnv1a(s, 0xCBF29CE4);
+    for (let i = 0; i < bloomK; i++) {
+      const pos = ((h1 + i * h2) >>> 0) % bloomBitCount;
+      if ((bloomBits[pos >> 3] & (1 << (pos & 7))) === 0) return false;
+    }
+    return true;
+  }
+
+  // New suffix walk: no array allocation, peel labels via indexOf.
+  function maybeBlocked(host) {
+    if (bloomContains(host)) return true;
+    let dot = host.indexOf('.');
+    while (dot >= 0 && dot < host.length - 1) {
+      const parent = host.substring(dot + 1);
+      if (parent.indexOf('.') < 0) break;
+      if (bloomContains(parent)) return true;
+      dot = host.indexOf('.', dot + 1);
+    }
+    return false;
+  }
+
+  const hostCache = Object.create(null);
+  const hostOrder = [];
+  const MAX_CACHE = 500;
+
+  function cacheGet(host) { return hostCache[host]; }
+  function cachePut(host, blocked) {
+    if (host in hostCache) { hostCache[host] = blocked; return; }
+    hostCache[host] = blocked;
+    hostOrder.push(host);
+    if (hostOrder.length > MAX_CACHE) {
+      const old = hostOrder.shift();
+      delete hostCache[old];
+    }
+  }
+
+  function checkSync(url) {
+    if (!url || typeof url !== 'string' || url.charCodeAt(0) !== 104) return false;
+    if (url.indexOf('http') !== 0) return false;
+    let host;
+    try { host = new URL(url).hostname; } catch (e) { return false; }
+    if (!host) return false;
+    const cached = cacheGet(host);
+    if (cached === false) return false;
+    if (cached === true) return true;
+    if (!bloomReady) return undefined;
+    if (!maybeBlocked(host)) {
+      cachePut(host, false);
+      return false;
+    }
+    return undefined;
+  }
+
+  function checkAsync(url) {
+    return callHandler('blockCheck', url).then((blocked) => {
+      try {
+        const host = new URL(url).hostname;
+        if (host) cachePut(host, !!blocked);
+      } catch (e) {}
+      return !!blocked;
+    });
+  }
+
+  function check(url) {
+    const sync = checkSync(url);
+    if (sync !== undefined) return Promise.resolve(sync);
+    return checkAsync(url);
+  }
+
+  return { check, checkSync, checkAsync, maybeBlocked, bloomContains };
+}
+
+module.exports = { makeNewInterceptor };

--- a/test/js/perf/old_interceptor.js
+++ b/test/js/perf/old_interceptor.js
@@ -1,0 +1,92 @@
+// Old (pre-rewrite) iOS JS interceptor logic, kept here for relative
+// benchmarking. The shape mirrors what was inlined in
+// `lib/services/webview.dart` before the sync-fast-path landed:
+//
+//   * `check(url)` always returns a Promise — even on bloom miss the
+//     caller pays a microtask roundtrip via `.then`.
+//   * `maybeBlocked(host)` walks the suffix hierarchy with
+//     `parts = host.split('.')` + `parts.slice(i).join('.')` per level,
+//     allocating a fresh array + string per parent.
+//   * Property setter wraps origSet in `check(value).then(b => if(!b)
+//     origSet.call(el, value))` — every `<img>.src = url` pays a
+//     microtask delay even when the bloom misses.
+//
+// This is a pure CPU/JS-runtime simulation of the cost: no jsdom DOM,
+// no real fetch. The point is to compare the algorithmic / scheduling
+// overhead, not to reproduce the network behaviour.
+
+'use strict';
+
+function fnv1a(s, seed) {
+  let h = seed >>> 0;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  return h >>> 0;
+}
+
+function makeOldInterceptor({ bloomBits, bloomBitCount, bloomK, callHandler }) {
+  let bloomReady = bloomBits != null;
+
+  function bloomContains(s) {
+    if (!bloomReady) return true;
+    const h1 = fnv1a(s, 0x811C9DC5);
+    const h2 = fnv1a(s, 0xCBF29CE4);
+    for (let i = 0; i < bloomK; i++) {
+      const pos = ((h1 + i * h2) >>> 0) % bloomBitCount;
+      if ((bloomBits[pos >> 3] & (1 << (pos & 7))) === 0) return false;
+    }
+    return true;
+  }
+
+  // Old suffix walk: allocates `parts` array + joinToString per level.
+  function maybeBlocked(host) {
+    if (bloomContains(host)) return true;
+    const parts = host.split('.');
+    for (let i = 1; i < parts.length - 1; i++) {
+      if (bloomContains(parts.slice(i).join('.'))) return true;
+    }
+    return false;
+  }
+
+  const allowedCache = Object.create(null);
+  const blockedCache = Object.create(null);
+  const cacheKeys = [];
+  const MAX_CACHE = 500;
+
+  function cacheResult(host, blocked) {
+    if (blocked) blockedCache[host] = 1;
+    else allowedCache[host] = 1;
+    cacheKeys.push(host);
+    if (cacheKeys.length > MAX_CACHE) {
+      const old = cacheKeys.shift();
+      delete allowedCache[old];
+      delete blockedCache[old];
+    }
+  }
+
+  function check(url) {
+    if (!url || typeof url !== 'string' || !url.startsWith('http')) {
+      return Promise.resolve(false);
+    }
+    let host;
+    try { host = new URL(url).hostname; } catch (e) { return Promise.resolve(false); }
+    if (allowedCache[host]) return Promise.resolve(false);
+    if (blockedCache[host]) return Promise.resolve(true);
+    if (!maybeBlocked(host)) {
+      cacheResult(host, false);
+      // Old behaviour also fires `blockResourceLoaded` here; the
+      // microtask cost is what we actually care about for this bench.
+      return Promise.resolve(false);
+    }
+    return callHandler('blockCheck', url).then((blocked) => {
+      cacheResult(host, !!blocked);
+      return !!blocked;
+    });
+  }
+
+  return { check, maybeBlocked, bloomContains };
+}
+
+module.exports = { makeOldInterceptor, fnv1a };


### PR DESCRIPTION
The hot path had four sources of slowness on every sub-resource:

* Android native checkUrl reparsed via java.net.URI (throws on common
  query-string chars), allocated a List per host.split('.') and a
  fresh substring per parts.subList().joinToString(), and reported
  every allowed request through a HashMap-allocating, lock-acquiring
  recordBlockEvent. A typical page = 200+ events of plumbing per
  page load on the WebView IO thread.
* ContentBlockerService.isBlocked used Uri.parse + per-level
  substring walk with no host cache, while DnsBlockService had
  already moved to a fast extractHost + cached suffix walk.
* iOS JS interceptor wrapped every fetch / XHR / Image.src setter
  in Promise.resolve().then(set), forcing a microtask delay on
  every image load even when bloom missed (the dominant case).
* DnsStats log used List.removeAt(0) — O(n) per overflow on a
  500-cap list — and notified listeners synchronously per request,
  which fired a setState storm on the dev-tools log view.

Fixes:

* New host_lookup.dart shared between DnsBlockService and
  ContentBlockerService: extractHost (no Uri.parse) + hostInSet
  (allocation-light suffix walk) + reusable HostFifoCache.
* ContentBlockerService.isBlocked gets the same FIFO host cache
  the DNS path already had.
* DnsStats.log → fixed-size ring buffer; record() takes a count
  so dedup'd repeats fold into the totals without growing the log.
* DnsBlockService notifies log listeners via a coalesced microtask
  instead of per-request — one rebuild per batch, not per URL.
* Android FastSubresourceInterceptor: per-instance host decision
  cache, allocation-free isInSet substring walk, hand-rolled
  extractHost (no java.net.URI), and per-host event dedup —
  pendingBlockEvents collapses repeats into a single record with
  count, so a CDN serving 50 assets enqueues one HashMap not 50.
* iOS JS interceptor: synchronous fast path for bloom misses (no
  Promise wrapping). Property setters keep the original synchronous
  semantics for the common case; Dart confirmation only runs on
  the rare bloom hit. PerformanceObserver-based block_resource_observer
  switches to a per-host batched flush via blockResourceLoadedBatch.
* Drop the per-navigation `[Navigation] $url` log line — every
  navigation triggered notifyListeners() on LogService, which
  rebuilt the dev-tools log tab.