### PR TITLE
Refactor DevToolsScreen to support nested webviews with DevToolsHost abstraction

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3379,7 +3379,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                       context,
                       MaterialPageRoute(
                         builder: (context) => DevToolsScreen(
-                          webViewModel: _webViewModels[_currentIndex!],
+                          host: WebViewModelDevToolsHost(_webViewModels[_currentIndex!]),
                           cookieManager: _cookieManager,
                           containerCookieManager: _containerCookieManager,
                           onSave: _saveWebViewModels,
@@ -3747,7 +3747,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                 context,
                 MaterialPageRoute(
                   builder: (context) => DevToolsScreen(
-                    webViewModel: _webViewModels[_currentIndex!],
+                    host: WebViewModelDevToolsHost(_webViewModels[_currentIndex!]),
                     cookieManager: _cookieManager,
                     containerCookieManager: _containerCookieManager,
                     onSave: _saveWebViewModels,

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -17,8 +17,122 @@ import 'package:webspace/settings/user_script.dart';
 
 typedef VoidAsyncCallback = Future<void> Function();
 
+/// Bag of dependencies DevToolsScreen reads from the surrounding webview.
+/// Two concrete implementations:
+///
+/// - [WebViewModelDevToolsHost] for top-level sites (`WebViewModel`-backed):
+///   exposes per-site state (cookie blocking, scripts) and DNS stats.
+/// - [NestedDevToolsHost] for [InAppWebViewScreen] popups (no
+///   `WebViewModel`): exposes only console + JS eval + HTML export.
+///
+/// `blockedCookies == null` is the sentinel for "no per-site state" and
+/// hides the Cookies, Scripts, and DNS surfaces.
+abstract class DevToolsHost {
+  String get name;
+  String? get siteId;
+  String get currentUrl;
+  WebViewController? get controller;
+  List<ConsoleLogEntry> get consoleLogs;
+  set onConsoleLogChanged(VoidCallback? cb);
+  List<Cookie> get cookies;
+  set cookies(List<Cookie> value);
+  Set<BlockedCookie>? get blockedCookies;
+  List<UserScriptConfig>? get siteUserScripts;
+  Set<String> get enabledGlobalScriptIds;
+  void reload();
+}
+
+class WebViewModelDevToolsHost implements DevToolsHost {
+  final WebViewModel model;
+  WebViewModelDevToolsHost(this.model);
+
+  @override
+  String get name => model.name;
+  @override
+  String? get siteId => model.siteId;
+  @override
+  String get currentUrl => model.currentUrl;
+  @override
+  WebViewController? get controller => model.controller;
+  @override
+  List<ConsoleLogEntry> get consoleLogs => model.consoleLogs;
+  @override
+  set onConsoleLogChanged(VoidCallback? cb) => model.onConsoleLogChanged = cb;
+  @override
+  List<Cookie> get cookies => model.cookies;
+  @override
+  set cookies(List<Cookie> value) => model.cookies = value;
+  @override
+  Set<BlockedCookie>? get blockedCookies => model.blockedCookies;
+  @override
+  List<UserScriptConfig>? get siteUserScripts => model.userScripts;
+  @override
+  Set<String> get enabledGlobalScriptIds => model.enabledGlobalScriptIds;
+  @override
+  void reload() => model.controller?.reload();
+}
+
+/// Console-only host for nested [InAppWebViewScreen]s. There is no
+/// WebViewModel in nested mode, so per-site cookie/script state is absent
+/// and DNS stats belong to the parent site's siteId (already exposed in
+/// the parent's DevTools); we surface neither here.
+class NestedDevToolsHost implements DevToolsHost {
+  @override
+  final String name;
+  @override
+  final String? siteId;
+  String _currentUrl;
+  WebViewController? _controller;
+  @override
+  final List<ConsoleLogEntry> consoleLogs = [];
+  VoidCallback? _onConsoleLogChanged;
+  @override
+  List<Cookie> cookies = const [];
+
+  NestedDevToolsHost({
+    required this.name,
+    required this.siteId,
+    required String currentUrl,
+  }) : _currentUrl = currentUrl;
+
+  @override
+  String get currentUrl => _currentUrl;
+  set currentUrl(String value) => _currentUrl = value;
+
+  @override
+  WebViewController? get controller => _controller;
+  set controller(WebViewController? value) => _controller = value;
+
+  @override
+  set onConsoleLogChanged(VoidCallback? cb) => _onConsoleLogChanged = cb;
+  VoidCallback? get onConsoleLogChanged => _onConsoleLogChanged;
+
+  static const _maxConsoleLogs = 500;
+
+  void appendConsole(String message, ConsoleMessageLevel level) {
+    consoleLogs.add(ConsoleLogEntry(
+      timestamp: DateTime.now(),
+      message: message,
+      level: level,
+    ));
+    if (consoleLogs.length > _maxConsoleLogs) {
+      consoleLogs.removeAt(0);
+    }
+    _onConsoleLogChanged?.call();
+  }
+
+  @override
+  Set<BlockedCookie>? get blockedCookies => null;
+  @override
+  List<UserScriptConfig>? get siteUserScripts => null;
+  @override
+  Set<String> get enabledGlobalScriptIds => const {};
+  @override
+  void reload() => _controller?.reload();
+}
+
 class DevToolsScreen extends StatefulWidget {
-  final WebViewModel? webViewModel;
+  final DevToolsHost? host;
   final CookieManager cookieManager;
   /// Container-mode counterpart of [cookieManager]; non-null when
   /// `_useContainers` is true. The cookie inspector reads/deletes
@@ -32,7 +146,7 @@ class DevToolsScreen extends StatefulWidget {
 
   const DevToolsScreen({
     super.key,
-    this.webViewModel,
+    this.host,
     required this.cookieManager,
     this.containerCookieManager,
     this.onSave,
@@ -66,10 +180,19 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   /// Snapshot of blocked cookies on entry, to detect changes on exit.
   late final Set<BlockedCookie> _initialBlockedCookies;
 
-  bool get _hasSite => widget.webViewModel != null;
+  bool get _hasHost => widget.host != null;
+  bool get _hasSiteState => widget.host?.blockedCookies != null;
 
   bool get _hasDnsBlocklist => DnsBlockService.instance.hasBlocklist;
-  int get _tabCount => _hasSite ? (_hasDnsBlocklist ? 4 : 3) : 1;
+  int get _tabCount {
+    var n = 1; // App Logs is always present.
+    if (_hasHost) n += 1; // Console
+    if (_hasSiteState) {
+      n += 1; // Cookies
+      if (_hasDnsBlocklist) n += 1; // DNS
+    }
+    return n;
+  }
 
   /// Filter for DNS log: null = all, true = blocked only, false = allowed only.
   bool? _dnsFilter;
@@ -78,13 +201,13 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   @override
   void initState() {
     super.initState();
-    _initialBlockedCookies = _hasSite
-        ? Set<BlockedCookie>.of(widget.webViewModel!.blockedCookies)
+    _initialBlockedCookies = _hasSiteState
+        ? Set<BlockedCookie>.of(widget.host!.blockedCookies!)
         : <BlockedCookie>{};
     LogService.instance.addListener(_onLogUpdate);
     DnsBlockService.instance.addDnsLogListener(_onDnsLogUpdate);
-    if (_hasSite) {
-      widget.webViewModel!.onConsoleLogChanged = _onConsoleUpdate;
+    if (_hasHost) {
+      widget.host!.onConsoleLogChanged = _onConsoleUpdate;
     }
   }
 
@@ -92,13 +215,15 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   void dispose() {
     LogService.instance.removeListener(_onLogUpdate);
     DnsBlockService.instance.removeDnsLogListener(_onDnsLogUpdate);
-    if (_hasSite) {
-      widget.webViewModel!.onConsoleLogChanged = null;
+    if (_hasHost) {
+      widget.host!.onConsoleLogChanged = null;
+    }
+    if (_hasSiteState) {
       // If blocked cookies changed while DevTools was open, reload the page
       // so the webview re-fetches cookies with the new rules applied.
-      final current = widget.webViewModel!.blockedCookies;
+      final current = widget.host!.blockedCookies!;
       if (!_setEquals(current, _initialBlockedCookies)) {
-        widget.webViewModel!.controller?.reload();
+        widget.host!.reload();
       }
     }
     _consoleScrollController.dispose();
@@ -130,11 +255,11 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   }
 
   List<Tab> get _tabs => [
-        if (_hasSite)
+        if (_hasHost)
           const Tab(icon: Icon(Icons.terminal, size: 18), text: 'Console'),
-        if (_hasSite)
+        if (_hasSiteState)
           const Tab(icon: Icon(Icons.cookie_outlined, size: 18), text: 'Cookies'),
-        if (_hasSite && _hasDnsBlocklist)
+        if (_hasSiteState && _hasDnsBlocklist)
           const Tab(icon: Icon(Icons.shield_outlined, size: 18), text: 'DNS'),
         const Tab(icon: Icon(Icons.list_alt, size: 18), text: 'Logs'),
       ];
@@ -164,13 +289,13 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
         appBar: AppBar(
           title: const Text('Developer Tools'),
           actions: [
-            if (_hasSite)
+            if (_hasSiteState)
               IconButton(
                 icon: const Icon(Icons.code, size: 20),
                 tooltip: 'Scripts',
                 onPressed: _showScriptsSheet,
               ),
-            if (_hasSite)
+            if (_hasHost)
               IconButton(
                 icon: const Icon(Icons.share, size: 20),
                 tooltip: 'Share HTML',
@@ -223,9 +348,9 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
             Expanded(
               child: TabBarView(
                 children: [
-                  if (_hasSite) _buildConsoleTab(),
-                  if (_hasSite) _buildCookiesTab(),
-                  if (_hasSite && _hasDnsBlocklist) _buildDnsTab(),
+                  if (_hasHost) _buildConsoleTab(),
+                  if (_hasSiteState) _buildCookiesTab(),
+                  if (_hasSiteState && _hasDnsBlocklist) _buildDnsTab(),
                   _buildAppLogsTab(),
                 ],
               ),
@@ -239,7 +364,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   // ── Console Tab ──
 
   Widget _buildConsoleTab() {
-    final allLogs = widget.webViewModel!.consoleLogs;
+    final allLogs = widget.host!.consoleLogs;
     final logs = _searchQuery.isEmpty
         ? allLogs
         : allLogs.where((e) => _matchesSearch(e.message)).toList();
@@ -271,7 +396,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
           TextButton.icon(
             onPressed: () {
               setState(() {
-                widget.webViewModel!.consoleLogs.clear();
+                widget.host!.consoleLogs.clear();
               });
             },
             icon: const Icon(Icons.delete_outline, size: 18),
@@ -333,7 +458,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   // ── Console Eval ──
 
   Widget _buildEvalInput() {
-    final hasController = widget.webViewModel?.controller != null;
+    final hasController = widget.host?.controller != null;
     return Container(
       decoration: BoxDecoration(
         border: Border(top: BorderSide(color: Theme.of(context).dividerColor)),
@@ -417,7 +542,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
     final source = _evalController.text.trim();
     if (source.isEmpty) return;
 
-    final controller = widget.webViewModel?.controller;
+    final controller = widget.host?.controller;
     if (controller == null) return;
 
     if (_isEvaluating) return;
@@ -429,13 +554,13 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
       }
       _evalHistoryIndex = -1;
 
-      widget.webViewModel!.consoleLogs.add(ConsoleLogEntry(
+      widget.host!.consoleLogs.add(ConsoleLogEntry(
         timestamp: DateTime.now(),
         message: source,
         level: ConsoleMessageLevel.LOG,
         isEvalInput: true,
       ));
-      widget.webViewModel!.onConsoleLogChanged?.call();
+      _onConsoleUpdate();
 
       // Directly embed code (no eval/Function) to respect CSP.
       // Phase 1: set sentinel. Phase 2: try as expression.
@@ -490,8 +615,8 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   // ── Cookies Tab ──
 
   Widget _buildCookiesTab() {
-    final allCookies = widget.webViewModel!.cookies;
-    final blocked = widget.webViewModel!.blockedCookies;
+    final allCookies = widget.host!.cookies;
+    final blocked = widget.host!.blockedCookies!;
     final cookies = _searchQuery.isEmpty
         ? allCookies
         : allCookies
@@ -565,23 +690,23 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   }
 
   Future<void> _refreshCookies() async {
-    final url = widget.webViewModel!.currentUrl;
+    final url = widget.host!.currentUrl;
     if (url.isEmpty) return;
     setState(() => _loadingCookies = true);
     try {
       final List<Cookie> cookies;
       final container = widget.containerCookieManager;
-      final controller = widget.webViewModel!.controller;
+      final controller = widget.host!.controller;
       if (container != null && controller != null) {
         cookies = await container.getCookies(
           controller: controller,
-          siteId: widget.webViewModel!.siteId,
+          siteId: widget.host!.siteId!,
           url: Uri.parse(url),
         );
         LogService.instance.log(
           'DevTools',
           'Cookie inspector via ContainerCookieManager: '
-              'siteId=${widget.webViewModel!.siteId} url=$url '
+              'siteId=${widget.host!.siteId} url=$url '
               'count=${cookies.length}',
         );
       } else {
@@ -589,13 +714,13 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
         LogService.instance.log(
           'DevTools',
           'Cookie inspector via legacy CookieManager: '
-              'siteId=${widget.webViewModel!.siteId} url=$url '
+              'siteId=${widget.host!.siteId} url=$url '
               'count=${cookies.length} '
               '(container=${container != null} ctrl=${controller != null})',
         );
       }
       if (mounted) {
-        widget.webViewModel!.cookies = cookies;
+        widget.host!.cookies = cookies;
         setState(() => _loadingCookies = false);
       }
     } catch (e) {
@@ -606,13 +731,13 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   }
 
   Future<void> _deleteCookie(Cookie cookie) async {
-    final url = Uri.parse(widget.webViewModel!.currentUrl);
+    final url = Uri.parse(widget.host!.currentUrl);
     final container = widget.containerCookieManager;
-    final controller = widget.webViewModel!.controller;
+    final controller = widget.host!.controller;
     if (container != null && controller != null) {
       await container.deleteCookie(
         controller: controller,
-        siteId: widget.webViewModel!.siteId,
+        siteId: widget.host!.siteId!,
         url: url,
         name: cookie.name,
         domain: cookie.domain,
@@ -635,10 +760,10 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   }
 
   Future<void> _blockCookie(Cookie cookie) async {
-    final domain = cookie.domain ?? extractDomain(widget.webViewModel!.currentUrl);
+    final domain = cookie.domain ?? extractDomain(widget.host!.currentUrl);
     final rule = BlockedCookie(name: cookie.name, domain: domain);
     setState(() {
-      widget.webViewModel!.blockedCookies.add(rule);
+      widget.host!.blockedCookies!.add(rule);
     });
     // Delete the cookie immediately from the webview
     await _deleteCookie(cookie);
@@ -647,7 +772,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
 
   Future<void> _unblockCookie(BlockedCookie rule) async {
     setState(() {
-      widget.webViewModel!.blockedCookies.remove(rule);
+      widget.host!.blockedCookies!.remove(rule);
     });
     await widget.onSave?.call();
     if (mounted) {
@@ -761,8 +886,8 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   // ── Scripts Bottom Sheet ──
 
   void _showScriptsSheet() {
-    final siteScripts = widget.webViewModel!.userScripts;
-    final enabledIds = widget.webViewModel!.enabledGlobalScriptIds;
+    final siteScripts = widget.host!.siteUserScripts ?? const <UserScriptConfig>[];
+    final enabledIds = widget.host!.enabledGlobalScriptIds;
     final activeGlobals = widget.globalUserScripts
         .where((g) => enabledIds.contains(g.id))
         .toList();
@@ -956,7 +1081,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
 
   Future<String?> _fetchHtml() async {
     if (_isFetchingHtml) return _exportedHtml;
-    final controller = widget.webViewModel!.controller;
+    final controller = widget.host!.controller;
     if (controller == null) return null;
 
     _isFetchingHtml = true;
@@ -988,7 +1113,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
     final html = _exportedHtml ?? await _fetchHtml();
     if (html == null || !mounted) return;
 
-    final domain = extractDomain(widget.webViewModel!.currentUrl);
+    final domain = extractDomain(widget.host!.currentUrl);
     final timestamp = DateTime.now().toIso8601String().replaceAll(':', '-').split('.')[0];
     SharePlus.instance.share(ShareParams(
       text: html,
@@ -1001,7 +1126,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
     if (html == null || !mounted) return;
 
     try {
-      final domain = extractDomain(widget.webViewModel!.currentUrl);
+      final domain = extractDomain(widget.host!.currentUrl);
       final timestamp = DateTime.now().toIso8601String().replaceAll(':', '-').split('.')[0];
       final fileName = '${domain}_$timestamp.html';
       final bytes = utf8.encode(html);
@@ -1046,7 +1171,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   // ── DNS Tab ──
 
   Widget _buildDnsTab() {
-    final stats = DnsBlockService.instance.statsForSite(widget.webViewModel!.siteId);
+    final stats = DnsBlockService.instance.statsForSite(widget.host!.siteId!);
     final allEntries = stats.log;
     List<DnsLogEntry> entries = _dnsFilter == null
         ? allEntries
@@ -1159,7 +1284,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
         children: [
           TextButton.icon(
             onPressed: () {
-              DnsBlockService.instance.clearStatsForSite(widget.webViewModel!.siteId);
+              DnsBlockService.instance.clearStatsForSite(widget.host!.siteId!);
             },
             icon: const Icon(Icons.delete_outline, size: 18),
             label: const Text('Clear'),

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -6,10 +6,12 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp show Pu
 import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import 'package:webspace/screens/dev_tools.dart';
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/settings/location.dart';
 import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/settings/user_script.dart';
+import 'package:webspace/web_view_model.dart' show extractDomain;
 import 'package:webspace/widgets/download_button.dart';
 import 'package:webspace/widgets/external_url_prompt.dart';
 import 'package:webspace/widgets/find_toolbar.dart';
@@ -105,6 +107,12 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
   bool _isFindVisible = false;
   FindMatchesResult findMatches = FindMatchesResult();
 
+  /// DevTools host for this nested webview. Captures console output and
+  /// tracks the current URL/controller so the user can open Developer
+  /// Tools (Console + JS eval + HTML export + app logs) from the popup
+  /// menu just like on the parent site.
+  late final NestedDevToolsHost _devToolsHost;
+
   @override
   void initState() {
     super.initState();
@@ -112,6 +120,11 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
     // Use home site title if provided
     title = widget.homeTitle;
     _currentUrl = widget.url;
+    _devToolsHost = NestedDevToolsHost(
+      name: widget.homeTitle ?? extractDomain(widget.url),
+      siteId: widget.siteId,
+      currentUrl: widget.url,
+    );
     final bool isMobile = Platform.isIOS || Platform.isAndroid;
     _pullToRefreshController = isMobile ? inapp.PullToRefreshController(
       settings: inapp.PullToRefreshSettings(enabled: true),
@@ -163,11 +176,15 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
         notificationsEnabled: widget.notificationsEnabled,
         pullToRefreshController: _pullToRefreshController,
         onUrlChanged: (url) {
+          _devToolsHost.currentUrl = url;
           if (mounted) {
             setState(() {
               _currentUrl = url;
             });
           }
+        },
+        onConsoleMessage: (message, level) {
+          _devToolsHost.appendConsole(message, level);
         },
         onFindResult: (activeMatch, totalMatches) {
           if (mounted) {
@@ -189,6 +206,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
       ),
       onControllerCreated: (controller) {
         _controller = controller;
+        _devToolsHost.controller = controller;
         // Remove all cookies on load
         controller.evaluateJavascript('''
           (function() {
@@ -363,6 +381,16 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
                     ],
                   ),
                 ),
+                PopupMenuItem<String>(
+                  value: "devTools",
+                  child: Row(
+                    children: [
+                      Icon(Icons.developer_mode),
+                      SizedBox(width: 8),
+                      Text("Developer Tools"),
+                    ],
+                  ),
+                ),
               ];
             },
             onSelected: (String value) async {
@@ -391,6 +419,17 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
                   break;
                 case 'refresh':
                   _controller?.reload();
+                  break;
+                case 'devTools':
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => DevToolsScreen(
+                        host: _devToolsHost,
+                        cookieManager: CookieManager(),
+                      ),
+                    ),
+                  );
                   break;
               }
             },

--- a/openspec/specs/developer-tools/spec.md
+++ b/openspec/specs/developer-tools/spec.md
@@ -234,6 +234,61 @@ The app SHALL show active user scripts for the current site via an AppBar action
 
 ---
 
+### Requirement: DEVTOOLS-008 - Nested Webview Developer Tools
+
+The app SHALL allow opening Developer Tools inside an [`InAppWebViewScreen`]
+nested webview (the screen that handles cross-domain navigations and
+window.open popups), in a reduced "console-only" mode that surfaces the
+features that don't depend on per-site state.
+
+The reduced mode SHALL show:
+
+- Console tab (capture, filter, copy, clear, JS eval).
+- App Logs tab.
+- Share HTML AppBar action.
+
+The reduced mode SHALL NOT show Cookies, DNS, or Scripts surfaces. Cookies
+and scripts belong to the parent site (the nested webview reuses the
+parent's container/jar and `siteId`), so the user manages them from the
+parent site's Developer Tools entry.
+
+#### Scenario: Open Developer Tools from a nested webview
+
+**Given** the user has followed an outbound link or opened a popup that
+landed in an `InAppWebViewScreen`
+**When** the user taps the three-dot menu in the nested screen's AppBar
+and selects "Developer Tools"
+**Then** `DevToolsScreen` opens with `host: NestedDevToolsHost(...)`
+**And** the Console and App Logs tabs are visible
+**And** the Cookies, DNS, and Scripts surfaces are hidden
+
+#### Scenario: Console captures messages from the nested page
+
+**Given** Developer Tools is open over a nested webview
+**When** the nested page produces a `console.log`/`warn`/`error`
+**Then** the message is delivered through `WebViewConfig.onConsoleMessage`
+to `NestedDevToolsHost.appendConsole`
+**And** it appears in the Console tab in real time
+
+#### Scenario: JS eval in a nested webview
+
+**Given** Developer Tools is open over a nested webview and the
+controller is bound
+**When** the user types a JS expression and taps Run
+**Then** the expression is evaluated against the nested webview's
+controller (NOT the parent site's), with the same CSP-safe direct
+injection used in the full mode
+
+#### Scenario: Share HTML from a nested webview
+
+**Given** Developer Tools is open over a nested webview
+**When** the user taps the share icon and chooses Share / Save / Copy
+**Then** the HTML returned by the nested webview's `controller.getHtml()`
+is shared / saved / copied
+**And** the filename uses the nested webview's current URL domain
+
+---
+
 ### Requirement: DEVTOOLS-007 - Console Eval
 
 The app SHALL provide a JavaScript evaluation input in the Console tab, allowing users to execute arbitrary JS in the context of the current page and see results inline, like a standard browser console.
@@ -276,7 +331,8 @@ The app SHALL provide a JavaScript evaluation input in the Console tab, allowing
 | File | Role |
 |------|------|
 | `lib/services/log_service.dart` | LogService singleton, LogEntry, LogLevel enum |
-| `lib/screens/dev_tools.dart` | DevToolsScreen with 3 tabs (Console, Cookies, App Logs) and AppBar actions (Scripts, Share HTML, Search) |
+| `lib/screens/dev_tools.dart` | DevToolsScreen plus DevToolsHost abstraction (WebViewModelDevToolsHost, NestedDevToolsHost). Tabs/actions are gated on `host != null` (Console, Share HTML) and `host.blockedCookies != null` (Cookies, DNS, Scripts). |
+| `lib/screens/inappbrowser.dart` | InAppWebViewScreen owns a NestedDevToolsHost: forwards onConsoleMessage / onUrlChanged / onControllerCreated and exposes a "Developer Tools" entry in the popup menu. |
 
 ### Data Models
 
@@ -300,9 +356,9 @@ class ConsoleLogEntry {
 ### Integration Points
 
 - `WebViewConfig.onConsoleMessage` callback wired in `WebViewFactory.createWebView()`
-- `WebViewModel.consoleLogs` list (max 500 entries)
+- `WebViewModel.consoleLogs` and `NestedDevToolsHost.consoleLogs`, both ring buffers (max 500 entries)
 - All service files use `LogService.instance.log()` instead of `debugPrint()`
-- Popup menu "Developer Tools" item in `main.dart`
+- Popup menu "Developer Tools" item in `main.dart` (top-level sites) and `inappbrowser.dart` (nested webviews)
 - "App Logs" tile in App Settings screen
 
 ---


### PR DESCRIPTION
## Summary

This PR introduces a `DevToolsHost` abstraction to decouple `DevToolsScreen` from `WebViewModel`, enabling Developer Tools to work in both top-level sites and nested webviews (popups/cross-domain navigations in `InAppWebViewScreen`). The nested mode surfaces console-only features (Console tab, JS eval, HTML export, App Logs) while hiding per-site state (Cookies, DNS, Scripts) that belongs to the parent site.

## Key Changes

- **New `DevToolsHost` abstraction** (`lib/screens/dev_tools.dart`):
  - Abstract interface defining the contract for DevTools data/operations
  - `WebViewModelDevToolsHost`: wraps `WebViewModel` for top-level sites
  - `NestedDevToolsHost`: lightweight host for nested webviews with console ring buffer (max 500 entries)

- **DevToolsScreen refactoring**:
  - Changed constructor parameter from `webViewModel` to `host: DevToolsHost?`
  - Introduced `_hasHost` (host exists) and `_hasSiteState` (host has per-site state) guards
  - Tab/action visibility now gated on these conditions:
    - Console tab: shown if `_hasHost`
    - Cookies/DNS/Scripts: shown if `_hasSiteState` (i.e., `host.blockedCookies != null`)
    - Share HTML action: shown if `_hasHost`
  - All `widget.webViewModel` references replaced with `widget.host` calls

- **InAppWebViewScreen integration** (`lib/screens/inappbrowser.dart`):
  - Creates and owns a `NestedDevToolsHost` instance
  - Wires `onUrlChanged` → `_devToolsHost.currentUrl`
  - Wires `onConsoleMessage` → `_devToolsHost.appendConsole()`
  - Wires `onControllerCreated` → `_devToolsHost.controller`
  - Added "Developer Tools" popup menu item that opens `DevToolsScreen(host: _devToolsHost, ...)`

- **Main.dart update**:
  - Changed DevTools invocation to wrap `WebViewModel` in `WebViewModelDevToolsHost`

## Implementation Details

- `NestedDevToolsHost.blockedCookies` returns `null` (sentinel value) to hide cookie/DNS/script surfaces
- Console logs in nested mode use same ring buffer pattern as `WebViewModel` (max 500 entries)
- JS eval in nested mode evaluates against the nested webview's controller, not the parent's
- HTML export uses the nested webview's current URL domain for filename generation
- All per-site operations (cookie refresh, blocking, DNS stats) safely null-check `blockedCookies` before access

https://claude.ai/code/session_01KRfM43B8uLpAEu5XbyCdgB