### PR TITLE
feat: implement Android background-poll strategy for notifications

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- Foreground service for NOTIF-005-A: keeps notification sites'
+         webviews polling while the app is backgrounded so their page JS
+         can fire pending notifications. specialUse covers the
+         "polling user-configured websites for updates" case — none of
+         the predefined service types (dataSync, mediaPlayback, location)
+         match a generic JS event loop. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <!-- Optional, requested at runtime only when the user taps "Use current location"
          in the per-site location picker. Not used for any background/tracking. -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
@@ -54,5 +62,13 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/flutter_inappwebview_android_provider_paths" />
         </provider>
+        <service
+            android:name=".BackgroundPollService"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Keep user-selected websites running so they can fire notifications while the app is backgrounded." />
+        </service>
     </application>
 </manifest>

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/BackgroundPollService.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/BackgroundPollService.kt
@@ -1,0 +1,124 @@
+package org.codeberg.theoden8.webspace
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+
+/**
+ * Foreground service backing NOTIF-005-A. Holds the app process alive
+ * across backgrounding so notification sites' WebViews keep executing
+ * their page JS — without this, Android eventually freezes the renderer
+ * once the activity is no longer visible and timer-driven polling stops.
+ *
+ * The service does NOT itself poll: it just calls `startForeground(...)`
+ * with a persistent notification, then waits to be stopped. The webviews
+ * continue running on the main process because the foreground service
+ * keeps that process from being killed for OOM or app standby reasons.
+ *
+ * Lifecycle is driven from Dart by [WebSpaceBackgroundPollPlugin] /
+ * [AndroidForegroundService]:
+ *   - START with extra `count` -> upgrade-or-start the persistent
+ *     notification text "WebSpace is checking N sites for updates".
+ *   - STOP -> [stopForeground] + [stopSelf].
+ */
+class BackgroundPollService : Service() {
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val action = intent?.action ?: ACTION_START
+        when (action) {
+            ACTION_START -> {
+                val count = intent?.getIntExtra(EXTRA_COUNT, 1) ?: 1
+                ensureChannel()
+                val notification = buildNotification(count)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    startForeground(
+                        NOTIFICATION_ID,
+                        notification,
+                        ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
+                    )
+                } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    startForeground(
+                        NOTIFICATION_ID,
+                        notification,
+                        ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
+                    )
+                } else {
+                    startForeground(NOTIFICATION_ID, notification)
+                }
+            }
+            ACTION_STOP -> {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    stopForeground(STOP_FOREGROUND_REMOVE)
+                } else {
+                    @Suppress("DEPRECATION")
+                    stopForeground(true)
+                }
+                stopSelf()
+            }
+        }
+        // START_NOT_STICKY: if the OS kills us on memory pressure, don't
+        // let it restart us with a null Intent — Dart will re-issue the
+        // start command on the next lifecycle event when appropriate.
+        return START_NOT_STICKY
+    }
+
+    private fun ensureChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val mgr = getSystemService(NotificationManager::class.java) ?: return
+        if (mgr.getNotificationChannel(CHANNEL_ID) != null) return
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Background polling",
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = "Persistent notification while WebSpace is keeping notification sites alive in the background."
+            setShowBadge(false)
+        }
+        mgr.createNotificationChannel(channel)
+    }
+
+    private fun buildNotification(count: Int): Notification {
+        val tapIntent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val pendingFlags =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            } else {
+                PendingIntent.FLAG_UPDATE_CURRENT
+            }
+        val contentPi = PendingIntent.getActivity(this, 0, tapIntent, pendingFlags)
+        val text = if (count == 1) {
+            "WebSpace is checking 1 site for updates"
+        } else {
+            "WebSpace is checking $count sites for updates"
+        }
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle("WebSpace")
+            .setContentText(text)
+            .setOngoing(true)
+            .setSilent(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setContentIntent(contentPi)
+            .build()
+    }
+
+    companion object {
+        const val ACTION_START = "org.codeberg.theoden8.webspace.background_poll.START"
+        const val ACTION_STOP = "org.codeberg.theoden8.webspace.background_poll.STOP"
+        const val EXTRA_COUNT = "count"
+        private const val CHANNEL_ID = "webspace_background_poll"
+        private const val NOTIFICATION_ID = 0xB6D11
+    }
+}

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -19,6 +19,7 @@ class MainActivity: FlutterActivity() {
     private var webInterceptPlugin: WebInterceptPlugin? = null
     private var locationPlugin: LocationPlugin? = null
     private var webSpaceContainerPlugin: WebSpaceContainerPlugin? = null
+    private var backgroundPollPlugin: WebSpaceBackgroundPollPlugin? = null
     private var pendingShareUrl: String? = null
 
     override fun getFlutterShellArgs(): FlutterShellArgs {
@@ -38,6 +39,7 @@ class MainActivity: FlutterActivity() {
         webInterceptPlugin = WebInterceptPlugin(this, flutterEngine)
         locationPlugin = LocationPlugin(this, flutterEngine)
         webSpaceContainerPlugin = WebSpaceContainerPlugin(flutterEngine)
+        backgroundPollPlugin = WebSpaceBackgroundPollPlugin(applicationContext, flutterEngine)
         pendingShareUrl = extractShareUrl(intent)
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, SHARE_CHANNEL).setMethodCallHandler { call, result ->
             when (call.method) {

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/WebSpaceBackgroundPollPlugin.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/WebSpaceBackgroundPollPlugin.kt
@@ -1,0 +1,69 @@
+package org.codeberg.theoden8.webspace
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Method-channel bridge for [BackgroundPollService]. Mirrors
+ * [AndroidForegroundService] on the Dart side.
+ *
+ * Methods:
+ *   - `start(count: Int)` — start (or update) the foreground service
+ *     with a persistent notification "WebSpace is checking N sites for
+ *     updates".
+ *   - `stop()` — stop the foreground service and dismiss the
+ *     notification.
+ *
+ * All calls return `null` (success) — the Dart side does not depend on a
+ * synchronous result; the service starts asynchronously after this call.
+ */
+class WebSpaceBackgroundPollPlugin(
+    private val context: Context,
+    flutterEngine: FlutterEngine,
+) {
+    private val channel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
+
+    init {
+        channel.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "start" -> {
+                    val count = call.argument<Int>("count") ?: 1
+                    val intent = Intent(context, BackgroundPollService::class.java).apply {
+                        action = BackgroundPollService.ACTION_START
+                        putExtra(BackgroundPollService.EXTRA_COUNT, count)
+                    }
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        context.startForegroundService(intent)
+                    } else {
+                        context.startService(intent)
+                    }
+                    result.success(null)
+                }
+                "stop" -> {
+                    val intent = Intent(context, BackgroundPollService::class.java).apply {
+                        action = BackgroundPollService.ACTION_STOP
+                    }
+                    // startService(STOP) so the service receives the
+                    // intent in onStartCommand, which calls stopForeground
+                    // + stopSelf. Plain stopService skips onStartCommand
+                    // and may leave the persistent notification visible
+                    // until the OS reaps it.
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        context.startForegroundService(intent)
+                    } else {
+                        context.startService(intent)
+                    }
+                    result.success(null)
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    companion object {
+        const val CHANNEL = "org.codeberg.theoden8.webspace/background-poll"
+    }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,10 +59,12 @@ import 'package:webspace/services/web_intercept_native.dart';
 import 'package:webspace/services/localcdn_service.dart';
 import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/shortcut_service.dart';
+import 'package:webspace/services/android_foreground_service.dart';
 import 'package:webspace/services/background_task_service.dart';
 import 'package:webspace/services/share_intent_service.dart';
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/notification_service.dart';
+import 'package:webspace/services/proxy_conflict_engine.dart';
 import 'package:webspace/services/suggested_sites_service.dart' as suggested_sites;
 import 'package:webspace/screens/dev_tools.dart';
 import 'package:webspace/settings/app_prefs.dart';
@@ -918,6 +920,10 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         unawaited(BackgroundTaskService.instance.beginGracePeriod());
         unawaited(BackgroundTaskService.instance.scheduleNextRefresh());
       }
+      // Android: ensure the foreground service is up before the
+      // process gets backgrounded so the OS doesn't freeze the renderer.
+      // No-op on other platforms.
+      unawaited(_updateForegroundService());
     } else if (state == AppLifecycleState.resumed) {
       _startForegroundPollTimer();
       // Await any in-flight pause before resuming to prevent ordering inversion
@@ -931,6 +937,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       // so we don't need the extension; iOS auto-ends after the expiration
       // handler fires, but explicit end is cleaner.
       unawaited(BackgroundTaskService.instance.endGracePeriod());
+      // Android: re-evaluate (idempotent). The service stays running
+      // whenever a notification site is loaded — the persistent
+      // notification is the user's signal that the app is holding the
+      // process alive — so this is mostly a no-op on resume, but
+      // ensures the state is correct if any sites were unloaded by a
+      // memory-pressure handler while we were backgrounded.
+      unawaited(_updateForegroundService());
     }
   }
 
@@ -1157,6 +1170,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     } else {
       setState(() {});
     }
+
+    // The user may have just toggled `notificationsEnabled` on/off, so
+    // re-evaluate whether the Android foreground service should be
+    // running. No-op on other platforms.
+    unawaited(_updateForegroundService());
   }
 
   /// Dispose every loaded webview. Used after global user script edits,
@@ -1436,6 +1454,10 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     }
 
     LogService.instance.log('CookieIsolation', 'After switch, loaded indices: $_loadedIndices');
+    // _loadedIndices may have changed (LRU eviction, conflict unload,
+    // first-load of target), so re-evaluate the Android foreground
+    // service. No-op on non-Android.
+    unawaited(_updateForegroundService());
     } finally {
       // Clear the in-flight marker only if we still own it; a newer
       // _setCurrentIndex caller will have already overwritten it with
@@ -1854,6 +1876,59 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       if (m.notificationsEnabled) return true;
     }
     return false;
+  }
+
+  /// NOTIF-005-A: Android `ProxyController` is process-wide, so a site
+  /// can become a notification (background-poll) site only if every
+  /// other already-enabled notification site shares its proxy
+  /// fingerprint. Returns the first conflicting site's name (for
+  /// explanatory subtitle) or `null` if [target] is free to enable.
+  ///
+  /// No-op (returns null) on non-Android — iOS uses `BGAppRefreshTask`
+  /// which doesn't share a process-wide proxy controller.
+  String? _notificationsBlockedBySite(WebViewModel target) {
+    if (!Platform.isAndroid) return null;
+    final others = <WebViewModel>[];
+    for (final m in _webViewModels) {
+      if (identical(m, target)) continue;
+      if (!m.notificationsEnabled) continue;
+      others.add(m);
+    }
+    final conflict = ProxyConflictEngine.firstConflict(
+      targetProxy: target.proxySettings,
+      otherEnabledProxies: others.map((m) => m.proxySettings),
+    );
+    if (conflict == null) return null;
+    final blocker = _webViewModels.firstWhere(
+      (m) => identical(m.proxySettings, conflict),
+      orElse: () => target,
+    );
+    return blocker.name.isNotEmpty
+        ? blocker.name
+        : (blocker.initUrl.isNotEmpty ? blocker.initUrl : 'Another site');
+  }
+
+  /// NOTIF-005-A: keep the Android foreground service running iff at
+  /// least one notification site is loaded. The service holds the app
+  /// process alive across backgrounding so notification sites' page JS
+  /// keeps executing.
+  ///
+  /// Idempotent — [AndroidForegroundService] dedupes start calls with
+  /// the same count.
+  Future<void> _updateForegroundService() async {
+    if (!Platform.isAndroid) return;
+    int count = 0;
+    for (int i = 0; i < _webViewModels.length; i++) {
+      final m = _webViewModels[i];
+      if (!m.notificationsEnabled) continue;
+      if (!_loadedIndices.contains(i)) continue;
+      count++;
+    }
+    if (count > 0) {
+      await AndroidForegroundService.instance.start(count);
+    } else {
+      await AndroidForegroundService.instance.stop();
+    }
   }
 
   /// Reload every notification site so its page JS gets a chance to fire
@@ -2827,6 +2902,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                       builder: (context) => SettingsScreen(
                         webViewModel: _webViewModels[_currentIndex!],
                         useContainers: _useContainers,
+                        notificationsBlockedBySite: _notificationsBlockedBySite(_webViewModels[_currentIndex!]),
                         globalUserScripts: _globalUserScripts,
                         onGlobalUserScriptsChanged: (scripts) {
                           _globalUserScripts = scripts;
@@ -3191,6 +3267,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                 builder: (context) => SettingsScreen(
                   webViewModel: _webViewModels[_currentIndex!],
                   useContainers: _useContainers,
+                  notificationsBlockedBySite: _notificationsBlockedBySite(_webViewModels[_currentIndex!]),
                   globalUserScripts: _globalUserScripts,
                   onGlobalUserScriptsChanged: (scripts) {
                     _globalUserScripts = scripts;
@@ -3615,6 +3692,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await HtmlCacheService.instance.removeOrphanedCaches(activeSiteIds);
     await HtmlImportStorage.instance.removeOrphanedImports(activeSiteIds);
     await _stateStorage.removeOrphans(activeSiteIds);
+
+    // Deletion may have just removed the last notification site; tear
+    // down the Android foreground service if so. No-op on other
+    // platforms.
+    unawaited(_updateForegroundService());
 
     if (!mounted) return;
     Navigator.pop(context);

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -89,6 +89,13 @@ class SettingsScreen extends StatefulWidget {
   final VoidCallback? onScriptsChanged;
   final bool useContainers;
 
+  /// Android-only: name of another site whose `notificationsEnabled` is
+  /// already on with a conflicting proxy fingerprint, or `null` if there
+  /// is no conflict. When non-null, the Notifications toggle renders
+  /// disabled with an explanatory subtitle (NOTIF-005-A). On other
+  /// platforms or when there's no conflict, this is `null`.
+  final String? notificationsBlockedBySite;
+
   SettingsScreen({
     required this.webViewModel,
     this.onSettingsSaved,
@@ -97,6 +104,7 @@ class SettingsScreen extends StatefulWidget {
     this.onGlobalUserScriptsChanged,
     this.onScriptsChanged,
     this.useContainers = false,
+    this.notificationsBlockedBySite,
   });
 
   @override
@@ -1195,37 +1203,56 @@ class _SettingsScreenState extends State<SettingsScreen> {
             },
           ),
           if (widget.useContainers)
-            SwitchListTile(
-              title: const Text('Notifications'),
-              subtitle: Text(
-                _notificationsEnabled &&
-                        NotificationService.instance.permissionGranted == false
-                    ? 'Notifications denied. Enable in Settings → '
-                        '${Platform.isIOS ? "Notifications → WebSpace" : "WebSpace → Notifications"}.'
-                    : 'Allow this site to show system notifications. Keeps the '
-                        'site polling in the background so notifications fire even '
-                        'when you are on a different tab.',
-              ),
-              value: _notificationsEnabled,
-              onChanged: (bool value) async {
-                setState(() {
-                  _notificationsEnabled = value;
-                });
-                if (!value) return;
-                // First-time iOS info dialog (NOTIF-005-I); idempotent
-                // via SharedPreferences flag. Show before requesting OS
-                // permission so the user understands the iOS limits
-                // before tapping Allow.
-                if (Platform.isIOS) {
-                  await maybeShowIosNotificationLimitsDialog(context);
-                }
-                // NOTIF-007 / 16.1: request OS permission proactively
-                // at toggle time, not lazily on first notification.
-                // Repeat calls after a denial are harmless (the OS
-                // returns the cached decision).
-                await NotificationService.instance.requestPermission();
-              },
-            ),
+            Builder(builder: (context) {
+              final blockedBy = widget.notificationsBlockedBySite;
+              // The conflict gate only forbids ENABLING. If the toggle
+              // is already on (state predates a proxy edit on another
+              // site), the user can still turn it off — we just don't
+              // let them flip it back on while the conflict stands.
+              final blocked = blockedBy != null && !_notificationsEnabled;
+              final permissionDenied = _notificationsEnabled &&
+                  NotificationService.instance.permissionGranted == false;
+              final String subtitle;
+              if (blocked) {
+                subtitle =
+                    'Cannot enable: "$blockedBy" is already polling in '
+                    'background with a different proxy. Android allows only '
+                    'one proxy at a time.';
+              } else if (permissionDenied) {
+                subtitle = 'Notifications denied. Enable in Settings → '
+                    '${Platform.isIOS ? "Notifications → WebSpace" : "WebSpace → Notifications"}.';
+              } else {
+                subtitle =
+                    'Allow this site to show system notifications. Keeps the '
+                    'site polling in the background so notifications fire even '
+                    'when you are on a different tab.';
+              }
+              return SwitchListTile(
+                title: const Text('Notifications'),
+                subtitle: Text(subtitle),
+                value: _notificationsEnabled,
+                onChanged: blocked
+                    ? null
+                    : (bool value) async {
+                        setState(() {
+                          _notificationsEnabled = value;
+                        });
+                        if (!value) return;
+                        // First-time iOS info dialog (NOTIF-005-I); idempotent
+                        // via SharedPreferences flag. Show before requesting OS
+                        // permission so the user understands the iOS limits
+                        // before tapping Allow.
+                        if (Platform.isIOS) {
+                          await maybeShowIosNotificationLimitsDialog(context);
+                        }
+                        // NOTIF-007 / 16.1: request OS permission proactively
+                        // at toggle time, not lazily on first notification.
+                        // Repeat calls after a denial are harmless (the OS
+                        // returns the cached decision).
+                        await NotificationService.instance.requestPermission();
+                      },
+              );
+            }),
           ..._buildLocationSection(),
           if (widget.onClearCookies != null)
             Padding(

--- a/lib/services/android_foreground_service.dart
+++ b/lib/services/android_foreground_service.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:webspace/services/log_service.dart';
+
+/// Dart-side bridge to [WebSpaceBackgroundPollPlugin] (Android
+/// foreground service for NOTIF-005-A). The service holds the app
+/// process alive across backgrounding so notification sites' webviews
+/// keep executing JS — Android otherwise eventually freezes the
+/// renderer once the activity is no longer visible.
+///
+/// Exposes:
+///
+///   - [start] — `startForeground(...)` with a persistent notification
+///     "WebSpace is checking N sites for updates". Idempotent: a second
+///     [start] with the same count is a no-op on the native side.
+///
+///   - [stop] — stops the service and dismisses the persistent
+///     notification. Idempotent.
+///
+/// On non-Android platforms every method is a no-op. iOS handles the
+/// equivalent via `BGAppRefreshTask`; desktop has no suspension contract.
+class AndroidForegroundService {
+  static final instance = AndroidForegroundService._();
+  AndroidForegroundService._();
+
+  static const _channel =
+      MethodChannel('org.codeberg.theoden8.webspace/background-poll');
+
+  bool _running = false;
+  int _lastCount = 0;
+
+  bool get running => _running;
+
+  Future<void> start(int siteCount) async {
+    if (!Platform.isAndroid) return;
+    if (siteCount <= 0) {
+      await stop();
+      return;
+    }
+    if (_running && siteCount == _lastCount) return;
+    try {
+      await _channel.invokeMethod('start', {'count': siteCount});
+      _running = true;
+      _lastCount = siteCount;
+      LogService.instance.log(
+        'BackgroundPoll',
+        'Android foreground service started for $siteCount site(s)',
+      );
+    } on PlatformException catch (e) {
+      LogService.instance.log(
+        'BackgroundPoll',
+        'Foreground service start failed: ${e.message}',
+        level: LogLevel.warning,
+      );
+    }
+  }
+
+  Future<void> stop() async {
+    if (!Platform.isAndroid) return;
+    if (!_running) return;
+    try {
+      await _channel.invokeMethod('stop');
+      LogService.instance.log(
+        'BackgroundPoll',
+        'Android foreground service stopped',
+      );
+    } on PlatformException catch (e) {
+      LogService.instance.log(
+        'BackgroundPoll',
+        'Foreground service stop failed: ${e.message}',
+        level: LogLevel.warning,
+      );
+    } finally {
+      _running = false;
+      _lastCount = 0;
+    }
+  }
+}

--- a/lib/services/proxy_conflict_engine.dart
+++ b/lib/services/proxy_conflict_engine.dart
@@ -1,0 +1,71 @@
+import 'package:webspace/settings/proxy.dart';
+
+/// Pure-Dart engine for the Android process-wide proxy constraint
+/// (NOTIF-005-A). `androidx.webkit.ProxyController.setProxyOverride`
+/// applies to ALL WebViews regardless of profile, so two background-poll
+/// sites with different proxies cannot run concurrently — only the
+/// most-recently-applied proxy is in effect.
+///
+/// The engine exposes two pure functions:
+///
+///   - [fingerprint] — collapses a [UserProxySettings] into a single
+///     string. Sites with identical fingerprints can run as
+///     background-poll concurrently; differing fingerprints conflict.
+///
+///   - [canEnable] — answers "can this site become a background-poll
+///     site without violating the constraint?" given the proxies of the
+///     OTHER currently-enabled sites.
+///
+/// Stays free of Flutter widgets / platform channels so it's testable in
+/// pure Dart and so [CookieIsolationEngine]-style behavior can be unit-
+/// covered without spinning up the Android channel.
+class ProxyConflictEngine {
+  /// Collapse a [UserProxySettings] into the fingerprint that
+  /// `ProxyController.setProxyOverride` actually distinguishes on. All
+  /// `DEFAULT` proxies are equivalent (no override applied); custom
+  /// proxies hash their full tuple including credentials, since
+  /// [ProxyController] differentiates them.
+  static String fingerprint(UserProxySettings p) {
+    if (p.type == ProxyType.DEFAULT) return 'default';
+    final type = p.type.toString().split('.').last;
+    final addr = p.address ?? '';
+    final user = p.username ?? '';
+    final pwd = p.password ?? '';
+    return '$type|$addr|$user|$pwd';
+  }
+
+  /// True iff the candidate site can be flipped to background-poll
+  /// without breaking the process-wide proxy constraint.
+  ///
+  /// Equivalent to: every entry in [otherEnabledProxies] has the same
+  /// fingerprint as [targetProxy]. The set of enabled fingerprints
+  /// post-toggle would have cardinality 1.
+  ///
+  /// [otherEnabledProxies] MUST exclude the target site's own proxy —
+  /// the caller owns the filter on `notificationsEnabled` AND `index !=
+  /// targetIndex`.
+  static bool canEnable({
+    required UserProxySettings targetProxy,
+    required Iterable<UserProxySettings> otherEnabledProxies,
+  }) {
+    final targetFp = fingerprint(targetProxy);
+    for (final other in otherEnabledProxies) {
+      if (fingerprint(other) != targetFp) return false;
+    }
+    return true;
+  }
+
+  /// First conflicting fingerprint, for human-readable explanatory
+  /// subtitles ("Cannot enable: another site is already polling with a
+  /// different proxy"). Returns null when [canEnable] would return true.
+  static UserProxySettings? firstConflict({
+    required UserProxySettings targetProxy,
+    required Iterable<UserProxySettings> otherEnabledProxies,
+  }) {
+    final targetFp = fingerprint(targetProxy);
+    for (final other in otherEnabledProxies) {
+      if (fingerprint(other) != targetFp) return other;
+    }
+    return null;
+  }
+}

--- a/openspec/changes/web-push-notifications/tasks.md
+++ b/openspec/changes/web-push-notifications/tasks.md
@@ -62,25 +62,25 @@
 
 ## 9. Android foreground service
 
-- [ ] 9.1 Add `POST_NOTIFICATIONS`, `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_SPECIAL_USE` permissions to `android/app/src/main/AndroidManifest.xml`.
-- [ ] 9.2 Declare a foreground service with `android:foregroundServiceType="specialUse"` in the manifest. Service class: `org.codeberg.theoden8.webspace.BackgroundPollService`.
-- [ ] 9.3 Implement `BackgroundPollService.kt` — minimal foreground service that calls `startForeground(...)` with a persistent notification (channel id `webspace_background_poll`, title "WebSpace is checking N sites for updates").
-- [ ] 9.4 Add a Dart-side wrapper `lib/services/android_foreground_service.dart` with `start(siteCount)` / `stop()` methods communicating via `MethodChannel('org.codeberg.theoden8.webspace/background-poll')`.
-- [ ] 9.5 Add a Kotlin plugin `WebSpaceBackgroundPollPlugin.kt` registered alongside existing plugins in `MainActivity.kt`. Method handlers: `start(count)` starts the service, `stop()` stops it.
+- [x] 9.1 `POST_NOTIFICATIONS` was already in [`AndroidManifest.xml`](../../../android/app/src/main/AndroidManifest.xml). Added `FOREGROUND_SERVICE` and `FOREGROUND_SERVICE_SPECIAL_USE`.
+- [x] 9.2 Declared the service with `android:foregroundServiceType="specialUse"` in the manifest, plus the required `PROPERTY_SPECIAL_USE_FGS_SUBTYPE` `<property>` describing the use case to the OS.
+- [x] 9.3 Implemented [`BackgroundPollService.kt`](../../../android/app/src/main/kotlin/org/codeberg/theoden8/webspace/BackgroundPollService.kt) — `startForeground(...)` with a low-importance, ongoing, silent notification on channel `webspace_background_poll`. Uses `ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE` on Q+. `START_NOT_STICKY` so OS-kill doesn't restart with a null intent.
+- [x] 9.4 Added [`AndroidForegroundService`](../../../lib/services/android_foreground_service.dart) — Dart wrapper around the method channel `org.codeberg.theoden8.webspace/background-poll`. `start(count)` is dedupe'd by last count; both methods are no-ops on non-Android.
+- [x] 9.5 Added [`WebSpaceBackgroundPollPlugin.kt`](../../../android/app/src/main/kotlin/org/codeberg/theoden8/webspace/WebSpaceBackgroundPollPlugin.kt) and registered it in [`MainActivity.configureFlutterEngine`](../../../android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt). The plugin starts/stops the service via `startForegroundService`; STOP routes through `onStartCommand` so `stopForeground(REMOVE)` runs and the persistent notification disappears immediately.
 - [ ] 9.6 Verify F-Droid build is clean: run `scripts/check_no_gms.sh build/app/outputs/flutter-apk/app-fdroid-release.apk` after `fvm flutter build apk --flavor fdroid --release`.
 
 ## 10. Android proxy conflict detection
 
-- [ ] 10.1 In `_WebSpacePageState`, add a method `bool _canEnableBackgroundPoll(WebViewModel target)` that returns false iff another site with `backgroundPoll == true` has a different `proxySettings`.
-- [ ] 10.2 Use `_canEnableBackgroundPoll` to gate the toggle in the per-site settings UI (task 5.2).
-- [ ] 10.3 When `_canEnableBackgroundPoll` is false, the toggle is disabled with the explanatory subtitle.
-- [ ] 10.4 Unit tests: extract the conflict detection to a pure function in `lib/services/proxy_conflict_engine.dart`. Test scenarios from NOTIF-005-A.
+- [x] 10.1 Added `_notificationsBlockedBySite(target)` in [`lib/main.dart`](../../../lib/main.dart) — wraps the engine and returns the blocking site's display name (or `null` if no conflict). Android-only.
+- [x] 10.2 Both `SettingsScreen` call sites in `main.dart` pass the result as `notificationsBlockedBySite`.
+- [x] 10.3 The Notifications `SwitchListTile` in [`lib/screens/settings.dart`](../../../lib/screens/settings.dart) renders disabled with an explanatory subtitle when blocked. Already-on toggles can still be turned off — the gate only forbids enabling.
+- [x] 10.4 Pure-Dart [`ProxyConflictEngine`](../../../lib/services/proxy_conflict_engine.dart) exposes `fingerprint`, `canEnable`, and `firstConflict`. Unit-covered by [`test/proxy_conflict_engine_test.dart`](../../../test/proxy_conflict_engine_test.dart) — all NOTIF-005-A scenarios (multiple DEFAULT, same custom proxy, SOCKS5 vs HTTP, DEFAULT vs custom, mismatched credentials).
 
 ## 11. Android background lifecycle
 
-- [ ] 11.1 In `_WebSpacePageState`, add `_updateForegroundService()` — recompute whether any background-poll site is loaded and proxy-eligible; start or stop the foreground service accordingly.
-- [ ] 11.2 Call `_updateForegroundService()` after: `_setCurrentIndex` settles, site addition/deletion, `backgroundPoll` toggle change, app pause/resume.
-- [ ] 11.3 Manual test (Android): enable `backgroundPoll` on a non-proxy site; verify the persistent notification appears. Disable; verify it disappears.
+- [x] 11.1 Added `_updateForegroundService()` in [`lib/main.dart`](../../../lib/main.dart) — counts notification sites currently in `_loadedIndices` and starts/stops the foreground service. Idempotent on the native side.
+- [x] 11.2 Called from `_handlePerSiteSettingsSaved` (toggle change), the tail of `_setCurrentIndex` (loaded-set mutations), `_deleteSite` (last notification site removed), and both branches of `didChangeAppLifecycleState` (so the service is up before the activity is hidden, and re-evaluated after a memory-pressure-driven unload during background).
+- [ ] 11.3 Manual test (Android): enable `notificationsEnabled` on a non-proxy site; verify the persistent notification appears. Disable; verify it disappears.
 
 ## 12. iOS background lifecycle
 

--- a/test/proxy_conflict_engine_test.dart
+++ b/test/proxy_conflict_engine_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webspace/services/proxy_conflict_engine.dart';
+import 'package:webspace/settings/proxy.dart';
+
+UserProxySettings _default() => UserProxySettings(type: ProxyType.DEFAULT);
+UserProxySettings _socks(String addr, {String? user, String? pwd}) =>
+    UserProxySettings(
+      type: ProxyType.SOCKS5,
+      address: addr,
+      username: user,
+      password: pwd,
+    );
+UserProxySettings _http(String addr) =>
+    UserProxySettings(type: ProxyType.HTTP, address: addr);
+
+void main() {
+  group('fingerprint', () {
+    test('all DEFAULT proxies share the same fingerprint regardless of'
+        ' stale address fields', () {
+      final a = _default();
+      final b = UserProxySettings(
+          type: ProxyType.DEFAULT, address: 'leftover:1080');
+      expect(ProxyConflictEngine.fingerprint(a),
+          ProxyConflictEngine.fingerprint(b));
+    });
+
+    test('different proxy types differ', () {
+      expect(
+        ProxyConflictEngine.fingerprint(_socks('localhost:9050')),
+        isNot(ProxyConflictEngine.fingerprint(_http('localhost:9050'))),
+      );
+    });
+
+    test('same type + same address but different credentials differ', () {
+      expect(
+        ProxyConflictEngine.fingerprint(_socks('a:1', user: 'u1')),
+        isNot(ProxyConflictEngine.fingerprint(_socks('a:1', user: 'u2'))),
+      );
+    });
+
+    test('two custom proxies with identical tuples are equal', () {
+      expect(
+        ProxyConflictEngine.fingerprint(_socks('a:1', user: 'u', pwd: 'p')),
+        ProxyConflictEngine.fingerprint(_socks('a:1', user: 'u', pwd: 'p')),
+      );
+    });
+  });
+
+  group('canEnable / firstConflict', () {
+    test('NOTIF-005-A: no other enabled sites — always true', () {
+      expect(
+        ProxyConflictEngine.canEnable(
+          targetProxy: _socks('a:1'),
+          otherEnabledProxies: const [],
+        ),
+        isTrue,
+      );
+      expect(
+        ProxyConflictEngine.firstConflict(
+          targetProxy: _socks('a:1'),
+          otherEnabledProxies: const [],
+        ),
+        isNull,
+      );
+    });
+
+    test('NOTIF-005-A scenario: multiple DEFAULT — toggle allowed', () {
+      // Site A and Site B both DEFAULT; user enables Site C (DEFAULT).
+      expect(
+        ProxyConflictEngine.canEnable(
+          targetProxy: _default(),
+          otherEnabledProxies: [_default(), _default()],
+        ),
+        isTrue,
+      );
+    });
+
+    test('NOTIF-005-A scenario: same custom SOCKS5 across sites — allowed',
+        () {
+      expect(
+        ProxyConflictEngine.canEnable(
+          targetProxy: _socks('localhost:9050'),
+          otherEnabledProxies: [_socks('localhost:9050')],
+        ),
+        isTrue,
+      );
+    });
+
+    test('NOTIF-005-A scenario: SOCKS5 conflicts with HTTP', () {
+      final blocker = _socks('localhost:9050');
+      final allowed = ProxyConflictEngine.canEnable(
+        targetProxy: _http('proxy:8080'),
+        otherEnabledProxies: [blocker],
+      );
+      expect(allowed, isFalse);
+
+      final conflict = ProxyConflictEngine.firstConflict(
+        targetProxy: _http('proxy:8080'),
+        otherEnabledProxies: [blocker],
+      );
+      expect(conflict, isNotNull);
+      expect(conflict!.type, ProxyType.SOCKS5);
+    });
+
+    test('NOTIF-005-A scenario: DEFAULT target, custom blocker — blocked', () {
+      // Site A enabled with custom proxy, user attempts to enable Site B
+      // (DEFAULT). Effective ProxyController state would flip — block.
+      expect(
+        ProxyConflictEngine.canEnable(
+          targetProxy: _default(),
+          otherEnabledProxies: [_socks('localhost:9050')],
+        ),
+        isFalse,
+      );
+    });
+
+    test('NOTIF-005-A scenario: same SOCKS host but mismatched credentials —'
+        ' blocked', () {
+      expect(
+        ProxyConflictEngine.canEnable(
+          targetProxy: _socks('a:1', user: 'alice'),
+          otherEnabledProxies: [_socks('a:1', user: 'bob')],
+        ),
+        isFalse,
+      );
+    });
+
+    test('Multiple already-enabled sites, target matches all — allowed', () {
+      expect(
+        ProxyConflictEngine.canEnable(
+          targetProxy: _socks('a:1', user: 'u', pwd: 'p'),
+          otherEnabledProxies: [
+            _socks('a:1', user: 'u', pwd: 'p'),
+            _socks('a:1', user: 'u', pwd: 'p'),
+          ],
+        ),
+        isTrue,
+      );
+    });
+
+    test('firstConflict returns the first mismatched entry, not the last',
+        () {
+      final first = _socks('a:1');
+      final second = _http('b:2');
+      final conflict = ProxyConflictEngine.firstConflict(
+        targetProxy: _default(),
+        otherEnabledProxies: [first, second],
+      );
+      expect(identical(conflict, first), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
NOTIF-005-A: foreground service keeps the app process alive while
notification sites poll in the background, plus a proxy-conflict gate
since ProxyController is process-wide on Android.

- BackgroundPollService + WebSpaceBackgroundPollPlugin with
  specialUse foregroundServiceType and an ongoing low-importance
  notification.
- ProxyConflictEngine + per-site UI gating: the toggle disables with
  an explanatory subtitle when another notification site has a
  different proxy fingerprint.
- _updateForegroundService called after _setCurrentIndex, settings
  save, deletion, and lifecycle pause/resume.