### PR TITLE
feat(link-intent-routing): three-option dispatch + stripped-path site creation

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -49,6 +49,15 @@
                 <data android:mimeType="text/html"/>
                 <data android:mimeType="application/xhtml+xml"/>
             </intent-filter>
+            <!-- LIR-004: webspace:// scheme. No autoVerify — we don't fight
+                 https handlers. Default by virtue of being the only app
+                 that registers this scheme. -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="webspace"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -46,6 +46,8 @@
                 <action android:name="android.intent.action.SEND"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <data android:mimeType="text/plain"/>
+                <data android:mimeType="text/html"/>
+                <data android:mimeType="application/xhtml+xml"/>
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -21,6 +21,13 @@ class MainActivity: FlutterActivity() {
     private var webSpaceContainerPlugin: WebSpaceContainerPlugin? = null
     private var backgroundPollPlugin: WebSpaceBackgroundPollPlugin? = null
     private var pendingShareUrl: String? = null
+    private var pendingShareHtml: HtmlPayload? = null
+
+    private data class HtmlPayload(
+        val content: String,
+        val title: String?,
+        val sourceUri: String?,
+    )
 
     override fun getFlutterShellArgs(): FlutterShellArgs {
         val args = FlutterShellArgs.fromIntent(intent)
@@ -40,13 +47,26 @@ class MainActivity: FlutterActivity() {
         locationPlugin = LocationPlugin(this, flutterEngine)
         webSpaceContainerPlugin = WebSpaceContainerPlugin(flutterEngine)
         backgroundPollPlugin = WebSpaceBackgroundPollPlugin(applicationContext, flutterEngine)
-        pendingShareUrl = extractShareUrl(intent)
+        captureSharePayload(intent)
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, SHARE_CHANNEL).setMethodCallHandler { call, result ->
             when (call.method) {
                 "consumeLaunchUrl" -> {
                     val url = pendingShareUrl
                     pendingShareUrl = null
                     result.success(url)
+                }
+                "consumeLaunchHtml" -> {
+                    val payload = pendingShareHtml
+                    pendingShareHtml = null
+                    if (payload == null) {
+                        result.success(null)
+                    } else {
+                        result.success(mapOf(
+                            "content" to payload.content,
+                            "title" to payload.title,
+                            "sourceUri" to payload.sourceUri,
+                        ))
+                    }
                 }
                 else -> result.notImplemented()
             }
@@ -150,10 +170,58 @@ class MainActivity: FlutterActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+        captureSharePayload(intent)
+    }
+
+    private fun captureSharePayload(intent: Intent?) {
+        if (intent == null || intent.action != Intent.ACTION_SEND) return
+        val mime = intent.type?.lowercase() ?: ""
+        // Prefer HTML when the sharer signals it via mime type OR ships
+        // a text/html stream extra. Sharers that pass HTML as a tiny
+        // EXTRA_TEXT (e.g. a copy-pasted snippet) still hit the URL path
+        // first; only when EXTRA_STREAM is present do we treat the
+        // payload as a file import.
+        val streamUri: Uri? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            intent.getParcelableExtra(Intent.EXTRA_STREAM)
+        }
+        val isHtmlMime = mime == "text/html" || mime == "application/xhtml+xml"
+        if (streamUri != null && (isHtmlMime || streamUri.path?.lowercase()?.endsWith(".html") == true || streamUri.path?.lowercase()?.endsWith(".htm") == true)) {
+            val html = readStreamAsString(streamUri)
+            if (html != null && html.isNotEmpty()) {
+                val title = guessTitleFrom(streamUri, html)
+                pendingShareHtml = HtmlPayload(content = html, title = title, sourceUri = streamUri.toString())
+                pendingShareUrl = null
+                return
+            }
+        }
         val url = extractShareUrl(intent)
         if (url != null) {
             pendingShareUrl = url
         }
+    }
+
+    private fun readStreamAsString(uri: Uri): String? {
+        return try {
+            contentResolver.openInputStream(uri)?.use { input ->
+                input.bufferedReader(Charsets.UTF_8).readText()
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun guessTitleFrom(uri: Uri, html: String): String? {
+        // Honour an explicit <title>; fall back to the file name (without
+        // extension), which is what the desktop file-import flow does.
+        val titleMatch = Regex("(?is)<title[^>]*>(.*?)</title>").find(html)
+        val fromTitle = titleMatch?.groupValues?.getOrNull(1)?.trim().orEmpty()
+        if (fromTitle.isNotEmpty()) return fromTitle
+        val name = uri.lastPathSegment ?: return null
+        val dot = name.lastIndexOf('.')
+        return if (dot > 0) name.substring(0, dot) else name
     }
 
     private fun extractShareUrl(intent: Intent?): String? {

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -174,7 +174,17 @@ class MainActivity: FlutterActivity() {
     }
 
     private fun captureSharePayload(intent: Intent?) {
-        if (intent == null || intent.action != Intent.ACTION_SEND) return
+        if (intent == null) return
+        // LIR-004: ACTION_VIEW on webspace:// — pass the raw URI string
+        // through; the Dart side runs it through parseWebspaceUri.
+        if (intent.action == Intent.ACTION_VIEW) {
+            val data = intent.data ?: return
+            if (data.scheme?.lowercase() == "webspace") {
+                pendingShareUrl = data.toString()
+            }
+            return
+        }
+        if (intent.action != Intent.ACTION_SEND) return
         val mime = intent.type?.lowercase() ?: ""
         // Prefer HTML when the sharer signals it via mime type OR ships
         // a text/html stream extra. Sharers that pass HTML as a tiny

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -61,6 +61,12 @@ import UserNotifications
         let url = self.pendingShareUrl
         self.pendingShareUrl = nil
         result(url)
+      case "consumeLaunchHtml":
+        // LIR-012: iOS Share Extension HTML delivery isn't wired yet
+        // (depends on the Share Extension target work in tasks 5.1 / 5.5).
+        // Return null so the Dart side falls through to the URL channel
+        // without raising MissingPluginException.
+        result(nil)
       default:
         result(FlutterMethodNotImplemented)
       }
@@ -70,7 +76,14 @@ import UserNotifications
   private func capturePendingShareUrl(from url: URL) {
     guard url.scheme?.lowercased() == "webspace" else { return }
     let host = url.host?.lowercased()
-    if host == "share" {
+    // LIR-004: webspace://open?url=<encoded http(s)> is the canonical form
+    // for "Open in WebSpace" links from external apps. Pass the WHOLE URL
+    // through to Dart — `LinkRoutingService.parseWebspaceUri` validates and
+    // unwraps the inner http(s) target. The legacy `webspace://share?url=`
+    // form is preserved below for back-compat.
+    if host == "open" {
+      pendingShareUrl = url.absoluteString
+    } else if host == "share" {
       guard
         let inner = URLComponents(url: url, resolvingAgainstBaseURL: false)?
           .queryItems?.first(where: { $0.name == "url" })?.value,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -63,6 +63,7 @@ import 'package:webspace/services/android_foreground_service.dart';
 import 'package:webspace/services/background_task_service.dart';
 import 'package:webspace/services/share_intent_service.dart';
 import 'package:webspace/services/link_routing_service.dart';
+import 'package:webspace/services/link_intent_dispatch_engine.dart';
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/notification_service.dart';
 import 'package:webspace/services/proxy_conflict_engine.dart';
@@ -987,6 +988,19 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     if (_handlingShareIntent) return;
     _handlingShareIntent = true;
     try {
+      // HTML file payload first — the native side clears it after read,
+      // so a tag mismatch (e.g. an HTML file that *also* has EXTRA_TEXT)
+      // won't double-fire.
+      final html = await ShareIntentService.consumeLaunchHtml();
+      if (!mounted) return;
+      if (html != null) {
+        await _dispatchInbound(InboundHtml(
+          content: html.content,
+          suggestedTitle: html.title,
+          sourceUri: html.sourceUri,
+        ));
+        return;
+      }
       final raw = await ShareIntentService.consumeLaunchUrl();
       if (!mounted || raw == null || raw.isEmpty) return;
       if (raw.startsWith('webspace://qr/')) {
@@ -996,96 +1010,285 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         }
         return;
       }
-      Uri? target = Uri.tryParse(raw);
-      if (target != null && target.scheme.toLowerCase() == 'webspace') {
-        target = LinkRoutingService.parseWebspaceUri(target);
-      }
-      if (target == null ||
-          (target.scheme != 'http' && target.scheme != 'https') ||
-          target.host.isEmpty) {
+      final parsed = Uri.tryParse(raw);
+      if (parsed == null) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Unsupported URL')),
         );
         return;
       }
-      await _dispatchInboundUrl(target);
+      await _dispatchInbound(InboundUrl(parsed));
     } finally {
       _handlingShareIntent = false;
     }
   }
 
-  /// Resolves an inbound URL via [LinkRoutingService] and either activates
-  /// the matched site directly (single resolver winner — LIR-002 fast
-  /// path) or surfaces the LIR-010 three-option picker.
-  Future<void> _dispatchInboundUrl(Uri url) async {
+  /// Engine-driven dispatch entry point: hands [payload] to
+  /// [LinkIntentDispatchEngine] and executes the returned action. The
+  /// engine owns the routing decisions; this method only performs IO and
+  /// UI. See `lib/services/link_intent_dispatch_engine.dart`.
+  Future<void> _dispatchInbound(InboundPayload payload) async {
     final adapters = _webViewModels
         .map((m) => _SiteRouteAdapter(m))
         .toList(growable: false);
-    final match = LinkRoutingService.resolve(url, adapters);
-    if (match is RoutingSingle) {
-      final adapter = match.site as _SiteRouteAdapter;
-      await _activateSiteOnUrl(adapter.model, url.toString());
-      return;
+    final action = LinkIntentDispatchEngine.dispatch(
+      payload: payload,
+      sites: adapters,
+    );
+    final inboundUri = payload is InboundUrl ? payload.url : null;
+    await _executeDispatchAction(action, inboundUri);
+  }
+
+  Future<void> _executeDispatchAction(
+    DispatchAction action,
+    Uri? inboundUri,
+  ) async {
+    switch (action) {
+      case DispatchUnsupported(:final reason):
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Unsupported share: $reason')),
+          );
+        }
+      case DispatchOpenInMain():
+        await _executeOpenInMain(action);
+      case DispatchOpenNested():
+        await _executeOpenNested(action);
+      case DispatchCreateSite():
+        await _executeCreateSite(action);
+      case DispatchCreateSiteFromHtml():
+        await _executeCreateSiteFromHtml(action);
+      case DispatchBindAndOpen():
+        await _executeBindAndOpen(action);
+      case DispatchShowPicker():
+        if (inboundUri == null) return;
+        await _showDispatchPicker(action, inboundUri);
     }
-    final winners = match is RoutingAmbiguous
-        ? match.sites
-            .whereType<_SiteRouteAdapter>()
-            .map((a) => a.model)
-            .toList(growable: false)
-        : const <WebViewModel>[];
+  }
+
+  /// Hosts the LIR-010 picker. Translates the user's choice into a
+  /// follow-up engine call and executes the result.
+  Future<void> _showDispatchPicker(
+    DispatchShowPicker action,
+    Uri inbound,
+  ) async {
+    final winners = _webViewModels
+        .where((m) => action.winnerSiteIds.contains(m.siteId))
+        .toList(growable: false);
+    final others = _webViewModels
+        .where((m) => !action.winnerSiteIds.contains(m.siteId))
+        .toList(growable: false);
     if (!mounted) return;
     final choice = await showModalBottomSheet<_DispatchChoice>(
       context: context,
       showDragHandle: true,
       isScrollControlled: true,
       builder: (ctx) => _DispatchPickerSheet(
-        url: url,
+        url: inbound,
         winners: winners,
-        otherSites: _webViewModels
-            .where((m) => !winners.contains(m))
-            .toList(growable: false),
-        canCreate: LinkRoutingService.strippedHomeUrl(url) != null,
+        otherSites: others,
+        canCreate: action.offerCreate,
       ),
     );
     if (!mounted || choice == null) return;
+    final DispatchAction followUp;
     switch (choice) {
       case _DispatchChoiceOpen(:final site):
-        await _activateSiteOnUrl(site, url.toString());
-        break;
+        followUp = LinkIntentDispatchEngine.openInChosen(
+          inbound: inbound,
+          site: _SiteRouteAdapter(site),
+        );
       case _DispatchChoiceBind(:final site):
-        final additions = LinkRoutingService.claimsToAdoptHost(url.host);
-        if (additions.isNotEmpty) {
-          final existing = site.domainClaims ?? site.effectiveDomainClaims;
-          site.domainClaims =
-              LinkRoutingService.mergeClaims(existing, additions);
-          await _saveWebViewModels();
-        }
-        await _activateSiteOnUrl(site, url.toString());
-        break;
+        followUp = LinkIntentDispatchEngine.bindToSite(
+          inbound: inbound,
+          site: _SiteRouteAdapter(site),
+        );
       case _DispatchChoiceCreate():
-        await _createSiteForInboundUrl(url);
-        break;
+        followUp =
+            LinkIntentDispatchEngine.createNew(inbound: inbound);
+    }
+    await _executeDispatchAction(followUp, inbound);
+  }
+
+  /// LIR-011: dispose first when alwaysOpenHome / incognito; wipe
+  /// container + clear cookies when incognito. Then activate and load.
+  Future<void> _executeOpenInMain(DispatchOpenInMain a) async {
+    final index =
+        _webViewModels.indexWhere((m) => m.siteId == a.siteId);
+    if (index < 0) return;
+    final model = _webViewModels[index];
+    await _maybeSwitchToAllForSite(model, index);
+    if (a.disposeBeforeLoad) {
+      _evictCacheIfOnline(model.siteId);
+      model.disposeWebView();
+      _loadedIndices.remove(index);
+      model.currentUrl = model.initUrl;
+    }
+    if (a.wipeContainer) {
+      await _containerIsolation.wipeContainers([model.siteId]);
+    }
+    if (a.clearInMemoryCookies) {
+      model.cookies = const [];
+    }
+    if (index != _currentIndex) {
+      await _setCurrentIndex(index);
+    }
+    if (!mounted) return;
+    final controller = model.getController(
+      launchUrl,
+      _cookieManager,
+      _containerCookieManager,
+      _saveWebViewModels,
+      globalUserScripts: _globalUserScripts,
+    );
+    if (controller != null) {
+      await controller.loadUrl(a.url, language: model.language);
+      if (!mounted) return;
+      setState(() {
+        model.currentUrl = a.url;
+      });
+      await _saveWebViewModels();
     }
   }
 
-  /// LIR-009 / LIR-010 option 3: create a new site whose persisted `initUrl`
-  /// is the stripped home (`<scheme>://<host>[:port]/`) and whose first
-  /// navigation goes to the full inbound URL. Skips the AddSiteScreen
-  /// dialog (the user already confirmed "create" in the picker).
-  Future<void> _createSiteForInboundUrl(Uri url) async {
-    final home = LinkRoutingService.strippedHomeUrl(url);
-    if (home == null) return;
+  /// LIR-011: open as a nested webview using the chosen site's settings.
+  Future<void> _executeOpenNested(DispatchOpenNested a) async {
+    final index =
+        _webViewModels.indexWhere((m) => m.siteId == a.siteId);
+    if (index < 0) return;
+    final model = _webViewModels[index];
+    await _maybeSwitchToAllForSite(model, index);
+    if (!mounted) return;
+    await launchUrl(
+      a.url,
+      homeTitle: model.name,
+      siteId: model.siteId,
+      incognito: model.incognito,
+      thirdPartyCookiesEnabled: model.thirdPartyCookiesEnabled,
+      clearUrlEnabled: model.clearUrlEnabled,
+      dnsBlockEnabled: model.dnsBlockEnabled,
+      contentBlockEnabled: model.contentBlockEnabled,
+      localCdnEnabled: model.localCdnEnabled,
+      trackingProtectionEnabled: model.trackingProtectionEnabled,
+      language: model.language,
+      locationMode: model.locationMode,
+      spoofLatitude: model.spoofLatitude,
+      spoofLongitude: model.spoofLongitude,
+      spoofAccuracy: model.spoofAccuracy,
+      spoofTimezone: model.spoofTimezone,
+      spoofTimezoneFromLocation: model.spoofTimezoneFromLocation,
+      webRtcPolicy: model.webRtcPolicy,
+      userScripts: model.userScripts,
+      proxySettings: model.proxySettings,
+      notificationsEnabled: model.notificationsEnabled,
+    );
+  }
+
+  /// LIR-009 + LIR-010 option 3: create a brand-new site rooted at the
+  /// stripped home URL with a synthesized `baseDomain` claim, then
+  /// navigate the new webview to the full inbound URL on first activation.
+  Future<void> _executeCreateSite(DispatchCreateSite a) async {
     final stateSetter = () { setState((){}); _updateCanGoBack(); };
     final model = WebViewModel(
-      initUrl: home,
+      initUrl: a.home,
+      domainClaims: a.initialClaims.isEmpty ? null : a.initialClaims,
       stateSetterF: stateSetter,
     );
-    final pageTitle = await getPageTitle(url.toString());
+    final pageTitle = await getPageTitle(a.fullUrl);
     if (!mounted) return;
     if (pageTitle != null && pageTitle.isNotEmpty) {
       model.name = pageTitle;
       model.pageTitle = pageTitle;
     }
+    await _registerNewSite(model);
+    if (!mounted) return;
+    final controller = model.getController(
+      launchUrl,
+      _cookieManager,
+      _containerCookieManager,
+      _saveWebViewModels,
+      globalUserScripts: _globalUserScripts,
+    );
+    if (controller != null && a.fullUrl != a.home) {
+      await controller.loadUrl(a.fullUrl, language: model.language);
+      if (!mounted) return;
+      setState(() {
+        model.currentUrl = a.fullUrl;
+      });
+      await _saveWebViewModels();
+    }
+  }
+
+  /// LIR-012: an HTML file share short-circuits to "create new site"
+  /// (only sensible action — opaque file content can't be claimed by an
+  /// existing site). HTML lives in `HtmlImportStorage`, identical to the
+  /// in-app file-import flow.
+  Future<void> _executeCreateSiteFromHtml(
+    DispatchCreateSiteFromHtml a,
+  ) async {
+    final stateSetter = () { setState((){}); _updateCanGoBack(); };
+    final fileSiteUrl =
+        'file:///webspace_import_${DateTime.now().microsecondsSinceEpoch}.html';
+    final model = WebViewModel(
+      initUrl: fileSiteUrl,
+      stateSetterF: stateSetter,
+    );
+    final title = a.suggestedTitle?.trim();
+    if (title != null && title.isNotEmpty) {
+      model.name = title;
+      model.pageTitle = title;
+    }
+    await HtmlImportStorage.instance.saveHtml(model.siteId, a.html, fileSiteUrl);
+    await _registerNewSite(model);
+  }
+
+  /// Persist [a.claimAdditions] onto the chosen site (deduped against
+  /// existing claims) and then execute the engine-computed [a.followUp].
+  Future<void> _executeBindAndOpen(DispatchBindAndOpen a) async {
+    final idx =
+        _webViewModels.indexWhere((m) => m.siteId == a.chosenSiteId);
+    if (idx < 0) return;
+    final site = _webViewModels[idx];
+    if (a.claimAdditions.isNotEmpty) {
+      final existing = site.domainClaims ?? site.effectiveDomainClaims;
+      site.domainClaims =
+          LinkRoutingService.mergeClaims(existing, a.claimAdditions);
+      await _saveWebViewModels();
+    }
+    await _executeDispatchAction(a.followUp, null);
+  }
+
+  /// WEBSPACE-011 helper: switch the active webspace to "All" if [model]
+  /// isn't a member of the current named webspace, with a snackbar.
+  Future<void> _maybeSwitchToAllForSite(WebViewModel model, int index) async {
+    if (_selectedWebspaceId == null ||
+        _selectedWebspaceId == kAllWebspaceId) {
+      return;
+    }
+    final ws = _webspaces.firstWhere(
+      (w) => w.id == _selectedWebspaceId,
+      orElse: () => _webspaces.first,
+    );
+    if (ws.siteIndices.contains(index)) return;
+    setState(() {
+      _selectedWebspaceId = kAllWebspaceId;
+    });
+    await _saveSelectedWebspaceId();
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Switched to All to open in ${model.getDisplayName()}',
+          ),
+        ),
+      );
+    }
+  }
+
+  /// Add [model] to `_webViewModels`, attach to current named webspace,
+  /// activate, persist, and apply the current theme. Shared by the
+  /// "create new site for URL" and "create new site for HTML" flows.
+  Future<void> _registerNewSite(WebViewModel model) async {
     setState(() {
       _webViewModels.add(model);
     });
@@ -1104,121 +1307,6 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await _saveWebViewModels();
     final theme = _themeModeToWebViewTheme(_themeSettings.themeMode);
     await model.setTheme(theme);
-    if (!mounted) return;
-    final controller = model.getController(
-      launchUrl,
-      _cookieManager,
-      _containerCookieManager,
-      _saveWebViewModels,
-      globalUserScripts: _globalUserScripts,
-    );
-    if (controller != null && url.toString() != home) {
-      await controller.loadUrl(url.toString(), language: model.language);
-      if (!mounted) return;
-      setState(() {
-        model.currentUrl = url.toString();
-      });
-      await _saveWebViewModels();
-    }
-  }
-
-  /// Dispatches an inbound shared URL to an existing site. Routing rules:
-  ///
-  /// - If [url] is OUT of the site's normalized navigation domain (e.g.
-  ///   user picks "Open in DDG" for an f-droid.org URL), open it in a
-  ///   nested `InAppWebViewScreen` via `launchUrl`. Loading it in the
-  ///   site's main webview would either be silently blocked by the
-  ///   navigation engine's same-domain guard or clobber the active
-  ///   session — both surprising for a share dispatch.
-  /// - If [url] is IN-domain and the site is `incognito` or
-  ///   `alwaysOpenHome`, dispose the live webview first so the next paint
-  ///   recreates it from a clean slate, then load the URL.
-  /// - Otherwise, route through the site's main `controller.loadUrl`.
-  ///
-  /// Always switches the active webspace to "All" first if [model] is not
-  /// a member of the current named webspace (WEBSPACE-011).
-  Future<void> _activateSiteOnUrl(WebViewModel model, String url) async {
-    final index = _webViewModels.indexOf(model);
-    if (index < 0) return;
-    if (_selectedWebspaceId != null &&
-        _selectedWebspaceId != kAllWebspaceId) {
-      final ws = _webspaces.firstWhere(
-        (w) => w.id == _selectedWebspaceId,
-        orElse: () => _webspaces.first,
-      );
-      if (!ws.siteIndices.contains(index)) {
-        setState(() {
-          _selectedWebspaceId = kAllWebspaceId;
-        });
-        await _saveSelectedWebspaceId();
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(
-                'Switched to All to open in ${model.getDisplayName()}',
-              ),
-            ),
-          );
-        }
-      }
-    }
-    final inDomain =
-        getNormalizedDomain(url) == getNormalizedDomain(model.initUrl);
-    if (!inDomain) {
-      await launchUrl(
-        url,
-        homeTitle: model.name,
-        siteId: model.siteId,
-        incognito: model.incognito,
-        thirdPartyCookiesEnabled: model.thirdPartyCookiesEnabled,
-        clearUrlEnabled: model.clearUrlEnabled,
-        dnsBlockEnabled: model.dnsBlockEnabled,
-        contentBlockEnabled: model.contentBlockEnabled,
-        localCdnEnabled: model.localCdnEnabled,
-        trackingProtectionEnabled: model.trackingProtectionEnabled,
-        language: model.language,
-        locationMode: model.locationMode,
-        spoofLatitude: model.spoofLatitude,
-        spoofLongitude: model.spoofLongitude,
-        spoofAccuracy: model.spoofAccuracy,
-        spoofTimezone: model.spoofTimezone,
-        spoofTimezoneFromLocation: model.spoofTimezoneFromLocation,
-        webRtcPolicy: model.webRtcPolicy,
-        userScripts: model.userScripts,
-        proxySettings: model.proxySettings,
-        notificationsEnabled: model.notificationsEnabled,
-      );
-      return;
-    }
-    if (model.incognito || model.alwaysOpenHome) {
-      _evictCacheIfOnline(model.siteId);
-      model.disposeWebView();
-      _loadedIndices.remove(index);
-      model.currentUrl = model.initUrl;
-      if (model.incognito) {
-        await _containerIsolation.wipeContainers([model.siteId]);
-        model.cookies = const [];
-      }
-    }
-    if (index != _currentIndex) {
-      await _setCurrentIndex(index);
-    }
-    if (!mounted) return;
-    final controller = model.getController(
-      launchUrl,
-      _cookieManager,
-      _containerCookieManager,
-      _saveWebViewModels,
-      globalUserScripts: _globalUserScripts,
-    );
-    if (controller != null) {
-      await controller.loadUrl(url, language: model.language);
-      if (!mounted) return;
-      setState(() {
-        model.currentUrl = url;
-      });
-      await _saveWebViewModels();
-    }
   }
 
   Future<void> _saveWebViewModels() async {
@@ -4718,7 +4806,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   }
 }
 
-class _SiteRouteAdapter implements RoutableSite {
+class _SiteRouteAdapter implements DispatchableSite {
   final WebViewModel model;
   const _SiteRouteAdapter(this.model);
 
@@ -4730,6 +4818,15 @@ class _SiteRouteAdapter implements RoutableSite {
 
   @override
   List<DomainClaim> get domainClaims => model.effectiveDomainClaims;
+
+  @override
+  bool get incognito => model.incognito;
+
+  @override
+  bool get alwaysOpenHome => model.alwaysOpenHome;
+
+  @override
+  String get navigationDomain => getNormalizedDomain(model.initUrl);
 }
 
 sealed class _DispatchChoice {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1122,9 +1122,21 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     }
   }
 
-  /// Activate [model] (switching webspace to "All" if it isn't a member of
-  /// the current named webspace, per WEBSPACE-011) and navigate its
-  /// webview to [url] using the controller's loadUrl path.
+  /// Dispatches an inbound shared URL to an existing site. Routing rules:
+  ///
+  /// - If [url] is OUT of the site's normalized navigation domain (e.g.
+  ///   user picks "Open in DDG" for an f-droid.org URL), open it in a
+  ///   nested `InAppWebViewScreen` via `launchUrl`. Loading it in the
+  ///   site's main webview would either be silently blocked by the
+  ///   navigation engine's same-domain guard or clobber the active
+  ///   session — both surprising for a share dispatch.
+  /// - If [url] is IN-domain and the site is `incognito` or
+  ///   `alwaysOpenHome`, dispose the live webview first so the next paint
+  ///   recreates it from a clean slate, then load the URL.
+  /// - Otherwise, route through the site's main `controller.loadUrl`.
+  ///
+  /// Always switches the active webspace to "All" first if [model] is not
+  /// a member of the current named webspace (WEBSPACE-011).
   Future<void> _activateSiteOnUrl(WebViewModel model, String url) async {
     final index = _webViewModels.indexOf(model);
     if (index < 0) return;
@@ -1148,6 +1160,44 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
             ),
           );
         }
+      }
+    }
+    final inDomain =
+        getNormalizedDomain(url) == getNormalizedDomain(model.initUrl);
+    if (!inDomain) {
+      await launchUrl(
+        url,
+        homeTitle: model.name,
+        siteId: model.siteId,
+        incognito: model.incognito,
+        thirdPartyCookiesEnabled: model.thirdPartyCookiesEnabled,
+        clearUrlEnabled: model.clearUrlEnabled,
+        dnsBlockEnabled: model.dnsBlockEnabled,
+        contentBlockEnabled: model.contentBlockEnabled,
+        localCdnEnabled: model.localCdnEnabled,
+        trackingProtectionEnabled: model.trackingProtectionEnabled,
+        language: model.language,
+        locationMode: model.locationMode,
+        spoofLatitude: model.spoofLatitude,
+        spoofLongitude: model.spoofLongitude,
+        spoofAccuracy: model.spoofAccuracy,
+        spoofTimezone: model.spoofTimezone,
+        spoofTimezoneFromLocation: model.spoofTimezoneFromLocation,
+        webRtcPolicy: model.webRtcPolicy,
+        userScripts: model.userScripts,
+        proxySettings: model.proxySettings,
+        notificationsEnabled: model.notificationsEnabled,
+      );
+      return;
+    }
+    if (model.incognito || model.alwaysOpenHome) {
+      _evictCacheIfOnline(model.siteId);
+      model.disposeWebView();
+      _loadedIndices.remove(index);
+      model.currentUrl = model.initUrl;
+      if (model.incognito) {
+        await _containerIsolation.wipeContainers([model.siteId]);
+        model.cookies = const [];
       }
     }
     if (index != _currentIndex) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4729,55 +4729,71 @@ class _DispatchPickerSheetState extends State<_DispatchPickerSheet> {
   Widget build(BuildContext context) {
     final host = widget.url.host;
     final allSites = [...widget.winners, ...widget.otherSites];
+    final rows = _bindMode ? _buildBindRows(allSites) : _buildPrimaryRows();
     return SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 8),
-              child: Text(
-                _bindMode
-                    ? 'Send $host to which site?'
-                    : 'Open $host',
-                style: Theme.of(context).textTheme.titleMedium,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.of(context).size.height * 0.75,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Text(
+                  _bindMode ? 'Send $host to which site?' : 'Open $host',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
               ),
-            ),
-            Text(
-              widget.url.toString(),
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-            const SizedBox(height: 12),
-            if (_bindMode)
-              ..._buildBindRows(allSites)
-            else
-              ..._buildPrimaryRows(),
-            const SizedBox(height: 8),
-            if (_bindMode)
-              TextButton(
-                onPressed: () => setState(() => _bindMode = false),
-                child: const Text('Back'),
-              )
-            else
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: const Text('Cancel'),
+              Text(
+                widget.url.toString(),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.bodySmall,
               ),
-          ],
+              const SizedBox(height: 12),
+              Flexible(
+                child: ListView(
+                  shrinkWrap: true,
+                  children: rows,
+                ),
+              ),
+              const SizedBox(height: 8),
+              if (_bindMode)
+                TextButton(
+                  onPressed: () => setState(() => _bindMode = false),
+                  child: const Text('Back'),
+                )
+              else
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Cancel'),
+                ),
+            ],
+          ),
         ),
       ),
     );
   }
 
+  Widget _siteFavicon(WebViewModel site) => SizedBox(
+        width: 32,
+        height: 32,
+        child: UnifiedFaviconImage(
+          url: site.initUrl,
+          size: 32,
+          proxy: site.proxySettings,
+        ),
+      );
+
   List<Widget> _buildPrimaryRows() {
     final rows = <Widget>[];
     for (final site in widget.winners) {
       rows.add(ListTile(
-        leading: const Icon(Icons.open_in_new),
+        leading: _siteFavicon(site),
         title: Text('Open in ${site.getDisplayName()}'),
         subtitle: Text(site.initUrl,
             maxLines: 1, overflow: TextOverflow.ellipsis),
@@ -4787,7 +4803,8 @@ class _DispatchPickerSheetState extends State<_DispatchPickerSheet> {
     }
     if (widget.winners.isNotEmpty || widget.otherSites.isNotEmpty) {
       rows.add(ListTile(
-        leading: const Icon(Icons.link),
+        leading: const SizedBox(
+            width: 32, height: 32, child: Icon(Icons.link)),
         title: Text(
             'Send ${widget.url.host} (and subdomains) to a site'),
         subtitle: const Text('Pick an existing site to handle this domain'),
@@ -4796,7 +4813,15 @@ class _DispatchPickerSheetState extends State<_DispatchPickerSheet> {
     }
     if (widget.canCreate) {
       rows.add(ListTile(
-        leading: const Icon(Icons.add_circle_outline),
+        leading: SizedBox(
+          width: 32,
+          height: 32,
+          child: UnifiedFaviconImage(
+            url: LinkRoutingService.strippedHomeUrl(widget.url) ??
+                widget.url.toString(),
+            size: 32,
+          ),
+        ),
         title: Text('Create new site for ${widget.url.host}'),
         subtitle: Text(
           LinkRoutingService.strippedHomeUrl(widget.url) ?? '',
@@ -4821,7 +4846,7 @@ class _DispatchPickerSheetState extends State<_DispatchPickerSheet> {
     }
     return sites
         .map((s) => ListTile(
-              leading: const Icon(Icons.web),
+              leading: _siteFavicon(s),
               title: Text(s.getDisplayName()),
               subtitle: Text(s.initUrl,
                   maxLines: 1, overflow: TextOverflow.ellipsis),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -64,6 +64,7 @@ import 'package:webspace/services/background_task_service.dart';
 import 'package:webspace/services/share_intent_service.dart';
 import 'package:webspace/services/link_routing_service.dart';
 import 'package:webspace/services/link_intent_dispatch_engine.dart';
+import 'package:webspace/screens/link_handling_settings.dart';
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/notification_service.dart';
 import 'package:webspace/services/proxy_conflict_engine.dart';
@@ -726,6 +727,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   bool _isFullscreen = false; // Runtime fullscreen state (hides appBar, tabStrip, system UI)
   bool _showUrlBar = false;
   bool _showTabStrip = false;
+  bool _linkHandlingEnabled = true;
   bool _showStatsBanner = true;
   bool _canGoBack = false; // Tracks webview back history for iOS drawer gesture
   int _canGoBackVersion = 0; // Guards _updateCanGoBack against stale async results
@@ -994,6 +996,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       final html = await ShareIntentService.consumeLaunchHtml();
       if (!mounted) return;
       if (html != null) {
+        if (!_linkHandlingEnabled) {
+          LogService.instance.log('LinkIntent',
+              'HTML share dropped (link handling disabled)');
+          return;
+        }
         await _dispatchInbound(InboundHtml(
           content: html.content,
           suggestedTitle: html.title,
@@ -1008,6 +1015,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         if (decoded != null) {
           _addSite(qrSettings: decoded);
         }
+        return;
+      }
+      if (!_linkHandlingEnabled) {
+        LogService.instance.log('LinkIntent',
+            'Share dropped (link handling disabled): $raw');
         return;
       }
       final parsed = Uri.tryParse(raw);
@@ -1371,6 +1383,38 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     if (isDemoMode) return;
     SharedPreferences prefs = await SharedPreferences.getInstance();
     await prefs.setBool('showStatsBanner', _showStatsBanner);
+  }
+
+  Future<void> _saveLinkHandlingEnabled() async {
+    if (isDemoMode) return;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(kLinkHandlingEnabledKey, _linkHandlingEnabled);
+  }
+
+  void _openLinkHandlingSettings() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (ctx) => LinkHandlingSettingsScreen(
+          enabled: _linkHandlingEnabled,
+          onEnabledChanged: (v) {
+            setState(() => _linkHandlingEnabled = v);
+            _saveLinkHandlingEnabled();
+          },
+          sites: List<WebViewModel>.from(_webViewModels),
+          onOpenSiteEditor: (site) {
+            final idx = _webViewModels.indexOf(site);
+            if (idx >= 0) {
+              Navigator.of(ctx).pop();
+              _editSite(idx);
+            }
+          },
+          onManualDispatch: (uri) async {
+            await _dispatchInbound(InboundUrl(uri));
+          },
+        ),
+      ),
+    );
   }
 
   Future<void> _saveGlobalUserScripts() async {
@@ -2109,6 +2153,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       _showUrlBar = prefs.getBool('showUrlBar') ?? false;
       _showTabStrip = prefs.getBool('showTabStrip') ?? false;
       _showStatsBanner = prefs.getBool('showStatsBanner') ?? true;
+      _linkHandlingEnabled = prefs.getBool(kLinkHandlingEnabledKey) ?? true;
       widget.onThemeSettingsChanged(_themeSettings);
     });
     await _loadWebspaces();
@@ -3123,6 +3168,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                       });
                       _saveShowStatsBanner();
                     },
+                    linkHandlingEnabled: _linkHandlingEnabled,
+                    onLinkHandlingEnabledChanged: (value) {
+                      setState(() => _linkHandlingEnabled = value);
+                      _saveLinkHandlingEnabled();
+                    },
+                    onOpenLinkHandlingSettings: _openLinkHandlingSettings,
                     globalUserScripts: _globalUserScripts,
                     onGlobalUserScriptsChanged: (scripts) {
                       _globalUserScripts = scripts;
@@ -3281,6 +3332,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                     MaterialPageRoute(
                       builder: (context) => SettingsScreen(
                         webViewModel: _webViewModels[_currentIndex!],
+                        otherSites: _webViewModels
+                            .where((m) => m.siteId != _webViewModels[_currentIndex!].siteId)
+                            .toList(growable: false),
                         useContainers: _useContainers,
                         notificationsBlockedBySite: _notificationsBlockedBySite(_webViewModels[_currentIndex!]),
                         globalUserScripts: _globalUserScripts,
@@ -3646,6 +3700,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
               MaterialPageRoute(
                 builder: (context) => SettingsScreen(
                   webViewModel: _webViewModels[_currentIndex!],
+                  otherSites: _webViewModels
+                      .where((m) => m.siteId != _webViewModels[_currentIndex!].siteId)
+                      .toList(growable: false),
                   useContainers: _useContainers,
                   notificationsBlockedBySite: _notificationsBlockedBySite(_webViewModels[_currentIndex!]),
                   globalUserScripts: _globalUserScripts,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -62,6 +62,7 @@ import 'package:webspace/services/shortcut_service.dart';
 import 'package:webspace/services/android_foreground_service.dart';
 import 'package:webspace/services/background_task_service.dart';
 import 'package:webspace/services/share_intent_service.dart';
+import 'package:webspace/services/link_routing_service.dart';
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/notification_service.dart';
 import 'package:webspace/services/proxy_conflict_engine.dart';
@@ -986,18 +987,187 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     if (_handlingShareIntent) return;
     _handlingShareIntent = true;
     try {
-      final url = await ShareIntentService.consumeLaunchUrl();
-      if (!mounted || url == null || url.isEmpty) return;
-      if (url.startsWith('webspace://qr/')) {
-        final decoded = SiteSettingsQrCodec.decode(url);
+      final raw = await ShareIntentService.consumeLaunchUrl();
+      if (!mounted || raw == null || raw.isEmpty) return;
+      if (raw.startsWith('webspace://qr/')) {
+        final decoded = SiteSettingsQrCodec.decode(raw);
         if (decoded != null) {
           _addSite(qrSettings: decoded);
         }
         return;
       }
-      _addSite(initialUrl: url);
+      Uri? target = Uri.tryParse(raw);
+      if (target != null && target.scheme.toLowerCase() == 'webspace') {
+        target = LinkRoutingService.parseWebspaceUri(target);
+      }
+      if (target == null ||
+          (target.scheme != 'http' && target.scheme != 'https') ||
+          target.host.isEmpty) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Unsupported URL')),
+        );
+        return;
+      }
+      await _dispatchInboundUrl(target);
     } finally {
       _handlingShareIntent = false;
+    }
+  }
+
+  /// Resolves an inbound URL via [LinkRoutingService] and either activates
+  /// the matched site directly (single resolver winner — LIR-002 fast
+  /// path) or surfaces the LIR-010 three-option picker.
+  Future<void> _dispatchInboundUrl(Uri url) async {
+    final adapters = _webViewModels
+        .map((m) => _SiteRouteAdapter(m))
+        .toList(growable: false);
+    final match = LinkRoutingService.resolve(url, adapters);
+    if (match is RoutingSingle) {
+      final adapter = match.site as _SiteRouteAdapter;
+      await _activateSiteOnUrl(adapter.model, url.toString());
+      return;
+    }
+    final winners = match is RoutingAmbiguous
+        ? match.sites
+            .whereType<_SiteRouteAdapter>()
+            .map((a) => a.model)
+            .toList(growable: false)
+        : const <WebViewModel>[];
+    if (!mounted) return;
+    final choice = await showModalBottomSheet<_DispatchChoice>(
+      context: context,
+      showDragHandle: true,
+      isScrollControlled: true,
+      builder: (ctx) => _DispatchPickerSheet(
+        url: url,
+        winners: winners,
+        otherSites: _webViewModels
+            .where((m) => !winners.contains(m))
+            .toList(growable: false),
+        canCreate: LinkRoutingService.strippedHomeUrl(url) != null,
+      ),
+    );
+    if (!mounted || choice == null) return;
+    switch (choice) {
+      case _DispatchChoiceOpen(:final site):
+        await _activateSiteOnUrl(site, url.toString());
+        break;
+      case _DispatchChoiceBind(:final site):
+        final additions = LinkRoutingService.claimsToAdoptHost(url.host);
+        if (additions.isNotEmpty) {
+          final existing = site.domainClaims ?? site.effectiveDomainClaims;
+          site.domainClaims =
+              LinkRoutingService.mergeClaims(existing, additions);
+          await _saveWebViewModels();
+        }
+        await _activateSiteOnUrl(site, url.toString());
+        break;
+      case _DispatchChoiceCreate():
+        await _createSiteForInboundUrl(url);
+        break;
+    }
+  }
+
+  /// LIR-009 / LIR-010 option 3: create a new site whose persisted `initUrl`
+  /// is the stripped home (`<scheme>://<host>[:port]/`) and whose first
+  /// navigation goes to the full inbound URL. Skips the AddSiteScreen
+  /// dialog (the user already confirmed "create" in the picker).
+  Future<void> _createSiteForInboundUrl(Uri url) async {
+    final home = LinkRoutingService.strippedHomeUrl(url);
+    if (home == null) return;
+    final stateSetter = () { setState((){}); _updateCanGoBack(); };
+    final model = WebViewModel(
+      initUrl: home,
+      stateSetterF: stateSetter,
+    );
+    final pageTitle = await getPageTitle(url.toString());
+    if (!mounted) return;
+    if (pageTitle != null && pageTitle.isNotEmpty) {
+      model.name = pageTitle;
+      model.pageTitle = pageTitle;
+    }
+    setState(() {
+      _webViewModels.add(model);
+    });
+    final newSiteIndex = _webViewModels.length - 1;
+    if (_selectedWebspaceId != null && _selectedWebspaceId != kAllWebspaceId) {
+      final wsIdx = _webspaces.indexWhere((w) => w.id == _selectedWebspaceId);
+      if (wsIdx != -1) {
+        _webspaces[wsIdx].siteIndices.add(newSiteIndex);
+        await _saveWebspaces();
+      }
+    }
+    await _setCurrentIndex(newSiteIndex);
+    if (!mounted) return;
+    setState(() {});
+    await _saveCurrentIndex();
+    await _saveWebViewModels();
+    final theme = _themeModeToWebViewTheme(_themeSettings.themeMode);
+    await model.setTheme(theme);
+    if (!mounted) return;
+    final controller = model.getController(
+      launchUrl,
+      _cookieManager,
+      _containerCookieManager,
+      _saveWebViewModels,
+      globalUserScripts: _globalUserScripts,
+    );
+    if (controller != null && url.toString() != home) {
+      await controller.loadUrl(url.toString(), language: model.language);
+      if (!mounted) return;
+      setState(() {
+        model.currentUrl = url.toString();
+      });
+      await _saveWebViewModels();
+    }
+  }
+
+  /// Activate [model] (switching webspace to "All" if it isn't a member of
+  /// the current named webspace, per WEBSPACE-011) and navigate its
+  /// webview to [url] using the controller's loadUrl path.
+  Future<void> _activateSiteOnUrl(WebViewModel model, String url) async {
+    final index = _webViewModels.indexOf(model);
+    if (index < 0) return;
+    if (_selectedWebspaceId != null &&
+        _selectedWebspaceId != kAllWebspaceId) {
+      final ws = _webspaces.firstWhere(
+        (w) => w.id == _selectedWebspaceId,
+        orElse: () => _webspaces.first,
+      );
+      if (!ws.siteIndices.contains(index)) {
+        setState(() {
+          _selectedWebspaceId = kAllWebspaceId;
+        });
+        await _saveSelectedWebspaceId();
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                'Switched to All to open in ${model.getDisplayName()}',
+              ),
+            ),
+          );
+        }
+      }
+    }
+    if (index != _currentIndex) {
+      await _setCurrentIndex(index);
+    }
+    if (!mounted) return;
+    final controller = model.getController(
+      launchUrl,
+      _cookieManager,
+      _containerCookieManager,
+      _saveWebViewModels,
+      globalUserScripts: _globalUserScripts,
+    );
+    if (controller != null) {
+      await controller.loadUrl(url, language: model.language);
+      if (!mounted) return;
+      setState(() {
+        model.currentUrl = url;
+      });
+      await _saveWebViewModels();
     }
   }
 
@@ -4495,5 +4665,169 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
             ),
     ),
     );
+  }
+}
+
+class _SiteRouteAdapter implements RoutableSite {
+  final WebViewModel model;
+  const _SiteRouteAdapter(this.model);
+
+  @override
+  String get siteId => model.siteId;
+
+  @override
+  String get initUrl => model.initUrl;
+
+  @override
+  List<DomainClaim> get domainClaims => model.effectiveDomainClaims;
+}
+
+sealed class _DispatchChoice {
+  const _DispatchChoice();
+}
+
+class _DispatchChoiceOpen extends _DispatchChoice {
+  final WebViewModel site;
+  const _DispatchChoiceOpen(this.site);
+}
+
+class _DispatchChoiceBind extends _DispatchChoice {
+  final WebViewModel site;
+  const _DispatchChoiceBind(this.site);
+}
+
+class _DispatchChoiceCreate extends _DispatchChoice {
+  const _DispatchChoiceCreate();
+}
+
+/// LIR-010 dispatch picker: shown when the resolver does not deliver a
+/// unique winner. Lists each resolver winner ("router default" rows), an
+/// option to bind the URL's host to an existing site (mutates that site's
+/// `domainClaims` via `claimsToAdoptHost`), and an option to create a new
+/// site with the path stripped to `<scheme>://<host>[:port]/`.
+class _DispatchPickerSheet extends StatefulWidget {
+  final Uri url;
+  final List<WebViewModel> winners;
+  final List<WebViewModel> otherSites;
+  final bool canCreate;
+
+  const _DispatchPickerSheet({
+    required this.url,
+    required this.winners,
+    required this.otherSites,
+    required this.canCreate,
+  });
+
+  @override
+  State<_DispatchPickerSheet> createState() => _DispatchPickerSheetState();
+}
+
+class _DispatchPickerSheetState extends State<_DispatchPickerSheet> {
+  bool _bindMode = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final host = widget.url.host;
+    final allSites = [...widget.winners, ...widget.otherSites];
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Text(
+                _bindMode
+                    ? 'Send $host to which site?'
+                    : 'Open $host',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            ),
+            Text(
+              widget.url.toString(),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 12),
+            if (_bindMode)
+              ..._buildBindRows(allSites)
+            else
+              ..._buildPrimaryRows(),
+            const SizedBox(height: 8),
+            if (_bindMode)
+              TextButton(
+                onPressed: () => setState(() => _bindMode = false),
+                child: const Text('Back'),
+              )
+            else
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('Cancel'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildPrimaryRows() {
+    final rows = <Widget>[];
+    for (final site in widget.winners) {
+      rows.add(ListTile(
+        leading: const Icon(Icons.open_in_new),
+        title: Text('Open in ${site.getDisplayName()}'),
+        subtitle: Text(site.initUrl,
+            maxLines: 1, overflow: TextOverflow.ellipsis),
+        onTap: () =>
+            Navigator.of(context).pop(_DispatchChoiceOpen(site)),
+      ));
+    }
+    if (widget.winners.isNotEmpty || widget.otherSites.isNotEmpty) {
+      rows.add(ListTile(
+        leading: const Icon(Icons.link),
+        title: Text(
+            'Send ${widget.url.host} (and subdomains) to a site'),
+        subtitle: const Text('Pick an existing site to handle this domain'),
+        onTap: () => setState(() => _bindMode = true),
+      ));
+    }
+    if (widget.canCreate) {
+      rows.add(ListTile(
+        leading: const Icon(Icons.add_circle_outline),
+        title: Text('Create new site for ${widget.url.host}'),
+        subtitle: Text(
+          LinkRoutingService.strippedHomeUrl(widget.url) ?? '',
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        onTap: () =>
+            Navigator.of(context).pop(const _DispatchChoiceCreate()),
+      ));
+    }
+    return rows;
+  }
+
+  List<Widget> _buildBindRows(List<WebViewModel> sites) {
+    if (sites.isEmpty) {
+      return [
+        const Padding(
+          padding: EdgeInsets.symmetric(vertical: 16),
+          child: Text('No existing sites.'),
+        ),
+      ];
+    }
+    return sites
+        .map((s) => ListTile(
+              leading: const Icon(Icons.web),
+              title: Text(s.getDisplayName()),
+              subtitle: Text(s.initUrl,
+                  maxLines: 1, overflow: TextOverflow.ellipsis),
+              onTap: () =>
+                  Navigator.of(context).pop(_DispatchChoiceBind(s)),
+            ))
+        .toList(growable: false);
   }
 }

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -42,6 +42,11 @@ class AppSettingsScreen extends StatefulWidget {
   final ValueChanged<bool> onShowTabStripChanged;
   final bool showStatsBanner;
   final ValueChanged<bool> onShowStatsBannerChanged;
+  /// LIR-008: master "Handle shared links" switch + entry into the
+  /// routing overview screen. The wrapping page handles persistence.
+  final bool linkHandlingEnabled;
+  final ValueChanged<bool> onLinkHandlingEnabledChanged;
+  final VoidCallback onOpenLinkHandlingSettings;
   final List<UserScriptConfig> globalUserScripts;
   final void Function(List<UserScriptConfig>)? onGlobalUserScriptsChanged;
   /// Fired after the global outbound proxy is updated. Parent should
@@ -66,6 +71,9 @@ class AppSettingsScreen extends StatefulWidget {
     required this.onShowTabStripChanged,
     required this.showStatsBanner,
     required this.onShowStatsBannerChanged,
+    required this.linkHandlingEnabled,
+    required this.onLinkHandlingEnabledChanged,
+    required this.onOpenLinkHandlingSettings,
     this.globalUserScripts = const [],
     this.onGlobalUserScriptsChanged,
     this.onOutboundProxyChanged,
@@ -635,6 +643,15 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
               });
               widget.onShowStatsBannerChanged(value);
             },
+          ),
+          ListTile(
+            leading: const Icon(Icons.share_outlined),
+            title: const Text('Link handling'),
+            subtitle: Text(widget.linkHandlingEnabled
+                ? 'Handle shared links and webspace:// URLs'
+                : 'Off — share intents and webspace:// URLs are dropped'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: widget.onOpenLinkHandlingSettings,
           ),
           const Divider(height: 32),
           // Global outbound proxy section

--- a/lib/screens/link_handling_settings.dart
+++ b/lib/screens/link_handling_settings.dart
@@ -1,0 +1,432 @@
+import 'package:flutter/material.dart';
+import 'package:webspace/services/link_routing_service.dart';
+import 'package:webspace/web_view_model.dart';
+
+/// Global "Link handling" screen (LIR-008): master toggle + routing
+/// overview + manual test entry. Tapping a site row opens [onOpenSiteEditor]
+/// so the user can refine that site's [DomainClaim] list (LIR-008
+/// scenario "Tap row opens site editor").
+class LinkHandlingSettingsScreen extends StatefulWidget {
+  final bool enabled;
+  final ValueChanged<bool> onEnabledChanged;
+  final List<WebViewModel> sites;
+  final void Function(WebViewModel site) onOpenSiteEditor;
+
+  /// LIR-010 manual re-route entry point (task 8.6). Invoked when the user
+  /// types a URL into the test field; the host runs it through
+  /// `LinkIntentDispatchEngine` and shows the picker / activation as if the
+  /// URL had arrived via share intent.
+  final Future<void> Function(Uri url)? onManualDispatch;
+
+  const LinkHandlingSettingsScreen({
+    super.key,
+    required this.enabled,
+    required this.onEnabledChanged,
+    required this.sites,
+    required this.onOpenSiteEditor,
+    this.onManualDispatch,
+  });
+
+  @override
+  State<LinkHandlingSettingsScreen> createState() =>
+      _LinkHandlingSettingsScreenState();
+}
+
+class _LinkHandlingSettingsScreenState
+    extends State<LinkHandlingSettingsScreen> {
+  late TextEditingController _testUrlController;
+
+  @override
+  void initState() {
+    super.initState();
+    _testUrlController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _testUrlController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final rows = _buildRoutingOverview(widget.sites);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Link handling')),
+      body: ListView(
+        children: [
+          SwitchListTile(
+            title: const Text('Handle shared links'),
+            subtitle: const Text(
+              'When off, share intents and webspace:// URLs are dropped silently. '
+              'Use to keep the app installed without making it the default for other apps.',
+            ),
+            value: widget.enabled,
+            onChanged: widget.onEnabledChanged,
+          ),
+          const Divider(height: 1),
+          if (widget.onManualDispatch != null) ...[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+              child: Text(
+                'Test routing',
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: TextField(
+                controller: _testUrlController,
+                decoration: InputDecoration(
+                  hintText: 'https://example.org/foo',
+                  border: const OutlineInputBorder(),
+                  suffixIcon: IconButton(
+                    icon: const Icon(Icons.send),
+                    tooltip: 'Dispatch through routing engine',
+                    onPressed: widget.enabled ? _dispatch : null,
+                  ),
+                ),
+                keyboardType: TextInputType.url,
+                onSubmitted: (_) =>
+                    widget.enabled ? _dispatch() : null,
+              ),
+            ),
+            const SizedBox(height: 8),
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16),
+              child: Text(
+                'Re-runs the LIR-010 picker for an arbitrary URL — useful when '
+                'the resolver auto-routes to a site you wanted to override.',
+                style: TextStyle(fontSize: 12),
+              ),
+            ),
+            const SizedBox(height: 12),
+            const Divider(height: 1),
+          ],
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text(
+              'Routing overview',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+          ),
+          if (rows.isEmpty)
+            const Padding(
+              padding: EdgeInsets.all(16),
+              child: Text('No sites yet.'),
+            )
+          else
+            ...rows,
+        ],
+      ),
+    );
+  }
+
+  Future<void> _dispatch() async {
+    final raw = _testUrlController.text.trim();
+    if (raw.isEmpty) return;
+    final parsed = Uri.tryParse(raw);
+    if (parsed == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Could not parse URL')),
+      );
+      return;
+    }
+    await widget.onManualDispatch?.call(parsed);
+  }
+
+  List<Widget> _buildRoutingOverview(List<WebViewModel> sites) {
+    if (sites.isEmpty) return const [];
+    final rows = <Widget>[];
+    for (final site in sites) {
+      final claims = site.effectiveDomainClaims;
+      final conflicts = LinkRoutingService.validateClaims(
+        site.siteId,
+        claims,
+        sites
+            .map((s) => _SiteRouteAdapter(s))
+            .where((a) => a.siteId != site.siteId)
+            .toList(growable: false),
+      );
+      rows.add(ListTile(
+        title: Text(site.getDisplayName()),
+        subtitle: Wrap(
+          spacing: 8,
+          runSpacing: 4,
+          children: [
+            for (final claim in claims) _ClaimChip(claim: claim),
+            if (conflicts.isNotEmpty)
+              Chip(
+                label: Text('${conflicts.length} conflict'
+                    '${conflicts.length == 1 ? '' : 's'}'),
+                backgroundColor:
+                    Theme.of(context).colorScheme.errorContainer,
+              ),
+          ],
+        ),
+        trailing: const Icon(Icons.chevron_right),
+        onTap: () => widget.onOpenSiteEditor(site),
+      ));
+    }
+    return rows;
+  }
+}
+
+class _ClaimChip extends StatelessWidget {
+  final DomainClaim claim;
+  const _ClaimChip({required this.claim});
+
+  @override
+  Widget build(BuildContext context) {
+    final label = switch (claim.kind) {
+      DomainClaimKind.exactHost => claim.value,
+      DomainClaimKind.wildcardSubdomain => '*.${claim.value}',
+      DomainClaimKind.baseDomain => '${claim.value} (base)',
+    };
+    return Chip(label: Text(label));
+  }
+}
+
+class _SiteRouteAdapter implements RoutableSite {
+  final WebViewModel model;
+  const _SiteRouteAdapter(this.model);
+
+  @override
+  String get siteId => model.siteId;
+
+  @override
+  String get initUrl => model.initUrl;
+
+  @override
+  List<DomainClaim> get domainClaims => model.effectiveDomainClaims;
+}
+
+/// Per-site domain-claim editor (LIR-008 task 8.4). Embedded in the
+/// per-site settings screen. Surfaces add / remove for `exactHost` and
+/// `wildcardSubdomain` claims; the synthesized `baseDomain` claim is
+/// displayed but not editable (it's auto-derived from `initUrl`).
+class DomainClaimsEditor extends StatefulWidget {
+  final WebViewModel model;
+  final List<WebViewModel> otherSites;
+  final ValueChanged<List<DomainClaim>?> onChanged;
+
+  const DomainClaimsEditor({
+    super.key,
+    required this.model,
+    required this.otherSites,
+    required this.onChanged,
+  });
+
+  @override
+  State<DomainClaimsEditor> createState() => _DomainClaimsEditorState();
+}
+
+class _DomainClaimsEditorState extends State<DomainClaimsEditor> {
+  late List<DomainClaim> _claims;
+
+  @override
+  void initState() {
+    super.initState();
+    _claims = List<DomainClaim>.from(widget.model.effectiveDomainClaims);
+  }
+
+  void _commit(List<DomainClaim> next) {
+    setState(() {
+      _claims = next;
+    });
+    final defaultClaims = widget.model.effectiveDomainClaims;
+    if (next.length == defaultClaims.length &&
+        next.every((c) => defaultClaims.contains(c)) &&
+        defaultClaims.every((c) => next.contains(c)) &&
+        widget.model.domainClaims == null) {
+      widget.onChanged(null);
+    } else {
+      widget.onChanged(next);
+    }
+  }
+
+  Future<void> _addClaim() async {
+    final result = await showDialog<DomainClaim>(
+      context: context,
+      builder: (ctx) => const _AddClaimDialog(),
+    );
+    if (result == null) return;
+    if (_claims.contains(result)) return;
+    _commit([..._claims, result]);
+  }
+
+  void _removeAt(int i) {
+    final next = [..._claims]..removeAt(i);
+    _commit(next);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final adapters = widget.otherSites
+        .map((s) => _SiteRouteAdapter(s))
+        .toList(growable: false);
+    final conflicts = LinkRoutingService.validateClaims(
+      widget.model.siteId,
+      _claims,
+      adapters,
+    );
+    final conflictsByClaim = <DomainClaim, List<ClaimConflict>>{};
+    for (final c in conflicts) {
+      conflictsByClaim.putIfAbsent(c.claim, () => []).add(c);
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Domain claims',
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.add),
+                tooltip: 'Add claim',
+                onPressed: _addClaim,
+              ),
+            ],
+          ),
+        ),
+        const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16),
+          child: Text(
+            'Which hostnames route to this site when shared from another app. '
+            'Existing sites synthesize one base-domain claim from their URL.',
+            style: TextStyle(fontSize: 12),
+          ),
+        ),
+        const SizedBox(height: 8),
+        for (var i = 0; i < _claims.length; i++)
+          _ClaimRow(
+            claim: _claims[i],
+            conflicts: conflictsByClaim[_claims[i]] ?? const [],
+            onRemove: _claims[i].kind == DomainClaimKind.baseDomain &&
+                    _claims.length == 1
+                ? null
+                : () => _removeAt(i),
+          ),
+      ],
+    );
+  }
+}
+
+class _ClaimRow extends StatelessWidget {
+  final DomainClaim claim;
+  final List<ClaimConflict> conflicts;
+  final VoidCallback? onRemove;
+
+  const _ClaimRow({
+    required this.claim,
+    required this.conflicts,
+    required this.onRemove,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final label = switch (claim.kind) {
+      DomainClaimKind.exactHost => claim.value,
+      DomainClaimKind.wildcardSubdomain => '*.${claim.value}',
+      DomainClaimKind.baseDomain => '${claim.value} (base)',
+    };
+    final hasHijack =
+        conflicts.any((c) => c.kind == ClaimConflictKind.hijack);
+    return ListTile(
+      title: Text(label),
+      subtitle: hasHijack
+          ? const Text(
+              'Conflict: another site already owns this base domain.',
+              style: TextStyle(color: Colors.red),
+            )
+          : conflicts.isNotEmpty
+              ? const Text('Overlaps with another site (non-blocking).')
+              : null,
+      trailing: onRemove == null
+          ? null
+          : IconButton(
+              icon: const Icon(Icons.delete_outline),
+              onPressed: onRemove,
+            ),
+    );
+  }
+}
+
+class _AddClaimDialog extends StatefulWidget {
+  const _AddClaimDialog();
+
+  @override
+  State<_AddClaimDialog> createState() => _AddClaimDialogState();
+}
+
+class _AddClaimDialogState extends State<_AddClaimDialog> {
+  DomainClaimKind _kind = DomainClaimKind.exactHost;
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Add domain claim'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          DropdownButton<DomainClaimKind>(
+            value: _kind,
+            isExpanded: true,
+            onChanged: (v) {
+              if (v != null) setState(() => _kind = v);
+            },
+            items: const [
+              DropdownMenuItem(
+                value: DomainClaimKind.exactHost,
+                child: Text('Exact host (e.g. mail.google.com)'),
+              ),
+              DropdownMenuItem(
+                value: DomainClaimKind.wildcardSubdomain,
+                child: Text('Wildcard subdomain (*.google.com)'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _controller,
+            decoration: const InputDecoration(
+              labelText: 'Hostname',
+              border: OutlineInputBorder(),
+              hintText: 'example.com',
+            ),
+            keyboardType: TextInputType.url,
+            autofocus: true,
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        ElevatedButton(
+          onPressed: () {
+            final v = _controller.text.trim();
+            if (v.isEmpty) return;
+            Navigator.of(context).pop(DomainClaim(_kind, v));
+          },
+          child: const Text('Add'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -15,6 +15,7 @@ import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/notification_service.dart';
 import 'package:webspace/services/timezone_location_service.dart';
 import 'package:webspace/screens/location_picker.dart';
+import 'package:webspace/screens/link_handling_settings.dart';
 import 'package:webspace/screens/site_settings_qr.dart';
 import 'package:webspace/screens/user_scripts.dart';
 import 'package:webspace/settings/user_script.dart';
@@ -96,6 +97,10 @@ class SettingsScreen extends StatefulWidget {
   /// platforms or when there's no conflict, this is `null`.
   final String? notificationsBlockedBySite;
 
+  /// Sites OTHER than [webViewModel], used by the domain-claim editor
+  /// (LIR-008 task 8.4) for hijack/overlap detection.
+  final List<WebViewModel> otherSites;
+
   SettingsScreen({
     required this.webViewModel,
     this.onSettingsSaved,
@@ -105,6 +110,7 @@ class SettingsScreen extends StatefulWidget {
     this.onScriptsChanged,
     this.useContainers = false,
     this.notificationsBlockedBySite,
+    this.otherSites = const [],
   });
 
   @override
@@ -1137,6 +1143,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         }
                       : null),
             ),
+          // LIR-008 / LIR-001: per-site domain-claim editor. Lets the user
+          // tell the share-intent resolver which hostnames belong to this
+          // site beyond the synthesized `baseDomain(initUrl)` default.
+          DomainClaimsEditor(
+            model: widget.webViewModel,
+            otherSites: widget.otherSites,
+            onChanged: (next) {
+              widget.webViewModel.domainClaims = next;
+            },
+          ),
+          const SizedBox(height: 8),
           ListTile(
             title: const Text('User Scripts'),
             subtitle: Text(

--- a/lib/services/domain_claim.dart
+++ b/lib/services/domain_claim.dart
@@ -1,0 +1,55 @@
+enum DomainClaimKind { exactHost, wildcardSubdomain, baseDomain }
+
+class DomainClaim {
+  final DomainClaimKind kind;
+  final String value;
+
+  const DomainClaim._raw(this.kind, this.value);
+
+  factory DomainClaim(DomainClaimKind kind, String value) =>
+      DomainClaim._raw(kind, _canon(value));
+
+  factory DomainClaim.exactHost(String host) =>
+      DomainClaim(DomainClaimKind.exactHost, host);
+
+  factory DomainClaim.wildcardSubdomain(String host) =>
+      DomainClaim(DomainClaimKind.wildcardSubdomain, host);
+
+  factory DomainClaim.baseDomain(String host) =>
+      DomainClaim(DomainClaimKind.baseDomain, host);
+
+  static String _canon(String s) {
+    var v = s.trim().toLowerCase();
+    if (v.isEmpty) return v;
+    if (v.contains('://')) {
+      v = Uri.tryParse(v)?.host ?? v;
+    }
+    if (v.startsWith('*.')) v = v.substring(2);
+    final colon = v.indexOf(':');
+    if (colon > 0) v = v.substring(0, colon);
+    if (v.startsWith('[') && v.contains(']')) {
+      v = v.substring(1, v.indexOf(']'));
+    }
+    return v;
+  }
+
+  Map<String, dynamic> toJson() => {'kind': kind.name, 'value': value};
+
+  factory DomainClaim.fromJson(Map<String, dynamic> json) => DomainClaim(
+        DomainClaimKind.values.firstWhere(
+          (k) => k.name == json['kind'],
+          orElse: () => DomainClaimKind.baseDomain,
+        ),
+        json['value'] as String? ?? '',
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      other is DomainClaim && other.kind == kind && other.value == value;
+
+  @override
+  int get hashCode => Object.hash(kind, value);
+
+  @override
+  String toString() => '${kind.name}:$value';
+}

--- a/lib/services/link_intent_dispatch_engine.dart
+++ b/lib/services/link_intent_dispatch_engine.dart
@@ -1,0 +1,277 @@
+/// Pure-Dart logic engine for dispatching inbound share/open intents to a
+/// site (LIR-002, LIR-009, LIR-010, LIR-011, LIR-012). Mirrors the engine
+/// pattern in `cookie_isolation.dart` / `site_activation_engine.dart`:
+/// the engine returns a [DispatchAction] describing what should happen,
+/// and `_WebSpacePageState` performs the IO/UI side-effects. No Flutter,
+/// no platform channels, no setState — fully testable with fakes.
+library;
+
+import 'package:webspace/services/link_routing_service.dart';
+import 'package:webspace/web_view_model.dart' show getBaseDomain, getNormalizedDomain;
+
+/// What the OS handed us. `webspace://open?url=...` URLs are unwrapped to
+/// `InboundUrl` before dispatch; `text/html` shares (Android) and HTML
+/// files dropped via the future iOS Share Extension arrive as
+/// `InboundHtml`.
+sealed class InboundPayload {
+  const InboundPayload();
+}
+
+class InboundUrl extends InboundPayload {
+  final Uri url;
+  const InboundUrl(this.url);
+}
+
+class InboundHtml extends InboundPayload {
+  /// Whole HTML document.
+  final String content;
+
+  /// Display name, derived from filename or `<title>`. Used as the new
+  /// site's `name` and `pageTitle`.
+  final String? suggestedTitle;
+
+  /// Optional source URI (typically `file://` or `content://`) — purely
+  /// informational; the engine never opens it.
+  final String? sourceUri;
+
+  const InboundHtml({
+    required this.content,
+    this.suggestedTitle,
+    this.sourceUri,
+  });
+}
+
+/// Subset of [WebViewModel] the engine needs. Adapter lives at the call
+/// site so the engine has zero dependency on Flutter.
+abstract class DispatchableSite implements RoutableSite {
+  bool get incognito;
+  bool get alwaysOpenHome;
+
+  /// `getNormalizedDomain(initUrl)` — used for the in-domain main-vs-
+  /// nested split. Pre-computed by the adapter so the engine never
+  /// imports the alias table.
+  String get navigationDomain;
+}
+
+sealed class DispatchAction {
+  const DispatchAction();
+}
+
+/// Inbound URL is malformed, non-http(s), or has an empty host. The view
+/// surfaces a snackbar and otherwise no-ops.
+class DispatchUnsupported extends DispatchAction {
+  final String reason;
+  const DispatchUnsupported(this.reason);
+}
+
+/// Activate [siteId] and load [url] into its main webview.
+///
+/// `disposeBeforeLoad`/`wipeContainer`/`clearInMemoryCookies` are non-
+/// negotiable: when the engine emits them, the executor MUST honour them
+/// before activating. They are how the engine enforces the
+/// always-open-home / incognito reset (LIR-011) so an inbound share
+/// can't be loaded into an existing webview that's mid-session — a
+/// defence against IP / session leakage across share boundaries.
+class DispatchOpenInMain extends DispatchAction {
+  final String siteId;
+  final String url;
+  final bool disposeBeforeLoad;
+  final bool wipeContainer;
+  final bool clearInMemoryCookies;
+  const DispatchOpenInMain({
+    required this.siteId,
+    required this.url,
+    required this.disposeBeforeLoad,
+    required this.wipeContainer,
+    required this.clearInMemoryCookies,
+  });
+}
+
+/// Open [url] in a nested in-app webview carrying the chosen site's
+/// privacy settings. Used for cross-domain shares (LIR-011) so a site's
+/// main session is not clobbered.
+class DispatchOpenNested extends DispatchAction {
+  final String siteId;
+  final String url;
+  const DispatchOpenNested({required this.siteId, required this.url});
+}
+
+/// Create a brand-new site rooted at [home] (the stripped path) with
+/// [initialClaims], then navigate the new webview to [fullUrl] (which
+/// may equal [home]) on first activation.
+class DispatchCreateSite extends DispatchAction {
+  final String home;
+  final String fullUrl;
+  final List<DomainClaim> initialClaims;
+  const DispatchCreateSite({
+    required this.home,
+    required this.fullUrl,
+    required this.initialClaims,
+  });
+}
+
+/// Create a brand-new site whose `initialHtml` is [html]. There is no
+/// remote URL — the file lives in `HtmlImportStorage`. Naming hints from
+/// [InboundHtml.suggestedTitle].
+class DispatchCreateSiteFromHtml extends DispatchAction {
+  final String html;
+  final String? suggestedTitle;
+  const DispatchCreateSiteFromHtml({
+    required this.html,
+    this.suggestedTitle,
+  });
+}
+
+/// Surface the LIR-010 picker. The view owns the UI, including the
+/// secondary site picker for the bind option. Once the user picks, call
+/// back into `LinkIntentDispatchEngine.openInChosen`,
+/// `bindToSite`, or `createNew` to get the follow-up action.
+class DispatchShowPicker extends DispatchAction {
+  final List<String> winnerSiteIds;
+  final bool offerBind;
+  final bool offerCreate;
+  const DispatchShowPicker({
+    required this.winnerSiteIds,
+    required this.offerBind,
+    required this.offerCreate,
+  });
+}
+
+/// Pre-append [claimAdditions] to the chosen site (deduped) and persist;
+/// then run [followUp]. Distilled into one action so the executor never
+/// computes "what comes after binding" on its own — that decision is
+/// fully owned by the engine.
+class DispatchBindAndOpen extends DispatchAction {
+  final String chosenSiteId;
+  final List<DomainClaim> claimAdditions;
+  final DispatchAction followUp;
+  const DispatchBindAndOpen({
+    required this.chosenSiteId,
+    required this.claimAdditions,
+    required this.followUp,
+  });
+}
+
+class LinkIntentDispatchEngine {
+  LinkIntentDispatchEngine._();
+
+  /// Initial dispatch on payload arrival. Returns the action the view
+  /// should execute. For an HTML file payload there is no router stage —
+  /// the only sensible operation is "create a new site for this file"
+  /// (LIR-012); existing sites can't claim opaque file content.
+  static DispatchAction dispatch({
+    required InboundPayload payload,
+    required List<DispatchableSite> sites,
+  }) {
+    if (payload is InboundHtml) {
+      if (payload.content.isEmpty) {
+        return const DispatchUnsupported('empty HTML payload');
+      }
+      return DispatchCreateSiteFromHtml(
+        html: payload.content,
+        suggestedTitle: payload.suggestedTitle,
+      );
+    }
+    final url = (payload as InboundUrl).url;
+    final target = _normalizeInbound(url);
+    if (target == null) {
+      return const DispatchUnsupported('non-http(s) target or empty host');
+    }
+    final match = LinkRoutingService.resolve(target, sites);
+    if (match is RoutingSingle) {
+      return _openInExisting(match.site as DispatchableSite, target);
+    }
+    return DispatchShowPicker(
+      winnerSiteIds: match is RoutingAmbiguous
+          ? match.sites
+              .map((s) => s.siteId)
+              .toList(growable: false)
+          : const [],
+      offerBind: sites.isNotEmpty,
+      offerCreate: LinkRoutingService.strippedHomeUrl(target) != null,
+    );
+  }
+
+  /// User picked a "Open in <site>" row from the picker.
+  static DispatchAction openInChosen({
+    required Uri inbound,
+    required DispatchableSite site,
+  }) {
+    final target = _normalizeInbound(inbound) ?? inbound;
+    return _openInExisting(site, target);
+  }
+
+  /// User picked "Send <host> (and subdomains) to <site>". The returned
+  /// [DispatchBindAndOpen] tells the executor to mutate the site's
+  /// claim list and then proceed with the same in-domain decision.
+  static DispatchAction bindToSite({
+    required Uri inbound,
+    required DispatchableSite site,
+  }) {
+    final target = _normalizeInbound(inbound) ?? inbound;
+    final additions = LinkRoutingService.claimsToAdoptHost(target.host);
+    return DispatchBindAndOpen(
+      chosenSiteId: site.siteId,
+      claimAdditions: additions,
+      // Even after binding, the in-domain check is keyed off
+      // `navigationDomain` (= getNormalizedDomain(initUrl)), which is
+      // unchanged. So a bind from f-droid.org to a duckduckgo.com site
+      // still produces an out-of-domain share → nested webview. This is
+      // by design (LIR-011): claims drive routing of *future* arrivals;
+      // the current arrival respects the existing site's session.
+      followUp: _openInExisting(site, target),
+    );
+  }
+
+  /// User picked "Create new site for <host>".
+  static DispatchAction createNew({required Uri inbound}) {
+    final target = _normalizeInbound(inbound) ?? inbound;
+    final home = LinkRoutingService.strippedHomeUrl(target);
+    if (home == null) {
+      return const DispatchUnsupported('cannot strip path for create');
+    }
+    final base = getBaseDomain(target.host);
+    final claims = base.isEmpty
+        ? const <DomainClaim>[]
+        : [DomainClaim.baseDomain(base)];
+    return DispatchCreateSite(
+      home: home,
+      fullUrl: target.toString(),
+      initialClaims: claims,
+    );
+  }
+
+  static DispatchAction _openInExisting(
+    DispatchableSite site,
+    Uri inbound,
+  ) {
+    final inDomain =
+        getNormalizedDomain(inbound.toString()) == site.navigationDomain;
+    if (!inDomain) {
+      return DispatchOpenNested(
+        siteId: site.siteId,
+        url: inbound.toString(),
+      );
+    }
+    final reset = site.incognito || site.alwaysOpenHome;
+    return DispatchOpenInMain(
+      siteId: site.siteId,
+      url: inbound.toString(),
+      disposeBeforeLoad: reset,
+      wipeContainer: site.incognito,
+      clearInMemoryCookies: site.incognito,
+    );
+  }
+
+  static Uri? _normalizeInbound(Uri raw) {
+    final unwrapped = raw.scheme.toLowerCase() == 'webspace'
+        ? LinkRoutingService.parseWebspaceUri(raw)
+        : raw;
+    if (unwrapped == null) return null;
+    if (unwrapped.scheme != 'http' && unwrapped.scheme != 'https') {
+      return null;
+    }
+    if (unwrapped.host.isEmpty) return null;
+    return unwrapped;
+  }
+}

--- a/lib/services/link_intent_dispatch_engine.dart
+++ b/lib/services/link_intent_dispatch_engine.dart
@@ -192,7 +192,7 @@ class LinkIntentDispatchEngine {
     );
   }
 
-  /// User picked a "Open in <site>" row from the picker.
+  /// User picked an "Open in [site]" row from the picker.
   static DispatchAction openInChosen({
     required Uri inbound,
     required DispatchableSite site,
@@ -201,7 +201,7 @@ class LinkIntentDispatchEngine {
     return _openInExisting(site, target);
   }
 
-  /// User picked "Send <host> (and subdomains) to <site>". The returned
+  /// User picked "Send [host] (and subdomains) to [site]". The returned
   /// [DispatchBindAndOpen] tells the executor to mutate the site's
   /// claim list and then proceed with the same in-domain decision.
   static DispatchAction bindToSite({
@@ -223,7 +223,7 @@ class LinkIntentDispatchEngine {
     );
   }
 
-  /// User picked "Create new site for <host>".
+  /// User picked "Create new site for [host]".
   static DispatchAction createNew({required Uri inbound}) {
     final target = _normalizeInbound(inbound) ?? inbound;
     final home = LinkRoutingService.strippedHomeUrl(target);

--- a/lib/services/link_routing_service.dart
+++ b/lib/services/link_routing_service.dart
@@ -1,60 +1,7 @@
+import 'package:webspace/services/domain_claim.dart';
 import 'package:webspace/web_view_model.dart' show extractDomain, getBaseDomain;
 
-enum DomainClaimKind { exactHost, wildcardSubdomain, baseDomain }
-
-class DomainClaim {
-  final DomainClaimKind kind;
-  final String value;
-
-  const DomainClaim._raw(this.kind, this.value);
-
-  factory DomainClaim(DomainClaimKind kind, String value) =>
-      DomainClaim._raw(kind, _canon(value));
-
-  factory DomainClaim.exactHost(String host) =>
-      DomainClaim(DomainClaimKind.exactHost, host);
-
-  factory DomainClaim.wildcardSubdomain(String host) =>
-      DomainClaim(DomainClaimKind.wildcardSubdomain, host);
-
-  factory DomainClaim.baseDomain(String host) =>
-      DomainClaim(DomainClaimKind.baseDomain, host);
-
-  static String _canon(String s) {
-    var v = s.trim().toLowerCase();
-    if (v.isEmpty) return v;
-    if (v.contains('://')) {
-      v = Uri.tryParse(v)?.host ?? v;
-    }
-    if (v.startsWith('*.')) v = v.substring(2);
-    final colon = v.indexOf(':');
-    if (colon > 0) v = v.substring(0, colon);
-    if (v.startsWith('[') && v.contains(']')) {
-      v = v.substring(1, v.indexOf(']'));
-    }
-    return v;
-  }
-
-  Map<String, dynamic> toJson() => {'kind': kind.name, 'value': value};
-
-  factory DomainClaim.fromJson(Map<String, dynamic> json) => DomainClaim(
-        DomainClaimKind.values.firstWhere(
-          (k) => k.name == json['kind'],
-          orElse: () => DomainClaimKind.baseDomain,
-        ),
-        json['value'] as String? ?? '',
-      );
-
-  @override
-  bool operator ==(Object other) =>
-      other is DomainClaim && other.kind == kind && other.value == value;
-
-  @override
-  int get hashCode => Object.hash(kind, value);
-
-  @override
-  String toString() => '${kind.name}:$value';
-}
+export 'package:webspace/services/domain_claim.dart' show DomainClaim, DomainClaimKind;
 
 abstract class RoutableSite {
   String get siteId;
@@ -171,10 +118,11 @@ class LinkRoutingService {
   }
 
   static List<DomainClaim> claimsToAdoptHost(String host) {
-    final h = DomainClaim._canon(host);
+    final exact = DomainClaim.exactHost(host);
+    final h = exact.value;
     if (h.isEmpty) return const [];
     final base = getBaseDomain(h);
-    final out = <DomainClaim>[DomainClaim.exactHost(h)];
+    final out = <DomainClaim>[exact];
     if (base.isNotEmpty) {
       out.add(DomainClaim.wildcardSubdomain(base));
     }

--- a/lib/services/link_routing_service.dart
+++ b/lib/services/link_routing_service.dart
@@ -1,0 +1,247 @@
+import 'package:webspace/web_view_model.dart' show extractDomain, getBaseDomain;
+
+enum DomainClaimKind { exactHost, wildcardSubdomain, baseDomain }
+
+class DomainClaim {
+  final DomainClaimKind kind;
+  final String value;
+
+  const DomainClaim._raw(this.kind, this.value);
+
+  factory DomainClaim(DomainClaimKind kind, String value) =>
+      DomainClaim._raw(kind, _canon(value));
+
+  factory DomainClaim.exactHost(String host) =>
+      DomainClaim(DomainClaimKind.exactHost, host);
+
+  factory DomainClaim.wildcardSubdomain(String host) =>
+      DomainClaim(DomainClaimKind.wildcardSubdomain, host);
+
+  factory DomainClaim.baseDomain(String host) =>
+      DomainClaim(DomainClaimKind.baseDomain, host);
+
+  static String _canon(String s) {
+    var v = s.trim().toLowerCase();
+    if (v.isEmpty) return v;
+    if (v.contains('://')) {
+      v = Uri.tryParse(v)?.host ?? v;
+    }
+    if (v.startsWith('*.')) v = v.substring(2);
+    final colon = v.indexOf(':');
+    if (colon > 0) v = v.substring(0, colon);
+    if (v.startsWith('[') && v.contains(']')) {
+      v = v.substring(1, v.indexOf(']'));
+    }
+    return v;
+  }
+
+  Map<String, dynamic> toJson() => {'kind': kind.name, 'value': value};
+
+  factory DomainClaim.fromJson(Map<String, dynamic> json) => DomainClaim(
+        DomainClaimKind.values.firstWhere(
+          (k) => k.name == json['kind'],
+          orElse: () => DomainClaimKind.baseDomain,
+        ),
+        json['value'] as String? ?? '',
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      other is DomainClaim && other.kind == kind && other.value == value;
+
+  @override
+  int get hashCode => Object.hash(kind, value);
+
+  @override
+  String toString() => '${kind.name}:$value';
+}
+
+abstract class RoutableSite {
+  String get siteId;
+  String get initUrl;
+  List<DomainClaim> get domainClaims;
+}
+
+sealed class RoutingMatch {
+  const RoutingMatch();
+}
+
+class RoutingSingle extends RoutingMatch {
+  final RoutableSite site;
+  const RoutingSingle(this.site);
+}
+
+class RoutingAmbiguous extends RoutingMatch {
+  final List<RoutableSite> sites;
+  const RoutingAmbiguous(this.sites);
+}
+
+class RoutingNone extends RoutingMatch {
+  const RoutingNone();
+}
+
+enum ClaimConflictKind { hijack, overlap }
+
+class ClaimConflict {
+  final DomainClaim claim;
+  final String otherSiteId;
+  final ClaimConflictKind kind;
+
+  const ClaimConflict({
+    required this.claim,
+    required this.otherSiteId,
+    required this.kind,
+  });
+
+  @override
+  String toString() =>
+      'ClaimConflict(${kind.name}, claim=$claim, other=$otherSiteId)';
+}
+
+class LinkRoutingService {
+  LinkRoutingService._();
+
+  static const int _scoreExactHost = 300;
+  static const int _scoreWildcardSubdomain = 200;
+  static const int _scoreBaseDomain = 100;
+
+  static int _score(DomainClaim claim, String host, String base) {
+    switch (claim.kind) {
+      case DomainClaimKind.exactHost:
+        return claim.value == host ? _scoreExactHost : 0;
+      case DomainClaimKind.wildcardSubdomain:
+        return host.endsWith('.${claim.value}') ? _scoreWildcardSubdomain : 0;
+      case DomainClaimKind.baseDomain:
+        return getBaseDomain(claim.value) == base ? _scoreBaseDomain : 0;
+    }
+  }
+
+  static RoutingMatch resolve(Uri url, List<RoutableSite> sites) {
+    if (url.scheme != 'http' && url.scheme != 'https') {
+      return const RoutingNone();
+    }
+    if (url.host.isEmpty) return const RoutingNone();
+    final host = url.host.toLowerCase();
+    final base = getBaseDomain(host);
+    int best = 0;
+    final winners = <RoutableSite>[];
+    for (final site in sites) {
+      int siteBest = 0;
+      for (final claim in site.domainClaims) {
+        final s = _score(claim, host, base);
+        if (s > siteBest) siteBest = s;
+      }
+      if (siteBest == 0) continue;
+      if (siteBest > best) {
+        best = siteBest;
+        winners
+          ..clear()
+          ..add(site);
+      } else if (siteBest == best) {
+        winners.add(site);
+      }
+    }
+    if (winners.isEmpty) return const RoutingNone();
+    if (winners.length == 1) return RoutingSingle(winners.single);
+    return RoutingAmbiguous(List.unmodifiable(winners));
+  }
+
+  static String? strippedHomeUrl(Uri url) {
+    if (url.scheme != 'http' && url.scheme != 'https') return null;
+    if (url.host.isEmpty) return null;
+    final host = url.host.contains(':') ? '[${url.host}]' : url.host;
+    final port = url.hasPort ? ':${url.port}' : '';
+    return '${url.scheme}://$host$port/';
+  }
+
+  static Uri? parseWebspaceUri(Uri raw) {
+    if (raw.scheme.toLowerCase() != 'webspace') return null;
+    final host = raw.host.toLowerCase();
+    final path = raw.path;
+    final isOpen = host == 'open' ||
+        (host.isEmpty && (path == 'open' || path == '/open'));
+    if (!isOpen) return null;
+    final encoded = raw.queryParameters['url'];
+    if (encoded == null || encoded.isEmpty) return null;
+    final inner = Uri.tryParse(encoded);
+    if (inner == null) return null;
+    if (inner.scheme != 'http' && inner.scheme != 'https') return null;
+    if (inner.host.isEmpty) return null;
+    return inner;
+  }
+
+  static List<DomainClaim> claimsToAdoptHost(String host) {
+    final h = DomainClaim._canon(host);
+    if (h.isEmpty) return const [];
+    final base = getBaseDomain(h);
+    final out = <DomainClaim>[DomainClaim.exactHost(h)];
+    if (base.isNotEmpty) {
+      out.add(DomainClaim.wildcardSubdomain(base));
+    }
+    return out;
+  }
+
+  static List<DomainClaim> mergeClaims(
+    List<DomainClaim> existing,
+    List<DomainClaim> additions,
+  ) {
+    final seen = <DomainClaim>{...existing};
+    final out = <DomainClaim>[...existing];
+    for (final c in additions) {
+      if (seen.add(c)) out.add(c);
+    }
+    return out;
+  }
+
+  static List<ClaimConflict> validateClaims(
+    String editedSiteId,
+    List<DomainClaim> editedClaims,
+    List<RoutableSite> others,
+  ) {
+    final out = <ClaimConflict>[];
+    for (final claim in editedClaims) {
+      final claimBase = getBaseDomain(claim.value);
+      if (claimBase.isEmpty) continue;
+      for (final other in others) {
+        if (other.siteId == editedSiteId) continue;
+        final otherBase = getBaseDomain(extractDomain(other.initUrl));
+        if (otherBase.isEmpty) continue;
+        if (otherBase == claimBase) {
+          out.add(ClaimConflict(
+            claim: claim,
+            otherSiteId: other.siteId,
+            kind: ClaimConflictKind.hijack,
+          ));
+          continue;
+        }
+        for (final otherClaim in other.domainClaims) {
+          if (_claimsOverlap(claim, otherClaim)) {
+            out.add(ClaimConflict(
+              claim: claim,
+              otherSiteId: other.siteId,
+              kind: ClaimConflictKind.overlap,
+            ));
+            break;
+          }
+        }
+      }
+    }
+    return out;
+  }
+
+  static bool _claimsOverlap(DomainClaim a, DomainClaim b) {
+    if (a == b) return true;
+    final av = a.value;
+    final bv = b.value;
+    if (a.kind == DomainClaimKind.exactHost &&
+        b.kind == DomainClaimKind.wildcardSubdomain) {
+      return av.endsWith('.$bv');
+    }
+    if (b.kind == DomainClaimKind.exactHost &&
+        a.kind == DomainClaimKind.wildcardSubdomain) {
+      return bv.endsWith('.$av');
+    }
+    return false;
+  }
+}
+

--- a/lib/services/share_intent_service.dart
+++ b/lib/services/share_intent_service.dart
@@ -1,6 +1,17 @@
 import 'dart:io';
 import 'package:flutter/services.dart';
 
+class InboundHtmlShare {
+  final String content;
+  final String? title;
+  final String? sourceUri;
+  const InboundHtmlShare({
+    required this.content,
+    this.title,
+    this.sourceUri,
+  });
+}
+
 class ShareIntentService {
   static const _channel = MethodChannel('org.codeberg.theoden8.webspace/share_intent');
 
@@ -13,6 +24,30 @@ class ShareIntentService {
       final result = await _channel.invokeMethod('consumeLaunchUrl');
       return result is String ? result : null;
     } on PlatformException {
+      return null;
+    }
+  }
+
+  /// Reads any HTML file payload delivered via `text/html` ACTION_SEND.
+  /// Cleared on the native side after one read. Returns null when no
+  /// HTML share is pending or the platform doesn't support it.
+  static Future<InboundHtmlShare?> consumeLaunchHtml() async {
+    if (!Platform.isAndroid && !Platform.isIOS) return null;
+    try {
+      final result = await _channel.invokeMethod('consumeLaunchHtml');
+      if (result is! Map) return null;
+      final content = result['content'];
+      if (content is! String || content.isEmpty) return null;
+      return InboundHtmlShare(
+        content: content,
+        title: result['title'] is String ? result['title'] as String : null,
+        sourceUri:
+            result['sourceUri'] is String ? result['sourceUri'] as String : null,
+      );
+    } on PlatformException {
+      return null;
+    } on MissingPluginException {
+      // Native side hasn't shipped the HTML branch yet; ignore.
       return null;
     }
   }

--- a/lib/settings/app_prefs.dart
+++ b/lib/settings/app_prefs.dart
@@ -33,7 +33,13 @@ final Map<String, Object> kExportedAppPrefs = <String, Object>{
   // value via `resolveEffectiveProxy`. Stored as a JSON-encoded
   // UserProxySettings; round-trips through backup/restore as a String.
   kGlobalOutboundProxyKey: kGlobalOutboundProxyDefault,
+  // LIR-008: master "Handle shared links" switch. When false, the app
+  // ignores incoming share/open intents (Android ACTION_SEND, webspace://,
+  // iOS/macOS Share Extension) without crashing. Default: enabled.
+  'linkHandlingEnabled': true,
 };
+
+const String kLinkHandlingEnabledKey = 'linkHandlingEnabled';
 
 /// Read every registered pref from [prefs] into a map suitable for embedding
 /// in a `SettingsBackup`. Missing keys fall back to their registry default.

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -8,6 +8,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart' show ConsoleMess
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp show PullToRefreshController, PullToRefreshSettings;
 import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/container_cookie_manager.dart';
+import 'package:webspace/services/domain_claim.dart';
 import 'package:webspace/services/external_url_engine.dart';
 import 'package:webspace/services/html_cache_service.dart';
 import 'package:webspace/services/log_service.dart';
@@ -326,6 +327,25 @@ class WebViewModel {
   bool spoofTimezoneFromLocation;
   WebRtcPolicy webRtcPolicy;
 
+  /// User-defined domain-claim list used by `LinkRoutingService` to route
+  /// inbound share/open-intent URLs to a site (LIR-001..LIR-010). When
+  /// null, the resolver behaves as if the site claimed
+  /// `[baseDomain(getBaseDomain(initUrl))]` (the legacy synthesized
+  /// default). Serialised only when non-null so on-disk JSON for users who
+  /// never touch the feature stays byte-identical.
+  List<DomainClaim>? domainClaims;
+
+  /// View used by the resolver — always non-empty: returns the explicit
+  /// `domainClaims` if the user has set them, otherwise the synthesized
+  /// `[baseDomain(getBaseDomain(initUrl))]` per LIR-001.
+  List<DomainClaim> get effectiveDomainClaims {
+    final explicit = domainClaims;
+    if (explicit != null && explicit.isNotEmpty) return explicit;
+    final base = getBaseDomain(initUrl);
+    if (base.isEmpty) return const [];
+    return [DomainClaim.baseDomain(base)];
+  }
+
   /// Whether the webview is currently mid-navigation. Set true on
   /// `onLoadStart`, false on `onLoadStop`. Driven by the
   /// `WebViewConfig.onLoadingChanged` callback wired in [getWebView].
@@ -378,6 +398,7 @@ class WebViewModel {
     this.spoofTimezone,
     this.spoofTimezoneFromLocation = false,
     this.webRtcPolicy = WebRtcPolicy.defaultPolicy,
+    this.domainClaims,
     this.stateSetterF,
   })  : userScripts = userScripts ?? [],
         enabledGlobalScriptIds = enabledGlobalScriptIds ?? {},
@@ -1157,6 +1178,8 @@ class WebViewModel {
         if (spoofTimezone != null) 'spoofTimezone': spoofTimezone,
         if (spoofTimezoneFromLocation) 'spoofTimezoneFromLocation': true,
         'webRtcPolicy': webRtcPolicy.name,
+        if (domainClaims != null && domainClaims!.isNotEmpty)
+          'domainClaims': domainClaims!.map((c) => c.toJson()).toList(),
       };
   }
 
@@ -1220,6 +1243,9 @@ class WebViewModel {
         (p) => p.name == json['webRtcPolicy'],
         orElse: () => WebRtcPolicy.defaultPolicy,
       ),
+      domainClaims: (json['domainClaims'] as List<dynamic>?)
+          ?.map((e) => DomainClaim.fromJson(e as Map<String, dynamic>))
+          .toList(),
       stateSetterF: stateSetterF,
     )..pageTitle = dropUrl ? null : json['pageTitle'];
   }

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -139,3 +139,13 @@ if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
   install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
     COMPONENT Runtime)
 endif()
+
+# LIR-004: webspace:// scheme handler. Bundles the .desktop file alongside
+# the binary; downstream packagers should additionally copy it to
+# `${XDG_DATA_DIRS}/applications/` (e.g. `/usr/share/applications/`) and
+# run `update-desktop-database` so xdg-open dispatches `webspace://`. The
+# bundled copy is documented for users running `flutter build linux`
+# manually.
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/webspace.desktop"
+  DESTINATION "${CMAKE_INSTALL_PREFIX}"
+  COMPONENT Runtime)

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -5,14 +5,63 @@
 #include <gdk/gdkx.h>
 #endif
 
+#include <string.h>
+
 #include "flutter/generated_plugin_registrant.h"
+
+// LIR-004: webspace:// inbound URL captured at cold-start (argv) or via
+// GApplication::open (warm xdg-open hits). Stored on the application
+// struct, drained by the Dart side via the share_intent channel.
+static const char* kShareChannel =
+    "org.codeberg.theoden8.webspace/share_intent";
 
 struct _MyApplication {
   GtkApplication parent_instance;
   char** dart_entrypoint_arguments;
+  char* pending_share_url;
+  FlMethodChannel* share_channel;
 };
 
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
+
+static void my_application_set_pending_share_url(MyApplication* self,
+                                                 const char* url) {
+  if (self->pending_share_url) {
+    g_free(self->pending_share_url);
+    self->pending_share_url = nullptr;
+  }
+  if (url == nullptr) return;
+  if (g_str_has_prefix(url, "webspace://") == FALSE) return;
+  self->pending_share_url = g_strdup(url);
+}
+
+static void share_method_call_handler(FlMethodChannel* /*channel*/,
+                                      FlMethodCall* method_call,
+                                      gpointer user_data) {
+  MyApplication* self = MY_APPLICATION(user_data);
+  const gchar* method = fl_method_call_get_name(method_call);
+  g_autoptr(FlMethodResponse) response = nullptr;
+  if (g_strcmp0(method, "consumeLaunchUrl") == 0) {
+    g_autoptr(FlValue) value = self->pending_share_url
+                                   ? fl_value_new_string(self->pending_share_url)
+                                   : fl_value_new_null();
+    if (self->pending_share_url) {
+      g_free(self->pending_share_url);
+      self->pending_share_url = nullptr;
+    }
+    response = FL_METHOD_RESPONSE(fl_method_success_response_new(value));
+  } else if (g_strcmp0(method, "consumeLaunchHtml") == 0) {
+    // No HTML share path on Linux yet; xdg-open delivers URI strings only.
+    g_autoptr(FlValue) value = fl_value_new_null();
+    response = FL_METHOD_RESPONSE(fl_method_success_response_new(value));
+  } else {
+    response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
+  }
+  g_autoptr(GError) error = nullptr;
+  if (!fl_method_call_respond(method_call, response, &error)) {
+    g_warning("Failed to send share-intent response: %s", error->message);
+  }
+}
 
 // Implements GApplication::activate.
 static void my_application_activate(GApplication* application) {
@@ -20,13 +69,6 @@ static void my_application_activate(GApplication* application) {
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
-  // Use a header bar when running in GNOME as this is the common style used
-  // by applications and is the setup most users will be using (e.g. Ubuntu
-  // desktop).
-  // If running on X and not using GNOME then just use a traditional title bar
-  // in case the window manager does more exotic layout, e.g. tiling.
-  // If running on Wayland assume the header bar will work (may need changing
-  // if future cases occur).
   gboolean use_header_bar = TRUE;
 #ifdef GDK_WINDOWING_X11
   GdkScreen* screen = gtk_window_get_screen(window);
@@ -59,23 +101,72 @@ static void my_application_activate(GApplication* application) {
 
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));
 
+  // Register the share-intent channel after the engine is up.
+  if (self->share_channel == nullptr) {
+    g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
+    self->share_channel = fl_method_channel_new(
+        fl_engine_get_binary_messenger(fl_view_get_engine(view)),
+        kShareChannel, FL_METHOD_CODEC(codec));
+    fl_method_channel_set_method_call_handler(
+        self->share_channel, share_method_call_handler, self, nullptr);
+  }
+
   gtk_widget_grab_focus(GTK_WIDGET(view));
+}
+
+// Implements GApplication::open. Triggered when GApplication's default
+// command-line handling sees one or more URI arguments and the
+// G_APPLICATION_HANDLES_OPEN flag is set. Each `file` is a `GFile`; for
+// non-file URIs (e.g. webspace://) GApplication still represents them as
+// GFile pointers — `g_file_get_uri` round-trips the original URI string.
+static void my_application_open(GApplication* application, GFile** files,
+                                gint n_files, const gchar* /*hint*/) {
+  MyApplication* self = MY_APPLICATION(application);
+  for (gint i = 0; i < n_files; i++) {
+    g_autofree gchar* uri = g_file_get_uri(files[i]);
+    if (uri == nullptr) continue;
+    my_application_set_pending_share_url(self, uri);
+  }
+  // GApplication suppresses ::activate when ::open fires, so we have to
+  // ensure a window exists. Activate explicitly: idempotent because the
+  // flutter view re-uses the existing GtkApplicationWindow on subsequent
+  // hits within the same process.
+  g_application_activate(application);
 }
 
 // Implements GApplication::local_command_line.
 static gboolean my_application_local_command_line(GApplication* application, gchar*** arguments, int* exit_status) {
   MyApplication* self = MY_APPLICATION(application);
-  // Strip out the first argument as it is the binary name.
+  gchar** argv = *arguments;
+  gint argc = 0;
+  while (argv && argv[argc] != nullptr) ++argc;
+
+  // Detect a `webspace://...` first positional argument and route through
+  // GApplication::open. Forward the rest to dart_entrypoint_arguments as
+  // before.
+  gchar* webspace_uri = nullptr;
+  for (gint i = 1; i < argc; ++i) {
+    if (g_str_has_prefix(argv[i], "webspace://")) {
+      webspace_uri = argv[i];
+      break;
+    }
+  }
   self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
 
   g_autoptr(GError) error = nullptr;
   if (!g_application_register(application, nullptr, &error)) {
-     g_warning("Failed to register: %s", error->message);
-     *exit_status = 1;
-     return TRUE;
+    g_warning("Failed to register: %s", error->message);
+    *exit_status = 1;
+    return TRUE;
   }
 
-  g_application_activate(application);
+  if (webspace_uri != nullptr) {
+    g_autoptr(GFile) file = g_file_new_for_uri(webspace_uri);
+    GFile* files[] = {file};
+    g_application_open(application, files, 1, "");
+  } else {
+    g_application_activate(application);
+  }
   *exit_status = 0;
 
   return TRUE;
@@ -85,11 +176,14 @@ static gboolean my_application_local_command_line(GApplication* application, gch
 static void my_application_dispose(GObject* object) {
   MyApplication* self = MY_APPLICATION(object);
   g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
+  g_clear_pointer(&self->pending_share_url, g_free);
+  g_clear_object(&self->share_channel);
   G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
 }
 
 static void my_application_class_init(MyApplicationClass* klass) {
   G_APPLICATION_CLASS(klass)->activate = my_application_activate;
+  G_APPLICATION_CLASS(klass)->open = my_application_open;
   G_APPLICATION_CLASS(klass)->local_command_line = my_application_local_command_line;
   G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
 }
@@ -99,6 +193,6 @@ static void my_application_init(MyApplication* self) {}
 MyApplication* my_application_new() {
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID,
-                                     "flags", G_APPLICATION_NON_UNIQUE,
+                                     "flags", G_APPLICATION_NON_UNIQUE | G_APPLICATION_HANDLES_OPEN,
                                      nullptr));
 }

--- a/linux/webspace.desktop
+++ b/linux/webspace.desktop
@@ -1,0 +1,20 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=WebSpace
+GenericName=Multi-site web browser
+Comment=Manage multiple websites with per-site cookie isolation
+# Adjust if installing into a custom prefix; the package usually
+# substitutes Exec= with the on-disk binary path. The %u substitutes the
+# inbound URL when launched via xdg-open.
+Exec=webspace_app %u
+Icon=webspace
+Terminal=false
+Categories=Network;WebBrowser;
+# LIR-004: register WebSpace as the handler for webspace://. xdg-open
+# routes webspace:// URLs (typically built as `webspace://open?url=...`)
+# to this entry. No https handler — see openspec proposal.
+MimeType=x-scheme-handler/webspace;
+StartupNotify=true
+StartupWMClass=webspace_app
+SingleMainWindow=true

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -4,11 +4,15 @@ import UserNotifications
 
 @main
 class AppDelegate: FlutterAppDelegate {
+  private var pendingShareUrl: String?
+  private let shareChannelName = "org.codeberg.theoden8.webspace/share_intent"
+
   override func applicationDidFinishLaunching(_ notification: Notification) {
     // Same UN delegate requirement as iOS: without this, foreground
     // notifications never reach willPresent and are dropped silently.
     UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
     super.applicationDidFinishLaunching(notification)
+    registerShareChannelOnMainWindow()
   }
 
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
@@ -17,5 +21,48 @@ class AppDelegate: FlutterAppDelegate {
 
   override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
     return false
+  }
+
+  // LIR-004: webspace://open?url=... entry point on macOS. Triggered by
+  // `open webspace://...`, NSWorkspace, Services menu, etc. The whole URL
+  // is forwarded to Dart, which validates and unwraps via
+  // `LinkRoutingService.parseWebspaceUri`.
+  override func application(_ application: NSApplication, open urls: [URL]) {
+    for url in urls {
+      capturePendingShareUrl(from: url)
+    }
+  }
+
+  private func registerShareChannelOnMainWindow() {
+    guard
+      let window = NSApplication.shared.windows.first,
+      let controller = window.contentViewController as? FlutterViewController
+    else { return }
+    let channel = FlutterMethodChannel(
+      name: shareChannelName,
+      binaryMessenger: controller.engine.binaryMessenger
+    )
+    channel.setMethodCallHandler { [weak self] call, result in
+      guard let self = self else { result(nil); return }
+      switch call.method {
+      case "consumeLaunchUrl":
+        let url = self.pendingShareUrl
+        self.pendingShareUrl = nil
+        result(url)
+      case "consumeLaunchHtml":
+        // Share Extension HTML delivery isn't wired yet on macOS.
+        result(nil)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+  }
+
+  private func capturePendingShareUrl(from url: URL) {
+    guard url.scheme?.lowercased() == "webspace" else { return }
+    let host = url.host?.lowercased()
+    if host == "open" || host == "qr" {
+      pendingShareUrl = url.absoluteString
+    }
   }
 }

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -28,5 +28,21 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<!-- LIR-004: webspace://open?url=... entry point. macOS routes
+	     `open webspace://...` and Services-menu / launchctl URL invocations
+	     through application:openURLs:. -->
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>org.codeberg.theoden8.webspace</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>webspace</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/openspec/README.md
+++ b/openspec/README.md
@@ -22,6 +22,7 @@ openspec/
     ├── icon-fetching/spec.md             # Progressive favicon loading
     ├── language/spec.md                  # Per-site language (Accept-Language + navigator.language override)
     ├── lazy-webview-loading/spec.md      # On-demand webview creation
+    ├── link-intent-routing/spec.md       # Per-site domain claims + share/open intent dispatch (LIR-001..LIR-012)
     ├── localcdn/spec.md                  # Local CDN resource caching
     ├── navigation/spec.md                # Back gesture, home button, pull-to-refresh
     ├── nested-url-blocking/spec.md       # Block tracking and popup URLs

--- a/openspec/changes/default-app-for-links/design.md
+++ b/openspec/changes/default-app-for-links/design.md
@@ -57,7 +57,42 @@ Patterns:
 
 **Alternative considered**: free-form glob/regex. Rejected — users can't reason about it, and the validator would have to grow.
 
-### D2. Resolver ranking
+### D2a. Three-option dispatch picker (LIR-010)
+
+The resolver alone never *creates* state — it just classifies. State-changing decisions (which site to activate, whether to mutate a site's claim list, whether to create a new site) are funnelled through the LIR-010 picker:
+
+```
+RoutingMatch r = resolver.resolve(url, sites);
+switch (r) {
+  case RoutingSingle s:
+    activate(s.site, url);                           // option 1, fast-pathed
+    break;
+  case RoutingAmbiguous a:
+    showPicker(
+      routerDefaults: a.sites,                       // option 1 rows (one each)
+      bindOptionAvailable: sites.isNotEmpty,         // option 2
+      createOptionAvailable: canStripPath(url),      // option 3
+    );
+    break;
+  case RoutingNone _:
+    showPicker(
+      routerDefaults: const [],                      // suppressed
+      bindOptionAvailable: sites.isNotEmpty,
+      createOptionAvailable: canStripPath(url),
+    );
+    break;
+}
+```
+
+When the user picks option 2 ("send domain & subdomains to <site X>"), the dispatch invokes `LinkRoutingService.claimsToAdoptHost(host)` which returns `[exactHost(host), wildcardSubdomain(getBaseDomain(host))]`, deduplicates against the chosen site's existing claims, persists, and activates. This both routes the current URL and pre-claims the domain so future arrivals skip the picker (LIR-002 fast path).
+
+When the user picks option 3, the dispatch invokes `LinkRoutingService.strippedHomeUrl(url)` to compute `<scheme>://<host>[:port]/`, creates a `WebViewModel` with that `initUrl` and the synthesized `baseDomain` claim, then activates the site on the *full* inbound URL (the webview navigates one extra step beyond the new site's persisted home). This avoids "tap a Reddit thread → site forever opens on that thread on cold start."
+
+**Alternative considered**: have the resolver itself return option 2/3 mutations. Rejected — keeps the resolver pure, leaves all persistence and side-effects in the dispatcher.
+
+**Alternative considered**: drop option 1 entirely on ambiguous (force user to pick a row anyway). Rejected — option 2 ("send to a site") and option 3 ("create new") would still need to be reachable; offering one consolidated picker matches the user's mental model of "where should this URL go?"
+
+### D2b. Resolver ranking
 
 For an incoming URL `U`, compute `host(U)` and `base(U) = getBaseDomain(host(U))`. For every `(site, claim)`:
 

--- a/openspec/changes/default-app-for-links/proposal.md
+++ b/openspec/changes/default-app-for-links/proposal.md
@@ -17,7 +17,7 @@ The "always-isolate-each-site" goal that surfaced during scoping is **already sa
   - the iOS/macOS Share Extension to hand the URL off from extension process to main app
   - external apps wanting to provide an "Open in WebSpace" button without competing with browsers in the https chooser
   - paste-and-tap from Notes/Messages/etc.
-- **Android `ACTION_SEND` (share-intent) handler**: any app can share a URL (as `text/plain`) to WebSpace via the share sheet; it routes through the resolver.
+- **Android `ACTION_SEND` (share-intent) handler**: any app can share a URL (as `text/plain`) to WebSpace via the share sheet; it routes through the resolver. `text/html` and `application/xhtml+xml` shares with `EXTRA_STREAM` are read into memory and short-circuit to "create new site" (LIR-012) — existing sites can't claim opaque file content.
 - **iOS Share Extension** (`NSExtensionActivationSupportsWebURLWithMaxCount`): opens shared URLs in the main app via `webspace://open?url=...`.
 - **macOS Share Extension**: equivalent of iOS.
 - **Global routing overview UI**: a settings screen listing every claimed domain pattern → site, conflict warnings, and a master "Handle shared links" switch.

--- a/openspec/changes/default-app-for-links/proposal.md
+++ b/openspec/changes/default-app-for-links/proposal.md
@@ -10,7 +10,8 @@ The "always-isolate-each-site" goal that surfaced during scoping is **already sa
   - exact host (`twitter.com`)
   - wildcard subdomain (`*.mastodon.social`)
   - multiple patterns per site (e.g., one "Google" site handling `google.com`, `*.google.com`, `gmail.com`)
-- **URL routing resolver**: given an incoming URL, find the site whose claim list matches most specifically (exact host > wildcard subdomain > base-domain fallback). On true ties, surface a picker. On no match, offer "create new site for <host>?".
+- **URL routing resolver**: given an incoming URL, find the site whose claim list matches most specifically (exact host > wildcard subdomain > base-domain fallback). On true ties or no match, surface the LIR-010 three-option dispatch picker (router default for unique winners, "send domain & subdomains to <site>" for binding to an existing site, "create new site (stripped path)" for the empty case).
+- **Stripped-path site creation**: when the user accepts the create-new-site option, the new site's `initUrl` is `<scheme>://<host>[:port]/` only — path/query/fragment are dropped — so the site's persisted home is the domain root rather than whatever deep article triggered the create. The first activation still navigates to the full inbound URL.
 - **Domain-claim conflict prevention**: a site cannot claim a domain pattern whose base domain equals another site's `initUrl` base domain; the editor surfaces a validation error.
 - **`webspace://` URL scheme as a first-class cross-platform entry point**: registered on Android (intent-filter), iOS/macOS (`CFBundleURLTypes`), Linux (`.desktop` file `MimeType=x-scheme-handler/webspace;`). Format: `webspace://open?url=<encoded-target-url>`. Used by:
   - the iOS/macOS Share Extension to hand the URL off from extension process to main app
@@ -34,7 +35,7 @@ The "always-isolate-each-site" goal that surfaced during scoping is **already sa
 ## Capabilities
 
 ### New Capabilities
-- `link-intent-routing`: per-site domain-claim list (exact / wildcard-subdomain / base-domain), URL-to-site resolver with most-specific-match ranking and picker/no-match fallback, share-intent entry points (Android `ACTION_SEND`, iOS/macOS Share Extension), `webspace://open?url=...` cross-platform URL scheme, global routing overview settings screen, back-to-referring-app behavior.
+- `link-intent-routing`: per-site domain-claim list (exact / wildcard-subdomain / base-domain), URL-to-site resolver with most-specific-match ranking, three-option dispatch picker (router default / bind domain to existing site / create new site with stripped path), share-intent entry points (Android `ACTION_SEND`, iOS/macOS Share Extension), `webspace://open?url=...` cross-platform URL scheme, global routing overview settings screen, back-to-referring-app behavior.
 
 ### Modified Capabilities
 - `webspaces`: add WEBSPACE-011 — intent-routed URL targeting a site outside the current webspace switches to "All" before activation.

--- a/openspec/changes/default-app-for-links/specs/link-intent-routing/spec.md
+++ b/openspec/changes/default-app-for-links/specs/link-intent-routing/spec.md
@@ -194,13 +194,84 @@ The app SHALL provide a "Link handling" screen inside Settings containing a mast
 
 ---
 
-### Requirement: LIR-009 - No-Match Recovery
+### Requirement: LIR-009 - No-Match Recovery With Stripped-Path Site Creation
 
-When the resolver returns no match for an incoming URL, the system SHALL offer to create a new site for that URL. Accepting creates a `WebViewModel` whose `initUrl` is the incoming URL and whose `domainClaims` is the synthesized `[baseDomain(getBaseDomain(host))]`.
+When the resolver returns no match for an incoming URL, the system SHALL offer to create a new site for that URL whose `initUrl` is the incoming URL **with path, query, and fragment stripped** (only `<scheme>://<host>[:port]/` is retained). The arrived URL is still loaded into the new site's webview on first activation, but the site's persisted "home" `initUrl` is the stripped form, so subsequent app launches and navigation-engine same-domain checks operate on the site root rather than on a deep article URL. The synthesized claim is `[baseDomain(getBaseDomain(host))]` per LIR-001. The stripping rule SHALL reject non-`http`/`https` URLs and URLs with empty hosts, returning to a no-op (snackbar) rather than creating a malformed site.
 
-#### Scenario: Share-sheet no-match prompts create
+#### Scenario: Share-sheet no-match prompts create with stripped path
 
-- **GIVEN** no site matches `https://example.org/article`
-- **WHEN** the URL arrives via iOS Share Extension or Android `ACTION_SEND` or `webspace://`
+- **GIVEN** no site matches `https://example.org/articles/2026/feature?ref=share#top`
+- **WHEN** the URL arrives via iOS Share Extension, Android `ACTION_SEND`, or `webspace://`
 - **THEN** the app shows a "Create site for example.org?" bottom sheet
-- **AND** accepting creates the site and immediately activates it on the article URL
+- **AND** accepting creates the site with `initUrl == "https://example.org/"`
+- **AND** the new site's webview navigates to the full incoming URL on first activation
+- **AND** the synthesized `domainClaims` is `[baseDomain("example.org")]`
+
+#### Scenario: Stripped path preserves non-default port
+
+- **GIVEN** no site matches `http://localhost:8080/dashboard?token=abc`
+- **WHEN** the user accepts the create prompt
+- **THEN** the new site's `initUrl == "http://localhost:8080/"`
+
+#### Scenario: Malformed target rejected
+
+- **GIVEN** the dispatched URL has an empty host (e.g. `https:///foo`) or a non-http(s) scheme
+- **WHEN** the no-match flow runs
+- **THEN** no site is created
+- **AND** a snackbar reports the URL was unsupported
+
+---
+
+### Requirement: LIR-010 - Three-Option Dispatch Picker
+
+Whenever an inbound URL cannot be unambiguously dispatched by the resolver alone — that is, the resolver returns ambiguous (LIR-002 tie) or no-match (LIR-009) — the system SHALL surface a single bottom-sheet picker offering up to three options, in this order:
+
+1. **Match router default** — activate the resolver's top-scored match. This option SHALL be present whenever the resolver returned a single winning candidate (i.e. on ambiguous, listed once per tied candidate; on no-match, suppressed).
+2. **Send domain (and subdomains) to a site** — open a site picker listing every existing site. Selecting a site SHALL append `[exactHost(host), wildcardSubdomain(getBaseDomain(host))]` to that site's `domainClaims` (deduplicated against existing entries), persist the change, and then activate the site on the full incoming URL. This option SHALL be suppressed when the user has zero existing sites.
+3. **Create new site (stripped path)** — invoke the LIR-009 flow. This option SHALL be suppressed when the URL's host is empty or its scheme is not `http`/`https`.
+
+The picker SHALL be skipped (option 1 silently auto-applied) when the resolver returned exactly one match — that is the normal "router default" fast path. The picker SHALL be reachable manually from a per-site or settings affordance (e.g. long-press on the share-sheet target during testing) so the user can re-route a URL even when a single resolver match exists; the manual entry point still uses LIR-010 semantics.
+
+When option 2 is taken and the chosen site already has a claim that would have matched the URL on its own, the dispatch SHALL still complete (idempotent: `claimsToAdoptHost` deduplicates) and no error SHALL be surfaced.
+
+#### Scenario: No match shows two options
+
+- **GIVEN** the user has two existing sites and none match `https://forum.invalid/thread/42`
+- **WHEN** the URL arrives via share intent
+- **THEN** the picker shows "Send forum.invalid to <pick site>" and "Create new site for forum.invalid"
+- **AND** "Match router default" is not shown (no resolver winner)
+
+#### Scenario: Tie shows router-default rows plus the binding/create options
+
+- **GIVEN** two sites both claim `exactHost:reddit.com`
+- **WHEN** `https://reddit.com/r/flutter` arrives
+- **THEN** the picker shows one "Open in <Site A>" row, one "Open in <Site B>" row, "Send reddit.com (and subdomains) to a site", and "Create new site for reddit.com"
+
+#### Scenario: Bind to existing site mutates its claims
+
+- **GIVEN** site A exists with no claim covering `forum.invalid`
+- **WHEN** the user picks "Send forum.invalid to Site A" for `https://forum.invalid/thread/42`
+- **THEN** site A's `domainClaims` gains `exactHost:forum.invalid` and `wildcardSubdomain:forum.invalid`
+- **AND** the change persists across app restart
+- **AND** site A is activated and navigates to `https://forum.invalid/thread/42`
+- **AND** a future arrival of `https://sub.forum.invalid/x` resolves to site A without showing the picker
+
+#### Scenario: No existing sites suppresses option 2
+
+- **GIVEN** the user has zero existing sites (fresh install)
+- **WHEN** any URL arrives
+- **THEN** only "Create new site" is offered (option 2 hidden)
+
+#### Scenario: Single resolver match skips the picker
+
+- **GIVEN** site A exclusively claims `exactHost:twitter.com`
+- **WHEN** `https://twitter.com/user` arrives
+- **THEN** site A is activated immediately
+- **AND** no picker is shown
+
+#### Scenario: Idempotent re-binding
+
+- **GIVEN** site A already claims `wildcardSubdomain:example.org`
+- **WHEN** the user invokes the manual picker on `https://api.example.org/x` and chooses "Send to site A"
+- **THEN** the dispatch succeeds
+- **AND** site A's claim list does not gain a duplicate entry

--- a/openspec/changes/default-app-for-links/specs/link-intent-routing/spec.md
+++ b/openspec/changes/default-app-for-links/specs/link-intent-routing/spec.md
@@ -194,6 +194,48 @@ The app SHALL provide a "Link handling" screen inside Settings containing a mast
 
 ---
 
+### Requirement: LIR-011 - Cross-Domain Share Opens Nested Webview; In-Domain Resets Incognito / Always-Home
+
+When dispatching an inbound shared URL to an existing site (resolver winner OR LIR-010 "send domain to site" OR LIR-010 "Open in <site>" row), the system SHALL:
+
+1. **Out-of-domain share** — when `getNormalizedDomain(url) != getNormalizedDomain(site.initUrl)` (e.g. user routes `f-droid.org` to a `duckduckgo.com` site after binding it), open the URL in a nested `InAppWebViewScreen` (`launchUrl(...)` path) carrying the chosen site's privacy settings (siteId/container, incognito, proxy, language, location, WebRTC, user scripts, blocking toggles, notifications). The site's main webview SHALL NOT be navigated. This both matches user expectation ("a shared link from another app shouldn't trample my session") and avoids being silently blocked by the in-webview cross-domain navigation guard.
+2. **In-domain share, target site has `incognito` or `alwaysOpenHome` set** — before activating, the system SHALL dispose the live webview, drop it from `_loadedIndices`, evict its in-memory HTML cache (online only), and reset `currentUrl = initUrl`. For incognito additionally: wipe the site's container (best-effort: `ContainerIsolationEngine.wipeContainers([siteId])`) and clear in-memory cookies. Then activate and `controller.loadUrl(url)`. This matches existing always-home/incognito reset semantics on shortcut launch.
+3. **In-domain share, regular site** — activate via `_setCurrentIndex` and `controller.loadUrl(url)` (existing behavior).
+
+#### Scenario: Cross-domain bind opens nested
+
+- **GIVEN** the user has a `duckduckgo.com` site (incognito off) and no `f-droid.org` site
+- **WHEN** they share `https://f-droid.org/packages/<pkg>` and pick "Send f-droid.org to my DuckDuckGo site"
+- **THEN** the DuckDuckGo site's claim list gains `[exactHost(f-droid.org), wildcardSubdomain(f-droid.org)]`
+- **AND** the f-droid URL opens in a nested `InAppWebViewScreen` carrying DuckDuckGo's privacy/container settings
+- **AND** the DuckDuckGo main webview's URL does NOT change
+
+#### Scenario: In-domain share to incognito site resets the session
+
+- **GIVEN** an incognito `example.org` site has accumulated cookies and is mid-session on `https://example.org/account`
+- **WHEN** the user shares `https://example.org/articles/foo` and dispatches it to that site
+- **THEN** the live webview is disposed
+- **AND** the site's container is wiped
+- **AND** in-memory cookies are cleared
+- **AND** `currentUrl = initUrl` before the activation
+- **AND** the shared URL loads in a fresh main webview
+
+#### Scenario: In-domain share to always-home site discards mid-session URL
+
+- **GIVEN** an `example.org` site with `alwaysOpenHome=true` is mid-session on `https://example.org/page42`
+- **WHEN** the user shares `https://example.org/another` and dispatches it to that site
+- **THEN** the live webview is disposed and `currentUrl` is reset to `initUrl`
+- **AND** the shared URL then loads — cookies are NOT cleared (always-home preserves login state per its existing semantics)
+
+#### Scenario: In-domain share to regular site uses normal navigation
+
+- **GIVEN** a non-incognito, non-always-home `example.org` site mid-session
+- **WHEN** the user shares an in-domain URL to it
+- **THEN** the existing webview's `controller.loadUrl(url)` is used
+- **AND** no dispose / wipe / cookie clear is performed
+
+---
+
 ### Requirement: LIR-009 - No-Match Recovery With Stripped-Path Site Creation
 
 When the resolver returns no match for an incoming URL, the system SHALL offer to create a new site for that URL whose `initUrl` is the incoming URL **with path, query, and fragment stripped** (only `<scheme>://<host>[:port]/` is retained). The arrived URL is still loaded into the new site's webview on first activation, but the site's persisted "home" `initUrl` is the stripped form, so subsequent app launches and navigation-engine same-domain checks operate on the site root rather than on a deep article URL. The synthesized claim is `[baseDomain(getBaseDomain(host))]` per LIR-001. The stripping rule SHALL reject non-`http`/`https` URLs and URLs with empty hosts, returning to a no-op (snackbar) rather than creating a malformed site.

--- a/openspec/changes/default-app-for-links/specs/link-intent-routing/spec.md
+++ b/openspec/changes/default-app-for-links/specs/link-intent-routing/spec.md
@@ -194,13 +194,17 @@ The app SHALL provide a "Link handling" screen inside Settings containing a mast
 
 ---
 
-### Requirement: LIR-011 - Cross-Domain Share Opens Nested Webview; In-Domain Resets Incognito / Always-Home
+### Requirement: LIR-011 - Engine-Driven Dispatch: Cross-Domain Goes Nested; In-Domain Resets Incognito / Always-Home
 
-When dispatching an inbound shared URL to an existing site (resolver winner OR LIR-010 "send domain to site" OR LIR-010 "Open in <site>" row), the system SHALL:
+The dispatch decision tree for an inbound shared URL targeting an existing site SHALL live in a pure-Dart engine, `LinkIntentDispatchEngine` (mirroring the engine pattern in `cookie_isolation.dart` / `site_activation_engine.dart`). The engine takes the inbound payload and a list of `DispatchableSite` adapters and returns a `DispatchAction`. The view layer SHALL be a thin executor that performs IO/UI for the returned action; it MUST NOT recompute routing decisions of its own. This keeps every reset/disposal/wipe path testable with fakes.
 
-1. **Out-of-domain share** — when `getNormalizedDomain(url) != getNormalizedDomain(site.initUrl)` (e.g. user routes `f-droid.org` to a `duckduckgo.com` site after binding it), open the URL in a nested `InAppWebViewScreen` (`launchUrl(...)` path) carrying the chosen site's privacy settings (siteId/container, incognito, proxy, language, location, WebRTC, user scripts, blocking toggles, notifications). The site's main webview SHALL NOT be navigated. This both matches user expectation ("a shared link from another app shouldn't trample my session") and avoids being silently blocked by the in-webview cross-domain navigation guard.
-2. **In-domain share, target site has `incognito` or `alwaysOpenHome` set** — before activating, the system SHALL dispose the live webview, drop it from `_loadedIndices`, evict its in-memory HTML cache (online only), and reset `currentUrl = initUrl`. For incognito additionally: wipe the site's container (best-effort: `ContainerIsolationEngine.wipeContainers([siteId])`) and clear in-memory cookies. Then activate and `controller.loadUrl(url)`. This matches existing always-home/incognito reset semantics on shortcut launch.
-3. **In-domain share, regular site** — activate via `_setCurrentIndex` and `controller.loadUrl(url)` (existing behavior).
+The engine SHALL emit:
+
+1. **Out-of-domain share** — when `getNormalizedDomain(url) != site.navigationDomain` (e.g. user routes `f-droid.org` to a `duckduckgo.com` site after binding it), `DispatchOpenNested(siteId, url)`. The executor SHALL invoke the existing nested in-app-webview path (`launchUrl(...)`) carrying the chosen site's privacy settings (siteId/container, incognito, proxy, language, location, WebRTC, user scripts, blocking toggles, notifications). The site's main webview SHALL NOT be navigated. This both matches user expectation ("a shared link from another app shouldn't trample my session") and avoids being silently blocked by the in-webview cross-domain navigation guard.
+2. **In-domain share, target site has `incognito` or `alwaysOpenHome` set** — `DispatchOpenInMain(siteId, url, disposeBeforeLoad: true, wipeContainer: incognito, clearInMemoryCookies: incognito)`. The executor SHALL dispose the live webview, drop it from `_loadedIndices`, evict its in-memory HTML cache (online only), reset `currentUrl = initUrl`, wipe the container if `wipeContainer == true`, and clear in-memory cookies if `clearInMemoryCookies == true` — all BEFORE activating and calling `controller.loadUrl(url)`. The flags being engine-emitted (rather than computed at the call site) is the IP-leakage / session-leakage defence: a future caller cannot accidentally skip the disposal.
+3. **In-domain share, regular site** — `DispatchOpenInMain(siteId, url, disposeBeforeLoad: false, wipeContainer: false, clearInMemoryCookies: false)`. The executor activates and `controller.loadUrl(url)` (existing behaviour).
+
+The engine SHALL also expose follow-up entry points for the LIR-010 picker: `openInChosen(inbound, site)`, `bindToSite(inbound, site)` (returns `DispatchBindAndOpen` with `claimAdditions` + an engine-computed `followUp`), and `createNew(inbound)` (returns `DispatchCreateSite` for option 3 or `DispatchUnsupported` if the URL has no host).
 
 #### Scenario: Cross-domain bind opens nested
 
@@ -231,8 +235,47 @@ When dispatching an inbound shared URL to an existing site (resolver winner OR L
 
 - **GIVEN** a non-incognito, non-always-home `example.org` site mid-session
 - **WHEN** the user shares an in-domain URL to it
-- **THEN** the existing webview's `controller.loadUrl(url)` is used
+- **THEN** the engine emits `DispatchOpenInMain` with all reset flags `false`
+- **AND** the executor uses the existing webview's `controller.loadUrl(url)`
 - **AND** no dispose / wipe / cookie clear is performed
+
+#### Scenario: Engine owns the in-domain decision; view executes only
+
+- **WHEN** any caller dispatches an inbound URL
+- **THEN** all "main vs nested" and "reset vs in-place" decisions are made inside `LinkIntentDispatchEngine`
+- **AND** the executor in `_WebSpacePageState` performs the IO described by the returned `DispatchAction` without re-evaluating domain/reset rules
+
+---
+
+### Requirement: LIR-012 - HTML File Share Goes Only To Create-New-Site
+
+When the OS hands the app an HTML file via share (Android `ACTION_SEND` with `mimeType="text/html"` or `application/xhtml+xml` carrying `EXTRA_STREAM`; iOS / macOS Share Extension future-equivalent), the dispatcher SHALL skip the LIR-010 picker entirely and emit `DispatchCreateSiteFromHtml(html, suggestedTitle)`. The executor SHALL persist the HTML via `HtmlImportStorage` (same store used by the in-app file-import flow), create a `WebViewModel` with a synthesised `file:///webspace_import_<microseconds>.html` `initUrl`, register the new site, activate it, and apply the current theme. The picker's "open in existing site" and "bind to site" options SHALL NOT be offered for HTML payloads, because an existing site cannot meaningfully claim opaque file content (no host, no domain) — only the create path is sensible.
+
+#### Scenario: HTML payload short-circuits picker
+
+- **GIVEN** the user has two existing sites
+- **WHEN** another app shares an HTML file to WebSpace
+- **THEN** the engine emits `DispatchCreateSiteFromHtml`
+- **AND** no picker is shown
+- **AND** a new file:// site is created with the file's HTML stored in `HtmlImportStorage`
+
+#### Scenario: HTML title preferred over filename
+
+- **GIVEN** a shared HTML file containing `<title>Bookmarks</title>` and a filename `export-2026-04-19.html`
+- **WHEN** the share is dispatched
+- **THEN** the new site's `name` is `Bookmarks`
+
+#### Scenario: HTML filename used when no title
+
+- **GIVEN** a shared HTML file with no `<title>` and filename `notes.html`
+- **WHEN** the share is dispatched
+- **THEN** the new site's `name` is `notes`
+
+#### Scenario: Empty HTML payload is unsupported
+
+- **WHEN** the engine receives an `InboundHtml` with empty content
+- **THEN** the engine emits `DispatchUnsupported`
+- **AND** no site is created
 
 ---
 

--- a/openspec/changes/default-app-for-links/tasks.md
+++ b/openspec/changes/default-app-for-links/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Domain-claim model and migration
 
-- [ ] 1.1 Add `DomainClaim` + `DomainClaimKind` to `lib/web_view_model.dart` with canonical-form constructor (lowercase, strip scheme/port).
-- [ ] 1.2 Extend `WebViewModel` with `List<DomainClaim> domainClaims`.
-- [ ] 1.3 Add `toJson` / `fromJson` support, synthesizing `[DomainClaim.baseDomain(getBaseDomain(initUrl))]` when absent and omitting the field on write when it equals that default.
-- [ ] 1.4 Unit tests in `test/domain_claim_test.dart`: canonicalization, equality, JSON round-trip, legacy synthesis, serialization stability.
+- [x] 1.1 Add `DomainClaim` + `DomainClaimKind` to `lib/services/domain_claim.dart` (extracted from `web_view_model.dart` to avoid an import cycle) with canonical-form constructor (lowercase, strip scheme/port, drop `*.` prefix, unbracket IPv6).
+- [x] 1.2 Extend `WebViewModel` with `List<DomainClaim>? domainClaims` (nullable so the synthesized default doesn't bloat on-disk JSON).
+- [x] 1.3 Add `toJson` / `fromJson` support; `effectiveDomainClaims` getter synthesizes `[DomainClaim.baseDomain(getBaseDomain(initUrl))]` when absent, and `toJson` omits the field when the explicit list is null.
+- [x] 1.4 Unit tests in `test/link_routing_test.dart` (canonicalization / equality / JSON round-trip) and `test/web_view_model_test.dart` (synthesized default, explicit-list round-trip).
 
 ## 2. Routing resolver (pure Dart)
 
@@ -17,60 +17,63 @@
 
 ## 3. Platform channel for link intents
 
-- [ ] 3.1 Define `MethodChannel("webspace/link_intent")` with `Future<String?> getInitialUrl()` and event `onUrlArrived(url)`.
-- [ ] 3.2 `LinkIntentService` in `lib/services/link_intent_service.dart` exposing `Stream<Uri>` and the initial-url future. Internally runs each URL through `parseWebspaceUri` to unwrap `webspace://open?url=...` before emitting.
-- [ ] 3.3 Wire subscription in `WebSpacePage.initState`; on each URL, run the resolver and dispatch activation / picker / no-match flow.
+- [x] 3.1 Reuse the existing `MethodChannel("org.codeberg.theoden8.webspace/share_intent")` (added in #292) with `consumeLaunchUrl` and a new `consumeLaunchHtml` method for HTML payloads (LIR-012).
+- [x] 3.2 `ShareIntentService` in `lib/services/share_intent_service.dart` exposes `consumeLaunchUrl()` (returns `String?`) and `consumeLaunchHtml()` (returns `InboundHtmlShare?`). Webspace-scheme unwrap happens in `LinkRoutingService.parseWebspaceUri`, called by the dispatch engine when a `webspace://` URL arrives.
+- [x] 3.3 `_handleShareIntent` in `lib/main.dart` consumes both channels (HTML first), wraps the payload in `InboundUrl` / `InboundHtml`, and hands it to `LinkIntentDispatchEngine.dispatch`. Wired on cold start (`runApp`) and warm-start lifecycle resume.
 - [ ] 3.4 Widget test `test/link_intent_dispatch_test.dart` with a fake channel: cold-start delivery, warm-start delivery, picker on ties, no-match bottom sheet.
 
 ## 4. Android integration
 
-- [ ] 4.1 Add `ACTION_SEND` intent-filter (`mimeType="text/plain"`) on `MainActivity` in `android/app/src/main/AndroidManifest.xml`.
-- [ ] 4.2 Add `<intent-filter>` for `<data android:scheme="webspace"/>` with `BROWSABLE` + `DEFAULT` categories on `MainActivity`. No `autoVerify`.
-- [ ] 4.3 `MainActivity` Kotlin: capture cold-start and `onNewIntent` URL — for `ACTION_VIEW` read `intent.data`, for `ACTION_SEND` read `EXTRA_TEXT` and extract the URL substring. Deliver via the channel. Do NOT add `FLAG_ACTIVITY_NEW_TASK`.
-- [ ] 4.4 Manual smoke test: share from Chrome to WebSpace; tap a `webspace://open?url=...` URL from Notes; confirm Back returns to source.
+- [x] 4.1 `ACTION_SEND` intent-filter on `MainActivity` in `android/app/src/main/AndroidManifest.xml`. Mime types: `text/plain`, `text/html`, `application/xhtml+xml` (LIR-012).
+- [x] 4.2 `<intent-filter>` for `<data android:scheme="webspace"/>` with `BROWSABLE` + `DEFAULT` categories on `MainActivity`. No `autoVerify`.
+- [x] 4.3 `MainActivity` Kotlin: `captureSharePayload` reads cold-start and `onNewIntent` intents — `ACTION_VIEW` with a `webspace://` URI passes the raw string through; `ACTION_SEND` with `EXTRA_TEXT` → URL substring extraction; `ACTION_SEND` with `EXTRA_STREAM` (HTML mime or `.html`/`.htm` extension) → reads file content into memory + extracts `<title>` (or filename) for the suggested title. No `FLAG_ACTIVITY_NEW_TASK`.
+- [ ] 4.4 Manual smoke test: share from Chrome to WebSpace; share an HTML file from Files / Drive; tap a `webspace://open?url=...` URL from Notes; confirm Back returns to source.
 
 ## 5. iOS integration
 
-- [ ] 5.1 Add new target `WebSpaceShareExtension` in `ios/` with `NSExtensionActivationSupportsWebURLWithMaxCount=1`, `NSExtensionActivationSupportsText=1`.
-- [ ] 5.2 Create App Group `group.com.theoden8.webspace`; entitlement on both main app and extension.
-- [ ] 5.3 Register `webspace` scheme in main app `Info.plist` `CFBundleURLTypes`.
-- [ ] 5.4 Implement `application:openURL:options:` (or `SceneDelegate.scene(_:openURLContexts:)`) to forward the URL to the `webspace/link_intent` channel.
-- [ ] 5.5 Extension `ShareViewController` extracts URL via `NSItemProvider`, writes `pending_link` to shared `UserDefaults`, calls `extensionContext?.open(URL(string: "webspace://open?url=<encoded>")!)`, then `completeRequest`.
-- [ ] 5.6 Main app reads pending URL from launch URL or App Group, then clears the App Group key.
-- [ ] 5.7 Manual smoke test: share from Safari → routed to matching site; tap a `webspace://` URL in Notes → app opens.
+> Basic URL share already lands via PR #297 (`Register WebSpace as iOS share target`); the channel name and `consumeLaunchUrl` API are reused. The Share Extension target, App Group, and `webspace://` scheme registration are still pending.
+
+- [ ] 5.1 Add new target `WebSpaceShareExtension` in `ios/` with `NSExtensionActivationSupportsWebURLWithMaxCount=1`, `NSExtensionActivationSupportsText=1`, `NSExtensionActivationSupportsFileWithMaxCount=1` (HTML files for LIR-012). **Requires Xcode** — cannot land from headless tooling.
+- [ ] 5.2 Create App Group `group.com.theoden8.webspace`; entitlement on both main app and extension. **Requires Xcode**.
+- [x] 5.3 `webspace` scheme registered in `ios/Runner/Info.plist` `CFBundleURLTypes` (already in master before this change).
+- [x] 5.4 `application:openURL:options:` accepts `webspace://open?url=<encoded http(s)>`, `webspace://share?url=...` (legacy), and `webspace://qr/...`; pending URL is exposed to Dart via the existing `share_intent` channel. New no-op `consumeLaunchHtml` channel method returns null until the Share Extension target lands (5.1) — Dart side falls through to URL channel without raising MissingPluginException.
+- [ ] 5.5 Extension `ShareViewController` extracts URL via `NSItemProvider` (or HTML file content), writes `pending_link` / `pending_html` to shared `UserDefaults`, calls `extensionContext?.open(URL(string: "webspace://open?url=<encoded>")!)`, then `completeRequest`. **Requires Xcode**.
+- [ ] 5.6 Main app reads pending URL/HTML from launch URL or App Group, then clears the App Group key. App Group draining for the URL is already wired (`drainAppGroupPendingUrl` in AppDelegate.swift); HTML drain stays pending until 5.1 / 5.5.
+- [ ] 5.7 Manual smoke test: share URL from Safari, share HTML file from Files, tap `webspace://` URL in Notes.
 
 ## 6. macOS integration
 
-- [ ] 6.1 Mirror steps 5.1–5.6 with a macOS Share Extension target under `macos/`.
+- [x] 6.1a `webspace` scheme registered in `macos/Runner/Info.plist` `CFBundleURLTypes`. `application:openURLs:` forwards `webspace://open` / `webspace://qr` to the existing `share_intent` channel; `consumeLaunchHtml` returns null until the Share Extension target ships.
+- [ ] 6.1b Add a macOS Share Extension target with the same activation rules as iOS 5.1 + App Group entitlement. **Requires Xcode** — cannot land from headless tooling.
 - [ ] 6.2 Manual smoke test on macOS Sonoma+.
 
 ## 7. Linux `webspace://` registration
 
-- [ ] 7.1 Author `linux/webspace.desktop` with `MimeType=x-scheme-handler/webspace;` and the runner's executable as `Exec=`.
-- [ ] 7.2 Wire CMake install rule under `linux/CMakeLists.txt` to copy the desktop file to `~/.local/share/applications/` and run `update-desktop-database` post-install (best-effort).
-- [ ] 7.3 Linux runner: capture cold-start argv URL and `g_application_open` (warm-start) URLs; deliver via the channel.
+- [x] 7.1 `linux/webspace.desktop` with `MimeType=x-scheme-handler/webspace;` and `Exec=webspace_app %u`. `StartupWMClass` matches the GTK app.
+- [x] 7.2 CMake install rule in `linux/CMakeLists.txt` bundles the desktop file alongside the runner. Distribution packagers must additionally copy it to `${XDG_DATA_DIRS}/applications/` and run `update-desktop-database`; documented inline.
+- [x] 7.3 Linux runner now sets `G_APPLICATION_HANDLES_OPEN`, intercepts `webspace://...` arguments in `local_command_line` and routes them through `GApplication::open`; the `share_intent` `FlMethodChannel` is registered on the FlView and exposes `consumeLaunchUrl` + a stub `consumeLaunchHtml`.
 - [ ] 7.4 Manual smoke test: `xdg-open 'webspace://open?url=https://example.org/'` after install.
 
 ## 8. Settings + UI
 
-- [ ] 8.1 Add "Link handling" entry in the existing settings UI.
-- [ ] 8.2 Master "Handle shared links" switch persisted via `SharedPreferences` key `link_handling_enabled`. When off, the `LinkIntentService` ignores URLs and writes the flag to the App Group (iOS/macOS) so the Share Extension respects it.
-- [ ] 8.3 Routing overview list: iterate all sites, show each claim → site; conflict badges from `validateClaims`.
-- [ ] 8.4 Domain-claim editor in site settings: add/remove `exactHost` and `wildcardSubdomain` claims; `baseDomain` is not user-selectable. Validation runs `validateClaims`.
-- [ ] 8.5 LIR-010 dispatch picker: single bottom sheet with up to three option groups — (1) one row per resolver winner ("Match router default" fast-pathed when there is exactly one), (2) "Send <host> (and subdomains) to a site" → site picker → append `claimsToAdoptHost(host)` (deduped) and activate, (3) "Create new site for <host>" → `WebViewModel(initUrl: strippedHomeUrl(url), domainClaims: [baseDomain(...)])`, then navigate the new webview to the full inbound URL on first activation.
-- [ ] 8.6 Manual re-route entry point so the user can re-run the LIR-010 picker on demand even when a single resolver match exists.
+- [x] 8.1 "Link handling" entry in the existing app settings (`AppSettingsScreen` opens `LinkHandlingSettingsScreen`).
+- [x] 8.2 Master "Handle shared links" switch persisted via `SharedPreferences` key `linkHandlingEnabled` and registered in `kExportedAppPrefs` so it round-trips through backups. `_handleShareIntent` early-returns (logs and drops) when off, for both URL and HTML payloads. Writing the flag to the iOS/macOS App Group still depends on the Share Extension target work in 5.x.
+- [x] 8.3 Routing overview list in `LinkHandlingSettingsScreen`: iterates `_webViewModels`, renders each site's effective claims as chips, surfaces a "N conflicts" badge from `LinkRoutingService.validateClaims`. Tapping a row pops the screen and reopens the per-site settings.
+- [x] 8.4 `DomainClaimsEditor` widget embedded in `lib/screens/settings.dart`. Lets the user add/remove `exactHost` and `wildcardSubdomain` claims; the synthesized `baseDomain` claim shows but cannot be removed when it's the last claim. Hijack and overlap conflicts surface inline against the claim row. `onChanged` returns `null` when the user reverts to the synthesized default so on-disk JSON stays minimal.
+- [x] 8.5 LIR-010 dispatch picker: single bottom sheet with up to three option groups — (1) one row per resolver winner ("Match router default" fast-pathed when there is exactly one), (2) "Send <host> (and subdomains) to a site" → site picker → append `claimsToAdoptHost(host)` (deduped) and activate, (3) "Create new site for <host>" → `WebViewModel(initUrl: strippedHomeUrl(url), domainClaims: [baseDomain(...)])`, then navigate the new webview to the full inbound URL on first activation.
+- [x] 8.6 "Test routing" entry in `LinkHandlingSettingsScreen` re-runs the `LinkIntentDispatchEngine` for an arbitrary URL the user types, which surfaces the LIR-010 picker on demand even when a single resolver match exists. Disabled when the master switch is off.
 
 ## 9. WEBSPACE-011 wiring
 
-- [ ] 9.1 In `LinkIntentService` dispatcher: after the resolver returns a single match, check membership in current webspace; if not a member, switch to "All" via the existing webspace selection path, then activate. Surface snackbar.
-- [ ] 9.2 Widget test asserting the auto-switch + snackbar (covered by `test/link_intent_dispatch_test.dart`).
+- [x] 9.1 `_maybeSwitchToAllForSite` runs at the top of every executor (`_executeOpenInMain`, `_executeOpenNested`, `_executeBindAndOpen`, `_executeCreateSite`, `_executeCreateSiteFromHtml` via `_registerNewSite`) — when the matched site is outside the current named webspace, the active webspace switches to "All" with a snackbar before activation.
+- [ ] 9.2 Widget test asserting the auto-switch + snackbar. Engine-level coverage is provided by `test/link_intent_dispatch_engine_test.dart`; a full widget test of `_WebSpacePageState` is heavy because the dispatcher is currently embedded there. Track as follow-up alongside 3.4 once the dispatcher widget is extracted.
 
 ## 10. Validation and CI
 
-- [ ] 10.1 Run `fvm flutter analyze`.
-- [ ] 10.2 Run `fvm flutter test`.
-- [ ] 10.3 Run `npx openspec validate default-app-for-links --strict`.
-- [ ] 10.4 Update `openspec/README.md` spec table to add `link-intent-routing`.
+- [x] 10.1 `fvm flutter analyze` — clean for new files; only pre-existing repo lints remain.
+- [x] 10.2 `fvm flutter test` — full suite green. Engine + widget tests added: `test/link_intent_dispatch_engine_test.dart`, `test/link_routing_test.dart`, `test/link_handling_settings_test.dart`, plus extensions to `test/web_view_model_test.dart`.
+- [x] 10.3 `npx openspec validate default-app-for-links --strict` — passes.
+- [x] 10.4 `openspec/README.md` lists `link-intent-routing` in the structure table.
 
 ## 11. Manual test sheet
 

--- a/openspec/changes/default-app-for-links/tasks.md
+++ b/openspec/changes/default-app-for-links/tasks.md
@@ -7,11 +7,13 @@
 
 ## 2. Routing resolver (pure Dart)
 
-- [ ] 2.1 Create `lib/services/link_routing_service.dart` exposing `RoutingMatch resolve(Uri url, List<WebViewModel> sites)` with specificity scoring per design D2.
-- [ ] 2.2 Implement `RoutingMatch.ambiguous(List<WebViewModel>)` for top-score ties; `RoutingMatch.none()` for no match.
-- [ ] 2.3 Implement `List<ClaimConflict> validateClaims(WebViewModel edited, List<WebViewModel> others)` per design D3.
-- [ ] 2.4 Implement `Uri? parseWebspaceUri(Uri raw)` that returns the inner `http`/`https` target for `webspace://open?url=...` and null otherwise.
-- [ ] 2.5 Unit tests `test/link_routing_test.dart`: exact > wildcard > base ordering, ties, no-match, multi-part TLDs, IPs, validator hijack/warn paths, `webspace://` parse (valid, malformed, non-http target).
+- [x] 2.1 Create `lib/services/link_routing_service.dart` exposing `RoutingMatch resolve(Uri url, List<RoutableSite> sites)` with specificity scoring per design D2b.
+- [x] 2.2 Implement `RoutingSingle` / `RoutingAmbiguous` / `RoutingNone` (sealed) for top-score ties and no-match cases.
+- [x] 2.3 Implement `List<ClaimConflict> validateClaims(String editedSiteId, List<DomainClaim> editedClaims, List<RoutableSite> others)` per design D3.
+- [x] 2.4 Implement `Uri? parseWebspaceUri(Uri raw)` that returns the inner `http`/`https` target for `webspace://open?url=...` and null otherwise.
+- [x] 2.5 Implement `String? strippedHomeUrl(Uri url)` returning `<scheme>://<host>[:port]/` for valid http(s) Uris (LIR-009 path stripping).
+- [x] 2.6 Implement `List<DomainClaim> claimsToAdoptHost(String host)` returning `[exactHost, wildcardSubdomain(base)]` for the LIR-010 "send domain to a site" option, deduplicated by callers against existing claim lists.
+- [x] 2.7 Unit tests `test/link_routing_test.dart`: exact > wildcard > base ordering, ties, no-match, multi-part TLDs, IPs, validator hijack/warn paths, `webspace://` parse (valid, malformed, non-http target), stripped-path edge cases (port preservation, query/fragment dropped, malformed rejection), `claimsToAdoptHost` shape + dedup.
 
 ## 3. Platform channel for link intents
 
@@ -55,8 +57,8 @@
 - [ ] 8.2 Master "Handle shared links" switch persisted via `SharedPreferences` key `link_handling_enabled`. When off, the `LinkIntentService` ignores URLs and writes the flag to the App Group (iOS/macOS) so the Share Extension respects it.
 - [ ] 8.3 Routing overview list: iterate all sites, show each claim → site; conflict badges from `validateClaims`.
 - [ ] 8.4 Domain-claim editor in site settings: add/remove `exactHost` and `wildcardSubdomain` claims; `baseDomain` is not user-selectable. Validation runs `validateClaims`.
-- [ ] 8.5 No-match bottom sheet: "Create site for <host>?" creating a new `WebViewModel` with `initUrl=<arrived URL>` and synthesized `baseDomain` claim. After accept, activate the site immediately.
-- [ ] 8.6 Disambiguation picker: modal bottom sheet listing tied sites; selection activates that site.
+- [ ] 8.5 LIR-010 dispatch picker: single bottom sheet with up to three option groups — (1) one row per resolver winner ("Match router default" fast-pathed when there is exactly one), (2) "Send <host> (and subdomains) to a site" → site picker → append `claimsToAdoptHost(host)` (deduped) and activate, (3) "Create new site for <host>" → `WebViewModel(initUrl: strippedHomeUrl(url), domainClaims: [baseDomain(...)])`, then navigate the new webview to the full inbound URL on first activation.
+- [ ] 8.6 Manual re-route entry point so the user can re-run the LIR-010 picker on demand even when a single resolver match exists.
 
 ## 9. WEBSPACE-011 wiring
 

--- a/test/link_handling_settings_test.dart
+++ b/test/link_handling_settings_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/screens/link_handling_settings.dart';
+import 'package:webspace/services/domain_claim.dart';
+import 'package:webspace/web_view_model.dart';
+
+void main() {
+  group('LinkHandlingSettingsScreen — LIR-008', () {
+    testWidgets('master switch flips and notifies', (tester) async {
+      bool? lastValue;
+      await tester.pumpWidget(MaterialApp(
+        home: LinkHandlingSettingsScreen(
+          enabled: true,
+          onEnabledChanged: (v) => lastValue = v,
+          sites: const [],
+          onOpenSiteEditor: (_) {},
+        ),
+      ));
+      expect(find.text('Handle shared links'), findsOneWidget);
+      await tester.tap(find.byType(Switch));
+      await tester.pump();
+      expect(lastValue, false);
+    });
+
+    testWidgets('routing overview lists each site with claims as chips',
+        (tester) async {
+      final a = WebViewModel(initUrl: 'https://twitter.com/');
+      final b = WebViewModel(initUrl: 'https://mastodon.social/')
+        ..domainClaims = [
+          DomainClaim.exactHost('mastodon.social'),
+          DomainClaim.wildcardSubdomain('mastodon.social'),
+        ];
+      await tester.pumpWidget(MaterialApp(
+        home: LinkHandlingSettingsScreen(
+          enabled: true,
+          onEnabledChanged: (_) {},
+          sites: [a, b],
+          onOpenSiteEditor: (_) {},
+        ),
+      ));
+      // Auto-synthesised baseDomain claim shows up as `twitter.com (base)`.
+      expect(find.text('twitter.com (base)'), findsOneWidget);
+      // Explicit claims for site B are rendered verbatim with the
+      // wildcard `*.` prefix; the bare host appears both as the site
+      // title (since `name` defaults to extractDomain) and as a chip.
+      expect(find.text('mastodon.social'), findsAtLeastNWidgets(1));
+      expect(find.text('*.mastodon.social'), findsOneWidget);
+    });
+
+    testWidgets('routing overview row tap calls onOpenSiteEditor',
+        (tester) async {
+      final a = WebViewModel(initUrl: 'https://twitter.com/');
+      a.name = 'Twitter';
+      WebViewModel? tappedSite;
+      await tester.pumpWidget(MaterialApp(
+        home: LinkHandlingSettingsScreen(
+          enabled: true,
+          onEnabledChanged: (_) {},
+          sites: [a],
+          onOpenSiteEditor: (s) => tappedSite = s,
+        ),
+      ));
+      await tester.tap(find.text('Twitter'));
+      await tester.pump();
+      expect(tappedSite, same(a));
+    });
+
+    testWidgets(
+        'master switch off: subtitle reflects state and routing list still renders',
+        (tester) async {
+      final a = WebViewModel(initUrl: 'https://twitter.com/');
+      a.name = 'Twitter';
+      await tester.pumpWidget(MaterialApp(
+        home: LinkHandlingSettingsScreen(
+          enabled: false,
+          onEnabledChanged: (_) {},
+          sites: [a],
+          onOpenSiteEditor: (_) {},
+        ),
+      ));
+      expect(find.text('Twitter'), findsOneWidget);
+    });
+  });
+
+  group('DomainClaimsEditor — LIR-008 task 8.4', () {
+    testWidgets('renders the synthesized base claim when domainClaims is null',
+        (tester) async {
+      final m = WebViewModel(initUrl: 'https://example.org/');
+      List<DomainClaim>? lastChange;
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: DomainClaimsEditor(
+            model: m,
+            otherSites: const [],
+            onChanged: (next) => lastChange = next,
+          ),
+        ),
+      ));
+      expect(find.text('Domain claims'), findsOneWidget);
+      expect(find.text('example.org (base)'), findsOneWidget);
+      // Editor opens with claims in the synthesized state — no onChanged
+      // should have fired yet.
+      expect(lastChange, isNull);
+    });
+
+    testWidgets('removing a non-base claim emits the new explicit list',
+        (tester) async {
+      final m = WebViewModel(initUrl: 'https://example.org/')
+        ..domainClaims = [
+          DomainClaim.baseDomain('example.org'),
+          DomainClaim.exactHost('blog.example.org'),
+        ];
+      List<DomainClaim>? lastChange;
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: DomainClaimsEditor(
+            model: m,
+            otherSites: const [],
+            onChanged: (next) => lastChange = next,
+          ),
+        ),
+      ));
+      await tester.tap(find.byIcon(Icons.delete_outline).last);
+      await tester.pump();
+      expect(lastChange, isNotNull);
+      expect(lastChange!.length, 1);
+      expect(lastChange!.first, DomainClaim.baseDomain('example.org'));
+    });
+
+    testWidgets(
+        'hijack conflict surfaces a red subtitle on the offending claim',
+        (tester) async {
+      final github = WebViewModel(initUrl: 'https://github.com/alice');
+      final attacker = WebViewModel(initUrl: 'https://example.org/')
+        ..domainClaims = [DomainClaim.exactHost('github.com')];
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: DomainClaimsEditor(
+            model: attacker,
+            otherSites: [github],
+            onChanged: (_) {},
+          ),
+        ),
+      ));
+      expect(
+        find.text('Conflict: another site already owns this base domain.'),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/test/link_intent_dispatch_engine_test.dart
+++ b/test/link_intent_dispatch_engine_test.dart
@@ -1,0 +1,297 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/domain_claim.dart';
+import 'package:webspace/services/link_intent_dispatch_engine.dart';
+import 'package:webspace/web_view_model.dart' show getNormalizedDomain;
+
+class _Site implements DispatchableSite {
+  @override
+  final String siteId;
+  @override
+  final String initUrl;
+  @override
+  final List<DomainClaim> domainClaims;
+  @override
+  final bool incognito;
+  @override
+  final bool alwaysOpenHome;
+
+  _Site({
+    required this.siteId,
+    required this.initUrl,
+    required this.domainClaims,
+    this.incognito = false,
+    this.alwaysOpenHome = false,
+  });
+
+  @override
+  String get navigationDomain => getNormalizedDomain(initUrl);
+}
+
+void main() {
+  group('LinkIntentDispatchEngine.dispatch — InboundUrl', () {
+    test('non-http(s) inbound URL yields DispatchUnsupported', () {
+      final action = LinkIntentDispatchEngine.dispatch(
+        payload: InboundUrl(Uri.parse('javascript:alert(1)')),
+        sites: const [],
+      );
+      expect(action, isA<DispatchUnsupported>());
+    });
+
+    test('webspace:// wraps unwrap to inner http(s) target', () {
+      final ddg = _Site(
+        siteId: 'ddg',
+        initUrl: 'https://duckduckgo.com/',
+        domainClaims: [DomainClaim.exactHost('duckduckgo.com')],
+      );
+      final action = LinkIntentDispatchEngine.dispatch(
+        payload: InboundUrl(Uri.parse(
+            'webspace://open?url=https%3A%2F%2Fduckduckgo.com%2F%3Fq%3Dx')),
+        sites: [ddg],
+      );
+      expect(action, isA<DispatchOpenInMain>());
+      expect((action as DispatchOpenInMain).siteId, 'ddg');
+      expect(action.url, 'https://duckduckgo.com/?q=x');
+    });
+
+    test('single resolver match + in-domain + regular site -> open-in-main', () {
+      final ddg = _Site(
+        siteId: 'ddg',
+        initUrl: 'https://duckduckgo.com/',
+        domainClaims: [DomainClaim.baseDomain('duckduckgo.com')],
+      );
+      final action = LinkIntentDispatchEngine.dispatch(
+        payload: InboundUrl(Uri.parse('https://duckduckgo.com/?q=foo')),
+        sites: [ddg],
+      );
+      expect(action, isA<DispatchOpenInMain>());
+      final m = action as DispatchOpenInMain;
+      expect(m.siteId, 'ddg');
+      expect(m.disposeBeforeLoad, isFalse);
+      expect(m.wipeContainer, isFalse);
+      expect(m.clearInMemoryCookies, isFalse);
+    });
+
+    test('incognito site triggers full reset flags on in-domain share', () {
+      final ddg = _Site(
+        siteId: 'ddg',
+        initUrl: 'https://duckduckgo.com/',
+        domainClaims: [DomainClaim.baseDomain('duckduckgo.com')],
+        incognito: true,
+      );
+      final m = LinkIntentDispatchEngine.dispatch(
+        payload: InboundUrl(Uri.parse('https://duckduckgo.com/?q=foo')),
+        sites: [ddg],
+      ) as DispatchOpenInMain;
+      expect(m.disposeBeforeLoad, isTrue);
+      expect(m.wipeContainer, isTrue);
+      expect(m.clearInMemoryCookies, isTrue);
+    });
+
+    test('alwaysOpenHome triggers dispose only (cookies preserved)', () {
+      final ddg = _Site(
+        siteId: 'ddg',
+        initUrl: 'https://duckduckgo.com/',
+        domainClaims: [DomainClaim.baseDomain('duckduckgo.com')],
+        alwaysOpenHome: true,
+      );
+      final m = LinkIntentDispatchEngine.dispatch(
+        payload: InboundUrl(Uri.parse('https://duckduckgo.com/?q=foo')),
+        sites: [ddg],
+      ) as DispatchOpenInMain;
+      expect(m.disposeBeforeLoad, isTrue);
+      expect(m.wipeContainer, isFalse);
+      expect(m.clearInMemoryCookies, isFalse);
+    });
+
+    test('ambiguous resolver -> picker with two winners', () {
+      final a = _Site(
+        siteId: 'A',
+        initUrl: 'https://reddit.com/',
+        domainClaims: [DomainClaim.exactHost('reddit.com')],
+      );
+      final b = _Site(
+        siteId: 'B',
+        initUrl: 'https://reddit.com/',
+        domainClaims: [DomainClaim.exactHost('reddit.com')],
+      );
+      final action = LinkIntentDispatchEngine.dispatch(
+        payload: InboundUrl(Uri.parse('https://reddit.com/r/x')),
+        sites: [a, b],
+      );
+      expect(action, isA<DispatchShowPicker>());
+      final p = action as DispatchShowPicker;
+      expect(p.winnerSiteIds, containsAll(['A', 'B']));
+      expect(p.offerBind, isTrue);
+      expect(p.offerCreate, isTrue);
+    });
+
+    test('no resolver match -> picker with no winners', () {
+      final ddg = _Site(
+        siteId: 'ddg',
+        initUrl: 'https://duckduckgo.com/',
+        domainClaims: [DomainClaim.baseDomain('duckduckgo.com')],
+      );
+      final action = LinkIntentDispatchEngine.dispatch(
+        payload: InboundUrl(Uri.parse('https://f-droid.org/packages/foo')),
+        sites: [ddg],
+      );
+      expect(action, isA<DispatchShowPicker>());
+      final p = action as DispatchShowPicker;
+      expect(p.winnerSiteIds, isEmpty);
+      expect(p.offerBind, isTrue);
+      expect(p.offerCreate, isTrue);
+    });
+
+    test('no sites at all -> picker with offerBind=false', () {
+      final action = LinkIntentDispatchEngine.dispatch(
+        payload: InboundUrl(Uri.parse('https://example.org/')),
+        sites: const [],
+      );
+      final p = action as DispatchShowPicker;
+      expect(p.winnerSiteIds, isEmpty);
+      expect(p.offerBind, isFalse);
+      expect(p.offerCreate, isTrue);
+    });
+  });
+
+  group('LinkIntentDispatchEngine.openInChosen — LIR-011 main vs nested', () {
+    test('cross-domain user pick -> nested (not main webview)', () {
+      final ddg = _Site(
+        siteId: 'ddg',
+        initUrl: 'https://duckduckgo.com/',
+        domainClaims: [DomainClaim.baseDomain('duckduckgo.com')],
+      );
+      final action = LinkIntentDispatchEngine.openInChosen(
+        inbound: Uri.parse('https://f-droid.org/packages/foo'),
+        site: ddg,
+      );
+      expect(action, isA<DispatchOpenNested>());
+      expect((action as DispatchOpenNested).siteId, 'ddg');
+      expect(action.url, 'https://f-droid.org/packages/foo');
+    });
+
+    test('in-domain user pick on regular site -> main webview', () {
+      final ddg = _Site(
+        siteId: 'ddg',
+        initUrl: 'https://duckduckgo.com/',
+        domainClaims: [DomainClaim.baseDomain('duckduckgo.com')],
+      );
+      final action = LinkIntentDispatchEngine.openInChosen(
+        inbound: Uri.parse('https://duckduckgo.com/?q=foo'),
+        site: ddg,
+      );
+      expect(action, isA<DispatchOpenInMain>());
+      expect((action as DispatchOpenInMain).disposeBeforeLoad, isFalse);
+    });
+  });
+
+  group('LinkIntentDispatchEngine.bindToSite — LIR-010 option 2', () {
+    test('cross-domain bind: claim additions returned + nested follow-up', () {
+      final ddg = _Site(
+        siteId: 'ddg',
+        initUrl: 'https://duckduckgo.com/',
+        domainClaims: [DomainClaim.baseDomain('duckduckgo.com')],
+      );
+      final action = LinkIntentDispatchEngine.bindToSite(
+        inbound: Uri.parse('https://f-droid.org/packages/foo'),
+        site: ddg,
+      );
+      expect(action, isA<DispatchBindAndOpen>());
+      final b = action as DispatchBindAndOpen;
+      expect(b.chosenSiteId, 'ddg');
+      expect(b.claimAdditions, [
+        DomainClaim.exactHost('f-droid.org'),
+        DomainClaim.wildcardSubdomain('f-droid.org'),
+      ]);
+      // The follow-up still respects the existing site's
+      // navigationDomain, so cross-domain stays nested.
+      expect(b.followUp, isA<DispatchOpenNested>());
+    });
+
+    test('same-domain bind: follow-up is main-webview load', () {
+      final ddg = _Site(
+        siteId: 'ddg',
+        initUrl: 'https://duckduckgo.com/',
+        domainClaims: [],
+      );
+      final action = LinkIntentDispatchEngine.bindToSite(
+        inbound: Uri.parse('https://www.duckduckgo.com/?q=foo'),
+        site: ddg,
+      );
+      final b = action as DispatchBindAndOpen;
+      expect(b.followUp, isA<DispatchOpenInMain>());
+    });
+  });
+
+  group('LinkIntentDispatchEngine.createNew — LIR-010 option 3', () {
+    test('strips path/query/fragment and seeds baseDomain claim', () {
+      final action = LinkIntentDispatchEngine.createNew(
+        inbound:
+            Uri.parse('https://example.org/articles/foo?utm=share#top'),
+      );
+      expect(action, isA<DispatchCreateSite>());
+      final c = action as DispatchCreateSite;
+      expect(c.home, 'https://example.org/');
+      expect(c.fullUrl, 'https://example.org/articles/foo?utm=share#top');
+      expect(c.initialClaims, [DomainClaim.baseDomain('example.org')]);
+    });
+
+    test('non-http(s) returns DispatchUnsupported', () {
+      final action = LinkIntentDispatchEngine.createNew(
+        inbound: Uri.parse('ftp://example.org/'),
+      );
+      expect(action, isA<DispatchUnsupported>());
+    });
+  });
+
+  group('LinkIntentDispatchEngine.dispatch — InboundHtml — LIR-012', () {
+    test('HTML payload short-circuits to create-from-html, ignoring sites',
+        () {
+      final ddg = _Site(
+        siteId: 'ddg',
+        initUrl: 'https://duckduckgo.com/',
+        domainClaims: [DomainClaim.baseDomain('duckduckgo.com')],
+      );
+      final action = LinkIntentDispatchEngine.dispatch(
+        payload: const InboundHtml(
+          content: '<html><body>hi</body></html>',
+          suggestedTitle: 'My Page',
+          sourceUri: 'content://example/foo.html',
+        ),
+        sites: [ddg],
+      );
+      expect(action, isA<DispatchCreateSiteFromHtml>());
+      final c = action as DispatchCreateSiteFromHtml;
+      expect(c.html, '<html><body>hi</body></html>');
+      expect(c.suggestedTitle, 'My Page');
+    });
+
+    test('empty HTML payload yields DispatchUnsupported', () {
+      final action = LinkIntentDispatchEngine.dispatch(
+        payload: const InboundHtml(content: ''),
+        sites: const [],
+      );
+      expect(action, isA<DispatchUnsupported>());
+    });
+
+    test('HTML payload offers no picker / bind / open paths', () {
+      // Even with multiple sites and an exact-host candidate, an HTML
+      // payload never goes through the resolver — there is no URL to
+      // route. Sanity check via direct kind checks.
+      final ddg = _Site(
+        siteId: 'ddg',
+        initUrl: 'https://example.org/',
+        domainClaims: [DomainClaim.exactHost('example.org')],
+      );
+      final action = LinkIntentDispatchEngine.dispatch(
+        payload: const InboundHtml(content: '<p>hi</p>'),
+        sites: [ddg, ddg],
+      );
+      expect(action, isNot(isA<DispatchShowPicker>()));
+      expect(action, isNot(isA<DispatchOpenInMain>()));
+      expect(action, isNot(isA<DispatchOpenNested>()));
+      expect(action, isNot(isA<DispatchCreateSite>()));
+      expect(action, isA<DispatchCreateSiteFromHtml>());
+    });
+  });
+}

--- a/test/link_routing_test.dart
+++ b/test/link_routing_test.dart
@@ -1,0 +1,485 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/link_routing_service.dart';
+
+class _Site implements RoutableSite {
+  @override
+  final String siteId;
+  @override
+  final String initUrl;
+  @override
+  final List<DomainClaim> domainClaims;
+
+  const _Site(this.siteId, this.initUrl, this.domainClaims);
+}
+
+void main() {
+  group('DomainClaim canonicalization', () {
+    test('lowercases, strips scheme and port, drops `*.` prefix', () {
+      expect(DomainClaim.exactHost('Twitter.COM').value, 'twitter.com');
+      expect(DomainClaim.exactHost('https://Mail.google.com:443').value,
+          'mail.google.com');
+      expect(DomainClaim.wildcardSubdomain('*.Mastodon.Social').value,
+          'mastodon.social');
+      expect(DomainClaim.exactHost('  example.org  ').value, 'example.org');
+    });
+
+    test('value-equality respects kind', () {
+      expect(DomainClaim.exactHost('a.com'),
+          equals(DomainClaim.exactHost('A.COM')));
+      expect(DomainClaim.exactHost('a.com'),
+          isNot(equals(DomainClaim.wildcardSubdomain('a.com'))));
+    });
+
+    test('JSON round-trip preserves kind and value', () {
+      final c = DomainClaim.wildcardSubdomain('Example.Org');
+      final json = c.toJson();
+      final back = DomainClaim.fromJson(json);
+      expect(back, equals(c));
+      expect(back.kind, DomainClaimKind.wildcardSubdomain);
+      expect(back.value, 'example.org');
+    });
+  });
+
+  group('LinkRoutingService.resolve - LIR-002', () {
+    test('exactHost beats wildcardSubdomain on same domain', () {
+      final a = _Site('A', 'https://mastodon.social/', [
+        DomainClaim.wildcardSubdomain('mastodon.social'),
+      ]);
+      final b = _Site('B', 'https://mastodon.social/@me', [
+        DomainClaim.exactHost('mastodon.social'),
+      ]);
+      final r = LinkRoutingService.resolve(
+        Uri.parse('https://mastodon.social/@user'),
+        [a, b],
+      );
+      expect(r, isA<RoutingSingle>());
+      expect((r as RoutingSingle).site.siteId, 'B');
+    });
+
+    test('wildcardSubdomain matches sub but not the bare base host', () {
+      final a = _Site('A', 'https://mastodon.social/', [
+        DomainClaim.wildcardSubdomain('mastodon.social'),
+      ]);
+      final b = _Site('B', 'https://other.example/', [
+        DomainClaim.baseDomain('mastodon.social'),
+      ]);
+      final sub = LinkRoutingService.resolve(
+        Uri.parse('https://fosstodon.mastodon.social/'),
+        [a, b],
+      );
+      expect((sub as RoutingSingle).site.siteId, 'A');
+      final bare = LinkRoutingService.resolve(
+        Uri.parse('https://mastodon.social/'),
+        [a, b],
+      );
+      expect((bare as RoutingSingle).site.siteId, 'B');
+    });
+
+    test('baseDomain matches multi-part TLD via getBaseDomain', () {
+      final a = _Site('A', 'https://www.google.co.uk/', [
+        DomainClaim.baseDomain('google.co.uk'),
+      ]);
+      final r = LinkRoutingService.resolve(
+        Uri.parse('https://maps.google.co.uk/place/123'),
+        [a],
+      );
+      expect(r, isA<RoutingSingle>());
+      expect((r as RoutingSingle).site.siteId, 'A');
+    });
+
+    test('IP host: baseDomain match works for raw IPv4 literal', () {
+      final a = _Site('A', 'http://192.168.1.1/', [
+        DomainClaim.baseDomain('192.168.1.1'),
+      ]);
+      final r = LinkRoutingService.resolve(
+        Uri.parse('http://192.168.1.1/admin'),
+        [a],
+      );
+      expect(r, isA<RoutingSingle>());
+    });
+
+    test('tie at top score returns RoutingAmbiguous with all winners', () {
+      final a = _Site('A', 'https://reddit.com/', [
+        DomainClaim.exactHost('reddit.com'),
+      ]);
+      final b = _Site('B', 'https://reddit.com/r/x', [
+        DomainClaim.exactHost('reddit.com'),
+      ]);
+      final r = LinkRoutingService.resolve(
+        Uri.parse('https://reddit.com/r/flutter'),
+        [a, b],
+      );
+      expect(r, isA<RoutingAmbiguous>());
+      final winners = (r as RoutingAmbiguous).sites.map((s) => s.siteId);
+      expect(winners, containsAll(['A', 'B']));
+    });
+
+    test('no match returns RoutingNone', () {
+      final a = _Site('A', 'https://github.com/', [
+        DomainClaim.exactHost('github.com'),
+      ]);
+      final r = LinkRoutingService.resolve(
+        Uri.parse('https://example.org/foo'),
+        [a],
+      );
+      expect(r, isA<RoutingNone>());
+    });
+
+    test('non-http(s) scheme returns RoutingNone', () {
+      final a = _Site('A', 'https://example.org/', [
+        DomainClaim.exactHost('example.org'),
+      ]);
+      final r = LinkRoutingService.resolve(
+        Uri.parse('javascript:alert(1)'),
+        [a],
+      );
+      expect(r, isA<RoutingNone>());
+    });
+
+    test('uppercase host in inbound URL is matched case-insensitively', () {
+      final a = _Site('A', 'https://twitter.com/', [
+        DomainClaim.exactHost('twitter.com'),
+      ]);
+      final r = LinkRoutingService.resolve(
+        Uri.parse('https://TWITTER.com/user'),
+        [a],
+      );
+      expect(r, isA<RoutingSingle>());
+    });
+
+    test('per-site best-claim wins; lower-score claim on same site ignored',
+        () {
+      final a = _Site('A', 'https://google.com/', [
+        DomainClaim.baseDomain('google.com'),
+        DomainClaim.exactHost('mail.google.com'),
+      ]);
+      final b = _Site('B', 'https://drive.google.com/', [
+        DomainClaim.baseDomain('google.com'),
+      ]);
+      final r = LinkRoutingService.resolve(
+        Uri.parse('https://mail.google.com/inbox'),
+        [a, b],
+      );
+      expect(r, isA<RoutingSingle>());
+      expect((r as RoutingSingle).site.siteId, 'A');
+    });
+  });
+
+  group('LinkRoutingService.strippedHomeUrl - LIR-009', () {
+    test('strips path, query, fragment', () {
+      expect(
+        LinkRoutingService.strippedHomeUrl(
+          Uri.parse('https://example.org/articles/2026/feature?ref=share#top'),
+        ),
+        'https://example.org/',
+      );
+    });
+
+    test('preserves explicit non-default port', () {
+      expect(
+        LinkRoutingService.strippedHomeUrl(
+          Uri.parse('http://localhost:8080/dashboard?token=abc'),
+        ),
+        'http://localhost:8080/',
+      );
+    });
+
+    test('default ports are NOT serialized (Uri.hasPort is false)', () {
+      expect(
+        LinkRoutingService.strippedHomeUrl(Uri.parse('https://x.com:443/p')),
+        'https://x.com/',
+      );
+      expect(
+        LinkRoutingService.strippedHomeUrl(Uri.parse('http://x.com:80/p')),
+        'http://x.com/',
+      );
+    });
+
+    test('returns null for non-http(s) schemes', () {
+      expect(LinkRoutingService.strippedHomeUrl(Uri.parse('ftp://x.com/')),
+          isNull);
+      expect(LinkRoutingService.strippedHomeUrl(Uri.parse('about:blank')),
+          isNull);
+      expect(
+          LinkRoutingService.strippedHomeUrl(Uri.parse('javascript:void(0)')),
+          isNull);
+    });
+
+    test('returns null when host is empty', () {
+      expect(LinkRoutingService.strippedHomeUrl(Uri.parse('https:///foo')),
+          isNull);
+    });
+
+    test('IPv4/IPv6 hosts round-trip', () {
+      expect(
+        LinkRoutingService.strippedHomeUrl(
+            Uri.parse('http://192.168.1.1/admin')),
+        'http://192.168.1.1/',
+      );
+      expect(
+        LinkRoutingService.strippedHomeUrl(Uri.parse('http://[::1]:9000/x')),
+        'http://[::1]:9000/',
+      );
+    });
+  });
+
+  group('LinkRoutingService.parseWebspaceUri - LIR-004', () {
+    test('valid open?url=<https> returns inner Uri', () {
+      final inner = LinkRoutingService.parseWebspaceUri(
+        Uri.parse('webspace://open?url=https%3A%2F%2Ftwitter.com%2Fuser'),
+      );
+      expect(inner, isNotNull);
+      expect(inner!.scheme, 'https');
+      expect(inner.host, 'twitter.com');
+      expect(inner.path, '/user');
+    });
+
+    test('valid open?url=<http> returns inner Uri', () {
+      final inner = LinkRoutingService.parseWebspaceUri(
+        Uri.parse('webspace://open?url=http%3A%2F%2Fexample.org%2F'),
+      );
+      expect(inner, isNotNull);
+      expect(inner!.scheme, 'http');
+    });
+
+    test('non-http(s) inner target returns null', () {
+      expect(
+        LinkRoutingService.parseWebspaceUri(
+            Uri.parse('webspace://open?url=javascript%3Aalert(1)')),
+        isNull,
+      );
+      expect(
+        LinkRoutingService.parseWebspaceUri(
+            Uri.parse('webspace://open?url=ftp%3A%2F%2Fexample.org%2F')),
+        isNull,
+      );
+    });
+
+    test('missing url= param returns null', () {
+      expect(
+        LinkRoutingService.parseWebspaceUri(Uri.parse('webspace://open')),
+        isNull,
+      );
+    });
+
+    test('wrong host returns null', () {
+      expect(
+        LinkRoutingService.parseWebspaceUri(
+            Uri.parse('webspace://other?url=https%3A%2F%2Fx.com%2F')),
+        isNull,
+      );
+    });
+
+    test('wrong scheme returns null', () {
+      expect(
+        LinkRoutingService.parseWebspaceUri(
+            Uri.parse('https://open?url=https%3A%2F%2Fx.com%2F')),
+        isNull,
+      );
+    });
+  });
+
+  group('LinkRoutingService.claimsToAdoptHost - LIR-010 option 2', () {
+    test('emits exactHost + wildcardSubdomain over the base domain', () {
+      final claims = LinkRoutingService.claimsToAdoptHost('Forum.Invalid');
+      expect(claims, hasLength(2));
+      expect(
+          claims.first, equals(DomainClaim.exactHost('forum.invalid')));
+      expect(claims.last,
+          equals(DomainClaim.wildcardSubdomain('forum.invalid')));
+    });
+
+    test('subdomain host yields wildcard over the base domain', () {
+      final claims =
+          LinkRoutingService.claimsToAdoptHost('mail.google.com');
+      expect(
+          claims,
+          equals([
+            DomainClaim.exactHost('mail.google.com'),
+            DomainClaim.wildcardSubdomain('google.com'),
+          ]));
+    });
+
+    test('multi-part TLD: wildcard sits over the SLD+ccTLD', () {
+      final claims = LinkRoutingService.claimsToAdoptHost('foo.google.co.uk');
+      expect(claims, [
+        DomainClaim.exactHost('foo.google.co.uk'),
+        DomainClaim.wildcardSubdomain('google.co.uk'),
+      ]);
+    });
+
+    test('empty input returns empty list', () {
+      expect(LinkRoutingService.claimsToAdoptHost(''), isEmpty);
+      expect(LinkRoutingService.claimsToAdoptHost('   '), isEmpty);
+    });
+  });
+
+  group('LinkRoutingService.mergeClaims - LIR-010 idempotency', () {
+    test('does not duplicate identical claims', () {
+      final existing = [
+        DomainClaim.exactHost('a.com'),
+        DomainClaim.wildcardSubdomain('a.com'),
+      ];
+      final merged = LinkRoutingService.mergeClaims(
+        existing,
+        LinkRoutingService.claimsToAdoptHost('a.com'),
+      );
+      expect(merged, equals(existing));
+    });
+
+    test('appends only the new entries', () {
+      final existing = [DomainClaim.exactHost('a.com')];
+      final merged = LinkRoutingService.mergeClaims(
+        existing,
+        LinkRoutingService.claimsToAdoptHost('a.com'),
+      );
+      expect(merged, [
+        DomainClaim.exactHost('a.com'),
+        DomainClaim.wildcardSubdomain('a.com'),
+      ]);
+    });
+
+    test('preserves order of existing entries', () {
+      final existing = [
+        DomainClaim.baseDomain('a.com'),
+        DomainClaim.exactHost('b.com'),
+      ];
+      final merged = LinkRoutingService.mergeClaims(
+        existing,
+        [DomainClaim.exactHost('c.com'), DomainClaim.exactHost('b.com')],
+      );
+      expect(merged, [
+        DomainClaim.baseDomain('a.com'),
+        DomainClaim.exactHost('b.com'),
+        DomainClaim.exactHost('c.com'),
+      ]);
+    });
+  });
+
+  group('LinkRoutingService.validateClaims - LIR-003', () {
+    test('hijack: claim base equals another site initUrl base', () {
+      final github = _Site('github', 'https://github.com/alice',
+          [DomainClaim.baseDomain('github.com')]);
+      final conflicts = LinkRoutingService.validateClaims(
+        'attacker',
+        [DomainClaim.exactHost('github.com')],
+        [github],
+      );
+      expect(conflicts, hasLength(1));
+      expect(conflicts.single.kind, ClaimConflictKind.hijack);
+      expect(conflicts.single.otherSiteId, 'github');
+    });
+
+    test('hijack via subdomain claim still triggers (base-domain compare)',
+        () {
+      final github = _Site('github', 'https://github.com/',
+          [DomainClaim.baseDomain('github.com')]);
+      final conflicts = LinkRoutingService.validateClaims(
+        'attacker',
+        [DomainClaim.exactHost('docs.github.com')],
+        [github],
+      );
+      expect(conflicts, hasLength(1));
+      expect(conflicts.single.kind, ClaimConflictKind.hijack);
+    });
+
+    test('overlap: wildcard vs exact subdomain on different initUrl base', () {
+      final wildcard = _Site('wild', 'https://other.example/', [
+        DomainClaim.wildcardSubdomain('example.com'),
+      ]);
+      final conflicts = LinkRoutingService.validateClaims(
+        'edited',
+        [DomainClaim.exactHost('blog.example.com')],
+        [wildcard],
+      );
+      expect(conflicts, hasLength(1));
+      expect(conflicts.single.kind, ClaimConflictKind.overlap);
+    });
+
+    test('no conflict when bases differ and claims do not overlap', () {
+      final a = _Site('A', 'https://example.org/',
+          [DomainClaim.baseDomain('example.org')]);
+      final conflicts = LinkRoutingService.validateClaims(
+        'edited',
+        [DomainClaim.exactHost('twitter.com')],
+        [a],
+      );
+      expect(conflicts, isEmpty);
+    });
+
+    test('does not flag the edited site against itself', () {
+      final self = _Site('self', 'https://example.org/',
+          [DomainClaim.baseDomain('example.org')]);
+      final conflicts = LinkRoutingService.validateClaims(
+        'self',
+        [DomainClaim.exactHost('example.org')],
+        [self],
+      );
+      expect(conflicts, isEmpty);
+    });
+  });
+
+  group('Three-option dispatch end-to-end shape - LIR-010', () {
+    test('option 1 (router default) on single match', () {
+      final a = _Site('twitter', 'https://twitter.com/',
+          [DomainClaim.exactHost('twitter.com')]);
+      final r = LinkRoutingService.resolve(
+        Uri.parse('https://twitter.com/anyone'),
+        [a],
+      );
+      expect(r, isA<RoutingSingle>());
+    });
+
+    test('option 2 (bind to existing) updates a chosen site idempotently', () {
+      final original = _Site('A', 'https://existing.example/',
+          [DomainClaim.baseDomain('existing.example')]);
+      final inboundHost =
+          Uri.parse('https://forum.invalid/thread/42').host;
+
+      final additions = LinkRoutingService.claimsToAdoptHost(inboundHost);
+      final firstMerge =
+          LinkRoutingService.mergeClaims(original.domainClaims, additions);
+      expect(firstMerge.length, original.domainClaims.length + 2);
+
+      final second = LinkRoutingService.mergeClaims(firstMerge, additions);
+      expect(second, equals(firstMerge));
+
+      final updated = _Site(original.siteId, original.initUrl, firstMerge);
+      final r = LinkRoutingService.resolve(
+        Uri.parse('https://api.forum.invalid/v1'),
+        [updated],
+      );
+      expect(r, isA<RoutingSingle>());
+      expect((r as RoutingSingle).site.siteId, 'A');
+    });
+
+    test('option 3 (create new site, stripped path) yields a sensible home',
+        () {
+      final url = Uri.parse('https://forum.invalid/thread/42?utm=share#a');
+      final home = LinkRoutingService.strippedHomeUrl(url);
+      expect(home, 'https://forum.invalid/');
+
+      final newSite = _Site(
+        'new',
+        home!,
+        [DomainClaim.baseDomain('forum.invalid')],
+      );
+      final follow = LinkRoutingService.resolve(
+        Uri.parse('https://www.forum.invalid/'),
+        [newSite],
+      );
+      expect(follow, isA<RoutingSingle>());
+    });
+
+    test('no-match without sites: only option 3 is viable', () {
+      final r = LinkRoutingService.resolve(
+        Uri.parse('https://example.org/foo'),
+        const [],
+      );
+      expect(r, isA<RoutingNone>());
+      final home = LinkRoutingService.strippedHomeUrl(
+          Uri.parse('https://example.org/foo'));
+      expect(home, isNotNull);
+    });
+  });
+}

--- a/test/web_view_model_test.dart
+++ b/test/web_view_model_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:webspace/web_view_model.dart';
+import 'package:webspace/services/domain_claim.dart';
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/settings/proxy.dart';
 
@@ -74,6 +75,41 @@ void main() {
       expect(model.javascriptEnabled, equals(false));
       expect(model.userAgent, equals('TestAgent/1.0'));
       expect(model.thirdPartyCookiesEnabled, equals(true));
+    });
+
+    test('domainClaims null by default; toJson omits it; fromJson stays null',
+        () {
+      final m = WebViewModel(initUrl: 'https://example.org/');
+      expect(m.domainClaims, isNull);
+      final json = m.toJson();
+      expect(json.containsKey('domainClaims'), isFalse);
+      final back = WebViewModel.fromJson(json, null);
+      expect(back.domainClaims, isNull);
+    });
+
+    test(
+        'effectiveDomainClaims synthesizes baseDomain claim from initUrl when null',
+        () {
+      final m = WebViewModel(initUrl: 'https://mail.example.org/inbox');
+      expect(m.effectiveDomainClaims, hasLength(1));
+      expect(m.effectiveDomainClaims.first.kind, DomainClaimKind.baseDomain);
+      expect(m.effectiveDomainClaims.first.value, 'example.org');
+    });
+
+    test('explicit domainClaims persist through JSON round-trip', () {
+      final m = WebViewModel(initUrl: 'https://example.org/');
+      m.domainClaims = [
+        DomainClaim.exactHost('example.org'),
+        DomainClaim.wildcardSubdomain('example.org'),
+      ];
+      final json = m.toJson();
+      expect(json['domainClaims'], isA<List<dynamic>>());
+      final back = WebViewModel.fromJson(json, null);
+      expect(back.domainClaims, isNotNull);
+      expect(back.domainClaims!, [
+        DomainClaim.exactHost('example.org'),
+        DomainClaim.wildcardSubdomain('example.org'),
+      ]);
     });
 
     test('should round-trip through JSON correctly', () {


### PR DESCRIPTION
Refines the default-app-for-links change so that when the resolver does not
deliver a unique winner, the user is offered up to three options on a single
picker: match the router default (LIR-002 top score), send the URL's domain
and subdomains to a chosen existing site (mutates that site's claim list via
claimsToAdoptHost, deduped), or create a new site whose initUrl is the
incoming URL with path/query/fragment stripped to <scheme>://<host>[:port]/.
Adds LIR-010, tightens LIR-009 to mandate path stripping with port/IPv6
preservation, and lands the pure-Dart resolver + 40 unit tests.