### PR TITLE
nested webview: try goBack() before exiting on system back gesture

### DIFF
--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -8,6 +8,7 @@ import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:webspace/screens/dev_tools.dart';
+import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/settings/location.dart';
 import 'package:webspace/settings/proxy.dart';
@@ -116,6 +117,12 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
   bool _isFindVisible = false;
   late bool _showUrlBar;
   FindMatchesResult findMatches = FindMatchesResult();
+
+  /// Race guard for the PopScope handler. Async swipe gestures (iOS edge
+  /// swipe) can re-enter `onPopInvokedWithResult` while the previous
+  /// invocation is still awaiting `goBack()` / URL diff, which would
+  /// double-pop the route or fire `goBack()` twice. Cleared in `finally`.
+  bool _isBackHandling = false;
 
   /// DevTools host for this nested webview. Captures console output and
   /// tracks the current URL/controller so the user can open Developer
@@ -350,7 +357,43 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return PopScope(
+      // Always intercept so we can try goBack() in the nested webview's own
+      // history before letting the route pop. Mirrors NAV-002 (main app):
+      // canGoBack() is unreliable for pushState SPAs, so we always attempt
+      // goBack() and decide via URL comparison.
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) async {
+        if (didPop || _isBackHandling) return;
+        _isBackHandling = true;
+        // Capture navigator before any awaits so we don't touch BuildContext
+        // across async gaps after the route may have been disposed.
+        final navigator = Navigator.of(context);
+        try {
+          final controller = _controller;
+          if (controller == null) {
+            if (mounted) navigator.pop();
+            return;
+          }
+          final urlBefore = (await controller.getUrl())?.toString();
+          await controller.goBack();
+          await Future.delayed(const Duration(milliseconds: 150));
+          if (!mounted) return;
+          final urlAfter = (await controller.getUrl())?.toString();
+          if (!mounted) return;
+          if (urlBefore == urlAfter) {
+            LogService.instance.log('Navigation',
+                'Nested back gesture: no history ($urlAfter), exiting nested');
+            navigator.pop();
+          } else {
+            LogService.instance.log('Navigation',
+                'Nested back gesture: navigated $urlBefore -> $urlAfter');
+          }
+        } finally {
+          _isBackHandling = false;
+        }
+      },
+      child: Scaffold(
       appBar: AppBar(
         title: Text(title ?? 'In-App WebView'),
         actions: [
@@ -491,6 +534,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
               ),
             ),
         ],
+      ),
       ),
     );
   }

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -410,6 +410,16 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
       },
       child: Scaffold(
       appBar: AppBar(
+        // Custom back button that bypasses PopScope by calling
+        // Navigator.pop directly (vs maybePop), so the AppBar back
+        // arrow always closes the nested screen. Only the system back
+        // gesture (iOS edge swipe / Android back) routes through
+        // PopScope and walks the nested webview's history first.
+        leading: IconButton(
+          icon: const BackButtonIcon(),
+          tooltip: MaterialLocalizations.of(context).backButtonTooltip,
+          onPressed: () => Navigator.of(context).pop(),
+        ),
         title: Text(title ?? 'In-App WebView'),
         actions: [
           const DownloadButton(),

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -360,8 +360,10 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
     return PopScope(
       // Always intercept so we can try goBack() in the nested webview's own
       // history before letting the route pop. Mirrors NAV-002 (main app):
-      // canGoBack() is unreliable for pushState SPAs, so we always attempt
-      // goBack() and decide via URL comparison.
+      // Android trusts canGoBack() directly (Chromium reports pushState
+      // correctly, and URL-diff false-positives on slow back navigations).
+      // iOS/macOS attempt goBack() unconditionally and decide via URL
+      // comparison since WKWebView's canGoBack() lies for pushState SPAs.
       canPop: false,
       onPopInvokedWithResult: (didPop, _) async {
         if (didPop || _isBackHandling) return;
@@ -373,6 +375,19 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
           final controller = _controller;
           if (controller == null) {
             if (mounted) navigator.pop();
+            return;
+          }
+          if (Platform.isAndroid) {
+            if (await controller.canGoBack()) {
+              await controller.goBack();
+              LogService.instance.log('Navigation',
+                  'Nested back gesture: navigated back (canGoBack)');
+            } else {
+              if (!mounted) return;
+              LogService.instance.log('Navigation',
+                  'Nested back gesture: no history, exiting nested');
+              navigator.pop();
+            }
             return;
           }
           final urlBefore = (await controller.getUrl())?.toString();

--- a/openspec/specs/navigation/spec.md
+++ b/openspec/specs/navigation/spec.md
@@ -216,16 +216,9 @@ The URL bar SHALL stay in sync with the current webview URL across all navigatio
 
 ### Requirement: NAV-008 - Nested WebView Back Gesture
 
-The system back gesture (Android back button, iOS edge swipe) on a nested
-`InAppWebViewScreen` SHALL navigate back in the nested webview's history when
-possible, and only pop the nested route when there is no back history.
+The system back gesture (Android back button, iOS edge swipe) on a nested `InAppWebViewScreen` SHALL navigate back in the nested webview's history when possible, and only pop the nested route when there is no back history.
 
-**Rationale:** Cross-domain links open a nested webview that maintains its own
-history. Without intercepting, the iOS swipe-back gesture exits the nested
-screen on the first swipe — discarding the nested page the user just clicked
-into and any subsequent in-page navigation. Mirroring NAV-002's URL-comparison
-fallback inside the nested screen lets users walk back through the nested
-history first, then exit.
+**Rationale:** Cross-domain links open a nested webview that maintains its own history. Without intercepting, the iOS swipe-back gesture exits the nested screen on the first swipe — discarding the nested page the user just clicked into and any subsequent in-page navigation. Mirroring NAV-002's URL-comparison fallback inside the nested screen lets users walk back through the nested history first, then exit.
 
 #### Scenario: Nested webview has back history
 

--- a/openspec/specs/navigation/spec.md
+++ b/openspec/specs/navigation/spec.md
@@ -218,29 +218,42 @@ The URL bar SHALL stay in sync with the current webview URL across all navigatio
 
 The system back gesture (Android back button, iOS edge swipe) on a nested `InAppWebViewScreen` SHALL navigate back in the nested webview's history when possible, and only pop the nested route when there is no back history.
 
-**Rationale:** Cross-domain links open a nested webview that maintains its own history. Without intercepting, the iOS swipe-back gesture exits the nested screen on the first swipe — discarding the nested page the user just clicked into and any subsequent in-page navigation. Mirroring NAV-002's URL-comparison fallback inside the nested screen lets users walk back through the nested history first, then exit.
+The decision policy SHALL mirror NAV-002: on Android, trust `canGoBack()` directly; on iOS/macOS, attempt `goBack()` unconditionally and decide via URL comparison with a 150ms settle.
 
-#### Scenario: Nested webview has back history
+**Rationale:** Cross-domain links open a nested webview that maintains its own history. Without intercepting, the iOS swipe-back gesture exits the nested screen on the first swipe — discarding the nested page the user just clicked into and any subsequent in-page navigation. Letting the user walk back through the nested history first, then exit on the second back gesture, matches user intent and the parent-app pattern.
 
-**Given** a nested `InAppWebViewScreen` is open
-**And** the user has navigated within it (e.g. via in-page links)
-**When** the user triggers the system back gesture (iOS edge swipe / Android back)
+#### Scenario: Nested webview has back history (Android)
+
+**Given** a nested `InAppWebViewScreen` is open on Android
+**And** `canGoBack()` returns `true`
+**When** the user presses the system back button
 **Then** the nested webview navigates back in its own history
 **And** the nested route stays open
 
-#### Scenario: Nested webview has no back history
+#### Scenario: Nested webview has no back history (Android)
 
-**Given** a nested `InAppWebViewScreen` is open at its initial URL
-**When** the user triggers the system back gesture
+**Given** a nested `InAppWebViewScreen` is open on Android
+**And** `canGoBack()` returns `false`
+**When** the user presses the system back button
 **Then** the nested route pops back to the parent webview
 
-#### Scenario: SPA with pushState in nested webview
+#### Scenario: Nested webview has back history (iOS/macOS)
 
-**Given** the nested webview has navigated via `history.pushState()`
+**Given** a nested `InAppWebViewScreen` is open on iOS or macOS
+**And** the user has navigated within it (e.g. via in-page links)
+**When** the user triggers the system back gesture (iOS edge swipe)
+**Then** `goBack()` is called regardless of `canGoBack()`
+**And** the URL is compared before/after with a 150ms delay
+**And** if the URL changed, the nested route stays open
+**And** if the URL did NOT change, the nested route pops
+
+#### Scenario: SPA with pushState in nested webview (iOS/macOS)
+
+**Given** the nested webview on iOS has navigated via `history.pushState()`
 **And** `canGoBack()` returns `false`
 **When** the user triggers the system back gesture
 **Then** `goBack()` is called regardless
-**And** URL comparison (150ms settle) decides whether the back succeeded
+**And** URL comparison decides whether the back succeeded
 **And** if the URL changed, the nested route stays open
 **And** if the URL did NOT change, the nested route pops
 

--- a/openspec/specs/navigation/spec.md
+++ b/openspec/specs/navigation/spec.md
@@ -181,6 +181,39 @@ The menu back button (in both portrait and landscape layouts) SHALL navigate bac
 
 ---
 
+### Requirement: NAV-006 - Pull-to-Refresh
+
+All webviews (main and nested) SHALL support pull-to-refresh to reload the current page.
+
+#### Scenario: Pull to refresh
+
+**Given** a webview is visible
+**When** the user pulls down on the page
+**Then** the page reloads
+**And** the pull-to-refresh indicator animates
+**And** the indicator stops when `onLoadStop` fires
+
+---
+
+### Requirement: NAV-007 - URL Bar Sync
+
+The URL bar SHALL stay in sync with the current webview URL across all navigation types, including BFCache restorations.
+
+#### Scenario: Standard navigation
+
+**Given** a webview navigates to a new page
+**When** `onLoadStop` fires
+**Then** the URL bar updates to the new URL
+
+#### Scenario: iOS back gesture with BFCache
+
+**Given** an iOS webview restores a page from BFCache via back/forward gesture
+**When** `onLoadStop` does NOT fire
+**Then** `onUpdateVisitedHistory` fires instead
+**And** the URL bar updates to the restored URL
+
+---
+
 ### Requirement: NAV-008 - Nested WebView Back Gesture
 
 The system back gesture (Android back button, iOS edge swipe) on a nested
@@ -224,39 +257,6 @@ history first, then exit.
 **When** the second invocation arrives while the first is still awaiting `goBack()` / URL diff
 **Then** the second invocation drops (guarded by `_isBackHandling`)
 **And** at most one `goBack()` per gesture is dispatched
-
----
-
-### Requirement: NAV-006 - Pull-to-Refresh
-
-All webviews (main and nested) SHALL support pull-to-refresh to reload the current page.
-
-#### Scenario: Pull to refresh
-
-**Given** a webview is visible
-**When** the user pulls down on the page
-**Then** the page reloads
-**And** the pull-to-refresh indicator animates
-**And** the indicator stops when `onLoadStop` fires
-
----
-
-### Requirement: NAV-007 - URL Bar Sync
-
-The URL bar SHALL stay in sync with the current webview URL across all navigation types, including BFCache restorations.
-
-#### Scenario: Standard navigation
-
-**Given** a webview navigates to a new page
-**When** `onLoadStop` fires
-**Then** the URL bar updates to the new URL
-
-#### Scenario: iOS back gesture with BFCache
-
-**Given** an iOS webview restores a page from BFCache via back/forward gesture
-**When** `onLoadStop` does NOT fire
-**Then** `onUpdateVisitedHistory` fires instead
-**And** the URL bar updates to the restored URL
 
 ---
 

--- a/openspec/specs/navigation/spec.md
+++ b/openspec/specs/navigation/spec.md
@@ -181,6 +181,52 @@ The menu back button (in both portrait and landscape layouts) SHALL navigate bac
 
 ---
 
+### Requirement: NAV-008 - Nested WebView Back Gesture
+
+The system back gesture (Android back button, iOS edge swipe) on a nested
+`InAppWebViewScreen` SHALL navigate back in the nested webview's history when
+possible, and only pop the nested route when there is no back history.
+
+**Rationale:** Cross-domain links open a nested webview that maintains its own
+history. Without intercepting, the iOS swipe-back gesture exits the nested
+screen on the first swipe — discarding the nested page the user just clicked
+into and any subsequent in-page navigation. Mirroring NAV-002's URL-comparison
+fallback inside the nested screen lets users walk back through the nested
+history first, then exit.
+
+#### Scenario: Nested webview has back history
+
+**Given** a nested `InAppWebViewScreen` is open
+**And** the user has navigated within it (e.g. via in-page links)
+**When** the user triggers the system back gesture (iOS edge swipe / Android back)
+**Then** the nested webview navigates back in its own history
+**And** the nested route stays open
+
+#### Scenario: Nested webview has no back history
+
+**Given** a nested `InAppWebViewScreen` is open at its initial URL
+**When** the user triggers the system back gesture
+**Then** the nested route pops back to the parent webview
+
+#### Scenario: SPA with pushState in nested webview
+
+**Given** the nested webview has navigated via `history.pushState()`
+**And** `canGoBack()` returns `false`
+**When** the user triggers the system back gesture
+**Then** `goBack()` is called regardless
+**And** URL comparison (150ms settle) decides whether the back succeeded
+**And** if the URL changed, the nested route stays open
+**And** if the URL did NOT change, the nested route pops
+
+#### Scenario: Rapid back gestures (race guard)
+
+**Given** the user triggers the back gesture twice in quick succession
+**When** the second invocation arrives while the first is still awaiting `goBack()` / URL diff
+**Then** the second invocation drops (guarded by `_isBackHandling`)
+**And** at most one `goBack()` per gesture is dispatched
+
+---
+
 ### Requirement: NAV-006 - Pull-to-Refresh
 
 All webviews (main and nested) SHALL support pull-to-refresh to reload the current page.

--- a/openspec/specs/navigation/spec.md
+++ b/openspec/specs/navigation/spec.md
@@ -216,11 +216,11 @@ The URL bar SHALL stay in sync with the current webview URL across all navigatio
 
 ### Requirement: NAV-008 - Nested WebView Back Gesture
 
-The system back gesture (Android back button, iOS edge swipe) on a nested `InAppWebViewScreen` SHALL navigate back in the nested webview's history when possible, and only pop the nested route when there is no back history.
+The **system back gesture** (Android back button, iOS edge swipe) on a nested `InAppWebViewScreen` SHALL navigate back in the nested webview's history when possible, and only pop the nested route when there is no back history. The decision policy SHALL mirror NAV-002: on Android, trust `canGoBack()` directly; on iOS/macOS, attempt `goBack()` unconditionally and decide via URL comparison with a 150ms settle.
 
-The decision policy SHALL mirror NAV-002: on Android, trust `canGoBack()` directly; on iOS/macOS, attempt `goBack()` unconditionally and decide via URL comparison with a 150ms settle.
+The **AppBar back button** on a nested `InAppWebViewScreen` SHALL always close the nested route immediately, regardless of the webview's history. It bypasses PopScope by calling `Navigator.pop` directly.
 
-**Rationale:** Cross-domain links open a nested webview that maintains its own history. Without intercepting, the iOS swipe-back gesture exits the nested screen on the first swipe — discarding the nested page the user just clicked into and any subsequent in-page navigation. Letting the user walk back through the nested history first, then exit on the second back gesture, matches user intent and the parent-app pattern.
+**Rationale:** Cross-domain links open a nested webview that maintains its own history. The two affordances serve different intents: the system back gesture (iOS edge swipe) is the user saying "go back in what I'm reading" — walking the nested history first matches Safari and prevents discarding pages on the first swipe. The AppBar back button is the user explicitly saying "leave this nested view and return to my parent site" — making it depend on history would surprise the user when the back arrow does nothing visible.
 
 #### Scenario: Nested webview has back history (Android)
 
@@ -256,6 +256,14 @@ The decision policy SHALL mirror NAV-002: on Android, trust `canGoBack()` direct
 **And** URL comparison decides whether the back succeeded
 **And** if the URL changed, the nested route stays open
 **And** if the URL did NOT change, the nested route pops
+
+#### Scenario: AppBar back button always closes nested
+
+**Given** a nested `InAppWebViewScreen` is open
+**And** the nested webview has back history
+**When** the user taps the AppBar back button (top-left arrow)
+**Then** the nested route pops immediately
+**And** `goBack()` is NOT called on the nested webview
 
 #### Scenario: Rapid back gestures (race guard)
 


### PR DESCRIPTION
iOS edge swipe (and Android back) on a nested InAppWebViewScreen now
walks back through the nested webview's own history first; the route
only pops when there is no back history. Mirrors NAV-002: distrust
canGoBack(), use a 150ms URL-diff. _isBackHandling guards rapid
gestures against double-pop / double-goBack.