### PR TITLE
Add per-site settings QR share / apply

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,11 @@
          in the per-site location picker. Not used for any background/tracking. -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- Optional, requested at runtime only when the user taps "Apply QR" in
+         per-site settings to scan a shared site-settings QR. Not used for
+         any background capture or media collection. -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
     <application
         android:label="Webspace"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -10,6 +10,8 @@
 	<string>This app may request access to your photo library when uploading files through web pages.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Used only when you tap "Use current location" in the per-site location picker, to fill in your coordinates for the site's spoofed location.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Used only when you tap "Apply QR" in per-site settings, to scan a shared site-settings QR code. The camera feed is not stored or transmitted.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -13,7 +13,9 @@ import 'package:webspace/services/localcdn_service.dart';
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/timezone_location_service.dart';
 import 'package:webspace/screens/location_picker.dart';
+import 'package:webspace/screens/site_settings_qr.dart';
 import 'package:webspace/screens/user_scripts.dart';
+import 'package:webspace/services/site_settings_qr_codec.dart';
 import 'package:webspace/settings/user_script.dart';
 import 'package:webspace/widgets/hint_button.dart';
 import 'package:webspace/widgets/root_messenger.dart';
@@ -138,62 +140,54 @@ class _SettingsScreenState extends State<SettingsScreen> {
   @override
   void initState() {
     super.initState();
-    // Force DEFAULT proxy on unsupported platforms
+    _userAgentController = TextEditingController();
+    _proxyAddressController = TextEditingController();
+    _proxyUsernameController = TextEditingController();
+    _proxyPasswordController = TextEditingController();
+    _latitudeController = TextEditingController();
+    _longitudeController = TextEditingController();
+    _accuracyController = TextEditingController();
+    _loadFromModel();
+  }
+
+  /// Mirror [widget.webViewModel] into the form state. Called from
+  /// [initState] and from the apply-from-QR handler after the decoded
+  /// payload has been written back into the model.
+  void _loadFromModel() {
+    final m = widget.webViewModel;
+    // Force DEFAULT proxy on unsupported platforms.
     _proxySettings = UserProxySettings(
       type: PlatformInfo.isProxySupported
-          ? widget.webViewModel.proxySettings.type
+          ? m.proxySettings.type
           : ProxyType.DEFAULT,
-      address: PlatformInfo.isProxySupported
-          ? widget.webViewModel.proxySettings.address
-          : null,
-      username: PlatformInfo.isProxySupported
-          ? widget.webViewModel.proxySettings.username
-          : null,
-      password: PlatformInfo.isProxySupported
-          ? widget.webViewModel.proxySettings.password
-          : null,
+      address: PlatformInfo.isProxySupported ? m.proxySettings.address : null,
+      username: PlatformInfo.isProxySupported ? m.proxySettings.username : null,
+      password: PlatformInfo.isProxySupported ? m.proxySettings.password : null,
     );
-    _userAgentController = TextEditingController(
-      text: getResetUserAgent(),
-    );
-    _proxyAddressController = TextEditingController(
-      text: _proxySettings.address ?? '',
-    );
-    _proxyUsernameController = TextEditingController(
-      text: _proxySettings.username ?? '',
-    );
-    _proxyPasswordController = TextEditingController(
-      text: _proxySettings.password ?? '',
-    );
-    _javascriptEnabled = widget.webViewModel.javascriptEnabled;
-    _thirdPartyCookiesEnabled = widget.webViewModel.thirdPartyCookiesEnabled;
-    _incognito = widget.webViewModel.incognito;
-    _clearUrlEnabled = widget.webViewModel.clearUrlEnabled;
-    _dnsBlockEnabled = widget.webViewModel.dnsBlockEnabled;
-    _contentBlockEnabled = widget.webViewModel.contentBlockEnabled;
-    _trackingProtectionEnabled = widget.webViewModel.trackingProtectionEnabled;
-    _localCdnEnabled = widget.webViewModel.localCdnEnabled;
-    _blockAutoRedirects = widget.webViewModel.blockAutoRedirects;
-    _fullscreenMode = widget.webViewModel.fullscreenMode;
-    _notificationsEnabled = widget.webViewModel.notificationsEnabled;
-    _backgroundPoll = widget.webViewModel.backgroundPoll;
-    _selectedLanguage = widget.webViewModel.language;
-    // locationMode is derived from whether coords are present at save time;
-    // no separate UI state needed (see _buildLocationTile).
-    _latitudeController = TextEditingController(
-      text: widget.webViewModel.spoofLatitude?.toString() ?? '',
-    );
-    _longitudeController = TextEditingController(
-      text: widget.webViewModel.spoofLongitude?.toString() ?? '',
-    );
-    _accuracyController = TextEditingController(
-      text: widget.webViewModel.spoofAccuracy.toString(),
-    );
-    _spoofTimezone = widget.webViewModel.spoofTimezone;
-    _spoofTimezoneFromLocation = widget.webViewModel.spoofTimezoneFromLocation;
-    _isLiveLocation = widget.webViewModel.locationMode == LocationMode.live;
-    _webRtcPolicy = widget.webViewModel.webRtcPolicy;
-    // Show credentials section if credentials already exist
+    _userAgentController.text = getResetUserAgent();
+    _proxyAddressController.text = _proxySettings.address ?? '';
+    _proxyUsernameController.text = _proxySettings.username ?? '';
+    _proxyPasswordController.text = _proxySettings.password ?? '';
+    _javascriptEnabled = m.javascriptEnabled;
+    _thirdPartyCookiesEnabled = m.thirdPartyCookiesEnabled;
+    _incognito = m.incognito;
+    _clearUrlEnabled = m.clearUrlEnabled;
+    _dnsBlockEnabled = m.dnsBlockEnabled;
+    _contentBlockEnabled = m.contentBlockEnabled;
+    _trackingProtectionEnabled = m.trackingProtectionEnabled;
+    _localCdnEnabled = m.localCdnEnabled;
+    _blockAutoRedirects = m.blockAutoRedirects;
+    _fullscreenMode = m.fullscreenMode;
+    _notificationsEnabled = m.notificationsEnabled;
+    _backgroundPoll = m.backgroundPoll;
+    _selectedLanguage = m.language;
+    _latitudeController.text = m.spoofLatitude?.toString() ?? '';
+    _longitudeController.text = m.spoofLongitude?.toString() ?? '';
+    _accuracyController.text = m.spoofAccuracy.toString();
+    _spoofTimezone = m.spoofTimezone;
+    _spoofTimezoneFromLocation = m.spoofTimezoneFromLocation;
+    _isLiveLocation = m.locationMode == LocationMode.live;
+    _webRtcPolicy = m.webRtcPolicy;
     _showProxyCredentials = _proxySettings.hasCredentials;
   }
 
@@ -413,6 +407,57 @@ class _SettingsScreenState extends State<SettingsScreen> {
         SnackBar(content: Text('Error saving settings: $e')),
       );
     }
+  }
+
+  Future<void> _applyFromQr() async {
+    final decoded = await showSiteSettingsQrApplyDialog(context);
+    if (decoded == null || !mounted) return;
+
+    // Hydrate then parse via WebViewModel.fromJson — the same code path
+    // used for backup imports — so deserialization stays in one place.
+    final incoming = WebViewModel.fromJson(
+      SiteSettingsQrCodec.hydrateForFromJson(decoded),
+      null,
+    );
+    final m = widget.webViewModel;
+
+    // Settings overwrite: per-site config from the QR replaces the current
+    // site's. Identity (siteId, currentUrl, cookies, scripts) stays put.
+    m.initUrl = incoming.initUrl;
+    m.name = incoming.name;
+    m.proxySettings = incoming.proxySettings;
+    m.javascriptEnabled = incoming.javascriptEnabled;
+    m.userAgent = incoming.userAgent;
+    m.thirdPartyCookiesEnabled = incoming.thirdPartyCookiesEnabled;
+    m.incognito = incoming.incognito;
+    m.language = incoming.language;
+    m.clearUrlEnabled = incoming.clearUrlEnabled;
+    m.dnsBlockEnabled = incoming.dnsBlockEnabled;
+    m.contentBlockEnabled = incoming.contentBlockEnabled;
+    m.trackingProtectionEnabled = incoming.trackingProtectionEnabled;
+    m.localCdnEnabled = incoming.localCdnEnabled;
+    m.blockAutoRedirects = incoming.blockAutoRedirects;
+    m.fullscreenMode = incoming.fullscreenMode;
+    m.notificationsEnabled = incoming.notificationsEnabled;
+    m.backgroundPoll = incoming.backgroundPoll;
+    m.locationMode = incoming.locationMode;
+    m.spoofLatitude = incoming.spoofLatitude;
+    m.spoofLongitude = incoming.spoofLongitude;
+    m.spoofAccuracy = incoming.spoofAccuracy;
+    m.spoofTimezone = incoming.spoofTimezone;
+    m.spoofTimezoneFromLocation = incoming.spoofTimezoneFromLocation;
+    m.webRtcPolicy = incoming.webRtcPolicy;
+
+    setState(_loadFromModel);
+    final proxyNeedsPassword = incoming.proxySettings.username != null &&
+        incoming.proxySettings.username!.isNotEmpty;
+    rootScaffoldMessengerKey.currentState?.showSnackBar(
+      SnackBar(
+        content: Text(proxyNeedsPassword
+            ? 'Settings applied. Re-enter proxy password and press Save.'
+            : 'Settings applied. Press Save to persist.'),
+      ),
+    );
   }
 
   Future<void> _openLocationPicker() async {
@@ -1259,6 +1304,31 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 },
               ),
             ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    icon: const Icon(Icons.qr_code),
+                    label: const Text('Share QR'),
+                    onPressed: () => showSiteSettingsQrShareDialog(
+                      context,
+                      widget.webViewModel,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: OutlinedButton.icon(
+                    icon: const Icon(Icons.qr_code_scanner),
+                    label: const Text('Apply QR'),
+                    onPressed: _applyFromQr,
+                  ),
+                ),
+              ],
+            ),
+          ),
           Padding(
             padding: const EdgeInsets.all(16.0),
             child: ElevatedButton(

--- a/lib/screens/site_settings_qr.dart
+++ b/lib/screens/site_settings_qr.dart
@@ -1,10 +1,20 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:share_plus/share_plus.dart';
 
+import 'package:webspace/screens/site_settings_qr_scanner.dart';
 import 'package:webspace/services/site_settings_qr_codec.dart';
 import 'package:webspace/web_view_model.dart';
+
+/// Camera scanning is wired up only where flutter_zxing's `ReaderWidget`
+/// has a working camera path. On desktop (Linux, macOS, Windows) and web
+/// the apply dialog skips straight to paste.
+bool _hasCameraScanner() =>
+    !kIsWeb && (Platform.isAndroid || Platform.isIOS);
 
 /// Show a dialog rendering [model]'s shareable subset as a QR code.
 /// Cookies, user scripts, secure cookies, and proxy passwords are stripped
@@ -77,13 +87,29 @@ Future<void> showSiteSettingsQrShareDialog(
   );
 }
 
-/// Show a dialog that asks the user to paste a `webspace://qr/site/...`
-/// payload. Returns the decoded shareable subset (per
-/// [SiteSettingsQrCodec.includedKeys]) on success, or null if the user
-/// cancels or the payload is malformed. Most native camera apps decode
-/// QR codes and produce the URI string — paste-and-apply works without a
-/// camera library and dodges F-Droid concerns about ML Kit barcode deps.
+/// Drive the apply-from-QR flow. On Android/iOS opens the in-app camera
+/// scanner first (flutter_zxing → ZXing C++, FOSS). On desktop or if the
+/// user backs out of the scanner, falls back to a paste dialog.
 Future<Map<String, dynamic>?> showSiteSettingsQrApplyDialog(
+  BuildContext context,
+) async {
+  if (_hasCameraScanner()) {
+    final scanned = await Navigator.of(context).push<Map<String, dynamic>>(
+      MaterialPageRoute(
+        builder: (_) => const SiteSettingsQrScannerScreen(),
+      ),
+    );
+    if (scanned != null) return scanned;
+    if (!context.mounted) return null;
+  }
+  return _showPasteDialog(context);
+}
+
+/// Paste-fallback dialog. Exposed so [showSiteSettingsQrApplyDialog] can
+/// route to it after the scanner is cancelled or on platforms without a
+/// camera path. Tests against the codec target this through the public
+/// entry point above; this helper is intentionally private.
+Future<Map<String, dynamic>?> _showPasteDialog(
   BuildContext context,
 ) async {
   final controller = TextEditingController();

--- a/lib/screens/site_settings_qr.dart
+++ b/lib/screens/site_settings_qr.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+import 'package:share_plus/share_plus.dart';
+
+import 'package:webspace/services/site_settings_qr_codec.dart';
+import 'package:webspace/web_view_model.dart';
+
+/// Show a dialog rendering [model]'s shareable subset as a QR code.
+/// Cookies, user scripts, secure cookies, and proxy passwords are stripped
+/// by [SiteSettingsQrCodec.shareableSubset] before encoding.
+Future<void> showSiteSettingsQrShareDialog(
+  BuildContext context,
+  WebViewModel model,
+) async {
+  final shared = SiteSettingsQrCodec.shareableSubset(model.toJson());
+  final encoded = SiteSettingsQrCodec.encode(shared);
+
+  await showDialog<void>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      title: const Text('Share site settings'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              color: Colors.white,
+              padding: const EdgeInsets.all(8),
+              child: QrImageView(
+                data: encoded,
+                version: QrVersions.auto,
+                size: 240,
+                backgroundColor: Colors.white,
+                errorCorrectionLevel: QrErrorCorrectLevel.M,
+                gapless: true,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Cookies, user scripts, and proxy passwords are not included.',
+              style: TextStyle(
+                fontSize: 12,
+                color: Theme.of(ctx).textTheme.bodySmall?.color,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton.icon(
+          icon: const Icon(Icons.copy),
+          label: const Text('Copy'),
+          onPressed: () async {
+            await Clipboard.setData(ClipboardData(text: encoded));
+            if (ctx.mounted) {
+              ScaffoldMessenger.of(ctx).showSnackBar(
+                const SnackBar(content: Text('Copied to clipboard')),
+              );
+            }
+          },
+        ),
+        TextButton.icon(
+          icon: const Icon(Icons.share),
+          label: const Text('Share'),
+          onPressed: () {
+            SharePlus.instance.share(ShareParams(text: encoded));
+          },
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(),
+          child: const Text('Close'),
+        ),
+      ],
+    ),
+  );
+}
+
+/// Show a dialog that asks the user to paste a `webspace://qr/site/...`
+/// payload. Returns the decoded shareable subset (per
+/// [SiteSettingsQrCodec.includedKeys]) on success, or null if the user
+/// cancels or the payload is malformed. Most native camera apps decode
+/// QR codes and produce the URI string — paste-and-apply works without a
+/// camera library and dodges F-Droid concerns about ML Kit barcode deps.
+Future<Map<String, dynamic>?> showSiteSettingsQrApplyDialog(
+  BuildContext context,
+) async {
+  final controller = TextEditingController();
+  String? errorText;
+
+  Map<String, dynamic>? tryDecode() {
+    final raw = controller.text.trim();
+    if (raw.isEmpty) return null;
+    return SiteSettingsQrCodec.decode(raw);
+  }
+
+  final result = await showDialog<Map<String, dynamic>>(
+    context: context,
+    builder: (ctx) => StatefulBuilder(
+      builder: (ctx, setState) => AlertDialog(
+        title: const Text('Apply settings from QR'),
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Text(
+                'Scan the QR with your camera and paste the resulting '
+                'webspace://qr/site/... URL here.',
+                style: TextStyle(fontSize: 13),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: controller,
+                minLines: 3,
+                maxLines: 6,
+                autofocus: true,
+                decoration: InputDecoration(
+                  hintText: 'webspace://qr/site/v1/...',
+                  border: const OutlineInputBorder(),
+                  errorText: errorText,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: TextButton.icon(
+                  icon: const Icon(Icons.paste),
+                  label: const Text('Paste from clipboard'),
+                  onPressed: () async {
+                    final data = await Clipboard.getData('text/plain');
+                    if (data?.text != null) {
+                      controller.text = data!.text!;
+                      setState(() => errorText = null);
+                    }
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () {
+              final decoded = tryDecode();
+              if (decoded == null) {
+                setState(() => errorText =
+                    'Not a valid WebSpace site-settings QR.');
+                return;
+              }
+              Navigator.of(ctx).pop(decoded);
+            },
+            child: const Text('Apply'),
+          ),
+        ],
+      ),
+    ),
+  );
+
+  controller.dispose();
+  return result;
+}

--- a/lib/screens/site_settings_qr_scanner.dart
+++ b/lib/screens/site_settings_qr_scanner.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_zxing/flutter_zxing.dart';
+
+import 'package:webspace/services/site_settings_qr_codec.dart';
+
+/// Full-screen camera scanner that returns the decoded shareable subset
+/// when a `webspace://qr/site/...` payload is detected.
+///
+/// Routed via `Navigator.push<Map<String, dynamic>>` from the apply flow.
+/// Pops with the decoded Map on success, null on user cancel. Scanning is
+/// gated to QR codes only (other formats are rejected at the codec layer
+/// — they won't decode — but we still hint via [ReaderWidget.codeFormat]
+/// so ZXing can short-circuit).
+class SiteSettingsQrScannerScreen extends StatefulWidget {
+  const SiteSettingsQrScannerScreen({super.key});
+
+  @override
+  State<SiteSettingsQrScannerScreen> createState() =>
+      _SiteSettingsQrScannerScreenState();
+}
+
+class _SiteSettingsQrScannerScreenState
+    extends State<SiteSettingsQrScannerScreen> {
+  bool _handled = false;
+  String? _lastError;
+
+  void _handleCode(Code code) {
+    if (_handled) return;
+    final text = code.text;
+    if (text == null || text.isEmpty) return;
+    final decoded = SiteSettingsQrCodec.decode(text);
+    if (decoded == null) {
+      setState(() {
+        _lastError =
+            'Scanned QR is not a WebSpace site-settings code.';
+      });
+      return;
+    }
+    _handled = true;
+    Navigator.of(context).pop<Map<String, dynamic>>(decoded);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Scan site-settings QR')),
+      body: Stack(
+        children: [
+          ReaderWidget(
+            codeFormat: Format.qrCode,
+            tryHarder: true,
+            tryRotate: true,
+            showGallery: false,
+            onScan: _handleCode,
+          ),
+          if (_lastError != null)
+            Positioned(
+              left: 16,
+              right: 16,
+              top: 16,
+              child: Material(
+                color: Colors.red.shade700.withAlpha(220),
+                borderRadius: BorderRadius.circular(8),
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Text(
+                    _lastError!,
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/site_settings_qr_codec.dart
+++ b/lib/services/site_settings_qr_codec.dart
@@ -1,0 +1,154 @@
+import 'dart:convert';
+import 'dart:io' show gzip;
+
+/// Encode/decode the QR-shareable subset of a [WebViewModel] JSON dict.
+///
+/// The QR payload intentionally carries only non-secret per-site
+/// configuration. Excluded by design: `cookies` (incl. secure cookies),
+/// `userScripts`, `enabledGlobalScriptIds`, `blockedCookies`, `siteId`
+/// (receiver mints fresh), `currentUrl`/`pageTitle` (runtime state).
+/// Proxy passwords never leave the device — `UserProxySettings.toJson`
+/// strips them per `proxy-password-secure-storage` (PWD-005).
+///
+/// Wire format: `webspace://qr/site/v1/<base64url>` where the payload is
+/// gzip-compressed UTF-8 JSON. base64url padding is stripped on encode and
+/// reapplied on decode.
+///
+/// When you add a new per-site field to [WebViewModel], decide whether it
+/// belongs in [includedKeys]. The drift test in
+/// `test/site_settings_qr_codec_test.dart` fails on any unknown key in
+/// `toJson` so an unreviewed field cannot silently flow into shared QRs.
+class SiteSettingsQrCodec {
+  SiteSettingsQrCodec._();
+
+  static const int currentVersion = 1;
+  static const String _scheme = 'webspace';
+  static const String _path = 'qr/site';
+
+  /// Per-site keys the QR is allowed to carry.
+  static const Set<String> includedKeys = {
+    'initUrl',
+    'name',
+    'proxySettings',
+    'javascriptEnabled',
+    'userAgent',
+    'thirdPartyCookiesEnabled',
+    'incognito',
+    'language',
+    'clearUrlEnabled',
+    'dnsBlockEnabled',
+    'contentBlockEnabled',
+    'trackingProtectionEnabled',
+    'localCdnEnabled',
+    'blockAutoRedirects',
+    'fullscreenMode',
+    'notificationsEnabled',
+    'backgroundPoll',
+    'locationMode',
+    'spoofLatitude',
+    'spoofLongitude',
+    'spoofAccuracy',
+    'spoofTimezone',
+    'spoofTimezoneFromLocation',
+    'webRtcPolicy',
+  };
+
+  /// Per-site keys deliberately stripped on share. Listed so the drift
+  /// test can detect a brand-new key that the dev forgot to classify.
+  static const Set<String> excludedKeys = {
+    'siteId',
+    'currentUrl',
+    'pageTitle',
+    'cookies',
+    'userScripts',
+    'enabledGlobalScriptIds',
+    'blockedCookies',
+  };
+
+  /// Strip a full `WebViewModel.toJson()` to the QR-shareable subset.
+  static Map<String, dynamic> shareableSubset(Map<String, dynamic> fullJson) {
+    final out = <String, dynamic>{};
+    for (final k in includedKeys) {
+      if (fullJson.containsKey(k)) out[k] = fullJson[k];
+    }
+    return out;
+  }
+
+  /// Pad a stripped subset with empty placeholders for fields
+  /// `WebViewModel.fromJson` reads as required (currently `cookies`).
+  static Map<String, dynamic> hydrateForFromJson(
+    Map<String, dynamic> stripped,
+  ) {
+    return {
+      ...stripped,
+      'cookies': const <dynamic>[],
+    };
+  }
+
+  /// Encode a shareable subset to a `webspace://qr/site/vN/<payload>` URI.
+  static String encode(Map<String, dynamic> shareable) {
+    final jsonStr = jsonEncode(shareable);
+    final compressed = gzip.encode(utf8.encode(jsonStr));
+    final payload = base64Url.encode(compressed).replaceAll('=', '');
+    return '$_scheme://$_path/v$currentVersion/$payload';
+  }
+
+  /// Decode a `webspace://qr/site/vN/<payload>` URI back to a shareable
+  /// subset. Returns null if the input is malformed, the version is newer
+  /// than [currentVersion], the payload fails gunzip, or `initUrl` is
+  /// missing. Any keys outside [includedKeys] in a successfully decoded
+  /// payload are dropped — a hostile sender cannot smuggle, e.g.,
+  /// `cookies` past the receiver's strip filter.
+  static Map<String, dynamic>? decode(String input) {
+    final parsed = _parse(input.trim());
+    if (parsed == null) return null;
+    try {
+      final padding = (4 - parsed.payload.length % 4) % 4;
+      final padded = parsed.payload + ('=' * padding);
+      final compressed = base64Url.decode(padded);
+      final bytes = gzip.decode(compressed);
+      final decoded = jsonDecode(utf8.decode(bytes));
+      if (decoded is! Map) return null;
+      final out = <String, dynamic>{};
+      for (final entry in decoded.entries) {
+        final key = entry.key;
+        if (key is String && includedKeys.contains(key)) {
+          out[key] = entry.value;
+        }
+      }
+      if (out['initUrl'] is! String ||
+          (out['initUrl'] as String).isEmpty) {
+        return null;
+      }
+      return out;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// True if [input] looks like a webspace QR URI (any version).
+  static bool looksLikeQrPayload(String input) {
+    return _parse(input.trim()) != null;
+  }
+
+  static _ParsedQr? _parse(String input) {
+    final prefix = '$_scheme://$_path/v';
+    if (!input.startsWith(prefix)) return null;
+    final tail = input.substring(prefix.length);
+    final slash = tail.indexOf('/');
+    if (slash <= 0) return null;
+    final version = int.tryParse(tail.substring(0, slash));
+    if (version == null || version < 1 || version > currentVersion) {
+      return null;
+    }
+    final payload = tail.substring(slash + 1);
+    if (payload.isEmpty) return null;
+    return _ParsedQr(version: version, payload: payload);
+  }
+}
+
+class _ParsedQr {
+  final int version;
+  final String payload;
+  _ParsedQr({required this.version, required this.payload});
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,11 +6,15 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_inappwebview_linux/flutter_inappwebview_linux_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
   g_autoptr(FlPluginRegistrar) flutter_inappwebview_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterInappwebviewLinuxPlugin");
   flutter_inappwebview_linux_plugin_register_with_registrar(flutter_inappwebview_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,12 +3,14 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
   flutter_inappwebview_linux
   flutter_secure_storage_linux
   url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  flutter_zxing
   jni
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import file_picker
+import file_selector_macos
 import flutter_inappwebview_macos
 import flutter_local_notifications
 import flutter_secure_storage_darwin
@@ -17,6 +18,7 @@ import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   InAppWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "InAppWebViewFlutterPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -821,6 +821,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  qr_flutter:
+    dependency: "direct main"
+    description:
+      name: qr_flutter
+      sha256: "5095f0fc6e3f71d08adef8feccc8cea4f12eec18a2e31c2e8d82cb6019f4b097"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   record_use:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,6 +65,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  camera:
+    dependency: transitive
+    description:
+      name: camera
+      sha256: "4142a19a38e388d3bab444227636610ba88982e36dff4552d5191a86f65dc437"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.4"
+  camera_android_camerax:
+    dependency: transitive
+    description:
+      name: camera_android_camerax
+      sha256: "8516fe308bc341a5067fb1a48edff0ddfa57c0d3cdcc9dbe7ceca3ba119e2577"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.30"
+  camera_avfoundation:
+    dependency: transitive
+    description:
+      name: camera_avfoundation
+      sha256: "11b4aee2f5e5e038982e152b4a342c749b414aa27857899d20f4323e94cb5f0b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.23+2"
+  camera_platform_interface:
+    dependency: transitive
+    description:
+      name: camera_platform_interface
+      sha256: "7ac852d77699acee79f0d438b793feee26721841e50973576419ff5c6d95e9b7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.13.0"
+  camera_web:
+    dependency: transitive
+    description:
+      name: camera_web
+      sha256: "57f49a635c8bf249d07fb95eb693d7e4dda6796dedb3777f9127fb54847beba7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+3"
   characters:
     dependency: transitive
     description:
@@ -217,6 +257,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "11.0.2"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: "35e0bd61ebcdb91a3505813b055b09b79dfdc7d0aee9c09a7ba59ae4bb13dc85"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+5"
   fixnum:
     dependency: transitive
     description:
@@ -451,6 +523,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_zxing:
+    dependency: "direct main"
+    description:
+      name: flutter_zxing
+      sha256: dbcd89da2c9aa84f48d7d7e1ba436825f8656a69b142abb7bcdb7c2d9c22d48c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
   fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
@@ -504,6 +584,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
+  image_picker:
+    dependency: transitive
+    description:
+      name: image_picker
+      sha256: "91c025426c2881c551100bce834e201c835a170151545f58d17da5180ca7d9ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: d5b3e1774af29c9ab00103afb0d4614070f924d2e0057ac867ec98800114793f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+17"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "66257a3191ab360d23a55c8241c91a6e329d31e94efa7be9cf7a212e65850214"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+6"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "1f81c5f2046b9ab724f85523e4af65be1d47b038160a8c8deed909762c308ed4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "86f0f15a309de7e1a552c12df9ce5b59fe927e71385329355aec4776c6a8ec91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: d248c86554a72b5495a31c56f060cf73a41c7ff541689327b1a7dbccc33adfae
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -1010,6 +1154,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   encrypt: ^5.0.3
   share_plus: ^12.0.0
   qr_flutter: ^4.1.0
+  flutter_zxing: ^2.2.1
   material_design_icons_flutter: ^7.0.7296
   flutter_local_notifications: ^21.0.0
   flutter_map: ^8.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   path_provider: ^2.1.0
   encrypt: ^5.0.3
   share_plus: ^12.0.0
+  qr_flutter: ^4.1.0
   material_design_icons_flutter: ^7.0.7296
   flutter_local_notifications: ^21.0.0
   flutter_map: ^8.0.0

--- a/test/site_settings_qr_codec_test.dart
+++ b/test/site_settings_qr_codec_test.dart
@@ -1,0 +1,284 @@
+import 'dart:convert';
+import 'dart:io' show gzip;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/site_settings_qr_codec.dart';
+import 'package:webspace/settings/proxy.dart';
+import 'package:webspace/settings/user_script.dart';
+import 'package:webspace/web_view_model.dart';
+
+void main() {
+  group('SiteSettingsQrCodec', () {
+    test('encode then decode is a no-op for the shareable subset', () {
+      final source = WebViewModel(
+        initUrl: 'https://example.com/start',
+        name: 'Example',
+        javascriptEnabled: false,
+        userAgent: 'TestAgent/1.0',
+        thirdPartyCookiesEnabled: true,
+        incognito: true,
+        language: 'fr',
+        clearUrlEnabled: false,
+        dnsBlockEnabled: false,
+        contentBlockEnabled: false,
+        trackingProtectionEnabled: false,
+        localCdnEnabled: false,
+        blockAutoRedirects: false,
+        fullscreenMode: true,
+        notificationsEnabled: true,
+        backgroundPoll: true,
+        locationMode: LocationMode.spoof,
+        spoofLatitude: 51.5074,
+        spoofLongitude: -0.1278,
+        spoofAccuracy: 25.0,
+        spoofTimezone: 'Europe/London',
+        spoofTimezoneFromLocation: true,
+        webRtcPolicy: WebRtcPolicy.relayOnly,
+        proxySettings: UserProxySettings(
+          type: ProxyType.SOCKS5,
+          address: 'proxy.example.com:1080',
+          username: 'alice',
+          password: 'never-shared',
+        ),
+      );
+
+      final shared = SiteSettingsQrCodec.shareableSubset(source.toJson());
+      final encoded = SiteSettingsQrCodec.encode(shared);
+      final decoded = SiteSettingsQrCodec.decode(encoded);
+
+      expect(decoded, equals(shared));
+
+      final hydrated = WebViewModel.fromJson(
+        SiteSettingsQrCodec.hydrateForFromJson(decoded!),
+        null,
+      );
+
+      expect(hydrated.initUrl, source.initUrl);
+      expect(hydrated.name, source.name);
+      expect(hydrated.javascriptEnabled, source.javascriptEnabled);
+      expect(hydrated.userAgent, source.userAgent);
+      expect(hydrated.thirdPartyCookiesEnabled,
+          source.thirdPartyCookiesEnabled);
+      expect(hydrated.incognito, source.incognito);
+      expect(hydrated.language, source.language);
+      expect(hydrated.clearUrlEnabled, source.clearUrlEnabled);
+      expect(hydrated.dnsBlockEnabled, source.dnsBlockEnabled);
+      expect(hydrated.contentBlockEnabled, source.contentBlockEnabled);
+      expect(hydrated.trackingProtectionEnabled,
+          source.trackingProtectionEnabled);
+      expect(hydrated.localCdnEnabled, source.localCdnEnabled);
+      expect(hydrated.blockAutoRedirects, source.blockAutoRedirects);
+      expect(hydrated.fullscreenMode, source.fullscreenMode);
+      expect(hydrated.notificationsEnabled, source.notificationsEnabled);
+      expect(hydrated.backgroundPoll, source.backgroundPoll);
+      expect(hydrated.locationMode, source.locationMode);
+      expect(hydrated.spoofLatitude, source.spoofLatitude);
+      expect(hydrated.spoofLongitude, source.spoofLongitude);
+      expect(hydrated.spoofAccuracy, source.spoofAccuracy);
+      expect(hydrated.spoofTimezone, source.spoofTimezone);
+      expect(hydrated.spoofTimezoneFromLocation,
+          source.spoofTimezoneFromLocation);
+      expect(hydrated.webRtcPolicy, source.webRtcPolicy);
+      expect(hydrated.proxySettings.type, ProxyType.SOCKS5);
+      expect(hydrated.proxySettings.address, 'proxy.example.com:1080');
+      expect(hydrated.proxySettings.username, 'alice');
+      expect(hydrated.proxySettings.password, isNull);
+
+      // Receiver mints a fresh siteId; cookies / scripts don't transfer.
+      expect(hydrated.siteId, isNot(source.siteId));
+      expect(hydrated.cookies, isEmpty);
+      expect(hydrated.userScripts, isEmpty);
+    });
+
+    test('emits webspace://qr/site/v1/<payload> URI', () {
+      final encoded = SiteSettingsQrCodec.encode({
+        'initUrl': 'https://example.com',
+      });
+      expect(encoded, startsWith('webspace://qr/site/v1/'));
+      expect(SiteSettingsQrCodec.looksLikeQrPayload(encoded), isTrue);
+    });
+
+    test('proxy password and secure cookies never appear in encoded output',
+        () {
+      final source = WebViewModel(
+        initUrl: 'https://secure.example.com',
+        proxySettings: UserProxySettings(
+          type: ProxyType.SOCKS5,
+          address: 'proxy.example.com:1080',
+          username: 'alice',
+          password: 'super-secret-password',
+        ),
+      );
+
+      final encoded = SiteSettingsQrCodec.encode(
+        SiteSettingsQrCodec.shareableSubset(source.toJson()),
+      );
+
+      // Round-trip through the wire: rebuild the inner JSON from the URI
+      // and assert the secret literals are absent — covers both encoded
+      // and gunzipped views of the payload.
+      final payload = encoded.split('/').last;
+      final padded = payload + '=' * ((4 - payload.length % 4) % 4);
+      final inner =
+          utf8.decode(gzip.decode(base64Url.decode(padded)));
+
+      expect(inner.contains('super-secret-password'), isFalse,
+          reason: 'proxy password (PWD-005) must never ride the QR');
+      expect(inner.contains('cookies'), isFalse,
+          reason: 'cookies are stripped from the share');
+    });
+
+    test('user scripts are never included in encoded output', () {
+      final source = WebViewModel(
+        initUrl: 'https://example.com',
+        userScripts: [
+          UserScriptConfig(
+            id: 'script-1',
+            name: 'Custom Script',
+            source: 'console.log("hello world");',
+            enabled: true,
+          ),
+        ],
+      );
+
+      final shared = SiteSettingsQrCodec.shareableSubset(source.toJson());
+      expect(shared.containsKey('userScripts'), isFalse);
+
+      final encoded = SiteSettingsQrCodec.encode(shared);
+      final payload = encoded.split('/').last;
+      final padded = payload + '=' * ((4 - payload.length % 4) % 4);
+      final inner =
+          utf8.decode(gzip.decode(base64Url.decode(padded)));
+
+      expect(inner.contains('console.log'), isFalse);
+      expect(inner.contains('userScripts'), isFalse);
+    });
+
+    test('decode strips smuggled fields outside the allowlist', () {
+      final hostile = {
+        'initUrl': 'https://example.com',
+        'cookies': [
+          {'name': 'session', 'value': 'stolen', 'isSecure': true}
+        ],
+        'userScripts': [
+          {'id': 'x', 'name': 'evil', 'source': 'alert(1)', 'enabled': true}
+        ],
+        'siteId': 'attacker-controlled-id',
+      };
+
+      // Hand-craft a wire payload that includes the smuggled fields.
+      final compressed = gzip.encode(utf8.encode(jsonEncode(hostile)));
+      final payload = base64Url.encode(compressed).replaceAll('=', '');
+      final uri = 'webspace://qr/site/v1/$payload';
+
+      final decoded = SiteSettingsQrCodec.decode(uri);
+      expect(decoded, isNotNull);
+      expect(decoded!['initUrl'], 'https://example.com');
+      expect(decoded.containsKey('cookies'), isFalse);
+      expect(decoded.containsKey('userScripts'), isFalse);
+      expect(decoded.containsKey('siteId'), isFalse);
+    });
+
+    test('decode rejects malformed input', () {
+      expect(SiteSettingsQrCodec.decode(''), isNull);
+      expect(SiteSettingsQrCodec.decode('not a uri'), isNull);
+      expect(SiteSettingsQrCodec.decode('https://example.com'), isNull);
+      expect(SiteSettingsQrCodec.decode('webspace://qr/site/'), isNull);
+      expect(SiteSettingsQrCodec.decode('webspace://qr/site/v1/'), isNull);
+      expect(SiteSettingsQrCodec.decode('webspace://qr/site/v1/!!!'), isNull);
+      expect(
+          SiteSettingsQrCodec.decode(
+              'webspace://qr/site/v1/${base64Url.encode(utf8.encode("not gzipped"))}'),
+          isNull);
+    });
+
+    test('decode rejects payloads missing initUrl', () {
+      final payload = {
+        'name': 'Example',
+        'javascriptEnabled': true,
+      };
+      final compressed = gzip.encode(utf8.encode(jsonEncode(payload)));
+      final body = base64Url.encode(compressed).replaceAll('=', '');
+      expect(
+          SiteSettingsQrCodec.decode('webspace://qr/site/v1/$body'), isNull);
+    });
+
+    test('decode rejects future schema versions', () {
+      final compressed =
+          gzip.encode(utf8.encode(jsonEncode({'initUrl': 'https://e.com'})));
+      final body = base64Url.encode(compressed).replaceAll('=', '');
+      expect(
+          SiteSettingsQrCodec.decode('webspace://qr/site/v999/$body'), isNull);
+    });
+
+    test('looksLikeQrPayload is strict about the prefix', () {
+      expect(
+          SiteSettingsQrCodec.looksLikeQrPayload(
+              'webspace://qr/site/v1/abc'),
+          isTrue);
+      expect(
+          SiteSettingsQrCodec.looksLikeQrPayload('https://example.com'),
+          isFalse);
+      expect(SiteSettingsQrCodec.looksLikeQrPayload(''), isFalse);
+    });
+
+    test('every WebViewModel.toJson key is classified', () {
+      // Drift guard: when a new per-site field is added to WebViewModel,
+      // the dev MUST decide whether it rides a shared QR. This test fails
+      // if a `toJson` key isn't in either set.
+      final fullToJson = WebViewModel(
+        initUrl: 'https://example.com',
+        spoofLatitude: 1.0,
+        spoofLongitude: 1.0,
+        spoofTimezone: 'UTC',
+        spoofTimezoneFromLocation: true,
+      ).toJson();
+
+      final classified = {
+        ...SiteSettingsQrCodec.includedKeys,
+        ...SiteSettingsQrCodec.excludedKeys,
+      };
+      final unknown =
+          fullToJson.keys.where((k) => !classified.contains(k)).toList();
+
+      expect(unknown, isEmpty,
+          reason:
+              'Unclassified WebViewModel.toJson keys: $unknown. Add to '
+              'SiteSettingsQrCodec.includedKeys or excludedKeys.');
+    });
+
+    test('encoded payload stays within QR Version 40 binary capacity', () {
+      // Real-world worst case: every toggle flipped, long URL, long name,
+      // long user-agent, full proxy with credentials, custom location.
+      final maximal = WebViewModel(
+        initUrl: 'https://${'sub.' * 12}example-with-a-fairly-long-domain.com'
+            '/some/long/path?with=query&parameters=that-are-quite-long',
+        name: 'A Reasonably Long Custom Site Name For Display Purposes',
+        userAgent:
+            'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, '
+            'like Gecko) Chrome/130.0.0.0 Safari/537.36',
+        language: 'en-US',
+        spoofTimezone: 'America/Argentina/ComodRivadavia',
+        spoofTimezoneFromLocation: true,
+        spoofLatitude: 40.7127281,
+        spoofLongitude: -74.0060152,
+        spoofAccuracy: 12.5,
+        locationMode: LocationMode.spoof,
+        webRtcPolicy: WebRtcPolicy.disabled,
+        proxySettings: UserProxySettings(
+          type: ProxyType.SOCKS5,
+          address: 'a-fairly-long-proxy-host.example.com:65535',
+          username: 'a-medium-length-username',
+        ),
+      );
+
+      final encoded = SiteSettingsQrCodec.encode(
+        SiteSettingsQrCodec.shareableSubset(maximal.toJson()),
+      );
+
+      // QR v40 binary mode at ECC-L holds 2,953 bytes. Even at ECC-H
+      // (1,273 bytes) we leave plenty of headroom.
+      expect(encoded.length, lessThan(900));
+    });
+  });
+}


### PR DESCRIPTION
Codec excludes cookies, user scripts, secure cookies, and proxy passwords by allowlist; receiver mints a fresh siteId. Share dialog renders via qr_flutter (FOSS); apply dialog accepts a pasted webspace://qr/site/v1/<payload> URI so we don't pull a barcode-scanning dep with a non-FOSS Android backend.