### PR TITLE
fix: make incognito sessions ephemeral across app restart (#298)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1700,8 +1700,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       // Load cookies from secure storage (keyed by siteId or legacy domain)
       final secureCookies = await _cookieSecureStorage.loadCookies();
 
-      // Load cookies into models by siteId (or migrate from domain-keyed)
+      // Load cookies into models by siteId (or migrate from domain-keyed).
+      // Incognito sites must start each launch with no cookies — even if
+      // legacy entries exist in secure storage from before the toggle was
+      // flipped on (issue #298).
       for (final webViewModel in loadedWebViewModels) {
+        if (webViewModel.incognito) continue;
         // Try siteId first (new format)
         var siteCookies = secureCookies[webViewModel.siteId];
         if (siteCookies == null || siteCookies.isEmpty) {
@@ -1793,15 +1797,28 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     // activated site. `_restoreCookiesForSite` re-nukes on every switch; this
     // extra pass covers launch before any site is activated.
     final activeSiteIdsAtStartup = _webViewModels.map((m) => m.siteId).toSet();
-    await _cookieSecureStorage.removeOrphanedCookies(activeSiteIdsAtStartup);
+    // Incognito sites are treated as orphans for any session-scoped GC
+    // (cookies, html cache, navigation state, container) so on-disk
+    // remnants don't outlive the process — see issue #298. Their config
+    // (proxy passwords, imported HTML for file:// sites) stays put.
+    final nonIncognitoSiteIds = {
+      for (final m in _webViewModels)
+        if (!m.incognito) m.siteId,
+    };
+    final incognitoSiteIds = activeSiteIdsAtStartup.difference(nonIncognitoSiteIds);
+    await _cookieSecureStorage.removeOrphanedCookies(nonIncognitoSiteIds);
     await _proxyPasswordStorage.removeOrphaned(activeSiteIdsAtStartup);
-    await HtmlCacheService.instance.removeOrphanedCaches(activeSiteIdsAtStartup);
+    await HtmlCacheService.instance.removeOrphanedCaches(nonIncognitoSiteIds);
     await HtmlImportStorage.instance.removeOrphanedImports(activeSiteIdsAtStartup);
-    await _stateStorage.removeOrphans(activeSiteIdsAtStartup);
+    await _stateStorage.removeOrphans(nonIncognitoSiteIds);
     await _cookieManager.deleteAllCookies();
     // Sweep containers whose owning site no longer exists. No-op when
     // the Container API is unsupported.
     await _containerIsolation.garbageCollectOrphans(activeSiteIdsAtStartup);
+    // Wipe containers for incognito sites — recreated empty on the
+    // next bind. Without this, localStorage/IDB/ServiceWorker/cache
+    // outlives the process and the next launch reads stale state.
+    await _containerIsolation.wipeContainers(incognitoSiteIds);
 
     // Always start at home screen on launch - only restore index if launched via shortcut
     final shortcutSiteId = await ShortcutService.getLaunchSiteId();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1826,6 +1826,17 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       shortcutSiteId: shortcutSiteId,
       models: _webViewModels,
     );
+    // A Home Shortcut represents the user's stated entry point for that
+    // site — they pinned it expecting "open google maps", not "resume
+    // wherever I last drifted to". Reset the launched site's currentUrl
+    // to its initUrl so a tapped shortcut always lands on the home URL,
+    // regardless of where the previous session ended up (issue #298).
+    if (indexToRestore != null) {
+      final m = _webViewModels[indexToRestore];
+      if (m.currentUrl != m.initUrl) {
+        m.currentUrl = m.initUrl;
+      }
+    }
 
     // Auto-load notification sites so they start polling immediately and
     // can fire notifications without waiting for the user to open them.

--- a/lib/services/container_isolation_engine.dart
+++ b/lib/services/container_isolation_engine.dart
@@ -85,4 +85,26 @@ class ContainerIsolationEngine {
     }
     return deleted;
   }
+
+  /// Deletes the named containers and recreates them empty. Used at
+  /// app startup to wipe localStorage / IndexedDB / ServiceWorker cache
+  /// / HTTP cache for incognito sites — without this, on-disk container
+  /// data outlives the process and the next launch reads back stale
+  /// session state (issue #298). Idempotent and safe before any
+  /// webview binds: containers are materialized lazily on first bind.
+  Future<int> wipeContainers(Iterable<String> siteIds) async {
+    if (!await containerNative.isSupported()) return 0;
+    int wiped = 0;
+    for (final siteId in siteIds) {
+      await containerNative.deleteContainer(siteId);
+      wiped++;
+    }
+    if (wiped > 0) {
+      LogService.instance.log(
+        'Container',
+        'Wiped $wiped incognito container(s) on startup',
+      );
+    }
+    return wiped;
+  }
 }

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -1111,10 +1111,16 @@ class WebViewModel {
   Map<String, dynamic> toJson() => {
         'siteId': siteId,
         'initUrl': initUrl,
-        'currentUrl': currentUrl,
+        // Incognito sites must not retain session state across app restarts:
+        // the currentUrl/pageTitle/cookies tuple is the user-visible session.
+        // Persisting currentUrl is what makes Google Maps reopen on the
+        // last-viewed coordinates after a kill (issue #298).
+        if (!incognito) 'currentUrl': currentUrl,
         'name': name,
-        'pageTitle': pageTitle,
-        'cookies': cookies.map((cookie) => cookie.toJson()).toList(),
+        if (!incognito) 'pageTitle': pageTitle,
+        'cookies': incognito
+            ? const <Map<String, dynamic>>[]
+            : cookies.map((cookie) => cookie.toJson()).toList(),
         'proxySettings': proxySettings.toJson(),
         'javascriptEnabled': javascriptEnabled,
         'userAgent': userAgent,
@@ -1144,21 +1150,26 @@ class WebViewModel {
       };
 
   factory WebViewModel.fromJson(Map<String, dynamic> json, Function? stateSetterF) {
+    final isIncognito = json['incognito'] as bool? ?? false;
     return WebViewModel(
       siteId: json['siteId'], // May be null for legacy data, will auto-generate
       initUrl: migrateLegacyFileImportUrl(json['initUrl'] as String),
-      currentUrl: json['currentUrl'] == null
+      // Drop persisted session state for incognito sites — handles legacy
+      // JSON written before the toJson fix (issue #298).
+      currentUrl: isIncognito || json['currentUrl'] == null
           ? null
           : migrateLegacyFileImportUrl(json['currentUrl'] as String),
       name: json['name'],
-      cookies: (json['cookies'] as List<dynamic>)
-          .map((dynamic e) => cookieFromJson(e))
-          .toList(),
+      cookies: isIncognito
+          ? const <Cookie>[]
+          : (json['cookies'] as List<dynamic>)
+              .map((dynamic e) => cookieFromJson(e))
+              .toList(),
       proxySettings: UserProxySettings.fromJson(json['proxySettings']),
       javascriptEnabled: json['javascriptEnabled'],
       userAgent: json['userAgent'],
       thirdPartyCookiesEnabled: json['thirdPartyCookiesEnabled'],
-      incognito: json['incognito'] ?? false,
+      incognito: isIncognito,
       language: json['language'],
       clearUrlEnabled: json['clearUrlEnabled'] ?? true,
       dnsBlockEnabled: json['dnsBlockEnabled'] ?? true,
@@ -1195,6 +1206,6 @@ class WebViewModel {
         orElse: () => WebRtcPolicy.defaultPolicy,
       ),
       stateSetterF: stateSetterF,
-    )..pageTitle = json['pageTitle'];
+    )..pageTitle = isIncognito ? null : json['pageTitle'];
   }
 }

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -102,6 +102,40 @@ The pinned-shortcut set is queried via `ShortcutManagerCompat.getShortcuts(FLAG_
 
 ---
 
+### Requirement: HS-006 - Shortcut Launch Resets To Home URL
+
+A pinned shortcut SHALL launch the targeted site at its `initUrl`, not at the last persisted `currentUrl`. The shortcut represents the user's stated entry point for that site (the URL they pinned), not the URL the previous session happened to drift to. Without this, location/tracking/state parameters that accumulate during a session resurface every time the shortcut is tapped — particularly visible on map and search sites that encode coordinates or query state in the URL (issue #298).
+
+This requirement applies only to **process-startup** launches (cold or post-kill). When the app is already running and the user taps a shortcut, the live in-memory session is preserved — the shortcut just brings the app to the foreground and switches to the site, matching HS-002's "App already running" scenario.
+
+#### Scenario: Cold-launch via shortcut resets to initUrl
+
+**Given** site A's `initUrl` is `https://www.google.com/maps`
+**And** the previous session ended with `currentUrl` = `https://www.google.com/maps/@40.7,-74.0,15z`
+**And** the user has force-killed the app
+**When** the user taps A's home shortcut
+**Then** the app starts up
+**And** A's webview is created with `initialUrl` = `https://www.google.com/maps`
+**And** the URL bar shows `https://www.google.com/maps`
+
+#### Scenario: Warm tap leaves running session intact
+
+**Given** the app is already running
+**And** site A's webview has navigated to `https://www.google.com/maps/@40.7,-74.0,15z`
+**When** the user taps A's home shortcut from the launcher
+**Then** the app comes to the foreground
+**And** A is selected
+**And** A's webview is at `https://www.google.com/maps/@40.7,-74.0,15z` (no reset)
+
+#### Scenario: Non-shortcut cold launch is unchanged
+
+**Given** the previous session ended with site A active at a deep `currentUrl`
+**When** the user opens WebSpace from its app icon (no shortcut intent)
+**Then** the app starts on the home screen with no site activated
+**And** if A is later opened, A's webview loads its persisted `currentUrl`
+
+---
+
 ## Implementation
 
 ### Platform Channel

--- a/openspec/specs/incognito-mode/spec.md
+++ b/openspec/specs/incognito-mode/spec.md
@@ -91,10 +91,7 @@ The session-scoped fields are: `currentUrl`, `pageTitle`, and
 
 ### Requirement: INC-004 - Session State Is Discarded On Deserialization
 
-When a `WebViewModel` is rehydrated from JSON (`fromJson`), the system
-SHALL discard any persisted session state if `incognito = true`. This
-covers JSON written by older builds (defense in depth) and JSON copied
-between devices.
+The system SHALL discard any persisted session state when a `WebViewModel` is rehydrated from JSON (`fromJson`) with `incognito = true`. This covers JSON written by older builds (defense in depth) and JSON copied between devices.
 
 #### Scenario: Legacy JSON with incognito + currentUrl
 
@@ -108,12 +105,7 @@ between devices.
 
 ### Requirement: INC-005 - Container On-Disk Data Is Wiped On Startup
 
-On the platforms where per-site native containers are used (see
-[per-site-containers](../per-site-containers/spec.md)), each
-container persists localStorage, IndexedDB, ServiceWorkers, and HTTP
-cache to disk. The system SHALL delete every incognito site's container
-during app startup, before any webview binds. The container is
-recreated empty on the next bind.
+The system SHALL delete every incognito site's native container during app startup, before any webview binds. On the platforms where per-site native containers are used (see [per-site-containers](../per-site-containers/spec.md)), each container persists localStorage, IndexedDB, ServiceWorkers, and HTTP cache to disk; the wipe is what makes those stores ephemeral. The container is recreated empty on the next bind.
 
 > **Why a wipe step is needed on top of `incognito = true`.** The fork
 > makes `incognito = true` ephemeral on Apple (`WKWebsiteDataStore.nonPersistent()`)
@@ -151,17 +143,7 @@ recreated empty on the next bind.
 
 ### Requirement: INC-006 - Encrypted Per-Site Storage Treats Incognito As Orphan
 
-The startup garbage-collection passes for session-scoped per-site
-stores SHALL treat incognito siteIds as orphaned, sweeping their
-entries even though the site itself is alive. This handles users who
-toggled an existing site to incognito after data accumulated.
-
-The session-scoped stores are: `CookieSecureStorage`,
-`HtmlCacheService`, and `WebViewStateStorage`.
-
-The non-session stores (`ProxyPasswordSecureStorage`,
-`HtmlImportStorage` for file:// imports) MUST be excluded from this
-treatment — they hold user configuration, not session data.
+The startup garbage-collection passes for session-scoped per-site stores SHALL treat incognito siteIds as orphaned, sweeping their entries even though the site itself is alive — this handles users who toggled an existing site to incognito after data accumulated. The session-scoped stores are: `CookieSecureStorage`, `HtmlCacheService`, and `WebViewStateStorage`. The non-session stores (`ProxyPasswordSecureStorage`, `HtmlImportStorage` for file:// imports) MUST be excluded from this treatment — they hold user configuration, not session data.
 
 #### Scenario: Pre-toggle cookies are swept
 

--- a/openspec/specs/incognito-mode/spec.md
+++ b/openspec/specs/incognito-mode/spec.md
@@ -1,0 +1,211 @@
+# Incognito Mode
+
+## Purpose
+
+A per-site `incognito` toggle that produces a session ephemeral to the
+process: nothing the site stores during a session — cookies,
+localStorage, IndexedDB, ServiceWorker registrations, HTTP cache, the
+last-visited URL, the last seen page title — survives an app restart.
+Configuration the user typed (init URL, custom name, proxy, language,
+location, etc.) does survive.
+
+The toggle has two effects woven into otherwise-shared code paths:
+
+1. **In-memory state stays available** while the app is alive, so a user
+   can keep using the site through tab switches, webspace switches, and
+   even an app-background → resume cycle.
+2. **On serialization to disk** and **on app restart**, the site's
+   session-scoped data is dropped so the next launch reads back nothing.
+
+The legacy [per-site cookie isolation engine](../per-site-cookie-isolation/spec.md)
+already exempts incognito sites from same-domain conflict resolution
+(ISO-005). This spec is the broader contract those exemptions live
+under.
+
+## Status
+
+- **Date**: 2026-05-04
+- **Status**: Implemented
+
+---
+
+## Requirements
+
+### Requirement: INC-001 - Cookies Are Not Captured
+
+Cookies in the shared `CookieManager` SHALL NOT be captured to a site's
+encrypted storage when that site is incognito.
+
+#### Scenario: Incognito site unloads without writing cookies
+
+**Given** an incognito site A is loaded and has accumulated session cookies in `CookieManager`
+**When** site A is unloaded (webspace switch, LRU eviction, conflict resolution)
+**Then** no cookies are written to A's siteId-keyed encrypted storage
+
+#### Scenario: Incognito site is exempt from domain conflict
+
+**Given** a regular site R and an incognito site I share the same base domain
+**When** the user activates I
+**Then** R remains loaded
+**And** I loads without triggering R's capture-nuke-restore
+
+---
+
+### Requirement: INC-002 - Navigation State Is Not Persisted
+
+The system SHALL NOT persist a webview's `saveState()` bytes (back/forward stack, scroll position, form data) for an incognito site.
+
+#### Scenario: Incognito site is unloaded
+
+**Given** an incognito site is loaded and the user has navigated several pages deep
+**When** the site is unloaded (memory pressure, LRU, manual go-home)
+**Then** no state bytes are written to encrypted state storage for the site's siteId
+
+---
+
+### Requirement: INC-003 - Session State Is Stripped On Serialization
+
+When a `WebViewModel` is serialized (`toJson`), the system SHALL omit
+fields that represent session state for incognito sites.
+
+The session-scoped fields are: `currentUrl`, `pageTitle`, and
+`cookies` (the in-memory list, distinct from the encrypted store).
+
+#### Scenario: Incognito JSON omits currentUrl
+
+**Given** an incognito `WebViewModel` whose `currentUrl` differs from `initUrl`
+**When** `toJson()` is called
+**Then** the resulting map does NOT contain a `currentUrl` key
+**And** does NOT contain a `pageTitle` key
+**And** the `cookies` list is empty regardless of the in-memory list
+
+#### Scenario: Non-incognito JSON retains session state
+
+**Given** a non-incognito `WebViewModel` with `currentUrl != initUrl` and a non-empty cookie list
+**When** `toJson()` is called
+**Then** `currentUrl` is present
+**And** `pageTitle` is present (may be null)
+**And** `cookies` reflects the in-memory list
+
+---
+
+### Requirement: INC-004 - Session State Is Discarded On Deserialization
+
+When a `WebViewModel` is rehydrated from JSON (`fromJson`), the system
+SHALL discard any persisted session state if `incognito = true`. This
+covers JSON written by older builds (defense in depth) and JSON copied
+between devices.
+
+#### Scenario: Legacy JSON with incognito + currentUrl
+
+**Given** a JSON map written by an older build with `incognito: true` and `currentUrl: "https://maps.google.com/maps/@40.7,-74.0,15z"`
+**When** `WebViewModel.fromJson(json, ...)` is called
+**Then** the resulting model's `currentUrl` equals its `initUrl`
+**And** the resulting model's `cookies` list is empty
+**And** the resulting model's `pageTitle` is null
+
+---
+
+### Requirement: INC-005 - Container On-Disk Data Is Wiped On Startup
+
+On the platforms where per-site native containers are used (see
+[per-site-containers](../per-site-containers/spec.md)), each
+container persists localStorage, IndexedDB, ServiceWorkers, and HTTP
+cache to disk. The system SHALL delete every incognito site's container
+during app startup, before any webview binds. The container is
+recreated empty on the next bind.
+
+> **Why a wipe step is needed on top of `incognito = true`.** The fork
+> makes `incognito = true` ephemeral on Apple (`WKWebsiteDataStore.nonPersistent()`)
+> and Linux (`webkit_network_session_new_ephemeral()`) by skipping the
+> container bind entirely on those platforms. On **Android System
+> WebView**, `setIncognito(true)` only clears the global `CookieManager`
+> and `WebSettings.setSavePassword/SaveFormData(false)` — the
+> `androidx.webkit.Profile` bound to the container keeps writing
+> localStorage / IndexedDB / cache / cookies to disk. Without an
+> explicit wipe, an Android incognito session leaks across app
+> restarts. The wipe is a no-op on platforms where the container was
+> never materialized, which preserves correctness without branching.
+
+#### Scenario: Incognito container is wiped on startup
+
+**Given** the previous app session left disk artifacts in the container `ws-<siteId>` for an incognito site (localStorage, IDB rows, cached resources)
+**When** the app starts and `_restoreAppState` runs
+**Then** `ContainerIsolationEngine.wipeContainers([siteId])` runs before any site activation
+**And** the on-disk container is deleted
+
+#### Scenario: Wipe is platform-aware no-op
+
+**Given** the running platform does not support the Container API (Windows, web, Android System WebView <110, iOS <17, macOS <14, WPE WebKit <2.40)
+**When** `wipeContainers([...])` runs
+**Then** it returns 0 without error
+
+#### Scenario: Non-incognito containers are preserved
+
+**Given** the user has a mix of incognito and non-incognito sites
+**When** `_restoreAppState` runs
+**Then** only the incognito sites' containers are deleted
+**And** non-incognito sites' containers (with their localStorage / IDB / cookies / SW / cache) are intact
+
+---
+
+### Requirement: INC-006 - Encrypted Per-Site Storage Treats Incognito As Orphan
+
+The startup garbage-collection passes for session-scoped per-site
+stores SHALL treat incognito siteIds as orphaned, sweeping their
+entries even though the site itself is alive. This handles users who
+toggled an existing site to incognito after data accumulated.
+
+The session-scoped stores are: `CookieSecureStorage`,
+`HtmlCacheService`, and `WebViewStateStorage`.
+
+The non-session stores (`ProxyPasswordSecureStorage`,
+`HtmlImportStorage` for file:// imports) MUST be excluded from this
+treatment — they hold user configuration, not session data.
+
+#### Scenario: Pre-toggle cookies are swept
+
+**Given** site A had cookies stored under its siteId in encrypted storage
+**And** the user has now toggled A to incognito
+**When** the app starts
+**Then** A's cookie entry is removed by the orphan sweep
+**And** A's proxy password (if any) and imported HTML (if any) remain
+
+#### Scenario: Pre-toggle navigation state is swept
+
+**Given** site A had a saved `interactionState` blob under its siteId
+**And** the user has now toggled A to incognito
+**When** the app starts
+**Then** A's state blob is removed by the orphan sweep
+
+---
+
+### Requirement: INC-007 - In-Memory State Survives App Lifecycle
+
+While the process is alive, an incognito site SHALL behave like any
+other site for the purpose of tab switches, webspace switches, and the
+foreground/background lifecycle. The "ephemeral" contract applies only
+across **process death** (app kill, OS-killed-while-backgrounded,
+forced restart).
+
+#### Scenario: Incognito state preserved across webspace switch
+
+**Given** an incognito site has navigated several pages deep
+**When** the user switches to another webspace and back
+**Then** the incognito site is at the same URL
+**And** its in-memory cookies / localStorage are intact (within the live native session)
+
+#### Scenario: Incognito state preserved across app background-resume
+
+**Given** an incognito site is loaded
+**When** the user backgrounds the app and returns within the OS retention window
+**Then** the site is at the same URL
+**And** the page state has not been wiped
+
+#### Scenario: Incognito state lost on app kill
+
+**Given** an incognito site has navigated to a deep URL and accumulated localStorage entries
+**When** the user force-kills the app and relaunches
+**Then** the site loads at its `initUrl`, not the deep URL
+**And** localStorage is empty
+**And** cookies are empty

--- a/test/container_isolation_engine_test.dart
+++ b/test/container_isolation_engine_test.dart
@@ -200,4 +200,72 @@ void main() {
       expect(native.profiles, isEmpty);
     });
   });
+
+  group('ContainerIsolationEngine — wipeContainers (incognito INC-005)', () {
+    test('deletes only the named incognito containers', () async {
+      final native = MockContainerNative();
+      final engine = ContainerIsolationEngine(containerNative: native);
+      await engine.bindForSite('regular-A');
+      await engine.bindForSite('incognito-B');
+      await engine.bindForSite('regular-C');
+
+      final wiped = await engine.wipeContainers(['incognito-B']);
+
+      expect(wiped, 1);
+      expect(native.profiles.keys, unorderedEquals(['regular-A', 'regular-C']));
+    });
+
+    test('handles multiple incognito siteIds', () async {
+      final native = MockContainerNative();
+      final engine = ContainerIsolationEngine(containerNative: native);
+      await engine.bindForSite('a');
+      await engine.bindForSite('b');
+      await engine.bindForSite('c');
+
+      final wiped = await engine.wipeContainers(['a', 'c']);
+
+      expect(wiped, 2);
+      expect(native.profiles.keys, ['b']);
+    });
+
+    test('no-op on empty input', () async {
+      final native = MockContainerNative();
+      final engine = ContainerIsolationEngine(containerNative: native);
+      await engine.bindForSite('a');
+
+      final wiped = await engine.wipeContainers(const []);
+
+      expect(wiped, 0);
+      expect(native.profiles.keys, ['a']);
+    });
+
+    test('short-circuits to 0 on unsupported platform', () async {
+      final native = MockContainerNative(supported: false);
+      final engine = ContainerIsolationEngine(containerNative: native);
+
+      final wiped = await engine.wipeContainers(['a', 'b']);
+
+      expect(wiped, 0);
+      expect(
+        native.calls.where((c) => c.startsWith('deleteContainer')).toList(),
+        isEmpty,
+        reason: 'no native delete should run when isSupported() == false',
+      );
+    });
+
+    test('passing a siteId without a container is a tolerated no-op',
+        () async {
+      // Mirrors the production `deleteContainer` contract: the native
+      // side returns false for an unknown name, the Dart side just
+      // counts the call. This covers the "user toggled incognito on a
+      // site whose container was never materialized" case.
+      final native = MockContainerNative();
+      final engine = ContainerIsolationEngine(containerNative: native);
+
+      final wiped = await engine.wipeContainers(['ghost']);
+
+      expect(wiped, 1);
+      expect(native.profiles, isEmpty);
+    });
+  });
 }

--- a/test/web_view_model_test.dart
+++ b/test/web_view_model_test.dart
@@ -386,6 +386,90 @@ void main() {
       expect(model.spoofTimezone, isNull);
       expect(model.webRtcPolicy, equals(WebRtcPolicy.defaultPolicy));
     });
+
+    group('incognito ephemerality (issue #298)', () {
+      test('toJson omits currentUrl/pageTitle and zeroes cookies (INC-003)', () {
+        final model = WebViewModel(
+          initUrl: 'https://www.google.com/maps',
+          currentUrl: 'https://www.google.com/maps/@40.7128,-74.0060,15z',
+          cookies: [Cookie(name: 'session', value: 'abc')],
+          incognito: true,
+        )..pageTitle = 'Google Maps';
+
+        final json = model.toJson();
+
+        expect(json.containsKey('currentUrl'), isFalse,
+            reason: 'currentUrl is the smoking gun: it would re-centre Maps '
+                'on the spoofed location after restart');
+        expect(json.containsKey('pageTitle'), isFalse);
+        expect(json['cookies'], isEmpty);
+        // Config the user typed must still survive a restart.
+        expect(json['initUrl'], 'https://www.google.com/maps');
+        expect(json['incognito'], isTrue);
+      });
+
+      test('non-incognito toJson keeps session state', () {
+        final model = WebViewModel(
+          initUrl: 'https://example.com',
+          currentUrl: 'https://example.com/page',
+          cookies: [Cookie(name: 'session', value: 'abc')],
+          incognito: false,
+        )..pageTitle = 'Example';
+
+        final json = model.toJson();
+
+        expect(json['currentUrl'], 'https://example.com/page');
+        expect(json['pageTitle'], 'Example');
+        expect((json['cookies'] as List), hasLength(1));
+      });
+
+      test(
+          'fromJson with incognito + legacy currentUrl/cookies discards them (INC-004)',
+          () {
+        // This is the exact shape produced by builds before the toJson
+        // fix: incognito=true, but currentUrl and cookies are persisted.
+        final json = {
+          'initUrl': 'https://www.google.com/maps',
+          'currentUrl':
+              'https://www.google.com/maps/@40.7128,-74.0060,15z',
+          'pageTitle': 'Stale Title',
+          'cookies': [
+            {'name': 'session', 'value': 'leak'}
+          ],
+          'proxySettings': {'type': 0, 'address': null},
+          'javascriptEnabled': true,
+          'userAgent': '',
+          'thirdPartyCookiesEnabled': false,
+          'incognito': true,
+        };
+
+        final model = WebViewModel.fromJson(json, null);
+
+        expect(model.currentUrl, equals(model.initUrl),
+            reason: 'incognito session must reset to initUrl on every load');
+        expect(model.cookies, isEmpty);
+        expect(model.pageTitle, isNull);
+        expect(model.incognito, isTrue);
+      });
+
+      test('round-trip from incognito: deep URL never resurfaces', () {
+        final original = WebViewModel(
+          initUrl: 'https://www.google.com/maps',
+          currentUrl: 'https://www.google.com/maps/@40.7128,-74.0060,15z',
+          cookies: [Cookie(name: 'session', value: 'abc')],
+          incognito: true,
+        )..pageTitle = 'Maps';
+
+        final restored =
+            WebViewModel.fromJson(original.toJson(), null);
+
+        expect(restored.currentUrl, equals(original.initUrl));
+        expect(restored.cookies, isEmpty);
+        expect(restored.pageTitle, isNull);
+        expect(restored.siteId, equals(original.siteId));
+        expect(restored.incognito, isTrue);
+      });
+    });
   });
 
   group('extractDomain', () {


### PR DESCRIPTION
Persisting currentUrl re-centred Google Maps on the previously-spoofed
location after a kill+relaunch even with location set back to Live, and
on Android the per-site Profile kept localStorage / IDB on disk because
the fork's setIncognito only nukes the global CookieManager.

WebViewModel now drops currentUrl, pageTitle, and the in-memory cookie
list on toJson when incognito; fromJson defends the same way against
legacy JSON. Startup wipes incognito containers and treats their
session-scoped per-site stores (cookies, html cache, state) as orphans.