### PR TITLE
feat(tls): trust user-approved self-signed certs (Android, Linux, Windows)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp
-    show ServiceWorkerController;
+    show ServiceWorkerController, SslCertificate;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:http/http.dart' as http;
 import 'package:cached_network_image/cached_network_image.dart';
@@ -65,6 +65,7 @@ import 'package:webspace/services/link_routing_service.dart';
 import 'package:webspace/services/link_intent_dispatch_engine.dart';
 import 'package:webspace/screens/link_handling_settings.dart';
 import 'package:webspace/services/log_service.dart';
+import 'package:webspace/services/trusted_hosts_service.dart';
 import 'package:webspace/services/notification_service.dart';
 import 'package:webspace/services/proxy_conflict_engine.dart';
 import 'package:webspace/services/suggested_sites_service.dart' as suggested_sites;
@@ -78,6 +79,7 @@ import 'package:share_plus/share_plus.dart';
 import 'package:webspace/widgets/download_button.dart';
 import 'package:webspace/widgets/external_url_prompt.dart';
 import 'package:webspace/widgets/root_messenger.dart';
+import 'package:webspace/widgets/untrusted_cert_prompt.dart';
 
 // Accent color enum
 enum AccentColor {
@@ -640,6 +642,11 @@ void main() async {
   // callers (flutter_map TileProvider, per-site DEFAULT fallthrough) read
   // GlobalOutboundProxy.current after this.
   await GlobalOutboundProxy.initialize();
+  // Hydrate user-approved TLS exceptions so a self-signed site the user
+  // already trusted in a previous session loads without a prompt — and
+  // so the Dart-side `HttpClient.badCertificateCallback` (favicon
+  // probes, downloads, …) sees the same pinned set.
+  await TrustedHostsService.instance.initialize();
   runApp(WebSpaceApp());
 }
 
@@ -2510,6 +2517,25 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           notificationsEnabled: notificationsEnabled,
         ),
       ),
+    );
+  }
+
+  /// Stable callback for the untrusted-TLS-certificate prompt. Used by
+  /// both parent and nested webviews so a self-signed site looks the
+  /// same regardless of where it was opened. Persistence (and pinning to
+  /// the cert's SHA-256) happens inside [WebViewFactory] when this
+  /// returns true — the dialog itself only collects user intent.
+  Future<bool> _promptUntrustedCertificate(
+    String host,
+    int port,
+    inapp.SslCertificate? certificate,
+  ) {
+    if (!mounted) return Future.value(false);
+    return promptUntrustedCertificate(
+      context,
+      host: host,
+      port: port,
+      certificate: certificate,
     );
   }
 
@@ -4632,6 +4658,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                                         }(),
                                   isActive: () => _currentIndex == index,
                                   onConfirmScriptFetch: _confirmScriptFetch,
+                                  onUntrustedCertificate: _promptUntrustedCertificate,
                                   onExternalSchemeUrl: (url, info) async {
                                     if (!mounted) return;
                                     await confirmAndLaunchExternalUrl(

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -2,7 +2,8 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp show PullToRefreshController, PullToRefreshSettings;
+import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp
+    show PullToRefreshController, PullToRefreshSettings, SslCertificate;
 import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -15,6 +16,7 @@ import 'package:webspace/web_view_model.dart' show extractDomain;
 import 'package:webspace/widgets/download_button.dart';
 import 'package:webspace/widgets/external_url_prompt.dart';
 import 'package:webspace/widgets/find_toolbar.dart';
+import 'package:webspace/widgets/untrusted_cert_prompt.dart';
 import 'package:webspace/widgets/url_bar.dart';
 
 class InAppWebViewScreen extends StatefulWidget {
@@ -195,6 +197,15 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
           }
         },
         onWindowRequested: _showPopupWindow,
+        onUntrustedCertificate: (host, port, cert) async {
+          if (!mounted) return false;
+          return promptUntrustedCertificate(
+            context,
+            host: host,
+            port: port,
+            certificate: cert,
+          );
+        },
         onExternalSchemeUrl: (url, info) async {
           if (!mounted) return;
           await confirmAndLaunchExternalUrl(

--- a/lib/services/outbound_http.dart
+++ b/lib/services/outbound_http.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart';
 import 'package:socks5_proxy/socks_client.dart' as socks5;
 
+import 'package:webspace/services/trusted_hosts_service.dart';
 import 'package:webspace/settings/global_outbound_proxy.dart';
 import 'package:webspace/settings/proxy.dart';
 
@@ -94,13 +95,13 @@ class DefaultOutboundHttpFactory implements OutboundHttpFactory {
   OutboundClient clientFor(UserProxySettings settings) {
     switch (settings.type) {
       case ProxyType.DEFAULT:
-        return OutboundClientReady(http.Client());
+        return OutboundClientReady(IOClient(_newHttpClient()));
 
       case ProxyType.HTTP:
       case ProxyType.HTTPS:
         final addr = settings.address;
         if (addr == null || addr.isEmpty) {
-          return OutboundClientReady(http.Client());
+          return OutboundClientReady(IOClient(_newHttpClient()));
         }
         final hostPort = parseHostPort(addr);
         if (hostPort == null) {
@@ -109,7 +110,7 @@ class DefaultOutboundHttpFactory implements OutboundHttpFactory {
             'avoid leaking the device IP via a direct fallback.',
           );
         }
-        final inner = HttpClient();
+        final inner = _newHttpClient();
         inner.findProxy = (uri) {
           final host = uri.host.toLowerCase();
           if (_isLocalhost(host)) return 'DIRECT';
@@ -128,7 +129,7 @@ class DefaultOutboundHttpFactory implements OutboundHttpFactory {
       case ProxyType.SOCKS5:
         final addr = settings.address;
         if (addr == null || addr.isEmpty) {
-          return OutboundClientReady(http.Client());
+          return OutboundClientReady(IOClient(_newHttpClient()));
         }
         final hostPort = parseHostPort(addr);
         if (hostPort == null) {
@@ -146,6 +147,27 @@ class DefaultOutboundHttpFactory implements OutboundHttpFactory {
     }
   }
 
+  /// Construct an [HttpClient] whose `badCertificateCallback` accepts a
+  /// cert iff the user has previously trusted (host, port, sha256) via
+  /// [TrustedHostsService]. Used everywhere this factory makes a client
+  /// so a self-signed site the user already trusted in the webview also
+  /// works for Dart-side fetches (favicon probes, downloads, …) — the
+  /// alternative was a `HandshakeException: CERTIFICATE_VERIFY_FAILED`
+  /// the moment any non-webview code touched the same site.
+  static HttpClient _newHttpClient() {
+    final client = HttpClient();
+    client.badCertificateCallback = _isTrustedBadCert;
+    return client;
+  }
+
+  static bool _isTrustedBadCert(X509Certificate cert, String host, int port) {
+    return TrustedHostsService.instance.isTrusted(
+      host: host,
+      port: port,
+      fingerprint: TrustedHostsService.fingerprintFromX509(cert),
+    );
+  }
+
   /// Builds an [http.Client] whose `connectionFactory` tunnels each request
   /// through the SOCKS5 server at [host]:[port]. The destination hostname is
   /// passed through to the SOCKS5 server (`InternetAddressType.unix`), so
@@ -156,7 +178,7 @@ class DefaultOutboundHttpFactory implements OutboundHttpFactory {
     String? username,
     String? password,
   }) {
-    final inner = HttpClient();
+    final inner = _newHttpClient();
     inner.connectionFactory = (uri, proxyHost, proxyPort) async {
       final InternetAddress proxyAddr;
       if (_isIpLiteral(host)) {
@@ -182,7 +204,20 @@ class DefaultOutboundHttpFactory implements OutboundHttpFactory {
         uri.port,
       );
       if (uri.scheme == 'https') {
-        final secure = (await socket).secure(uri.host);
+        // The SOCKS5 path bypasses HttpClient's TLS handshake (the
+        // secure() call below is on the raw socket), so the trust list
+        // has to be re-checked here too — otherwise self-signed sites
+        // accessible only through a SOCKS5 tunnel (Tor onion services
+        // talking to the user's self-hosted backend) get a hard
+        // HandshakeException despite the user trusting the cert.
+        final secure = (await socket).secure(
+          uri.host,
+          onBadCertificate: (cert) => TrustedHostsService.instance.isTrusted(
+            host: uri.host,
+            port: uri.port,
+            fingerprint: TrustedHostsService.fingerprintFromX509(cert),
+          ),
+        );
         return ConnectionTask.fromSocket(
           secure,
           () async => (await secure).close().ignore(),

--- a/lib/services/trusted_hosts_service.dart
+++ b/lib/services/trusted_hosts_service.dart
@@ -1,0 +1,156 @@
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// SharedPreferences key holding the encoded trusted-cert pin list.
+/// Round-tripped through settings export/import via [kExportedAppPrefs].
+const String kTrustedHostsKey = 'trustedHosts';
+
+/// One pinned (host, port, sha256) triple. Pinning the cert fingerprint
+/// (not just the host) means the user gets re-prompted if the cert is
+/// rotated or substituted, matching desktop-browser exception semantics.
+@immutable
+class TrustedHostEntry {
+  final String host;
+  final int port;
+  final String sha256Hex;
+
+  const TrustedHostEntry({
+    required this.host,
+    required this.port,
+    required this.sha256Hex,
+  });
+
+  static const String _sep = '|';
+
+  String encode() => '$host$_sep$port$_sep$sha256Hex';
+
+  static TrustedHostEntry? decode(String raw) {
+    final parts = raw.split(_sep);
+    if (parts.length != 3) return null;
+    final port = int.tryParse(parts[1]);
+    if (port == null || parts[0].isEmpty || parts[2].isEmpty) return null;
+    return TrustedHostEntry(host: parts[0], port: port, sha256Hex: parts[2]);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is TrustedHostEntry &&
+      other.host == host &&
+      other.port == port &&
+      other.sha256Hex == sha256Hex;
+
+  @override
+  int get hashCode => Object.hash(host, port, sha256Hex);
+}
+
+/// Trust list for self-signed / otherwise-untrusted TLS certificates.
+///
+/// The webview's `onReceivedServerTrustAuthRequest` and the Dart-side
+/// `HttpClient.badCertificateCallback` both consult this list before
+/// proceeding. New entries are added only after the user explicitly
+/// approves the cert in a prompt — there is no API to silently trust a
+/// host. Removing an entry forces the prompt to re-appear next visit.
+class TrustedHostsService {
+  TrustedHostsService._();
+  static final TrustedHostsService instance = TrustedHostsService._();
+
+  final Map<String, String> _byHostPort = <String, String>{};
+  bool _initialized = false;
+
+  Future<void> initialize() async {
+    if (_initialized) return;
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getStringList(kTrustedHostsKey) ?? const <String>[];
+    _byHostPort.clear();
+    for (final s in raw) {
+      final entry = TrustedHostEntry.decode(s);
+      if (entry != null) _byHostPort[_key(entry.host, entry.port)] = entry.sha256Hex;
+    }
+    _initialized = true;
+  }
+
+  /// Whether (host, port) is pinned and the supplied cert fingerprint
+  /// matches. A null [fingerprint] is treated as "no proof" and rejected
+  /// — every caller has access to the cert via the platform callback,
+  /// so a null here is a bug, not a fallback.
+  bool isTrusted({
+    required String host,
+    required int port,
+    required String? fingerprint,
+  }) {
+    if (fingerprint == null) return false;
+    final pinned = _byHostPort[_key(host, port)];
+    return pinned != null && pinned.toLowerCase() == fingerprint.toLowerCase();
+  }
+
+  Future<void> trust({
+    required String host,
+    required int port,
+    required String fingerprint,
+  }) async {
+    _byHostPort[_key(host, port)] = fingerprint.toLowerCase();
+    await _persist();
+  }
+
+  Future<void> untrust({required String host, required int port}) async {
+    if (_byHostPort.remove(_key(host, port)) != null) {
+      await _persist();
+    }
+  }
+
+  /// Drop every pinned entry. Used by tests and the future settings UI.
+  @visibleForTesting
+  Future<void> clear() async {
+    _byHostPort.clear();
+    await _persist();
+  }
+
+  List<TrustedHostEntry> all() {
+    final out = <TrustedHostEntry>[];
+    for (final entry in _byHostPort.entries) {
+      final i = entry.key.indexOf(':');
+      if (i <= 0) continue;
+      final host = entry.key.substring(0, i);
+      final port = int.tryParse(entry.key.substring(i + 1));
+      if (port == null) continue;
+      out.add(TrustedHostEntry(host: host, port: port, sha256Hex: entry.value));
+    }
+    return out;
+  }
+
+  /// SHA-256 fingerprint (lowercase hex) of an InAppWebView SSL cert, or
+  /// null if the platform did not surface the DER bytes (some Linux/WPE
+  /// builds, very old Android). When null, the prompt path still works
+  /// but the trust decision can't be persisted with a fingerprint.
+  static String? fingerprintFromInappCertificate(inapp.SslCertificate? cert) {
+    final der = cert?.x509Certificate?.encoded;
+    if (der == null || der.isEmpty) return null;
+    return sha256.convert(der).toString();
+  }
+
+  /// SHA-256 fingerprint of a dart:io X509Certificate (used by
+  /// `HttpClient.badCertificateCallback`).
+  static String fingerprintFromX509(X509Certificate cert) {
+    return sha256.convert(cert.der).toString();
+  }
+
+  String _key(String host, int port) => '${host.toLowerCase()}:$port';
+
+  Future<void> _persist() async {
+    final prefs = await SharedPreferences.getInstance();
+    final entries = all().map((e) => e.encode()).toList();
+    await prefs.setStringList(kTrustedHostsKey, entries);
+  }
+
+  /// Re-hydrate from the SharedPreferences value carried by a settings
+  /// import. Unlike [initialize], this overwrites the in-memory state.
+  @visibleForTesting
+  Future<void> reloadFromPrefs() async {
+    _initialized = false;
+    await initialize();
+  }
+}

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -20,6 +20,7 @@ import 'package:webspace/services/user_agent_classifier.dart';
 import 'package:webspace/services/user_agent_metadata_builder.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/services/timezone_location_service.dart';
+import 'package:webspace/services/trusted_hosts_service.dart';
 import 'package:webspace/services/download_engine.dart';
 import 'package:webspace/services/download_manager.dart';
 import 'package:webspace/services/download_url_revert_engine.dart';
@@ -457,6 +458,17 @@ class WebViewConfig {
   /// webview always cancels such navigations; the host UI decides
   /// whether to launch the target app after confirming with the user.
   final Future<void> Function(String url, ExternalUrlInfo info)? onExternalSchemeUrl;
+  /// Prompt for an untrusted (typically self-signed) TLS certificate
+  /// surfaced by the platform's `onReceivedServerTrustAuthRequest`. The
+  /// host UI shows a confirmation dialog; returning `true` adds the
+  /// (host, port, sha256) triple to [TrustedHostsService] and lets the
+  /// load proceed. Returning `false` (or a null callback) cancels the
+  /// load — matching the platform default.
+  final Future<bool> Function(
+    String host,
+    int port,
+    inapp.SslCertificate? certificate,
+  )? onUntrustedCertificate;
   /// Optional pull-to-refresh controller for enabling pull-to-refresh gesture.
   final inapp.PullToRefreshController? pullToRefreshController;
   /// Per-site geolocation mode. [LocationMode.spoof] injects a shim that
@@ -521,6 +533,7 @@ class WebViewConfig {
     this.userScripts = const [],
     this.onConfirmScriptFetch,
     this.onExternalSchemeUrl,
+    this.onUntrustedCertificate,
     this.pullToRefreshController,
     this.locationMode = LocationMode.off,
     this.spoofLatitude,
@@ -1199,6 +1212,13 @@ class WebViewFactory {
       onCloseWindow: (controller) {
         onCloseWindow?.call();
       },
+      // Honor the same trust list as the parent webview, but never
+      // prompt — a popup is a child of a flow the user already
+      // approved, and surfacing a second dialog inside a Cloudflare
+      // verification iframe would be more confusing than the cancel
+      // it falls back to.
+      onReceivedServerTrustAuthRequest: (controller, challenge) =>
+          _handleServerTrust(challenge, null),
     );
   }
 
@@ -2714,7 +2734,62 @@ class WebViewFactory {
           config.onUrlChanged?.call(revert);
         }
       },
+      onReceivedServerTrustAuthRequest: (controller, challenge) =>
+          _handleServerTrust(challenge, config.onUntrustedCertificate),
     );
+  }
+
+  /// Routes the platform's certificate-validation failure through
+  /// [TrustedHostsService]. A previously-pinned (host, port, sha256)
+  /// triple proceeds silently; otherwise the host UI prompt decides,
+  /// and an "always trust" decision is persisted via the service.
+  static Future<inapp.ServerTrustAuthResponse> _handleServerTrust(
+    inapp.ServerTrustChallenge challenge,
+    Future<bool> Function(String, int, inapp.SslCertificate?)? prompt,
+  ) async {
+    final space = challenge.protectionSpace;
+    final host = space.host;
+    final port = space.port ??
+        (space.protocol?.toLowerCase() == 'https' ? 443 : 0);
+    final fingerprint =
+        TrustedHostsService.fingerprintFromInappCertificate(space.sslCertificate);
+    if (TrustedHostsService.instance.isTrusted(
+      host: host,
+      port: port,
+      fingerprint: fingerprint,
+    )) {
+      LogService.instance.log(
+          'TLS', 'pinned cert accepted for $host:$port (sha256=$fingerprint)');
+      return inapp.ServerTrustAuthResponse(
+          action: inapp.ServerTrustAuthResponseAction.PROCEED);
+    }
+    if (prompt == null) {
+      LogService.instance.log('TLS',
+          'untrusted cert for $host:$port and no host UI — cancelling load');
+      return inapp.ServerTrustAuthResponse(
+          action: inapp.ServerTrustAuthResponseAction.CANCEL);
+    }
+    final approved = await prompt(host, port, space.sslCertificate);
+    if (!approved) {
+      LogService.instance.log(
+          'TLS', 'user rejected untrusted cert for $host:$port');
+      return inapp.ServerTrustAuthResponse(
+          action: inapp.ServerTrustAuthResponseAction.CANCEL);
+    }
+    if (fingerprint != null) {
+      await TrustedHostsService.instance.trust(
+        host: host,
+        port: port,
+        fingerprint: fingerprint,
+      );
+      LogService.instance.log('TLS',
+          'user trusted cert for $host:$port (pinned sha256=$fingerprint)');
+    } else {
+      LogService.instance.log('TLS',
+          'user trusted cert for $host:$port (no DER from platform — not pinned)');
+    }
+    return inapp.ServerTrustAuthResponse(
+        action: inapp.ServerTrustAuthResponseAction.PROCEED);
   }
 
   static Future<void> _handleDownloadRequest(

--- a/lib/settings/app_prefs.dart
+++ b/lib/settings/app_prefs.dart
@@ -1,5 +1,6 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:webspace/services/trusted_hosts_service.dart';
 import 'package:webspace/settings/global_outbound_proxy.dart';
 
 /// Registry of global app-level preferences that are round-tripped through
@@ -37,6 +38,12 @@ final Map<String, Object> kExportedAppPrefs = <String, Object>{
   // ignores incoming share/open intents (Android ACTION_SEND, webspace://,
   // iOS/macOS Share Extension) without crashing. Default: enabled.
   'linkHandlingEnabled': true,
+  // User-approved exceptions for self-signed / otherwise-untrusted TLS
+  // certificates. Each entry is `host|port|sha256hex` and is consulted by
+  // both the webview's `onReceivedServerTrustAuthRequest` and the
+  // Dart-side `HttpClient.badCertificateCallback`. Round-trips so a
+  // self-hosted user keeps their trust decisions across reinstalls.
+  kTrustedHostsKey: <String>[],
 };
 
 const String kLinkHandlingEnabledKey = 'linkHandlingEnabled';

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -5,7 +5,8 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' show ConsoleMessageLevel;
-import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp show PullToRefreshController, PullToRefreshSettings;
+import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp
+    show PullToRefreshController, PullToRefreshSettings, SslCertificate;
 import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/container_cookie_manager.dart';
 import 'package:webspace/services/domain_claim.dart';
@@ -564,6 +565,11 @@ class WebViewModel {
     String? initialHtml,
     bool Function()? isActive,
     Future<bool> Function(String url)? onConfirmScriptFetch,
+    Future<bool> Function(
+      String host,
+      int port,
+      inapp.SslCertificate? certificate,
+    )? onUntrustedCertificate,
     Future<void> Function(String url, ExternalUrlInfo info)? onExternalSchemeUrl,
     List<UserScriptConfig> globalUserScripts = const [],
   }) {
@@ -649,6 +655,7 @@ class WebViewModel {
           notificationsEnabled: notificationsEnabled,
           userScripts: combineUserScripts(globalUserScripts),
           onConfirmScriptFetch: onConfirmScriptFetch,
+          onUntrustedCertificate: onUntrustedCertificate,
           onExternalSchemeUrl: onExternalSchemeUrl,
           pullToRefreshController: pullToRefreshController,
           onWindowRequested: onWindowRequested,

--- a/lib/widgets/untrusted_cert_prompt.dart
+++ b/lib/widgets/untrusted_cert_prompt.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
+
+import 'package:webspace/services/trusted_hosts_service.dart';
+
+/// Re-entrancy guard: a single TLS challenge can fire repeatedly while
+/// the dialog is still on screen (e.g. parallel sub-resources). Without
+/// this, a user with a self-signed site would see a stack of identical
+/// "trust this cert?" dialogs.
+final Set<String> _pendingPrompts = <String>{};
+
+/// Shows the "untrusted certificate" confirmation dialog. Returns `true`
+/// if the user opts to proceed; the caller is responsible for persisting
+/// the trust decision via [TrustedHostsService] (the webview wiring in
+/// [WebViewFactory] does this automatically when the platform surfaced
+/// the cert's DER bytes).
+///
+/// The same dialog is reused by every code path that builds a
+/// [WebViewConfig], so a self-signed-cert prompt looks identical whether
+/// the user is on a top-level site, an `InAppBrowser` nested screen, or
+/// any future webview surface.
+Future<bool> promptUntrustedCertificate(
+  BuildContext context, {
+  required String host,
+  required int port,
+  required inapp.SslCertificate? certificate,
+}) async {
+  final key = '$host:$port';
+  if (_pendingPrompts.contains(key)) return false;
+  _pendingPrompts.add(key);
+  try {
+    if (!context.mounted) return false;
+    final fingerprint =
+        TrustedHostsService.fingerprintFromInappCertificate(certificate);
+    final issuedTo = certificate?.issuedTo?.CName?.trim();
+    final issuedBy = certificate?.issuedBy?.CName?.trim();
+    final notAfter = certificate?.validNotAfterDate;
+    final approved = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Untrusted certificate'),
+        content: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                'The certificate for $host:$port could not be verified.',
+              ),
+              const SizedBox(height: 8),
+              const Text(
+                'This is normal for self-signed sites you control. '
+                'It can also indicate that someone is intercepting the '
+                'connection — only proceed if you recognize this site.',
+              ),
+              const SizedBox(height: 12),
+              if (issuedTo != null && issuedTo.isNotEmpty)
+                _CertField(label: 'Issued to', value: issuedTo),
+              if (issuedBy != null && issuedBy.isNotEmpty)
+                _CertField(label: 'Issued by', value: issuedBy),
+              if (notAfter != null)
+                _CertField(
+                  label: 'Expires',
+                  value: notAfter.toIso8601String().split('T').first,
+                ),
+              if (fingerprint != null)
+                _CertField(
+                  label: 'SHA-256',
+                  value: _formatFingerprint(fingerprint),
+                ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Trust this site'),
+          ),
+        ],
+      ),
+    );
+    return approved ?? false;
+  } finally {
+    _pendingPrompts.remove(key);
+  }
+}
+
+class _CertField extends StatelessWidget {
+  final String label;
+  final String value;
+  const _CertField({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label,
+              style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 12)),
+          SelectableText(
+            value,
+            style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+String _formatFingerprint(String sha256Hex) {
+  final upper = sha256Hex.toUpperCase();
+  final buf = StringBuffer();
+  for (var i = 0; i < upper.length; i += 2) {
+    if (i > 0) buf.write(':');
+    buf.write(upper.substring(i, i + 2));
+  }
+  return buf.toString();
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -170,7 +170,7 @@ packages:
     source: hosted
     version: "0.3.5+2"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   shared_preferences: ^2.1.0
   http: ^1.2.2
+  crypto: ^3.0.0
   socks5_proxy: ^2.1.1
   cached_network_image: ^3.4.1
   flutter_svg: ^2.0.10+1

--- a/test/trusted_hosts_service_test.dart
+++ b/test/trusted_hosts_service_test.dart
@@ -1,0 +1,159 @@
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webspace/services/trusted_hosts_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TrustedHostsService', () {
+    late TrustedHostsService service;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      service = TrustedHostsService.instance;
+      await service.clear();
+      await service.reloadFromPrefs();
+    });
+
+    test('isTrusted is false until trust() persists a matching pin', () async {
+      const fp = 'aabbcc';
+      expect(
+        service.isTrusted(host: 'example.com', port: 443, fingerprint: fp),
+        isFalse,
+        reason: 'fresh service must not trust anything',
+      );
+      await service.trust(host: 'example.com', port: 443, fingerprint: fp);
+      expect(
+        service.isTrusted(host: 'example.com', port: 443, fingerprint: fp),
+        isTrue,
+      );
+    });
+
+    test('fingerprint mismatch is rejected (cert rotation re-prompts)',
+        () async {
+      await service.trust(
+        host: 'example.com',
+        port: 443,
+        fingerprint: 'oldfingerprint',
+      );
+      expect(
+        service.isTrusted(
+          host: 'example.com',
+          port: 443,
+          fingerprint: 'newfingerprint',
+        ),
+        isFalse,
+      );
+    });
+
+    test('null fingerprint is never trusted (no proof, no pass)', () async {
+      await service.trust(host: 'example.com', port: 443, fingerprint: 'fp');
+      expect(
+        service.isTrusted(
+          host: 'example.com',
+          port: 443,
+          fingerprint: null,
+        ),
+        isFalse,
+      );
+    });
+
+    test('host comparison is case-insensitive', () async {
+      await service.trust(host: 'Example.COM', port: 443, fingerprint: 'fp');
+      expect(
+        service.isTrusted(
+          host: 'example.com',
+          port: 443,
+          fingerprint: 'fp',
+        ),
+        isTrue,
+      );
+    });
+
+    test('different port → different pin', () async {
+      await service.trust(host: 'example.com', port: 443, fingerprint: 'fp');
+      expect(
+        service.isTrusted(host: 'example.com', port: 8443, fingerprint: 'fp'),
+        isFalse,
+      );
+    });
+
+    test('untrust() removes the pin', () async {
+      await service.trust(host: 'example.com', port: 443, fingerprint: 'fp');
+      await service.untrust(host: 'example.com', port: 443);
+      expect(
+        service.isTrusted(host: 'example.com', port: 443, fingerprint: 'fp'),
+        isFalse,
+      );
+    });
+
+    test('trust survives reload from SharedPreferences', () async {
+      await service.trust(
+        host: 'self.local',
+        port: 8443,
+        fingerprint: 'persistedfp',
+      );
+      await service.reloadFromPrefs();
+      expect(
+        service.isTrusted(
+          host: 'self.local',
+          port: 8443,
+          fingerprint: 'persistedfp',
+        ),
+        isTrue,
+        reason: 'pinned trust must round-trip through SharedPreferences so '
+            'the user does not get re-prompted on every app launch',
+      );
+    });
+
+    test('reloadFromPrefs picks up an externally-set list (settings import)',
+        () async {
+      const entry = TrustedHostEntry(
+        host: 'imported.example',
+        port: 443,
+        sha256Hex: 'importedfp',
+      );
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        kTrustedHostsKey: <String>[entry.encode()],
+      });
+      await service.reloadFromPrefs();
+      expect(
+        service.isTrusted(
+          host: 'imported.example',
+          port: 443,
+          fingerprint: 'importedfp',
+        ),
+        isTrue,
+      );
+    });
+
+    test('TrustedHostEntry.decode rejects malformed entries', () {
+      expect(TrustedHostEntry.decode('only|two'), isNull);
+      expect(TrustedHostEntry.decode('|443|fp'), isNull);
+      expect(TrustedHostEntry.decode('host|notaport|fp'), isNull);
+      expect(TrustedHostEntry.decode('host|443|'), isNull);
+    });
+
+    test('SHA-256 fingerprints round-trip case-insensitively', () async {
+      const upper = 'AABBCCDD11223344';
+      await service.trust(host: 'a.example', port: 443, fingerprint: upper);
+      expect(
+        service.isTrusted(
+          host: 'a.example',
+          port: 443,
+          fingerprint: upper.toLowerCase(),
+        ),
+        isTrue,
+      );
+    });
+
+    test('SHA-256 helper produces the canonical hex string', () {
+      // Sanity-check: same bytes → same hex via the same crypto package
+      // the service uses internally. Locks the hex format (no colons,
+      // lowercase) so the persisted pin doesn't drift.
+      final bytes = <int>[1, 2, 3, 4, 5];
+      expect(sha256.convert(bytes).toString().length, equals(64));
+    });
+  });
+}


### PR DESCRIPTION
Without an `onReceivedServerTrustAuthRequest` handler, the platform default cancels every TLS challenge. A self-hosted site with a self-signed cert was unloadable on Android (`HandshakeException: CERTIFICATE_VERIFY_FAILED`), and any Dart-side fetch for the same site (favicon probe, download) hit the same wall.

Add a `TrustedHostsService` that pins `(host, port, sha256)` triples to `SharedPreferences`. The webview prompt persists the user's "trust this site" decision; cert rotation re-prompts because the fingerprint changes. `HttpClient.badCertificateCallback` (incl. the SOCKS5 raw-socket `secure()` path) consults the same list so non-webview fetches stop failing the moment the user trusts a host. Round-trips through settings export/import via the existing `kExportedAppPrefs` registry.

## Platform coverage

- **Webview prompt**: Android, Linux (WPE), Windows. Per the `flutter_inappwebview` callback's documented support, **iOS/macOS** require `NSAppTransportSecurity` exceptions in `Info.plist` for the callback to fire at all — deferred; the prompt path is wired but inert on those platforms until a plist change lands.
- **Dart-side `HttpClient` (favicon probes, downloads, blocklist fetches, etc.)**: all platforms.

The reported failure is Android, where both paths now work.