### PR TITLE
Add unsaved changes detection to settings screens

### DIFF
--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -109,6 +109,13 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
   late TextEditingController _outboundProxyPasswordController;
   bool _outboundProxyShowCredentials = false;
   bool _outboundProxyObscurePassword = true;
+  /// Snapshot of the outbound proxy fields at last persisted state. Most
+  /// of this screen auto-applies on change, but the proxy text fields only
+  /// flush via `onEditingComplete` / `onFieldSubmitted`, so a user who
+  /// types a partial value and pops via the system back gesture would
+  /// silently lose the edit. [_isOutboundProxyDirty] drives the PopScope
+  /// guard so we prompt instead.
+  late Map<String, Object?> _initialOutboundProxy;
 
   // DNS Blocklist state
   bool _isDownloadingBlocklist = false;
@@ -152,6 +159,10 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
       text: _outboundProxy.password ?? '',
     );
     _outboundProxyShowCredentials = _outboundProxy.hasCredentials;
+    _initialOutboundProxy = _currentOutboundProxySnapshot();
+    _outboundProxyAddressController.addListener(_onProxyFieldChanged);
+    _outboundProxyUsernameController.addListener(_onProxyFieldChanged);
+    _outboundProxyPasswordController.addListener(_onProxyFieldChanged);
     _spinController = AnimationController(
       vsync: this,
       duration: const Duration(seconds: 1),
@@ -257,6 +268,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
     await GlobalOutboundProxy.update(settings);
     setState(() {
       _outboundProxy = settings;
+      _initialOutboundProxy = _currentOutboundProxySnapshot();
     });
     // Force every loaded webview to be rebuilt so the new global proxy
     // takes effect immediately. Without this the change only applies to
@@ -284,6 +296,53 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
         const SnackBar(content: Text('Outbound proxy updated')),
       );
     }
+  }
+
+  void _onProxyFieldChanged() {
+    if (mounted) setState(() {});
+  }
+
+  Map<String, Object?> _currentOutboundProxySnapshot() => {
+        'type': _outboundProxy.type,
+        'address': _outboundProxyAddressController.text,
+        'username': _outboundProxyUsernameController.text,
+        'password': _outboundProxyPasswordController.text,
+        'showCreds': _outboundProxyShowCredentials,
+      };
+
+  bool _isOutboundProxyDirty() {
+    final cur = _currentOutboundProxySnapshot();
+    for (final key in _initialOutboundProxy.keys) {
+      if (cur[key] != _initialOutboundProxy[key]) return true;
+    }
+    return false;
+  }
+
+  Future<bool> _confirmDiscardProxy() async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Discard changes?'),
+        content: const Text(
+          'You have unsaved changes to the outbound proxy. '
+          'Leaving now will discard them.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Keep editing'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text(
+              'Discard',
+              style: TextStyle(color: Colors.red),
+            ),
+          ),
+        ],
+      ),
+    );
+    return result ?? false;
   }
 
   Future<void> _loadBlocklistState() async {
@@ -571,7 +630,21 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return PopScope(
+      canPop: !_isOutboundProxyDirty(),
+      onPopInvokedWithResult: (didPop, _) async {
+        if (didPop) return;
+        final navigator = Navigator.of(context);
+        final discard = await _confirmDiscardProxy();
+        if (discard != true || !mounted) return;
+        setState(() {
+          _initialOutboundProxy = _currentOutboundProxySnapshot();
+        });
+        await WidgetsBinding.instance.endOfFrame;
+        if (!mounted) return;
+        navigator.pop();
+      },
+      child: Scaffold(
       appBar: AppBar(
         title: const Text('App Settings'),
       ),
@@ -1309,6 +1382,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
             },
           ),
         ],
+      ),
       ),
     );
   }

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -148,6 +148,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
   bool _isLiveLocation = false;
   late WebRtcPolicy _webRtcPolicy;
 
+  /// Snapshot of every form field captured after [_loadFromModel] (and again
+  /// after a successful save). [_isDirty] compares the live form against
+  /// this map to decide whether to prompt before pop. Text-controller
+  /// listeners poke setState on every keystroke so [PopScope.canPop] gets
+  /// re-evaluated.
+  late Map<String, Object?> _initialSnapshot;
+
   String getResetUserAgent() {
     return (widget.webViewModel.userAgent == '') ? (widget.webViewModel.defaultUserAgent ?? '') : widget.webViewModel.userAgent;
   }
@@ -163,7 +170,83 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _longitudeController = TextEditingController();
     _accuracyController = TextEditingController();
     _loadFromModel();
+    _initialSnapshot = _currentSnapshot();
+    _userAgentController.addListener(_onAnyFieldChanged);
+    _proxyAddressController.addListener(_onAnyFieldChanged);
+    _proxyUsernameController.addListener(_onAnyFieldChanged);
+    _proxyPasswordController.addListener(_onAnyFieldChanged);
+    _latitudeController.addListener(_onAnyFieldChanged);
+    _longitudeController.addListener(_onAnyFieldChanged);
+    _accuracyController.addListener(_onAnyFieldChanged);
     NotificationService.instance.addPermissionListener(_onPermissionChanged);
+  }
+
+  void _onAnyFieldChanged() {
+    if (mounted) setState(() {});
+  }
+
+  Map<String, Object?> _currentSnapshot() => {
+        'proxyType': _proxySettings.type,
+        'proxyAddress': _proxyAddressController.text,
+        'proxyUsername': _proxyUsernameController.text,
+        'proxyPassword': _proxyPasswordController.text,
+        'showProxyCredentials': _showProxyCredentials,
+        'userAgent': _userAgentController.text,
+        'javascriptEnabled': _javascriptEnabled,
+        'thirdPartyCookiesEnabled': _thirdPartyCookiesEnabled,
+        'incognito': _incognito,
+        'alwaysOpenHome': _alwaysOpenHome,
+        'clearUrlEnabled': _clearUrlEnabled,
+        'dnsBlockEnabled': _dnsBlockEnabled,
+        'contentBlockEnabled': _contentBlockEnabled,
+        'trackingProtectionEnabled': _trackingProtectionEnabled,
+        'localCdnEnabled': _localCdnEnabled,
+        'blockAutoRedirects': _blockAutoRedirects,
+        'fullscreenMode': _fullscreenMode,
+        'notificationsEnabled': _notificationsEnabled,
+        'selectedLanguage': _selectedLanguage,
+        'latitude': _latitudeController.text,
+        'longitude': _longitudeController.text,
+        'accuracy': _accuracyController.text,
+        'spoofTimezone': _spoofTimezone,
+        'spoofTimezoneFromLocation': _spoofTimezoneFromLocation,
+        'isLiveLocation': _isLiveLocation,
+        'webRtcPolicy': _webRtcPolicy,
+      };
+
+  bool _isDirty() {
+    final cur = _currentSnapshot();
+    for (final key in _initialSnapshot.keys) {
+      if (cur[key] != _initialSnapshot[key]) return true;
+    }
+    return false;
+  }
+
+  Future<bool> _confirmDiscard() async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Discard changes?'),
+        content: const Text(
+          'You have unsaved changes to this site\'s settings. '
+          'Leaving now will discard them.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Keep editing'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text(
+              'Discard',
+              style: TextStyle(color: Colors.red),
+            ),
+          ),
+        ],
+      ),
+    );
+    return result ?? false;
   }
 
   void _onPermissionChanged() {
@@ -409,6 +492,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
       // Update current URL to ensure reload
       widget.webViewModel.currentUrl = currentUrl;
+
+      // Mark the form clean so the PopScope guard (canPop: !_isDirty()) lets
+      // this pop through without prompting for discard. Wait one frame so
+      // the rebuild commits the new canPop value before we call pop.
+      setState(() {
+        _initialSnapshot = _currentSnapshot();
+      });
+      await WidgetsBinding.instance.endOfFrame;
+      if (!mounted) return;
 
       // Pop first so the Settings route leaves the tree before the parent
       // rebuilds. Notifying the parent inline would mark the Navigator dirty
@@ -800,7 +892,21 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return PopScope(
+      canPop: !_isDirty(),
+      onPopInvokedWithResult: (didPop, _) async {
+        if (didPop) return;
+        final navigator = Navigator.of(context);
+        final discard = await _confirmDiscard();
+        if (discard != true || !mounted) return;
+        setState(() {
+          _initialSnapshot = _currentSnapshot();
+        });
+        await WidgetsBinding.instance.endOfFrame;
+        if (!mounted) return;
+        navigator.pop();
+      },
+      child: Scaffold(
       appBar: AppBar(title: Text('Settings')),
       body: ListView(
         children: [
@@ -1357,6 +1463,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
           ),
         ],
+      ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
This PR adds unsaved changes detection to the Settings and App Settings screens, prompting users before discarding edits when navigating away via system back gesture or navigation.

## Key Changes

**lib/screens/settings.dart:**
- Added `_initialSnapshot` map to track form state at initialization and after successful saves
- Implemented `_currentSnapshot()` to capture all form field values
- Implemented `_isDirty()` to compare current state against initial snapshot
- Implemented `_confirmDiscard()` dialog to prompt user before discarding changes
- Added text controller listeners (`_onAnyFieldChanged`) to trigger re-evaluation of dirty state on every keystroke
- Wrapped `Scaffold` with `PopScope` that prevents pop when dirty and shows confirmation dialog
- Updated save logic to reset `_initialSnapshot` after successful save, allowing clean navigation

**lib/screens/app_settings.dart:**
- Added `_initialOutboundProxy` snapshot for outbound proxy configuration fields
- Implemented `_currentOutboundProxySnapshot()` to capture proxy field values
- Implemented `_isOutboundProxyDirty()` to detect unsaved proxy changes
- Implemented `_confirmDiscardProxy()` dialog for proxy-specific confirmation
- Added text controller listeners for proxy fields to trigger dirty state re-evaluation
- Wrapped `Scaffold` with `PopScope` guarding against dirty proxy state
- Updated proxy save logic to reset snapshot after successful update

## Implementation Details

- Uses `PopScope.canPop` to prevent navigation when dirty, triggering `onPopInvokedWithResult` callback
- Text controller listeners call `setState()` on every keystroke to re-evaluate `canPop` condition
- After successful save/discard, uses `WidgetsBinding.instance.endOfFrame` to ensure UI updates before navigation
- Snapshot comparison is shallow equality check suitable for the form field types (strings, bools, enums)
- Maintains consistency between both screens with similar implementation patterns

https://claude.ai/code/session_01WiGzGR4WkFZACrQ7u5bizR