### PR TITLE
Preserve imported HTML files on decrypt failure

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1366,6 +1366,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   /// activate, persist, and apply the current theme. Shared by the
   /// "create new site for URL" and "create new site for HTML" flows.
   Future<void> _registerNewSite(WebViewModel model) async {
+    // Apply theme before _setCurrentIndex triggers the first build —
+    // initialHtml reads currentTheme to pick the dark prelude for cached
+    // HTML (file:// imports especially, which never reload to live), and
+    // the model defaults to WebViewTheme.light otherwise.
+    await model.setTheme(_themeModeToWebViewTheme(_themeSettings.themeMode));
     setState(() {
       _webViewModels.add(model);
     });
@@ -1382,8 +1387,6 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     setState(() {});
     await _saveCurrentIndex();
     await _saveWebViewModels();
-    final theme = _themeModeToWebViewTheme(_themeSettings.themeMode);
-    await model.setTheme(theme);
   }
 
   Future<void> _saveWebViewModels() async {
@@ -2303,16 +2306,22 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       }
     }
 
-    // Set current index (async for cookie restoration)
-    await _setCurrentIndex(indexToRestore);
-    if (!mounted) return;
-    setState(() {}); // Trigger UI update after async operation
-
-    // Apply saved theme to all restored webviews
+    // Apply saved theme BEFORE _setCurrentIndex so the first build sees
+    // the right currentTheme — initialHtml reads it to pick the dark
+    // prelude for cached HTML (file:// imports especially, which never
+    // reload to live and so paint with whatever prelude the first build
+    // chose). Models default to WebViewTheme.light, so without this the
+    // first frame on a dark theme flashes white before the controller
+    // is created and re-applies via setController().
     final webViewTheme = _themeModeToWebViewTheme(_themeSettings.themeMode);
     for (var webViewModel in List.from(_webViewModels)) {
       await webViewModel.setTheme(webViewTheme);
     }
+
+    // Set current index (async for cookie restoration)
+    await _setCurrentIndex(indexToRestore);
+    if (!mounted) return;
+    setState(() {}); // Trigger UI update after async operation
 
     _startForegroundPollTimer();
 
@@ -3916,32 +3925,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       }
     }
 
-    setState(() {
-      _webViewModels.add(model);
-    });
-
-    final newSiteIndex = _webViewModels.length - 1;
-
-    // If a non-"All" webspace is currently selected, add the new site to it
-    if (_selectedWebspaceId != null && _selectedWebspaceId != kAllWebspaceId) {
-      final webspaceIndex = _webspaces.indexWhere((ws) => ws.id == _selectedWebspaceId);
-      if (webspaceIndex != -1) {
-        _webspaces[webspaceIndex].siteIndices.add(newSiteIndex);
-        await _saveWebspaces();
-      }
-    }
-
-    // Set current index (async for cookie handling)
-    await _setCurrentIndex(newSiteIndex);
-    if (!mounted) return;
-    setState(() {}); // Update UI after async operation
-
-    await _saveCurrentIndex();
-    await _saveWebViewModels();
-
-    // Apply current theme to new webview
-    final webViewTheme = _themeModeToWebViewTheme(_themeSettings.themeMode);
-    await model.setTheme(webViewTheme);
+    await _registerNewSite(model);
   }
 
   void _editSite(int index) async {

--- a/lib/services/html_import_storage.dart
+++ b/lib/services/html_import_storage.dart
@@ -102,6 +102,7 @@ class HtmlImportStorage {
 
     try {
       final files = await _storageDirectory!.list().toList();
+      var skipped = 0;
       for (final entity in files) {
         if (entity is File && entity.path.endsWith('.enc')) {
           try {
@@ -114,20 +115,26 @@ class HtmlImportStorage {
                 final html = decrypted.substring(newlineIndex + 1);
                 _memoryStore[siteId] = html;
               } else {
-                LogService.instance.log('HtmlImport', 'Discarded invalid import file: ${entity.path}', level: LogLevel.warning);
-                await entity.delete();
+                // Imports are the only copy of user-supplied data — never
+                // delete on parse failure. The fallback page renders if the
+                // bytes can't be loaded, but the file stays on disk in case
+                // the AES key is recoverable (e.g. flutter_secure_storage
+                // returns the original key on a later launch after a
+                // transient Android Keystore read failure).
+                LogService.instance.log('HtmlImport', 'Skipping invalid import file (kept on disk): ${entity.path}', level: LogLevel.warning);
+                skipped++;
               }
             } else {
-              LogService.instance.log('HtmlImport', 'Discarded undecryptable import file: ${entity.path}', level: LogLevel.warning);
-              await entity.delete();
+              LogService.instance.log('HtmlImport', 'Skipping undecryptable import file (kept on disk): ${entity.path}', level: LogLevel.warning);
+              skipped++;
             }
           } catch (e) {
-            LogService.instance.log('HtmlImport', 'Discarded corrupted import file: ${entity.path} ($e)', level: LogLevel.warning);
-            await entity.delete();
+            LogService.instance.log('HtmlImport', 'Skipping unreadable import file (kept on disk): ${entity.path} ($e)', level: LogLevel.warning);
+            skipped++;
           }
         }
       }
-      LogService.instance.log('HtmlImport', 'Pre-loaded ${_memoryStore.length} imported pages');
+      LogService.instance.log('HtmlImport', 'Pre-loaded ${_memoryStore.length} imported pages (skipped $skipped unreadable file(s))');
     } catch (e) {
       LogService.instance.log('HtmlImport', 'Error pre-loading imports: $e', level: LogLevel.error);
     }

--- a/openspec/specs/file-import-sites/spec.md
+++ b/openspec/specs/file-import-sites/spec.md
@@ -118,6 +118,18 @@ via `buildFileImportFallbackHtml` instead of trying to load the
 synthetic `file:///<filename>` URL, which chromium would reject as
 `ERR_FILE_NOT_FOUND`.
 
+#### Scenario: Decrypt failure keeps the file on disk
+
+**Given** an import file exists on disk but `_preloadAll` cannot
+decrypt it (transient `flutter_secure_storage` read miss generates a
+fresh AES key, on-disk corruption, …)
+**When** the preload runs
+**Then** the file MUST be left untouched on disk and only skipped
+in-memory. Imports are the only copy of user-supplied data, so a
+parse failure must not destroy them — if the original AES key is
+later recoverable, the bytes are still there. The user sees the
+fallback page in the meantime (per the previous scenario).
+
 #### Scenario: No page title fetch
 
 **Given** a site is created from an HTML file

--- a/test/html_import_storage_test.dart
+++ b/test/html_import_storage_test.dart
@@ -168,20 +168,44 @@ void main() {
   });
 
   group('HtmlImportStorage robustness', () {
-    test('corrupt entry on disk is reaped on preload, returns null on load',
+    test('corrupt entry stays on disk (not reaped) and returns null in memory',
         () async {
+      // Imports are user data, the only copy on the device — never delete
+      // on parse failure. The fallback page covers the unreadable case;
+      // the encrypted bytes stay in case the AES key recovers later
+      // (e.g. transient Android Keystore read failure on next launch).
       final s = await newStorage();
       await s.saveHtml('s', '<p>orig</p>', 'file:///s.html');
-      // Corrupt the on-disk file with garbage.
       final filePath = '${tempDir.path}/html_imports/s.enc';
       await File(filePath).writeAsString('not valid base64!!!');
 
-      // Fresh instance to drop in-memory state, then preload.
       final s2 = await newStorage();
       await s2.preloadAll();
 
       expect(s2.getHtmlSync('s'), isNull);
-      expect(await File(filePath).exists(), isFalse);
+      expect(await File(filePath).exists(), isTrue);
+    });
+
+    test('lost AES key does not destroy imports on preload', () async {
+      // Regression: a flutter_secure_storage read miss (Android Keystore
+      // reset, OEM bug, …) caused HtmlImportStorage to generate a fresh
+      // AES key on launch, fail to decrypt every existing import, and
+      // delete them — wiping the user's only copy of data they imported
+      // by hand. The bytes must survive.
+      final first = await newStorage();
+      await first.saveHtml('a', '<p>kept</p>', 'file:///a.html');
+      final filePath = '${tempDir.path}/html_imports/a.enc';
+      expect(await File(filePath).exists(), isTrue);
+
+      // Simulate the secure-storage key going missing between launches.
+      fakeStorage = MockFlutterSecureStorage();
+      final second = await newStorage();
+      await second.preloadAll();
+
+      // In-memory load is empty (decrypt failed under the new key),
+      // but the encrypted file MUST remain on disk.
+      expect(second.getHtmlSync('a'), isNull);
+      expect(await File(filePath).exists(), isTrue);
     });
 
     test('files larger than 10 MB are not saved', () async {


### PR DESCRIPTION
## Summary
This PR fixes a critical data loss issue where imported HTML files were being deleted when decryption failed, and also improves theme application timing during app initialization to prevent visual flashing.

## Key Changes

**Data Preservation (Primary Fix)**
- Modified `HtmlImportStorage.preloadAll()` to skip unreadable/undecryptable import files instead of deleting them
- Imported HTML files are now treated as irreplaceable user data — they remain on disk even if decryption fails, allowing recovery if the AES key becomes available later (e.g., after transient Android Keystore read failures)
- Updated logging to distinguish between skipped files and successfully loaded imports
- Added regression test covering the scenario where the secure storage key is lost between app launches

**Theme Application Timing**
- Moved theme application to occur *before* `_setCurrentIndex()` in both app initialization and new site registration flows
- This ensures the first build sees the correct `currentTheme`, preventing white flashes on dark theme launches
- The `initialHtml` property reads `currentTheme` to select the appropriate dark prelude for cached HTML (especially file:// imports that never reload)
- Refactored `_createSiteFromHtml()` to use the new `_registerNewSite()` helper method, eliminating duplicate theme-setting logic

**Test Updates**
- Updated `HtmlImportStorage` robustness tests to verify files are preserved rather than deleted
- Added new test case for the lost AES key scenario
- Updated spec documentation to formalize the file preservation requirement

## Implementation Details
- The fallback page (via `buildFileImportFallbackHtml`) handles the case where encrypted bytes cannot be decrypted, so users see a graceful error rather than a missing page
- Skipped files are logged with a count for debugging visibility
- Theme timing fix applies to both cold starts (app initialization) and hot operations (new site creation)

https://claude.ai/code/session_01SHh88eQVeJSecBw6xQ2evW