### PR TITLE
Add port-aware domain claim matching for link routing

### DIFF
--- a/lib/screens/link_handling_settings.dart
+++ b/lib/screens/link_handling_settings.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:webspace/services/link_routing_service.dart';
 import 'package:webspace/web_view_model.dart';
+import 'package:webspace/widgets/hint_button.dart';
 
 /// Global "Link handling" screen (LIR-008): master toggle + routing
 /// overview + manual test entry. Tapping a site row opens [onOpenSiteEditor]
@@ -287,6 +288,13 @@ class _DomainClaimsEditorState extends State<DomainClaimsEditor> {
                   style: Theme.of(context).textTheme.titleSmall,
                 ),
               ),
+              const HintButton(
+                title: 'Domain claims',
+                description:
+                    'Which hostnames route to this site when shared from '
+                    'another app. Existing sites synthesize one base-domain '
+                    'claim from their URL.',
+              ),
               IconButton(
                 icon: const Icon(Icons.add),
                 tooltip: 'Add claim',
@@ -295,15 +303,6 @@ class _DomainClaimsEditorState extends State<DomainClaimsEditor> {
             ],
           ),
         ),
-        const Padding(
-          padding: EdgeInsets.symmetric(horizontal: 16),
-          child: Text(
-            'Which hostnames route to this site when shared from another app. '
-            'Existing sites synthesize one base-domain claim from their URL.',
-            style: TextStyle(fontSize: 12),
-          ),
-        ),
-        const SizedBox(height: 8),
         for (var i = 0; i < _claims.length; i++)
           _ClaimRow(
             claim: _claims[i],

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -1143,17 +1143,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         }
                       : null),
             ),
-          // LIR-008 / LIR-001: per-site domain-claim editor. Lets the user
-          // tell the share-intent resolver which hostnames belong to this
-          // site beyond the synthesized `baseDomain(initUrl)` default.
-          DomainClaimsEditor(
-            model: widget.webViewModel,
-            otherSites: widget.otherSites,
-            onChanged: (next) {
-              widget.webViewModel.domainClaims = next;
-            },
-          ),
-          const SizedBox(height: 8),
           ListTile(
             title: const Text('User Scripts'),
             subtitle: Text(
@@ -1249,24 +1238,36 @@ class _SettingsScreenState extends State<SettingsScreen> {
               final blocked = blockedBy != null && !_notificationsEnabled;
               final permissionDenied = _notificationsEnabled &&
                   NotificationService.instance.permissionGranted == false;
-              final String subtitle;
+              final Widget? subtitle;
               if (blocked) {
-                subtitle =
-                    'Cannot enable: "$blockedBy" is already polling in '
-                    'background with a different proxy. Android allows only '
-                    'one proxy at a time.';
+                subtitle = Text(
+                  'Cannot enable: "$blockedBy" is already polling in '
+                  'background with a different proxy. Android allows only '
+                  'one proxy at a time.',
+                );
               } else if (permissionDenied) {
-                subtitle = 'Notifications denied. Enable in Settings → '
-                    '${Platform.isIOS ? "Notifications → WebSpace" : "WebSpace → Notifications"}.';
+                subtitle = Text(
+                  'Notifications denied. Enable in Settings → '
+                  '${Platform.isIOS ? "Notifications → WebSpace" : "WebSpace → Notifications"}.',
+                );
               } else {
-                subtitle =
-                    'Allow this site to show system notifications. Keeps the '
-                    'site polling in the background so notifications fire even '
-                    'when you are on a different tab.';
+                subtitle = null;
               }
               return SwitchListTile(
-                title: const Text('Notifications'),
-                subtitle: Text(subtitle),
+                title: Row(
+                  children: const [
+                    Flexible(child: Text('Notifications')),
+                    HintButton(
+                      title: 'Notifications',
+                      description:
+                          'Allow this site to show system notifications. '
+                          'Keeps the site polling in the background so '
+                          'notifications fire even when you are on a '
+                          'different tab.',
+                    ),
+                  ],
+                ),
+                subtitle: subtitle,
                 value: _notificationsEnabled,
                 onChanged: blocked
                     ? null
@@ -1291,6 +1292,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
               );
             }),
           ..._buildLocationSection(),
+          DomainClaimsEditor(
+            model: widget.webViewModel,
+            otherSites: widget.otherSites,
+            onChanged: (next) {
+              widget.webViewModel.domainClaims = next;
+            },
+          ),
+          const SizedBox(height: 8),
           if (widget.onClearCookies != null)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),

--- a/lib/services/domain_claim.dart
+++ b/lib/services/domain_claim.dart
@@ -7,7 +7,7 @@ class DomainClaim {
   const DomainClaim._raw(this.kind, this.value);
 
   factory DomainClaim(DomainClaimKind kind, String value) =>
-      DomainClaim._raw(kind, _canon(value));
+      DomainClaim._raw(kind, _canon(kind, value));
 
   factory DomainClaim.exactHost(String host) =>
       DomainClaim(DomainClaimKind.exactHost, host);
@@ -18,19 +18,43 @@ class DomainClaim {
   factory DomainClaim.baseDomain(String host) =>
       DomainClaim(DomainClaimKind.baseDomain, host);
 
-  static String _canon(String s) {
+  static String _canon(DomainClaimKind kind, String s) {
     var v = s.trim().toLowerCase();
     if (v.isEmpty) return v;
     if (v.contains('://')) {
-      v = Uri.tryParse(v)?.host ?? v;
+      final parsed = Uri.tryParse(v);
+      if (parsed != null && parsed.host.isNotEmpty) {
+        final h = parsed.host;
+        final wrapped = h.contains(':') && !h.startsWith('[') ? '[$h]' : h;
+        v = parsed.hasPort ? '$wrapped:${parsed.port}' : wrapped;
+      }
     }
     if (v.startsWith('*.')) v = v.substring(2);
-    final colon = v.indexOf(':');
-    if (colon > 0) v = v.substring(0, colon);
-    if (v.startsWith('[') && v.contains(']')) {
-      v = v.substring(1, v.indexOf(']'));
+    String host;
+    String portSuffix = '';
+    if (v.startsWith('[')) {
+      final close = v.indexOf(']');
+      if (close > 0) {
+        host = v.substring(1, close);
+        final rest = v.substring(close + 1);
+        if (rest.startsWith(':')) portSuffix = rest;
+      } else {
+        host = v;
+      }
+    } else {
+      final colon = v.indexOf(':');
+      if (colon > 0) {
+        host = v.substring(0, colon);
+        portSuffix = v.substring(colon);
+      } else {
+        host = v;
+      }
     }
-    return v;
+    if (kind == DomainClaimKind.exactHost && portSuffix.isNotEmpty) {
+      final h = host.contains(':') ? '[$host]' : host;
+      return '$h$portSuffix';
+    }
+    return host;
   }
 
   Map<String, dynamic> toJson() => {'kind': kind.name, 'value': value};

--- a/lib/services/link_intent_dispatch_engine.dart
+++ b/lib/services/link_intent_dispatch_engine.dart
@@ -209,7 +209,7 @@ class LinkIntentDispatchEngine {
     required DispatchableSite site,
   }) {
     final target = _normalizeInbound(inbound) ?? inbound;
-    final additions = LinkRoutingService.claimsToAdoptHost(target.host);
+    final additions = LinkRoutingService.claimsToAdoptUrl(target);
     return DispatchBindAndOpen(
       chosenSiteId: site.siteId,
       claimAdditions: additions,
@@ -230,10 +230,14 @@ class LinkIntentDispatchEngine {
     if (home == null) {
       return const DispatchUnsupported('cannot strip path for create');
     }
-    final base = getBaseDomain(target.host);
-    final claims = base.isEmpty
-        ? const <DomainClaim>[]
-        : [DomainClaim.baseDomain(base)];
+    final claims = target.hasPort
+        ? LinkRoutingService.claimsToAdoptUrl(target)
+        : () {
+            final base = getBaseDomain(target.host);
+            return base.isEmpty
+                ? const <DomainClaim>[]
+                : [DomainClaim.baseDomain(base)];
+          }();
     return DispatchCreateSite(
       home: home,
       fullUrl: target.toString(),

--- a/lib/services/link_routing_service.dart
+++ b/lib/services/link_routing_service.dart
@@ -52,13 +52,32 @@ class LinkRoutingService {
   static const int _scoreWildcardSubdomain = 200;
   static const int _scoreBaseDomain = 100;
 
-  static int _score(DomainClaim claim, String host, String base) {
+  /// Authority key for routing: `host` when the URL's port is the scheme
+  /// default, `host:port` otherwise (with brackets around IPv6 hosts when
+  /// a port is appended, so the form is unambiguous).
+  static String hostAuthority(Uri url) {
+    final host = url.host.toLowerCase();
+    if (host.isEmpty) return '';
+    if (!url.hasPort) return host;
+    final h = host.contains(':') && !host.startsWith('[') ? '[$host]' : host;
+    return '$h:${url.port}';
+  }
+
+  static int _score(
+    DomainClaim claim,
+    String hostKey,
+    String host,
+    String base,
+    bool defaultPort,
+  ) {
     switch (claim.kind) {
       case DomainClaimKind.exactHost:
-        return claim.value == host ? _scoreExactHost : 0;
+        return claim.value == hostKey ? _scoreExactHost : 0;
       case DomainClaimKind.wildcardSubdomain:
+        if (!defaultPort) return 0;
         return host.endsWith('.${claim.value}') ? _scoreWildcardSubdomain : 0;
       case DomainClaimKind.baseDomain:
+        if (!defaultPort) return 0;
         return getBaseDomain(claim.value) == base ? _scoreBaseDomain : 0;
     }
   }
@@ -70,12 +89,14 @@ class LinkRoutingService {
     if (url.host.isEmpty) return const RoutingNone();
     final host = url.host.toLowerCase();
     final base = getBaseDomain(host);
+    final hostKey = hostAuthority(url);
+    final defaultPort = !url.hasPort;
     int best = 0;
     final winners = <RoutableSite>[];
     for (final site in sites) {
       int siteBest = 0;
       for (final claim in site.domainClaims) {
-        final s = _score(claim, host, base);
+        final s = _score(claim, hostKey, host, base, defaultPort);
         if (s > siteBest) siteBest = s;
       }
       if (siteBest == 0) continue;
@@ -117,6 +138,25 @@ class LinkRoutingService {
     return inner;
   }
 
+  /// Build the claim list to bind a site to an inbound URL (LIR-010 option
+  /// 2). For default-port URLs this emits both an `exactHost` and a
+  /// `wildcardSubdomain` over the base domain. For URLs with a non-default
+  /// port (e.g. `http://localhost:8080/`) only the port-bearing
+  /// `exactHost` is emitted — wildcard / subdomain semantics do not apply
+  /// to ad-hoc service ports.
+  static List<DomainClaim> claimsToAdoptUrl(Uri url) {
+    final host = url.host.toLowerCase();
+    if (host.isEmpty) return const [];
+    if (url.hasPort) {
+      final wrapped =
+          host.contains(':') && !host.startsWith('[') ? '[$host]' : host;
+      return [DomainClaim.exactHost('$wrapped:${url.port}')];
+    }
+    return claimsToAdoptHost(host);
+  }
+
+  /// Default-port variant kept for callers that only have a hostname.
+  /// Use [claimsToAdoptUrl] when a port-bearing URL is available.
   static List<DomainClaim> claimsToAdoptHost(String host) {
     final exact = DomainClaim.exactHost(host);
     final h = exact.value;

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -341,6 +341,12 @@ class WebViewModel {
   List<DomainClaim> get effectiveDomainClaims {
     final explicit = domainClaims;
     if (explicit != null && explicit.isNotEmpty) return explicit;
+    final uri = Uri.tryParse(initUrl);
+    if (uri != null && uri.host.isNotEmpty && uri.hasPort) {
+      final h = uri.host.toLowerCase();
+      final wrapped = h.contains(':') && !h.startsWith('[') ? '[$h]' : h;
+      return [DomainClaim.exactHost('$wrapped:${uri.port}')];
+    }
     final base = getBaseDomain(initUrl);
     if (base.isEmpty) return const [];
     return [DomainClaim.baseDomain(base)];

--- a/test/link_intent_dispatch_engine_test.dart
+++ b/test/link_intent_dispatch_engine_test.dart
@@ -242,6 +242,16 @@ void main() {
       );
       expect(action, isA<DispatchUnsupported>());
     });
+
+    test('non-default port seeds an exactHost host:port claim, no wildcard',
+        () {
+      final action = LinkIntentDispatchEngine.createNew(
+        inbound: Uri.parse('http://localhost:8080/admin?token=x'),
+      );
+      final c = action as DispatchCreateSite;
+      expect(c.home, 'http://localhost:8080/');
+      expect(c.initialClaims, [DomainClaim.exactHost('localhost:8080')]);
+    });
   });
 
   group('LinkIntentDispatchEngine.dispatch — InboundHtml — LIR-012', () {

--- a/test/link_routing_test.dart
+++ b/test/link_routing_test.dart
@@ -14,13 +14,27 @@ class _Site implements RoutableSite {
 
 void main() {
   group('DomainClaim canonicalization', () {
-    test('lowercases, strips scheme and port, drops `*.` prefix', () {
+    test('lowercases, strips scheme and default port, drops `*.` prefix', () {
       expect(DomainClaim.exactHost('Twitter.COM').value, 'twitter.com');
       expect(DomainClaim.exactHost('https://Mail.google.com:443').value,
           'mail.google.com');
       expect(DomainClaim.wildcardSubdomain('*.Mastodon.Social').value,
           'mastodon.social');
       expect(DomainClaim.exactHost('  example.org  ').value, 'example.org');
+    });
+
+    test('exactHost preserves explicit non-default port', () {
+      expect(DomainClaim.exactHost('localhost:8080').value, 'localhost:8080');
+      expect(DomainClaim.exactHost('http://localhost:8080').value,
+          'localhost:8080');
+      expect(DomainClaim.exactHost('https://Service.Example:8443').value,
+          'service.example:8443');
+    });
+
+    test('wildcardSubdomain and baseDomain strip port even when given', () {
+      expect(DomainClaim.wildcardSubdomain('localhost:8080').value, 'localhost');
+      expect(DomainClaim.baseDomain('https://example.org:8443').value,
+          'example.org');
     });
 
     test('value-equality respects kind', () {
@@ -145,6 +159,69 @@ void main() {
         [a],
       );
       expect(r, isA<RoutingSingle>());
+    });
+
+    test('exactHost with port matches host:port URL', () {
+      final a = _Site('A', 'http://localhost:8080/', [
+        DomainClaim.exactHost('localhost:8080'),
+      ]);
+      final r = LinkRoutingService.resolve(
+        Uri.parse('http://localhost:8080/dashboard'),
+        [a],
+      );
+      expect(r, isA<RoutingSingle>());
+      expect((r as RoutingSingle).site.siteId, 'A');
+    });
+
+    test('exactHost without port does NOT match a port-bearing URL', () {
+      final a = _Site('A', 'http://localhost/', [
+        DomainClaim.exactHost('localhost'),
+      ]);
+      final r = LinkRoutingService.resolve(
+        Uri.parse('http://localhost:8080/x'),
+        [a],
+      );
+      expect(r, isA<RoutingNone>());
+    });
+
+    test(
+        'wildcardSubdomain and baseDomain do NOT match URLs with non-default port',
+        () {
+      final a = _Site('A', 'http://localhost/', [
+        DomainClaim.wildcardSubdomain('localhost'),
+        DomainClaim.baseDomain('localhost'),
+      ]);
+      final r = LinkRoutingService.resolve(
+        Uri.parse('http://api.localhost:8080/x'),
+        [a],
+      );
+      expect(r, isA<RoutingNone>());
+    });
+
+    test('default https port (443) is treated as no port', () {
+      final a = _Site('A', 'https://example.org/', [
+        DomainClaim.wildcardSubdomain('example.org'),
+      ]);
+      final r = LinkRoutingService.resolve(
+        Uri.parse('https://api.example.org:443/x'),
+        [a],
+      );
+      expect(r, isA<RoutingSingle>());
+      expect((r as RoutingSingle).site.siteId, 'A');
+    });
+
+    test('mismatched ports do not collide on exact host', () {
+      final a = _Site('A', 'http://localhost:8080/', [
+        DomainClaim.exactHost('localhost:8080'),
+      ]);
+      final b = _Site('B', 'http://localhost:9090/', [
+        DomainClaim.exactHost('localhost:9090'),
+      ]);
+      final r = LinkRoutingService.resolve(
+        Uri.parse('http://localhost:8080/x'),
+        [a, b],
+      );
+      expect((r as RoutingSingle).site.siteId, 'A');
     });
 
     test('per-site best-claim wins; lower-score claim on same site ignored',
@@ -311,6 +388,35 @@ void main() {
     test('empty input returns empty list', () {
       expect(LinkRoutingService.claimsToAdoptHost(''), isEmpty);
       expect(LinkRoutingService.claimsToAdoptHost('   '), isEmpty);
+    });
+  });
+
+  group('LinkRoutingService.claimsToAdoptUrl - non-default port', () {
+    test('default-port URL emits exact + wildcard like host variant', () {
+      final claims = LinkRoutingService.claimsToAdoptUrl(
+        Uri.parse('https://forum.invalid/thread/42'),
+      );
+      expect(claims, [
+        DomainClaim.exactHost('forum.invalid'),
+        DomainClaim.wildcardSubdomain('forum.invalid'),
+      ]);
+    });
+
+    test('non-default port URL emits a single port-bearing exactHost', () {
+      final claims = LinkRoutingService.claimsToAdoptUrl(
+        Uri.parse('http://localhost:8080/dashboard'),
+      );
+      expect(claims, [DomainClaim.exactHost('localhost:8080')]);
+    });
+
+    test('explicit default port is treated as default', () {
+      final claims = LinkRoutingService.claimsToAdoptUrl(
+        Uri.parse('https://example.org:443/'),
+      );
+      expect(claims, [
+        DomainClaim.exactHost('example.org'),
+        DomainClaim.wildcardSubdomain('example.org'),
+      ]);
     });
   });
 


### PR DESCRIPTION
## Summary
This PR extends the link routing system to properly handle URLs with non-default ports (e.g., `http://localhost:8080/`). Previously, port information was stripped during domain claim canonicalization, preventing sites from claiming specific port-bearing hosts. Now the system distinguishes between default-port URLs (which support wildcard/subdomain matching) and non-default port URLs (which only support exact host matching with the port included).

## Key Changes

- **Domain claim canonicalization** (`domain_claim.dart`):
  - Updated `_canon()` to preserve ports in `exactHost` claims while stripping them from `wildcardSubdomain` and `baseDomain` claims
  - Added proper IPv6 address handling with bracket wrapping when ports are present
  - Port stripping now respects the claim kind, allowing `exactHost('localhost:8080')` while normalizing wildcard claims to hostnames only

- **Link routing matching** (`link_routing_service.dart`):
  - Added `hostAuthority()` helper to compute the routing key (host or host:port) from a URL
  - Modified `_score()` to use the full host:port key for `exactHost` matching
  - Added port-awareness: `wildcardSubdomain` and `baseDomain` claims only match URLs with default ports
  - New `claimsToAdoptUrl()` method generates appropriate claims based on port presence:
    - Default-port URLs: emit both `exactHost` and `wildcardSubdomain` claims
    - Non-default port URLs: emit only the port-bearing `exactHost` claim

- **Site initialization** (`web_view_model.dart`):
  - Updated `effectiveDomainClaims` to synthesize port-bearing `exactHost` claims for sites initialized with non-default port URLs

- **Intent dispatch** (`link_intent_dispatch_engine.dart`):
  - Updated to use `claimsToAdoptUrl()` instead of `claimsToAdoptHost()` to preserve port information when binding or creating sites

- **UI improvements** (`settings.dart`, `link_handling_settings.dart`):
  - Moved domain claims editor to appear after location section for better UX
  - Converted notification subtitle to use `HintButton` for better information presentation
  - Added hint button to domain claims editor header

## Notable Implementation Details

- IPv6 addresses are wrapped in brackets when a port is appended (e.g., `[::1]:8080`) to maintain unambiguous parsing
- Default ports (80 for HTTP, 443 for HTTPS) are treated as "no port" for matching purposes, maintaining backward compatibility
- Wildcard and base domain claims explicitly reject non-default port URLs, preventing unintended matches on development/test servers
- Comprehensive test coverage added for port-bearing URLs, default port handling, and port collision scenarios

https://claude.ai/code/session_019EzNKjGHVcD7rSWGYh3gfD