### PR TITLE
Fix foreground notification handling on iOS and macOS

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import UserNotifications
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
@@ -9,6 +10,10 @@ import UIKit
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    // Without this, iOS drops local notifications posted while the app
+    // is foregrounded: the plugin's presentBanner/Alert/Sound options
+    // never run because the willPresent delegate method isn't called.
+    UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
     GeneratedPluginRegistrant.register(with: self)
     if let controller = window?.rootViewController as? FlutterViewController {
       locationPlugin = LocationPlugin(messenger: controller.binaryMessenger)

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -1,8 +1,16 @@
 import Cocoa
 import FlutterMacOS
+import UserNotifications
 
 @main
 class AppDelegate: FlutterAppDelegate {
+  override func applicationDidFinishLaunching(_ notification: Notification) {
+    // Same UN delegate requirement as iOS: without this, foreground
+    // notifications never reach willPresent and are dropped silently.
+    UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
+    super.applicationDidFinishLaunching(notification)
+  }
+
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true
   }


### PR DESCRIPTION
## Summary
This PR fixes an issue where foreground notifications were being silently dropped on both iOS and macOS platforms. The fix ensures that the `UNUserNotificationCenter` delegate is properly set on the app delegate, allowing the `willPresent` delegate method to be called for notifications received while the app is in the foreground.

## Key Changes
- **iOS**: Added `UserNotifications` import and set the `UNUserNotificationCenter` delegate in `application(_:didFinishLaunchingWithOptions:)` to enable foreground notification handling
- **macOS**: Added `UserNotifications` import and overrode `applicationDidFinishLaunching(_:)` to set the `UNUserNotificationCenter` delegate before calling the parent implementation

## Implementation Details
- Both platforms now explicitly assign `self` as the `UNUserNotificationCenterDelegate` during app initialization
- This ensures that notification presentation options (banner, alert, sound) configured in the plugin are properly executed when notifications arrive while the app is foregrounded
- The fix is applied early in the app lifecycle to guarantee the delegate is set before any notifications are processed

https://claude.ai/code/session_019MnM3fAqYYmwJu7uewhjAZ