### PR TITLE
decouple live location from tracking protection (#326)

### DIFF
--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -149,15 +149,11 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
         localCdnEnabled: widget.localCdnEnabled || widget.trackingProtectionEnabled,
         trackingProtectionEnabled: widget.trackingProtectionEnabled,
         language: widget.language,
-        // Live geolocation leaks the device's real position around any
-        // proxy and through every spoof shim, so the umbrella demotes
-        // it to off; static spoof coords are kept and force the
-        // timezone to "From picked location". With no coords the
-        // umbrella leaves the timezone alone.
-        locationMode: widget.trackingProtectionEnabled &&
-                widget.locationMode == LocationMode.live
-            ? LocationMode.off
-            : widget.locationMode,
+        // Geolocation mode is independent of the umbrella. Static
+        // spoof coords still force the timezone to "From picked
+        // location" so Date/Intl match the spoofed geo. With no coords
+        // the umbrella leaves the timezone alone.
+        locationMode: widget.locationMode,
         spoofLatitude: widget.spoofLatitude,
         spoofLongitude: widget.spoofLongitude,
         spoofAccuracy: widget.spoofAccuracy,

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -582,12 +582,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
     // Derive the active segment from current state. `Static` is selected
     // when there are coords AND we're not in live mode; `Live` is selected
     // when the live flag is on (regardless of whether stale coords linger
-    // — they're ignored on save in that branch). Tracking Protection
-    // disallows live (it leaks real GPS around the proxy and shim) and
-    // forces the segment to Off when no coords are picked.
-    final bool liveBlocked = _trackingProtectionEnabled;
+    // — they're ignored on save in that branch).
     final _LocationSegment selected = _isLiveLocation
-        ? (liveBlocked ? _LocationSegment.off : _LocationSegment.live)
+        ? _LocationSegment.live
         : (hasCoords ? _LocationSegment.staticCoords : _LocationSegment.off);
 
     void onSegmentChanged(Set<_LocationSegment> values) {
@@ -630,11 +627,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
             value: _LocationSegment.staticCoords,
             icon: Icon(Icons.map_outlined),
             label: Text('Static')),
-        ButtonSegment(
+        const ButtonSegment(
             value: _LocationSegment.live,
-            icon: const Icon(Icons.my_location),
-            label: const Text('Live'),
-            enabled: !liveBlocked),
+            icon: Icon(Icons.my_location),
+            label: Text('Live')),
       ],
       selected: {selected},
       onSelectionChanged: onSegmentChanged,
@@ -644,14 +640,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
     Widget detail;
     switch (selected) {
       case _LocationSegment.off:
-        detail = Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        detail = const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16, vertical: 4),
           child: Text(
-            liveBlocked
-                ? 'Sites use the webview default (typically denied). '
-                    'Live tracking is blocked by Tracking Protection.'
-                : 'Sites use the webview default (typically denied).',
-            style: const TextStyle(fontSize: 12),
+            'Sites use the webview default (typically denied).',
+            style: TextStyle(fontSize: 12),
           ),
         );
         break;

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -623,16 +623,15 @@ class WebViewModel {
           contentBlockEnabled: contentBlockEnabled || trackingProtectionEnabled,
           localCdnEnabled: localCdnEnabled || trackingProtectionEnabled,
           trackingProtectionEnabled: trackingProtectionEnabled,
-          // Live geolocation leaks the device's real position around any
-          // proxy and through every spoof shim, so the umbrella demotes
-          // it to off. Static spoof coords are kept and force the
-          // timezone to "From picked location" so Date/Intl values
-          // match the spoofed geo. When no coords are picked the
-          // umbrella does NOT touch the timezone — the stored choice
-          // (or system default) stands.
-          locationMode: trackingProtectionEnabled && locationMode == LocationMode.live
-              ? LocationMode.off
-              : locationMode,
+          // Geolocation mode is independent of the umbrella: legitimate
+          // uses (maps, ride-share, weather) need real GPS even when
+          // the user wants tracker-blocking + fingerprinting protection
+          // active. Static spoof coords still force the timezone to
+          // "From picked location" so Date/Intl values match the
+          // spoofed geo. When no coords are picked the umbrella does
+          // NOT touch the timezone — the stored choice (or system
+          // default) stands.
+          locationMode: locationMode,
           spoofLatitude: spoofLatitude,
           spoofLongitude: spoofLongitude,
           spoofAccuracy: spoofAccuracy,

--- a/openspec/specs/tracking-protection/spec.md
+++ b/openspec/specs/tracking-protection/spec.md
@@ -44,10 +44,12 @@ Add a per-site `trackingProtectionEnabled` boolean (default true) to
   their stored value — `WebViewModel.getWebView` and
   `InAppWebViewScreen` compute `effective = stored ||
   trackingProtectionEnabled` and pass that to `WebViewConfig`.
-* `LocationMode.live` is demoted to `LocationMode.off` at the
-  `WebViewConfig` boundary (real GPS leaks around proxies and shims),
-  and when a static spoof location is set the timezone is forced to
+* When a static spoof location is set, the timezone is forced to
   "from picked location" so `Date` / `Intl` match the spoofed geo.
+  The geolocation mode itself (`off` / `spoof` / `live`) is NOT
+  touched by the umbrella — legitimate uses such as maps and
+  ride-share need live GPS even under tracker protection, and the
+  user is in control of which mode applies per site.
 * A JS shim
   ([lib/services/anti_fingerprinting_shim.dart](../../../lib/services/anti_fingerprinting_shim.dart))
   is injected at `DOCUMENT_START` into every frame of the site,
@@ -56,9 +58,8 @@ Add a per-site `trackingProtectionEnabled` boolean (default true) to
   a Mulberry32 PRNG keyed off an FNV-1a hash of the seed.
 
 When false, the four sub-toggles act independently as they did pre-
-umbrella, the anti-fingerprinting shim is not injected, live
-geolocation and any stored timezone are honoured, and per-site
-fingerprinting protection is off.
+umbrella, the anti-fingerprinting shim is not injected, any stored
+timezone is honoured, and per-site fingerprinting protection is off.
 
 ---
 
@@ -453,26 +454,27 @@ seeded noise per frame.
 
 ### Requirement: ETP-018 - Geolocation and timezone forcing
 
-When `trackingProtectionEnabled` is true the umbrella SHALL demote
-`LocationMode.live` to `LocationMode.off` at the `WebViewConfig`
-boundary (the device's real GPS would leak around any proxy and through
-every spoof shim) and, if a static spoof location is set
-(`spoofLatitude` and `spoofLongitude` both non-null), SHALL force the
-effective timezone to "from picked location"
+When `trackingProtectionEnabled` is true the umbrella SHALL, if a
+static spoof location is set (`spoofLatitude` and `spoofLongitude`
+both non-null), force the effective timezone to "from picked location"
 (`spoofTimezoneFromLocation: true`, `spoofTimezone: null`) so spoofed
 `Date` / `Intl.DateTimeFormat` values match the spoofed geo. With no
 spoof location set the umbrella SHALL leave the timezone untouched.
-Stored fields on `WebViewModel` are unchanged; only the `WebViewConfig`
-sees the forced values, and the same forcing applies to nested webviews
-via `InAppWebViewScreen.initState`.
+The umbrella SHALL NOT modify `locationMode`: `off` / `spoof` / `live`
+flow to `WebViewConfig` verbatim because legitimate use cases (maps,
+navigation, weather) need real GPS even under tracker-blocking, and
+the geolocation mode is the user's per-site choice. Stored fields on
+`WebViewModel` are unchanged; only the `WebViewConfig` sees the
+forced timezone values, and the same forcing applies to nested
+webviews via `InAppWebViewScreen.initState`.
 
-#### Scenario: Live location demoted to off
+#### Scenario: Live location is independent of the umbrella
 
 **Given** a site with `locationMode: LocationMode.live` and
 `trackingProtectionEnabled: true`
 **When** the webview is constructed
-**Then** the `WebViewConfig` has `locationMode: LocationMode.off`
-**And** the same demotion applies to nested webviews
+**Then** the `WebViewConfig` has `locationMode: LocationMode.live`
+**And** the same passthrough applies to nested webviews
 
 #### Scenario: Static spoof coords force from-location timezone
 
@@ -492,11 +494,11 @@ and `trackingProtectionEnabled: true`
 **Then** the `WebViewConfig` has `spoofTimezone: 'Europe/London'`
 **And** `spoofTimezoneFromLocation: false`
 
-#### Scenario: Settings UI locks Live segment and timezone
+#### Scenario: Settings UI keeps Live selectable under the umbrella
 
 **Given** the umbrella is on
 **Then** the per-site Settings geolocation `SegmentedButton` Live
-segment is rendered with `enabled: false`
+segment is rendered enabled and selectable
 **And** when spoof coords are set the timezone `DropdownButtonFormField`
 locks to "From picked location" with `onChanged: null` and a helper
 text of "Forced to "From picked location" by Tracking Protection"


### PR DESCRIPTION
Tracking Protection no longer demotes LocationMode.live to off, and
the Settings UI stops disabling the Live segment under the umbrella.
Legitimate live-GPS uses (maps, navigation, weather) need real
coordinates even when the user wants tracker-blocking and
anti-fingerprinting active; the mode is the user's per-site choice.
Timezone forcing from static spoof coords is unchanged.