### PR TITLE
Wrap window.fetch to intercept blob: URLs and bypass CSP

### DIFF
--- a/lib/services/blob_url_capture.dart
+++ b/lib/services/blob_url_capture.dart
@@ -94,25 +94,54 @@ const String blobUrlCaptureScript = r'''
     if (typeof origFetch === 'function') {
       var _patchedFetch = function fetch(input, init) {
         var url = '';
+        var method = 'GET';
         try {
           if (typeof input === 'string') {
             url = input;
+            if (init && typeof init.method === 'string') {
+              method = init.method.toUpperCase();
+            }
           } else if (input && typeof input.url === 'string') {
             url = input.url;
+            // init.method, when present, overrides Request.method (per
+            // the fetch spec). Mirror that ordering.
+            if (init && typeof init.method === 'string') {
+              method = init.method.toUpperCase();
+            } else if (typeof input.method === 'string') {
+              method = input.method.toUpperCase();
+            }
           }
         } catch (_) {}
-        if (url && url.indexOf('blob:') === 0) {
-          var blob = map.get(url);
-          if (blob) {
+        // Only intercept GET/HEAD on captured blob: URLs. Anything else
+        // (POST/PUT, abort already fired) falls through to the original
+        // fetch so the page sees real-fetch semantics — including a
+        // proper TypeError or AbortError instead of a silent success.
+        if (url && url.indexOf('blob:') === 0 &&
+            (method === 'GET' || method === 'HEAD')) {
+          var signal = (init && init.signal) ||
+              (input && typeof input !== 'string' && input.signal) || null;
+          if (signal && signal.aborted) {
             try {
-              return Promise.resolve(new Response(blob, {
-                status: 200,
-                statusText: 'OK',
-                headers: {
-                  'Content-Type': blob.type || 'application/octet-stream',
-                },
-              }));
+              var reason = signal.reason !== undefined
+                ? signal.reason
+                : new DOMException('aborted', 'AbortError');
+              return Promise.reject(reason);
             } catch (_) {}
+          } else {
+            var blob = map.get(url);
+            if (blob) {
+              try {
+                var body = method === 'HEAD' ? null : blob;
+                return Promise.resolve(new Response(body, {
+                  status: 200,
+                  statusText: 'OK',
+                  headers: {
+                    'Content-Type': blob.type || 'application/octet-stream',
+                    'Content-Length': String(blob.size || 0),
+                  },
+                }));
+              } catch (_) {}
+            }
           }
         }
         return origFetch.apply(this, arguments);

--- a/lib/services/blob_url_capture.dart
+++ b/lib/services/blob_url_capture.dart
@@ -13,6 +13,15 @@ import 'dart:convert';
 /// skip the network/connect-src code path entirely. URL.revokeObjectURL
 /// releases the entry so the Blob can be GC'd. The map is bounded so a
 /// pathological page that never revokes can't grow it without limit.
+///
+/// The same shim also wraps `window.fetch`: when page JS itself calls
+/// `fetch(blobUrl)` (e.g. github.githubassets.com's
+/// `fetch-utilities-*.js`), the wrapper recognises the blob: URL, looks
+/// up the captured Blob and resolves with a synthesised Response built
+/// directly from it. The browser's CSP `connect-src` enforcer never sees
+/// the request, because no real fetch is dispatched. Uncaptured blob:
+/// URLs and every non-blob URL fall through to the original fetch
+/// unchanged.
 const String blobUrlCaptureScript = r'''
 (function() {
   if (window.__webspaceBlobs) return;
@@ -73,6 +82,45 @@ const String blobUrlCaptureScript = r'''
       asNative(_patchedRevoke, 'revokeObjectURL');
       URL.revokeObjectURL = _patchedRevoke;
     }
+
+    // window.fetch wrapper — intercepts fetch(blob:URL) for any blob we
+    // captured at createObjectURL time and resolves with a Response
+    // synthesised from the Blob. No network call is dispatched, so the
+    // CSP connect-src enforcer never runs against the blob: URL. Page
+    // code (e.g. github.com's fetch-utilities) and our own download
+    // IIFE both benefit. Non-blob URLs and uncaptured blob: URLs fall
+    // through to the original fetch.
+    var origFetch = window.fetch;
+    if (typeof origFetch === 'function') {
+      var _patchedFetch = function fetch(input, init) {
+        var url = '';
+        try {
+          if (typeof input === 'string') {
+            url = input;
+          } else if (input && typeof input.url === 'string') {
+            url = input.url;
+          }
+        } catch (_) {}
+        if (url && url.indexOf('blob:') === 0) {
+          var blob = map.get(url);
+          if (blob) {
+            try {
+              return Promise.resolve(new Response(blob, {
+                status: 200,
+                statusText: 'OK',
+                headers: {
+                  'Content-Type': blob.type || 'application/octet-stream',
+                },
+              }));
+            } catch (_) {}
+          }
+        }
+        return origFetch.apply(this, arguments);
+      };
+      asNative(_patchedFetch, 'fetch');
+      try { window.fetch = _patchedFetch; } catch (_) {}
+    }
+
     Object.defineProperty(window, '__webspaceBlobs', {
       value: { get: function(url) { return map.get(url); } },
       configurable: false,

--- a/openspec/specs/downloads/spec.md
+++ b/openspec/specs/downloads/spec.md
@@ -170,6 +170,18 @@ blob is same-origin — the WebView enforces the directive where stock
 Chrome/Firefox internally exempt blob reads — and a fetch-only
 implementation silently breaks downloads on those sites.
 
+The same shim MUST also wrap `window.fetch` so that a `fetch(blobUrl)`
+call originating from page JS itself (e.g. github.com's
+`fetch-utilities-*.js` or any other site that reads a same-origin Blob
+via `fetch` rather than via our IIFE) resolves with a `Response`
+synthesised directly from the captured Blob, without dispatching a
+real network request. Non-blob URLs and uncaptured blob: URLs MUST
+fall through to the original `fetch` unchanged. The wrapper MUST
+preserve `Function.prototype.toString` semantics so the page sees
+`fetch.toString()` reporting `[native code]`. This contract is
+required because page-driven `fetch(blob:)` would otherwise surface
+to the user as a failed download even when our own IIFE never runs.
+
 #### Scenario: Pairdrop WebRTC file transfer
 **Given** pairdrop.net produces an in-memory `Blob` and triggers a
   download via `<a download href="blob:...">`
@@ -190,6 +202,21 @@ implementation silently breaks downloads on those sites.
   without invoking `fetch`
 **And** the `DownloadTask` completes successfully without producing a
   CSP `connect-src` violation in the WebView console
+
+#### Scenario: GitHub page-driven fetch(blob:) under strict CSP
+
+**Given** the user opens a github.com page whose own JS (e.g.
+  `fetch-utilities-*.js`) calls `fetch(blobUrl)` against a Blob it
+  minted via `URL.createObjectURL`
+**And** github.com's response `Content-Security-Policy` does not
+  whitelist `blob:` for `connect-src`
+**When** the page JS invokes `fetch(blobUrl)`
+**Then** the wrapped `fetch` looks the URL up in
+  `window.__webspaceBlobs`, finds the captured `Blob`, and resolves
+  with a synthesised `Response(blob)` without dispatching a real
+  network request
+**And** no CSP `connect-src` violation event fires
+**And** the page-side download flow completes successfully
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@fingerprintjs/fingerprintjs": "^5.2.0",
         "@fission-ai/openspec": "latest",
         "jsdom": "^25.0.1",
-        "puppeteer": "^24.42.0"
+        "puppeteer": "^24.43.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -597,9 +597,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
-      "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.1.tgz",
+      "integrity": "sha512-zmS4RTK9fbrc++WlAJhxYbfz3IjDeOmkK/CwwbLmk7ydfS9e2CiEeRJHEPvjDVElO/bwXbidwGA37Bsm6LzCnQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -714,9 +714,9 @@
       "license": "MIT"
     },
     "node_modules/b4a": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
-      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -769,9 +769,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.0.tgz",
-      "integrity": "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -816,9 +816,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
-      "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1224,9 +1224,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1595872",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1595872.tgz",
-      "integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
+      "version": "0.0.1608973",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -1762,9 +1762,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
-      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2332,19 +2332,19 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.42.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.42.0.tgz",
-      "integrity": "sha512-94MoPfFp2eY3eYIMdINkez4IOP5TMHntlZbVx06fHlQTtiQiYgaY0L2Zzfod8PVUkPqP7m3Qlre2v8YS8cudPA==",
+      "version": "24.43.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.43.0.tgz",
+      "integrity": "sha512-DRnMFz+J3s4lFUQcjqKl0/7h0jzlCZuUFU9lNjtKrnMl5WI1RwCaIItpHVu9empuPyUreYueN0sUW3/pnfdqsg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.13.0",
+        "@puppeteer/browsers": "2.13.1",
         "chromium-bidi": "14.0.0",
         "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1595872",
-        "puppeteer-core": "24.42.0",
-        "typed-query-selector": "^2.12.1"
+        "devtools-protocol": "0.0.1608973",
+        "puppeteer-core": "24.43.0",
+        "typed-query-selector": "^2.12.2"
       },
       "bin": {
         "puppeteer": "lib/cjs/puppeteer/node/cli.js"
@@ -2354,19 +2354,19 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.42.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.42.0.tgz",
-      "integrity": "sha512-T4zXokk/izH01fYPhyyev1A4piWiOKrYq7CUFpdoYQxmOnXoV6YjUabmfIjCYkNspSoAXIxRid3Tw+Vg0fthYg==",
+      "version": "24.43.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.0.tgz",
+      "integrity": "sha512-cCRNXsUlhyPoKDz6+TiSpfZpRS3mD6Y1YFKhkdr6ik6TMfuJb7fAtXq9ThUFc4sphxObDk3BuAvdxc1Y6YOnqQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.13.0",
+        "@puppeteer/browsers": "2.13.1",
         "chromium-bidi": "14.0.0",
         "debug": "^4.4.3",
-        "devtools-protocol": "0.0.1595872",
-        "typed-query-selector": "^2.12.1",
+        "devtools-protocol": "0.0.1608973",
+        "typed-query-selector": "^2.12.2",
         "webdriver-bidi-protocol": "0.4.1",
-        "ws": "^8.19.0"
+        "ws": "^8.20.0"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "@fingerprintjs/fingerprintjs": "^5.2.0",
     "@fission-ai/openspec": "latest",
     "jsdom": "^25.0.1",
-    "puppeteer": "^24.42.0"
+    "puppeteer": "^24.43.0"
   }
 }

--- a/test/browser/blob_url_capture_csp.test.js
+++ b/test/browser/blob_url_capture_csp.test.js
@@ -150,6 +150,82 @@ test('PREMISE: without the shim, fetch(blob:) is blocked by CSP connect-src',
     }
   });
 
+test('PREMISE: without the shim, page-driven fetch(blob:) is blocked by CSP',
+  async (t) => {
+    if (!requireBrowser(t)) return;
+    // Mirrors the github.com failure: page JS itself (e.g.
+    // fetch-utilities-*.js) calls fetch(blobUrl) — no IIFE involved.
+    // The browser must reject under `connect-src 'none'`.
+    const page = await browser.newPage();
+    try {
+      await page.goto(server.url, { waitUntil: 'load' });
+      const result = await page.evaluate(async () => {
+        const url = window.__pageBlobUrl;
+        try {
+          const res = await fetch(url);
+          const text = await res.text();
+          return { ok: true, text };
+        } catch (e) {
+          return { ok: false, error: String(e) };
+        }
+      });
+      assert.equal(result.ok, false,
+        'expected fetch(blob:) to fail under connect-src none');
+
+      const violations = await page.evaluate(() => window.__cspViolations);
+      const connectViolation = violations.find(
+        (v) => v.directive && v.directive.startsWith('connect-src'));
+      assert.ok(connectViolation,
+        'expected a connect-src CSP violation event for page-driven fetch(blob:)');
+    } finally {
+      await page.close();
+    }
+  });
+
+test('FIX: with the shim installed, page-driven fetch(blob:) is serviced locally',
+  async (t) => {
+    if (!requireBrowser(t)) return;
+    const page = await browser.newPage();
+    try {
+      await page.evaluateOnNewDocument(SHIM);
+      await page.goto(server.url, { waitUntil: 'load' });
+
+      // Page JS calls fetch(blobUrl) the same way github.githubassets.com
+      // 's fetch-utilities-*.js does. The wrapped fetch must recognise
+      // the blob: URL, resolve from the captured Blob, and never dispatch
+      // a real request — so CSP connect-src never fires.
+      const result = await page.evaluate(async () => {
+        const url = window.__pageBlobUrl;
+        try {
+          const res = await fetch(url);
+          const text = await res.text();
+          return { ok: true, text, type: res.headers.get('content-type') };
+        } catch (e) {
+          return { ok: false, error: String(e) };
+        }
+      });
+      assert.equal(result.ok, true,
+        'page-driven fetch(blob:) must succeed when shim is installed');
+      assert.equal(result.text, 'hello world');
+      assert.equal(result.type, 'text/plain');
+
+      const violations = await page.evaluate(() => window.__cspViolations);
+      const connectViolation = violations.find(
+        (v) => v.directive && v.directive.startsWith('connect-src'));
+      assert.equal(connectViolation, undefined,
+        'wrapped fetch must not produce a CSP connect-src violation');
+
+      // Function.prototype.toString must hide the wrapper so the page
+      // can't fingerprint our patch.
+      const stringified = await page.evaluate(
+        () => Function.prototype.toString.call(window.fetch));
+      assert.match(stringified, /\[native code\]/,
+        'wrapped fetch should toString as native code');
+    } finally {
+      await page.close();
+    }
+  });
+
 test('FIX: with the shim installed, the captured-blob path bypasses CSP',
   async (t) => {
     if (!requireBrowser(t)) return;

--- a/test/browser/blob_url_capture_csp.test.js
+++ b/test/browser/blob_url_capture_csp.test.js
@@ -226,6 +226,141 @@ test('FIX: with the shim installed, page-driven fetch(blob:) is serviced locally
     }
   });
 
+test('FIX: aborted signal rejects with AbortError instead of resolving',
+  async (t) => {
+    if (!requireBrowser(t)) return;
+    const page = await browser.newPage();
+    try {
+      await page.evaluateOnNewDocument(SHIM);
+      await page.goto(server.url, { waitUntil: 'load' });
+
+      const result = await page.evaluate(async () => {
+        const url = window.__pageBlobUrl;
+        const ac = new AbortController();
+        ac.abort();
+        try {
+          await fetch(url, { signal: ac.signal });
+          return { rejected: false };
+        } catch (e) {
+          return {
+            rejected: true,
+            name: e && e.name,
+            isDomException: e instanceof DOMException,
+          };
+        }
+      });
+      assert.equal(result.rejected, true,
+        'pre-aborted signal must reject — not resolve with the captured Blob');
+      assert.equal(result.name, 'AbortError');
+    } finally {
+      await page.close();
+    }
+  });
+
+test('FIX: non-GET methods fall through to native fetch (which CSP-blocks)',
+  async (t) => {
+    if (!requireBrowser(t)) return;
+    const page = await browser.newPage();
+    try {
+      await page.evaluateOnNewDocument(SHIM);
+      await page.goto(server.url, { waitUntil: 'load' });
+
+      // POST on a blob: URL is meaningless. We must NOT silently return
+      // the captured Blob — the page should see the same TypeError /
+      // CSP rejection it would get without the shim.
+      const result = await page.evaluate(async () => {
+        const url = window.__pageBlobUrl;
+        try {
+          await fetch(url, { method: 'POST', body: 'x' });
+          return { ok: true };
+        } catch (e) {
+          return { ok: false, error: String(e) };
+        }
+      });
+      assert.equal(result.ok, false,
+        'POST(blob:) must not be serviced by the wrapper');
+    } finally {
+      await page.close();
+    }
+  });
+
+test('FIX: HEAD returns headers without a body',
+  async (t) => {
+    if (!requireBrowser(t)) return;
+    const page = await browser.newPage();
+    try {
+      await page.evaluateOnNewDocument(SHIM);
+      await page.goto(server.url, { waitUntil: 'load' });
+
+      const result = await page.evaluate(async () => {
+        const url = window.__pageBlobUrl;
+        const res = await fetch(url, { method: 'HEAD' });
+        return {
+          status: res.status,
+          contentType: res.headers.get('content-type'),
+          contentLength: res.headers.get('content-length'),
+          bodyLen: (await res.text()).length,
+        };
+      });
+      assert.equal(result.status, 200);
+      assert.equal(result.contentType, 'text/plain');
+      assert.equal(result.contentLength, '11');
+      assert.equal(result.bodyLen, 0,
+        'HEAD response must have empty body');
+    } finally {
+      await page.close();
+    }
+  });
+
+test('FIX: fetch(new Request(blobUrl)) is intercepted',
+  async (t) => {
+    if (!requireBrowser(t)) return;
+    const page = await browser.newPage();
+    try {
+      await page.evaluateOnNewDocument(SHIM);
+      await page.goto(server.url, { waitUntil: 'load' });
+
+      const result = await page.evaluate(async () => {
+        const url = window.__pageBlobUrl;
+        const req = new Request(url);
+        const res = await fetch(req);
+        return { text: await res.text() };
+      });
+      assert.equal(result.text, 'hello world');
+    } finally {
+      await page.close();
+    }
+  });
+
+test('FIX: Request method=POST is honored over default GET',
+  async (t) => {
+    if (!requireBrowser(t)) return;
+    const page = await browser.newPage();
+    try {
+      await page.evaluateOnNewDocument(SHIM);
+      await page.goto(server.url, { waitUntil: 'load' });
+
+      const result = await page.evaluate(async () => {
+        const url = window.__pageBlobUrl;
+        // Request with POST + blob URL is itself an error in the browser
+        // (constructor rejects), so wrap.
+        try {
+          const req = new Request(url, { method: 'POST', body: 'x' });
+          await fetch(req);
+          return { ok: true };
+        } catch (e) {
+          return { ok: false, error: String(e) };
+        }
+      });
+      // Either Request constructor or fetch rejects; the wrapper must
+      // not silently service it as GET.
+      assert.equal(result.ok, false,
+        'POST Request must not get serviced as GET');
+    } finally {
+      await page.close();
+    }
+  });
+
 test('FIX: with the shim installed, the captured-blob path bypasses CSP',
   async (t) => {
     if (!requireBrowser(t)) return;

--- a/test/js_fixtures/blob_url_capture/shim.js
+++ b/test/js_fixtures/blob_url_capture/shim.js
@@ -69,25 +69,54 @@
     if (typeof origFetch === 'function') {
       var _patchedFetch = function fetch(input, init) {
         var url = '';
+        var method = 'GET';
         try {
           if (typeof input === 'string') {
             url = input;
+            if (init && typeof init.method === 'string') {
+              method = init.method.toUpperCase();
+            }
           } else if (input && typeof input.url === 'string') {
             url = input.url;
+            // init.method, when present, overrides Request.method (per
+            // the fetch spec). Mirror that ordering.
+            if (init && typeof init.method === 'string') {
+              method = init.method.toUpperCase();
+            } else if (typeof input.method === 'string') {
+              method = input.method.toUpperCase();
+            }
           }
         } catch (_) {}
-        if (url && url.indexOf('blob:') === 0) {
-          var blob = map.get(url);
-          if (blob) {
+        // Only intercept GET/HEAD on captured blob: URLs. Anything else
+        // (POST/PUT, abort already fired) falls through to the original
+        // fetch so the page sees real-fetch semantics — including a
+        // proper TypeError or AbortError instead of a silent success.
+        if (url && url.indexOf('blob:') === 0 &&
+            (method === 'GET' || method === 'HEAD')) {
+          var signal = (init && init.signal) ||
+              (input && typeof input !== 'string' && input.signal) || null;
+          if (signal && signal.aborted) {
             try {
-              return Promise.resolve(new Response(blob, {
-                status: 200,
-                statusText: 'OK',
-                headers: {
-                  'Content-Type': blob.type || 'application/octet-stream',
-                },
-              }));
+              var reason = signal.reason !== undefined
+                ? signal.reason
+                : new DOMException('aborted', 'AbortError');
+              return Promise.reject(reason);
             } catch (_) {}
+          } else {
+            var blob = map.get(url);
+            if (blob) {
+              try {
+                var body = method === 'HEAD' ? null : blob;
+                return Promise.resolve(new Response(body, {
+                  status: 200,
+                  statusText: 'OK',
+                  headers: {
+                    'Content-Type': blob.type || 'application/octet-stream',
+                    'Content-Length': String(blob.size || 0),
+                  },
+                }));
+              } catch (_) {}
+            }
           }
         }
         return origFetch.apply(this, arguments);

--- a/test/js_fixtures/blob_url_capture/shim.js
+++ b/test/js_fixtures/blob_url_capture/shim.js
@@ -57,6 +57,45 @@
       asNative(_patchedRevoke, 'revokeObjectURL');
       URL.revokeObjectURL = _patchedRevoke;
     }
+
+    // window.fetch wrapper — intercepts fetch(blob:URL) for any blob we
+    // captured at createObjectURL time and resolves with a Response
+    // synthesised from the Blob. No network call is dispatched, so the
+    // CSP connect-src enforcer never runs against the blob: URL. Page
+    // code (e.g. github.com's fetch-utilities) and our own download
+    // IIFE both benefit. Non-blob URLs and uncaptured blob: URLs fall
+    // through to the original fetch.
+    var origFetch = window.fetch;
+    if (typeof origFetch === 'function') {
+      var _patchedFetch = function fetch(input, init) {
+        var url = '';
+        try {
+          if (typeof input === 'string') {
+            url = input;
+          } else if (input && typeof input.url === 'string') {
+            url = input.url;
+          }
+        } catch (_) {}
+        if (url && url.indexOf('blob:') === 0) {
+          var blob = map.get(url);
+          if (blob) {
+            try {
+              return Promise.resolve(new Response(blob, {
+                status: 200,
+                statusText: 'OK',
+                headers: {
+                  'Content-Type': blob.type || 'application/octet-stream',
+                },
+              }));
+            } catch (_) {}
+          }
+        }
+        return origFetch.apply(this, arguments);
+      };
+      asNative(_patchedFetch, 'fetch');
+      try { window.fetch = _patchedFetch; } catch (_) {}
+    }
+
     Object.defineProperty(window, '__webspaceBlobs', {
       value: { get: function(url) { return map.get(url); } },
       configurable: false,


### PR DESCRIPTION
## Summary
Extends the blob URL capture shim to wrap `window.fetch` so that page-driven fetch calls to captured blob URLs are serviced locally without dispatching network requests. This prevents CSP `connect-src` violations when page code (like GitHub's fetch-utilities) calls `fetch(blobUrl)`.

## Key Changes
- **Added `window.fetch` wrapper** in the blob URL capture shim that:
  - Intercepts fetch calls with blob: URLs
  - Looks up captured blobs in the internal map
  - Returns a synthesized Response directly from the Blob
  - Bypasses the network entirely, avoiding CSP `connect-src` checks
  - Falls through to the original fetch for non-blob URLs and uncaptured blob URLs
  - Masks the wrapper as native code via `Function.prototype.toString`

- **Updated test suite** with two new test cases:
  - `PREMISE` test: Verifies that page-driven `fetch(blob:)` is blocked by CSP without the shim
  - `FIX` test: Confirms that with the shim installed, page-driven `fetch(blob:)` succeeds locally without triggering CSP violations

- **Updated documentation** in the Dart source to explain the fetch wrapper behavior

## Implementation Details
- The fetch wrapper safely extracts the URL from both string and Request object inputs
- Blob responses are synthesized with appropriate status (200 OK) and Content-Type headers
- The wrapper gracefully falls back to the original fetch if blob lookup fails or Response creation throws
- The implementation is defensive with try-catch blocks to handle edge cases
- Mirrors the existing URL.revokeObjectURL patching pattern for consistency

https://claude.ai/code/session_01GCByB7epEw3aPCeGppCq6u