### PR TITLE
Add per-site Always Open Home toggle

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -968,10 +968,14 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     if (!mounted) return;
     if (siteId != null) {
       final index = _webViewModels.indexWhere((m) => m.siteId == siteId);
-      if (index >= 0 && index != _currentIndex) {
-        await _setCurrentIndex(index);
-        if (!mounted) return;
+      if (index >= 0) {
+        _resetAlwaysOpenHomeOnShortcut(index);
+        if (index != _currentIndex) {
+          await _setCurrentIndex(index);
+          if (!mounted) return;
+        }
         setState(() {});
+        await _saveWebViewModels();
       }
     }
   }
@@ -1865,6 +1869,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       if (m.currentUrl != m.initUrl) {
         m.currentUrl = m.initUrl;
       }
+      // Webspace-scoped reset: every flagged sibling in a webspace that
+      // contains the launched site also drops to its initUrl. Mostly a
+      // no-op on cold launch (fromJson already stripped currentUrl for
+      // flagged sites) but kept here for defense in depth and parity
+      // with the warm-launch path in `_handleShortcutIntent`.
+      _resetAlwaysOpenHomeOnShortcut(indexToRestore);
     }
 
     // Auto-load notification sites so they start polling immediately and
@@ -2641,6 +2651,33 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   /// rebuilt webview boots clean and goes straight to the live home URL
   /// rather than flashing a stale cached frame. Offline: the cache is
   /// preserved — it's the only content we can render without network.
+  /// Reset every "Always open Home" / incognito site that shares a named
+  /// webspace with [launchedIndex] back to its `initUrl` and tear down its
+  /// live webview so the next paint reloads at home. Called from both the
+  /// cold and warm shortcut entrypoints — on cold launch most flagged
+  /// sites already had `currentUrl` dropped during `fromJson`, so the
+  /// pass is mostly a no-op there; on warm launch it is the only thing
+  /// that resets siblings.
+  void _resetAlwaysOpenHomeOnShortcut(int launchedIndex) {
+    final indices = WebspaceSelectionEngine.indicesToResetOnShortcutLaunch(
+      launchedIndex: launchedIndex,
+      webspaces: _webspaces,
+      flag: (i) {
+        if (i < 0 || i >= _webViewModels.length) return false;
+        final m = _webViewModels[i];
+        return m.alwaysOpenHome || m.incognito;
+      },
+    );
+    for (final i in indices) {
+      final m = _webViewModels[i];
+      if (m.currentUrl == m.initUrl && m.webview == null) continue;
+      _evictCacheIfOnline(m.siteId);
+      m.currentUrl = m.initUrl;
+      m.disposeWebView();
+      _loadedIndices.remove(i);
+    }
+  }
+
   void _goHome() {
     if (_currentIndex == null || _currentIndex! >= _webViewModels.length) return;
     final model = _webViewModels[_currentIndex!];

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -120,6 +120,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late bool _javascriptEnabled;
   late bool _thirdPartyCookiesEnabled;
   late bool _incognito;
+  late bool _alwaysOpenHome;
   late bool _clearUrlEnabled;
   late bool _dnsBlockEnabled;
   late bool _contentBlockEnabled;
@@ -184,6 +185,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _javascriptEnabled = m.javascriptEnabled;
     _thirdPartyCookiesEnabled = m.thirdPartyCookiesEnabled;
     _incognito = m.incognito;
+    _alwaysOpenHome = m.alwaysOpenHome;
     _clearUrlEnabled = m.clearUrlEnabled;
     _dnsBlockEnabled = m.dnsBlockEnabled;
     _contentBlockEnabled = m.contentBlockEnabled;
@@ -351,6 +353,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       widget.webViewModel.javascriptEnabled = _javascriptEnabled;
       widget.webViewModel.thirdPartyCookiesEnabled = _thirdPartyCookiesEnabled;
       widget.webViewModel.incognito = _incognito;
+      widget.webViewModel.alwaysOpenHome = _alwaysOpenHome;
       widget.webViewModel.clearUrlEnabled = _clearUrlEnabled;
       widget.webViewModel.dnsBlockEnabled = _dnsBlockEnabled;
       widget.webViewModel.contentBlockEnabled = _contentBlockEnabled;
@@ -966,6 +969,23 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 _incognito = value;
               });
             },
+          ),
+          SwitchListTile(
+            title: const Text('Always open Home'),
+            subtitle: Text(
+              _incognito
+                  ? 'Forced on by Incognito'
+                  : 'Reset URL on app restart and home-screen shortcut '
+                      '(cookies persist)',
+            ),
+            value: _incognito || _alwaysOpenHome,
+            onChanged: _incognito
+                ? null
+                : (bool value) {
+                    setState(() {
+                      _alwaysOpenHome = value;
+                    });
+                  },
           ),
           SwitchListTile(
             title: Row(

--- a/lib/services/site_settings_qr_codec.dart
+++ b/lib/services/site_settings_qr_codec.dart
@@ -34,6 +34,7 @@ class SiteSettingsQrCodec {
     'userAgent',
     'thirdPartyCookiesEnabled',
     'incognito',
+    'alwaysOpenHome',
     'language',
     'clearUrlEnabled',
     'dnsBlockEnabled',

--- a/lib/services/webspace_selection_engine.dart
+++ b/lib/services/webspace_selection_engine.dart
@@ -49,6 +49,34 @@ class WebspaceSelectionEngine {
         .toSet();
   }
 
+  /// Site indices that should reset to their `initUrl` when the user taps
+  /// an Android home-shortcut for [launchedIndex]: every site flagged
+  /// (predicate true) that shares at least one named webspace with the
+  /// launched site. The launched site itself is included if it satisfies
+  /// the predicate. The synthetic "All" webspace is ignored — it has no
+  /// stored `siteIndices` so it never anchors the reset (a flagged site
+  /// only living in "All" still resets via its own toJson trip).
+  ///
+  /// Pure: no `setState`, no controller calls, no IO. The caller maps
+  /// the returned indices back to webview disposal + persistence.
+  static Set<int> indicesToResetOnShortcutLaunch({
+    required int launchedIndex,
+    required List<Webspace> webspaces,
+    required bool Function(int index) flag,
+  }) {
+    if (launchedIndex < 0) return const {};
+    // Anchor on the launched site itself, then expand by any named
+    // webspace it lives in. A site that only lives in the synthetic "All"
+    // webspace still resets via its own flag — no sibling propagation.
+    final candidates = <int>{launchedIndex};
+    for (final ws in webspaces) {
+      if (ws.isAll) continue;
+      if (!ws.siteIndices.contains(launchedIndex)) continue;
+      candidates.addAll(ws.siteIndices);
+    }
+    return {for (final i in candidates) if (flag(i)) i};
+  }
+
   /// Strips out-of-bounds `siteIndices` from every webspace in place. Used
   /// after reorderings or imports where indices may have drifted. No-op for
   /// webspaces whose indices are already in-bounds.

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -278,6 +278,12 @@ class WebViewModel {
   String userAgent;
   bool thirdPartyCookiesEnabled;
   bool incognito; // Private browsing mode - no cookies/cache persist
+  /// When true, the site's currentUrl/pageTitle are not persisted: every
+  /// app restart and every Android home-shortcut tap returns the site to
+  /// its `initUrl`. Cookies / localStorage / IDB ARE preserved (the user
+  /// keeps their login session); only the navigation URL resets. Implied
+  /// by [incognito], which adds the cookie/storage wipe on top.
+  bool alwaysOpenHome;
   String? language; // Language code (e.g., 'en', 'es'), null = system default
   bool clearUrlEnabled; // Strip tracking parameters from URLs via ClearURLs
   bool dnsBlockEnabled; // Block navigation to domains on Hagezi DNS blocklist
@@ -352,6 +358,7 @@ class WebViewModel {
     this.userAgent = '',
     this.thirdPartyCookiesEnabled = false,
     this.incognito = false,
+    this.alwaysOpenHome = false,
     this.language,
     this.clearUrlEnabled = true,
     this.dnsBlockEnabled = true,
@@ -1108,16 +1115,18 @@ class WebViewModel {
   /// The proxy password is never serialised — same contract as
   /// `isSecure=true` cookies, which are also stripped from exports. See
   /// `openspec/specs/proxy-password-secure-storage/spec.md` (PWD-005).
-  Map<String, dynamic> toJson() => {
+  Map<String, dynamic> toJson() {
+    // currentUrl/pageTitle are dropped when either incognito (full ephemeral
+    // session — issue #298) or alwaysOpenHome (URL-only ephemeral, cookies
+    // persist) is set. Cookies are dropped only by incognito; alwaysOpenHome
+    // banking-style sites keep their login state.
+    final dropUrl = incognito || alwaysOpenHome;
+    return {
         'siteId': siteId,
         'initUrl': initUrl,
-        // Incognito sites must not retain session state across app restarts:
-        // the currentUrl/pageTitle/cookies tuple is the user-visible session.
-        // Persisting currentUrl is what makes Google Maps reopen on the
-        // last-viewed coordinates after a kill (issue #298).
-        if (!incognito) 'currentUrl': currentUrl,
+        if (!dropUrl) 'currentUrl': currentUrl,
         'name': name,
-        if (!incognito) 'pageTitle': pageTitle,
+        if (!dropUrl) 'pageTitle': pageTitle,
         'cookies': incognito
             ? const <Map<String, dynamic>>[]
             : cookies.map((cookie) => cookie.toJson()).toList(),
@@ -1126,6 +1135,7 @@ class WebViewModel {
         'userAgent': userAgent,
         'thirdPartyCookiesEnabled': thirdPartyCookiesEnabled,
         'incognito': incognito,
+        'alwaysOpenHome': alwaysOpenHome,
         'language': language,
         'clearUrlEnabled': clearUrlEnabled,
         'dnsBlockEnabled': dnsBlockEnabled,
@@ -1148,15 +1158,19 @@ class WebViewModel {
         if (spoofTimezoneFromLocation) 'spoofTimezoneFromLocation': true,
         'webRtcPolicy': webRtcPolicy.name,
       };
+  }
 
   factory WebViewModel.fromJson(Map<String, dynamic> json, Function? stateSetterF) {
     final isIncognito = json['incognito'] as bool? ?? false;
+    final isAlwaysOpenHome = json['alwaysOpenHome'] as bool? ?? false;
+    // Either flag drops persisted currentUrl/pageTitle on rehydrate; only
+    // incognito additionally clears cookies. Defends against legacy JSON
+    // written by older builds that didn't strip on toJson.
+    final dropUrl = isIncognito || isAlwaysOpenHome;
     return WebViewModel(
       siteId: json['siteId'], // May be null for legacy data, will auto-generate
       initUrl: migrateLegacyFileImportUrl(json['initUrl'] as String),
-      // Drop persisted session state for incognito sites — handles legacy
-      // JSON written before the toJson fix (issue #298).
-      currentUrl: isIncognito || json['currentUrl'] == null
+      currentUrl: dropUrl || json['currentUrl'] == null
           ? null
           : migrateLegacyFileImportUrl(json['currentUrl'] as String),
       name: json['name'],
@@ -1170,6 +1184,7 @@ class WebViewModel {
       userAgent: json['userAgent'],
       thirdPartyCookiesEnabled: json['thirdPartyCookiesEnabled'],
       incognito: isIncognito,
+      alwaysOpenHome: isAlwaysOpenHome,
       language: json['language'],
       clearUrlEnabled: json['clearUrlEnabled'] ?? true,
       dnsBlockEnabled: json['dnsBlockEnabled'] ?? true,
@@ -1206,6 +1221,6 @@ class WebViewModel {
         orElse: () => WebRtcPolicy.defaultPolicy,
       ),
       stateSetterF: stateSetterF,
-    )..pageTitle = isIncognito ? null : json['pageTitle'];
+    )..pageTitle = dropUrl ? null : json['pageTitle'];
   }
 }

--- a/openspec/specs/always-open-home/spec.md
+++ b/openspec/specs/always-open-home/spec.md
@@ -1,0 +1,186 @@
+# Always Open Home
+
+## Purpose
+
+A per-site `alwaysOpenHome` toggle that makes the site's *navigation
+URL* ephemeral while keeping its persistent state (cookies,
+localStorage, IndexedDB, HTTP cache) intact. The site reverts to its
+`initUrl` on **app restart** and on **Android home-shortcut tap**, but
+the user's logged-in session, preferences, and other cookie-backed
+state survive both events.
+
+Two motivating cases the user split out from
+[incognito-mode](../incognito-mode/spec.md) (which ALSO drops
+cookies):
+
+- **Banking** — cookies persist so login/2FA stays streamlined, but
+  every entry lands on the login screen rather than a "session expired"
+  redirect from a deep account page.
+- **Weather** — cookies persist so a saved city / unit preference
+  survives, but the site reopens at the home-town view rather than
+  whatever city the user last drifted to.
+
+[Incognito mode](../incognito-mode/spec.md) implies `alwaysOpenHome`
+as a strict subset: an incognito site already drops `currentUrl` on
+serialize and reloads home on shortcut tap; the additional
+incognito-only effect is the cookie / localStorage wipe.
+
+## Status
+
+- **Date**: 2026-05-05
+- **Status**: Implemented
+
+---
+
+## Requirements
+
+### Requirement: AOH-001 - URL State Is Stripped On Serialization
+
+The system SHALL omit `currentUrl` and `pageTitle` from the JSON
+produced by `WebViewModel.toJson` when `alwaysOpenHome = true`. The
+`cookies` list and every other persistent field SHALL be retained
+unchanged on the same call.
+
+#### Scenario: Always-open-home JSON omits currentUrl
+
+**Given** a `WebViewModel` with `alwaysOpenHome = true`, `incognito = false`, and `currentUrl != initUrl`
+**When** `toJson()` is called
+**Then** the resulting map does NOT contain a `currentUrl` key
+**And** does NOT contain a `pageTitle` key
+**And** the `cookies` list reflects the in-memory list (unchanged)
+
+#### Scenario: Plain site JSON retains URL
+
+**Given** a `WebViewModel` with `alwaysOpenHome = false` and `incognito = false`
+**When** `toJson()` is called
+**Then** `currentUrl` is present
+**And** `pageTitle` is present (may be null)
+
+---
+
+### Requirement: AOH-002 - URL State Is Discarded On Deserialization
+
+The system SHALL discard any persisted `currentUrl` / `pageTitle` when
+a `WebViewModel` is rehydrated with `alwaysOpenHome = true`. This
+covers JSON written by older builds (defense in depth) and JSON
+imported from settings backups.
+
+#### Scenario: Legacy JSON with alwaysOpenHome + currentUrl
+
+**Given** a JSON map written by a build that did not strip on toJson, with `alwaysOpenHome: true` and `currentUrl: "https://www.bank.example/account/123"`
+**When** `WebViewModel.fromJson(json, ...)` is called
+**Then** the resulting model's `currentUrl` equals its `initUrl`
+**And** the resulting model's `pageTitle` is null
+**And** the resulting model's `cookies` reflect the persisted list (NOT cleared)
+
+---
+
+### Requirement: AOH-003 - Cookies Are Preserved
+
+The toggle SHALL NOT clear cookies, localStorage, IndexedDB, HTTP
+cache, or any other persistent per-site store on serialize, on
+deserialize, on shortcut tap, or on app start. The semantic boundary
+between `alwaysOpenHome` and [incognito](../incognito-mode/spec.md) is
+exactly that: incognito wipes session storage, alwaysOpenHome leaves
+it alone.
+
+#### Scenario: Banking site cookies survive app restart
+
+**Given** a banking site with `alwaysOpenHome = true` and a logged-in session cookie
+**When** the user kills the app and relaunches
+**Then** the site's webview loads at `initUrl` (e.g. login URL)
+**And** the persisted cookie is restored from `CookieSecureStorage`
+**And** the bank redirects the login page to the dashboard automatically (or session continues seamlessly)
+
+---
+
+### Requirement: AOH-004 - Webspace-Scoped Reset On Shortcut Tap
+
+The system SHALL reset `currentUrl` to `initUrl` for every flagged
+site that shares at least one named webspace with the launched site
+when the user taps an Android home-shortcut. A site is "flagged"
+when `alwaysOpenHome = true` or `incognito = true`. The launched site
+itself is reset whenever it is flagged. The synthetic "All" webspace
+MUST NOT count as shared membership for this rule.
+
+The reset SHALL apply to both cold launches via shortcut (overlapping
+with [HS-006](../home-shortcut/spec.md), which already resets the
+launched site itself regardless of its flag) and warm taps while the
+app is already running.
+
+#### Scenario: Warm shortcut tap resets banking siblings
+
+**Given** webspace "Banking" contains site A (login.bank.example) and site B (login.creditcard.example), both with `alwaysOpenHome = true`
+**And** the app is running and B is currently active and has navigated to `https://login.creditcard.example/account/123`
+**And** the user is currently in the "Banking" webspace
+**When** the user taps A's home-screen shortcut
+**Then** A becomes active
+**And** A's webview is created with URL `initUrl` (or stays at `initUrl` if not yet built)
+**And** B's webview is disposed
+**And** B's `currentUrl` is reset to its `initUrl`
+**And** the next time B is shown, it reloads at `initUrl`
+
+#### Scenario: Webspace boundary keeps unrelated flagged sites untouched
+
+**Given** webspace "Banking" contains site A (`alwaysOpenHome = true`)
+**And** webspace "Mail" contains site C (`alwaysOpenHome = true`), distinct from "Banking"
+**And** A and C share no named webspace
+**When** the user warm-taps A's home-screen shortcut
+**Then** A resets to its initUrl
+**And** C's currentUrl is unchanged
+
+#### Scenario: Unflagged launched site still gets HS-006 cold-reset
+
+**Given** site A has `alwaysOpenHome = false`
+**And** the user cold-launches the app via A's home shortcut
+**Then** A's currentUrl resets to its initUrl per [HS-006](../home-shortcut/spec.md)
+**And** no flagged sibling propagation runs against A's webspace if A's flag is false (the flag controls the propagation; sibling flagged sites in A's webspace still reset because the propagation is anchored on the launched site, not gated by its own flag)
+
+---
+
+### Requirement: AOH-005 - Incognito Implies Always Open Home
+
+A site with `incognito = true` SHALL be treated by the URL-stripping
+and shortcut-reset paths as if `alwaysOpenHome` were also true,
+regardless of the stored `alwaysOpenHome` value.
+
+#### Scenario: Incognito serialization drops URL
+
+**Given** a `WebViewModel` with `incognito = true` and `alwaysOpenHome = false`
+**When** `toJson()` is called
+**Then** the resulting map does NOT contain `currentUrl` or `pageTitle`
+**And** the `cookies` list is empty (incognito's separate contract — see [INC-003](../incognito-mode/spec.md))
+
+#### Scenario: Settings UI grays out the toggle when incognito is on
+
+**Given** the user opens per-site settings for a site with `incognito = true`
+**When** the page renders
+**Then** the "Always open Home" switch is shown ON
+**And** the switch is disabled (no `onChanged` callback)
+**And** the subtitle reads "Forced on by Incognito"
+
+---
+
+## Implementation
+
+### Files
+
+#### Modified
+
+- `lib/web_view_model.dart` — `alwaysOpenHome` field, ctor param,
+  `toJson` URL-strip gate, `fromJson` URL-strip gate.
+- `lib/main.dart` — `_resetAlwaysOpenHomeOnShortcut(int)` helper
+  invoked from `_restoreAppState` (cold) and `_handleShortcutIntent`
+  (warm).
+- `lib/services/webspace_selection_engine.dart` —
+  `indicesToResetOnShortcutLaunch` pure helper computes the reset set
+  from the launched index + the webspaces list + a flag predicate.
+- `lib/screens/settings.dart` — per-site `SwitchListTile` for the
+  toggle, gated on `_incognito`.
+
+#### Tests
+
+- `test/web_view_model_test.dart` — toJson/fromJson scenarios for the
+  new flag.
+- `test/webspace_selection_engine_test.dart` —
+  `indicesToResetOnShortcutLaunch` cases.

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -102,6 +102,28 @@ The pinned-shortcut set is queried via `ShortcutManagerCompat.getShortcuts(FLAG_
 
 ---
 
+### Requirement: HS-007 - Shortcut Tap Propagates To Flagged Siblings
+
+The system SHALL reset `currentUrl` to `initUrl` for every flagged
+sibling of the launched site when an Android home-shortcut is tapped.
+A site is "flagged" if `alwaysOpenHome = true` or `incognito = true`.
+A "sibling" is any site that shares at least one named webspace with
+the launched site. The full cold/warm, "All"-webspace, and scenario
+detail lives in [always-open-home/AOH-004](../always-open-home/spec.md).
+
+This requirement layers on top of HS-006: HS-006 governs the launched
+site itself on cold launch; HS-007 governs the propagation to siblings
+in any webspace containing the launched site.
+
+#### Scenario: Sibling resets cross-reference
+
+**Given** the user has set `alwaysOpenHome = true` for site B in webspace W and the app is running
+**When** the user warm-taps the home shortcut for site A in webspace W
+**Then** B's `currentUrl` resets to its `initUrl` per [AOH-004](../always-open-home/spec.md)
+**And** B's webview is disposed so the next paint reloads at home
+
+---
+
 ### Requirement: HS-006 - Shortcut Launch Resets To Home URL
 
 A pinned shortcut SHALL launch the targeted site at its `initUrl`, not at the last persisted `currentUrl`. The shortcut represents the user's stated entry point for that site (the URL they pinned), not the URL the previous session happened to drift to. Without this, location/tracking/state parameters that accumulate during a session resurface every time the shortcut is tapped — particularly visible on map and search sites that encode coordinates or query state in the URL (issue #298).

--- a/test/web_view_model_test.dart
+++ b/test/web_view_model_test.dart
@@ -470,6 +470,96 @@ void main() {
         expect(restored.incognito, isTrue);
       });
     });
+
+    group('alwaysOpenHome (banking case)', () {
+      test('toJson omits currentUrl/pageTitle but keeps cookies (AOH-001/003)', () {
+        final model = WebViewModel(
+          initUrl: 'https://login.bank.example',
+          currentUrl: 'https://login.bank.example/account/123',
+          cookies: [Cookie(name: 'session', value: 'keep_me')],
+          alwaysOpenHome: true,
+        )..pageTitle = 'Account 123';
+
+        final json = model.toJson();
+
+        expect(json.containsKey('currentUrl'), isFalse);
+        expect(json.containsKey('pageTitle'), isFalse);
+        // The whole point of the toggle vs incognito: cookies survive.
+        expect((json['cookies'] as List), hasLength(1));
+        expect((json['cookies'] as List)[0]['name'], 'session');
+        expect(json['alwaysOpenHome'], isTrue);
+      });
+
+      test('fromJson with alwaysOpenHome + legacy currentUrl strips it (AOH-002)', () {
+        final json = {
+          'initUrl': 'https://login.bank.example',
+          'currentUrl': 'https://login.bank.example/account/123',
+          'pageTitle': 'Stale Account',
+          'cookies': [
+            {'name': 'session', 'value': 'keep_me'}
+          ],
+          'proxySettings': {'type': 0, 'address': null},
+          'javascriptEnabled': true,
+          'userAgent': '',
+          'thirdPartyCookiesEnabled': false,
+          'alwaysOpenHome': true,
+        };
+
+        final model = WebViewModel.fromJson(json, null);
+
+        expect(model.currentUrl, equals(model.initUrl));
+        expect(model.pageTitle, isNull);
+        // Cookies preserved — distinguishes from incognito's INC-004.
+        expect(model.cookies, hasLength(1));
+        expect(model.cookies[0].name, 'session');
+        expect(model.alwaysOpenHome, isTrue);
+      });
+
+      test('alwaysOpenHome defaults to false when missing from JSON', () {
+        final json = {
+          'initUrl': 'https://example.com',
+          'currentUrl': 'https://example.com',
+          'cookies': [],
+          'proxySettings': {'type': 0, 'address': null},
+          'javascriptEnabled': true,
+          'userAgent': '',
+          'thirdPartyCookiesEnabled': false,
+        };
+
+        final model = WebViewModel.fromJson(json, null);
+        expect(model.alwaysOpenHome, isFalse);
+      });
+
+      test('non-flagged site keeps URL through round-trip', () {
+        final original = WebViewModel(
+          initUrl: 'https://example.com',
+          currentUrl: 'https://example.com/deep',
+          alwaysOpenHome: false,
+          incognito: false,
+        );
+
+        final restored = WebViewModel.fromJson(original.toJson(), null);
+
+        expect(restored.currentUrl, 'https://example.com/deep');
+      });
+
+      test('incognito + alwaysOpenHome: cookies cleared (incognito wins on cookies)', () {
+        // AOH-005: incognito implies alwaysOpenHome; the URL drop overlaps
+        // but the cookie wipe is incognito-only.
+        final model = WebViewModel(
+          initUrl: 'https://example.com',
+          currentUrl: 'https://example.com/deep',
+          cookies: [Cookie(name: 's', value: 'v')],
+          incognito: true,
+          alwaysOpenHome: true,
+        );
+
+        final json = model.toJson();
+
+        expect(json.containsKey('currentUrl'), isFalse);
+        expect(json['cookies'], isEmpty);
+      });
+    });
   });
 
   group('extractDomain', () {

--- a/test/webspace_selection_engine_test.dart
+++ b/test/webspace_selection_engine_test.dart
@@ -108,6 +108,99 @@ void main() {
     });
   });
 
+  group('WebspaceSelectionEngine.indicesToResetOnShortcutLaunch', () {
+    test('resets flagged siblings sharing a named webspace with the launched site', () {
+      // Banking webspace: A (launched) and B (flagged); Mail: C (flagged
+      // but unrelated). Tap on A's shortcut should reset B, not C.
+      final result = WebspaceSelectionEngine.indicesToResetOnShortcutLaunch(
+        launchedIndex: 0,
+        webspaces: [
+          Webspace(id: 'banking', name: 'Banking', siteIndices: [0, 1]),
+          Webspace(id: 'mail', name: 'Mail', siteIndices: [2]),
+        ],
+        flag: (i) => i == 1 || i == 2,
+      );
+      expect(result, {1});
+    });
+
+    test('includes the launched site when it satisfies the flag', () {
+      final result = WebspaceSelectionEngine.indicesToResetOnShortcutLaunch(
+        launchedIndex: 0,
+        webspaces: [
+          Webspace(id: 'banking', name: 'Banking', siteIndices: [0]),
+        ],
+        flag: (i) => true,
+      );
+      expect(result, {0});
+    });
+
+    test('excludes the launched site when its flag is false but resets siblings', () {
+      // The launched site itself is unflagged (e.g. user opened a shortcut
+      // for a non-banking site that happens to share a webspace with a
+      // flagged one). Sibling propagation still runs.
+      final result = WebspaceSelectionEngine.indicesToResetOnShortcutLaunch(
+        launchedIndex: 0,
+        webspaces: [
+          Webspace(id: 'mixed', name: 'Mixed', siteIndices: [0, 1]),
+        ],
+        flag: (i) => i == 1,
+      );
+      expect(result, {1});
+    });
+
+    test('skips the synthetic All webspace when computing siblings', () {
+      // The launched site lives in "All" and a named webspace; only the
+      // named webspace anchors the propagation. Without this, every site
+      // in the app would reset on any shortcut tap.
+      final result = WebspaceSelectionEngine.indicesToResetOnShortcutLaunch(
+        launchedIndex: 0,
+        webspaces: [
+          Webspace.all()..siteIndices = [0, 1, 2, 3],
+          Webspace(id: 'banking', name: 'Banking', siteIndices: [0, 2]),
+        ],
+        flag: (i) => true,
+      );
+      expect(result, {0, 2});
+    });
+
+    test('returns empty when launchedIndex is negative', () {
+      final result = WebspaceSelectionEngine.indicesToResetOnShortcutLaunch(
+        launchedIndex: -1,
+        webspaces: [Webspace(id: 'w', name: 'W', siteIndices: [0])],
+        flag: (i) => true,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('only the launched site resets when it lives only in the All webspace', () {
+      // No named webspace contains the launched site, so siblings cannot
+      // be inferred. The launched site itself is still anchored — if its
+      // flag is true, it resets via its own toJson trip plus this set.
+      final result = WebspaceSelectionEngine.indicesToResetOnShortcutLaunch(
+        launchedIndex: 0,
+        webspaces: [
+          Webspace(id: 'other', name: 'Other', siteIndices: [1, 2]),
+        ],
+        flag: (i) => true,
+      );
+      expect(result, {0});
+    });
+
+    test('site in multiple named webspaces resets union of flagged members', () {
+      final result = WebspaceSelectionEngine.indicesToResetOnShortcutLaunch(
+        launchedIndex: 0,
+        webspaces: [
+          Webspace(id: 'banking', name: 'Banking', siteIndices: [0, 1]),
+          Webspace(id: 'work', name: 'Work', siteIndices: [0, 2, 3]),
+          Webspace(id: 'misc', name: 'Misc', siteIndices: [4]),
+        ],
+        flag: (i) => i == 1 || i == 3 || i == 4,
+      );
+      // Misc is unrelated to A, so 4 stays.
+      expect(result, {1, 3});
+    });
+  });
+
   group('WebspaceSelectionEngine.cleanupWebspaceIndices', () {
     test('strips out-of-bounds indices in place', () {
       final webspaces = [


### PR DESCRIPTION
Splits the URL-only ephemeral half of #298's incognito fix into its own
toggle so banking/weather sites can keep cookies while still landing on
the home URL. Persisted currentUrl/pageTitle drop on toJson and on
shortcut tap; cookies and other persistent stores are untouched
(distinct from incognito's full session wipe). Shortcut-tap propagation
resets every flagged sibling that shares a named webspace with the
launched site, anchored on the launched index.