### PR TITLE
Register WebSpace as iOS share target

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -808,7 +808,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ShareExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -844,7 +844,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ShareExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -881,7 +881,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ShareExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		7B0E0000000000000000001E /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0E0000000000000000000A /* ShareViewController.swift */; };
+		7B0E0000000000000000001F /* ShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 7B0E00000000000000000009 /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -27,6 +29,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 97C146ED1CF9000F007C117D;
 			remoteInfo = Runner;
+		};
+		7B0E00000000000000000021 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7B0E00000000000000000000;
+			remoteInfo = ShareExtension;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -39,6 +48,17 @@
 			files = (
 			);
 			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7B0E00000000000000000020 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				7B0E0000000000000000001F /* ShareExtension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -69,6 +89,11 @@
 		C372016466C2527503C84FCB /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		CD964C23AA9270E09F7D97A7 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		DC8E72CF1B6DBE422FFDC631 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		7B0E00000000000000000009 /* ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		7B0E0000000000000000000A /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
+		7B0E0000000000000000000B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7B0E0000000000000000000C /* ShareExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ShareExtension.entitlements; sourceTree = "<group>"; };
+		7B0E0000000000000000000D /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +110,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				897CA73A1B12E395D36631E0 /* Pods_Runner.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7B0E00000000000000000007 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -138,6 +170,7 @@
 			children = (
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
+				7B0E00000000000000000008 /* ShareExtension */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
 				6AA06D92C2DB28FF1BF07304 /* Pods */,
@@ -150,6 +183,7 @@
 			children = (
 				97C146EE1CF9000F007C117D /* Runner.app */,
 				331C8081294A63A400263BE5 /* RunnerTests.xctest */,
+				7B0E00000000000000000009 /* ShareExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -167,8 +201,19 @@
 				7AC100002ED2DC5600515811 /* LocationPlugin.swift */,
 				7AC100022ED2DC5600515813 /* BackgroundTaskPlugin.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
+				7B0E0000000000000000000D /* Runner.entitlements */,
 			);
 			path = Runner;
+			sourceTree = "<group>";
+		};
+		7B0E00000000000000000008 /* ShareExtension */ = {
+			isa = PBXGroup;
+			children = (
+				7B0E0000000000000000000A /* ShareViewController.swift */,
+				7B0E0000000000000000000B /* Info.plist */,
+				7B0E0000000000000000000C /* ShareExtension.entitlements */,
+			);
+			path = ShareExtension;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -203,17 +248,36 @@
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
+				7B0E00000000000000000020 /* Embed App Extensions */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				BB87C89DAC9B3EFDF00A64EB /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				7B0E00000000000000000022 /* PBXTargetDependency */,
 			);
 			name = Runner;
 			productName = Runner;
 			productReference = 97C146EE1CF9000F007C117D /* Runner.app */;
 			productType = "com.apple.product-type.application";
+		};
+		7B0E00000000000000000000 /* ShareExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7B0E00000000000000000001 /* Build configuration list for PBXNativeTarget "ShareExtension" */;
+			buildPhases = (
+				7B0E00000000000000000005 /* Sources */,
+				7B0E00000000000000000007 /* Frameworks */,
+				7B0E00000000000000000006 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ShareExtension;
+			productName = ShareExtension;
+			productReference = 7B0E00000000000000000009 /* ShareExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -233,6 +297,10 @@
 						CreatedOnToolsVersion = 7.3.1;
 						LastSwiftMigration = 1100;
 					};
+					7B0E00000000000000000000 = {
+						CreatedOnToolsVersion = 15.0;
+						LastSwiftMigration = 1500;
+					};
 				};
 			};
 			buildConfigurationList = 97C146E91CF9000F007C117D /* Build configuration list for PBXProject "Runner" */;
@@ -250,6 +318,7 @@
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
 				331C8080294A63A400263BE5 /* RunnerTests */,
+				7B0E00000000000000000000 /* ShareExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -270,6 +339,13 @@
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7B0E00000000000000000006 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -390,6 +466,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7B0E00000000000000000005 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7B0E0000000000000000001E /* ShareViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -397,6 +481,11 @@
 			isa = PBXTargetDependency;
 			target = 97C146ED1CF9000F007C117D /* Runner */;
 			targetProxy = 331C8085294A63A400263BE5 /* PBXContainerItemProxy */;
+		};
+		7B0E00000000000000000022 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7B0E00000000000000000000 /* ShareExtension */;
+			targetProxy = 7B0E00000000000000000021 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -478,6 +567,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 7NGC2P87LM;
 				ENABLE_BITCODE = NO;
@@ -661,6 +751,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 7NGC2P87LM;
 				ENABLE_BITCODE = NO;
@@ -684,6 +775,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 7NGC2P87LM;
 				ENABLE_BITCODE = NO;
@@ -699,6 +791,115 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
+		};
+		7B0E00000000000000000002 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 7NGC2P87LM;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = ShareExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.codeberg.theoden8.webspace.ShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		7B0E00000000000000000003 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 7NGC2P87LM;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = ShareExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.codeberg.theoden8.webspace.ShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		7B0E00000000000000000004 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 7NGC2P87LM;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = ShareExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.codeberg.theoden8.webspace.ShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Profile;
 		};
 /* End XCBuildConfiguration section */
 
@@ -729,6 +930,16 @@
 				97C147061CF9000F007C117D /* Debug */,
 				97C147071CF9000F007C117D /* Release */,
 				249021D4217E4FDB00AE95B9 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7B0E00000000000000000001 /* Build configuration list for PBXNativeTarget "ShareExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7B0E00000000000000000002 /* Debug */,
+				7B0E00000000000000000003 /* Release */,
+				7B0E00000000000000000004 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -7,6 +7,11 @@ import UserNotifications
 @objc class AppDelegate: FlutterAppDelegate {
   private var locationPlugin: LocationPlugin?
   private var backgroundTaskPlugin: BackgroundTaskPlugin?
+  private var pendingShareUrl: String?
+
+  private let shareChannelName = "org.codeberg.theoden8.webspace/share_intent"
+  private let appGroupId = "group.org.codeberg.theoden8.webspace"
+  private let pendingUrlKey = "pending_share_url"
 
   override func application(
     _ application: UIApplication,
@@ -27,7 +32,64 @@ import UserNotifications
     if let controller = window?.rootViewController as? FlutterViewController {
       locationPlugin = LocationPlugin(messenger: controller.binaryMessenger)
       backgroundTaskPlugin = BackgroundTaskPlugin(messenger: controller.binaryMessenger)
+      registerShareChannel(controller.binaryMessenger)
     }
+    if let url = launchOptions?[.url] as? URL {
+      capturePendingShareUrl(from: url)
+    }
+    drainAppGroupPendingUrl()
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  override func application(
+    _ app: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  ) -> Bool {
+    capturePendingShareUrl(from: url)
+    drainAppGroupPendingUrl()
+    return super.application(app, open: url, options: options)
+  }
+
+  private func registerShareChannel(_ messenger: FlutterBinaryMessenger) {
+    let channel = FlutterMethodChannel(name: shareChannelName, binaryMessenger: messenger)
+    channel.setMethodCallHandler { [weak self] call, result in
+      guard let self = self else { result(nil); return }
+      switch call.method {
+      case "consumeLaunchUrl":
+        self.drainAppGroupPendingUrl()
+        let url = self.pendingShareUrl
+        self.pendingShareUrl = nil
+        result(url)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+  }
+
+  private func capturePendingShareUrl(from url: URL) {
+    guard url.scheme?.lowercased() == "webspace" else { return }
+    let host = url.host?.lowercased()
+    if host == "share" {
+      guard
+        let inner = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+          .queryItems?.first(where: { $0.name == "url" })?.value,
+        let httpScheme = URL(string: inner)?.scheme?.lowercased(),
+        httpScheme == "http" || httpScheme == "https"
+      else { return }
+      pendingShareUrl = inner
+    } else if host == "qr" {
+      // Pass the original webspace:// URL through; Dart routes it to the
+      // QR-apply path by scheme.
+      pendingShareUrl = url.absoluteString
+    }
+  }
+
+  private func drainAppGroupPendingUrl() {
+    guard let defaults = UserDefaults(suiteName: appGroupId) else { return }
+    if let stored = defaults.string(forKey: pendingUrlKey), !stored.isEmpty {
+      pendingShareUrl = stored
+      defaults.removeObject(forKey: pendingUrlKey)
+    }
   }
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -56,5 +56,18 @@
 	<array>
 		<string>org.codeberg.theoden8.webspace.notification-refresh</string>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>org.codeberg.theoden8.webspace</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>webspace</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.org.codeberg.theoden8.webspace</string>
+	</array>
+</dict>
+</plist>

--- a/ios/ShareExtension/Info.plist
+++ b/ios/ShareExtension/Info.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Add to WebSpace</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+			</dict>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+	</dict>
+</dict>
+</plist>

--- a/ios/ShareExtension/ShareExtension.entitlements
+++ b/ios/ShareExtension/ShareExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.org.codeberg.theoden8.webspace</string>
+	</array>
+</dict>
+</plist>

--- a/ios/ShareExtension/ShareViewController.swift
+++ b/ios/ShareExtension/ShareViewController.swift
@@ -1,0 +1,123 @@
+import UIKit
+import Social
+import MobileCoreServices
+import UniformTypeIdentifiers
+
+@objc(ShareViewController)
+final class ShareViewController: UIViewController {
+
+    private static let appGroupId = "group.org.codeberg.theoden8.webspace"
+    private static let pendingUrlKey = "pending_share_url"
+    private static let hostScheme = "webspace"
+    private static let hostHost = "share"
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+        extractURL { url in
+            DispatchQueue.main.async {
+                guard let url = url, !url.isEmpty else {
+                    self.finish(); return
+                }
+                self.handOff(url)
+                self.finish()
+            }
+        }
+    }
+
+    private func extractURL(_ done: @escaping (String?) -> Void) {
+        guard let item = (extensionContext?.inputItems as? [NSExtensionItem])?.first,
+              let providers = item.attachments, !providers.isEmpty else {
+            done(nil); return
+        }
+
+        let urlType = UTType.url.identifier
+        let textType = UTType.plainText.identifier
+        let group = DispatchGroup()
+        let lock = NSLock()
+        var found: String?
+
+        let publish: (String?) -> Void = { value in
+            guard let value = value, !value.isEmpty else { return }
+            lock.lock(); defer { lock.unlock() }
+            if found == nil { found = value }
+        }
+
+        for provider in providers {
+            if provider.hasItemConformingToTypeIdentifier(urlType) {
+                group.enter()
+                provider.loadItem(forTypeIdentifier: urlType, options: nil) { value, _ in
+                    if let url = value as? URL,
+                       let scheme = url.scheme?.lowercased(),
+                       scheme == "http" || scheme == "https" {
+                        publish(url.absoluteString)
+                    } else if let s = value as? String {
+                        publish(ShareViewController.firstHttpUrl(in: s))
+                    }
+                    group.leave()
+                }
+            } else if provider.hasItemConformingToTypeIdentifier(textType) {
+                group.enter()
+                provider.loadItem(forTypeIdentifier: textType, options: nil) { value, _ in
+                    if let s = value as? String {
+                        publish(ShareViewController.firstHttpUrl(in: s))
+                    }
+                    group.leave()
+                }
+            }
+        }
+
+        group.notify(queue: .global()) {
+            done(found)
+        }
+    }
+
+    private static func firstHttpUrl(in text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let url = URL(string: trimmed),
+           let scheme = url.scheme?.lowercased(),
+           scheme == "http" || scheme == "https" {
+            return trimmed
+        }
+        let pattern = "https?://\\S+"
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else { return nil }
+        let range = NSRange(trimmed.startIndex..., in: trimmed)
+        guard let match = regex.firstMatch(in: trimmed, options: [], range: range),
+              let r = Range(match.range, in: trimmed) else {
+            return nil
+        }
+        return String(trimmed[r])
+    }
+
+    private func handOff(_ url: String) {
+        if let defaults = UserDefaults(suiteName: ShareViewController.appGroupId) {
+            defaults.set(url, forKey: ShareViewController.pendingUrlKey)
+        }
+        var components = URLComponents()
+        components.scheme = ShareViewController.hostScheme
+        components.host = ShareViewController.hostHost
+        components.queryItems = [URLQueryItem(name: "url", value: url)]
+        if let openUrl = components.url {
+            openHostApp(openUrl)
+        }
+    }
+
+    private func finish() {
+        extensionContext?.completeRequest(returningItems: nil, completionHandler: nil)
+    }
+
+    // extensionContext.open is restricted to today widgets; for share
+    // extensions the supported workaround is to walk the responder chain
+    // up to UIApplication and invoke openURL via the ObjC runtime.
+    private func openHostApp(_ url: URL) {
+        var responder: UIResponder? = self
+        let selector = NSSelectorFromString("openURL:")
+        while let r = responder {
+            if r.responds(to: selector) && !(r is UIViewController) {
+                _ = r.perform(selector, with: url)
+                return
+            }
+            responder = r.next
+        }
+    }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -971,6 +971,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     try {
       final url = await ShareIntentService.consumeLaunchUrl();
       if (!mounted || url == null || url.isEmpty) return;
+      if (url.startsWith('webspace://qr/')) {
+        final decoded = SiteSettingsQrCodec.decode(url);
+        if (decoded != null) {
+          _addSite(qrSettings: decoded);
+        }
+        return;
+      }
       _addSite(initialUrl: url);
     } finally {
       _handlingShareIntent = false;
@@ -3248,44 +3255,49 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     );
   }
 
-  void _addSite({String? initialUrl}) async {
-    final result = await Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (context) => AddSiteScreen(
-          themeMode: _themeSettings.themeMode,
-          onThemeModeChanged: (ThemeMode mode) async {
-            setState(() {
-              _themeSettings = _themeSettings.copyWith(themeMode: mode);
-            });
-            widget.onThemeSettingsChanged(_themeSettings);
-            await _saveThemeSettings();
+  void _addSite({String? initialUrl, Map<String, dynamic>? qrSettings}) async {
+    Object? result;
+    if (qrSettings != null) {
+      result = {'qrSettings': qrSettings};
+    } else {
+      result = await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => AddSiteScreen(
+            themeMode: _themeSettings.themeMode,
+            onThemeModeChanged: (ThemeMode mode) async {
+              setState(() {
+                _themeSettings = _themeSettings.copyWith(themeMode: mode);
+              });
+              widget.onThemeSettingsChanged(_themeSettings);
+              await _saveThemeSettings();
 
-            // Apply theme to all webviews
-            final webViewTheme = _themeModeToWebViewTheme(_themeSettings.themeMode);
-            for (var webViewModel in _webViewModels) {
-              await webViewModel.setTheme(webViewTheme);
-            }
-          },
-          suggestions: _suggestedSites,
-          onSuggestionsChanged: (sites) {
-            _suggestedSites = sites;
-            suggested_sites.saveSuggestedSites(sites);
-          },
-          initialUrl: initialUrl,
+              // Apply theme to all webviews
+              final webViewTheme = _themeModeToWebViewTheme(_themeSettings.themeMode);
+              for (var webViewModel in _webViewModels) {
+                await webViewModel.setTheme(webViewTheme);
+              }
+            },
+            suggestions: _suggestedSites,
+            onSuggestionsChanged: (sites) {
+              _suggestedSites = sites;
+              suggested_sites.saveSuggestedSites(sites);
+            },
+            initialUrl: initialUrl,
+          ),
         ),
-      ),
-    );
+      );
+    }
     if (result == null || result is! Map<String, dynamic>) return;
     if (!mounted) return;
 
     final stateSetter = () { setState((){}); _updateCanGoBack(); };
     late WebViewModel model;
-    final qrSettings = result['qrSettings'] as Map<String, dynamic>?;
+    final resultQrSettings = result['qrSettings'] as Map<String, dynamic>?;
 
-    if (qrSettings != null) {
+    if (resultQrSettings != null) {
       model = WebViewModel.fromJson(
-        SiteSettingsQrCodec.hydrateForFromJson(qrSettings),
+        SiteSettingsQrCodec.hydrateForFromJson(resultQrSettings),
         stateSetter,
       );
       if ((model.name ?? '').isEmpty) {

--- a/lib/services/share_intent_service.dart
+++ b/lib/services/share_intent_service.dart
@@ -8,7 +8,7 @@ class ShareIntentService {
   /// and clears it from the native side so the same URL is not handed out
   /// twice. Returns null if no inbound URL is pending.
   static Future<String?> consumeLaunchUrl() async {
-    if (!Platform.isAndroid) return null;
+    if (!Platform.isAndroid && !Platform.isIOS) return null;
     try {
       final result = await _channel.invokeMethod('consumeLaunchUrl');
       return result is String ? result : null;


### PR DESCRIPTION
Adds a Share Extension that hands shared URLs to the host app via the
existing webspace:// scheme (now CFBundleURLTypes-registered) plus an
App Group container as cold-start fallback. The host AppDelegate
mirrors Android's MethodChannel and routes:

- webspace://share?url=https://... -> AddSiteScreen prefilled
- webspace://qr/site/v1/...        -> QR-apply (skip scanner/paste)

So tapping a webspace://qr/... URL in Notes/Messages now opens the
in-app QR-apply flow with the payload already decoded, and the Share
Extension surfaces WebSpace in the iOS system share sheet.