### PR TITLE
perf(content-blocker): drop runtime CSS sweep — kill typing-lag freeze

### DIFF
--- a/integration_test/js_bridge_benchmark_test.dart
+++ b/integration_test/js_bridge_benchmark_test.dart
@@ -1,0 +1,286 @@
+// JS<->Dart bridge wall-clock bench for the content/DNS blocking hot path.
+//
+// The pure-Dart benches in test/dns_block_benchmark_test.dart and
+// test/dns_block_alternatives_benchmark_test.dart measure the in-process
+// algorithm cost only. On iOS/macOS sub-resource blocking actually
+// roundtrips through window.flutter_inappwebview.callHandler('blockCheck',
+// url) for every Bloom-positive URL. That JS->Dart->JS hop has a fixed
+// per-call floor that no in-process bench can see. This test fills the
+// gap by driving a real platform WebView and timing back-to-back
+// callHandler invocations.
+//
+// Three variants:
+//   noop          — handler returns false immediately. Establishes the
+//                   bridge floor (serialisation + IPC + reply), nothing
+//                   else.
+//   blockcheck_empty
+//                 — wires up the production blockCheck handler with
+//                   empty DNS+ABP rule sets. isBlocked() short-circuits
+//                   on _blockedDomains.isEmpty. Roughly: bridge + one
+//                   Set.isEmpty check.
+//   blockcheck_seeded
+//                 — seeds DnsBlockService with 100k synthetic domains
+//                   plus a 5k ABP set. Each iteration uses a fresh host
+//                   (no per-host cache hit) so we exercise Bloom +
+//                   suffix walk + cache insert per call.
+//
+// Each variant runs N=500 sequential awaited calls. Sequential because
+// p50/p99 per-call latency is the metric; parallel queueing would hide
+// the per-call cost behind throughput. Numbers print as
+// "p50/p90/p99/max us" plus throughput. Run on the platform you want
+// to measure — bridge cost differs between WKWebView, AndroidX WebView
+// and WPE WebKit.
+//
+// Headless Linux harness: see openspec/specs/integration-tests/spec.md.
+//
+// Usage:
+//   fvm flutter test integration_test/js_bridge_benchmark_test.dart
+//
+// Or against a connected device:
+//   fvm flutter drive \
+//     --driver=test_driver/integration_test.dart \
+//     --target=integration_test/js_bridge_benchmark_test.dart \
+//     -d <device-id>
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:webspace/services/content_blocker_service.dart';
+import 'package:webspace/services/dns_block_service.dart';
+
+const int _iterations = 500;
+
+class _Result {
+  _Result(this.label, this.samplesUs, this.totalMs);
+  final String label;
+  final List<int> samplesUs;
+  final double totalMs;
+
+  int _pct(double q) {
+    final sorted = [...samplesUs]..sort();
+    final idx = (sorted.length * q).floor().clamp(0, sorted.length - 1);
+    return sorted[idx];
+  }
+
+  @override
+  String toString() {
+    final p50 = _pct(0.50);
+    final p90 = _pct(0.90);
+    final p99 = _pct(0.99);
+    final max = (samplesUs.isEmpty
+        ? 0
+        : (samplesUs.reduce((a, b) => a > b ? a : b)));
+    final mean = samplesUs.isEmpty
+        ? 0
+        : samplesUs.reduce((a, b) => a + b) / samplesUs.length;
+    final throughput = samplesUs.isEmpty
+        ? 0
+        : (1e6 * samplesUs.length / (totalMs * 1000));
+    return '[$label] n=${samplesUs.length} '
+        'p50=${p50}us p90=${p90}us p99=${p99}us max=${max}us '
+        'mean=${mean.toStringAsFixed(1)}us '
+        'total=${totalMs.toStringAsFixed(1)}ms '
+        'thru=${throughput.toStringAsFixed(0)}/s';
+  }
+}
+
+Future<_Result> _runVariant({
+  required WidgetTester tester,
+  required String label,
+  required void Function(inapp.InAppWebViewController) installHandlers,
+  required String jsHandlerName,
+  required int iterations,
+}) async {
+  final ready = Completer<inapp.InAppWebViewController>();
+  final done = Completer<_Result>();
+  late inapp.InAppWebViewController controller;
+
+  // The JS driver lives in the page. It awaits each callHandler
+  // sequentially (Promise chain) and records (b - a) per call using
+  // performance.now(). Running the loop in JS rather than Dart keeps
+  // the measured cost equal to one bridge roundtrip; if Dart drove the
+  // loop with controller.evaluateJavascript we'd be measuring TWO
+  // roundtrips per iteration (call out, call back).
+  final html = '''
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head><body>
+<script>
+async function bench(handler, n) {
+  const samples = new Array(n);
+  // Synthetic hosts. Vary per-iteration so the production blockCheck
+  // host cache (HostFifoCache) doesn't degenerate to a hot single-key
+  // load. 6-char tail keeps URLs short to minimise serialisation cost
+  // outside the actual bridge floor.
+  const tail = 'abcdefghijklmnopqrstuvwxyz';
+  function host(i) {
+    let s = 'b';
+    let v = i;
+    for (let k = 0; k < 5; k++) { s += tail[v % 26]; v = (v / 26) | 0; }
+    return s + '.example.test';
+  }
+  const t0 = performance.now();
+  for (let i = 0; i < n; i++) {
+    const url = 'https://' + host(i) + '/r';
+    const a = performance.now();
+    await window.flutter_inappwebview.callHandler(handler, url);
+    const b = performance.now();
+    samples[i] = Math.round((b - a) * 1000); // microseconds
+  }
+  const total = performance.now() - t0;
+  await window.flutter_inappwebview.callHandler('benchDone', {
+    samples: samples,
+    totalMs: total,
+  });
+}
+window.__startBench = bench;
+</script>
+</body></html>
+''';
+
+  final widget = MaterialApp(
+    home: Scaffold(
+      body: SizedBox(
+        width: 320,
+        height: 240,
+        child: inapp.InAppWebView(
+          initialData: inapp.InAppWebViewInitialData(
+            data: html,
+            mimeType: 'text/html',
+            encoding: 'utf-8',
+            baseUrl: inapp.WebUri('about:blank'),
+          ),
+          onWebViewCreated: (c) {
+            controller = c;
+            installHandlers(c);
+            c.addJavaScriptHandler(
+              handlerName: 'benchDone',
+              callback: (args) {
+                if (done.isCompleted) return null;
+                final m = args.first as Map;
+                final raw = (m['samples'] as List).cast<num>();
+                final samples = raw.map((e) => e.toInt()).toList();
+                final totalMs = (m['totalMs'] as num).toDouble();
+                done.complete(_Result(label, samples, totalMs));
+                return null;
+              },
+            );
+          },
+          onLoadStop: (c, _) {
+            if (!ready.isCompleted) ready.complete(c);
+          },
+        ),
+      ),
+    ),
+  );
+
+  await tester.pumpWidget(widget);
+
+  // pumpAndSettle won't return while the WebView is animating frames,
+  // so drive the test with explicit pumps + a wall-clock timeout.
+  final readyDeadline = DateTime.now().add(const Duration(seconds: 30));
+  while (!ready.isCompleted && DateTime.now().isBefore(readyDeadline)) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+  expect(ready.isCompleted, true,
+      reason: 'WebView did not reach onLoadStop within 30s');
+
+  await controller.evaluateJavascript(
+    source: 'window.__startBench(${_jsString(jsHandlerName)}, $iterations);',
+  );
+
+  final benchDeadline = DateTime.now().add(const Duration(minutes: 2));
+  while (!done.isCompleted && DateTime.now().isBefore(benchDeadline)) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+  expect(done.isCompleted, true,
+      reason: 'Bench did not report results within 2min');
+
+  return done.future;
+}
+
+String _jsString(String s) {
+  final escaped = s.replaceAll(r'\', r'\\').replaceAll("'", r"\'");
+  return "'$escaped'";
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('JS bridge: noop handler floor', (tester) async {
+    final r = await _runVariant(
+      tester: tester,
+      label: 'noop',
+      iterations: _iterations,
+      installHandlers: (c) {
+        c.addJavaScriptHandler(
+          handlerName: 'noop',
+          callback: (args) => false,
+        );
+      },
+      jsHandlerName: 'noop',
+    );
+    debugPrint(r.toString());
+  });
+
+  testWidgets('JS bridge: blockCheck shape, empty rules', (tester) async {
+    DnsBlockService.instance.loadDomainsFromString('');
+    ContentBlockerService.instance.setBlockedDomainsForTest(<String>{});
+    final r = await _runVariant(
+      tester: tester,
+      label: 'blockcheck_empty',
+      iterations: _iterations,
+      installHandlers: (c) {
+        c.addJavaScriptHandler(
+          handlerName: 'blockCheck',
+          callback: (args) {
+            if (args.isEmpty || args[0] is! String) return false;
+            final url = args[0] as String;
+            if (DnsBlockService.instance.isBlocked(url)) return true;
+            if (ContentBlockerService.instance.isBlocked(url)) return true;
+            return false;
+          },
+        );
+      },
+      jsHandlerName: 'blockCheck',
+    );
+    debugPrint(r.toString());
+  });
+
+  testWidgets('JS bridge: blockCheck shape, 100k DNS + 5k ABP seeded',
+      (tester) async {
+    final dnsBuf = StringBuffer();
+    for (var i = 0; i < 100000; i++) {
+      dnsBuf.writeln('seed-$i.tracker.test');
+    }
+    DnsBlockService.instance.loadDomainsFromString(dnsBuf.toString());
+
+    final abp = <String>{};
+    for (var i = 0; i < 5000; i++) {
+      abp.add('ad-$i.adnet.test');
+    }
+    ContentBlockerService.instance.setBlockedDomainsForTest(abp);
+
+    final r = await _runVariant(
+      tester: tester,
+      label: 'blockcheck_seeded',
+      iterations: _iterations,
+      installHandlers: (c) {
+        c.addJavaScriptHandler(
+          handlerName: 'blockCheck',
+          callback: (args) {
+            if (args.isEmpty || args[0] is! String) return false;
+            final url = args[0] as String;
+            if (DnsBlockService.instance.isBlocked(url)) return true;
+            if (ContentBlockerService.instance.isBlocked(url)) return true;
+            return false;
+          },
+        );
+      },
+      jsHandlerName: 'blockCheck',
+    );
+    debugPrint(r.toString());
+  });
+}

--- a/lib/services/content_blocker_shim.dart
+++ b/lib/services/content_blocker_shim.dart
@@ -82,42 +82,107 @@ String? buildContentBlockerCosmeticShim({
   }
   var BATCHES = [$batchArray];
   var TEXT_RULES = $textRulesJs;
-  function hideCSS() {
+
+  // Per-batch try/catch isolates a malformed selector to its own batch.
+  // `root` is either `document` (one-shot install sweep) or a freshly
+  // added subtree (mutation handler). When it's an Element we also
+  // test the root itself — `querySelectorAll` only walks descendants.
+  function applyCss(root) {
+    var rootIsEl = root.nodeType === 1;
     for (var i = 0; i < BATCHES.length; i++) {
-      try { document.querySelectorAll(BATCHES[i]).forEach(function(el) { el.style.display = 'none'; }); } catch(e) {}
-    }
-  }
-  function hideText() {
-    for (var i = 0; i < TEXT_RULES.length; i++) {
-      var r = TEXT_RULES[i];
+      var b = BATCHES[i];
       try {
-        document.querySelectorAll(r.sel).forEach(function(el) {
-          var text = el.textContent || '';
-          for (var j = 0; j < r.pats.length; j++) {
-            if (text.indexOf(r.pats[j]) !== -1) {
-              el.style.display = 'none';
-              break;
-            }
-          }
-        });
+        if (rootIsEl && root.matches(b)) root.style.display = 'none';
+        var els = root.querySelectorAll(b);
+        for (var j = 0; j < els.length; j++) els[j].style.display = 'none';
       } catch(e) {}
     }
   }
-  function hide() { hideCSS(); hideText(); }
-  hide();
-  var t = null;
-  var obs = new MutationObserver(function() {
-    if (t) clearTimeout(t);
-    t = setTimeout(hide, 50);
-  });
-  if (document.body) {
-    obs.observe(document.body, { childList: true, subtree: true });
-  } else {
-    document.addEventListener('DOMContentLoaded', function() {
-      hide();
-      if (document.body) obs.observe(document.body, { childList: true, subtree: true });
-    });
+  function applyText(root) {
+    var rootIsEl = root.nodeType === 1;
+    for (var i = 0; i < TEXT_RULES.length; i++) {
+      var r = TEXT_RULES[i];
+      try {
+        if (rootIsEl && root.matches(r.sel)) {
+          var t0 = root.textContent || '';
+          for (var p0 = 0; p0 < r.pats.length; p0++) {
+            if (t0.indexOf(r.pats[p0]) !== -1) { root.style.display = 'none'; break; }
+          }
+        }
+        var els = root.querySelectorAll(r.sel);
+        for (var j = 0; j < els.length; j++) {
+          var el = els[j];
+          var t = el.textContent || '';
+          for (var p = 0; p < r.pats.length; p++) {
+            if (t.indexOf(r.pats[p]) !== -1) { el.style.display = 'none'; break; }
+          }
+        }
+      } catch(e) {}
+    }
   }
+  // Skip subtrees inside [contenteditable=true]. Typing in editors
+  // generates DOM churn that the cosmetic shim cannot usefully act on
+  // and which dominated keystroke wall-clock when the runtime sweep
+  // re-queried the whole document.
+  function isInsideEditable(el) {
+    var n = el;
+    while (n && n.nodeType === 1) {
+      if (n.isContentEditable === true) return true;
+      if (n.getAttribute) {
+        var ce = n.getAttribute('contenteditable');
+        if (ce === '' || ce === 'true' || ce === 'plaintext-only') return true;
+      }
+      n = n.parentNode;
+    }
+    return false;
+  }
+  function applyBoth(root) {
+    if (root.nodeType === 1 && isInsideEditable(root)) return;
+    applyCss(root);
+    applyText(root);
+  }
+
+  // One full-document sweep at install. Subsequent work is scoped to
+  // added subtrees only — pre-2026 the runtime sweep re-queried the
+  // whole document on every mutation burst, which on a 1.7k-element
+  // discussion page with 13.6k EasyList selectors cost seconds per
+  // typing pause.
+  applyCss(document);
+  applyText(document);
+
+  var pending = [];
+  var t = null;
+  function flush() {
+    t = null;
+    var roots = pending;
+    pending = [];
+    for (var i = 0; i < roots.length; i++) {
+      if (roots[i].isConnected) applyBoth(roots[i]);
+    }
+  }
+  function startObserving() {
+    if (!document.body) {
+      document.addEventListener('DOMContentLoaded', startObserving);
+      return;
+    }
+    var obs = new MutationObserver(function(mutations) {
+      var added = false;
+      for (var m = 0; m < mutations.length; m++) {
+        var nodes = mutations[m].addedNodes;
+        for (var n = 0; n < nodes.length; n++) {
+          var node = nodes[n];
+          if (node.nodeType !== 1) continue;
+          pending.push(node);
+          added = true;
+        }
+      }
+      if (!added) return;
+      if (t != null) clearTimeout(t);
+      t = setTimeout(flush, 50);
+    });
+    obs.observe(document.body, { childList: true, subtree: true });
+  }
+  startObserving();
 })();
 ''';
 }

--- a/lib/services/content_blocker_shim.dart
+++ b/lib/services/content_blocker_shim.dart
@@ -38,28 +38,26 @@ String? buildContentBlockerEarlyCssShim(List<String> selectors) {
 ''';
 }
 
-/// Build the post-load cosmetic shim — the early CSS tag, plus
-/// runtime querySelectorAll passes (batched to survive a single bad
-/// selector), plus a MutationObserver that re-runs both passes on DOM
-/// changes. Returns `null` when both [selectors] and [textRules] are
-/// empty.
+/// Build the post-load cosmetic shim — the early CSS `<style>` tag
+/// (handles every selector-based hide via the browser's CSS engine,
+/// including dynamically-added or class-flipped elements) plus a
+/// debounced MutationObserver running text-content rules (CSS can't
+/// match on text content, so those need JS). Returns `null` when both
+/// [selectors] and [textRules] are empty.
+///
+/// Equivalence with the previous shape (which also ran a runtime
+/// `querySelectorAll` sweep writing inline `style.display = 'none'`
+/// for selector matches) is asserted in
+/// `test/js/content_blocker_shim_equivalence.test.js` and
+/// `test/browser/content_blocker_shim_equivalence.test.js` —
+/// computed-style is identical for every selector match the old
+/// shape covered.
 String? buildContentBlockerCosmeticShim({
   required List<String> selectors,
   required List<ContentBlockerTextRule> textRules,
 }) {
   if (selectors.isEmpty && textRules.isEmpty) return null;
   final cssText = _buildCssText(selectors);
-
-  // Batch selectors so a single malformed entry only blocks its
-  // batch, not every other selector. 20 per batch matches what
-  // ContentBlockerService used historically.
-  final escaped = selectors.map(_escapeForJsString).toList();
-  final batches = <String>[];
-  for (var i = 0; i < escaped.length; i += 20) {
-    final end = (i + 20 < escaped.length) ? i + 20 : escaped.length;
-    batches.add(escaped.sublist(i, end).join(', '));
-  }
-  final batchArray = batches.map((b) => "'$b'").join(',');
 
   final textRulesJs = StringBuffer('[');
   for (var i = 0; i < textRules.length; i++) {
@@ -80,13 +78,19 @@ String? buildContentBlockerCosmeticShim({
     s.textContent = '$cssText';
     (document.head || document.documentElement).appendChild(s);
   }
-  var BATCHES = [$batchArray];
+  // Selector-based hiding is handled entirely by the early <style>
+  // tag above. The browser's CSS engine matches the rules (with
+  // !important) against every element, present and future, with no
+  // JS work — including elements that LATER gain a matching class or
+  // attribute (something the prior runtime querySelectorAll sweep
+  // could not catch since it only observed childList mutations).
+  // Equivalence asserted via test/js/content_blocker_shim_equivalence.test.js
+  // and test/browser/content_blocker_shim_equivalence.test.js.
+  //
+  // Text-content rules (#?# / :-abp-contains) cannot be expressed in
+  // CSS, so they keep a debounced MutationObserver that re-runs the
+  // text scan on DOM bursts.
   var TEXT_RULES = $textRulesJs;
-  function hideCSS() {
-    for (var i = 0; i < BATCHES.length; i++) {
-      try { document.querySelectorAll(BATCHES[i]).forEach(function(el) { el.style.display = 'none'; }); } catch(e) {}
-    }
-  }
   function hideText() {
     for (var i = 0; i < TEXT_RULES.length; i++) {
       var r = TEXT_RULES[i];
@@ -103,20 +107,21 @@ String? buildContentBlockerCosmeticShim({
       } catch(e) {}
     }
   }
-  function hide() { hideCSS(); hideText(); }
-  hide();
-  var t = null;
-  var obs = new MutationObserver(function() {
-    if (t) clearTimeout(t);
-    t = setTimeout(hide, 50);
-  });
-  if (document.body) {
-    obs.observe(document.body, { childList: true, subtree: true });
-  } else {
-    document.addEventListener('DOMContentLoaded', function() {
-      hide();
-      if (document.body) obs.observe(document.body, { childList: true, subtree: true });
+  hideText();
+  if (TEXT_RULES.length > 0) {
+    var t = null;
+    var obs = new MutationObserver(function() {
+      if (t) clearTimeout(t);
+      t = setTimeout(hideText, 50);
     });
+    if (document.body) {
+      obs.observe(document.body, { childList: true, subtree: true });
+    } else {
+      document.addEventListener('DOMContentLoaded', function() {
+        hideText();
+        if (document.body) obs.observe(document.body, { childList: true, subtree: true });
+      });
+    }
   }
 })();
 ''';

--- a/lib/services/content_blocker_shim.dart
+++ b/lib/services/content_blocker_shim.dart
@@ -82,107 +82,42 @@ String? buildContentBlockerCosmeticShim({
   }
   var BATCHES = [$batchArray];
   var TEXT_RULES = $textRulesJs;
-
-  // Per-batch try/catch isolates a malformed selector to its own batch.
-  // `root` is either `document` (one-shot install sweep) or a freshly
-  // added subtree (mutation handler). When it's an Element we also
-  // test the root itself — `querySelectorAll` only walks descendants.
-  function applyCss(root) {
-    var rootIsEl = root.nodeType === 1;
+  function hideCSS() {
     for (var i = 0; i < BATCHES.length; i++) {
-      var b = BATCHES[i];
-      try {
-        if (rootIsEl && root.matches(b)) root.style.display = 'none';
-        var els = root.querySelectorAll(b);
-        for (var j = 0; j < els.length; j++) els[j].style.display = 'none';
-      } catch(e) {}
+      try { document.querySelectorAll(BATCHES[i]).forEach(function(el) { el.style.display = 'none'; }); } catch(e) {}
     }
   }
-  function applyText(root) {
-    var rootIsEl = root.nodeType === 1;
+  function hideText() {
     for (var i = 0; i < TEXT_RULES.length; i++) {
       var r = TEXT_RULES[i];
       try {
-        if (rootIsEl && root.matches(r.sel)) {
-          var t0 = root.textContent || '';
-          for (var p0 = 0; p0 < r.pats.length; p0++) {
-            if (t0.indexOf(r.pats[p0]) !== -1) { root.style.display = 'none'; break; }
+        document.querySelectorAll(r.sel).forEach(function(el) {
+          var text = el.textContent || '';
+          for (var j = 0; j < r.pats.length; j++) {
+            if (text.indexOf(r.pats[j]) !== -1) {
+              el.style.display = 'none';
+              break;
+            }
           }
-        }
-        var els = root.querySelectorAll(r.sel);
-        for (var j = 0; j < els.length; j++) {
-          var el = els[j];
-          var t = el.textContent || '';
-          for (var p = 0; p < r.pats.length; p++) {
-            if (t.indexOf(r.pats[p]) !== -1) { el.style.display = 'none'; break; }
-          }
-        }
+        });
       } catch(e) {}
     }
   }
-  // Skip subtrees inside [contenteditable=true]. Typing in editors
-  // generates DOM churn that the cosmetic shim cannot usefully act on
-  // and which dominated keystroke wall-clock when the runtime sweep
-  // re-queried the whole document.
-  function isInsideEditable(el) {
-    var n = el;
-    while (n && n.nodeType === 1) {
-      if (n.isContentEditable === true) return true;
-      if (n.getAttribute) {
-        var ce = n.getAttribute('contenteditable');
-        if (ce === '' || ce === 'true' || ce === 'plaintext-only') return true;
-      }
-      n = n.parentNode;
-    }
-    return false;
-  }
-  function applyBoth(root) {
-    if (root.nodeType === 1 && isInsideEditable(root)) return;
-    applyCss(root);
-    applyText(root);
-  }
-
-  // One full-document sweep at install. Subsequent work is scoped to
-  // added subtrees only — pre-2026 the runtime sweep re-queried the
-  // whole document on every mutation burst, which on a 1.7k-element
-  // discussion page with 13.6k EasyList selectors cost seconds per
-  // typing pause.
-  applyCss(document);
-  applyText(document);
-
-  var pending = [];
+  function hide() { hideCSS(); hideText(); }
+  hide();
   var t = null;
-  function flush() {
-    t = null;
-    var roots = pending;
-    pending = [];
-    for (var i = 0; i < roots.length; i++) {
-      if (roots[i].isConnected) applyBoth(roots[i]);
-    }
-  }
-  function startObserving() {
-    if (!document.body) {
-      document.addEventListener('DOMContentLoaded', startObserving);
-      return;
-    }
-    var obs = new MutationObserver(function(mutations) {
-      var added = false;
-      for (var m = 0; m < mutations.length; m++) {
-        var nodes = mutations[m].addedNodes;
-        for (var n = 0; n < nodes.length; n++) {
-          var node = nodes[n];
-          if (node.nodeType !== 1) continue;
-          pending.push(node);
-          added = true;
-        }
-      }
-      if (!added) return;
-      if (t != null) clearTimeout(t);
-      t = setTimeout(flush, 50);
-    });
+  var obs = new MutationObserver(function() {
+    if (t) clearTimeout(t);
+    t = setTimeout(hide, 50);
+  });
+  if (document.body) {
     obs.observe(document.body, { childList: true, subtree: true });
+  } else {
+    document.addEventListener('DOMContentLoaded', function() {
+      hide();
+      if (document.body) obs.observe(document.body, { childList: true, subtree: true });
+    });
   }
-  startObserving();
 })();
 ''';
 }

--- a/test/browser/content_blocker_shim_equivalence.test.js
+++ b/test/browser/content_blocker_shim_equivalence.test.js
@@ -257,9 +257,9 @@ test('tier-2 equivalence: text-content rules agree in both shapes',
       'sanity: clean paragraph must remain visible');
   });
 
-// ---------- known non-equivalence ----------
+// ---------- inline-style invariant ----------
 
-test('tier-2 NON-equivalence: inline el.style.display differs (rendering same)',
+test('tier-2: inline el.style.display empty for selector matches in both shapes',
   async (t) => {
     if (!requireBrowser(browser, t)) return;
     async function snap(shim) {
@@ -279,16 +279,17 @@ test('tier-2 NON-equivalence: inline el.style.display differs (rendering same)',
     }
     const a = await snap(COSMETIC);
     const b = await snap(COSMETIC_CSS_ONLY);
-    // Computed style (what affects rendering) MUST agree.
+    // Computed style — what affects rendering — MUST agree.
     assert.equal(a.computed, b.computed,
       `computed-display must match: current=${a.computed} ` +
       `css-only=${b.computed}`);
     assert.equal(a.computed, 'none', 'sanity');
-    // Inline style differs by design — current writes 'none', css-only
-    // doesn't. Asserted so any future change that re-introduces the
-    // inline write must be deliberate.
-    assert.equal(a.inline, 'none',
-      'current shim writes inline style for selector matches');
+    // Neither shape writes inline style for selector matches now (the
+    // pre-2026 runtime sweep that wrote `el.style.display = 'none'`
+    // was dropped). Locked in here so any future change that re-
+    // introduces the inline write must be deliberate.
+    assert.equal(a.inline, '',
+      'shipped shim does not write inline style for selector matches');
     assert.equal(b.inline, '',
-      'css-only does NOT write inline style for selector matches');
+      'reference shim does not write inline style for selector matches');
   });

--- a/test/browser/content_blocker_shim_equivalence.test.js
+++ b/test/browser/content_blocker_shim_equivalence.test.js
@@ -1,0 +1,294 @@
+// Tier 2 — real-Chromium equivalence proof for the proposed CSS-only
+// cosmetic shim. Companion to test/js/content_blocker_shim_equivalence.test.js
+// (jsdom). The jsdom layer asserts equivalence in the CSS engine
+// jsdom can model; this layer asserts it under a real engine, where
+// CSS specificity, !important precedence, MutationObserver timing,
+// and stylesheet-level matching all behave to spec.
+//
+// What this proves: dropping the runtime cosmetic-CSS sweep from
+// `lib/services/content_blocker_shim.dart` does NOT change the
+// observable computed-style of any element on a representative page
+// — including dynamically-added matches and class-flipped matches.
+// The user-visible privacy posture is identical for selector-based
+// rules. Inline `el.style.display` differs (the css-only shape never
+// writes inline style for selector matches), but rendering is the
+// same; that is asserted via `getComputedStyle`.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const {
+  setupBrowser, requireBrowser, readFixture,
+} = require('./helpers/launch');
+
+const COSMETIC = readFixture('content_blocker/cosmetic.js');
+
+// Same CSS-only shim shape as the tier-1 test. Inlined here so this
+// file is self-contained and the contract under test is visible.
+const COSMETIC_CSS_ONLY = `
+(function() {
+  var ID = '_webspace_content_blocker_style';
+  if (!document.getElementById(ID)) {
+    var s = document.createElement('style');
+    s.id = ID;
+    s.textContent =
+      '.ad-banner { display: none !important; } ' +
+      '.sponsored { display: none !important; } ' +
+      '#sidebar-ad { display: none !important; } ' +
+      '[data-ad-slot] { display: none !important; } ' +
+      'a[href*="track."] { display: none !important; } ';
+    (document.head || document.documentElement).appendChild(s);
+  }
+  var TEXT_RULES = [{sel:'div.article > p', pats:['Sponsored content']}];
+  function hideText() {
+    for (var i = 0; i < TEXT_RULES.length; i++) {
+      var r = TEXT_RULES[i];
+      try {
+        document.querySelectorAll(r.sel).forEach(function(el) {
+          var text = el.textContent || '';
+          for (var j = 0; j < r.pats.length; j++) {
+            if (text.indexOf(r.pats[j]) !== -1) {
+              el.style.display = 'none';
+              break;
+            }
+          }
+        });
+      } catch (e) {}
+    }
+  }
+  hideText();
+  var t = null;
+  var obs = new MutationObserver(function() {
+    if (t) clearTimeout(t);
+    t = setTimeout(hideText, 50);
+  });
+  if (document.body) {
+    obs.observe(document.body, { childList: true, subtree: true });
+  } else {
+    document.addEventListener('DOMContentLoaded', function() {
+      hideText();
+      obs.observe(document.body, { childList: true, subtree: true });
+    });
+  }
+})();
+`;
+
+const browser = setupBrowser();
+
+// Page deliberately ships its OWN stylesheet that says
+// `.ad-banner { display: block }` etc., so we exercise the !important
+// override on a real CSS engine. Without `!important` the early CSS
+// would silently lose to the page rule.
+const HOST_HTML = `<!doctype html><html><head>
+<style>
+  .ad-banner { display: block; }
+  .sponsored { display: block; }
+  #sidebar-ad { display: block; }
+  [data-ad-slot] { display: block; }
+  a[href*="track."] { display: inline; }
+</style></head><body>
+  <div class="ad-banner" id="ad1">ad</div>
+  <div class="sponsored" id="sp1">sponsored block</div>
+  <div id="sidebar-ad">sidebar</div>
+  <div data-ad-slot="123" id="slot">slot</div>
+  <a href="https://track.example.com/x" id="trk">tracker</a>
+  <div class="article">
+    <p id="text-match">Sponsored content here</p>
+    <p id="text-no-match">Real article body</p>
+  </div>
+  <p id="keep">unrelated</p>
+</body></html>`;
+
+const SELECTOR_IDS =
+  ['ad1', 'sp1', 'sidebar-ad', 'slot', 'trk', 'keep', 'text-no-match'];
+
+function startHost() {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(HOST_HTML);
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({
+        url: `http://127.0.0.1:${port}/`,
+        close: () => new Promise((r) => server.close(r)),
+      });
+    });
+  });
+}
+
+// Run the shim post-load (same workaround as content_blocker_real.test.js)
+// so document.head exists when the <style> tag is appended.
+async function snapshotComputedAfterShim(shim, mutate) {
+  const server = await startHost();
+  const page = await browser.browser.newPage();
+  try {
+    await page.goto(server.url, { waitUntil: 'load' });
+    await page.evaluate(shim);
+    if (mutate) await mutate(page);
+    return await page.evaluate((ids) => {
+      const out = {};
+      for (const id of ids) {
+        const el = document.getElementById(id);
+        out[id] = el == null ? '<missing>' : getComputedStyle(el).display;
+      }
+      return out;
+    }, SELECTOR_IDS);
+  } finally {
+    await page.close();
+    await server.close();
+  }
+}
+
+// ---------- existing-DOM equivalence ----------
+
+test('tier-2 equivalence: static DOM, both shapes agree on getComputedStyle',
+  async (t) => {
+    if (!requireBrowser(browser, t)) return;
+    const a = await snapshotComputedAfterShim(COSMETIC);
+    const b = await snapshotComputedAfterShim(COSMETIC_CSS_ONLY);
+    assert.deepEqual(b, a,
+      `Real-engine: CSS-only must match current shim per-id. ` +
+      `current=${JSON.stringify(a)} css-only=${JSON.stringify(b)}`);
+    // Sanity — both must hide the targets in the face of the page's
+    // competing display:block, otherwise the test is asserting
+    // matching FAILURES.
+    assert.equal(a.ad1, 'none', 'sanity: !important must beat page rule');
+    assert.notEqual(a.keep, 'none', 'sanity: unrelated stays visible');
+  });
+
+// ---------- dynamically-added matches ----------
+
+test('tier-2 equivalence: late-added .ad-banner agrees in both shapes',
+  async (t) => {
+    if (!requireBrowser(browser, t)) return;
+    async function lateAdd(shim) {
+      const server = await startHost();
+      const page = await browser.browser.newPage();
+      try {
+        await page.goto(server.url, { waitUntil: 'load' });
+        await page.evaluate(shim);
+        return await page.evaluate(async () => {
+          const newAd = document.createElement('div');
+          newAd.className = 'ad-banner';
+          newAd.id = 'late-ad';
+          newAd.textContent = 'late';
+          document.body.appendChild(newAd);
+          // Allow time for any debounced sweep to settle.
+          await new Promise((r) => setTimeout(r, 150));
+          return getComputedStyle(newAd).display;
+        });
+      } finally {
+        await page.close();
+        await server.close();
+      }
+    }
+    const a = await lateAdd(COSMETIC);
+    const b = await lateAdd(COSMETIC_CSS_ONLY);
+    assert.equal(a, b,
+      `late-added .ad-banner: current=${a} css-only=${b}`);
+    assert.equal(a, 'none', 'both must hide the late-added ad');
+  });
+
+// ---------- class added LATER (CSS-engine re-match required) ----------
+
+test('tier-2 equivalence: class flip from no-match to .ad-banner agrees',
+  async (t) => {
+    if (!requireBrowser(browser, t)) return;
+    async function flip(shim) {
+      const server = await startHost();
+      const page = await browser.browser.newPage();
+      try {
+        await page.goto(server.url, { waitUntil: 'load' });
+        await page.evaluate(shim);
+        return await page.evaluate(async () => {
+          // #keep starts as a no-match. Flip its class to .ad-banner —
+          // CSS engine re-matches automatically; current shim's
+          // MutationObserver only watches childList (NOT attributes),
+          // so its runtime sweep would NOT see the change. The test
+          // confirms that, given CSS-engine-driven matching, both
+          // shapes converge.
+          const k = document.getElementById('keep');
+          k.className = 'ad-banner';
+          await new Promise((r) => setTimeout(r, 150));
+          return getComputedStyle(k).display;
+        });
+      } finally {
+        await page.close();
+        await server.close();
+      }
+    }
+    const a = await flip(COSMETIC);
+    const b = await flip(COSMETIC_CSS_ONLY);
+    assert.equal(a, b,
+      `class flip: current=${a} css-only=${b}`);
+    assert.equal(a, 'none',
+      'CSS engine must hide #keep after it gains .ad-banner');
+  });
+
+// ---------- text rules ----------
+
+test('tier-2 equivalence: text-content rules agree in both shapes',
+  async (t) => {
+    if (!requireBrowser(browser, t)) return;
+    async function snap(shim) {
+      const server = await startHost();
+      const page = await browser.browser.newPage();
+      try {
+        await page.goto(server.url, { waitUntil: 'load' });
+        await page.evaluate(shim);
+        return await page.evaluate(() => ({
+          match: getComputedStyle(document.getElementById('text-match')).display,
+          nomatch: getComputedStyle(document.getElementById('text-no-match')).display,
+        }));
+      } finally {
+        await page.close();
+        await server.close();
+      }
+    }
+    const a = await snap(COSMETIC);
+    const b = await snap(COSMETIC_CSS_ONLY);
+    assert.deepEqual(b, a, `text rules: current=${JSON.stringify(a)} ` +
+      `css-only=${JSON.stringify(b)}`);
+    assert.equal(a.match, 'none',
+      'sanity: paragraph with "Sponsored content" must be hidden');
+    assert.notEqual(a.nomatch, 'none',
+      'sanity: clean paragraph must remain visible');
+  });
+
+// ---------- known non-equivalence ----------
+
+test('tier-2 NON-equivalence: inline el.style.display differs (rendering same)',
+  async (t) => {
+    if (!requireBrowser(browser, t)) return;
+    async function snap(shim) {
+      const server = await startHost();
+      const page = await browser.browser.newPage();
+      try {
+        await page.goto(server.url, { waitUntil: 'load' });
+        await page.evaluate(shim);
+        return await page.evaluate(() => ({
+          inline: document.getElementById('ad1').style.display,
+          computed: getComputedStyle(document.getElementById('ad1')).display,
+        }));
+      } finally {
+        await page.close();
+        await server.close();
+      }
+    }
+    const a = await snap(COSMETIC);
+    const b = await snap(COSMETIC_CSS_ONLY);
+    // Computed style (what affects rendering) MUST agree.
+    assert.equal(a.computed, b.computed,
+      `computed-display must match: current=${a.computed} ` +
+      `css-only=${b.computed}`);
+    assert.equal(a.computed, 'none', 'sanity');
+    // Inline style differs by design — current writes 'none', css-only
+    // doesn't. Asserted so any future change that re-introduces the
+    // inline write must be deliberate.
+    assert.equal(a.inline, 'none',
+      'current shim writes inline style for selector matches');
+    assert.equal(b.inline, '',
+      'css-only does NOT write inline style for selector matches');
+  });

--- a/test/js/content_blocker_shim.test.js
+++ b/test/js/content_blocker_shim.test.js
@@ -217,3 +217,33 @@ test('cosmetic_multi: MutationObserver re-applies text rules to dynamic DOM',
     assert.equal(late.style.display, 'none',
       'MutationObserver must re-run text rules on later inserts');
   });
+
+// Cosmetic shim must not sweep nodes added inside [contenteditable].
+// Editor pages (github / gmail) churn the composer subtree on every
+// keystroke. The pre-2026 shim re-queried the whole document on each
+// burst and dominated keystroke wall-clock at scale; the current shape
+// scopes work to added subtrees and bails out when any ancestor is
+// contenteditable.
+test('cosmetic fixture: skips subtrees inside [contenteditable=true]',
+  async () => {
+    const dom = makeDom({
+      html: '<!doctype html><html><body>' +
+        '<div id="composer" contenteditable="true"></div>' +
+        '</body></html>',
+    });
+    runInDom(dom, COSMETIC);
+    const doc = dom.window.document;
+    // Insert an ad-banner-classed element INSIDE the composer. The
+    // global early-CSS still applies (display:none !important via the
+    // <style> tag) but the runtime sweep must NOT touch inline style —
+    // that's the signal the shim correctly bailed out before running
+    // querySelectorAll on the composer subtree.
+    const composer = doc.getElementById('composer');
+    const inside = doc.createElement('div');
+    inside.className = 'ad-banner';
+    inside.id = 'inside-editable';
+    composer.appendChild(inside);
+    await new Promise((r) => setTimeout(r, 100));
+    assert.equal(inside.style.display, '',
+      'runtime sweep must not write inline style inside contenteditable');
+  });

--- a/test/js/content_blocker_shim.test.js
+++ b/test/js/content_blocker_shim.test.js
@@ -217,33 +217,3 @@ test('cosmetic_multi: MutationObserver re-applies text rules to dynamic DOM',
     assert.equal(late.style.display, 'none',
       'MutationObserver must re-run text rules on later inserts');
   });
-
-// Cosmetic shim must not sweep nodes added inside [contenteditable].
-// Editor pages (github / gmail) churn the composer subtree on every
-// keystroke. The pre-2026 shim re-queried the whole document on each
-// burst and dominated keystroke wall-clock at scale; the current shape
-// scopes work to added subtrees and bails out when any ancestor is
-// contenteditable.
-test('cosmetic fixture: skips subtrees inside [contenteditable=true]',
-  async () => {
-    const dom = makeDom({
-      html: '<!doctype html><html><body>' +
-        '<div id="composer" contenteditable="true"></div>' +
-        '</body></html>',
-    });
-    runInDom(dom, COSMETIC);
-    const doc = dom.window.document;
-    // Insert an ad-banner-classed element INSIDE the composer. The
-    // global early-CSS still applies (display:none !important via the
-    // <style> tag) but the runtime sweep must NOT touch inline style —
-    // that's the signal the shim correctly bailed out before running
-    // querySelectorAll on the composer subtree.
-    const composer = doc.getElementById('composer');
-    const inside = doc.createElement('div');
-    inside.className = 'ad-banner';
-    inside.id = 'inside-editable';
-    composer.appendChild(inside);
-    await new Promise((r) => setTimeout(r, 100));
-    assert.equal(inside.style.display, '',
-      'runtime sweep must not write inline style inside contenteditable');
-  });

--- a/test/js/content_blocker_shim.test.js
+++ b/test/js/content_blocker_shim.test.js
@@ -61,26 +61,24 @@ test('early_css is idempotent — second injection is a no-op', () => {
 
 // ---------- cosmetic ----------
 
-test('cosmetic fixture: hides matching elements via inline style', () => {
-  // The cosmetic shim's hide() pass walks querySelectorAll for each
-  // batched selector and sets el.style.display='none'. Checking the
-  // inline style is the jsdom-friendly way to assert it ran;
-  // computed-style assertions belong in Tier 2 against a real
-  // engine.
-  const dom = makeDom({ html: HOST_HTML });
-  runInDom(dom, COSMETIC);
-  const ad = dom.window.document.getElementById('ad1');
-  const sp = dom.window.document.getElementById('sp1');
-  const sidebar = dom.window.document.getElementById('sidebar-ad');
-  const trk = dom.window.document.getElementById('trk');
-  const keep = dom.window.document.getElementById('keep');
-  assert.equal(ad.style.display, 'none');
-  assert.equal(sp.style.display, 'none');
-  assert.equal(sidebar.style.display, 'none');
-  assert.equal(trk.style.display, 'none');
-  assert.equal(keep.style.display, '',
-    'unrelated elements must not be hidden');
-});
+test('cosmetic fixture: hides matching elements via early-CSS computed style',
+  () => {
+    // Selector-based hides are owned by the early <style> tag (the
+    // cosmetic shim's runtime CSS sweep was dropped). Computed style
+    // is the contract; el.style.display is empty for these (the only
+    // inline writes the shim does are for text-content rules).
+    const dom = makeDom({ html: HOST_HTML });
+    runInDom(dom, COSMETIC);
+    const cs = (id) =>
+      dom.window.getComputedStyle(dom.window.document.getElementById(id))
+        .display;
+    assert.equal(cs('ad1'), 'none');
+    assert.equal(cs('sp1'), 'none');
+    assert.equal(cs('sidebar-ad'), 'none');
+    assert.equal(cs('trk'), 'none');
+    assert.notEqual(cs('keep'), 'none',
+      'unrelated elements must not be hidden');
+  });
 
 test('cosmetic fixture: text-match hides matching paragraphs', () => {
   const dom = makeDom({ html: HOST_HTML });
@@ -93,21 +91,22 @@ test('cosmetic fixture: text-match hides matching paragraphs', () => {
     'paragraph without sponsor text must not be hidden');
 });
 
-test('cosmetic fixture: MutationObserver hides dynamically-added matches',
+test('cosmetic fixture: late-added matches hide via early-CSS (no JS sweep)',
   async () => {
     const dom = makeDom({ html: '<!doctype html><html><body></body></html>' });
     runInDom(dom, COSMETIC);
-    // Insert an ad after the shim has already run. The
-    // MutationObserver's debounced 50ms hide() pass should catch it.
+    // Append an ad-banner AFTER the shim runs. The CSS engine matches
+    // it automatically — no debounced JS sweep involved.
     const doc = dom.window.document;
     const newAd = doc.createElement('div');
     newAd.className = 'ad-banner';
     newAd.id = 'late-ad';
     doc.body.appendChild(newAd);
-    // Wait past the shim's 50ms debounce.
+    // Briefly wait so any text-rules observer pass settles (it only
+    // affects #?# rules; this element is selector-only).
     await new Promise((r) => setTimeout(r, 100));
-    assert.equal(newAd.style.display, 'none',
-      'MutationObserver must hide ads inserted after the shim runs');
+    assert.equal(dom.window.getComputedStyle(newAd).display, 'none',
+      'late-added .ad-banner must be hidden by the early <style>');
   });
 
 test('cosmetic fixture: <style> tag survives MutationObserver passes', () => {
@@ -148,33 +147,46 @@ const MULTI_HTML = `<!doctype html><html><body>
   <div class="bio" id="b-reader">Reader response: thanks.</div>
 </body></html>`;
 
-test('cosmetic_multi: batches of 20 + 5; bad selector poisons only its batch',
+test('cosmetic_multi: malformed selector is dropped by the CSS parser, others apply',
   () => {
+    // Pre-2026 the shim ran a runtime querySelectorAll sweep grouped
+    // into batches of 20 — a malformed selector would throw and
+    // poison its whole batch. The runtime sweep was dropped; selector
+    // hides are handled entirely by the early <style> tag now. CSS
+    // parsers are forgiving of invalid rules: the malformed
+    // `>>>invalid<<<` rule is silently discarded and EVERY other valid
+    // selector in the same stylesheet still applies. That is a strict
+    // improvement on the old behaviour, where 4 valid selectors were
+    // collateral-damage hidden behind a malformed sibling.
     const dom = makeDom({ html: MULTI_HTML });
     runInDom(dom, COSMETIC_MULTI);
     const doc = dom.window.document;
-    // Every batch1-* element belongs to a clean batch -> hidden.
+    const cs = (id) =>
+      dom.window.getComputedStyle(doc.getElementById(id)).display;
+
     const letters = 'abcdefghijklmnopqrst'.split('');
     for (const ch of letters) {
       const el = doc.querySelector('.batch1-' + ch);
-      assert.equal(el.style.display, 'none',
-        '.batch1-' + ch + ' must be hidden by the clean batch');
+      el.id = 'b1-' + ch;
+      assert.equal(dom.window.getComputedStyle(el).display, 'none',
+        '.batch1-' + ch + ' must be hidden by the early CSS');
     }
-    // Every batch2-* element shared a batch with `>>>invalid<<<`, whose
-    // syntax error makes the comma-joined selector list throw inside
-    // querySelectorAll. Per-batch try/catch absorbs it but no element
-    // in that batch gets hidden.
+    // The selectors that previously shared a batch with `>>>invalid<<<`
+    // are valid CSS by themselves. Under the early-CSS model they are
+    // hidden — the malformed rule is discarded by the parser without
+    // affecting the others.
     for (const id of ['b2b', 'b2c', 'b2d', 'b2e']) {
-      assert.equal(doc.getElementById(id).style.display, '',
-        '#' + id + ' must NOT be hidden — its batch was poisoned');
+      assert.equal(cs(id), 'none',
+        '#' + id + ' must be hidden — its rule is valid CSS, the ' +
+        'malformed sibling no longer drags it down');
     }
   });
 
 test('cosmetic_multi: malformed selector does not throw out of the shim',
   () => {
-    // Smoke test — if the per-batch try/catch were missing, runInDom
-    // would propagate the SyntaxError out of window.eval and fail the
-    // test before any assertion ran.
+    // Smoke test — the early <style> tag accepts the full ruleset
+    // including `>>>invalid<<<`; the CSS parser silently drops the
+    // bad rule. Eval must not throw.
     const dom = makeDom({ html: MULTI_HTML });
     assert.doesNotThrow(() => runInDom(dom, COSMETIC_MULTI));
   });

--- a/test/js/content_blocker_shim_equivalence.test.js
+++ b/test/js/content_blocker_shim_equivalence.test.js
@@ -223,24 +223,27 @@ test('equivalence: text-content rules agree in both shapes', () => {
   }
 });
 
-// ---------- known non-equivalence (documented) ----------
+// ---------- inline-style invariant ----------
 
-test('NON-equivalence: current writes inline style, css-only does not',
+test('inline el.style.display: empty for selector matches in both shapes',
   () => {
-    // This test documents the ONE observable difference between the
-    // two shapes: the current shim writes el.style.display = 'none'
-    // for selector-based hides; CSS-only relies on the <style> rule.
-    // Pages that introspect el.style.display (rather than computed
-    // style) will see different values. This is deliberate; the
-    // user-visible state (rendering) is the same.
+    // After the runtime cosmetic-CSS sweep was dropped, NEITHER shape
+    // writes inline style for selector-based hides. Pages that
+    // previously introspected el.style.display would have seen 'none'
+    // under the pre-2026 shape; both variants now show ''. Computed
+    // style — what affects rendering — remains 'none'.
     const domA = makeDom({ html: HOST_HTML });
     runShim(domA, COSMETIC);
     const domB = makeDom({ html: HOST_HTML });
     runShim(domB, COSMETIC_CSS_ONLY);
     const ad1A = domA.window.document.getElementById('ad1');
     const ad1B = domB.window.document.getElementById('ad1');
-    assert.equal(ad1A.style.display, 'none',
-      'current shim writes inline style');
+    assert.equal(ad1A.style.display, '',
+      'shipped shim does not write inline style for selector matches');
     assert.equal(ad1B.style.display, '',
-      'css-only does NOT write inline style');
+      'reference css-only shim also does not write inline style');
+    assert.equal(domA.window.getComputedStyle(ad1A).display, 'none',
+      'shipped shim still hides via early CSS');
+    assert.equal(domB.window.getComputedStyle(ad1B).display, 'none',
+      'reference shim hides via early CSS');
   });

--- a/test/js/content_blocker_shim_equivalence.test.js
+++ b/test/js/content_blocker_shim_equivalence.test.js
@@ -1,0 +1,246 @@
+// Tier 1 — jsdom equivalence proof for the proposed CSS-only cosmetic
+// shim. The current shim has TWO redundant mechanisms for selector-
+// based hides:
+//
+//   1. Early `<style>` tag with `selector { display: none !important }`
+//      — applied by the browser's CSS engine to every matching element,
+//      now and in the future, automatically.
+//   2. Runtime `querySelectorAll(selector).forEach(el => el.style.display
+//      = 'none')` — JS-side inline-style writes, re-run on every
+//      MutationObserver burst.
+//
+// (1) is sufficient for selector-based hides. (2) was added defensively
+// but is the source of perceived typing lag on editor-heavy pages
+// (test/js/perf/cosmetic_keystroke.bench.js). Text-content rules can't
+// be expressed in CSS so they MUST stay in the runtime observer.
+//
+// This test asserts that — measured via `getComputedStyle()` rather
+// than `el.style.display` — the current shim and a CSS-only variant
+// produce indistinguishable observable state for every selector-based
+// case the existing shim covers. If they disagree, the optimization
+// is unsafe and the test must catch it.
+//
+// What CSS-only DROPS:
+//   * The inline `style="display:none"` write. Page scripts that read
+//     `el.style.display` will see `''` instead of `'none'`. This is
+//     deliberate; equivalence is asserted at computed-style level
+//     because that's what affects rendering.
+//
+// What CSS-only KEEPS:
+//   * Early `<style>` injection with `!important`.
+//   * MutationObserver re-running text-content rules (CSS can't match
+//     by text content, so this stays).
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { makeDom, runInDom, readFixture } = require('./helpers/load_shim');
+
+const COSMETIC = readFixture('content_blocker/cosmetic.js');
+
+// Build a minimal CSS-only cosmetic shim equivalent to what we'd ship.
+// Same `<style>` injection as the current shim, but no runtime
+// `hideCSS()` and the MutationObserver only re-runs text rules.
+//
+// Selectors and text rules are exactly the ones baked into the
+// `cosmetic.js` fixture (test/js_fixtures/content_blocker/cosmetic.js)
+// — kept in sync via tool/dump_shim_js.dart. Hardcoding them here is
+// acceptable for an equivalence test: if the dumper changes the
+// fixture's selector set, this file is updated alongside it.
+const COSMETIC_CSS_ONLY = `
+(function() {
+  var ID = '_webspace_content_blocker_style';
+  if (!document.getElementById(ID)) {
+    var s = document.createElement('style');
+    s.id = ID;
+    s.textContent =
+      '.ad-banner { display: none !important; } ' +
+      '.sponsored { display: none !important; } ' +
+      '#sidebar-ad { display: none !important; } ' +
+      '[data-ad-slot] { display: none !important; } ' +
+      'a[href*="track."] { display: none !important; } ';
+    (document.head || document.documentElement).appendChild(s);
+  }
+  // Text rules (CSS can't match on text content): keep the observer,
+  // scoped to whole-document re-scan on debounce. Same shape as
+  // current shim's hideText path.
+  var TEXT_RULES = [{sel:'div.article > p', pats:['Sponsored content']}];
+  function hideText() {
+    for (var i = 0; i < TEXT_RULES.length; i++) {
+      var r = TEXT_RULES[i];
+      try {
+        document.querySelectorAll(r.sel).forEach(function(el) {
+          var text = el.textContent || '';
+          for (var j = 0; j < r.pats.length; j++) {
+            if (text.indexOf(r.pats[j]) !== -1) {
+              el.style.display = 'none';
+              break;
+            }
+          }
+        });
+      } catch (e) {}
+    }
+  }
+  hideText();
+  var t = null;
+  var obs = new MutationObserver(function() {
+    if (t) clearTimeout(t);
+    t = setTimeout(hideText, 50);
+  });
+  if (document.body) {
+    obs.observe(document.body, { childList: true, subtree: true });
+  } else {
+    document.addEventListener('DOMContentLoaded', function() {
+      hideText();
+      obs.observe(document.body, { childList: true, subtree: true });
+    });
+  }
+})();
+`;
+
+const HOST_HTML = `<!doctype html><html><body>
+  <div class="ad-banner" id="ad1">ad</div>
+  <div class="sponsored" id="sp1">sponsored block</div>
+  <div id="sidebar-ad">sidebar</div>
+  <div data-ad-slot="123" id="slot">slot</div>
+  <a href="https://track.example.com/x" id="trk">tracker</a>
+  <div class="article">
+    <p id="text-match">Sponsored content here</p>
+    <p id="text-no-match">Real article body</p>
+  </div>
+  <p id="keep">unrelated</p>
+</body></html>`;
+
+// ---------- helpers ----------
+
+function snapshotComputed(dom, ids) {
+  const out = {};
+  for (const id of ids) {
+    const el = dom.window.document.getElementById(id);
+    if (el == null) {
+      out[id] = '<missing>';
+      continue;
+    }
+    out[id] = dom.window.getComputedStyle(el).display;
+  }
+  return out;
+}
+
+function runShim(dom, shim) {
+  runInDom(dom, shim);
+}
+
+const SELECTOR_IDS =
+  ['ad1', 'sp1', 'sidebar-ad', 'slot', 'trk', 'keep', 'text-no-match'];
+
+// ---------- existing-DOM equivalence ----------
+
+test('equivalence: selector-based hides agree on getComputedStyle (static DOM)',
+  () => {
+    const domA = makeDom({ html: HOST_HTML });
+    runShim(domA, COSMETIC);
+    const a = snapshotComputed(domA, SELECTOR_IDS);
+
+    const domB = makeDom({ html: HOST_HTML });
+    runShim(domB, COSMETIC_CSS_ONLY);
+    const b = snapshotComputed(domB, SELECTOR_IDS);
+
+    assert.deepEqual(b, a,
+      `CSS-only and current shim must produce identical computed-display ` +
+      `for selector-based elements. got A=${JSON.stringify(a)} ` +
+      `B=${JSON.stringify(b)}`);
+
+    // Sanity: the shape that BOTH variants must agree on is non-trivial.
+    // ad1/sp1/sidebar-ad/slot/trk should all be hidden; keep should not.
+    assert.equal(a.ad1, 'none');
+    assert.equal(a.keep !== 'none', true,
+      'keep must be visible; if not, both variants are wrong but equal');
+  });
+
+// ---------- dynamically-added matches ----------
+
+test('equivalence: late-added matches hide via getComputedStyle in both shapes',
+  async () => {
+    async function lateAddAndSnapshot(shim) {
+      const dom = makeDom({
+        html: '<!doctype html><html><body></body></html>',
+      });
+      runShim(dom, shim);
+      const newAd = dom.window.document.createElement('div');
+      newAd.className = 'ad-banner';
+      newAd.id = 'late-ad';
+      dom.window.document.body.appendChild(newAd);
+      await new Promise((r) => setTimeout(r, 100));
+      return dom.window.getComputedStyle(newAd).display;
+    }
+    const a = await lateAddAndSnapshot(COSMETIC);
+    const b = await lateAddAndSnapshot(COSMETIC_CSS_ONLY);
+    assert.equal(a, b,
+      `late-added .ad-banner must reach the same computed display. ` +
+      `current=${a} css-only=${b}`);
+    assert.equal(a, 'none', 'both variants must hide the late-added ad');
+  });
+
+// ---------- class added LATER (deferred match) ----------
+
+test('equivalence: class added after creation hides in both shapes',
+  async () => {
+    async function classFlipAndSnapshot(shim) {
+      const dom = makeDom({
+        html: '<!doctype html><html><body><div id="d">x</div></body></html>',
+      });
+      runShim(dom, shim);
+      const d = dom.window.document.getElementById('d');
+      d.className = 'ad-banner';   // becomes a match
+      await new Promise((r) => setTimeout(r, 100));
+      return dom.window.getComputedStyle(d).display;
+    }
+    const a = await classFlipAndSnapshot(COSMETIC);
+    const b = await classFlipAndSnapshot(COSMETIC_CSS_ONLY);
+    assert.equal(a, b,
+      `element that GAINS .ad-banner must reach the same computed display. ` +
+      `current=${a} css-only=${b}`);
+    assert.equal(a, 'none',
+      'both variants must hide an element after it gains a matching class');
+  });
+
+// ---------- text rules: must agree (both keep the observer) ----------
+
+test('equivalence: text-content rules agree in both shapes', () => {
+  const domA = makeDom({ html: HOST_HTML });
+  runShim(domA, COSMETIC);
+  const domB = makeDom({ html: HOST_HTML });
+  runShim(domB, COSMETIC_CSS_ONLY);
+  const ids = ['text-match', 'text-no-match'];
+  // Text rules write inline style in BOTH variants — assert on inline
+  // here, since computed-style for text-content matches relies on the
+  // same mechanism in both shapes.
+  for (const id of ids) {
+    assert.equal(
+      domA.window.document.getElementById(id).style.display,
+      domB.window.document.getElementById(id).style.display,
+      `${id}: text-rule outcome must match between shapes`,
+    );
+  }
+});
+
+// ---------- known non-equivalence (documented) ----------
+
+test('NON-equivalence: current writes inline style, css-only does not',
+  () => {
+    // This test documents the ONE observable difference between the
+    // two shapes: the current shim writes el.style.display = 'none'
+    // for selector-based hides; CSS-only relies on the <style> rule.
+    // Pages that introspect el.style.display (rather than computed
+    // style) will see different values. This is deliberate; the
+    // user-visible state (rendering) is the same.
+    const domA = makeDom({ html: HOST_HTML });
+    runShim(domA, COSMETIC);
+    const domB = makeDom({ html: HOST_HTML });
+    runShim(domB, COSMETIC_CSS_ONLY);
+    const ad1A = domA.window.document.getElementById('ad1');
+    const ad1B = domB.window.document.getElementById('ad1');
+    assert.equal(ad1A.style.display, 'none',
+      'current shim writes inline style');
+    assert.equal(ad1B.style.display, '',
+      'css-only does NOT write inline style');
+  });

--- a/test/js/perf/blocking_real.bench.js
+++ b/test/js/perf/blocking_real.bench.js
@@ -1,0 +1,404 @@
+// Real-list JS interceptor bench — EasyList + Hagezi Ultimate.
+//
+// Companion to blocking.bench.js, which uses synthetic data. This one
+// loads the actual production lists so we can see:
+//   * bloom build time + size at production scale
+//   * bloom false-positive rate against a non-block host stream
+//   * suffix-walk cost on real domain shapes (deep + shallow mixed)
+//   * sync fast-path throughput, separated by block vs non-block
+//   * roundtrip rate (= fraction of requests that escape the JS sync
+//     path and need a Dart callHandler)
+//
+// Lists are NOT bundled. Cache them once under tmp/ and re-use:
+//
+//   mkdir -p tmp/blocklists
+//   curl -fL -o tmp/blocklists/easylist.txt \
+//     https://easylist.to/easylist/easylist.txt
+//   curl -fL -o tmp/blocklists/easyprivacy.txt \
+//     https://easylist.to/easylist/easyprivacy.txt
+//   curl -fL -o tmp/blocklists/hagezi_ultimate.txt \
+//     https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/domains/ultimate.txt
+//
+//   node test/js/perf/blocking_real.bench.js
+//
+// Override the cache directory with BLOCKLIST_DIR=/some/path.
+//
+// The per-list parsers mirror the production Dart code:
+//   * Hagezi: bare domain per line, `#` comment lines.
+//   * EasyList: only `||domain^` (and `||domain`) rules become DNS
+//     domains. ##cosmetic / #?# text-hide / regex / option-laden
+//     network rules are ignored — same as
+//     `lib/services/abp_filter_parser.dart` (`_simpleDomainRule`).
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { performance } = require('node:perf_hooks');
+const { makeNewInterceptor } = require('./new_interceptor');
+const { buildBloom } = require('./bloom_build');
+
+const CACHE_DIR = process.env.BLOCKLIST_DIR ||
+  path.resolve(__dirname, '../../../tmp/blocklists');
+
+// ---------------- List loading ----------------
+
+function loadHagezi(file) {
+  const raw = fs.readFileSync(file, 'utf8');
+  const out = new Set();
+  for (const line of raw.split('\n')) {
+    const t = line.trim();
+    if (!t || t.charCodeAt(0) === 35 /* # */) continue;
+    out.add(t.toLowerCase());
+  }
+  return out;
+}
+
+// Same shape as `_simpleDomainRule` in abp_filter_parser.dart:
+//   ^\|\|([a-zA-Z0-9._-]+)\^?$
+const ABP_DOMAIN_RE = /^\|\|([a-zA-Z0-9._-]+)\^?$/;
+
+function loadEasyListDomains(file) {
+  const raw = fs.readFileSync(file, 'utf8');
+  const out = new Set();
+  for (const line of raw.split('\n')) {
+    const t = line.trim();
+    if (!t || t.charCodeAt(0) === 33 /* ! */ || t.charCodeAt(0) === 91 /* [ */) continue;
+    // Strip trailing options before matching (||tracker.com^$third-party).
+    let pattern = t;
+    const dollar = t.lastIndexOf('$');
+    if (dollar > 0) {
+      const after = t.substring(dollar + 1);
+      if (!after.includes('//') && !after.startsWith('/')) {
+        pattern = t.substring(0, dollar);
+      }
+    }
+    const m = ABP_DOMAIN_RE.exec(pattern);
+    if (m) out.add(m[1].toLowerCase());
+  }
+  return out;
+}
+
+// ---------------- Workloads ----------------
+
+function rng(seed) {
+  let s = seed >>> 0;
+  return function next() {
+    s = (s + 0x6D2B79F5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// "Real-shape" non-block hosts: shallow .com/.org/.net and a sprinkling
+// of CDN-shaped 4-label hosts. Deliberately constructed so suffix walk
+// has to visit multiple parents on most queries — that's the realistic
+// cost on a long-tail page.
+function makeNonBlockHosts(count, seed = 11) {
+  const next = rng(seed);
+  const tlds = ['com', 'net', 'org', 'io', 'co'];
+  const out = [];
+  for (let i = 0; i < count; i++) {
+    const tld = tlds[(next() * tlds.length) | 0];
+    const labelLen = 6 + ((next() * 8) | 0);
+    let name = '';
+    for (let j = 0; j < labelLen; j++) {
+      name += String.fromCharCode(97 + ((next() * 26) | 0));
+    }
+    if ((next() * 4) | 0) {
+      // Mostly add a CDN-style sub: cdn1.shop.example.com
+      const sub = ['cdn1', 'cdn2', 'static', 'img', 'i', 'edge', 'assets'][
+        (next() * 7) | 0
+      ];
+      out.push(`${sub}.${name}.${tld}`);
+    } else {
+      out.push(`${name}.${tld}`);
+    }
+  }
+  return out;
+}
+
+function sampleArray(arr, count, seed = 22) {
+  const next = rng(seed);
+  const out = new Array(count);
+  for (let i = 0; i < count; i++) {
+    out[i] = arr[(next() * arr.length) | 0];
+  }
+  return out;
+}
+
+// ---------------- Helpers ----------------
+
+function fmt(ms) {
+  if (ms < 0.01) return `${(ms * 1000).toFixed(2)}us`;
+  if (ms < 1) return `${ms.toFixed(3)}ms`;
+  return `${ms.toFixed(2)}ms`;
+}
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[(sorted.length / 2) | 0];
+}
+
+function bench(label, fn, { warmup = 1, iters = 5 } = {}) {
+  for (let i = 0; i < warmup; i++) fn();
+  const samples = [];
+  for (let i = 0; i < iters; i++) {
+    const t0 = performance.now();
+    fn();
+    samples.push(performance.now() - t0);
+  }
+  const sorted = [...samples].sort((a, b) => a - b);
+  return {
+    label,
+    median: sorted[(sorted.length / 2) | 0],
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+  };
+}
+
+function row(label, value) {
+  console.log(`  ${label.padEnd(50)} ${value}`);
+}
+
+function reportBench(r) {
+  row(r.label, `${fmt(r.median)} (min ${fmt(r.min)} max ${fmt(r.max)})`);
+}
+
+// ---------------- Bench ----------------
+
+function ensureFile(name) {
+  const file = path.join(CACHE_DIR, name);
+  if (!fs.existsSync(file)) {
+    console.error(
+      `Missing ${file}.\n` +
+      `Cache the lists first (see header of ${path.basename(__filename)}).`,
+    );
+    process.exit(2);
+  }
+  return file;
+}
+
+function main() {
+  const easylistFile = ensureFile('easylist.txt');
+  const easyprivacyFile = ensureFile('easyprivacy.txt');
+  const hageziFile = ensureFile('hagezi_ultimate.txt');
+
+  console.log('Loading lists...');
+  const t0 = performance.now();
+  const dns = loadHagezi(hageziFile);
+  const tDns = performance.now() - t0;
+
+  const t1 = performance.now();
+  const abp = new Set([
+    ...loadEasyListDomains(easylistFile),
+    ...loadEasyListDomains(easyprivacyFile),
+  ]);
+  const tAbp = performance.now() - t1;
+
+  const merged = new Set([...dns, ...abp]);
+  console.log(`  DNS  domains: ${dns.size.toLocaleString()} (parsed in ${fmt(tDns)})`);
+  console.log(`  ABP  domains: ${abp.size.toLocaleString()} (parsed in ${fmt(tAbp)})`);
+  console.log(`  merged       : ${merged.size.toLocaleString()}`);
+  console.log(`  ABP novel    : ${[...abp].filter((d) => !dns.has(d)).length.toLocaleString()} (not also in DNS)`);
+
+  console.log('\nBuilding bloom (fpRate=0.05)...');
+  const t2 = performance.now();
+  const items = [...merged];
+  const bloom = buildBloom(items, 0.05);
+  const tBuild = performance.now() - t2;
+  console.log(
+    `  bits=${bloom.bits.length} bytes (${(bloom.bits.length / 1024 / 1024).toFixed(2)} MiB)` +
+    `, k=${bloom.k}, bitCount=${bloom.bitCount.toLocaleString()}, build=${fmt(tBuild)}`,
+  );
+
+  // Two host pools.
+  const nonBlockHosts = makeNonBlockHosts(50_000);
+  const blockHostsAll = [...dns];
+
+  // ---------- Bloom membership accuracy ----------
+  // Hosts that ARE in the set: every one must be a bloom hit
+  // (no false negatives possible). Hosts NOT in the set: the bloom
+  // tells us whether it would short-circuit (no Dart roundtrip) or
+  // would have to escalate (false positive).
+  console.log('\nBloom membership on real lists:');
+  const interceptor = makeNewInterceptor({
+    bloomBits: bloom.bits,
+    bloomBitCount: bloom.bitCount,
+    bloomK: bloom.k,
+    callHandler: () => Promise.resolve(false),
+  });
+
+  // Sample of in-set hosts.
+  const inSetSample = sampleArray(blockHostsAll, 20_000, 33);
+  let inSetHits = 0;
+  for (const h of inSetSample) {
+    if (interceptor.bloomContains(h)) inSetHits++;
+  }
+  row('in-set hosts (n=20000): bloom hits',
+      `${inSetHits} (${(100 * inSetHits / inSetSample.length).toFixed(2)}% — must be 100%)`);
+
+  // Synthetic non-block hosts.
+  let outSetFp = 0;
+  for (const h of nonBlockHosts) {
+    if (interceptor.bloomContains(h)) outSetFp++;
+  }
+  row('non-block hosts (n=50000): bloom false positives',
+      `${outSetFp} (${(100 * outSetFp / nonBlockHosts.length).toFixed(3)}% — target ≤ 5%)`);
+
+  // ---------- Suffix-walk cost ----------
+  // Block path: maybeBlocked returns true on the first label (bloom
+  // hit happens immediately on the leaf host). Cost is one bloom probe.
+  // Non-block path: walks every label up to the public suffix without
+  // ever hitting. Each level pays one bloom probe = k FNV-1a hashes.
+  console.log('\nSuffix walk (cold cache, no Dart roundtrip):');
+  const blockHosts = sampleArray(blockHostsAll, 50_000, 44);
+
+  const blockWalk = bench(
+    'block path: 50K real blocked hosts',
+    () => {
+      for (const h of blockHosts) interceptor.maybeBlocked(h);
+    },
+    { iters: 7 },
+  );
+  reportBench(blockWalk);
+  row('  per-call (block)',
+      `${(blockWalk.median * 1000 / blockHosts.length).toFixed(3)}us`);
+
+  const nonBlockWalk = bench(
+    'non-block path: 50K synthetic safe hosts',
+    () => {
+      for (const h of nonBlockHosts) interceptor.maybeBlocked(h);
+    },
+    { iters: 7 },
+  );
+  reportBench(nonBlockWalk);
+  row('  per-call (non-block)',
+      `${(nonBlockWalk.median * 1000 / nonBlockHosts.length).toFixed(3)}us`);
+
+  // ---------- Full checkSync flow (URL parse + cache + bloom) ----------
+  // Mirrors what runs on every fetch / XHR / src= setter.
+  console.log('\nFull checkSync (URL parse + FIFO cache + bloom + walk):');
+
+  const blockUrls = blockHosts.map((h) => `https://${h}/path`);
+  const nonBlockUrls = nonBlockHosts.map((h) => `https://${h}/path`);
+
+  // Cold cache each iteration: rebuild interceptor.
+  function freshInterceptor() {
+    return makeNewInterceptor({
+      bloomBits: bloom.bits,
+      bloomBitCount: bloom.bitCount,
+      bloomK: bloom.k,
+      callHandler: () => Promise.resolve(false),
+    });
+  }
+
+  // Cold-cache: every URL is fresh.
+  // (For block URLs the result is `undefined` -> Dart roundtrip needed.)
+  const coldBlock = bench(
+    'cold cache, block URLs (50K) -> undecided (roundtrip)',
+    () => {
+      const i = freshInterceptor();
+      let undecided = 0;
+      for (const u of blockUrls) {
+        if (i.checkSync(u) === undefined) undecided++;
+      }
+      if (undecided !== blockUrls.length) {
+        throw new Error(`expected all undecided, got ${undecided}/${blockUrls.length}`);
+      }
+    },
+    { iters: 5 },
+  );
+  reportBench(coldBlock);
+  row('  per-call', `${(coldBlock.median * 1000 / blockUrls.length).toFixed(3)}us`);
+
+  const coldNonBlock = bench(
+    'cold cache, non-block URLs (50K) -> sync false (no roundtrip)',
+    () => {
+      const i = freshInterceptor();
+      let undecided = 0;
+      for (const u of nonBlockUrls) {
+        if (i.checkSync(u) === undefined) undecided++;
+      }
+      // We expect ~bloom FP rate to be undecided.
+    },
+    { iters: 5 },
+  );
+  reportBench(coldNonBlock);
+  row('  per-call', `${(coldNonBlock.median * 1000 / nonBlockUrls.length).toFixed(3)}us`);
+
+  // Hot cache: warm the cache once, then re-bench.
+  const warm = freshInterceptor();
+  for (const u of nonBlockUrls) warm.checkSync(u); // populates cache with `false`s
+  const hotNonBlock = bench(
+    'hot cache, non-block URLs (50K) -> cache hit',
+    () => {
+      for (const u of nonBlockUrls) warm.checkSync(u);
+    },
+    { iters: 5 },
+  );
+  reportBench(hotNonBlock);
+  row('  per-call', `${(hotNonBlock.median * 1000 / nonBlockUrls.length).toFixed(3)}us`);
+
+  // ---------- Mixed workload — what one page actually looks like ----------
+  // Typical news/social page: ~200 sub-resources across ~30 unique
+  // hosts. With Hagezi+EasyList loaded and no per-site exemptions, a
+  // representative ad-heavy page sees roughly 5–10% of *requests* hit
+  // the bloom (most blocked CDNs are reused across many requests).
+  console.log('\nMixed workload (200 reqs, 30 unique hosts, bloom hit rate ~10%):');
+  const HIT_FRAC = 0.10;
+  const REQS = 200;
+  const HOSTS = 30;
+  const next = rng(77);
+  const pageHosts = [];
+  const hitCount = Math.round(HOSTS * HIT_FRAC);
+  for (let i = 0; i < hitCount; i++) {
+    pageHosts.push(blockHostsAll[(next() * blockHostsAll.length) | 0]);
+  }
+  for (let i = hitCount; i < HOSTS; i++) {
+    pageHosts.push(nonBlockHosts[(next() * nonBlockHosts.length) | 0]);
+  }
+  const pageStream = [];
+  for (let i = 0; i < REQS; i++) {
+    pageStream.push(`https://${pageHosts[(next() * pageHosts.length) | 0]}/r${i}`);
+  }
+
+  let lastRoundtrips = 0;
+  let lastSynced = 0;
+  const page = bench(
+    'one page (200 reqs, fresh interceptor)',
+    () => {
+      const i = freshInterceptor();
+      let roundtrips = 0;
+      let synced = 0;
+      for (const u of pageStream) {
+        const r = i.checkSync(u);
+        if (r === undefined) roundtrips++;
+        else synced++;
+      }
+      lastRoundtrips = roundtrips;
+      lastSynced = synced;
+    },
+    { iters: 7 },
+  );
+  reportBench(page);
+  row('  decisions: sync vs roundtrip',
+      `${lastSynced} sync, ${lastRoundtrips} roundtrip ` +
+      `(${(100 * lastRoundtrips / pageStream.length).toFixed(1)}% Dart hit)`);
+
+  // ---------- Summary ----------
+  console.log('\nNotes:');
+  console.log('  * Block per-call cost = 1 bloom probe (k FNV-1a hashes).');
+  console.log('    Non-block = 1 probe per label up to the public suffix —');
+  console.log('    that is where suffix-walk cost shows up.');
+  console.log('  * "% Dart hit" in the mixed workload is the RPC rate that');
+  console.log('    hits blockCheck on iOS/macOS. Multiply by the per-call');
+  console.log('    bridge cost from integration_test/js_bridge_benchmark_test');
+  console.log('    to estimate per-page roundtrip wall-clock.');
+  console.log('  * Sync hot-cache cost is steady-state on a long-lived tab,');
+  console.log('    once every host has been seen at least once.');
+}
+
+main();

--- a/test/js/perf/cosmetic_keystroke.bench.js
+++ b/test/js/perf/cosmetic_keystroke.bench.js
@@ -1,0 +1,473 @@
+// Cosmetic-shim keystroke bench. Quantifies the *typing-lag* cost of
+// the content_blocker cosmetic shim — the suspected dominant cost on
+// editor-heavy pages like github.com when block is on.
+//
+// What this measures (and what blocking_real.bench.js does NOT):
+//   * Wall-clock cost of `hide()` on a representative DOM, run over
+//     every cosmetic selector batch (`querySelectorAll` per batch +
+//     `display:none` writes on matches).
+//   * Per-keystroke cost when the MutationObserver fires `hide()` after
+//     each typing pause (the 50ms-debounced path).
+//   * Cost when re-running on every mutation (the no-debounce variant)
+//     — useful as a worst-case bound and to validate the debounce.
+//
+// The bench replays the EXACT shim shape from
+// `lib/services/content_blocker_shim.dart`:
+//   * 20 selectors per BATCH, each batch is a comma-joined
+//     `querySelectorAll`.
+//   * `hide()` = hideCSS() + hideText() each MutationObserver fire.
+//   * Selectors: global EasyList cosmetic rules + the github.com
+//     suffix-walk (`github.com` then walk parents) — same as
+//     `_collectRules` in content_blocker_service.dart.
+//
+// Lists are NOT bundled. Same cache as blocking_real.bench.js:
+//   BLOCKLIST_DIR=tmp/blocklists  (defaults to ../../../tmp/blocklists)
+//
+// Run:
+//   node test/js/perf/cosmetic_keystroke.bench.js
+//
+// Caveats:
+//   * jsdom's selector engine is slower than WebKit — absolute numbers
+//     are pessimistic. The relative cost between variants is the
+//     transferable signal.
+//   * The DOM is synthetic (built to roughly the depth and tag mix of
+//     a github.com PR-discussion page). Real-DOM numbers can be
+//     produced by piping a captured outerHTML in via STDIN or
+//     `--dom <path>` (not implemented here yet).
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { performance } = require('node:perf_hooks');
+const { JSDOM } = require('jsdom');
+
+const CACHE_DIR = process.env.BLOCKLIST_DIR ||
+  path.resolve(__dirname, '../../../tmp/blocklists');
+
+// ---------------- EasyList cosmetic parser ----------------
+//
+// Mirrors the cosmetic side of `lib/services/abp_filter_parser.dart`:
+//   * `##selector`              -> global cosmetic
+//   * `domain##selector`        -> domain-scoped (comma-separated)
+//   * `domain##selector` with ~excl, :-abp-, :has-text, :matches-path
+//     etc. is rejected (kept identical to Dart).
+
+function parseCosmetics(file) {
+  const raw = fs.readFileSync(file, 'utf8');
+  const global = [];
+  const byDomain = new Map();
+  for (const line of raw.split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    const c0 = t.charCodeAt(0);
+    if (c0 === 33 /* ! */ || c0 === 91 /* [ */) continue;
+
+    // We only want plain ##  (no #?#, no #$#, no #@#).
+    const idx = t.indexOf('##');
+    if (idx < 0) continue;
+    const prev = idx > 0 ? t.charCodeAt(idx - 1) : 0;
+    if (prev === 63 /* ? */ || prev === 36 /* $ */ || prev === 64 /* @ */) {
+      continue;
+    }
+
+    const after = t.substring(idx);
+    if (
+      after.startsWith('##^') ||
+      after.includes(':has-text(') ||
+      after.includes(':contains(') ||
+      after.includes(':-abp-') ||
+      after.includes(':matches-path(') ||
+      after.includes(':matches-attr(') ||
+      after.includes(':min-text-length(') ||
+      after.includes(':watch-attr(')
+    ) {
+      continue;
+    }
+
+    const sel = t.substring(idx + 2).trim();
+    if (!sel) continue;
+
+    const domainsStr = idx > 0 ? t.substring(0, idx) : '';
+    if (!domainsStr) {
+      global.push(sel);
+    } else {
+      for (const d of domainsStr.split(',')) {
+        const dd = d.trim();
+        if (!dd || dd.startsWith('~')) continue;
+        if (!byDomain.has(dd)) byDomain.set(dd, []);
+        byDomain.get(dd).push(sel);
+      }
+    }
+  }
+  return { global, byDomain };
+}
+
+function collectForHost(host, parsed) {
+  // Same loop as content_blocker_service.dart `_collectRules`.
+  const out = [...parsed.global];
+  let domain = host;
+  while (domain) {
+    const v = parsed.byDomain.get(domain);
+    if (v) out.push(...v);
+    const dot = domain.indexOf('.');
+    if (dot < 0) break;
+    domain = domain.substring(dot + 1);
+  }
+  return out;
+}
+
+// ---------------- Shim install (mirrors content_blocker_shim.dart) ----------------
+
+function installShim(window, selectors, textRules) {
+  const { document } = window;
+
+  // Early CSS — the same `display: none !important` stylesheet.
+  const earlyCss = selectors
+    .map((s) => `${s} { display: none !important; }`)
+    .join(' ');
+  const styleEl = document.createElement('style');
+  styleEl.textContent = earlyCss;
+  (document.head || document.documentElement).appendChild(styleEl);
+
+  // BATCHES of 20.
+  const BATCHES = [];
+  for (let i = 0; i < selectors.length; i += 20) {
+    BATCHES.push(selectors.slice(i, i + 20).join(', '));
+  }
+  const TEXT_RULES = textRules || [];
+
+  function hideCSS() {
+    for (let i = 0; i < BATCHES.length; i++) {
+      try {
+        document.querySelectorAll(BATCHES[i]).forEach((el) => {
+          el.style.display = 'none';
+        });
+      } catch (e) {
+        /* malformed batch — same swallow as production */
+      }
+    }
+  }
+  function hideText() {
+    for (let i = 0; i < TEXT_RULES.length; i++) {
+      const r = TEXT_RULES[i];
+      try {
+        document.querySelectorAll(r.sel).forEach((el) => {
+          const text = el.textContent || '';
+          for (let j = 0; j < r.pats.length; j++) {
+            if (text.indexOf(r.pats[j]) !== -1) {
+              el.style.display = 'none';
+              break;
+            }
+          }
+        });
+      } catch (e) {}
+    }
+  }
+  function hide() {
+    hideCSS();
+    hideText();
+  }
+
+  // The MutationObserver from the shim — debounced 50ms.
+  let t = null;
+  const obs = new window.MutationObserver(() => {
+    if (t) clearTimeout(t);
+    t = setTimeout(hide, 50);
+  });
+  obs.observe(document.body, { childList: true, subtree: true });
+
+  return {
+    BATCHES,
+    hide,
+    hideCSS,
+    hideText,
+    flushDebounce() {
+      if (t) {
+        clearTimeout(t);
+        t = null;
+        hide();
+      }
+    },
+    disconnect() {
+      obs.disconnect();
+      if (t) clearTimeout(t);
+    },
+  };
+}
+
+// ---------------- Synthetic DOM resembling a github discussion ----------------
+
+function buildSyntheticDom(commentCount = 30) {
+  // Rough shape: header, side panels, N comment blocks each with
+  // avatar / metadata / body / reactions / nested reply form. Total
+  // node count lands around 5000-8000 elements which is in the ballpark
+  // of a real PR-discussion page.
+  const sections = [];
+  for (let i = 0; i < commentCount; i++) {
+    sections.push(`
+      <article class="comment" id="c-${i}">
+        <header class="comment-header">
+          <a class="user user-mention" href="/u/u${i}">@u${i}</a>
+          <time>${new Date().toISOString()}</time>
+          <button class="reactions-toggle">…</button>
+        </header>
+        <div class="comment-body markdown-body">
+          <p>Some content for comment ${i}.</p>
+          <ul><li>item</li><li>item</li><li>item</li></ul>
+          <pre><code>code block ${i}</code></pre>
+        </div>
+        <footer class="reactions">
+          <button class="reaction"></button>
+          <button class="reaction"></button>
+          <button class="reaction"></button>
+        </footer>
+      </article>`);
+  }
+  const html = `<!doctype html><html><head><meta charset="utf-8"></head><body>
+    <header class="page-header">
+      <a class="logo" href="/">L</a>
+      <nav class="primary"></nav>
+      <button id="add-comment">New</button>
+    </header>
+    <aside class="sidebar"><ul><li>a</li><li>b</li><li>c</li></ul></aside>
+    <main class="discussion">
+      ${sections.join('\n')}
+    </main>
+    <form id="comment-editor">
+      <div id="composer" contenteditable="true"></div>
+      <ul id="suggestion-popover" hidden></ul>
+    </form>
+  </body></html>`;
+  return new JSDOM(html, { runScripts: 'outside-only', pretendToBeVisual: true });
+}
+
+// ---------------- Typing simulator ----------------
+//
+// Each "keystroke" is a small DOM mutation in `#composer` plus a
+// re-render of the suggestion popover (matches what real React-driven
+// editors do).
+
+function simulateKeystroke(window, charIdx) {
+  const { document } = window;
+  const composer = document.querySelector('#composer');
+  const span = document.createElement('span');
+  span.textContent = String.fromCharCode(97 + (charIdx % 26));
+  composer.appendChild(span);
+
+  const popover = document.querySelector('#suggestion-popover');
+  popover.hidden = false;
+  // Rebuild the popover children: 5 suggestion <li>s with avatar imgs.
+  while (popover.firstChild) popover.removeChild(popover.firstChild);
+  for (let i = 0; i < 5; i++) {
+    const li = document.createElement('li');
+    li.className = 'suggestion';
+    const img = document.createElement('img');
+    img.alt = '';
+    img.src = `https://avatars.example/${charIdx}-${i}.png`;
+    li.appendChild(img);
+    const txt = document.createElement('span');
+    txt.textContent = `user-${charIdx}-${i}`;
+    li.appendChild(txt);
+    popover.appendChild(li);
+  }
+}
+
+// ---------------- Bench helpers ----------------
+
+function fmt(ms) {
+  if (ms < 0.01) return `${(ms * 1000).toFixed(2)}us`;
+  if (ms < 1) return `${ms.toFixed(3)}ms`;
+  return `${ms.toFixed(2)}ms`;
+}
+
+function row(label, value) {
+  console.log(`  ${label.padEnd(56)} ${value}`);
+}
+
+function median(xs) {
+  const s = [...xs].sort((a, b) => a - b);
+  return s[(s.length / 2) | 0];
+}
+function pct(xs, q) {
+  const s = [...xs].sort((a, b) => a - b);
+  return s[Math.min(s.length - 1, (s.length * q) | 0)];
+}
+
+// ---------------- Bench ----------------
+
+function ensureFile(name) {
+  const p = path.join(CACHE_DIR, name);
+  if (!fs.existsSync(p)) {
+    console.error(`Missing ${p}. Cache lists per blocking_real.bench.js header.`);
+    process.exit(2);
+  }
+  return p;
+}
+
+async function main() {
+  const easylist = ensureFile('easylist.txt');
+  const easyprivacy = ensureFile('easyprivacy.txt');
+
+  console.log('Parsing cosmetic rules...');
+  const t0 = performance.now();
+  const cosmeticsA = parseCosmetics(easylist);
+  const cosmeticsB = parseCosmetics(easyprivacy);
+  // Merge: keep the same shape as the Dart parser (one map per file is
+  // fine — domain-keyed). For a single host we just collect from both.
+  const merged = { global: [...cosmeticsA.global, ...cosmeticsB.global], byDomain: new Map() };
+  for (const [k, v] of cosmeticsA.byDomain) merged.byDomain.set(k, v.slice());
+  for (const [k, v] of cosmeticsB.byDomain) {
+    if (merged.byDomain.has(k)) merged.byDomain.get(k).push(...v);
+    else merged.byDomain.set(k, v.slice());
+  }
+  const tParse = performance.now() - t0;
+  console.log(`  global: ${merged.global.length.toLocaleString()} selectors`);
+  console.log(`  domain-scoped: ${merged.byDomain.size.toLocaleString()} hosts`);
+  console.log(`  parse time: ${fmt(tParse)}`);
+
+  const HOST = 'github.com';
+  const selectors = collectForHost(HOST, merged);
+  console.log(`\nSelectors active for ${HOST}: ${selectors.length.toLocaleString()}`);
+  console.log(
+    `  -> ${Math.ceil(selectors.length / 20).toLocaleString()} BATCHES of 20 ` +
+    '(one querySelectorAll per BATCH).',
+  );
+
+  // ---------- Single-shot hide() on a fresh page ----------
+  console.log('\nFresh page: cost of one hide() sweep on a synthetic discussion DOM');
+
+  const sizes = [10, 30, 100];
+  for (const n of sizes) {
+    const dom = buildSyntheticDom(n);
+    const win = dom.window;
+    const totalNodes = win.document.querySelectorAll('*').length;
+    const shim = installShim(win, selectors, []);
+    // Measure hide() — disconnect observer noise first.
+    shim.disconnect();
+    // Warmup x2.
+    shim.hide();
+    shim.hide();
+    const samples = [];
+    for (let i = 0; i < 5; i++) {
+      const a = performance.now();
+      shim.hide();
+      samples.push(performance.now() - a);
+    }
+    row(
+      `comments=${n} (~${totalNodes} elements)`,
+      `median=${fmt(median(samples))} max=${fmt(Math.max(...samples))}`,
+    );
+    win.close();
+  }
+
+  // ---------- Typing: per-keystroke wall-clock ----------
+  // We simulate ${KEYS} keystrokes at typing speed (~80 ms apart), let
+  // the debounce coalesce into hide() runs, and report:
+  //   * "input -> hide done": wall-clock from a keystroke that triggers
+  //     the debounce window to the `hide()` returning.
+  //   * "input -> next paint slot": MutationObserver schedules in a
+  //     microtask, so per-keystroke we measure the observer callback
+  //     time only (the debounce timer fires later).
+  //
+  // The numbers are interesting both ways: observer callback is the
+  // immediate jitter the user sees on each keystroke; hide() cost is
+  // the perceptible "freeze" between bursts.
+
+  console.log('\nTyping bench: 200 keystrokes at 80ms apart, debounce 50ms');
+
+  for (const blockOn of [false, true]) {
+    const dom = buildSyntheticDom(50);
+    const win = dom.window;
+    let shim = null;
+    let observerCbs = 0;
+    let observerCbTotalMs = 0;
+    let hideRuns = 0;
+    let hideTotalMs = 0;
+
+    // We replace the shim's MutationObserver with our own that times
+    // both phases — observer callback (fires per microtask after a
+    // mutation) and hide() (fires after the debounce timeout).
+    if (blockOn) {
+      const { document } = win;
+      const earlyCss = selectors
+        .map((s) => `${s} { display: none !important; }`)
+        .join(' ');
+      const styleEl = document.createElement('style');
+      styleEl.textContent = earlyCss;
+      (document.head || document.documentElement).appendChild(styleEl);
+      const BATCHES = [];
+      for (let i = 0; i < selectors.length; i += 20) {
+        BATCHES.push(selectors.slice(i, i + 20).join(', '));
+      }
+      const hide = () => {
+        const a = performance.now();
+        for (let i = 0; i < BATCHES.length; i++) {
+          try {
+            document.querySelectorAll(BATCHES[i]).forEach((el) => {
+              el.style.display = 'none';
+            });
+          } catch (e) {}
+        }
+        hideTotalMs += performance.now() - a;
+        hideRuns++;
+      };
+      let t = null;
+      const obs = new win.MutationObserver(() => {
+        const a = performance.now();
+        if (t) clearTimeout(t);
+        t = setTimeout(hide, 50);
+        observerCbTotalMs += performance.now() - a;
+        observerCbs++;
+      });
+      obs.observe(document.body, { childList: true, subtree: true });
+      shim = { obs, hideRuns: () => hideRuns, hideMs: () => hideTotalMs };
+    }
+
+    // Drive keystrokes synchronously; node's setTimeout still fires in
+    // the right order so the debounce logic works as long as we yield.
+    const keyTimes = [];
+    const KEYS = 200;
+    for (let i = 0; i < KEYS; i++) {
+      const a = performance.now();
+      simulateKeystroke(win, i);
+      keyTimes.push(performance.now() - a);
+      // Yield so MutationObserver microtasks (and the debounce timer
+      // when due) get a chance to run.
+      // eslint-disable-next-line no-await-in-loop
+    }
+    // Flush observers + any pending debounce.
+    // setTimeout(50ms) -> wait at least 200ms before reading numbers.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    const tag = blockOn ? 'block ON ' : 'block OFF';
+    row(
+      `${tag} keystroke wall-clock`,
+      `median=${fmt(median(keyTimes))} p99=${fmt(pct(keyTimes, 0.99))} ` +
+        `max=${fmt(Math.max(...keyTimes))}`,
+    );
+    if (blockOn && shim) {
+      row(
+        `${tag} mutation-observer callback (per keystroke)`,
+        `runs=${observerCbs} total=${fmt(observerCbTotalMs)} ` +
+          `mean=${fmt(observerCbTotalMs / Math.max(1, observerCbs))}`,
+      );
+      row(
+        `${tag} hide() (debounce-coalesced full sweep)`,
+        `runs=${shim.hideRuns()} total=${fmt(shim.hideMs())} ` +
+          `mean=${fmt(shim.hideMs() / Math.max(1, shim.hideRuns()))}`,
+      );
+    }
+    win.close();
+  }
+}
+
+(async () => {
+  await main();
+  console.log('\nNotes:');
+  console.log('  * "block OFF" is the no-shim baseline — pure DOM mutation cost.');
+  console.log('  * "block ON keystroke wall-clock" is the visible jitter PER');
+  console.log('    keystroke. The observer callback adds to this directly.');
+  console.log('  * "hide() ... mean" is the freeze visible after each typing');
+  console.log('    pause >= 50ms — this is the dominant cost on a high-DOM page.');
+  console.log('  * jsdom is slower than WebKit; use the relative ON/OFF ratio.');
+})();

--- a/test/js/perf/cosmetic_keystroke.bench.js
+++ b/test/js/perf/cosmetic_keystroke.bench.js
@@ -8,12 +8,21 @@
 //             MutationObserver -> 50ms-debounced hide() that re-queries
 //             the WHOLE document on every burst.
 //   * explored — same install sweep, but the mutation handler scopes
-//             work to the freshly-added subtree only. Useful as a
-//             reference point — was prototyped, found to REGRESS on
-//             keystroke-heavy pages because the per-call selector-parse
-//             overhead (684 BATCHES of 20) outweighs the saved
-//             tree-walk when many small subtrees are added per burst.
-//             Recorded here so the trade-off stays measurable.
+//             work to the freshly-added subtree only.
+//
+// Two workloads:
+//   * "composer + popover" — each keystroke appends a span to a
+//     contenteditable composer AND rebuilds a small popover. The
+//     composer adds ACCUMULATE (no removal between keystrokes), so
+//     by flush time 200 spans are connected; this stresses the
+//     "many tiny subtrees" cost of `explored`.
+//   * "popover only" — same workload minus the composer churn. No
+//     editable subtree in play. Tests whether `explored` beats
+//     `current` on its own merits.
+//
+// Without a real captured mutation trace from github.com it's not
+// possible to say which workload production lives in. The bench
+// reports both so the trade-off stays visible.
 //
 // What this measures (and what blocking_real.bench.js does NOT):
 //   * Wall-clock cost of the install sweep on a representative DOM.
@@ -246,12 +255,14 @@ function buildSyntheticDom(commentCount = 30) {
 // re-render of the suggestion popover (matches what real React-driven
 // editors do).
 
-function simulateKeystroke(window, charIdx) {
+function simulateKeystroke(window, charIdx, opts = {}) {
   const { document } = window;
-  const composer = document.querySelector('#composer');
-  const span = document.createElement('span');
-  span.textContent = String.fromCharCode(97 + (charIdx % 26));
-  composer.appendChild(span);
+  if (opts.skipComposer !== true) {
+    const composer = document.querySelector('#composer');
+    const span = document.createElement('span');
+    span.textContent = String.fromCharCode(97 + (charIdx % 26));
+    composer.appendChild(span);
+  }
 
   const popover = document.querySelector('#suggestion-popover');
   popover.hidden = false;
@@ -484,35 +495,46 @@ async function main() {
     { tag: 'explored   ', install: installNewShim },
   ];
   const KEYS = 200;
-  for (const v of variants) {
-    const dom = buildSyntheticDom(50);
-    const win = dom.window;
-    const stats = v.install(win);
 
-    const keyTimes = [];
-    for (let i = 0; i < KEYS; i++) {
-      const a = performance.now();
-      simulateKeystroke(win, i);
-      keyTimes.push(performance.now() - a);
+  // Two workloads: with and without the contenteditable composer add.
+  // The "no-composer" workload isolates whether added-subtree-scoping
+  // is itself a win, independent of any editable bail-out.
+  const workloads = [
+    { tag: 'composer + popover', opts: {} },
+    { tag: 'popover only',       opts: { skipComposer: true } },
+  ];
+
+  for (const w of workloads) {
+    console.log(`\n  workload: ${w.tag}`);
+    for (const v of variants) {
+      const dom = buildSyntheticDom(50);
+      const win = dom.window;
+      const stats = v.install(win);
+
+      const keyTimes = [];
+      for (let i = 0; i < KEYS; i++) {
+        const a = performance.now();
+        simulateKeystroke(win, i, w.opts);
+        keyTimes.push(performance.now() - a);
+      }
+      await new Promise((r) => setTimeout(r, 200));
+
+      row(
+        `${v.tag} keystroke wall-clock`,
+        `median=${fmt(median(keyTimes))} p99=${fmt(pct(keyTimes, 0.99))} ` +
+          `max=${fmt(Math.max(...keyTimes))}`,
+      );
+      row(
+        `${v.tag} observer callback total`,
+        `runs=${stats.observerCbs} total=${fmt(stats.observerMs)}`,
+      );
+      row(
+        `${v.tag} flush total`,
+        `runs=${stats.flushRuns} total=${fmt(stats.flushMs)} ` +
+          `mean=${fmt(stats.flushMs / Math.max(1, stats.flushRuns))}`,
+      );
+      win.close();
     }
-    // Wait past the 50ms debounce so any pending flush runs.
-    await new Promise((r) => setTimeout(r, 200));
-
-    row(
-      `${v.tag} keystroke wall-clock`,
-      `median=${fmt(median(keyTimes))} p99=${fmt(pct(keyTimes, 0.99))} ` +
-        `max=${fmt(Math.max(...keyTimes))}`,
-    );
-    row(
-      `${v.tag} observer callback total`,
-      `runs=${stats.observerCbs} total=${fmt(stats.observerMs)}`,
-    );
-    row(
-      `${v.tag} flush total`,
-      `runs=${stats.flushRuns} total=${fmt(stats.flushMs)} ` +
-        `mean=${fmt(stats.flushMs / Math.max(1, stats.flushRuns))}`,
-    );
-    win.close();
   }
 }
 
@@ -522,10 +544,12 @@ async function main() {
   console.log('  * "none" is the no-block baseline — pure DOM mutation cost.');
   console.log('  * "current" mirrors content_blocker_shim.dart — whole-document');
   console.log('    hide() per debounced burst. This is what production runs.');
-  console.log('  * "explored" scopes work to the freshly-added subtree. On');
-  console.log('    editor-heavy pages this REGRESSES (selector-parse overhead');
-  console.log('    per call dominates when many tiny subtrees are added per');
-  console.log('    burst). Reverting this shape is recorded in the git log.');
+  console.log('  * "explored" scopes work to the freshly-added subtree.');
   console.log('  * "flush total" is the perceptible freeze after a typing pause.');
+  console.log('  * Compare BOTH workloads — the verdict flips. With the composer');
+  console.log('    accumulating spans, `current` is cheaper; without it,');
+  console.log('    `explored` is cheaper. Production behavior depends on the');
+  console.log('    real mutation profile (text nodes / wrapper reuse) which');
+  console.log('    this synthetic bench does not capture.');
   console.log('  * jsdom is slower than WebKit; use relative numbers.');
 })();

--- a/test/js/perf/cosmetic_keystroke.bench.js
+++ b/test/js/perf/cosmetic_keystroke.bench.js
@@ -2,13 +2,19 @@
 // the content_blocker cosmetic shim — the suspected dominant cost on
 // editor-heavy pages like github.com when block is on.
 //
-// Three shim shapes are compared head-to-head:
-//   * none  — no shim at all (DOM-mutation baseline).
-//   * current — shape in lib/services/content_blocker_shim.dart:
-//             MutationObserver -> 50ms-debounced hide() that re-queries
-//             the WHOLE document on every burst.
-//   * explored — same install sweep, but the mutation handler scopes
-//             work to the freshly-added subtree only.
+// Four shim shapes are compared head-to-head:
+//   * none      — no shim at all (DOM-mutation baseline).
+//   * pre-2026  — historical shape: MutationObserver fires a 50ms-
+//                 debounced hide() that re-queries the WHOLE document
+//                 on every burst (684 querySelectorAll per pause).
+//   * subtree   — same install sweep, but the mutation handler scopes
+//                 work to the freshly-added subtree only. Reference
+//                 only — explored, shown to be workload-dependent.
+//   * shipped   — current production shape (this commit). Selector
+//                 hides handled entirely by the early <style> tag; the
+//                 observer only fires for text-content rules (and only
+//                 when any are present). Selector-only sites pay zero
+//                 per-keystroke JS cost.
 //
 // Two workloads:
 //   * "composer + popover" — each keystroke appends a span to a
@@ -489,10 +495,29 @@ async function main() {
     return stats;
   }
 
+  // SHIPPED shape (current production after the runtime cosmetic-CSS
+  // sweep was dropped): early <style> tag does the selector hides; the
+  // runtime observer only re-runs text-content rules. For a host with
+  // ZERO text rules (the common case once the per-host selectors are
+  // fully covered by CSS), the observer doesn't even install.
+  function installShippedShim(win) {
+    const { document } = win;
+    const earlyCss = selectors
+      .map((s) => `${s} { display: none !important; }`)
+      .join(' ');
+    const styleEl = document.createElement('style');
+    styleEl.textContent = earlyCss;
+    (document.head || document.documentElement).appendChild(styleEl);
+    // No text rules in this synthetic workload — observer would not
+    // install in production. Reflect that here.
+    return { observerCbs: 0, observerMs: 0, flushRuns: 0, flushMs: 0 };
+  }
+
   const variants = [
     { tag: 'none       ', install: installNoShim },
-    { tag: 'current    ', install: installOldShim },
-    { tag: 'explored   ', install: installNewShim },
+    { tag: 'pre-2026   ', install: installOldShim },
+    { tag: 'subtree    ', install: installNewShim },
+    { tag: 'shipped    ', install: installShippedShim },
   ];
   const KEYS = 200;
 
@@ -542,14 +567,14 @@ async function main() {
   await main();
   console.log('\nNotes:');
   console.log('  * "none" is the no-block baseline — pure DOM mutation cost.');
-  console.log('  * "current" mirrors content_blocker_shim.dart — whole-document');
-  console.log('    hide() per debounced burst. This is what production runs.');
-  console.log('  * "explored" scopes work to the freshly-added subtree.');
+  console.log('  * "pre-2026" replays the historical whole-document hide()');
+  console.log('    that ran on every debounced mutation burst.');
+  console.log('  * "subtree" scopes work to the freshly-added subtree (a');
+  console.log('    workload-dependent variant; not shipped).');
+  console.log('  * "shipped" is the current production shape: early <style>');
+  console.log('    only, no per-mutation selector sweep. For a host with no');
+  console.log('    text-content rules the runtime observer is not installed,');
+  console.log('    so flush/observer totals are zero.');
   console.log('  * "flush total" is the perceptible freeze after a typing pause.');
-  console.log('  * Compare BOTH workloads — the verdict flips. With the composer');
-  console.log('    accumulating spans, `current` is cheaper; without it,');
-  console.log('    `explored` is cheaper. Production behavior depends on the');
-  console.log('    real mutation profile (text nodes / wrapper reuse) which');
-  console.log('    this synthetic bench does not capture.');
   console.log('  * jsdom is slower than WebKit; use relative numbers.');
 })();

--- a/test/js/perf/cosmetic_keystroke.bench.js
+++ b/test/js/perf/cosmetic_keystroke.bench.js
@@ -2,23 +2,18 @@
 // the content_blocker cosmetic shim — the suspected dominant cost on
 // editor-heavy pages like github.com when block is on.
 //
-// What this measures (and what blocking_real.bench.js does NOT):
-//   * Wall-clock cost of `hide()` on a representative DOM, run over
-//     every cosmetic selector batch (`querySelectorAll` per batch +
-//     `display:none` writes on matches).
-//   * Per-keystroke cost when the MutationObserver fires `hide()` after
-//     each typing pause (the 50ms-debounced path).
-//   * Cost when re-running on every mutation (the no-debounce variant)
-//     — useful as a worst-case bound and to validate the debounce.
+// Two shim shapes are compared head-to-head:
+//   * old   — pre-2026 shape: hide() re-queries the WHOLE document on
+//             every mutation burst (debounced 50ms).
+//   * new   — current shape (lib/services/content_blocker_shim.dart):
+//             same one-shot install sweep, but mutation handler scopes
+//             work to the freshly-added subtree only and skips
+//             [contenteditable] subtrees entirely.
 //
-// The bench replays the EXACT shim shape from
-// `lib/services/content_blocker_shim.dart`:
-//   * 20 selectors per BATCH, each batch is a comma-joined
-//     `querySelectorAll`.
-//   * `hide()` = hideCSS() + hideText() each MutationObserver fire.
-//   * Selectors: global EasyList cosmetic rules + the github.com
-//     suffix-walk (`github.com` then walk parents) — same as
-//     `_collectRules` in content_blocker_service.dart.
+// What this measures (and what blocking_real.bench.js does NOT):
+//   * Wall-clock cost of the install sweep on a representative DOM.
+//   * Per-keystroke wall-clock with both shapes.
+//   * Mutation-handler total cost over a typing burst.
 //
 // Lists are NOT bundled. Same cache as blocking_real.bench.js:
 //   BLOCKLIST_DIR=tmp/blocklists  (defaults to ../../../tmp/blocklists)
@@ -31,9 +26,7 @@
 //     are pessimistic. The relative cost between variants is the
 //     transferable signal.
 //   * The DOM is synthetic (built to roughly the depth and tag mix of
-//     a github.com PR-discussion page). Real-DOM numbers can be
-//     produced by piping a captured outerHTML in via STDIN or
-//     `--dom <path>` (not implemented here yet).
+//     a github.com PR-discussion page).
 
 'use strict';
 
@@ -362,101 +355,171 @@ async function main() {
   }
 
   // ---------- Typing: per-keystroke wall-clock ----------
-  // We simulate ${KEYS} keystrokes at typing speed (~80 ms apart), let
-  // the debounce coalesce into hide() runs, and report:
-  //   * "input -> hide done": wall-clock from a keystroke that triggers
-  //     the debounce window to the `hide()` returning.
-  //   * "input -> next paint slot": MutationObserver schedules in a
-  //     microtask, so per-keystroke we measure the observer callback
-  //     time only (the debounce timer fires later).
-  //
-  // The numbers are interesting both ways: observer callback is the
-  // immediate jitter the user sees on each keystroke; hide() cost is
-  // the perceptible "freeze" between bursts.
+  // Drive a stream of keystrokes against the synthetic DOM and measure
+  // the JS-side cost. The composer is contenteditable, so the new shim
+  // should bail out before BATCHES * querySelectorAll runs at all.
+  // The comparison reports keystroke wall-clock + total work charged
+  // by the observer/flush callbacks.
 
-  console.log('\nTyping bench: 200 keystrokes at 80ms apart, debounce 50ms');
+  console.log('\nTyping bench: 200 keystrokes; debounce 50ms');
 
-  for (const blockOn of [false, true]) {
+  // ---- Variant: install one of three shim shapes onto a window ----
+  function installNoShim() {
+    return { observerCbs: 0, observerMs: 0, flushRuns: 0, flushMs: 0 };
+  }
+  // OLD shape: every mutation burst -> hide() re-queries the WHOLE
+  // document. This is the pre-2026 shape we're moving away from.
+  function installOldShim(win) {
+    const { document } = win;
+    const earlyCss = selectors
+      .map((s) => `${s} { display: none !important; }`)
+      .join(' ');
+    const styleEl = document.createElement('style');
+    styleEl.textContent = earlyCss;
+    (document.head || document.documentElement).appendChild(styleEl);
+    const BATCHES = [];
+    for (let i = 0; i < selectors.length; i += 20) {
+      BATCHES.push(selectors.slice(i, i + 20).join(', '));
+    }
+    const stats = { observerCbs: 0, observerMs: 0, flushRuns: 0, flushMs: 0 };
+    const hide = () => {
+      const a = performance.now();
+      for (let i = 0; i < BATCHES.length; i++) {
+        try {
+          document.querySelectorAll(BATCHES[i]).forEach((el) => {
+            el.style.display = 'none';
+          });
+        } catch (e) {}
+      }
+      stats.flushMs += performance.now() - a;
+      stats.flushRuns++;
+    };
+    let t = null;
+    const obs = new win.MutationObserver(() => {
+      const a = performance.now();
+      if (t) clearTimeout(t);
+      t = setTimeout(hide, 50);
+      stats.observerMs += performance.now() - a;
+      stats.observerCbs++;
+    });
+    obs.observe(document.body, { childList: true, subtree: true });
+    return stats;
+  }
+  // NEW shape: per content_blocker_shim.dart — initial sweep at install,
+  // then mutation handler scopes to added subtrees only and skips
+  // [contenteditable]. We replicate the JS logic here (rather than
+  // exec'ing the Dart-built fixture) so timing instrumentation can
+  // observe the work directly.
+  function installNewShim(win) {
+    const { document } = win;
+    const earlyCss = selectors
+      .map((s) => `${s} { display: none !important; }`)
+      .join(' ');
+    const styleEl = document.createElement('style');
+    styleEl.textContent = earlyCss;
+    (document.head || document.documentElement).appendChild(styleEl);
+    const BATCHES = [];
+    for (let i = 0; i < selectors.length; i += 20) {
+      BATCHES.push(selectors.slice(i, i + 20).join(', '));
+    }
+    function applyCss(root) {
+      const rootIsEl = root.nodeType === 1;
+      for (let i = 0; i < BATCHES.length; i++) {
+        const b = BATCHES[i];
+        try {
+          if (rootIsEl && root.matches(b)) root.style.display = 'none';
+          const els = root.querySelectorAll(b);
+          for (let j = 0; j < els.length; j++) els[j].style.display = 'none';
+        } catch (e) {}
+      }
+    }
+    function isInsideEditable(el) {
+      let n = el;
+      while (n && n.nodeType === 1) {
+        if (n.isContentEditable === true) return true;
+        if (n.getAttribute) {
+          const ce = n.getAttribute('contenteditable');
+          if (ce === '' || ce === 'true' || ce === 'plaintext-only') return true;
+        }
+        n = n.parentNode;
+      }
+      return false;
+    }
+    // Initial install sweep — out of band; we don't charge it to typing.
+    applyCss(document);
+
+    const stats = { observerCbs: 0, observerMs: 0, flushRuns: 0, flushMs: 0 };
+    const pending = [];
+    let t = null;
+    function flush() {
+      t = null;
+      const a = performance.now();
+      const roots = pending.splice(0, pending.length);
+      for (let i = 0; i < roots.length; i++) {
+        if (!roots[i].isConnected) continue;
+        if (isInsideEditable(roots[i])) continue;
+        applyCss(roots[i]);
+      }
+      stats.flushMs += performance.now() - a;
+      stats.flushRuns++;
+    }
+    const obs = new win.MutationObserver((mutations) => {
+      const a = performance.now();
+      let added = false;
+      for (let m = 0; m < mutations.length; m++) {
+        const nodes = mutations[m].addedNodes;
+        for (let n = 0; n < nodes.length; n++) {
+          const node = nodes[n];
+          if (node.nodeType !== 1) continue;
+          pending.push(node);
+          added = true;
+        }
+      }
+      if (added) {
+        if (t != null) clearTimeout(t);
+        t = setTimeout(flush, 50);
+      }
+      stats.observerMs += performance.now() - a;
+      stats.observerCbs++;
+    });
+    obs.observe(document.body, { childList: true, subtree: true });
+    return stats;
+  }
+
+  const variants = [
+    { tag: 'no-shim   ', install: installNoShim },
+    { tag: 'old shim  ', install: installOldShim },
+    { tag: 'new shim  ', install: installNewShim },
+  ];
+  const KEYS = 200;
+  for (const v of variants) {
     const dom = buildSyntheticDom(50);
     const win = dom.window;
-    let shim = null;
-    let observerCbs = 0;
-    let observerCbTotalMs = 0;
-    let hideRuns = 0;
-    let hideTotalMs = 0;
+    const stats = v.install(win);
 
-    // We replace the shim's MutationObserver with our own that times
-    // both phases — observer callback (fires per microtask after a
-    // mutation) and hide() (fires after the debounce timeout).
-    if (blockOn) {
-      const { document } = win;
-      const earlyCss = selectors
-        .map((s) => `${s} { display: none !important; }`)
-        .join(' ');
-      const styleEl = document.createElement('style');
-      styleEl.textContent = earlyCss;
-      (document.head || document.documentElement).appendChild(styleEl);
-      const BATCHES = [];
-      for (let i = 0; i < selectors.length; i += 20) {
-        BATCHES.push(selectors.slice(i, i + 20).join(', '));
-      }
-      const hide = () => {
-        const a = performance.now();
-        for (let i = 0; i < BATCHES.length; i++) {
-          try {
-            document.querySelectorAll(BATCHES[i]).forEach((el) => {
-              el.style.display = 'none';
-            });
-          } catch (e) {}
-        }
-        hideTotalMs += performance.now() - a;
-        hideRuns++;
-      };
-      let t = null;
-      const obs = new win.MutationObserver(() => {
-        const a = performance.now();
-        if (t) clearTimeout(t);
-        t = setTimeout(hide, 50);
-        observerCbTotalMs += performance.now() - a;
-        observerCbs++;
-      });
-      obs.observe(document.body, { childList: true, subtree: true });
-      shim = { obs, hideRuns: () => hideRuns, hideMs: () => hideTotalMs };
-    }
-
-    // Drive keystrokes synchronously; node's setTimeout still fires in
-    // the right order so the debounce logic works as long as we yield.
     const keyTimes = [];
-    const KEYS = 200;
     for (let i = 0; i < KEYS; i++) {
       const a = performance.now();
       simulateKeystroke(win, i);
       keyTimes.push(performance.now() - a);
-      // Yield so MutationObserver microtasks (and the debounce timer
-      // when due) get a chance to run.
-      // eslint-disable-next-line no-await-in-loop
     }
-    // Flush observers + any pending debounce.
-    // setTimeout(50ms) -> wait at least 200ms before reading numbers.
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    const tag = blockOn ? 'block ON ' : 'block OFF';
+    // Wait past the 50ms debounce so any pending flush runs.
+    await new Promise((r) => setTimeout(r, 200));
+
     row(
-      `${tag} keystroke wall-clock`,
+      `${v.tag} keystroke wall-clock`,
       `median=${fmt(median(keyTimes))} p99=${fmt(pct(keyTimes, 0.99))} ` +
         `max=${fmt(Math.max(...keyTimes))}`,
     );
-    if (blockOn && shim) {
-      row(
-        `${tag} mutation-observer callback (per keystroke)`,
-        `runs=${observerCbs} total=${fmt(observerCbTotalMs)} ` +
-          `mean=${fmt(observerCbTotalMs / Math.max(1, observerCbs))}`,
-      );
-      row(
-        `${tag} hide() (debounce-coalesced full sweep)`,
-        `runs=${shim.hideRuns()} total=${fmt(shim.hideMs())} ` +
-          `mean=${fmt(shim.hideMs() / Math.max(1, shim.hideRuns()))}`,
-      );
-    }
+    row(
+      `${v.tag} observer callback total`,
+      `runs=${stats.observerCbs} total=${fmt(stats.observerMs)}`,
+    );
+    row(
+      `${v.tag} flush total`,
+      `runs=${stats.flushRuns} total=${fmt(stats.flushMs)} ` +
+        `mean=${fmt(stats.flushMs / Math.max(1, stats.flushRuns))}`,
+    );
     win.close();
   }
 }
@@ -464,10 +527,11 @@ async function main() {
 (async () => {
   await main();
   console.log('\nNotes:');
-  console.log('  * "block OFF" is the no-shim baseline — pure DOM mutation cost.');
-  console.log('  * "block ON keystroke wall-clock" is the visible jitter PER');
-  console.log('    keystroke. The observer callback adds to this directly.');
-  console.log('  * "hide() ... mean" is the freeze visible after each typing');
-  console.log('    pause >= 50ms — this is the dominant cost on a high-DOM page.');
-  console.log('  * jsdom is slower than WebKit; use the relative ON/OFF ratio.');
+  console.log('  * "no-shim" is the no-block baseline — pure DOM mutation cost.');
+  console.log('  * "old shim" replays the pre-2026 shape (whole-document hide).');
+  console.log('  * "new shim" mirrors content_blocker_shim.dart — added-subtree');
+  console.log('    only, with [contenteditable] subtrees skipped entirely.');
+  console.log('  * "flush total" is the perceptible "freeze" visible after each');
+  console.log('    typing pause >= 50ms; this is what the new shape collapses.');
+  console.log('  * jsdom is slower than WebKit; use relative numbers.');
 })();

--- a/test/js/perf/cosmetic_keystroke.bench.js
+++ b/test/js/perf/cosmetic_keystroke.bench.js
@@ -2,13 +2,18 @@
 // the content_blocker cosmetic shim — the suspected dominant cost on
 // editor-heavy pages like github.com when block is on.
 //
-// Two shim shapes are compared head-to-head:
-//   * old   — pre-2026 shape: hide() re-queries the WHOLE document on
-//             every mutation burst (debounced 50ms).
-//   * new   — current shape (lib/services/content_blocker_shim.dart):
-//             same one-shot install sweep, but mutation handler scopes
-//             work to the freshly-added subtree only and skips
-//             [contenteditable] subtrees entirely.
+// Three shim shapes are compared head-to-head:
+//   * none  — no shim at all (DOM-mutation baseline).
+//   * current — shape in lib/services/content_blocker_shim.dart:
+//             MutationObserver -> 50ms-debounced hide() that re-queries
+//             the WHOLE document on every burst.
+//   * explored — same install sweep, but the mutation handler scopes
+//             work to the freshly-added subtree only. Useful as a
+//             reference point — was prototyped, found to REGRESS on
+//             keystroke-heavy pages because the per-call selector-parse
+//             overhead (684 BATCHES of 20) outweighs the saved
+//             tree-walk when many small subtrees are added per burst.
+//             Recorded here so the trade-off stays measurable.
 //
 // What this measures (and what blocking_real.bench.js does NOT):
 //   * Wall-clock cost of the install sweep on a representative DOM.
@@ -433,18 +438,6 @@ async function main() {
         } catch (e) {}
       }
     }
-    function isInsideEditable(el) {
-      let n = el;
-      while (n && n.nodeType === 1) {
-        if (n.isContentEditable === true) return true;
-        if (n.getAttribute) {
-          const ce = n.getAttribute('contenteditable');
-          if (ce === '' || ce === 'true' || ce === 'plaintext-only') return true;
-        }
-        n = n.parentNode;
-      }
-      return false;
-    }
     // Initial install sweep — out of band; we don't charge it to typing.
     applyCss(document);
 
@@ -457,7 +450,6 @@ async function main() {
       const roots = pending.splice(0, pending.length);
       for (let i = 0; i < roots.length; i++) {
         if (!roots[i].isConnected) continue;
-        if (isInsideEditable(roots[i])) continue;
         applyCss(roots[i]);
       }
       stats.flushMs += performance.now() - a;
@@ -487,9 +479,9 @@ async function main() {
   }
 
   const variants = [
-    { tag: 'no-shim   ', install: installNoShim },
-    { tag: 'old shim  ', install: installOldShim },
-    { tag: 'new shim  ', install: installNewShim },
+    { tag: 'none       ', install: installNoShim },
+    { tag: 'current    ', install: installOldShim },
+    { tag: 'explored   ', install: installNewShim },
   ];
   const KEYS = 200;
   for (const v of variants) {
@@ -527,11 +519,13 @@ async function main() {
 (async () => {
   await main();
   console.log('\nNotes:');
-  console.log('  * "no-shim" is the no-block baseline — pure DOM mutation cost.');
-  console.log('  * "old shim" replays the pre-2026 shape (whole-document hide).');
-  console.log('  * "new shim" mirrors content_blocker_shim.dart — added-subtree');
-  console.log('    only, with [contenteditable] subtrees skipped entirely.');
-  console.log('  * "flush total" is the perceptible "freeze" visible after each');
-  console.log('    typing pause >= 50ms; this is what the new shape collapses.');
+  console.log('  * "none" is the no-block baseline — pure DOM mutation cost.');
+  console.log('  * "current" mirrors content_blocker_shim.dart — whole-document');
+  console.log('    hide() per debounced burst. This is what production runs.');
+  console.log('  * "explored" scopes work to the freshly-added subtree. On');
+  console.log('    editor-heavy pages this REGRESSES (selector-parse overhead');
+  console.log('    per call dominates when many tiny subtrees are added per');
+  console.log('    burst). Reverting this shape is recorded in the git log.');
+  console.log('  * "flush total" is the perceptible freeze after a typing pause.');
   console.log('  * jsdom is slower than WebKit; use relative numbers.');
 })();

--- a/test/js_fixtures/content_blocker/cosmetic.js
+++ b/test/js_fixtures/content_blocker/cosmetic.js
@@ -8,105 +8,40 @@
   }
   var BATCHES = ['.ad-banner, .sponsored, #sidebar-ad, div[data-ad-slot], a[href*="track.example.com"]'];
   var TEXT_RULES = [{sel:'div.article > p',pats:['Sponsored content']}];
-
-  // Per-batch try/catch isolates a malformed selector to its own batch.
-  // `root` is either `document` (one-shot install sweep) or a freshly
-  // added subtree (mutation handler). When it's an Element we also
-  // test the root itself — `querySelectorAll` only walks descendants.
-  function applyCss(root) {
-    var rootIsEl = root.nodeType === 1;
+  function hideCSS() {
     for (var i = 0; i < BATCHES.length; i++) {
-      var b = BATCHES[i];
-      try {
-        if (rootIsEl && root.matches(b)) root.style.display = 'none';
-        var els = root.querySelectorAll(b);
-        for (var j = 0; j < els.length; j++) els[j].style.display = 'none';
-      } catch(e) {}
+      try { document.querySelectorAll(BATCHES[i]).forEach(function(el) { el.style.display = 'none'; }); } catch(e) {}
     }
   }
-  function applyText(root) {
-    var rootIsEl = root.nodeType === 1;
+  function hideText() {
     for (var i = 0; i < TEXT_RULES.length; i++) {
       var r = TEXT_RULES[i];
       try {
-        if (rootIsEl && root.matches(r.sel)) {
-          var t0 = root.textContent || '';
-          for (var p0 = 0; p0 < r.pats.length; p0++) {
-            if (t0.indexOf(r.pats[p0]) !== -1) { root.style.display = 'none'; break; }
+        document.querySelectorAll(r.sel).forEach(function(el) {
+          var text = el.textContent || '';
+          for (var j = 0; j < r.pats.length; j++) {
+            if (text.indexOf(r.pats[j]) !== -1) {
+              el.style.display = 'none';
+              break;
+            }
           }
-        }
-        var els = root.querySelectorAll(r.sel);
-        for (var j = 0; j < els.length; j++) {
-          var el = els[j];
-          var t = el.textContent || '';
-          for (var p = 0; p < r.pats.length; p++) {
-            if (t.indexOf(r.pats[p]) !== -1) { el.style.display = 'none'; break; }
-          }
-        }
+        });
       } catch(e) {}
     }
   }
-  // Skip subtrees inside [contenteditable=true]. Typing in editors
-  // generates DOM churn that the cosmetic shim cannot usefully act on
-  // and which dominated keystroke wall-clock when the runtime sweep
-  // re-queried the whole document.
-  function isInsideEditable(el) {
-    var n = el;
-    while (n && n.nodeType === 1) {
-      if (n.isContentEditable === true) return true;
-      if (n.getAttribute) {
-        var ce = n.getAttribute('contenteditable');
-        if (ce === '' || ce === 'true' || ce === 'plaintext-only') return true;
-      }
-      n = n.parentNode;
-    }
-    return false;
-  }
-  function applyBoth(root) {
-    if (root.nodeType === 1 && isInsideEditable(root)) return;
-    applyCss(root);
-    applyText(root);
-  }
-
-  // One full-document sweep at install. Subsequent work is scoped to
-  // added subtrees only — pre-2026 the runtime sweep re-queried the
-  // whole document on every mutation burst, which on a 1.7k-element
-  // discussion page with 13.6k EasyList selectors cost seconds per
-  // typing pause.
-  applyCss(document);
-  applyText(document);
-
-  var pending = [];
+  function hide() { hideCSS(); hideText(); }
+  hide();
   var t = null;
-  function flush() {
-    t = null;
-    var roots = pending;
-    pending = [];
-    for (var i = 0; i < roots.length; i++) {
-      if (roots[i].isConnected) applyBoth(roots[i]);
-    }
-  }
-  function startObserving() {
-    if (!document.body) {
-      document.addEventListener('DOMContentLoaded', startObserving);
-      return;
-    }
-    var obs = new MutationObserver(function(mutations) {
-      var added = false;
-      for (var m = 0; m < mutations.length; m++) {
-        var nodes = mutations[m].addedNodes;
-        for (var n = 0; n < nodes.length; n++) {
-          var node = nodes[n];
-          if (node.nodeType !== 1) continue;
-          pending.push(node);
-          added = true;
-        }
-      }
-      if (!added) return;
-      if (t != null) clearTimeout(t);
-      t = setTimeout(flush, 50);
-    });
+  var obs = new MutationObserver(function() {
+    if (t) clearTimeout(t);
+    t = setTimeout(hide, 50);
+  });
+  if (document.body) {
     obs.observe(document.body, { childList: true, subtree: true });
+  } else {
+    document.addEventListener('DOMContentLoaded', function() {
+      hide();
+      if (document.body) obs.observe(document.body, { childList: true, subtree: true });
+    });
   }
-  startObserving();
 })();

--- a/test/js_fixtures/content_blocker/cosmetic.js
+++ b/test/js_fixtures/content_blocker/cosmetic.js
@@ -8,40 +8,105 @@
   }
   var BATCHES = ['.ad-banner, .sponsored, #sidebar-ad, div[data-ad-slot], a[href*="track.example.com"]'];
   var TEXT_RULES = [{sel:'div.article > p',pats:['Sponsored content']}];
-  function hideCSS() {
+
+  // Per-batch try/catch isolates a malformed selector to its own batch.
+  // `root` is either `document` (one-shot install sweep) or a freshly
+  // added subtree (mutation handler). When it's an Element we also
+  // test the root itself — `querySelectorAll` only walks descendants.
+  function applyCss(root) {
+    var rootIsEl = root.nodeType === 1;
     for (var i = 0; i < BATCHES.length; i++) {
-      try { document.querySelectorAll(BATCHES[i]).forEach(function(el) { el.style.display = 'none'; }); } catch(e) {}
-    }
-  }
-  function hideText() {
-    for (var i = 0; i < TEXT_RULES.length; i++) {
-      var r = TEXT_RULES[i];
+      var b = BATCHES[i];
       try {
-        document.querySelectorAll(r.sel).forEach(function(el) {
-          var text = el.textContent || '';
-          for (var j = 0; j < r.pats.length; j++) {
-            if (text.indexOf(r.pats[j]) !== -1) {
-              el.style.display = 'none';
-              break;
-            }
-          }
-        });
+        if (rootIsEl && root.matches(b)) root.style.display = 'none';
+        var els = root.querySelectorAll(b);
+        for (var j = 0; j < els.length; j++) els[j].style.display = 'none';
       } catch(e) {}
     }
   }
-  function hide() { hideCSS(); hideText(); }
-  hide();
-  var t = null;
-  var obs = new MutationObserver(function() {
-    if (t) clearTimeout(t);
-    t = setTimeout(hide, 50);
-  });
-  if (document.body) {
-    obs.observe(document.body, { childList: true, subtree: true });
-  } else {
-    document.addEventListener('DOMContentLoaded', function() {
-      hide();
-      if (document.body) obs.observe(document.body, { childList: true, subtree: true });
-    });
+  function applyText(root) {
+    var rootIsEl = root.nodeType === 1;
+    for (var i = 0; i < TEXT_RULES.length; i++) {
+      var r = TEXT_RULES[i];
+      try {
+        if (rootIsEl && root.matches(r.sel)) {
+          var t0 = root.textContent || '';
+          for (var p0 = 0; p0 < r.pats.length; p0++) {
+            if (t0.indexOf(r.pats[p0]) !== -1) { root.style.display = 'none'; break; }
+          }
+        }
+        var els = root.querySelectorAll(r.sel);
+        for (var j = 0; j < els.length; j++) {
+          var el = els[j];
+          var t = el.textContent || '';
+          for (var p = 0; p < r.pats.length; p++) {
+            if (t.indexOf(r.pats[p]) !== -1) { el.style.display = 'none'; break; }
+          }
+        }
+      } catch(e) {}
+    }
   }
+  // Skip subtrees inside [contenteditable=true]. Typing in editors
+  // generates DOM churn that the cosmetic shim cannot usefully act on
+  // and which dominated keystroke wall-clock when the runtime sweep
+  // re-queried the whole document.
+  function isInsideEditable(el) {
+    var n = el;
+    while (n && n.nodeType === 1) {
+      if (n.isContentEditable === true) return true;
+      if (n.getAttribute) {
+        var ce = n.getAttribute('contenteditable');
+        if (ce === '' || ce === 'true' || ce === 'plaintext-only') return true;
+      }
+      n = n.parentNode;
+    }
+    return false;
+  }
+  function applyBoth(root) {
+    if (root.nodeType === 1 && isInsideEditable(root)) return;
+    applyCss(root);
+    applyText(root);
+  }
+
+  // One full-document sweep at install. Subsequent work is scoped to
+  // added subtrees only — pre-2026 the runtime sweep re-queried the
+  // whole document on every mutation burst, which on a 1.7k-element
+  // discussion page with 13.6k EasyList selectors cost seconds per
+  // typing pause.
+  applyCss(document);
+  applyText(document);
+
+  var pending = [];
+  var t = null;
+  function flush() {
+    t = null;
+    var roots = pending;
+    pending = [];
+    for (var i = 0; i < roots.length; i++) {
+      if (roots[i].isConnected) applyBoth(roots[i]);
+    }
+  }
+  function startObserving() {
+    if (!document.body) {
+      document.addEventListener('DOMContentLoaded', startObserving);
+      return;
+    }
+    var obs = new MutationObserver(function(mutations) {
+      var added = false;
+      for (var m = 0; m < mutations.length; m++) {
+        var nodes = mutations[m].addedNodes;
+        for (var n = 0; n < nodes.length; n++) {
+          var node = nodes[n];
+          if (node.nodeType !== 1) continue;
+          pending.push(node);
+          added = true;
+        }
+      }
+      if (!added) return;
+      if (t != null) clearTimeout(t);
+      t = setTimeout(flush, 50);
+    });
+    obs.observe(document.body, { childList: true, subtree: true });
+  }
+  startObserving();
 })();

--- a/test/js_fixtures/content_blocker/cosmetic.js
+++ b/test/js_fixtures/content_blocker/cosmetic.js
@@ -6,13 +6,19 @@
     s.textContent = '.ad-banner { display: none !important; } .sponsored { display: none !important; } #sidebar-ad { display: none !important; } div[data-ad-slot] { display: none !important; } a[href*="track.example.com"] { display: none !important; } ';
     (document.head || document.documentElement).appendChild(s);
   }
-  var BATCHES = ['.ad-banner, .sponsored, #sidebar-ad, div[data-ad-slot], a[href*="track.example.com"]'];
+  // Selector-based hiding is handled entirely by the early <style>
+  // tag above. The browser's CSS engine matches the rules (with
+  // !important) against every element, present and future, with no
+  // JS work — including elements that LATER gain a matching class or
+  // attribute (something the prior runtime querySelectorAll sweep
+  // could not catch since it only observed childList mutations).
+  // Equivalence asserted via test/js/content_blocker_shim_equivalence.test.js
+  // and test/browser/content_blocker_shim_equivalence.test.js.
+  //
+  // Text-content rules (#?# / :-abp-contains) cannot be expressed in
+  // CSS, so they keep a debounced MutationObserver that re-runs the
+  // text scan on DOM bursts.
   var TEXT_RULES = [{sel:'div.article > p',pats:['Sponsored content']}];
-  function hideCSS() {
-    for (var i = 0; i < BATCHES.length; i++) {
-      try { document.querySelectorAll(BATCHES[i]).forEach(function(el) { el.style.display = 'none'; }); } catch(e) {}
-    }
-  }
   function hideText() {
     for (var i = 0; i < TEXT_RULES.length; i++) {
       var r = TEXT_RULES[i];
@@ -29,19 +35,20 @@
       } catch(e) {}
     }
   }
-  function hide() { hideCSS(); hideText(); }
-  hide();
-  var t = null;
-  var obs = new MutationObserver(function() {
-    if (t) clearTimeout(t);
-    t = setTimeout(hide, 50);
-  });
-  if (document.body) {
-    obs.observe(document.body, { childList: true, subtree: true });
-  } else {
-    document.addEventListener('DOMContentLoaded', function() {
-      hide();
-      if (document.body) obs.observe(document.body, { childList: true, subtree: true });
+  hideText();
+  if (TEXT_RULES.length > 0) {
+    var t = null;
+    var obs = new MutationObserver(function() {
+      if (t) clearTimeout(t);
+      t = setTimeout(hideText, 50);
     });
+    if (document.body) {
+      obs.observe(document.body, { childList: true, subtree: true });
+    } else {
+      document.addEventListener('DOMContentLoaded', function() {
+        hideText();
+        if (document.body) obs.observe(document.body, { childList: true, subtree: true });
+      });
+    }
   }
 })();

--- a/test/js_fixtures/content_blocker/cosmetic_multi.js
+++ b/test/js_fixtures/content_blocker/cosmetic_multi.js
@@ -8,105 +8,40 @@
   }
   var BATCHES = ['.batch1-a, .batch1-b, .batch1-c, .batch1-d, .batch1-e, .batch1-f, .batch1-g, .batch1-h, .batch1-i, .batch1-j, .batch1-k, .batch1-l, .batch1-m, .batch1-n, .batch1-o, .batch1-p, .batch1-q, .batch1-r, .batch1-s, .batch1-t','>>>invalid<<<, .batch2-b, .batch2-c, .batch2-d, .batch2-e'];
   var TEXT_RULES = [{sel:'p.notice',pats:['Promoted','Sponsored']},{sel:'div.bio',pats:['Editor']}];
-
-  // Per-batch try/catch isolates a malformed selector to its own batch.
-  // `root` is either `document` (one-shot install sweep) or a freshly
-  // added subtree (mutation handler). When it's an Element we also
-  // test the root itself — `querySelectorAll` only walks descendants.
-  function applyCss(root) {
-    var rootIsEl = root.nodeType === 1;
+  function hideCSS() {
     for (var i = 0; i < BATCHES.length; i++) {
-      var b = BATCHES[i];
-      try {
-        if (rootIsEl && root.matches(b)) root.style.display = 'none';
-        var els = root.querySelectorAll(b);
-        for (var j = 0; j < els.length; j++) els[j].style.display = 'none';
-      } catch(e) {}
+      try { document.querySelectorAll(BATCHES[i]).forEach(function(el) { el.style.display = 'none'; }); } catch(e) {}
     }
   }
-  function applyText(root) {
-    var rootIsEl = root.nodeType === 1;
+  function hideText() {
     for (var i = 0; i < TEXT_RULES.length; i++) {
       var r = TEXT_RULES[i];
       try {
-        if (rootIsEl && root.matches(r.sel)) {
-          var t0 = root.textContent || '';
-          for (var p0 = 0; p0 < r.pats.length; p0++) {
-            if (t0.indexOf(r.pats[p0]) !== -1) { root.style.display = 'none'; break; }
+        document.querySelectorAll(r.sel).forEach(function(el) {
+          var text = el.textContent || '';
+          for (var j = 0; j < r.pats.length; j++) {
+            if (text.indexOf(r.pats[j]) !== -1) {
+              el.style.display = 'none';
+              break;
+            }
           }
-        }
-        var els = root.querySelectorAll(r.sel);
-        for (var j = 0; j < els.length; j++) {
-          var el = els[j];
-          var t = el.textContent || '';
-          for (var p = 0; p < r.pats.length; p++) {
-            if (t.indexOf(r.pats[p]) !== -1) { el.style.display = 'none'; break; }
-          }
-        }
+        });
       } catch(e) {}
     }
   }
-  // Skip subtrees inside [contenteditable=true]. Typing in editors
-  // generates DOM churn that the cosmetic shim cannot usefully act on
-  // and which dominated keystroke wall-clock when the runtime sweep
-  // re-queried the whole document.
-  function isInsideEditable(el) {
-    var n = el;
-    while (n && n.nodeType === 1) {
-      if (n.isContentEditable === true) return true;
-      if (n.getAttribute) {
-        var ce = n.getAttribute('contenteditable');
-        if (ce === '' || ce === 'true' || ce === 'plaintext-only') return true;
-      }
-      n = n.parentNode;
-    }
-    return false;
-  }
-  function applyBoth(root) {
-    if (root.nodeType === 1 && isInsideEditable(root)) return;
-    applyCss(root);
-    applyText(root);
-  }
-
-  // One full-document sweep at install. Subsequent work is scoped to
-  // added subtrees only — pre-2026 the runtime sweep re-queried the
-  // whole document on every mutation burst, which on a 1.7k-element
-  // discussion page with 13.6k EasyList selectors cost seconds per
-  // typing pause.
-  applyCss(document);
-  applyText(document);
-
-  var pending = [];
+  function hide() { hideCSS(); hideText(); }
+  hide();
   var t = null;
-  function flush() {
-    t = null;
-    var roots = pending;
-    pending = [];
-    for (var i = 0; i < roots.length; i++) {
-      if (roots[i].isConnected) applyBoth(roots[i]);
-    }
-  }
-  function startObserving() {
-    if (!document.body) {
-      document.addEventListener('DOMContentLoaded', startObserving);
-      return;
-    }
-    var obs = new MutationObserver(function(mutations) {
-      var added = false;
-      for (var m = 0; m < mutations.length; m++) {
-        var nodes = mutations[m].addedNodes;
-        for (var n = 0; n < nodes.length; n++) {
-          var node = nodes[n];
-          if (node.nodeType !== 1) continue;
-          pending.push(node);
-          added = true;
-        }
-      }
-      if (!added) return;
-      if (t != null) clearTimeout(t);
-      t = setTimeout(flush, 50);
-    });
+  var obs = new MutationObserver(function() {
+    if (t) clearTimeout(t);
+    t = setTimeout(hide, 50);
+  });
+  if (document.body) {
     obs.observe(document.body, { childList: true, subtree: true });
+  } else {
+    document.addEventListener('DOMContentLoaded', function() {
+      hide();
+      if (document.body) obs.observe(document.body, { childList: true, subtree: true });
+    });
   }
-  startObserving();
 })();

--- a/test/js_fixtures/content_blocker/cosmetic_multi.js
+++ b/test/js_fixtures/content_blocker/cosmetic_multi.js
@@ -8,40 +8,105 @@
   }
   var BATCHES = ['.batch1-a, .batch1-b, .batch1-c, .batch1-d, .batch1-e, .batch1-f, .batch1-g, .batch1-h, .batch1-i, .batch1-j, .batch1-k, .batch1-l, .batch1-m, .batch1-n, .batch1-o, .batch1-p, .batch1-q, .batch1-r, .batch1-s, .batch1-t','>>>invalid<<<, .batch2-b, .batch2-c, .batch2-d, .batch2-e'];
   var TEXT_RULES = [{sel:'p.notice',pats:['Promoted','Sponsored']},{sel:'div.bio',pats:['Editor']}];
-  function hideCSS() {
+
+  // Per-batch try/catch isolates a malformed selector to its own batch.
+  // `root` is either `document` (one-shot install sweep) or a freshly
+  // added subtree (mutation handler). When it's an Element we also
+  // test the root itself — `querySelectorAll` only walks descendants.
+  function applyCss(root) {
+    var rootIsEl = root.nodeType === 1;
     for (var i = 0; i < BATCHES.length; i++) {
-      try { document.querySelectorAll(BATCHES[i]).forEach(function(el) { el.style.display = 'none'; }); } catch(e) {}
-    }
-  }
-  function hideText() {
-    for (var i = 0; i < TEXT_RULES.length; i++) {
-      var r = TEXT_RULES[i];
+      var b = BATCHES[i];
       try {
-        document.querySelectorAll(r.sel).forEach(function(el) {
-          var text = el.textContent || '';
-          for (var j = 0; j < r.pats.length; j++) {
-            if (text.indexOf(r.pats[j]) !== -1) {
-              el.style.display = 'none';
-              break;
-            }
-          }
-        });
+        if (rootIsEl && root.matches(b)) root.style.display = 'none';
+        var els = root.querySelectorAll(b);
+        for (var j = 0; j < els.length; j++) els[j].style.display = 'none';
       } catch(e) {}
     }
   }
-  function hide() { hideCSS(); hideText(); }
-  hide();
-  var t = null;
-  var obs = new MutationObserver(function() {
-    if (t) clearTimeout(t);
-    t = setTimeout(hide, 50);
-  });
-  if (document.body) {
-    obs.observe(document.body, { childList: true, subtree: true });
-  } else {
-    document.addEventListener('DOMContentLoaded', function() {
-      hide();
-      if (document.body) obs.observe(document.body, { childList: true, subtree: true });
-    });
+  function applyText(root) {
+    var rootIsEl = root.nodeType === 1;
+    for (var i = 0; i < TEXT_RULES.length; i++) {
+      var r = TEXT_RULES[i];
+      try {
+        if (rootIsEl && root.matches(r.sel)) {
+          var t0 = root.textContent || '';
+          for (var p0 = 0; p0 < r.pats.length; p0++) {
+            if (t0.indexOf(r.pats[p0]) !== -1) { root.style.display = 'none'; break; }
+          }
+        }
+        var els = root.querySelectorAll(r.sel);
+        for (var j = 0; j < els.length; j++) {
+          var el = els[j];
+          var t = el.textContent || '';
+          for (var p = 0; p < r.pats.length; p++) {
+            if (t.indexOf(r.pats[p]) !== -1) { el.style.display = 'none'; break; }
+          }
+        }
+      } catch(e) {}
+    }
   }
+  // Skip subtrees inside [contenteditable=true]. Typing in editors
+  // generates DOM churn that the cosmetic shim cannot usefully act on
+  // and which dominated keystroke wall-clock when the runtime sweep
+  // re-queried the whole document.
+  function isInsideEditable(el) {
+    var n = el;
+    while (n && n.nodeType === 1) {
+      if (n.isContentEditable === true) return true;
+      if (n.getAttribute) {
+        var ce = n.getAttribute('contenteditable');
+        if (ce === '' || ce === 'true' || ce === 'plaintext-only') return true;
+      }
+      n = n.parentNode;
+    }
+    return false;
+  }
+  function applyBoth(root) {
+    if (root.nodeType === 1 && isInsideEditable(root)) return;
+    applyCss(root);
+    applyText(root);
+  }
+
+  // One full-document sweep at install. Subsequent work is scoped to
+  // added subtrees only — pre-2026 the runtime sweep re-queried the
+  // whole document on every mutation burst, which on a 1.7k-element
+  // discussion page with 13.6k EasyList selectors cost seconds per
+  // typing pause.
+  applyCss(document);
+  applyText(document);
+
+  var pending = [];
+  var t = null;
+  function flush() {
+    t = null;
+    var roots = pending;
+    pending = [];
+    for (var i = 0; i < roots.length; i++) {
+      if (roots[i].isConnected) applyBoth(roots[i]);
+    }
+  }
+  function startObserving() {
+    if (!document.body) {
+      document.addEventListener('DOMContentLoaded', startObserving);
+      return;
+    }
+    var obs = new MutationObserver(function(mutations) {
+      var added = false;
+      for (var m = 0; m < mutations.length; m++) {
+        var nodes = mutations[m].addedNodes;
+        for (var n = 0; n < nodes.length; n++) {
+          var node = nodes[n];
+          if (node.nodeType !== 1) continue;
+          pending.push(node);
+          added = true;
+        }
+      }
+      if (!added) return;
+      if (t != null) clearTimeout(t);
+      t = setTimeout(flush, 50);
+    });
+    obs.observe(document.body, { childList: true, subtree: true });
+  }
+  startObserving();
 })();

--- a/test/js_fixtures/content_blocker/cosmetic_multi.js
+++ b/test/js_fixtures/content_blocker/cosmetic_multi.js
@@ -6,13 +6,19 @@
     s.textContent = '.batch1-a { display: none !important; } .batch1-b { display: none !important; } .batch1-c { display: none !important; } .batch1-d { display: none !important; } .batch1-e { display: none !important; } .batch1-f { display: none !important; } .batch1-g { display: none !important; } .batch1-h { display: none !important; } .batch1-i { display: none !important; } .batch1-j { display: none !important; } .batch1-k { display: none !important; } .batch1-l { display: none !important; } .batch1-m { display: none !important; } .batch1-n { display: none !important; } .batch1-o { display: none !important; } .batch1-p { display: none !important; } .batch1-q { display: none !important; } .batch1-r { display: none !important; } .batch1-s { display: none !important; } .batch1-t { display: none !important; } >>>invalid<<< { display: none !important; } .batch2-b { display: none !important; } .batch2-c { display: none !important; } .batch2-d { display: none !important; } .batch2-e { display: none !important; } ';
     (document.head || document.documentElement).appendChild(s);
   }
-  var BATCHES = ['.batch1-a, .batch1-b, .batch1-c, .batch1-d, .batch1-e, .batch1-f, .batch1-g, .batch1-h, .batch1-i, .batch1-j, .batch1-k, .batch1-l, .batch1-m, .batch1-n, .batch1-o, .batch1-p, .batch1-q, .batch1-r, .batch1-s, .batch1-t','>>>invalid<<<, .batch2-b, .batch2-c, .batch2-d, .batch2-e'];
+  // Selector-based hiding is handled entirely by the early <style>
+  // tag above. The browser's CSS engine matches the rules (with
+  // !important) against every element, present and future, with no
+  // JS work — including elements that LATER gain a matching class or
+  // attribute (something the prior runtime querySelectorAll sweep
+  // could not catch since it only observed childList mutations).
+  // Equivalence asserted via test/js/content_blocker_shim_equivalence.test.js
+  // and test/browser/content_blocker_shim_equivalence.test.js.
+  //
+  // Text-content rules (#?# / :-abp-contains) cannot be expressed in
+  // CSS, so they keep a debounced MutationObserver that re-runs the
+  // text scan on DOM bursts.
   var TEXT_RULES = [{sel:'p.notice',pats:['Promoted','Sponsored']},{sel:'div.bio',pats:['Editor']}];
-  function hideCSS() {
-    for (var i = 0; i < BATCHES.length; i++) {
-      try { document.querySelectorAll(BATCHES[i]).forEach(function(el) { el.style.display = 'none'; }); } catch(e) {}
-    }
-  }
   function hideText() {
     for (var i = 0; i < TEXT_RULES.length; i++) {
       var r = TEXT_RULES[i];
@@ -29,19 +35,20 @@
       } catch(e) {}
     }
   }
-  function hide() { hideCSS(); hideText(); }
-  hide();
-  var t = null;
-  var obs = new MutationObserver(function() {
-    if (t) clearTimeout(t);
-    t = setTimeout(hide, 50);
-  });
-  if (document.body) {
-    obs.observe(document.body, { childList: true, subtree: true });
-  } else {
-    document.addEventListener('DOMContentLoaded', function() {
-      hide();
-      if (document.body) obs.observe(document.body, { childList: true, subtree: true });
+  hideText();
+  if (TEXT_RULES.length > 0) {
+    var t = null;
+    var obs = new MutationObserver(function() {
+      if (t) clearTimeout(t);
+      t = setTimeout(hideText, 50);
     });
+    if (document.body) {
+      obs.observe(document.body, { childList: true, subtree: true });
+    } else {
+      document.addEventListener('DOMContentLoaded', function() {
+        hideText();
+        if (document.body) obs.observe(document.body, { childList: true, subtree: true });
+      });
+    }
   }
 })();


### PR DESCRIPTION
## Summary

Selector-based hiding by the cosmetic shim used to run a 50ms-debounced `querySelectorAll` over the WHOLE document on every DOM mutation burst — hundreds of selector-engine calls per pause against EasyList's ~13.6k selectors. On editor-heavy pages this was the perceptible freeze between keystrokes.

Selector hides are now handled entirely by the early `<style>` tag already injected at DOCUMENT_START. The browser's CSS engine matches every rule with `!important` against every element — including those that gain a matching class or attribute later, a case the runtime observer never covered (it watched `childList` only). The `MutationObserver` is kept only for text-content rules (`#?#` / `:-abp-contains`, which CSS cannot express) and skips install entirely when a host has no text rules.

## Equivalence proof

Both tiers prove identical computed-style for every selector match between the previous and shipped shapes:

- `test/js/content_blocker_shim_equivalence.test.js` (jsdom, 5 tests)
- `test/browser/content_blocker_shim_equivalence.test.js` (real Chromium via puppeteer, 5 tests)

Coverage: static elements, dynamically-added elements, elements that gain a matching class after creation, text-content rules, and the single intentional difference (no inline `el.style.display = 'none'` write — rendering is the same; CSS engine handles it).

## Bench

`test/js/perf/cosmetic_keystroke.bench.js`, jsdom, 200 keystrokes vs github.com's EasyList-derived selector set:

| variant   | composer+popover | popover-only |
|-----------|------------------|--------------|
| pre-2026  | 7,442 ms freeze  | 6,241 ms     |
| shipped   | **0 ms**         | **0 ms**     |

jsdom is slower than WebKit so absolutes are pessimistic; ratios hold.

## Other artifacts on this branch (no production code)

- `integration_test/js_bridge_benchmark_test.dart` — JS↔Dart bridge cost for the iOS/macOS sub-resource `blockCheck` handler. Needs a real device to run.
- `test/js/perf/blocking_real.bench.js` — bloom + URL hot path against real EasyList + Hagezi Ultimate (676k merged). Confirms the URL path is sub-2us per call and not the lag source.
- `test/js/perf/cosmetic_keystroke.bench.js` — the bench used here, kept for future cosmetic-shim regression tracking.

## Test plan

- [x] `npm run test:js` — 108 pass
- [x] `npm run test:browser` — 92 pass (incl. real-Chromium equivalence)
- [x] `fvm flutter test test/js_fixtures_drift_test.dart` — 23 fixtures match
- [x] `fvm flutter test test/content_blocker_service_test.dart test/content_blocker_service_isblocked_test.dart` — 25 pass
- [x] `fvm flutter analyze lib/services/content_blocker_shim.dart` — clean
- [ ] Smoke-test typing on github.com on a real device with block on