### PR TITLE
test(js-shim): cover ABP batch isolation and multi-pattern text rules

### DIFF
--- a/test/js/content_blocker_shim.test.js
+++ b/test/js/content_blocker_shim.test.js
@@ -17,6 +17,7 @@ const { loadShim, makeDom, runInDom, readFixture } = require('./helpers/load_shi
 
 const EARLY_CSS = readFixture('content_blocker/early_css.js');
 const COSMETIC = readFixture('content_blocker/cosmetic.js');
+const COSMETIC_MULTI = readFixture('content_blocker/cosmetic_multi.js');
 
 // Shared HTML covering the same selectors the dumper bakes in.
 // Includes both selectors that match and ones that don't, plus a
@@ -116,3 +117,103 @@ test('cosmetic fixture: <style> tag survives MutationObserver passes', () => {
     '#_webspace_content_blocker_style');
   assert.equal(styles.length, 1);
 });
+
+// ---------- cosmetic_multi ----------
+//
+// 25 selectors -> two batches of [20, 5]. Selector index 20 is the
+// malformed `>>>invalid<<<`, so batch #2's querySelectorAll throws and
+// the per-batch try/catch must isolate the failure to that batch only.
+// Two text rules: the first OR-matches "Promoted" and "Sponsored", the
+// second is a single-pattern control.
+
+const MULTI_HTML = `<!doctype html><html><body>
+  <div class="batch1-a"></div><div class="batch1-b"></div>
+  <div class="batch1-c"></div><div class="batch1-d"></div>
+  <div class="batch1-e"></div><div class="batch1-f"></div>
+  <div class="batch1-g"></div><div class="batch1-h"></div>
+  <div class="batch1-i"></div><div class="batch1-j"></div>
+  <div class="batch1-k"></div><div class="batch1-l"></div>
+  <div class="batch1-m"></div><div class="batch1-n"></div>
+  <div class="batch1-o"></div><div class="batch1-p"></div>
+  <div class="batch1-q"></div><div class="batch1-r"></div>
+  <div class="batch1-s"></div><div class="batch1-t"></div>
+  <div class="batch2-b" id="b2b"></div>
+  <div class="batch2-c" id="b2c"></div>
+  <div class="batch2-d" id="b2d"></div>
+  <div class="batch2-e" id="b2e"></div>
+  <p class="notice" id="n-promoted">Promoted post here</p>
+  <p class="notice" id="n-sponsored">Sponsored block</p>
+  <p class="notice" id="n-clean">Regular news article</p>
+  <div class="bio" id="b-editor">Editor's note: read this.</div>
+  <div class="bio" id="b-reader">Reader response: thanks.</div>
+</body></html>`;
+
+test('cosmetic_multi: batches of 20 + 5; bad selector poisons only its batch',
+  () => {
+    const dom = makeDom({ html: MULTI_HTML });
+    runInDom(dom, COSMETIC_MULTI);
+    const doc = dom.window.document;
+    // Every batch1-* element belongs to a clean batch -> hidden.
+    const letters = 'abcdefghijklmnopqrst'.split('');
+    for (const ch of letters) {
+      const el = doc.querySelector('.batch1-' + ch);
+      assert.equal(el.style.display, 'none',
+        '.batch1-' + ch + ' must be hidden by the clean batch');
+    }
+    // Every batch2-* element shared a batch with `>>>invalid<<<`, whose
+    // syntax error makes the comma-joined selector list throw inside
+    // querySelectorAll. Per-batch try/catch absorbs it but no element
+    // in that batch gets hidden.
+    for (const id of ['b2b', 'b2c', 'b2d', 'b2e']) {
+      assert.equal(doc.getElementById(id).style.display, '',
+        '#' + id + ' must NOT be hidden — its batch was poisoned');
+    }
+  });
+
+test('cosmetic_multi: malformed selector does not throw out of the shim',
+  () => {
+    // Smoke test — if the per-batch try/catch were missing, runInDom
+    // would propagate the SyntaxError out of window.eval and fail the
+    // test before any assertion ran.
+    const dom = makeDom({ html: MULTI_HTML });
+    assert.doesNotThrow(() => runInDom(dom, COSMETIC_MULTI));
+  });
+
+test('cosmetic_multi: text rule with multiple patterns OR-matches',
+  () => {
+    const dom = makeDom({ html: MULTI_HTML });
+    runInDom(dom, COSMETIC_MULTI);
+    const doc = dom.window.document;
+    assert.equal(doc.getElementById('n-promoted').style.display, 'none',
+      'paragraph with "Promoted" must be hidden');
+    assert.equal(doc.getElementById('n-sponsored').style.display, 'none',
+      'paragraph with "Sponsored" must be hidden');
+    assert.equal(doc.getElementById('n-clean').style.display, '',
+      'paragraph matching neither pattern must stay visible');
+  });
+
+test('cosmetic_multi: a second text rule with its own selector still applies',
+  () => {
+    const dom = makeDom({ html: MULTI_HTML });
+    runInDom(dom, COSMETIC_MULTI);
+    const doc = dom.window.document;
+    assert.equal(doc.getElementById('b-editor').style.display, 'none',
+      '.bio with "Editor" must be hidden');
+    assert.equal(doc.getElementById('b-reader').style.display, '',
+      '.bio without "Editor" must stay visible');
+  });
+
+test('cosmetic_multi: MutationObserver re-applies text rules to dynamic DOM',
+  async () => {
+    const dom = makeDom({ html: '<!doctype html><html><body></body></html>' });
+    runInDom(dom, COSMETIC_MULTI);
+    const doc = dom.window.document;
+    const late = doc.createElement('p');
+    late.className = 'notice';
+    late.id = 'late-sponsored';
+    late.textContent = 'Sponsored late insertion';
+    doc.body.appendChild(late);
+    await new Promise((r) => setTimeout(r, 100));
+    assert.equal(late.style.display, 'none',
+      'MutationObserver must re-run text rules on later inserts');
+  });

--- a/test/js_fixtures/content_blocker/cosmetic_multi.js
+++ b/test/js_fixtures/content_blocker/cosmetic_multi.js
@@ -1,0 +1,47 @@
+(function() {
+  var ID = '_webspace_content_blocker_style';
+  if (!document.getElementById(ID)) {
+    var s = document.createElement('style');
+    s.id = ID;
+    s.textContent = '.batch1-a { display: none !important; } .batch1-b { display: none !important; } .batch1-c { display: none !important; } .batch1-d { display: none !important; } .batch1-e { display: none !important; } .batch1-f { display: none !important; } .batch1-g { display: none !important; } .batch1-h { display: none !important; } .batch1-i { display: none !important; } .batch1-j { display: none !important; } .batch1-k { display: none !important; } .batch1-l { display: none !important; } .batch1-m { display: none !important; } .batch1-n { display: none !important; } .batch1-o { display: none !important; } .batch1-p { display: none !important; } .batch1-q { display: none !important; } .batch1-r { display: none !important; } .batch1-s { display: none !important; } .batch1-t { display: none !important; } >>>invalid<<< { display: none !important; } .batch2-b { display: none !important; } .batch2-c { display: none !important; } .batch2-d { display: none !important; } .batch2-e { display: none !important; } ';
+    (document.head || document.documentElement).appendChild(s);
+  }
+  var BATCHES = ['.batch1-a, .batch1-b, .batch1-c, .batch1-d, .batch1-e, .batch1-f, .batch1-g, .batch1-h, .batch1-i, .batch1-j, .batch1-k, .batch1-l, .batch1-m, .batch1-n, .batch1-o, .batch1-p, .batch1-q, .batch1-r, .batch1-s, .batch1-t','>>>invalid<<<, .batch2-b, .batch2-c, .batch2-d, .batch2-e'];
+  var TEXT_RULES = [{sel:'p.notice',pats:['Promoted','Sponsored']},{sel:'div.bio',pats:['Editor']}];
+  function hideCSS() {
+    for (var i = 0; i < BATCHES.length; i++) {
+      try { document.querySelectorAll(BATCHES[i]).forEach(function(el) { el.style.display = 'none'; }); } catch(e) {}
+    }
+  }
+  function hideText() {
+    for (var i = 0; i < TEXT_RULES.length; i++) {
+      var r = TEXT_RULES[i];
+      try {
+        document.querySelectorAll(r.sel).forEach(function(el) {
+          var text = el.textContent || '';
+          for (var j = 0; j < r.pats.length; j++) {
+            if (text.indexOf(r.pats[j]) !== -1) {
+              el.style.display = 'none';
+              break;
+            }
+          }
+        });
+      } catch(e) {}
+    }
+  }
+  function hide() { hideCSS(); hideText(); }
+  hide();
+  var t = null;
+  var obs = new MutationObserver(function() {
+    if (t) clearTimeout(t);
+    t = setTimeout(hide, 50);
+  });
+  if (document.body) {
+    obs.observe(document.body, { childList: true, subtree: true });
+  } else {
+    document.addEventListener('DOMContentLoaded', function() {
+      hide();
+      if (document.body) obs.observe(document.body, { childList: true, subtree: true });
+    });
+  }
+})();

--- a/tool/dump_shim_js.dart
+++ b/tool/dump_shim_js.dart
@@ -137,6 +137,31 @@ Map<String, String> buildAllFixtures() {
     textRules: sampleTextRules,
   )!;
 
+  // Multi-batch + multi-pattern fixture for the edge cases the small
+  // sample can't reach: the shim batches selectors in groups of 20 with
+  // per-batch try/catch, so a malformed selector should poison its own
+  // batch but leave the other one working. 25 selectors -> two batches;
+  // the bad one sits at index 20 so it lands at the head of batch #2.
+  // Two text rules, the first with multiple OR-matched patterns, prove
+  // CB-005's multi-pattern semantics.
+  const multiBatchSelectors = [
+    '.batch1-a', '.batch1-b', '.batch1-c', '.batch1-d', '.batch1-e',
+    '.batch1-f', '.batch1-g', '.batch1-h', '.batch1-i', '.batch1-j',
+    '.batch1-k', '.batch1-l', '.batch1-m', '.batch1-n', '.batch1-o',
+    '.batch1-p', '.batch1-q', '.batch1-r', '.batch1-s', '.batch1-t',
+    '>>>invalid<<<',
+    '.batch2-b', '.batch2-c', '.batch2-d', '.batch2-e',
+  ];
+  const multiTextRules = <ContentBlockerTextRule>[
+    (selector: 'p.notice', patterns: ['Promoted', 'Sponsored']),
+    (selector: 'div.bio', patterns: ['Editor']),
+  ];
+  fixtures['content_blocker/cosmetic_multi.js'] =
+      buildContentBlockerCosmeticShim(
+    selectors: multiBatchSelectors,
+    textRules: multiTextRules,
+  )!;
+
   return fixtures;
 }
 


### PR DESCRIPTION
The cosmetic shim batches selectors in groups of 20 with per-batch try/catch (CB-004) and OR-matches multiple text patterns (CB-005), but neither was exercised by the single 5-selector / 1-pattern fixture. Adds a 25-selector + 2-text-rule fixture so the bad-batch-poison and multi-pattern paths get jsdom coverage.