### PR TITLE
fix(tracking-protection): randomize fingerprint per launch in incognito

### DIFF
--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -1113,7 +1113,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       'screen dimensions, hardware concurrency, plugins, battery, '
                       'speech voices, high-resolution timers, and bounding-box '
                       'measurements. The fingerprint stays stable per site across '
-                      'launches but differs between sites and between users.',
+                      'launches but differs between sites and between users. '
+                      'When Incognito is also enabled for this site, the '
+                      'fingerprint is rerolled on every app launch so the '
+                      'site cannot re-identify you across cold restarts.',
                 ),
               ],
             ),

--- a/lib/services/anti_fingerprinting_shim.dart
+++ b/lib/services/anti_fingerprinting_shim.dart
@@ -65,6 +65,28 @@ String computeAntiFingerprintingSeed({
   return incognito ? '$siteId:$launchNonce' : siteId;
 }
 
+/// Compose the full anti-fingerprinting `UserScript.source` (shim body
+/// plus the trailing `\n;null;` evaluator-return) for the given site
+/// configuration, or `null` if the umbrella is off / no siteId is set.
+///
+/// Lives alongside [computeAntiFingerprintingSeed] so the entire chain —
+/// gate → seed derivation → shim text — is exercisable from `flutter test`
+/// without standing up `WebViewFactory.createWebView`.
+String? buildAntiFingerprintingScriptSource({
+  required String? siteId,
+  required bool trackingProtectionEnabled,
+  required bool incognito,
+  required String launchNonce,
+}) {
+  if (!trackingProtectionEnabled || siteId == null) return null;
+  final seed = computeAntiFingerprintingSeed(
+    siteId: siteId,
+    incognito: incognito,
+    launchNonce: launchNonce,
+  );
+  return '${buildAntiFingerprintingShim(seed)}\n;null;';
+}
+
 /// Build the per-site anti-fingerprinting shim seeded by [seed]. The seed
 /// is computed via [computeAntiFingerprintingSeed] — siteId-only for
 /// non-incognito (stable per site) or `siteId:launchNonce` for incognito

--- a/lib/services/anti_fingerprinting_shim.dart
+++ b/lib/services/anti_fingerprinting_shim.dart
@@ -45,9 +45,30 @@
 
 import 'dart:convert';
 
+/// Compute the seed string passed to [buildAntiFingerprintingShim].
+///
+/// Non-incognito sites seed with `siteId` verbatim — the fingerprint stays
+/// stable across launches (ETP-004 baseline).
+///
+/// Incognito sites mix in a process-lifetime [launchNonce] (typically
+/// `LaunchNonce.value`) so the fingerprint is stable within a single app
+/// session — no flicker on iframe re-injection or nested webview opens —
+/// but randomizes across cold restarts. The `incognito` flag already implies
+/// the user wants a fresh-visitor posture each launch; reusing the same
+/// fingerprint across launches would itself be a stable cross-session
+/// identifier (issue #327, ETP-019).
+String computeAntiFingerprintingSeed({
+  required String siteId,
+  required bool incognito,
+  required String launchNonce,
+}) {
+  return incognito ? '$siteId:$launchNonce' : siteId;
+}
+
 /// Build the per-site anti-fingerprinting shim seeded by [seed]. The seed
-/// MUST be stable per site (we pass `siteId`) so the same site always
-/// reports the same fingerprint across launches.
+/// is computed via [computeAntiFingerprintingSeed] — siteId-only for
+/// non-incognito (stable per site) or `siteId:launchNonce` for incognito
+/// (stable per session, randomized per launch).
 String buildAntiFingerprintingShim(String seed) {
   final encodedSeed = jsonEncode(seed);
   return '''

--- a/lib/services/launch_nonce.dart
+++ b/lib/services/launch_nonce.dart
@@ -1,0 +1,29 @@
+import 'dart:math';
+
+/// Process-lifetime random nonce used to randomize the anti-fingerprinting
+/// PRNG seed for `incognito` sites across launches (issue #327, ETP-019).
+///
+/// Generated lazily on first access via `Random.secure` and cached for the
+/// rest of the process. Cold restart → fresh nonce → fresh fingerprint.
+/// App resume from background is NOT a launch and reuses the same nonce.
+class LaunchNonce {
+  static String? _value;
+
+  static String get value => _value ??= _generate();
+
+  static String _generate() {
+    final rng = Random.secure();
+    final bytes = List<int>.generate(16, (_) => rng.nextInt(256));
+    return bytes
+        .map((b) => b.toRadixString(16).padLeft(2, '0'))
+        .join();
+  }
+
+  static void overrideForTesting(String value) {
+    _value = value;
+  }
+
+  static void resetForTesting() {
+    _value = null;
+  }
+}

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -11,6 +11,7 @@ import 'package:webspace/services/blob_url_capture.dart';
 import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/do_not_track_shim.dart';
 import 'package:webspace/services/language_shim.dart';
+import 'package:webspace/services/launch_nonce.dart';
 import 'package:webspace/services/theme_color_scheme_shim.dart';
 import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
@@ -1320,10 +1321,21 @@ class WebViewFactory {
     // sees a stable fingerprint across launches but different sites see
     // different ones. Must run before site scripts capture the unpatched
     // references and must reach iframes.
+    //
+    // Incognito carve-out (issue #327, ETP-019): when the site is incognito
+    // the seed mixes in `LaunchNonce.value` so the fingerprint randomizes
+    // across cold restarts. Within one process the nonce is constant, so
+    // every iframe / nested webview / tab switch in the same launch sees
+    // the same fingerprint.
     if (config.trackingProtectionEnabled && config.siteId != null) {
+      final seed = computeAntiFingerprintingSeed(
+        siteId: config.siteId!,
+        incognito: config.incognito,
+        launchNonce: LaunchNonce.value,
+      );
       userScripts.add(inapp.UserScript(
         groupName: 'anti_fingerprinting',
-        source: '${buildAntiFingerprintingShim(config.siteId!)}\n;null;',
+        source: '${buildAntiFingerprintingShim(seed)}\n;null;',
         injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
         forMainFrameOnly: false,
       ));

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1327,15 +1327,16 @@ class WebViewFactory {
     // across cold restarts. Within one process the nonce is constant, so
     // every iframe / nested webview / tab switch in the same launch sees
     // the same fingerprint.
-    if (config.trackingProtectionEnabled && config.siteId != null) {
-      final seed = computeAntiFingerprintingSeed(
-        siteId: config.siteId!,
-        incognito: config.incognito,
-        launchNonce: LaunchNonce.value,
-      );
+    final antiFpSource = buildAntiFingerprintingScriptSource(
+      siteId: config.siteId,
+      trackingProtectionEnabled: config.trackingProtectionEnabled,
+      incognito: config.incognito,
+      launchNonce: LaunchNonce.value,
+    );
+    if (antiFpSource != null) {
       userScripts.add(inapp.UserScript(
         groupName: 'anti_fingerprinting',
-        source: '${buildAntiFingerprintingShim(seed)}\n;null;',
+        source: antiFpSource,
         injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
         forMainFrameOnly: false,
       ));

--- a/openspec/changes/incognito-fingerprint-randomization/proposal.md
+++ b/openspec/changes/incognito-fingerprint-randomization/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Issue #327: when both Tracking Protection and Incognito are enabled for a site, the anti-fingerprinting shim still seeds its PRNG with `siteId` alone, so the fingerprint is identical across launches. That's the documented and desired posture for non-incognito sites (so a session-stable identity reduces re-identification jitter that itself becomes a tell), but for an incognito site the user has already declared "treat me as a fresh visitor every launch". Returning the same Canvas hash, WebGL strings, screen dims, hardware concurrency, audio buffer noise, etc. across cold restarts breaks that contract — the per-site fingerprint is itself a stable cross-launch identifier.
+
+## What Changes
+
+- Mix a process-lifetime random nonce into the fingerprint seed when `incognito && trackingProtectionEnabled`. Non-incognito sites are unchanged (siteId-only seed → stable per-site fingerprint, current ETP-004 behavior).
+- New `lib/services/launch_nonce.dart`: lazy `LaunchNonce.value` generated once per process via `Random.secure`, stable for the lifetime of the process so multiple reads within a session see the same fingerprint. Cold restart → fresh nonce → fresh fingerprint.
+- New pure helper `computeAntiFingerprintingSeed({siteId, incognito, launchNonce})` in `anti_fingerprinting_shim.dart` so the seed-derivation rule is unit-testable in isolation.
+- `WebViewFactory.createWebView` swaps `siteId!` for `computeAntiFingerprintingSeed(...)` at the existing shim-injection site.
+- Spec: amend ETP-004 to carve out the incognito case; add ETP-019 covering the launch-nonce contract.
+
+## Scope
+
+- Behaviour change is gated on `incognito && trackingProtectionEnabled`. Both off → no change. TP only → no change. Incognito only → shim isn't injected anyway (gated upstream).
+- No new dependencies, no native platform code, no plugin changes.
+- The nonce is per-process, not per-tab. All incognito sites in a launch share the same nonce so two incognito tabs of the same site see the same fingerprint within the session (no flicker on iframe re-injection).
+
+## Non-Goals
+
+- No real-engine fingerprint proofing — the existing jsdom test tier is unchanged. We only assert the seed-derivation logic; the downstream shim-text changes are already covered by ETP-004's "different seeds → different shim" scenario.
+- No persistence of the nonce. Backgrounding the app is NOT a launch boundary; only process restart regenerates it. (Matches the user-mental-model of "I closed the app and reopened it".)
+- No cross-platform divergence: `Random.secure` is available on every platform we ship.

--- a/openspec/changes/incognito-fingerprint-randomization/specs/tracking-protection/spec.md
+++ b/openspec/changes/incognito-fingerprint-randomization/specs/tracking-protection/spec.md
@@ -1,0 +1,84 @@
+# Enhanced Tracking Protection — incognito fingerprint randomization delta
+
+## MODIFIED Requirements
+
+### Requirement: ETP-004 - Per-site stability and cross-site uniqueness
+
+The shim's randomized values SHALL be deterministic per `siteId` so a non-incognito site sees the same fingerprint across launches, but distinct seeds SHALL produce distinct shim sources so two sites differ. When the site has `incognito` set, the seed SHALL additionally mix in the per-launch nonce defined by ETP-019, so the fingerprint is stable within a single app session but randomizes across cold restarts. The shim builder itself remains a pure function of its seed string — the seed-derivation rule lives in `computeAntiFingerprintingSeed` ([lib/services/anti_fingerprinting_shim.dart](../../../../../lib/services/anti_fingerprinting_shim.dart)).
+
+#### Scenario: Same seed reproduces the same shim
+
+**Given** `buildAntiFingerprintingShim('seed-A')` returns string `S1`
+**When** the same builder is invoked again with the same seed
+**Then** the result equals `S1`
+
+#### Scenario: Different seeds produce different shim text
+
+**Given** `buildAntiFingerprintingShim('seed-A')` returns `S1`
+**And** `buildAntiFingerprintingShim('seed-B')` returns `S2`
+**Then** `S1 != S2`
+**And** both contain the literal seed string for the FNV-1a hash
+
+#### Scenario: Non-incognito seed is the siteId verbatim
+
+**Given** `computeAntiFingerprintingSeed(siteId: 's1', incognito: false, launchNonce: 'n1')`
+**Then** the returned seed equals `'s1'`
+**And** `computeAntiFingerprintingSeed(siteId: 's1', incognito: false, launchNonce: 'n2')` also equals `'s1'`
+(non-incognito sites see the same fingerprint across launches regardless of nonce)
+
+#### Scenario: Incognito seed mixes in the launch nonce
+
+**Given** `computeAntiFingerprintingSeed(siteId: 's1', incognito: true, launchNonce: 'n1')` returns `seed1`
+**And** `computeAntiFingerprintingSeed(siteId: 's1', incognito: true, launchNonce: 'n2')` returns `seed2`
+**Then** `seed1 != seed2`
+**And** `seed1 != 's1'`
+**And** both seeds embed the siteId so two incognito sites under the same nonce remain distinct
+
+#### Scenario: Incognito seed is stable within a launch
+
+**Given** the launch nonce is `n1` for the lifetime of the process
+**When** `computeAntiFingerprintingSeed(siteId: 's1', incognito: true, launchNonce: 'n1')` is called twice within that process
+**Then** both calls return the same seed
+(same fingerprint across iframe re-injections, tab switches, and nested webview opens within one session)
+
+---
+
+## ADDED Requirements
+
+### Requirement: ETP-019 - Per-launch nonce for incognito fingerprint randomization
+
+The system SHALL maintain a process-lifetime random nonce, exposed as `LaunchNonce.value` in [lib/services/launch_nonce.dart](../../../../../lib/services/launch_nonce.dart). The nonce SHALL be generated lazily on first read using `dart:math` `Random.secure` and SHALL remain identical for every subsequent read within the same process. The nonce SHALL NOT be persisted to disk: a new process start (cold launch, OS-killed restore, debug hot-restart) SHALL produce a fresh nonce. App resume from background is NOT a new launch and SHALL NOT regenerate the nonce. The nonce SHALL be mixed into the anti-fingerprinting seed only when the site has `incognito: true` (per ETP-004).
+
+#### Scenario: Stable across reads within a process
+
+**Given** `LaunchNonce.value` returns `n` on first read
+**When** `LaunchNonce.value` is read again later in the same process
+**Then** the returned value equals `n`
+
+#### Scenario: Non-empty cryptographic random
+
+**Given** `LaunchNonce.value` is read
+**Then** the returned string is non-empty
+**And** matches `^[0-9a-f]+$` (hex encoding of `Random.secure` bytes)
+
+#### Scenario: Test override
+
+**Given** a test calls `LaunchNonce.overrideForTesting('fixed')`
+**When** `LaunchNonce.value` is read
+**Then** the returned value equals `'fixed'`
+**And** a subsequent `LaunchNonce.resetForTesting()` causes the next read to regenerate a fresh random nonce
+
+#### Scenario: Incognito + Tracking Protection randomizes per launch
+
+**Given** a site has `incognito: true` and `trackingProtectionEnabled: true`
+**When** the webview is constructed
+**Then** the seed passed to `buildAntiFingerprintingShim` is `'${siteId}:${LaunchNonce.value}'`
+**And** after a process restart the seed embeds a different nonce
+**And** therefore the shim source (and every fingerprintable surface seeded by the PRNG) changes across launches
+
+#### Scenario: Non-incognito site keeps stable per-site fingerprint
+
+**Given** a site has `incognito: false` and `trackingProtectionEnabled: true`
+**When** the webview is constructed
+**Then** the seed passed to `buildAntiFingerprintingShim` is `siteId` verbatim
+**And** the fingerprint is identical across launches (ETP-004 baseline preserved)

--- a/openspec/changes/incognito-fingerprint-randomization/tasks.md
+++ b/openspec/changes/incognito-fingerprint-randomization/tasks.md
@@ -1,0 +1,23 @@
+## 1. Launch nonce service
+
+- [ ] 1.1 Create `lib/services/launch_nonce.dart` exposing `LaunchNonce.value` (lazy-initialised hex string from `Random.secure`, 16 bytes / 32 hex chars), `LaunchNonce.overrideForTesting(String?)`, and `LaunchNonce.resetForTesting()`.
+- [ ] 1.2 Create `test/launch_nonce_test.dart` covering: (a) two reads within a process return the same value; (b) the value is non-empty hex; (c) `overrideForTesting` is honoured and `resetForTesting` clears it.
+
+## 2. Seed derivation helper
+
+- [ ] 2.1 Add `computeAntiFingerprintingSeed({required String siteId, required bool incognito, required String launchNonce})` to `lib/services/anti_fingerprinting_shim.dart`. Returns `'$siteId:$launchNonce'` when `incognito` is true, otherwise `siteId`.
+- [ ] 2.2 Extend `test/anti_fingerprinting_shim_test.dart` with a `computeAntiFingerprintingSeed` group covering: non-incognito returns siteId verbatim; incognito mixes the nonce; same (siteId, nonce) → same seed; different nonces → different seeds; different siteIds → different seeds.
+
+## 3. Wire into the shim-injection site
+
+- [ ] 3.1 In `lib/services/webview.dart` (`WebViewFactory.createWebView`, ~line 1326), replace `buildAntiFingerprintingShim(config.siteId!)` with `buildAntiFingerprintingShim(computeAntiFingerprintingSeed(siteId: config.siteId!, incognito: config.incognito, launchNonce: LaunchNonce.value))`.
+- [ ] 3.2 Update the inline comment block above the injection so it documents the incognito carve-out.
+
+## 4. Spec
+
+- [ ] 4.1 Add `openspec/changes/incognito-fingerprint-randomization/specs/tracking-protection/spec.md` with MODIFIED ETP-004 (incognito carve-out) and ADDED ETP-019 (launch-nonce contract).
+
+## 5. Verification
+
+- [ ] 5.1 `fvm flutter test test/anti_fingerprinting_shim_test.dart test/launch_nonce_test.dart`
+- [ ] 5.2 `fvm flutter analyze`

--- a/openspec/changes/incognito-fingerprint-randomization/tasks.md
+++ b/openspec/changes/incognito-fingerprint-randomization/tasks.md
@@ -10,8 +10,9 @@
 
 ## 3. Wire into the shim-injection site
 
-- [ ] 3.1 In `lib/services/webview.dart` (`WebViewFactory.createWebView`, ~line 1326), replace `buildAntiFingerprintingShim(config.siteId!)` with `buildAntiFingerprintingShim(computeAntiFingerprintingSeed(siteId: config.siteId!, incognito: config.incognito, launchNonce: LaunchNonce.value))`.
-- [ ] 3.2 Update the inline comment block above the injection so it documents the incognito carve-out.
+- [ ] 3.1 Add `buildAntiFingerprintingScriptSource({siteId, trackingProtectionEnabled, incognito, launchNonce})` in `lib/services/anti_fingerprinting_shim.dart` returning `String?` — encapsulates the umbrella + siteId gate, the seed derivation, and the `\n;null;` evaluator-return contract, so the entire chain is exercisable from `flutter test`.
+- [ ] 3.2 In `lib/services/webview.dart` (`WebViewFactory.createWebView`, ~line 1326), replace the direct `buildAntiFingerprintingShim(config.siteId!)` call with `buildAntiFingerprintingScriptSource(...)` driven by `LaunchNonce.value`; keep the inline comment block documenting the incognito carve-out.
+- [ ] 3.3 Add a `fingerprint ephemerality (issue #327)` group in `test/anti_fingerprinting_shim_test.dart` (parallel to `incognito ephemerality (issue #298)` in `test/web_view_model_test.dart`) covering: TP off → no shim; TP on + null siteId → no shim; non-incognito identical across simulated launches; incognito differs across simulated launches; incognito stable within one launch; cross-site uniqueness preserved under a shared launch nonce; toggling incognito changes the fingerprint; `\n;null;` sentinel preserved.
 
 ## 4. Spec
 

--- a/openspec/changes/incognito-fingerprint-randomization/tasks.md
+++ b/openspec/changes/incognito-fingerprint-randomization/tasks.md
@@ -18,7 +18,36 @@
 
 - [ ] 4.1 Add `openspec/changes/incognito-fingerprint-randomization/specs/tracking-protection/spec.md` with MODIFIED ETP-004 (incognito carve-out) and ADDED ETP-019 (launch-nonce contract).
 
-## 5. Verification
+## 5. Tier 3 real-engine coverage
 
-- [ ] 5.1 `fvm flutter test test/anti_fingerprinting_shim_test.dart test/launch_nonce_test.dart`
-- [ ] 5.2 `fvm flutter analyze`
+- [ ] 5.1 Add two pinned-seed fixtures to `tool/dump_shim_js.dart` —
+      `anti_fingerprinting/shim_seed_alpha_launch_one.js` and
+      `shim_seed_alpha_launch_two.js` — built via
+      `computeAntiFingerprintingSeed(siteId: 'alpha-fixture-seed',
+      incognito: true, launchNonce: 'nonce-launch-one' | 'nonce-launch-two')`.
+- [ ] 5.2 Re-dump fixtures: `fvm dart run tool/dump_shim_js.dart`. The drift
+      test in `test/js_fixtures_drift_test.dart` enforces these are in
+      sync with the builders going forward.
+- [ ] 5.3 Add a `#327 incognito fingerprint rerolls per launch` block in
+      `test/browser/fingerprint_real_engine.test.js` asserting under
+      headless Chromium + FingerprintJS: (a) two simulated launches with
+      different nonces produce distinct `canvas` components for the same
+      siteId; (b) the same shim loaded twice yields identical components
+      (in-launch stability); (c) the non-incognito (siteId-only) shim
+      differs from the incognito (siteId:nonce) shim for the same siteId.
+
+## 6. Doc cleanup
+
+- [ ] 6.1 Replace the stale "Playwright + CreepJS follow-up tier" phrasing
+      in `lib/services/anti_fingerprinting_shim.dart`,
+      `openspec/specs/tracking-protection/spec.md`,
+      `test/js/anti_fingerprinting_shim.test.js`,
+      `test/js/helpers/load_shim.js`, and `test/js_fixtures/README.md`.
+      The Tier 3 harness already exists and runs under Puppeteer +
+      FingerprintJS; the leftover "follow-up tier" comments predate it.
+
+## 7. Verification
+
+- [ ] 7.1 `fvm flutter test test/anti_fingerprinting_shim_test.dart test/launch_nonce_test.dart test/js_fixtures_drift_test.dart`
+- [ ] 7.2 `npm run test:browser -- test/browser/fingerprint_real_engine.test.js`
+- [ ] 7.3 `fvm flutter analyze` (no new issues from changed files)

--- a/openspec/specs/tracking-protection/spec.md
+++ b/openspec/specs/tracking-protection/spec.md
@@ -669,5 +669,6 @@ jsdom omits real Canvas/WebGL/Audio engines. Tests stub these with inert
 classes that record calls; they assert wrapper shape (prototype methods
 replaced, `[native code]` toString, return value transformed) rather
 than the noise's effect on real engine output. Real-engine fingerprint
-proofing belongs to a follow-up Playwright + CreepJS tier (not in scope
-for this change).
+proofing runs under Puppeteer + FingerprintJS in
+`test/browser/fingerprint_real_engine.test.js`, with CreepJS-style
+lie-detection probes in `test/browser/lie_detection.test.js`.

--- a/test/anti_fingerprinting_shim_test.dart
+++ b/test/anti_fingerprinting_shim_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:webspace/services/anti_fingerprinting_shim.dart';
+import 'package:webspace/services/launch_nonce.dart';
 
 void main() {
   group('buildAntiFingerprintingShim', () {
@@ -245,6 +246,140 @@ void main() {
       );
       final shim = buildAntiFingerprintingShim(seed);
       expect(shim, contains('"site-A:nonce-1"'));
+    });
+  });
+
+  group('fingerprint ephemerality (issue #327)', () {
+    // Parallel to the `incognito ephemerality (issue #298)` group in
+    // web_view_model_test.dart, but for the anti-fingerprinting shim:
+    // exercises the full gate -> seed -> shim chain so a regression in
+    // the wiring at WebViewFactory.createWebView (siteId/incognito arg
+    // mix-ups, dropped gate, missed LaunchNonce read) gets caught.
+
+    setUp(LaunchNonce.resetForTesting);
+    tearDown(LaunchNonce.resetForTesting);
+
+    String? scriptFor({
+      required String siteId,
+      required bool trackingProtectionEnabled,
+      required bool incognito,
+    }) {
+      return buildAntiFingerprintingScriptSource(
+        siteId: siteId,
+        trackingProtectionEnabled: trackingProtectionEnabled,
+        incognito: incognito,
+        launchNonce: LaunchNonce.value,
+      );
+    }
+
+    test('TP off -> no shim regardless of incognito', () {
+      expect(
+        scriptFor(siteId: 's1', trackingProtectionEnabled: false, incognito: false),
+        isNull,
+      );
+      expect(
+        scriptFor(siteId: 's1', trackingProtectionEnabled: false, incognito: true),
+        isNull,
+      );
+    });
+
+    test('TP on without siteId -> no shim', () {
+      // Mirrors ETP-003 "Shim NOT injected without siteId" — exercised
+      // through the script-source helper to pin the gate at the wiring
+      // layer too, not just the JS-side builder.
+      final src = buildAntiFingerprintingScriptSource(
+        siteId: null,
+        trackingProtectionEnabled: true,
+        incognito: true,
+        launchNonce: LaunchNonce.value,
+      );
+      expect(src, isNull);
+    });
+
+    test('non-incognito: fingerprint identical across launches (ETP-004)', () {
+      // Simulate launch 1.
+      final launch1 = scriptFor(
+        siteId: 'site-A', trackingProtectionEnabled: true, incognito: false,
+      );
+      // Simulate launch 2 by tearing down the process-lifetime nonce.
+      LaunchNonce.resetForTesting();
+      final launch2 = scriptFor(
+        siteId: 'site-A', trackingProtectionEnabled: true, incognito: false,
+      );
+      expect(launch1, isNotNull);
+      expect(launch2, equals(launch1),
+          reason: 'non-incognito sites must keep a stable per-site '
+              'fingerprint across cold restarts (ETP-004 baseline)');
+    });
+
+    test('incognito: fingerprint differs across launches (#327)', () {
+      // The exact behaviour the user reported missing in v0.2.3: with
+      // both TP and Incognito on, the fingerprint persisted across
+      // launches because the seed was siteId-only.
+      final launch1 = scriptFor(
+        siteId: 'site-A', trackingProtectionEnabled: true, incognito: true,
+      );
+      LaunchNonce.resetForTesting();
+      final launch2 = scriptFor(
+        siteId: 'site-A', trackingProtectionEnabled: true, incognito: true,
+      );
+      expect(launch1, isNotNull);
+      expect(launch2, isNot(equals(launch1)),
+          reason: 'incognito + TP must reroll the fingerprint per launch '
+              '(issue #327 / ETP-019)');
+    });
+
+    test('incognito: fingerprint stable within one launch', () {
+      // Same launch — same nonce — same fingerprint. Prevents flicker
+      // across iframe re-injection, nested webview opens, and tab
+      // switches within one app session.
+      LaunchNonce.overrideForTesting('pinned-nonce');
+      final first = scriptFor(
+        siteId: 'site-A', trackingProtectionEnabled: true, incognito: true,
+      );
+      final second = scriptFor(
+        siteId: 'site-A', trackingProtectionEnabled: true, incognito: true,
+      );
+      expect(second, equals(first));
+    });
+
+    test('two incognito sites in one launch keep cross-site uniqueness', () {
+      LaunchNonce.overrideForTesting('pinned-nonce');
+      final a = scriptFor(
+        siteId: 'site-A', trackingProtectionEnabled: true, incognito: true,
+      );
+      final b = scriptFor(
+        siteId: 'site-B', trackingProtectionEnabled: true, incognito: true,
+      );
+      expect(a, isNotNull);
+      expect(b, isNot(equals(a)),
+          reason: 'sharing the launch nonce must not collapse two sites '
+              'into the same fingerprint');
+    });
+
+    test('toggling incognito changes the fingerprint for the same site', () {
+      LaunchNonce.overrideForTesting('pinned-nonce');
+      final stable = scriptFor(
+        siteId: 'site-A', trackingProtectionEnabled: true, incognito: false,
+      );
+      final ephemeral = scriptFor(
+        siteId: 'site-A', trackingProtectionEnabled: true, incognito: true,
+      );
+      expect(ephemeral, isNot(equals(stable)),
+          reason: 'enabling incognito is the user opt-out from the stable '
+              'per-site identity — the fingerprint must change');
+    });
+
+    test('script source carries the InAppWebView return-value sentinel', () {
+      // WebViewFactory.createWebView appends `\n;null;` to every shim
+      // source so the evaluator returns null instead of the IIFE return
+      // value (which the platform channel cannot serialize for some
+      // shapes). Keep that contract pinned in the helper.
+      LaunchNonce.overrideForTesting('pinned-nonce');
+      final src = scriptFor(
+        siteId: 'site-A', trackingProtectionEnabled: true, incognito: false,
+      );
+      expect(src, endsWith('\n;null;'));
     });
   });
 }

--- a/test/anti_fingerprinting_shim_test.dart
+++ b/test/anti_fingerprinting_shim_test.dart
@@ -150,4 +150,101 @@ void main() {
       expect(js, contains('[native code]'));
     });
   });
+
+  group('computeAntiFingerprintingSeed', () {
+    // Issue #327 / ETP-019: incognito sites must randomize their
+    // fingerprint per launch, while non-incognito sites keep the
+    // ETP-004 stable-per-site posture.
+
+    test('non-incognito returns siteId verbatim', () {
+      final seed = computeAntiFingerprintingSeed(
+        siteId: 'site-A',
+        incognito: false,
+        launchNonce: 'nonce-1',
+      );
+      expect(seed, equals('site-A'));
+    });
+
+    test('non-incognito ignores the launch nonce entirely', () {
+      // Stable per-site fingerprint across launches: same siteId, two
+      // different launches, same seed.
+      final s1 = computeAntiFingerprintingSeed(
+        siteId: 'site-A', incognito: false, launchNonce: 'nonce-1',
+      );
+      final s2 = computeAntiFingerprintingSeed(
+        siteId: 'site-A', incognito: false, launchNonce: 'nonce-2',
+      );
+      expect(s1, equals(s2));
+    });
+
+    test('incognito mixes in the nonce', () {
+      final seed = computeAntiFingerprintingSeed(
+        siteId: 'site-A',
+        incognito: true,
+        launchNonce: 'nonce-1',
+      );
+      expect(seed, isNot(equals('site-A')));
+      expect(seed, contains('site-A'));
+      expect(seed, contains('nonce-1'));
+    });
+
+    test('incognito + same (siteId, nonce) -> same seed (in-session stability)',
+        () {
+      // Same fingerprint across iframe re-injection within one app
+      // session — flicker would itself be a fingerprintable signal.
+      final s1 = computeAntiFingerprintingSeed(
+        siteId: 'site-A', incognito: true, launchNonce: 'nonce-1',
+      );
+      final s2 = computeAntiFingerprintingSeed(
+        siteId: 'site-A', incognito: true, launchNonce: 'nonce-1',
+      );
+      expect(s1, equals(s2));
+    });
+
+    test('incognito + different nonces -> different seeds (per-launch reroll)',
+        () {
+      final s1 = computeAntiFingerprintingSeed(
+        siteId: 'site-A', incognito: true, launchNonce: 'nonce-1',
+      );
+      final s2 = computeAntiFingerprintingSeed(
+        siteId: 'site-A', incognito: true, launchNonce: 'nonce-2',
+      );
+      expect(s1, isNot(equals(s2)));
+    });
+
+    test('incognito + different siteIds, same nonce -> different seeds', () {
+      // Two incognito tabs in the same launch must still see distinct
+      // fingerprints (cross-site uniqueness, ETP-004).
+      final a = computeAntiFingerprintingSeed(
+        siteId: 'site-A', incognito: true, launchNonce: 'nonce-1',
+      );
+      final b = computeAntiFingerprintingSeed(
+        siteId: 'site-B', incognito: true, launchNonce: 'nonce-1',
+      );
+      expect(a, isNot(equals(b)));
+    });
+
+    test('toggling incognito for the same site changes the seed', () {
+      // The whole point of issue #327: the user enabled incognito to opt
+      // out of the stable identity, so the seed MUST differ from the
+      // non-incognito case.
+      final stable = computeAntiFingerprintingSeed(
+        siteId: 'site-A', incognito: false, launchNonce: 'nonce-1',
+      );
+      final ephemeral = computeAntiFingerprintingSeed(
+        siteId: 'site-A', incognito: true, launchNonce: 'nonce-1',
+      );
+      expect(ephemeral, isNot(equals(stable)));
+    });
+
+    test('seed flows through buildAntiFingerprintingShim end-to-end', () {
+      // Sanity: the seed string we compute appears in the generated
+      // shim source, so the JS-side PRNG is keyed off the right value.
+      final seed = computeAntiFingerprintingSeed(
+        siteId: 'site-A', incognito: true, launchNonce: 'nonce-1',
+      );
+      final shim = buildAntiFingerprintingShim(seed);
+      expect(shim, contains('"site-A:nonce-1"'));
+    });
+  });
 }

--- a/test/browser/fingerprint_real_engine.test.js
+++ b/test/browser/fingerprint_real_engine.test.js
@@ -34,6 +34,18 @@ const TZ_TOKYO = readFixture('location_spoof/timezone_only_tokyo.js');
 const FULL_COMBO = readFixture('location_spoof/full_combo.js');
 const STATIC_TOKYO = readFixture('location_spoof/static_tokyo.js');
 
+// Issue #327 fixtures: same siteId ('alpha-fixture-seed'), two
+// different process-lifetime nonces. Building these in the Dart fixture
+// dumper (tool/dump_shim_js.dart) keeps the seed strings under spec
+// control and prevents this test from accidentally generating its own
+// shim with a divergent JS-side hashing rule.
+const ANTI_FP_LAUNCH_ONE =
+    readFixture('anti_fingerprinting/shim_seed_alpha_launch_one.js');
+const ANTI_FP_LAUNCH_TWO =
+    readFixture('anti_fingerprinting/shim_seed_alpha_launch_two.js');
+const ANTI_FP_STABLE =
+    readFixture('anti_fingerprinting/shim_seed_alpha.js');
+
 const browser = setupBrowser();
 
 // Run the FingerprintJS detector inside the page and return its
@@ -151,6 +163,70 @@ test('FingerprintJS: full_combo dateTimeLocale embeds spoofed zone',
       assert.ok(c.dateTimeLocale.length > 0,
         'dateTimeLocale should be a non-empty formatted date');
     });
+  });
+
+// ---------- #327 incognito fingerprint rerolls per launch ----------
+//
+// Tier 1 (Dart unit tests on `computeAntiFingerprintingSeed` /
+// `buildAntiFingerprintingScriptSource`) and Tier 2 (jsdom shape
+// tests) prove the seed-derivation logic and shim shape. This tier
+// closes the loop under real Chromium: load FingerprintJS against
+// two shims that share a siteId but differ only in the launch nonce,
+// and assert the report's noise-bearing components diverge. If a
+// future refactor accidentally drops the nonce (siteId-only seed),
+// the two reports would coincide and this test fails.
+
+async function fingerprintWith(t, shim) {
+  let result;
+  await withShim(t, shim, async (page) => {
+    result = await runFingerprintJS(page);
+  });
+  return result;
+}
+
+test('FingerprintJS: incognito launches under same siteId produce ' +
+     'distinct canvas signatures (#327)',
+  async (t) => {
+    const r1 = await fingerprintWith(t, ANTI_FP_LAUNCH_ONE);
+    const r2 = await fingerprintWith(t, ANTI_FP_LAUNCH_TWO);
+    if (!r1 || !r2) return; // requireBrowser already skipped
+    // FingerprintJS's `canvas` component is an object with `winding`
+    // (a boolean) and two data-URL strings — `text` and `geometry` —
+    // hashed from the painted canvas. Our shim noises ~1/32 pixels
+    // via a seeded PRNG, so two different seeds must produce two
+    // different data URLs. Comparing the full object lets either
+    // string diverge.
+    assert.notDeepEqual(r1.canvas, r2.canvas,
+      'two incognito launches with different nonces must yield ' +
+      'different canvas fingerprints (issue #327)');
+  });
+
+test('FingerprintJS: same shim loaded twice yields identical canvas ' +
+     '(in-launch stability)',
+  async (t) => {
+    // Within one launch the nonce is constant, so two page-loads of
+    // the same shim must produce the same canvas hash — otherwise
+    // FingerprintJS would re-identify the SAME session as a new one
+    // on every page load.
+    const r1 = await fingerprintWith(t, ANTI_FP_LAUNCH_ONE);
+    const r2 = await fingerprintWith(t, ANTI_FP_LAUNCH_ONE);
+    if (!r1 || !r2) return;
+    assert.deepEqual(r1.canvas, r2.canvas,
+      'same shim must produce the same canvas fingerprint on repeat');
+  });
+
+test('FingerprintJS: non-incognito (siteId-only seed) differs from ' +
+     'incognito (siteId:nonce seed) for the same siteId',
+  async (t) => {
+    // The user's opt-in to Incognito must visibly change what a real
+    // fingerprinter sees, otherwise the toggle is cosmetic. Same
+    // siteId, ETP-004 stable seed vs ETP-019 nonced seed.
+    const stable = await fingerprintWith(t, ANTI_FP_STABLE);
+    const ephemeral = await fingerprintWith(t, ANTI_FP_LAUNCH_ONE);
+    if (!stable || !ephemeral) return;
+    assert.notDeepEqual(stable.canvas, ephemeral.canvas,
+      'toggling incognito for the same site must change the canvas '
+      + 'fingerprint a real fingerprinter sees');
   });
 
 test('FingerprintJS: shim survives full report without throwing',

--- a/test/js/anti_fingerprinting_shim.test.js
+++ b/test/js/anti_fingerprinting_shim.test.js
@@ -7,8 +7,8 @@
 // patch prototypes and surface seeded noise — we assert the patch shape
 // (wrapper installed, [native code] toString, return value transformed)
 // rather than the noise's effect on real engine output, which jsdom
-// can't reproduce. Real-engine fingerprint proofing belongs to a follow-
-// up Playwright + CreepJS tier.
+// can't reproduce. Real-engine fingerprint proofing runs under Puppeteer
+// + FingerprintJS in test/browser/fingerprint_real_engine.test.js.
 
 const test = require('node:test');
 const assert = require('node:assert/strict');

--- a/test/js/helpers/load_shim.js
+++ b/test/js/helpers/load_shim.js
@@ -11,8 +11,9 @@
 // jsdom is not a real browser. APIs missing from jsdom (canvas fingerprint,
 // WebGL, audio context, real CSS layout) cannot be exercised here — assert
 // on shim *shape* (constructors replaced, getters defined, properties set)
-// rather than on real-engine behaviour. For end-to-end privacy proofing run
-// the same fixture through Playwright + CreepJS in a follow-up tier.
+// rather than on real-engine behaviour. End-to-end privacy proofing runs
+// the same fixture through Puppeteer + FingerprintJS in
+// test/browser/fingerprint_real_engine.test.js.
 
 const fs = require('node:fs');
 const path = require('node:path');

--- a/test/js_fixtures/README.md
+++ b/test/js_fixtures/README.md
@@ -43,8 +43,10 @@ date — useful in pre-commit hooks.
   constructors replaced, getters defined, properties set — not against
   real-engine behaviour.
 - For end-to-end privacy proofing (does the shim actually hide what
-  fingerprinters see?), a Tier 2 setup using Playwright + an open-source
-  detector like [CreepJS](https://github.com/abrahamjuliot/creepjs) or
+  fingerprinters see?), the Tier 3 harness under `test/browser/` loads
+  these fixtures into headless Chromium via Puppeteer and runs
   [fingerprintjs/fingerprintjs](https://github.com/fingerprintjs/fingerprintjs)
-  is the natural follow-up. That tier hasn't been built yet; the jsdom
-  tests here only prove the patches install correctly.
+  against them — see `test/browser/fingerprint_real_engine.test.js`.
+  CreepJS-style lie-detection probes (toString leaks, own-property
+  leaks, iframe-prototype escape) live in
+  `test/browser/lie_detection.test.js`.

--- a/test/js_fixtures/anti_fingerprinting/shim_seed_alpha_launch_one.js
+++ b/test/js_fixtures/anti_fingerprinting/shim_seed_alpha_launch_one.js
@@ -1,106 +1,9 @@
-// Per-site anti-fingerprinting JavaScript shim.
-//
-// Injected at DOCUMENT_START into every frame when a site's umbrella
-// `trackingProtectionEnabled` toggle is on. Surfaces covered:
-//
-//   * Canvas 2D     — toDataURL / toBlob / getImageData seeded noise
-//   * WebGL / WebGL2 — getParameter (vendor/renderer), getSupportedExtensions
-//                      list, readPixels seeded noise
-//   * Audio          — AudioBuffer.getChannelData / copyFromChannel,
-//                      AnalyserNode.getFloat{Frequency,TimeDomain}Data noise
-//   * Text metrics   — Canvas/Offscreen measureText jitter, document.fonts.check
-//                      restricted to a small common-fonts allowlist
-//   * Screen         — width/height/availWidth/availHeight/colorDepth/pixelDepth
-//   * Hardware       — navigator.hardwareConcurrency, navigator.deviceMemory
-//   * Plugins/MIME   — navigator.plugins / navigator.mimeTypes -> empty
-//   * Battery        — navigator.getBattery() -> fixed values
-//   * Speech         — speechSynthesis.getVoices() -> []
-//   * Timing         — performance.now() / Date.now() quantized to 100ms
-//   * Layout         — Element.getBoundingClientRect sub-pixel jitter
-//
-// All values that vary per site are derived from a Mulberry32 PRNG seeded
-// off [seed] (the per-site siteId), so the same site always reports the
-// same fingerprint across sessions, but two different sites — or two users
-// of the same site — see distinct fingerprints. Noise added to large
-// arrays (canvas pixels, audio buffers) uses sub-seeds salted with the
-// call's input range so a script can't average it away by reading the
-// same buffer twice.
-//
-// Patches go on Web*RenderingContext / Navigator / Screen / etc.
-// PROTOTYPES, never the instance, so a fingerprinter walking
-// `Object.getOwnPropertyNames(navigator)` doesn't see a tell. Every
-// wrapper goes through `asNative(...)` so `Function.prototype.toString`
-// reports `[native code]` — the WeakMap keyed there is the same one
-// `desktop_mode_shim.dart` and `location_spoof_service.dart` use.
-//
-// The shim is wrapped in a re-entrance guard (`__ws_anti_fp_shim__`)
-// because Android System WebView and WKWebView both re-run
-// initialUserScripts on every frame; without the guard the second run
-// would wrap the already-wrapped methods and amplify the noise.
-//
-// jsdom can exercise the shape (prototype methods replaced, getters
-// installed) but not the noise on real Canvas/WebGL/Audio data — those
-// engines are absent. End-to-end fingerprint proofing runs the dumped
-// fixture through Puppeteer + FingerprintJS in
-// test/browser/fingerprint_real_engine.test.js.
-
-import 'dart:convert';
-
-/// Compute the seed string passed to [buildAntiFingerprintingShim].
-///
-/// Non-incognito sites seed with `siteId` verbatim — the fingerprint stays
-/// stable across launches (ETP-004 baseline).
-///
-/// Incognito sites mix in a process-lifetime [launchNonce] (typically
-/// `LaunchNonce.value`) so the fingerprint is stable within a single app
-/// session — no flicker on iframe re-injection or nested webview opens —
-/// but randomizes across cold restarts. The `incognito` flag already implies
-/// the user wants a fresh-visitor posture each launch; reusing the same
-/// fingerprint across launches would itself be a stable cross-session
-/// identifier (issue #327, ETP-019).
-String computeAntiFingerprintingSeed({
-  required String siteId,
-  required bool incognito,
-  required String launchNonce,
-}) {
-  return incognito ? '$siteId:$launchNonce' : siteId;
-}
-
-/// Compose the full anti-fingerprinting `UserScript.source` (shim body
-/// plus the trailing `\n;null;` evaluator-return) for the given site
-/// configuration, or `null` if the umbrella is off / no siteId is set.
-///
-/// Lives alongside [computeAntiFingerprintingSeed] so the entire chain —
-/// gate → seed derivation → shim text — is exercisable from `flutter test`
-/// without standing up `WebViewFactory.createWebView`.
-String? buildAntiFingerprintingScriptSource({
-  required String? siteId,
-  required bool trackingProtectionEnabled,
-  required bool incognito,
-  required String launchNonce,
-}) {
-  if (!trackingProtectionEnabled || siteId == null) return null;
-  final seed = computeAntiFingerprintingSeed(
-    siteId: siteId,
-    incognito: incognito,
-    launchNonce: launchNonce,
-  );
-  return '${buildAntiFingerprintingShim(seed)}\n;null;';
-}
-
-/// Build the per-site anti-fingerprinting shim seeded by [seed]. The seed
-/// is computed via [computeAntiFingerprintingSeed] — siteId-only for
-/// non-incognito (stable per site) or `siteId:launchNonce` for incognito
-/// (stable per session, randomized per launch).
-String buildAntiFingerprintingShim(String seed) {
-  final encodedSeed = jsonEncode(seed);
-  return '''
 (function() {
   'use strict';
   if (window.__ws_anti_fp_shim__) return;
   window.__ws_anti_fp_shim__ = true;
 
-  var SEED = $encodedSeed;
+  var SEED = "alpha-fixture-seed:nonce-launch-one";
 
   // Shared Function.prototype.toString stubs — same WeakMap as
   // desktop_mode_shim.dart and location_spoof_service.dart so all three
@@ -559,7 +462,7 @@ String buildAntiFingerprintingShim(String seed) {
           var families = s.split(',');
           for (var i = 0; i < families.length; i++) {
             var f = families[i]
-              .replace(/^([0-9.]+(px|em|rem|pt|%)?\\s+|bold\\s+|italic\\s+|normal\\s+|oblique\\s+)+/i, '')
+              .replace(/^([0-9.]+(px|em|rem|pt|%)?\s+|bold\s+|italic\s+|normal\s+|oblique\s+)+/i, '')
               .replace(/['"]/g, '')
               .trim();
             if (COMMON_FONTS[f]) return true;
@@ -570,5 +473,3 @@ String buildAntiFingerprintingShim(String seed) {
     }
   } catch (e) {}
 })();
-''';
-}

--- a/test/js_fixtures/anti_fingerprinting/shim_seed_alpha_launch_two.js
+++ b/test/js_fixtures/anti_fingerprinting/shim_seed_alpha_launch_two.js
@@ -1,106 +1,9 @@
-// Per-site anti-fingerprinting JavaScript shim.
-//
-// Injected at DOCUMENT_START into every frame when a site's umbrella
-// `trackingProtectionEnabled` toggle is on. Surfaces covered:
-//
-//   * Canvas 2D     — toDataURL / toBlob / getImageData seeded noise
-//   * WebGL / WebGL2 — getParameter (vendor/renderer), getSupportedExtensions
-//                      list, readPixels seeded noise
-//   * Audio          — AudioBuffer.getChannelData / copyFromChannel,
-//                      AnalyserNode.getFloat{Frequency,TimeDomain}Data noise
-//   * Text metrics   — Canvas/Offscreen measureText jitter, document.fonts.check
-//                      restricted to a small common-fonts allowlist
-//   * Screen         — width/height/availWidth/availHeight/colorDepth/pixelDepth
-//   * Hardware       — navigator.hardwareConcurrency, navigator.deviceMemory
-//   * Plugins/MIME   — navigator.plugins / navigator.mimeTypes -> empty
-//   * Battery        — navigator.getBattery() -> fixed values
-//   * Speech         — speechSynthesis.getVoices() -> []
-//   * Timing         — performance.now() / Date.now() quantized to 100ms
-//   * Layout         — Element.getBoundingClientRect sub-pixel jitter
-//
-// All values that vary per site are derived from a Mulberry32 PRNG seeded
-// off [seed] (the per-site siteId), so the same site always reports the
-// same fingerprint across sessions, but two different sites — or two users
-// of the same site — see distinct fingerprints. Noise added to large
-// arrays (canvas pixels, audio buffers) uses sub-seeds salted with the
-// call's input range so a script can't average it away by reading the
-// same buffer twice.
-//
-// Patches go on Web*RenderingContext / Navigator / Screen / etc.
-// PROTOTYPES, never the instance, so a fingerprinter walking
-// `Object.getOwnPropertyNames(navigator)` doesn't see a tell. Every
-// wrapper goes through `asNative(...)` so `Function.prototype.toString`
-// reports `[native code]` — the WeakMap keyed there is the same one
-// `desktop_mode_shim.dart` and `location_spoof_service.dart` use.
-//
-// The shim is wrapped in a re-entrance guard (`__ws_anti_fp_shim__`)
-// because Android System WebView and WKWebView both re-run
-// initialUserScripts on every frame; without the guard the second run
-// would wrap the already-wrapped methods and amplify the noise.
-//
-// jsdom can exercise the shape (prototype methods replaced, getters
-// installed) but not the noise on real Canvas/WebGL/Audio data — those
-// engines are absent. End-to-end fingerprint proofing runs the dumped
-// fixture through Puppeteer + FingerprintJS in
-// test/browser/fingerprint_real_engine.test.js.
-
-import 'dart:convert';
-
-/// Compute the seed string passed to [buildAntiFingerprintingShim].
-///
-/// Non-incognito sites seed with `siteId` verbatim — the fingerprint stays
-/// stable across launches (ETP-004 baseline).
-///
-/// Incognito sites mix in a process-lifetime [launchNonce] (typically
-/// `LaunchNonce.value`) so the fingerprint is stable within a single app
-/// session — no flicker on iframe re-injection or nested webview opens —
-/// but randomizes across cold restarts. The `incognito` flag already implies
-/// the user wants a fresh-visitor posture each launch; reusing the same
-/// fingerprint across launches would itself be a stable cross-session
-/// identifier (issue #327, ETP-019).
-String computeAntiFingerprintingSeed({
-  required String siteId,
-  required bool incognito,
-  required String launchNonce,
-}) {
-  return incognito ? '$siteId:$launchNonce' : siteId;
-}
-
-/// Compose the full anti-fingerprinting `UserScript.source` (shim body
-/// plus the trailing `\n;null;` evaluator-return) for the given site
-/// configuration, or `null` if the umbrella is off / no siteId is set.
-///
-/// Lives alongside [computeAntiFingerprintingSeed] so the entire chain —
-/// gate → seed derivation → shim text — is exercisable from `flutter test`
-/// without standing up `WebViewFactory.createWebView`.
-String? buildAntiFingerprintingScriptSource({
-  required String? siteId,
-  required bool trackingProtectionEnabled,
-  required bool incognito,
-  required String launchNonce,
-}) {
-  if (!trackingProtectionEnabled || siteId == null) return null;
-  final seed = computeAntiFingerprintingSeed(
-    siteId: siteId,
-    incognito: incognito,
-    launchNonce: launchNonce,
-  );
-  return '${buildAntiFingerprintingShim(seed)}\n;null;';
-}
-
-/// Build the per-site anti-fingerprinting shim seeded by [seed]. The seed
-/// is computed via [computeAntiFingerprintingSeed] — siteId-only for
-/// non-incognito (stable per site) or `siteId:launchNonce` for incognito
-/// (stable per session, randomized per launch).
-String buildAntiFingerprintingShim(String seed) {
-  final encodedSeed = jsonEncode(seed);
-  return '''
 (function() {
   'use strict';
   if (window.__ws_anti_fp_shim__) return;
   window.__ws_anti_fp_shim__ = true;
 
-  var SEED = $encodedSeed;
+  var SEED = "alpha-fixture-seed:nonce-launch-two";
 
   // Shared Function.prototype.toString stubs — same WeakMap as
   // desktop_mode_shim.dart and location_spoof_service.dart so all three
@@ -559,7 +462,7 @@ String buildAntiFingerprintingShim(String seed) {
           var families = s.split(',');
           for (var i = 0; i < families.length; i++) {
             var f = families[i]
-              .replace(/^([0-9.]+(px|em|rem|pt|%)?\\s+|bold\\s+|italic\\s+|normal\\s+|oblique\\s+)+/i, '')
+              .replace(/^([0-9.]+(px|em|rem|pt|%)?\s+|bold\s+|italic\s+|normal\s+|oblique\s+)+/i, '')
               .replace(/['"]/g, '')
               .trim();
             if (COMMON_FONTS[f]) return true;
@@ -570,5 +473,3 @@ String buildAntiFingerprintingShim(String seed) {
     }
   } catch (e) {}
 })();
-''';
-}

--- a/test/launch_nonce_test.dart
+++ b/test/launch_nonce_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/launch_nonce.dart';
+
+void main() {
+  group('LaunchNonce', () {
+    setUp(LaunchNonce.resetForTesting);
+    tearDown(LaunchNonce.resetForTesting);
+
+    test('two reads within a process return the same value', () {
+      // Same fingerprint across iframe re-injection / nested webview opens
+      // / tab switches within one app session — without this, every read
+      // would re-randomize and the user's site would see flicker.
+      final first = LaunchNonce.value;
+      final second = LaunchNonce.value;
+      expect(second, equals(first));
+    });
+
+    test('generated value is non-empty lowercase hex', () {
+      // Random.secure produces 16 bytes -> 32 hex characters.
+      final v = LaunchNonce.value;
+      expect(v, isNotEmpty);
+      expect(v, matches(RegExp(r'^[0-9a-f]+$')));
+      expect(v.length, equals(32));
+    });
+
+    test('different process starts produce different nonces (statistical)', () {
+      // Simulate two cold launches by reading, resetting, reading again.
+      // The collision probability for two 128-bit Random.secure draws is
+      // negligible (< 2^-128), so a flake here means the RNG is broken.
+      final n1 = LaunchNonce.value;
+      LaunchNonce.resetForTesting();
+      final n2 = LaunchNonce.value;
+      expect(n2, isNot(equals(n1)));
+    });
+
+    test('overrideForTesting pins the value', () {
+      LaunchNonce.overrideForTesting('fixed-nonce');
+      expect(LaunchNonce.value, equals('fixed-nonce'));
+      // Stable across reads even when overridden.
+      expect(LaunchNonce.value, equals('fixed-nonce'));
+    });
+
+    test('resetForTesting clears an override and re-randomizes', () {
+      LaunchNonce.overrideForTesting('fixed-nonce');
+      expect(LaunchNonce.value, equals('fixed-nonce'));
+      LaunchNonce.resetForTesting();
+      final regenerated = LaunchNonce.value;
+      expect(regenerated, isNot(equals('fixed-nonce')));
+      expect(regenerated, matches(RegExp(r'^[0-9a-f]+$')));
+    });
+  });
+}

--- a/tool/dump_shim_js.dart
+++ b/tool/dump_shim_js.dart
@@ -109,6 +109,24 @@ Map<String, String> buildAllFixtures() {
   fixtures['anti_fingerprinting/shim_seed_beta.js'] =
       buildAntiFingerprintingShim('beta-fixture-seed');
 
+  // Issue #327 / ETP-019: two simulated incognito launches under the
+  // SAME siteId but DIFFERENT process-lifetime nonces. The real-engine
+  // tier asserts FingerprintJS sees distinct canvas/WebGL/audio
+  // signatures across these, proving the per-launch reroll lands at
+  // an off-the-shelf fingerprinter (not just at our own Dart probes).
+  fixtures['anti_fingerprinting/shim_seed_alpha_launch_one.js'] =
+      buildAntiFingerprintingShim(computeAntiFingerprintingSeed(
+    siteId: 'alpha-fixture-seed',
+    incognito: true,
+    launchNonce: 'nonce-launch-one',
+  ));
+  fixtures['anti_fingerprinting/shim_seed_alpha_launch_two.js'] =
+      buildAntiFingerprintingShim(computeAntiFingerprintingSeed(
+    siteId: 'alpha-fixture-seed',
+    incognito: true,
+    launchNonce: 'nonce-launch-two',
+  ));
+
   fixtures['language/en.js'] = buildLanguageShim('en');
   fixtures['language/fr_FR.js'] = buildLanguageShim('fr-FR');
   fixtures['language/ja.js'] = buildLanguageShim('ja');


### PR DESCRIPTION
Closes #327. Mix a process-lifetime nonce into the anti-fingerprinting
seed when both Tracking Protection and Incognito are on, so the
fingerprint stays stable within a session but rerolls across cold
restarts. Non-incognito sites keep the ETP-004 stable-per-site posture.