### PR TITLE
nested webview: add URL bar toggle to popup menu

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2603,6 +2603,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           webRtcPolicy: webRtcPolicy,
           userScripts: userScripts,
           onConfirmScriptFetch: _confirmScriptFetch,
+          onShowUrlBarChanged: (show) async {
+            if (!mounted) return;
+            setState(() {
+              _showUrlBar = show;
+            });
+            await _saveShowUrlBar();
+          },
           proxySettings: proxySettings,
           notificationsEnabled: notificationsEnabled,
         ),

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -482,11 +482,14 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
             ),
           Expanded(child: _webView),
           if (_showUrlBar)
-            UrlBar(
-              currentUrl: _currentUrl,
-              onUrlSubmitted: (url) {
-                _controller?.loadUrl(url, language: widget.language);
-              },
+            SafeArea(
+              top: false,
+              child: UrlBar(
+                currentUrl: _currentUrl,
+                onUrlSubmitted: (url) {
+                  _controller?.loadUrl(url, language: widget.language);
+                },
+              ),
             ),
         ],
       ),

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -44,6 +44,10 @@ class InAppWebViewScreen extends StatefulWidget {
   /// working when the user follows an outbound link into a nested screen.
   final List<UserScriptConfig> userScripts;
   final Future<bool> Function(String url)? onConfirmScriptFetch;
+  /// Invoked when the user toggles the URL bar from this nested screen's
+  /// popup menu. Threaded back to `_WebSpacePageState` so the change
+  /// updates the same global preference shown in the parent menu.
+  final Future<void> Function(bool show)? onShowUrlBarChanged;
   /// Per-site proxy of the parent site that opened this nested browser.
   /// Forwarded into the nested [WebViewConfig] so cross-domain links from
   /// a proxied site stay proxied. Resolves through the global outbound
@@ -73,6 +77,7 @@ class InAppWebViewScreen extends StatefulWidget {
     this.webRtcPolicy = WebRtcPolicy.defaultPolicy,
     this.userScripts = const [],
     this.onConfirmScriptFetch,
+    this.onShowUrlBarChanged,
     UserProxySettings? proxySettings,
     this.notificationsEnabled = false,
   }) : proxySettings = proxySettings ??
@@ -107,6 +112,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
   late final Widget _webView;
 
   bool _isFindVisible = false;
+  late bool _showUrlBar;
   FindMatchesResult findMatches = FindMatchesResult();
 
   /// DevTools host for this nested webview. Captures console output and
@@ -122,6 +128,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
     // Use home site title if provided
     title = widget.homeTitle;
     _currentUrl = widget.url;
+    _showUrlBar = widget.showUrlBar;
     _devToolsHost = NestedDevToolsHost(
       name: widget.homeTitle ?? extractDomain(widget.url),
       siteId: widget.siteId,
@@ -393,6 +400,16 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
                   ),
                 ),
                 PopupMenuItem<String>(
+                  value: "toggleUrlBar",
+                  child: Row(
+                    children: [
+                      Icon(_showUrlBar ? Icons.visibility_off : Icons.visibility),
+                      SizedBox(width: 8),
+                      Text(_showUrlBar ? "Hide URL Bar" : "Show URL Bar"),
+                    ],
+                  ),
+                ),
+                PopupMenuItem<String>(
                   value: "devTools",
                   child: Row(
                     children: [
@@ -428,6 +445,12 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
                 case 'search':
                   _toggleFind();
                   break;
+                case 'toggleUrlBar':
+                  setState(() {
+                    _showUrlBar = !_showUrlBar;
+                  });
+                  await widget.onShowUrlBarChanged?.call(_showUrlBar);
+                  break;
                 case 'refresh':
                   _controller?.reload();
                   break;
@@ -458,7 +481,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
               },
             ),
           Expanded(child: _webView),
-          if (widget.showUrlBar)
+          if (_showUrlBar)
             UrlBar(
               currentUrl: _currentUrl,
               onUrlSubmitted: (url) {


### PR DESCRIPTION
Seed _showUrlBar from the parent's global preference on init, then let
the nested popup-menu entry flip both the local visibility and the
global setting via a threaded callback. Without this, hiding the URL
bar globally left nested screens with no way to verify the current
location.