### PR TITLE
Add support for sharing URLs to the app via Android share intent

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,6 +34,11 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="text/plain"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -2,6 +2,7 @@ package org.codeberg.theoden8.webspace
 
 import android.content.Intent
 import android.graphics.BitmapFactory
+import android.net.Uri
 import android.os.Build
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
@@ -14,9 +15,11 @@ import java.net.URL
 
 class MainActivity: FlutterActivity() {
     private val CHANNEL = "org.codeberg.theoden8.webspace/shortcuts"
+    private val SHARE_CHANNEL = "org.codeberg.theoden8.webspace/share_intent"
     private var webInterceptPlugin: WebInterceptPlugin? = null
     private var locationPlugin: LocationPlugin? = null
     private var webSpaceContainerPlugin: WebSpaceContainerPlugin? = null
+    private var pendingShareUrl: String? = null
 
     override fun getFlutterShellArgs(): FlutterShellArgs {
         val args = FlutterShellArgs.fromIntent(intent)
@@ -35,6 +38,17 @@ class MainActivity: FlutterActivity() {
         webInterceptPlugin = WebInterceptPlugin(this, flutterEngine)
         locationPlugin = LocationPlugin(this, flutterEngine)
         webSpaceContainerPlugin = WebSpaceContainerPlugin(flutterEngine)
+        pendingShareUrl = extractShareUrl(intent)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, SHARE_CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "consumeLaunchUrl" -> {
+                    val url = pendingShareUrl
+                    pendingShareUrl = null
+                    result.success(url)
+                }
+                else -> result.notImplemented()
+            }
+        }
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
             when (call.method) {
                 "pinShortcut" -> {
@@ -134,6 +148,23 @@ class MainActivity: FlutterActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+        val url = extractShareUrl(intent)
+        if (url != null) {
+            pendingShareUrl = url
+        }
+    }
+
+    private fun extractShareUrl(intent: Intent?): String? {
+        if (intent == null || intent.action != Intent.ACTION_SEND) return null
+        val text = intent.getStringExtra(Intent.EXTRA_TEXT)?.trim() ?: return null
+        if (text.isEmpty()) return null
+        val direct = Uri.parse(text)
+        val directScheme = direct.scheme?.lowercase()
+        return if (directScheme == "http" || directScheme == "https") {
+            text
+        } else {
+            Regex("""https?://\S+""").find(text)?.value
+        }
     }
 
     override fun onRequestPermissionsResult(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,6 +59,7 @@ import 'package:webspace/services/web_intercept_native.dart';
 import 'package:webspace/services/localcdn_service.dart';
 import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/shortcut_service.dart';
+import 'package:webspace/services/share_intent_service.dart';
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/notification_service.dart';
 import 'package:webspace/services/suggested_sites_service.dart' as suggested_sites;
@@ -912,6 +913,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       // Await any in-flight pause before resuming to prevent ordering inversion
       _resumeAfterLifecyclePause();
       _handleShortcutIntent();
+      _handleShareIntent();
       // Pinned shortcuts may have been added (via the launcher's pin dialog)
       // or removed (by the user from the launcher) while we were backgrounded.
       _refreshPinnedSiteIds();
@@ -944,6 +946,20 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         if (!mounted) return;
         setState(() {});
       }
+    }
+  }
+
+  bool _handlingShareIntent = false;
+
+  Future<void> _handleShareIntent() async {
+    if (_handlingShareIntent) return;
+    _handlingShareIntent = true;
+    try {
+      final url = await ShareIntentService.consumeLaunchUrl();
+      if (!mounted || url == null || url.isEmpty) return;
+      _addSite(initialUrl: url);
+    } finally {
+      _handlingShareIntent = false;
     }
   }
 
@@ -1803,6 +1819,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
     await NotificationService.instance.init();
     NotificationService.instance.onNotificationTapped = _onNotificationTapped;
+
+    // Cold-start path for ACTION_SEND share intents: open AddSiteScreen
+    // prefilled with the shared URL once startup is settled. The resumed
+    // lifecycle hook handles the warm path.
+    unawaited(_handleShareIntent());
   }
 
   void _onNotificationTapped(String siteId) {
@@ -3173,7 +3194,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     );
   }
 
-  void _addSite() async {
+  void _addSite({String? initialUrl}) async {
     final result = await Navigator.push(
       context,
       MaterialPageRoute(
@@ -3197,6 +3218,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
             _suggestedSites = sites;
             suggested_sites.saveSuggestedSites(sites);
           },
+          initialUrl: initialUrl,
         ),
       ),
     );

--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -295,12 +295,14 @@ class AddSiteScreen extends StatefulWidget {
   final Function(ThemeMode) onThemeModeChanged;
   final List<SiteSuggestion> suggestions;
   final Function(List<SiteSuggestion>) onSuggestionsChanged;
+  final String? initialUrl;
 
   AddSiteScreen({
     required this.themeMode,
     required this.onThemeModeChanged,
     required this.suggestions,
     required this.onSuggestionsChanged,
+    this.initialUrl,
   });
 
   @override
@@ -318,6 +320,10 @@ class _AddSiteScreenState extends State<AddSiteScreen> {
     super.initState();
     _suggestions = List.of(widget.suggestions);
     _urlController.addListener(_onUrlChanged);
+    if (widget.initialUrl != null && widget.initialUrl!.isNotEmpty) {
+      _urlController.text = widget.initialUrl!;
+      WidgetsBinding.instance.addPostFrameCallback((_) => _updatePreview());
+    }
   }
 
   @override

--- a/lib/services/share_intent_service.dart
+++ b/lib/services/share_intent_service.dart
@@ -1,0 +1,19 @@
+import 'dart:io';
+import 'package:flutter/services.dart';
+
+class ShareIntentService {
+  static const _channel = MethodChannel('org.codeberg.theoden8.webspace/share_intent');
+
+  /// Reads any URL delivered to the app via an inbound share / VIEW intent
+  /// and clears it from the native side so the same URL is not handed out
+  /// twice. Returns null if no inbound URL is pending.
+  static Future<String?> consumeLaunchUrl() async {
+    if (!Platform.isAndroid) return null;
+    try {
+      final result = await _channel.invokeMethod('consumeLaunchUrl');
+      return result is String ? result : null;
+    } on PlatformException {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds support for receiving and handling URLs shared to the app via Android's share intent (ACTION_SEND). When a user shares a URL from another app, the WebSpace app will now open and automatically populate the add site screen with the shared URL.

## Key Changes
- **Android Manifest**: Added intent filter to handle `ACTION_SEND` with `text/plain` MIME type, allowing the app to appear in Android's share menu
- **MainActivity.kt**: 
  - Added `SHARE_CHANNEL` for Dart-native communication about share intents
  - Implemented `extractShareUrl()` method to parse URLs from share intent extras, supporting both direct URLs and URLs embedded in text
  - Added `pendingShareUrl` state to track the shared URL across app lifecycle
  - Set up method channel handler for `consumeLaunchUrl()` to deliver the URL to Dart and clear it after consumption
  - Updated `onNewIntent()` to handle share intents when app is already running (warm start)
- **ShareIntentService.dart**: New service class to communicate with native Android code and retrieve pending share URLs
- **AddSiteScreen**: 
  - Added `initialUrl` parameter to accept pre-filled URLs
  - Initialize URL controller with the provided initial URL and trigger preview update
- **main.dart**:
  - Added `_handleShareIntent()` method to consume and process shared URLs
  - Called during both cold start (in `initState`) and warm start (in `didChangeAppLifecycleState`)
  - Prevents duplicate handling with `_handlingShareIntent` flag
  - Automatically opens AddSiteScreen with the shared URL pre-filled

## Implementation Details
- The `extractShareUrl()` function intelligently extracts URLs from share intent text by first checking if the entire text is a valid HTTP(S) URL, then falling back to regex pattern matching for URLs embedded in longer text
- Share intent handling is guarded against duplicate processing to prevent race conditions
- The implementation supports both cold-start (app not running) and warm-start (app already running) scenarios

https://claude.ai/code/session_017ph8b2snXfXhgz7SKsHXLx