### PR TITLE
feat(home-shortcut): expose iOS home shortcuts via App Intents

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7AC100012ED2DC5600515811 /* LocationPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC100002ED2DC5600515811 /* LocationPlugin.swift */; };
 		7AC100032ED2DC5600515813 /* BackgroundTaskPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC100022ED2DC5600515813 /* BackgroundTaskPlugin.swift */; };
+		7AC200012ED2DC5600515820 /* ShortcutsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC200002ED2DC5600515820 /* ShortcutsPlugin.swift */; };
+		7AC200032ED2DC5600515821 /* WebSpaceAppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC200022ED2DC5600515821 /* WebSpaceAppIntents.swift */; };
 		897CA73A1B12E395D36631E0 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEB686F40D1F327FFB98EB57 /* Pods_Runner.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -74,6 +76,8 @@
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AC100002ED2DC5600515811 /* LocationPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationPlugin.swift; sourceTree = "<group>"; };
 		7AC100022ED2DC5600515813 /* BackgroundTaskPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundTaskPlugin.swift; sourceTree = "<group>"; };
+		7AC200002ED2DC5600515820 /* ShortcutsPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShortcutsPlugin.swift; sourceTree = "<group>"; };
+		7AC200022ED2DC5600515821 /* WebSpaceAppIntents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebSpaceAppIntents.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		8978E62AB7C1945FA3477F81 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
@@ -200,6 +204,8 @@
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				7AC100002ED2DC5600515811 /* LocationPlugin.swift */,
 				7AC100022ED2DC5600515813 /* BackgroundTaskPlugin.swift */,
+				7AC200002ED2DC5600515820 /* ShortcutsPlugin.swift */,
+				7AC200022ED2DC5600515821 /* WebSpaceAppIntents.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 				7B0E0000000000000000000D /* Runner.entitlements */,
 			);
@@ -462,6 +468,8 @@
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				7AC100012ED2DC5600515811 /* LocationPlugin.swift in Sources */,
 				7AC100032ED2DC5600515813 /* BackgroundTaskPlugin.swift in Sources */,
+				7AC200012ED2DC5600515820 /* ShortcutsPlugin.swift in Sources */,
+				7AC200032ED2DC5600515821 /* WebSpaceAppIntents.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -7,6 +7,7 @@ import UserNotifications
 @objc class AppDelegate: FlutterAppDelegate {
   private var locationPlugin: LocationPlugin?
   private var backgroundTaskPlugin: BackgroundTaskPlugin?
+  private var shortcutsPlugin: ShortcutsPlugin?
   private var pendingShareUrl: String?
 
   private let shareChannelName = "org.codeberg.theoden8.webspace/share_intent"
@@ -32,6 +33,7 @@ import UserNotifications
     if let controller = window?.rootViewController as? FlutterViewController {
       locationPlugin = LocationPlugin(messenger: controller.binaryMessenger)
       backgroundTaskPlugin = BackgroundTaskPlugin(messenger: controller.binaryMessenger)
+      shortcutsPlugin = ShortcutsPlugin(messenger: controller.binaryMessenger)
       registerShareChannel(controller.binaryMessenger)
     }
     if let url = launchOptions?[.url] as? URL {

--- a/ios/Runner/ShortcutsPlugin.swift
+++ b/ios/Runner/ShortcutsPlugin.swift
@@ -1,0 +1,110 @@
+import Flutter
+import Foundation
+import UIKit
+
+#if canImport(AppIntents)
+import AppIntents
+#endif
+
+/// iOS bridge for [`ShortcutService`](../../lib/services/shortcut_service.dart).
+///
+/// Android pins shortcuts directly via `ShortcutManager.requestPinShortcut`.
+/// iOS has no equivalent public API, so on iOS the menu defers to the
+/// Shortcuts app: this plugin keeps an App Group-backed site list in sync so
+/// `WebSpaceShortcuts` / `SiteEntityQuery` (iOS 16+) can surface the user's
+/// real sites in the action picker, and deep-links to `shortcuts://` when
+/// the user taps "Add to Home Screen" on iOS.
+///
+/// When an `OpenSiteIntent` runs, it stashes the chosen siteId in App Group
+/// UserDefaults; `getLaunchSiteId` drains that key the next time Flutter
+/// asks (cold launch in `_restoreAppState`, warm launch in
+/// `_handleShortcutIntent`).
+class ShortcutsPlugin: NSObject {
+  private let channel: FlutterMethodChannel
+  private static let channelName = "org.codeberg.theoden8.webspace/shortcuts"
+  private static let appGroupId = "group.org.codeberg.theoden8.webspace"
+  private static let sitesKey = "shortcut_sites"
+  private static let pendingKey = "pending_shortcut_site_id"
+
+  init(messenger: FlutterBinaryMessenger) {
+    self.channel = FlutterMethodChannel(
+      name: Self.channelName,
+      binaryMessenger: messenger
+    )
+    super.init()
+    self.channel.setMethodCallHandler { [weak self] call, result in
+      self?.handle(call: call, result: result)
+    }
+  }
+
+  private func handle(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "isAppIntentsSupported":
+      if #available(iOS 16, *) {
+        result(true)
+      } else {
+        result(false)
+      }
+    case "syncSites":
+      let args = call.arguments as? [String: Any]
+      let sites = args?["sites"] as? [[String: Any]] ?? []
+      syncSites(sites)
+      result(true)
+    case "getLaunchSiteId":
+      result(drainPendingSiteId())
+    case "pinShortcut":
+      openShortcutsApp(result: result)
+    case "removeShortcut":
+      // No-op on iOS: we don't pin, we don't track.
+      result(nil)
+    case "getPinnedSiteIds":
+      // iOS has no public API to enumerate home-screen tiles.
+      result([])
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func syncSites(_ rawSites: [[String: Any]]) {
+    let entries: [[String: String]] = rawSites.compactMap { dict in
+      guard let id = dict["siteId"] as? String,
+            let name = dict["label"] as? String,
+            !id.isEmpty
+      else { return nil }
+      return ["id": id, "name": name]
+    }
+    guard let defaults = UserDefaults(suiteName: Self.appGroupId) else {
+      NSLog("[WebSpace] ShortcutsPlugin: App Group \(Self.appGroupId) unavailable")
+      return
+    }
+    if let json = try? JSONSerialization.data(withJSONObject: entries) {
+      defaults.set(json, forKey: Self.sitesKey)
+    }
+    #if canImport(AppIntents)
+    if #available(iOS 16, *) {
+      WebSpaceShortcuts.updateAppShortcutParameters()
+    }
+    #endif
+  }
+
+  private func drainPendingSiteId() -> String? {
+    guard let defaults = UserDefaults(suiteName: Self.appGroupId),
+          let siteId = defaults.string(forKey: Self.pendingKey),
+          !siteId.isEmpty
+    else { return nil }
+    defaults.removeObject(forKey: Self.pendingKey)
+    return siteId
+  }
+
+  private func openShortcutsApp(result: @escaping FlutterResult) {
+    guard let url = URL(string: "shortcuts://") else {
+      result(false)
+      return
+    }
+    DispatchQueue.main.async {
+      UIApplication.shared.open(url, options: [:]) { success in
+        result(success)
+      }
+    }
+  }
+}

--- a/ios/Runner/WebSpaceAppIntents.swift
+++ b/ios/Runner/WebSpaceAppIntents.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+#if canImport(AppIntents)
+import AppIntents
+
+/// Key for the JSON-encoded `[{id, name}]` site list in the shared App Group
+/// UserDefaults. Written by Dart via `ShortcutsPlugin.syncSites`; read by
+/// `SiteEntityQuery` when Shortcuts.app asks for available entities.
+let kShortcutSitesKey = "shortcut_sites"
+
+/// Key for the pending siteId that an `OpenSiteIntent` has just resolved.
+/// Drained by `ShortcutsPlugin.getLaunchSiteId` (and ultimately by the
+/// Dart-side `_handleShortcutIntent` / `_restoreAppState` paths).
+let kPendingShortcutSiteIdKey = "pending_shortcut_site_id"
+
+let kShortcutAppGroupId = "group.org.codeberg.theoden8.webspace"
+
+/// One synced WebSpace site as it appears to App Intents. Decoded from the
+/// JSON the Dart side writes; only the fields the picker / OpenIntent need
+/// live here (`id`, `name`) so the on-disk shape stays small.
+@available(iOS 16, *)
+struct SiteEntity: AppEntity {
+  let id: String
+  let name: String
+
+  static var typeDisplayRepresentation: TypeDisplayRepresentation {
+    TypeDisplayRepresentation(name: "Site")
+  }
+
+  var displayRepresentation: DisplayRepresentation {
+    DisplayRepresentation(title: "\(name)")
+  }
+
+  static var defaultQuery = SiteEntityQuery()
+}
+
+/// Backing query for the `OpenSiteIntent.site` parameter. Reads the synced
+/// site list from App Group UserDefaults so the Shortcuts.app picker shows
+/// real WebSpace sites by name. Returns an empty list if the entitlement is
+/// missing or no sites have been synced yet.
+@available(iOS 16, *)
+struct SiteEntityQuery: EntityQuery {
+  func entities(for identifiers: [SiteEntity.ID]) async throws -> [SiteEntity] {
+    let all = Self.loadAll()
+    let wanted = Set(identifiers)
+    return all.filter { wanted.contains($0.id) }
+  }
+
+  func suggestedEntities() async throws -> [SiteEntity] {
+    Self.loadAll()
+  }
+
+  static func loadAll() -> [SiteEntity] {
+    guard let defaults = UserDefaults(suiteName: kShortcutAppGroupId),
+          let data = defaults.data(forKey: kShortcutSitesKey) ?? defaults.string(forKey: kShortcutSitesKey)?.data(using: .utf8)
+    else {
+      return []
+    }
+    guard let raw = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+      return []
+    }
+    return raw.compactMap { dict in
+      guard let id = dict["id"] as? String, let name = dict["name"] as? String else {
+        return nil
+      }
+      return SiteEntity(id: id, name: name)
+    }
+  }
+}
+
+/// App Intent the user invokes from Shortcuts.app / Spotlight / Siri to open
+/// a specific WebSpace site. Conforming to `OpenIntent` foregrounds the host
+/// app; `perform()` just stashes the chosen siteId in the App Group so the
+/// existing Flutter resume / cold-launch path can route it.
+@available(iOS 16, *)
+struct OpenSiteIntent: AppIntent, OpenIntent {
+  static var title: LocalizedStringResource = "Open Site"
+  static var description = IntentDescription("Open a WebSpace site by name.")
+  static var openAppWhenRun: Bool = true
+
+  @Parameter(title: "Site")
+  var target: SiteEntity
+
+  init() {}
+
+  init(target: SiteEntity) {
+    self.target = target
+  }
+
+  func perform() async throws -> some IntentResult {
+    if let defaults = UserDefaults(suiteName: kShortcutAppGroupId) {
+      defaults.set(target.id, forKey: kPendingShortcutSiteIdKey)
+    } else {
+      NSLog("[WebSpace] OpenSiteIntent: App Group \(kShortcutAppGroupId) unavailable")
+    }
+    return .result()
+  }
+}
+
+/// Declares the discoverable App Shortcut iOS surfaces in Shortcuts.app,
+/// Spotlight, and Siri. The phrase template includes the `\(.$target)` slot
+/// so the picker prompts for a site at add-time. Updated dynamically by
+/// `ShortcutsPlugin.syncSites` via `updateAppShortcutParameters()` whenever
+/// the user's site list changes.
+@available(iOS 16, *)
+struct WebSpaceShortcuts: AppShortcutsProvider {
+  static var appShortcuts: [AppShortcut] {
+    AppShortcut(
+      intent: OpenSiteIntent(),
+      phrases: [
+        "Open \(\.$target) in \(.applicationName)",
+        "Open \(\.$target) site in \(.applicationName)",
+      ],
+      shortTitle: "Open Site",
+      systemImageName: "globe"
+    )
+  }
+}
+
+#endif

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -795,12 +795,85 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   // "Home Shortcut" menu item can hide for sites that are already pinned.
   Set<String> _pinnedSiteIds = const <String>{};
 
+  // HS-006/007: iOS 16+ exposes home shortcuts via App Intents. Probed once
+  // at startup so the menu can render synchronously without a future on
+  // every overflow-menu open.
+  bool _iosAppIntentsSupported = false;
+
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     _restoreAppState();
     _refreshPinnedSiteIds();
+    _probeIosAppIntents();
+  }
+
+  Future<void> _probeIosAppIntents() async {
+    final supported = await ShortcutService.isAppIntentsSupported();
+    if (!mounted || supported == _iosAppIntentsSupported) return;
+    setState(() {
+      _iosAppIntentsSupported = supported;
+    });
+  }
+
+  /// HS-004 / HS-005: gate the "Home Shortcut" menu item. On Android, hide
+  /// once the site already has a pinned shortcut (HS-005). On iOS 16+ the
+  /// item is always visible (iOS has no API to detect home-screen pinning).
+  /// Other platforms hide it.
+  bool _isHomeShortcutMenuVisible(int index) {
+    if (index >= _webViewModels.length) return false;
+    if (Platform.isAndroid) {
+      return !_pinnedSiteIds.contains(_webViewModels[index].siteId);
+    }
+    if (Platform.isIOS) {
+      return _iosAppIntentsSupported;
+    }
+    return false;
+  }
+
+  /// Routes the "Home Shortcut" menu tap. Android pins directly; iOS shows
+  /// the HS-008 instructional dialog then deep-links to Shortcuts.app.
+  Future<void> _handleAddToHome(WebViewModel model) async {
+    if (Platform.isAndroid) {
+      final faviconUrl = FaviconUrlCache.get(model.initUrl);
+      final isSvg = faviconUrl != null && faviconUrl.toLowerCase().endsWith('.svg');
+      await ShortcutService.pinShortcut(
+        siteId: model.siteId,
+        label: model.name,
+        iconUrl: isSvg ? null : faviconUrl,
+      );
+      return;
+    }
+    if (Platform.isIOS && _iosAppIntentsSupported) {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('Add to Home Screen'),
+          content: Text(
+            'iOS adds WebSpace sites through the Shortcuts app.\n\n'
+            'In Shortcuts, find the "Open Site" action under WebSpace, pick '
+            '"${model.name}", then tap "Add to Home Screen" from the share menu.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              child: const Text('Open Shortcuts'),
+            ),
+          ],
+        ),
+      );
+      if (confirmed == true) {
+        await ShortcutService.pinShortcut(
+          siteId: model.siteId,
+          label: model.name,
+        );
+      }
+    }
   }
 
   Future<void> _refreshPinnedSiteIds() async {
@@ -1428,6 +1501,23 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       return jsonEncode(json);
     }).toList();
     await prefs.setStringList('webViewModels', webViewModelsJson);
+    _syncShortcutSites();
+  }
+
+  /// HS-007: push the current site list to the iOS App Intents picker so
+  /// renames / additions / deletions show up in Shortcuts.app the next time
+  /// the user touches it. No-op on non-iOS platforms.
+  void _syncShortcutSites() {
+    if (!Platform.isIOS) return;
+    final sites = [
+      for (final m in _webViewModels)
+        ShortcutSite(
+          siteId: m.siteId,
+          label: m.name,
+          iconUrl: FaviconUrlCache.get(m.initUrl),
+        ),
+    ];
+    unawaited(ShortcutService.syncSites(sites));
   }
 
   Future<void> _saveCurrentIndex() async {
@@ -3402,9 +3492,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                     ],
                   ),
                 ),
-                if (Platform.isAndroid &&
-                    _currentIndex != null &&
-                    !_pinnedSiteIds.contains(_webViewModels[_currentIndex!].siteId))
+                if (_currentIndex != null && _isHomeShortcutMenuVisible(_currentIndex!))
                   PopupMenuItem<String>(
                     value: "addToHome",
                     child: Row(
@@ -3462,14 +3550,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                 break;
                 case 'addToHome':
                   if (_currentIndex != null) {
-                    final model = _webViewModels[_currentIndex!];
-                    final faviconUrl = FaviconUrlCache.get(model.initUrl);
-                    final isSvg = faviconUrl != null && faviconUrl.toLowerCase().endsWith('.svg');
-                    await ShortcutService.pinShortcut(
-                      siteId: model.siteId,
-                      label: model.name,
-                      iconUrl: isSvg ? null : faviconUrl,
-                    );
+                    await _handleAddToHome(_webViewModels[_currentIndex!]);
                   }
                 break;
                 case 'devTools':
@@ -3770,9 +3851,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
               ],
             ),
           ),
-          if (Platform.isAndroid &&
-              _currentIndex != null &&
-              !_pinnedSiteIds.contains(_webViewModels[_currentIndex!].siteId))
+          if (_currentIndex != null && _isHomeShortcutMenuVisible(_currentIndex!))
             PopupMenuItem<String>(
               value: "addToHome",
               child: Row(
@@ -3830,14 +3909,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           break;
           case 'addToHome':
             if (_currentIndex != null) {
-              final model = _webViewModels[_currentIndex!];
-              final faviconUrl = FaviconUrlCache.get(model.initUrl);
-              final isSvg = faviconUrl != null && faviconUrl.toLowerCase().endsWith('.svg');
-              await ShortcutService.pinShortcut(
-                siteId: model.siteId,
-                label: model.name,
-                iconUrl: isSvg ? null : faviconUrl,
-              );
+              await _handleAddToHome(_webViewModels[_currentIndex!]);
             }
           break;
           case 'devTools':

--- a/lib/services/shortcut_service.dart
+++ b/lib/services/shortcut_service.dart
@@ -1,17 +1,43 @@
 import 'dart:io';
 import 'package:flutter/services.dart';
 
+/// One site as it crosses the platform-channel boundary into the iOS App
+/// Intents picker (HS-007). `iconUrl` is reserved for future favicon syncing
+/// and is currently unused on the Swift side.
+class ShortcutSite {
+  final String siteId;
+  final String label;
+  final String? iconUrl;
+
+  const ShortcutSite({
+    required this.siteId,
+    required this.label,
+    this.iconUrl,
+  });
+
+  Map<String, dynamic> toMap() => {
+        'siteId': siteId,
+        'label': label,
+        if (iconUrl != null) 'iconUrl': iconUrl,
+      };
+}
+
 class ShortcutService {
   static const _channel = MethodChannel('org.codeberg.theoden8.webspace/shortcuts');
 
-  /// Request a pinned home screen shortcut for a site (Android only).
-  /// Returns true if the request was made successfully.
+  /// Request a pinned home screen shortcut for a site.
+  ///
+  /// Android: hands the request to `ShortcutManagerCompat.requestPinShortcut`
+  /// and returns whether the system dialog opened. iOS 16+: opens the
+  /// Shortcuts app — the caller is responsible for showing the
+  /// instructional dialog (HS-008) before invoking. Returns false on
+  /// platforms without either path.
   static Future<bool> pinShortcut({
     required String siteId,
     required String label,
     String? iconUrl,
   }) async {
-    if (!Platform.isAndroid) return false;
+    if (!Platform.isAndroid && !Platform.isIOS) return false;
     try {
       final result = await _channel.invokeMethod('pinShortcut', {
         'siteId': siteId,
@@ -25,6 +51,8 @@ class ShortcutService {
   }
 
   /// Remove a pinned shortcut when a site is deleted (Android only).
+  /// On iOS the App Intents site list is rebuilt from the user's actual
+  /// sites by `syncSites` so a deletion drops out implicitly.
   static Future<void> removeShortcut(String siteId) async {
     if (!Platform.isAndroid) return;
     try {
@@ -34,9 +62,10 @@ class ShortcutService {
     }
   }
 
-  /// Get the siteId from the launch intent (if app was opened via shortcut).
+  /// Get the siteId from the launch intent if the app was opened via a
+  /// pinned shortcut (Android) or a Shortcuts.app `OpenSiteIntent` (iOS 16+).
   static Future<String?> getLaunchSiteId() async {
-    if (!Platform.isAndroid) return null;
+    if (!Platform.isAndroid && !Platform.isIOS) return null;
     try {
       return await _channel.invokeMethod('getLaunchSiteId');
     } on PlatformException {
@@ -45,6 +74,8 @@ class ShortcutService {
   }
 
   /// Get the set of siteIds that currently have a pinned home shortcut.
+  /// Android-only — iOS has no public API to enumerate home-screen tiles, so
+  /// this always returns an empty set on iOS.
   static Future<Set<String>> getPinnedSiteIds() async {
     if (!Platform.isAndroid) return const <String>{};
     try {
@@ -55,6 +86,33 @@ class ShortcutService {
       return const <String>{};
     } on PlatformException {
       return const <String>{};
+    }
+  }
+
+  /// Push the user's current site list to the iOS App Intents picker
+  /// (HS-007). Writes `[{id, name}]` into the shared App Group UserDefaults
+  /// so `SiteEntityQuery` returns real sites. No-op on non-iOS platforms.
+  static Future<void> syncSites(List<ShortcutSite> sites) async {
+    if (!Platform.isIOS) return;
+    try {
+      await _channel.invokeMethod('syncSites', {
+        'sites': sites.map((s) => s.toMap()).toList(),
+      });
+    } on PlatformException {
+      // best-effort; the picker just shows stale data until next call.
+    }
+  }
+
+  /// True iff the iOS App Intents-based path is available (iOS 16+). False
+  /// on Android (Android uses its own pin path, not gated by this), on
+  /// older iOS, and on every other platform.
+  static Future<bool> isAppIntentsSupported() async {
+    if (!Platform.isIOS) return false;
+    try {
+      final result = await _channel.invokeMethod('isAppIntentsSupported');
+      return result == true;
+    } on PlatformException {
+      return false;
     }
   }
 }

--- a/openspec/changes/ios-home-shortcuts/proposal.md
+++ b/openspec/changes/ios-home-shortcuts/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The Home Shortcut feature (HS-001..HS-005) is currently Android-only — HS-004 hides the menu item on iOS because iOS has no public API equivalent to `ShortcutManager.requestPinShortcut()`. Users have asked for a comparable iOS path. Apple's answer for "discoverable app-defined actions a user can drop on the home screen" is **App Intents** (iOS 16+): we expose `OpenSiteIntent` with a `SiteEntity` parameter; iOS surfaces it in Shortcuts.app, Spotlight, and Siri; the user creates a Shortcut for the desired site and taps "Add to Home Screen" from the Shortcuts.app share sheet.
+
+Safari's "Add to Home Screen" is not viable here — the resulting icon opens the URL in Safari, bypassing per-site cookie isolation, proxy, language, geo, tracking-protection shim. Defeating the entire app.
+
+## What Changes
+
+- **`OpenSiteIntent` App Intent (iOS 16+)**: Swift `AppIntent` conforming to `OpenIntent`, parameterized on a `SiteEntity`. When run, writes the target `siteId` to App Group `UserDefaults` and brings WebSpace to the foreground. The existing `_handleShortcutIntent` flow (which already polls `ShortcutService.getLaunchSiteId()` on resume / cold launch) picks it up.
+- **`SiteEntity` + `SiteEntityQuery`**: Dynamic entity backed by the user's actual site list, read from App Group `UserDefaults`. Lets the Shortcuts.app parameter picker show real WebSpace sites by name (and favicon when available) rather than asking the user to type a URL.
+- **`WebSpaceShortcuts` provider**: `AppShortcutsProvider` declares "Open Site" as the discoverable App Shortcut. Re-resolved when sites change via `updateAppShortcutParameters()`.
+- **Dart `ShortcutService` extension**: `syncSites(...)` writes the site list to App Group `UserDefaults` so `SiteEntityQuery` can read it. Called from `_saveWebViewModels` on iOS. `isAppIntentsSupported()` returns true on iOS 16+ (Swift `if #available`). `getLaunchSiteId()` drains the pending key on iOS, same shape as Android.
+- **Menu item on iOS 16+**: Reuses the existing "Home Shortcut" entry. On iOS the label reads "Add to Home Screen" and tapping it opens an instructional dialog with an "Open Shortcuts App" button (deep-linked via `shortcuts://`). HS-005 (hide when pinned) only applies to Android — iOS has no public API to detect home-screen pinning.
+
+## Scope
+
+- **iOS 16+**: full App Intents path.
+- **iOS 13/14/15**: feature unavailable, menu item hidden. No fallback URL-scheme onboarding — adds complexity, low value.
+- **macOS / Linux / Web**: unchanged (not supported).
+- **Android**: unchanged (existing `requestPinShortcut` path).
+
+## Non-Goals
+
+- No App Group favicon sync for v1. `SiteEntity.displayRepresentation` ships site name only; the icon shown in Shortcuts.app is the app icon. Caching favicons to the App Group container so the entity picker shows per-site icons is a future iteration — adds significant download/lifecycle code for marginal UX gain.
+- No URL-scheme fallback (`webspace://site?id=...`) for iOS <16. iOS 16 is four years old by 2026; gating cleanly avoids a second code path nobody will read.
+- No `OpenAppIntent` for site creation, search, or "open URL". Out of scope — this change is "the iOS equivalent of HS-001..HS-005".
+- No deployment-target bump. Existing target stays at 14.0; App Intents code is `@available(iOS 16, *)` gated.

--- a/openspec/changes/ios-home-shortcuts/specs/home-shortcut/spec.md
+++ b/openspec/changes/ios-home-shortcuts/specs/home-shortcut/spec.md
@@ -1,0 +1,152 @@
+# Home Shortcut — iOS App Intents delta
+
+## MODIFIED Requirements
+
+### Requirement: HS-004 - Platform Availability
+
+The "Home Shortcut" menu item SHALL be shown on Android and on iOS 16+. On macOS, Linux, web, and iOS 13/14/15 the menu item SHALL be hidden.
+
+#### Scenario: Menu item shown on Android
+
+**Given** the app is running on Android
+**When** the user opens the overflow menu for a site that is not already pinned
+**Then** the "Home Shortcut" option is shown
+
+#### Scenario: Menu item shown on iOS 16 or later
+
+**Given** the app is running on iOS 16.0 or later
+**When** the user opens the overflow menu for any site
+**Then** the "Home Shortcut" option is shown
+
+#### Scenario: Menu item hidden on iOS 15 or earlier
+
+**Given** the app is running on iOS 13, 14, or 15
+**When** the user opens the overflow menu
+**Then** the "Home Shortcut" option is not shown
+
+#### Scenario: Menu item hidden on macOS and Linux
+
+**Given** the app is running on macOS or Linux
+**When** the user opens the overflow menu
+**Then** the "Home Shortcut" option is not shown
+
+---
+
+### Requirement: HS-005 - Hide When Already Pinned (Android only)
+
+On Android, the "Home Shortcut" menu item SHALL be hidden when the current site already has a pinned shortcut, and SHALL reappear if the user removes the shortcut from the launcher. On iOS this scenario does not apply: iOS does not expose an API to query whether an App Shortcut tile is currently on the home screen, so the menu item stays available on iOS regardless of pin state.
+
+#### Scenario: Android — site already has a pinned shortcut
+
+**Given** the user previously pinned a shortcut for the current site on Android
+**When** the user opens the overflow menu
+**Then** the "Home Shortcut" option is not shown for that site
+
+#### Scenario: Android — shortcut removed from launcher
+
+**Given** the user removed a previously pinned shortcut from their Android home screen
+**When** the user backgrounds and re-foregrounds the app, then opens the overflow menu
+**Then** the "Home Shortcut" option is shown again
+
+#### Scenario: iOS — pin state is not detected
+
+**Given** the user has already added a shortcut for the current site to the iOS home screen
+**When** the user opens the overflow menu
+**Then** the "Home Shortcut" option is still shown (iOS cannot detect prior pinning)
+
+---
+
+## ADDED Requirements
+
+### Requirement: HS-006 - iOS App Intent for Site Launching
+
+The system SHALL expose an iOS App Intent named "Open Site" that opens WebSpace and navigates to a chosen site. The intent SHALL conform to `OpenIntent` so iOS brings WebSpace to the foreground when the intent runs. The intent's site parameter SHALL be backed by a dynamic `AppEntity` query that returns the user's actual WebSpace sites.
+
+#### Scenario: User adds the Open Site shortcut in Shortcuts.app
+
+**Given** the user has WebSpace installed on iOS 16 or later
+**When** the user opens the Shortcuts app and adds the "Open Site" action from WebSpace
+**Then** the action shows a "Site" parameter whose picker lists every site currently in WebSpace by name
+
+#### Scenario: Shortcut launches WebSpace to the chosen site
+
+**Given** the user has added a Shortcut wired to `OpenSiteIntent` with a specific site selected
+**When** the user taps the Shortcut tile on their home screen
+**Then** WebSpace launches (or comes to the foreground)
+**And** the chosen site is selected and loaded
+**And** the site's `currentUrl` is reset to its `initUrl` (matching the Android home-shortcut "land on home" behavior)
+
+#### Scenario: Cold launch via Shortcut
+
+**Given** WebSpace is not running
+**When** the user taps a Shortcut wired to `OpenSiteIntent` from the home screen
+**Then** the app cold-launches
+**And** `_restoreAppState` reads the pending siteId via `ShortcutService.getLaunchSiteId()`
+**And** the chosen site is the initial active index
+
+#### Scenario: Warm launch via Shortcut
+
+**Given** WebSpace is already running in the background
+**When** the user taps a Shortcut wired to `OpenSiteIntent`
+**Then** the app comes to the foreground
+**And** `_handleShortcutIntent` reads the pending siteId on the resume lifecycle event
+**And** the chosen site becomes active
+
+---
+
+### Requirement: HS-007 - Site List Synced to App Group
+
+The system SHALL keep the iOS App Intents site picker in sync with the user's actual WebSpace sites. Whenever the persisted site list changes, the system SHALL write the current `[{siteId, name}]` list to `UserDefaults(suiteName: "group.org.codeberg.theoden8.webspace")` under key `shortcut_sites`, and SHALL invalidate the App Shortcuts parameter cache via `AppShortcutsProvider.updateAppShortcutParameters()` so the Shortcuts app re-queries the entity provider.
+
+#### Scenario: Site added
+
+**Given** WebSpace is running on iOS 16+
+**When** the user creates a new site
+**Then** the new site appears in the App Intents picker the next time Shortcuts.app queries
+
+#### Scenario: Site renamed
+
+**Given** a site exists in WebSpace
+**When** the user renames it
+**Then** the new name is reflected in the App Intents picker after the next save
+
+#### Scenario: Site deleted
+
+**Given** a site is referenced by an existing user-created Shortcut
+**When** the user deletes the site in WebSpace
+**Then** the deleted site no longer appears in the App Intents picker
+**And** invoking the orphaned Shortcut performs no navigation (the entity resolves to nil)
+
+#### Scenario: App Group unavailable
+
+**Given** `UserDefaults(suiteName:)` returns nil (entitlement missing)
+**When** `syncSites` is invoked
+**Then** the method completes without crashing
+**And** logs a warning
+
+---
+
+### Requirement: HS-008 - iOS "Add to Home Screen" Dialog
+
+On iOS, tapping the "Home Shortcut" menu item SHALL show an instructional dialog explaining that iOS surfaces WebSpace sites through the Shortcuts app, with a primary button that deep-links to Shortcuts.app. The system SHALL NOT attempt to pin a shortcut programmatically (iOS has no such public API).
+
+#### Scenario: Dialog content
+
+**Given** the user is on iOS 16+
+**When** the user taps "Home Shortcut" in the overflow menu
+**Then** an `AlertDialog` is shown explaining: "iOS adds WebSpace sites via the Shortcuts app. Find the 'Open Site' action for WebSpace, pick this site, then tap 'Add to Home Screen'."
+**And** the dialog has an "Open Shortcuts" primary button and a "Cancel" button
+
+#### Scenario: User confirms
+
+**Given** the iOS instructional dialog is shown
+**When** the user taps "Open Shortcuts"
+**Then** the system opens the URL `shortcuts://` via `UIApplication.shared.open`
+**And** the Shortcuts.app launches
+
+#### Scenario: User cancels
+
+**Given** the iOS instructional dialog is shown
+**When** the user taps "Cancel"
+**Then** the dialog dismisses
+**And** Shortcuts.app is not opened

--- a/openspec/changes/ios-home-shortcuts/tasks.md
+++ b/openspec/changes/ios-home-shortcuts/tasks.md
@@ -1,0 +1,61 @@
+## 1. Dart-side service layer
+
+- [ ] 1.1 Add `ShortcutSite` value type to `lib/services/shortcut_service.dart` (`siteId`, `label`, `iconUrl`).
+- [ ] 1.2 Add `ShortcutService.syncSites(List<ShortcutSite>)`. On iOS, invokes `syncSites` over the existing `org.codeberg.theoden8.webspace/shortcuts` method channel. No-op elsewhere.
+- [ ] 1.3 Add `ShortcutService.isAppIntentsSupported()` returning `Future<bool>`. Invokes `isAppIntentsSupported` on iOS; false elsewhere.
+- [ ] 1.4 Drop the `Platform.isAndroid` early-return in `pinShortcut`. On iOS, invoke `pinShortcut` (Swift side decides UX — opens Shortcuts.app).
+- [ ] 1.5 Drop the early-return in `getLaunchSiteId` so it works on iOS too.
+- [ ] 1.6 Leave `getPinnedSiteIds` Android-only (iOS returns empty set — no concept of home-screen pinning detection).
+
+## 2. iOS App Intents (`ios/Runner/WebSpaceAppIntents.swift`)
+
+- [ ] 2.1 Define `SiteEntity: AppEntity` (iOS 16+) with `id: String` (siteId), `name: String`, and `DisplayRepresentation` using the name.
+- [ ] 2.2 Define `SiteEntityQuery: EntityQuery` (iOS 16+) reading the synced site list from `UserDefaults(suiteName: "group.org.codeberg.theoden8.webspace")` under key `shortcut_sites` (JSON-encoded `[{id, name}]`). Implement `entities(for:)`, `suggestedEntities()`, and `allEntities()` (or `entities(matching:)` if iOS 17+).
+- [ ] 2.3 Define `OpenSiteIntent: AppIntent, OpenIntent` (iOS 16+). `@Parameter` is `site: SiteEntity`. `perform()` writes `pending_shortcut_site_id` to App Group UserDefaults and returns `.result()`. `openAppWhenRun = true` so iOS foregrounds WebSpace.
+- [ ] 2.4 Define `WebSpaceShortcuts: AppShortcutsProvider` (iOS 16+) returning one `AppShortcut` for `OpenSiteIntent` with phrase template `"Open \(\.$site) in WebSpace"` and `systemImageName: "globe"`.
+
+## 3. iOS method-channel bridge (`ios/Runner/ShortcutsPlugin.swift`)
+
+- [ ] 3.1 Implement `ShortcutsPlugin(messenger:)` constructor mirroring `BackgroundTaskPlugin`. Register channel `org.codeberg.theoden8.webspace/shortcuts`.
+- [ ] 3.2 Handle `isAppIntentsSupported` — return `true` if `#available(iOS 16, *)`, else `false`.
+- [ ] 3.3 Handle `syncSites` — receive `{sites: [{siteId, label, iconUrl?}]}`, JSON-encode `[{id, name}]`, write to App Group UserDefaults key `shortcut_sites`. On iOS 16+ call `WebSpaceShortcuts.updateAppShortcutParameters()` to trigger re-query.
+- [ ] 3.4 Handle `getLaunchSiteId` — read `pending_shortcut_site_id` from App Group UserDefaults, delete the key, return the value (or nil).
+- [ ] 3.5 Handle `pinShortcut` — open `shortcuts://` via `UIApplication.shared.open`, return success. (The Dart UI shows the instructional dialog first.)
+- [ ] 3.6 Handle `removeShortcut` / `getPinnedSiteIds` — return nil/empty list. Not applicable to iOS.
+
+## 4. AppDelegate wiring
+
+- [ ] 4.1 Add `private var shortcutsPlugin: ShortcutsPlugin?` to `AppDelegate`.
+- [ ] 4.2 Instantiate `ShortcutsPlugin(messenger: controller.binaryMessenger)` alongside `LocationPlugin` and `BackgroundTaskPlugin` in `application(_:didFinishLaunchingWithOptions:)`.
+
+## 5. Xcode project registration
+
+- [ ] 5.1 Add `WebSpaceAppIntents.swift` and `ShortcutsPlugin.swift` PBXBuildFile + PBXFileReference entries.
+- [ ] 5.2 Add both to the Runner PBXGroup children.
+- [ ] 5.3 Add both to the Runner Sources build phase.
+
+## 6. Flutter UI wiring (`lib/main.dart`)
+
+- [ ] 6.1 Add `bool _iosAppIntentsSupported = false` to `_WebSpacePageState`.
+- [ ] 6.2 In `initState` (after `_restoreAppState`), set `_iosAppIntentsSupported` via `ShortcutService.isAppIntentsSupported()`.
+- [ ] 6.3 In both menu builders (around lines 3405 and 3773), replace the Android-only gate with: `(Platform.isAndroid && !_pinnedSiteIds.contains(siteId)) || (Platform.isIOS && _iosAppIntentsSupported)`. Label stays "Home Shortcut".
+- [ ] 6.4 In both `addToHome` handlers, branch on platform: Android keeps current `ShortcutService.pinShortcut(...)` direct call; iOS shows an `AlertDialog` ("Open Shortcuts App" / "Cancel") explaining the flow, then calls `ShortcutService.pinShortcut(...)` on confirm to deep-link to Shortcuts.app.
+- [ ] 6.5 Call `ShortcutService.syncSites(...)` after `_saveWebViewModels()` finishes (so the App Intent picker stays current as sites are added/renamed/deleted). Build the list from `_webViewModels`.
+- [ ] 6.6 Also call `syncSites` once at the tail of `_restoreAppState` so a freshly installed app populates the intent index before the user opens Shortcuts.app.
+
+## 7. Spec update
+
+- [ ] 7.1 Edit `openspec/specs/home-shortcut/spec.md`: rewrite HS-004 to allow iOS 16+, add HS-006 (App Intents), HS-007 (App Group sync), HS-008 (instructional dialog).
+- [ ] 7.2 Note in HS-005 that pinning detection is Android-only (iOS has no public API).
+
+## 8. Tests
+
+- [ ] 8.1 Add `test/shortcut_service_test.dart`:
+  - `ShortcutSite` round-trips through the platform call arg encoder.
+  - `syncSites` is a no-op on non-iOS platforms (mock the method channel — confirm no call).
+  - `isAppIntentsSupported` returns false off iOS.
+- [ ] 8.2 Run `fvm flutter analyze` and `fvm flutter test`.
+
+## 9. CLAUDE.md note
+
+- [ ] 9.1 Add a one-line entry to the per-site-settings table in CLAUDE.md mentioning iOS App Intents, OR leave alone if home-shortcut already covered (it is).

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Allow users to add a site shortcut to the Android home screen. Tapping the shortcut launches WebSpace and navigates to that site.
+Allow users to add a site shortcut to the home screen. Tapping the shortcut launches WebSpace and navigates to that site. On Android the system pins the shortcut directly via `ShortcutManagerCompat.requestPinShortcut`. On iOS 16+ the system exposes WebSpace sites as App Intents (`OpenSiteIntent`) that the user adds through the Shortcuts app and pins to the home screen from there.
 
 ## Status
 
@@ -70,35 +70,156 @@ The system SHALL use the site's favicon as the shortcut icon when available, fal
 
 ---
 
-### Requirement: HS-004 - Android Only
+### Requirement: HS-004 - Platform Availability
 
-The feature SHALL only be available on Android. On iOS/macOS, the menu item is not shown.
+The "Home Shortcut" menu item SHALL be shown on Android and on iOS 16+. On macOS, Linux, web, and iOS 13/14/15 the menu item SHALL be hidden.
 
-#### Scenario: Menu item hidden on non-Android platforms
+#### Scenario: Menu item shown on Android
 
-**Given** the app is running on iOS or macOS
+**Given** the app is running on Android
+**When** the user opens the overflow menu for a site that is not already pinned
+**Then** the "Home Shortcut" option is shown
+
+#### Scenario: Menu item shown on iOS 16 or later
+
+**Given** the app is running on iOS 16.0 or later
+**When** the user opens the overflow menu for any site
+**Then** the "Home Shortcut" option is shown
+
+#### Scenario: Menu item hidden on iOS 15 or earlier
+
+**Given** the app is running on iOS 13, 14, or 15
 **When** the user opens the overflow menu
-**Then** the "Add to Home Screen" option is not shown
+**Then** the "Home Shortcut" option is not shown
+
+#### Scenario: Menu item hidden on macOS and Linux
+
+**Given** the app is running on macOS or Linux
+**When** the user opens the overflow menu
+**Then** the "Home Shortcut" option is not shown
 
 ---
 
-### Requirement: HS-005 - Hide When Already Pinned
+### Requirement: HS-005 - Hide When Already Pinned (Android only)
 
-Sites in WebSpace are stable, so a home shortcut is a one-time setup per site. The "Home Shortcut" menu item SHALL be hidden when the current site already has a pinned shortcut, and SHALL reappear if the user removes the shortcut from the launcher.
+Sites in WebSpace are stable, so a home shortcut is a one-time setup per site. On Android, the "Home Shortcut" menu item SHALL be hidden when the current site already has a pinned shortcut, and SHALL reappear if the user removes the shortcut from the launcher. On iOS this scenario does not apply: iOS does not expose an API to query whether an App Shortcut tile is currently on the home screen, so the menu item stays available on iOS regardless of pin state.
 
-#### Scenario: Site already has a pinned shortcut
+#### Scenario: Android — site already has a pinned shortcut
 
-**Given** the user previously pinned a shortcut for the current site
+**Given** the user previously pinned a shortcut for the current site on Android
 **When** the user opens the overflow menu
 **Then** the "Home Shortcut" option is not shown for that site
 
-#### Scenario: Shortcut removed from launcher
+#### Scenario: Android — shortcut removed from launcher
 
 **Given** the user removed a previously pinned shortcut from their home screen
 **When** the user backgrounds and re-foregrounds the app, then opens the overflow menu for that site
 **Then** the "Home Shortcut" option is shown again
 
-The pinned-shortcut set is queried via `ShortcutManagerCompat.getShortcuts(FLAG_MATCH_PINNED)` exposed through the platform channel as `getPinnedSiteIds`. The cached set is refreshed on `initState` and on `AppLifecycleState.resumed`, which covers both the in-app pin flow (the launcher's pin dialog backgrounds the app) and out-of-app removal.
+#### Scenario: iOS — pin state is not detected
+
+**Given** the user has already added a shortcut for the current site to the iOS home screen
+**When** the user opens the overflow menu
+**Then** the "Home Shortcut" option is still shown (iOS cannot detect prior pinning)
+
+The Android pinned-shortcut set is queried via `ShortcutManagerCompat.getShortcuts(FLAG_MATCH_PINNED)` exposed through the platform channel as `getPinnedSiteIds`. The cached set is refreshed on `initState` and on `AppLifecycleState.resumed`, which covers both the in-app pin flow (the launcher's pin dialog backgrounds the app) and out-of-app removal. On iOS the same channel method returns an empty list.
+
+---
+
+### Requirement: HS-008 - iOS App Intent for Site Launching
+
+The system SHALL expose an iOS App Intent named "Open Site" that opens WebSpace and navigates to a chosen site. The intent SHALL conform to `OpenIntent` so iOS brings WebSpace to the foreground when the intent runs. The intent's site parameter SHALL be backed by a dynamic `AppEntity` query that returns the user's actual WebSpace sites.
+
+Only available on iOS 16+. On older iOS the intent type is compiled but never registered; the menu item is hidden per HS-004.
+
+#### Scenario: User adds the Open Site shortcut in Shortcuts.app
+
+**Given** the user has WebSpace installed on iOS 16 or later
+**When** the user opens the Shortcuts app and adds the "Open Site" action from WebSpace
+**Then** the action shows a "Site" parameter whose picker lists every site currently in WebSpace by name
+
+#### Scenario: Shortcut launches WebSpace to the chosen site
+
+**Given** the user has added a Shortcut wired to `OpenSiteIntent` with a specific site selected
+**When** the user taps the Shortcut tile on their home screen
+**Then** WebSpace launches (or comes to the foreground)
+**And** the chosen site is selected and loaded
+**And** the site's `currentUrl` resets to its `initUrl` on cold-launch (HS-006)
+
+#### Scenario: Cold launch via Shortcut
+
+**Given** WebSpace is not running
+**When** the user taps a Shortcut wired to `OpenSiteIntent` from the home screen
+**Then** the app cold-launches
+**And** `_restoreAppState` reads the pending siteId via `ShortcutService.getLaunchSiteId()`
+**And** the chosen site is the initial active index
+
+#### Scenario: Warm launch via Shortcut
+
+**Given** WebSpace is already running in the background
+**When** the user taps a Shortcut wired to `OpenSiteIntent`
+**Then** the app comes to the foreground
+**And** `_handleShortcutIntent` reads the pending siteId on the resume lifecycle event
+**And** the chosen site becomes active
+
+---
+
+### Requirement: HS-009 - Site List Synced to App Group
+
+The system SHALL keep the iOS App Intents site picker in sync with the user's actual WebSpace sites. Whenever the persisted site list changes (`_saveWebViewModels`), the system SHALL write the current `[{id, name}]` list to `UserDefaults(suiteName: "group.org.codeberg.theoden8.webspace")` under key `shortcut_sites`, and SHALL invalidate the App Shortcuts parameter cache via `AppShortcutsProvider.updateAppShortcutParameters()` so the Shortcuts app re-queries the entity provider.
+
+#### Scenario: Site added
+
+**Given** WebSpace is running on iOS 16+
+**When** the user creates a new site
+**Then** the new site appears in the App Intents picker the next time Shortcuts.app queries
+
+#### Scenario: Site renamed
+
+**Given** a site exists in WebSpace
+**When** the user renames it
+**Then** the new name is reflected in the App Intents picker after the next save
+
+#### Scenario: Site deleted
+
+**Given** a site is referenced by an existing user-created Shortcut
+**When** the user deletes the site in WebSpace
+**Then** the deleted site no longer appears in the App Intents picker
+**And** invoking the orphaned Shortcut performs no navigation (the entity resolves to nil)
+
+#### Scenario: App Group unavailable
+
+**Given** `UserDefaults(suiteName:)` returns nil (entitlement missing)
+**When** `syncSites` is invoked
+**Then** the method completes without crashing
+**And** logs a warning
+
+---
+
+### Requirement: HS-010 - iOS "Add to Home Screen" Dialog
+
+On iOS, tapping the "Home Shortcut" menu item SHALL show an instructional dialog explaining that iOS surfaces WebSpace sites through the Shortcuts app, with a primary button that deep-links to Shortcuts.app. The system SHALL NOT attempt to pin a shortcut programmatically (iOS has no such public API).
+
+#### Scenario: Dialog content
+
+**Given** the user is on iOS 16+
+**When** the user taps "Home Shortcut" in the overflow menu
+**Then** an `AlertDialog` is shown explaining the iOS flow ("find the Open Site action under WebSpace, pick this site, then tap Add to Home Screen")
+**And** the dialog has an "Open Shortcuts" primary button and a "Cancel" button
+
+#### Scenario: User confirms
+
+**Given** the iOS instructional dialog is shown
+**When** the user taps "Open Shortcuts"
+**Then** the system opens the URL `shortcuts://` via `UIApplication.shared.open`
+**And** the Shortcuts.app launches
+
+#### Scenario: User cancels
+
+**Given** the iOS instructional dialog is shown
+**When** the user taps "Cancel"
+**Then** the dialog dismisses
+**And** Shortcuts.app is not opened
 
 ---
 
@@ -162,13 +283,26 @@ This requirement applies only to **process-startup** launches (cold or post-kill
 
 ### Platform Channel
 
-Flutter communicates with native Android code via `MethodChannel('org.codeberg.theoden8.webspace/shortcuts')`.
+Both Android and iOS share the channel `MethodChannel('org.codeberg.theoden8.webspace/shortcuts')`.
 
 Methods:
-- `pinShortcut({siteId, label, iconUrl})` — requests a pinned shortcut via `ShortcutManagerCompat.requestPinShortcut()`
-- `removeShortcut(siteId)` — disables and removes the dynamic+pinned shortcut for a deleted site
-- `getLaunchSiteId()` — returns the `siteId` from the launch intent extra (if launched via shortcut)
-- `getPinnedSiteIds()` — returns the set of `siteId`s currently pinned, derived from `ShortcutManagerCompat.getShortcuts(FLAG_MATCH_PINNED)` by stripping the `site_` prefix
+- `pinShortcut({siteId, label, iconUrl})` — **Android**: requests a pinned shortcut via `ShortcutManagerCompat.requestPinShortcut()`. **iOS 16+**: opens `shortcuts://` (the Dart UI shows the HS-010 instructional dialog first).
+- `removeShortcut(siteId)` — Android: disables and removes the dynamic+pinned shortcut for a deleted site. iOS: no-op (the App Intents site list is recomputed from `_webViewModels` on every save via HS-009).
+- `getLaunchSiteId()` — **Android**: returns the `siteId` from the launch intent extra. **iOS**: drains the `pending_shortcut_site_id` key from App Group UserDefaults (written by `OpenSiteIntent.perform()`).
+- `getPinnedSiteIds()` — Android: returns the set of `siteId`s currently pinned, derived from `ShortcutManagerCompat.getShortcuts(FLAG_MATCH_PINNED)` by stripping the `site_` prefix. iOS: always returns an empty list (no public API for pin-state introspection).
+- `syncSites({sites: [{siteId, label, iconUrl?}]})` — **iOS only**: writes `[{id, name}]` to App Group UserDefaults under `shortcut_sites` and calls `WebSpaceShortcuts.updateAppShortcutParameters()` to refresh the Shortcuts.app picker. No-op on Android.
+- `isAppIntentsSupported()` — **iOS**: true if `#available(iOS 16, *)`. Other platforms: false.
+
+### iOS App Intents
+
+`ios/Runner/WebSpaceAppIntents.swift` defines (all `@available(iOS 16, *)`):
+
+- `SiteEntity: AppEntity` — one synced site with `id: String` (siteId) and `name: String`.
+- `SiteEntityQuery: EntityQuery` — reads the synced site list from App Group UserDefaults under `shortcut_sites` so Shortcuts.app's parameter picker shows real WebSpace sites.
+- `OpenSiteIntent: AppIntent, OpenIntent` — parameterized on `SiteEntity`. `openAppWhenRun = true` foregrounds WebSpace; `perform()` writes the chosen siteId to App Group UserDefaults under `pending_shortcut_site_id`.
+- `WebSpaceShortcuts: AppShortcutsProvider` — declares the discoverable "Open Site" App Shortcut with phrase template `"Open \(\.$target) in WebSpace"`.
+
+The Swift method-channel handler lives in `ios/Runner/ShortcutsPlugin.swift` and is registered alongside the other plugins in `AppDelegate.application(_:didFinishLaunchingWithOptions:)`.
 
 ### Shortcut Intent
 
@@ -194,14 +328,19 @@ no widget tree required.
 ### Files
 
 #### New
-- `lib/services/shortcut_service.dart` — Flutter wrapper around the platform channel
+- `lib/services/shortcut_service.dart` — Flutter wrapper around the platform channel (Android pin + iOS sync/launch)
 - `lib/services/startup_restore_engine.dart` — `resolveLaunchTarget` shortcut→index resolution
+- `ios/Runner/WebSpaceAppIntents.swift` — `SiteEntity`, `SiteEntityQuery`, `OpenSiteIntent`, `WebSpaceShortcuts` (iOS 16+)
+- `ios/Runner/ShortcutsPlugin.swift` — iOS method-channel handler
 - `test/startup_restore_engine_test.dart` — unit tests for the resolution rule
+- `test/shortcut_service_test.dart` — unit tests for the Dart service surface
 - `openspec/specs/home-shortcut/spec.md` — this specification
 
 #### Modified
 - `android/app/src/main/kotlin/.../MainActivity.kt` — native shortcut creation and intent handling
-- `lib/main.dart` — menu item, shortcut action, launch intent handling
+- `ios/Runner/AppDelegate.swift` — wire `ShortcutsPlugin`
+- `ios/Runner.xcodeproj/project.pbxproj` — register the new Swift files
+- `lib/main.dart` — menu item, shortcut action, launch intent handling, iOS site sync
 
 ---
 

--- a/test/shortcut_service_test.dart
+++ b/test/shortcut_service_test.dart
@@ -1,0 +1,127 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/shortcut_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel =
+      MethodChannel('org.codeberg.theoden8.webspace/shortcuts');
+
+  late List<MethodCall> calls;
+
+  setUp(() {
+    calls = [];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      // Default to a permissive value; individual tests can re-register.
+      if (call.method == 'isAppIntentsSupported') return true;
+      if (call.method == 'getPinnedSiteIds') return <Object?>[];
+      return null;
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  group('ShortcutSite', () {
+    test('toMap omits iconUrl when null', () {
+      final m = const ShortcutSite(siteId: 'abc', label: 'Site A').toMap();
+      expect(m, {'siteId': 'abc', 'label': 'Site A'});
+    });
+
+    test('toMap includes iconUrl when present', () {
+      final m = const ShortcutSite(
+        siteId: 'abc',
+        label: 'Site A',
+        iconUrl: 'https://example.com/favicon.png',
+      ).toMap();
+      expect(m, {
+        'siteId': 'abc',
+        'label': 'Site A',
+        'iconUrl': 'https://example.com/favicon.png',
+      });
+    });
+  });
+
+  group('ShortcutService — non-mobile host', () {
+    // Test host is the OS running `flutter test` (Linux on CI, macOS for local
+    // dev). All methods that gate on Platform.isAndroid / Platform.isIOS must
+    // short-circuit without touching the channel.
+    final isMobileHost = Platform.isAndroid || Platform.isIOS;
+
+    test('syncSites is a no-op off iOS', () async {
+      await ShortcutService.syncSites(const [
+        ShortcutSite(siteId: 'a', label: 'A'),
+      ]);
+      if (!Platform.isIOS) {
+        expect(calls, isEmpty);
+      }
+    });
+
+    test('isAppIntentsSupported is false off iOS', () async {
+      final supported = await ShortcutService.isAppIntentsSupported();
+      if (!Platform.isIOS) {
+        expect(supported, isFalse);
+        expect(calls, isEmpty);
+      }
+    });
+
+    test('pinShortcut is false on non-mobile host', () async {
+      final ok = await ShortcutService.pinShortcut(
+        siteId: 'a',
+        label: 'A',
+      );
+      if (!isMobileHost) {
+        expect(ok, isFalse);
+        expect(calls, isEmpty);
+      }
+    });
+
+    test('getLaunchSiteId is null on non-mobile host', () async {
+      final id = await ShortcutService.getLaunchSiteId();
+      if (!isMobileHost) {
+        expect(id, isNull);
+        expect(calls, isEmpty);
+      }
+    });
+
+    test('getPinnedSiteIds is empty off Android', () async {
+      final ids = await ShortcutService.getPinnedSiteIds();
+      if (!Platform.isAndroid) {
+        expect(ids, isEmpty);
+        expect(calls, isEmpty);
+      }
+    });
+
+    test('removeShortcut is a no-op off Android', () async {
+      await ShortcutService.removeShortcut('a');
+      if (!Platform.isAndroid) {
+        expect(calls, isEmpty);
+      }
+    });
+  });
+
+  group('ShortcutService — channel error handling', () {
+    test('platform exceptions degrade to safe defaults', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+        throw PlatformException(code: 'boom');
+      });
+      // On a non-mobile host these all short-circuit before touching the
+      // channel; this case really exercises mobile hosts. Still: the calls
+      // must never throw a PlatformException out of the service.
+      expect(await ShortcutService.pinShortcut(siteId: 'a', label: 'A'), isFalse);
+      expect(await ShortcutService.getLaunchSiteId(), isNull);
+      expect(await ShortcutService.getPinnedSiteIds(), isEmpty);
+      expect(await ShortcutService.isAppIntentsSupported(), isFalse);
+      await ShortcutService.syncSites(const []);
+      await ShortcutService.removeShortcut('a');
+    });
+  });
+}


### PR DESCRIPTION
iOS 16+ surfaces WebSpace sites in Shortcuts.app through OpenSiteIntent /
SiteEntity, so users can pick "Open Site", choose a specific site, and tap
"Add to Home Screen". HS-004 is broadened from Android-only; HS-008..HS-010
add the iOS intent, App Group sync, and instructional dialog. Older iOS
keeps the menu hidden — no URL-scheme fallback.