### PR TITLE
fix: skip HTML save during cached-then-live boot reload (#290)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2409,6 +2409,16 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     return _webViewModels[_currentIndex!].getController(launchUrl, _cookieManager, _containerCookieManager, _saveWebViewModels, globalUserScripts: _globalUserScripts);
   }
 
+  /// User-driven reload of the current site (Refresh button, Clear-cookies).
+  /// Delegates to [WebViewModel.userDrivenReload] which drops the
+  /// HtmlCacheService snapshot and the chromium HTTP cache before the
+  /// reload, so the user actually gets fresh content instead of being
+  /// served the same stale page from disk cache (issue #290).
+  Future<void> _refreshCurrentSite() async {
+    if (_currentIndex == null || _currentIndex! >= _webViewModels.length) return;
+    await _webViewModels[_currentIndex!].userDrivenReload();
+  }
+
   /// Update _canGoBack from the current webview's controller.
   /// Used on iOS to enable drawer edge-swipe when there's no back history.
   /// Note: canGoBack() can return false for pushState/SPA navigations even
@@ -2663,7 +2673,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                             if (loading) {
                               getController()?.stopLoading();
                             } else {
-                              getController()?.reload();
+                              _refreshCurrentSite();
                             }
                           },
                         );
@@ -2762,7 +2772,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                         onClearCookies: () {
                           _webViewModels[_currentIndex!].deleteCookies(_cookieManager, _containerCookieManager);
                           _saveWebViewModels();
-                          getController()?.reload();
+                          _refreshCurrentSite();
                         },
                         onSettingsSaved: _handlePerSiteSettingsSaved,
                       ),
@@ -3027,7 +3037,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                       if (loading) {
                         getController()?.stopLoading();
                       } else {
-                        getController()?.reload();
+                        _refreshCurrentSite();
                       }
                     },
                   );
@@ -3126,7 +3136,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                   onClearCookies: () {
                     _webViewModels[_currentIndex!].deleteCookies(_cookieManager, _containerCookieManager);
                     _saveWebViewModels();
-                    getController()?.reload();
+                    _refreshCurrentSite();
                   },
                   onSettingsSaved: _handlePerSiteSettingsSaved,
                 ),

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -2479,7 +2479,8 @@ class WebViewFactory {
         //
         // Skipped for offline runs via the `isOnline()` check — there's
         // no live to fetch, so the cached page is the answer.
-        if (pendingLiveReload && navigationGen == 0) {
+        final firedLiveReload = pendingLiveReload && navigationGen == 0;
+        if (firedLiveReload) {
           pendingLiveReload = false;
           ConnectivityService.instance.isOnline().then((online) {
             if (!online) return;
@@ -2531,7 +2532,19 @@ class WebViewFactory {
         // via shouldFetchHtml so the per-onLoadStop storm is collapsed
         // before we ask chromium to serialize the DOM — the IPC, not
         // the encrypt+write afterward, is the lifecycle-racing piece.
+        //
+        // Skip when we just fired the cached-then-live reload above:
+        // the reload IPC reaches the renderer before our `getHtml()`
+        // does, so the serialized DOM here is the partial mid-reload
+        // markup (often a few-KB SPA shell) — and saving that clobbers
+        // the previously-cached fully-rendered snapshot. On next launch
+        // the corrupt shell loads as initialData and the SPA's hydration
+        // throws (`Cannot read properties of null`) leaving a blank
+        // page. The post-reload `onLoadStop` saves the live HTML
+        // instead; `_lastSaveAt` isn't bumped here, so its debounce
+        // stays open.
         if (config.onHtmlLoaded != null
+            && !firedLiveReload
             && (config.shouldFetchHtml?.call() ?? true)) {
           try {
             final html = await controller.getHtml();

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -6,10 +6,12 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' show ConsoleMessageLevel;
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp show PullToRefreshController, PullToRefreshSettings;
+import 'package:webspace/services/connectivity_service.dart';
+import 'package:webspace/services/container_cookie_manager.dart';
 import 'package:webspace/services/external_url_engine.dart';
+import 'package:webspace/services/html_cache_service.dart';
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/navigation_decision_engine.dart';
-import 'package:webspace/services/container_cookie_manager.dart';
 import 'package:webspace/services/site_lifecycle_promotion_engine.dart';
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/settings/location.dart';
@@ -541,7 +543,7 @@ class WebViewModel {
       final pullToRefreshController = isMobile ? inapp.PullToRefreshController(
         settings: inapp.PullToRefreshSettings(enabled: true),
         onRefresh: () async {
-          controller?.reload();
+          await userDrivenReload();
         },
       ) : null;
       // Track last user gesture on same-domain navigation, so we can
@@ -1012,6 +1014,40 @@ class WebViewModel {
           'Cleared in-memory cache for "$name" (siteId: $siteId)');
     } catch (_) {
       // Controller may have been disposed mid-call.
+    }
+  }
+
+  /// User-driven hard reload (pull-to-refresh, Refresh button, Clear-cookies).
+  ///
+  /// In addition to `controller.reload()`, drop:
+  ///   * the [HtmlCacheService] in-memory snapshot for this site, so any
+  ///     subsequent webview rebuild before the post-reload save lands
+  ///     can't feed the rebuilt webview the stale snapshot the user
+  ///     just told us to refresh — bumps the eviction generation, so
+  ///     an in-flight save from the disposed view is rejected at write
+  ///     time and can't resurrect the dropped bytes;
+  ///   * the chromium HTTP/image cache, so the reload actually hits
+  ///     the network instead of being satisfied from disk cache (a
+  ///     stale-cached HTML response is what bit issue #290 — the user
+  ///     pulled to refresh and saw the same stale page because chromium
+  ///     served the cached response).
+  ///
+  /// Online-gated for the HtmlCache eviction: offline users keep the
+  /// snapshot as their only renderable content. The HTTP cache clear
+  /// runs unconditionally — clearing it offline is harmless (no live
+  /// fetch will succeed anyway, and any post-online reload will
+  /// repopulate it) and avoids a second connectivity probe on the
+  /// hot path.
+  Future<void> userDrivenReload() async {
+    if (controller == null) return;
+    if (ConnectivityService.instance.lastKnownOnline ?? true) {
+      HtmlCacheService.instance.evictInMemory(siteId);
+    }
+    await clearWebViewCache();
+    try {
+      await controller!.reload();
+    } catch (_) {
+      // Controller may have been disposed between the cache clear and the reload.
     }
   }
 


### PR DESCRIPTION
`controller.reload()` is fire-and-forget, so by the time the same
onLoadStop reaches `getHtml()` the renderer is mid-navigation and
serializes a partial SPA shell — that clobbers the good fully-rendered
snapshot. Next launch loads the corrupt shell as initialData and the
SPA's hydration throws `Cannot read properties of null`, leaving a
blank page. Skip the save on the cached-load onLoadStop; the post-reload
onLoadStop captures the live HTML.