### PR TITLE
Consolidate backgroundPoll into notificationsEnabled setting

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -901,7 +901,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       _foregroundPollTimer?.cancel();
       _foregroundPollTimer = null;
       if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
-        if (!_webViewModels[_currentIndex!].backgroundPoll) {
+        if (!_webViewModels[_currentIndex!].notificationsEnabled) {
           _lifecyclePauseFuture = _webViewModels[_currentIndex!].pauseForAppLifecycle();
         }
         final activeIdx = _currentIndex!;
@@ -924,7 +924,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       _lifecyclePauseFuture = null;
     }
     if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
-      if (!_webViewModels[_currentIndex!].backgroundPoll) {
+      if (!_webViewModels[_currentIndex!].notificationsEnabled) {
         await _webViewModels[_currentIndex!].resumeFromAppLifecycle();
       }
     }
@@ -1780,9 +1780,10 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       models: _webViewModels,
     );
 
-    // Auto-load background-poll sites so they start running immediately
+    // Auto-load notification sites so they start polling immediately and
+    // can fire notifications without waiting for the user to open them.
     for (int i = 0; i < _webViewModels.length; i++) {
-      if (_webViewModels[i].backgroundPoll) {
+      if (_webViewModels[i].notificationsEnabled) {
         _loadedIndices.add(i);
       }
     }
@@ -1828,7 +1829,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     if (index == _activationInFlightIndex) return SiteRetentionPriority.activating;
     if (index >= 0 && index < _webViewModels.length) {
       final m = _webViewModels[index];
-      if (m.backgroundPoll || m.notificationsEnabled) {
+      if (m.notificationsEnabled) {
         return SiteRetentionPriority.notification;
       }
     }
@@ -1839,7 +1840,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
   void _onForegroundPollTick() {
     for (int i = 0; i < _webViewModels.length; i++) {
-      if (_webViewModels[i].backgroundPoll &&
+      if (_webViewModels[i].notificationsEnabled &&
           i != _currentIndex &&
           _loadedIndices.contains(i)) {
         _webViewModels[i].controller?.reload();

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -118,7 +118,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late bool _blockAutoRedirects;
   late bool _fullscreenMode;
   late bool _notificationsEnabled;
-  late bool _backgroundPoll;
   String? _selectedLanguage;
   bool _obscureProxyPassword = true;
   bool _showProxyCredentials = false;
@@ -178,7 +177,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _blockAutoRedirects = m.blockAutoRedirects;
     _fullscreenMode = m.fullscreenMode;
     _notificationsEnabled = m.notificationsEnabled;
-    _backgroundPoll = m.backgroundPoll;
     _selectedLanguage = m.language;
     _latitudeController.text = m.spoofLatitude?.toString() ?? '';
     _longitudeController.text = m.spoofLongitude?.toString() ?? '';
@@ -345,7 +343,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
       widget.webViewModel.blockAutoRedirects = _blockAutoRedirects;
       widget.webViewModel.fullscreenMode = _fullscreenMode;
       widget.webViewModel.notificationsEnabled = _notificationsEnabled;
-      widget.webViewModel.backgroundPoll = _backgroundPoll;
       widget.webViewModel.language = _selectedLanguage;
       // locationMode is derived from the UI state:
       // - `_isLiveLocation` → live (real device GPS forwarded through the shim)
@@ -1192,26 +1189,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
           if (widget.useContainers)
             SwitchListTile(
               title: const Text('Notifications'),
-              subtitle: const Text('Allow this site to show system notifications'),
+              subtitle: const Text(
+                'Allow this site to show system notifications. Keeps the '
+                'site polling in the background so notifications fire even '
+                'when you are on a different tab.',
+              ),
               value: _notificationsEnabled,
               onChanged: (bool value) {
                 setState(() {
                   _notificationsEnabled = value;
-                });
-              },
-            ),
-          if (widget.useContainers)
-            SwitchListTile(
-              title: const Text('Background polling'),
-              subtitle: Text(
-                Platform.isIOS
-                    ? 'Check for updates periodically (~15-30 min while app is closed)'
-                    : 'Keep checking for updates while app is backgrounded',
-              ),
-              value: _backgroundPoll,
-              onChanged: (bool value) {
-                setState(() {
-                  _backgroundPoll = value;
                 });
               },
             ),

--- a/lib/services/foreground_poll_engine.dart
+++ b/lib/services/foreground_poll_engine.dart
@@ -3,13 +3,13 @@ class ForegroundPollEngine {
     required int siteCount,
     required int? currentIndex,
     required Set<int> loadedIndices,
-    required bool Function(int index) isBackgroundPoll,
+    required bool Function(int index) isPolled,
   }) {
     final result = <int>[];
     for (int i = 0; i < siteCount; i++) {
       if (i != currentIndex &&
           loadedIndices.contains(i) &&
-          isBackgroundPoll(i)) {
+          isPolled(i)) {
         result.add(i);
       }
     }

--- a/lib/services/site_retention_priority.dart
+++ b/lib/services/site_retention_priority.dart
@@ -12,8 +12,8 @@ enum SiteRetentionPriority {
   /// Target of an in-flight `_setCurrentIndex` — never evicted.
   activating,
 
-  /// User explicitly opted this site into notifications or background
-  /// polling — evicting it silently breaks the user's intent.
+  /// User explicitly opted this site into notifications (which implies
+  /// background polling) — evicting it silently breaks the user's intent.
   notification,
 
   /// In the active webspace — evict only after lower-priority sites.

--- a/lib/services/site_settings_qr_codec.dart
+++ b/lib/services/site_settings_qr_codec.dart
@@ -43,7 +43,6 @@ class SiteSettingsQrCodec {
     'blockAutoRedirects',
     'fullscreenMode',
     'notificationsEnabled',
-    'backgroundPoll',
     'locationMode',
     'spoofLatitude',
     'spoofLongitude',

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -289,8 +289,12 @@ class WebViewModel {
   bool localCdnEnabled; // Serve CDN resources from local cache for privacy
   bool blockAutoRedirects; // Block script-initiated cross-domain navigations
   bool fullscreenMode; // Auto-enter fullscreen when this site is selected
-  bool notificationsEnabled; // Allow this site to show system notifications
-  bool backgroundPoll; // Keep checking for updates while app is backgrounded
+  /// Allow this site to show system notifications. Implies background
+  /// polling: the site is auto-loaded on startup, kept resident across
+  /// site switches and app-lifecycle pauses, and reloaded periodically by
+  /// the foreground poll timer so it can detect new content and fire
+  /// notifications even when the user isn't looking at it.
+  bool notificationsEnabled;
   List<UserScriptConfig> userScripts; // Per-site user scripts
   /// IDs of global user scripts opted into for this site. Global scripts
   /// are stored once in app state (shared source/URL) and each site
@@ -355,7 +359,6 @@ class WebViewModel {
     this.blockAutoRedirects = true,
     this.fullscreenMode = false,
     this.notificationsEnabled = false,
-    this.backgroundPoll = false,
     List<UserScriptConfig>? userScripts,
     Set<String>? enabledGlobalScriptIds,
     Set<BlockedCookie>? blockedCookies,
@@ -931,8 +934,16 @@ class WebViewModel {
   /// This is a resource hint, not a security boundary — see
   /// [WebViewController.pause] for the full caveat list. To safely mutate
   /// cookies or proxy under a webview, dispose it instead.
+  ///
+  /// Skipped for sites with [notificationsEnabled] set: on iOS, per-instance
+  /// pause is implemented via `pauseTimers()` (the plugin's alert-deadlock
+  /// hack), which freezes this WebView's JS thread. That stalls any
+  /// setInterval / setTimeout / WebSocket-driven notification poller until
+  /// the user switches back, at which point all queued notifications fire
+  /// at once. Sites the user enabled notifications on must keep running.
   Future<void> pauseWebView() async {
     if (controller == null) return;
+    if (notificationsEnabled) return;
     try {
       await controller!.pause();
       LogService.instance.log('WebView', 'Paused webview for "$name" (siteId: $siteId)');
@@ -1082,7 +1093,6 @@ class WebViewModel {
         'blockAutoRedirects': blockAutoRedirects,
         'fullscreenMode': fullscreenMode,
         'notificationsEnabled': notificationsEnabled,
-        'backgroundPoll': backgroundPoll,
         'userScripts': userScripts.map((s) => s.toJson()).toList(),
         if (enabledGlobalScriptIds.isNotEmpty)
           'enabledGlobalScriptIds': enabledGlobalScriptIds.toList(),
@@ -1121,8 +1131,10 @@ class WebViewModel {
       localCdnEnabled: json['localCdnEnabled'] ?? true,
       blockAutoRedirects: json['blockAutoRedirects'] ?? true,
       fullscreenMode: json['fullscreenMode'] ?? false,
-      notificationsEnabled: json['notificationsEnabled'] ?? false,
-      backgroundPoll: json['backgroundPoll'] ?? false,
+      notificationsEnabled:
+          (json['notificationsEnabled'] as bool?) ??
+              (json['backgroundPoll'] as bool?) ??
+              false,
       userScripts: (json['userScripts'] as List<dynamic>?)
           ?.map((e) => UserScriptConfig.fromJson(e as Map<String, dynamic>))
           .toList(),

--- a/test/fixtures/notification_test.html
+++ b/test/fixtures/notification_test.html
@@ -52,7 +52,7 @@
     <h3>Periodic Notifications</h3>
     <button onclick="togglePeriodic()" id="periodicBtn">Start Periodic (every 1 min)</button>
     <p>Count: <strong id="periodicCount">0</strong> | Status: <strong id="periodicStatus">stopped</strong></p>
-    <p class="info">Fires a notification every 60 seconds. Use to test background polling — enable backgroundPoll, start periodic, then background the app.</p>
+    <p class="info">Fires a notification every 60 seconds. Use to test background polling — enable Notifications on this site, start periodic, then either switch to a different tab or background the app.</p>
   </div>
 
   <div class="section">

--- a/test/foreground_poll_engine_test.dart
+++ b/test/foreground_poll_engine_test.dart
@@ -3,12 +3,12 @@ import 'package:webspace/services/foreground_poll_engine.dart';
 
 void main() {
   group('ForegroundPollEngine.indicesToRefresh', () {
-    test('returns empty when no sites have backgroundPoll', () {
+    test('returns empty when no sites are polled', () {
       final result = ForegroundPollEngine.indicesToRefresh(
         siteCount: 3,
         currentIndex: 0,
         loadedIndices: {0, 1, 2},
-        isBackgroundPoll: (_) => false,
+        isPolled: (_) => false,
       );
       expect(result, isEmpty);
     });
@@ -18,7 +18,7 @@ void main() {
         siteCount: 3,
         currentIndex: 1,
         loadedIndices: {0, 1, 2},
-        isBackgroundPoll: (_) => true,
+        isPolled: (_) => true,
       );
       expect(result, [0, 2]);
     });
@@ -28,18 +28,18 @@ void main() {
         siteCount: 4,
         currentIndex: 0,
         loadedIndices: {0, 2},
-        isBackgroundPoll: (_) => true,
+        isPolled: (_) => true,
       );
       expect(result, [2]);
     });
 
-    test('returns all loaded backgroundPoll sites except current', () {
-      final bgPollSet = {1, 3};
+    test('returns all loaded polled sites except current', () {
+      final polledSet = {1, 3};
       final result = ForegroundPollEngine.indicesToRefresh(
         siteCount: 5,
         currentIndex: 0,
         loadedIndices: {0, 1, 2, 3, 4},
-        isBackgroundPoll: (i) => bgPollSet.contains(i),
+        isPolled: (i) => polledSet.contains(i),
       );
       expect(result, [1, 3]);
     });
@@ -49,7 +49,7 @@ void main() {
         siteCount: 2,
         currentIndex: null,
         loadedIndices: {0, 1},
-        isBackgroundPoll: (_) => true,
+        isPolled: (_) => true,
       );
       expect(result, [0, 1]);
     });

--- a/test/site_settings_qr_codec_test.dart
+++ b/test/site_settings_qr_codec_test.dart
@@ -26,7 +26,6 @@ void main() {
         blockAutoRedirects: false,
         fullscreenMode: true,
         notificationsEnabled: true,
-        backgroundPoll: true,
         locationMode: LocationMode.spoof,
         spoofLatitude: 51.5074,
         spoofLongitude: -0.1278,
@@ -70,7 +69,6 @@ void main() {
       expect(hydrated.blockAutoRedirects, source.blockAutoRedirects);
       expect(hydrated.fullscreenMode, source.fullscreenMode);
       expect(hydrated.notificationsEnabled, source.notificationsEnabled);
-      expect(hydrated.backgroundPoll, source.backgroundPoll);
       expect(hydrated.locationMode, source.locationMode);
       expect(hydrated.spoofLatitude, source.spoofLatitude);
       expect(hydrated.spoofLongitude, source.spoofLongitude);

--- a/test/web_view_model_test.dart
+++ b/test/web_view_model_test.dart
@@ -26,7 +26,6 @@ void main() {
       expect(model.localCdnEnabled, isTrue);
       expect(model.fullscreenMode, isFalse);
       expect(model.notificationsEnabled, isFalse);
-      expect(model.backgroundPoll, isFalse);
     });
 
     test('should serialize to JSON correctly', () {
@@ -283,7 +282,7 @@ void main() {
       expect(restored.fullscreenMode, isTrue);
     });
 
-    test('notificationsEnabled and backgroundPoll default to false when missing from JSON', () {
+    test('notificationsEnabled defaults to false when missing from JSON', () {
       final json = {
         'initUrl': 'https://example.com',
         'currentUrl': 'https://example.com',
@@ -296,23 +295,38 @@ void main() {
 
       final model = WebViewModel.fromJson(json, null);
       expect(model.notificationsEnabled, isFalse);
-      expect(model.backgroundPoll, isFalse);
     });
 
-    test('notificationsEnabled and backgroundPoll true are preserved through serialization', () {
+    test('notificationsEnabled true is preserved through serialization', () {
       final model = WebViewModel(
         initUrl: 'https://example.com',
         notificationsEnabled: true,
-        backgroundPoll: true,
       );
 
       final json = model.toJson();
       expect(json['notificationsEnabled'], equals(true));
-      expect(json['backgroundPoll'], equals(true));
 
       final restored = WebViewModel.fromJson(json, null);
       expect(restored.notificationsEnabled, isTrue);
-      expect(restored.backgroundPoll, isTrue);
+    });
+
+    test('legacy backgroundPoll JSON migrates to notificationsEnabled', () {
+      // Sites stored under the previous schema (separate backgroundPoll
+      // toggle, notifications off) should still be polled and able to
+      // fire notifications after upgrade.
+      final json = {
+        'initUrl': 'https://example.com',
+        'currentUrl': 'https://example.com',
+        'cookies': [],
+        'proxySettings': {'type': 0, 'address': null},
+        'javascriptEnabled': true,
+        'userAgent': '',
+        'thirdPartyCookiesEnabled': false,
+        'backgroundPoll': true,
+      };
+
+      final model = WebViewModel.fromJson(json, null);
+      expect(model.notificationsEnabled, isTrue);
     });
 
     test('location spoof fields default to off and null', () {

--- a/test/webview_pause_lifecycle_test.dart
+++ b/test/webview_pause_lifecycle_test.dart
@@ -32,8 +32,15 @@ class _RecordingController extends Fake implements WebViewController {
   }
 }
 
-WebViewModel _modelWith(WebViewController? controller) {
-  final m = WebViewModel(initUrl: 'https://example.com', name: 'Example');
+WebViewModel _modelWith(
+  WebViewController? controller, {
+  bool notificationsEnabled = false,
+}) {
+  final m = WebViewModel(
+    initUrl: 'https://example.com',
+    name: 'Example',
+    notificationsEnabled: notificationsEnabled,
+  );
   m.controller = controller;
   return m;
 }
@@ -90,6 +97,28 @@ void main() {
       expect(c.calls, ['pause', 'pauseAllJsTimers', 'resume', 'resumeAllJsTimers']);
       expect(c.calls.where((s) => s == 'pauseAllJsTimers').length, 1);
       expect(c.calls.where((s) => s == 'resumeAllJsTimers').length, 1);
+    });
+  });
+
+  group('WebViewModel pause skips notification sites', () {
+    test('pauseWebView() with notificationsEnabled is a no-op', () async {
+      final c = _RecordingController();
+      await _modelWith(c, notificationsEnabled: true).pauseWebView();
+      expect(c.calls, isEmpty,
+          reason: 'On iOS, per-instance pause uses pauseTimers() (alert-deadlock '
+              'hack) which freezes JS — that stalls notification pollers until '
+              'the site is resumed. Sites the user opted in to notifications '
+              'must keep running on a site switch.');
+    });
+
+    test('resumeWebView() still resumes a notification site', () async {
+      // pauseWebView is a no-op for notification sites, but resume must
+      // still run — site activation always resumes the new active webview,
+      // and skipping it would leave a previously-paused (e.g. via the
+      // app-lifecycle path) site frozen.
+      final c = _RecordingController();
+      await _modelWith(c, notificationsEnabled: true).resumeWebView();
+      expect(c.calls, ['resume']);
     });
   });
 


### PR DESCRIPTION
## Summary
This PR consolidates the separate `backgroundPoll` and `notificationsEnabled` settings into a single `notificationsEnabled` flag. Sites with notifications enabled now automatically keep running in the background and are polled periodically, eliminating the need for a separate background polling toggle.

## Key Changes

- **Removed `backgroundPoll` property** from `WebViewModel` and all related UI/serialization code
- **Updated `notificationsEnabled` semantics** to imply background polling behavior:
  - Sites with notifications enabled are auto-loaded on startup
  - They remain resident across site switches and app-lifecycle pauses
  - They are periodically reloaded by the foreground poll timer
  - They skip the pause operation to keep running (except on app lifecycle pause)
- **Migrated legacy data**: Sites with `backgroundPoll: true` in stored JSON automatically migrate to `notificationsEnabled: true`
- **Simplified settings UI**: Removed the separate "Background polling" toggle and updated the "Notifications" description to clarify the background polling behavior
- **Updated pause logic**: `pauseWebView()` now skips pausing for notification-enabled sites (with detailed documentation of the iOS alert-deadlock hack rationale)
- **Renamed internal APIs**: `isBackgroundPoll` → `isPolled` in `ForegroundPollEngine` for clarity
- **Updated app lifecycle handling**: References to `backgroundPoll` replaced with `notificationsEnabled` checks
- **Updated site retention priority**: Consolidated documentation to reflect that notification sites (which now include background polling) should not be evicted

## Implementation Details

- The migration from `backgroundPoll` to `notificationsEnabled` is handled in `WebViewModel.fromJson()` with a fallback chain: `notificationsEnabled ?? backgroundPoll ?? false`
- Added comprehensive documentation to `pauseWebView()` explaining why notification sites skip pausing
- Updated test fixtures and test descriptions to reflect the consolidated behavior
- The QR codec no longer serializes `backgroundPoll`, reducing QR code size for shared site settings

https://claude.ai/code/session_01MT2xmMJnc8in84AtSTKseT