### PR TITLE
Enable cleartext traffic for Android application

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
     <application
         android:label="Webspace"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
## Summary
This change enables cleartext (unencrypted HTTP) traffic for the Android application by adding the `android:usesCleartextTraffic="true"` attribute to the application manifest.

## Changes Made
- Added `android:usesCleartextTraffic="true"` to the `<application>` tag in AndroidManifest.xml

## Implementation Details
By default, Android 9 (API level 28) and higher block cleartext traffic for security reasons. This change explicitly allows the application to communicate over unencrypted HTTP connections, which may be necessary for:
- Development/testing environments
- Legacy backend services that don't support HTTPS
- Local network communication

**Note:** This should be used cautiously in production environments as it reduces security. Consider using HTTPS or restricting cleartext traffic to specific domains via a network security configuration file when possible.

https://claude.ai/code/session_01NCCeVNuWWjp2tyQDZ7SdJ8