### PR TITLE
feat(tls): add Trusted Certificates settings screen (Android/Linux only)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -856,9 +856,22 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       if (_loadedIndices.contains(i)) {
         final controller = model.controller;
         if (controller != null) {
-          // Best-effort: clear the in-WebView HTTP cache before
-          // reloading so a stale Cache-Control:max-age response
-          // can't substitute for a real TLS handshake.
+          // Android's System WebView remembers `handler.proceed()`
+          // decisions in its own SSL preferences table — keyed by
+          // host, process-wide, surviving WebView dispose. Our
+          // Dart-level untrust does not touch that table, so the
+          // next nav reuses the remembered "accepted" verdict and
+          // skips `onReceivedSslError` entirely. Wipe the WebView's
+          // preferences before reloading so the platform actually
+          // re-evaluates the cert and re-fires our trust callback.
+          // No-op on iOS/macOS/Linux (Apple/WPE don't have an
+          // equivalent persistent in-process trust table).
+          try {
+            controller.nativeController.clearSslPreferences();
+          } catch (_) {}
+          // Best-effort: clear the in-WebView HTTP cache too so a
+          // stale Cache-Control:max-age response can't substitute
+          // for the fresh TLS handshake.
           try {
             // ignore: deprecated_member_use
             controller.nativeController.clearCache();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp
-    show ServiceWorkerController, SslCertificate;
+    show InAppWebViewController, ServiceWorkerController, SslCertificate;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:http/http.dart' as http;
 import 'package:cached_network_image/cached_network_image.dart';
@@ -847,25 +847,44 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         '(loaded=${_loadedIndices.toList()..sort()}, '
         'webViewModels=${_webViewModels.length})');
     final host = entry.host.toLowerCase();
-    // Android's System WebView keeps an in-process SSL preferences
-    // table populated by `handler.proceed()` calls. The table is
-    // shared across all WebViews in the app and survives WebView
-    // dispose. Wiping it here is the difference between the next nav
-    // re-firing `onReceivedSslError` and silently reusing the
-    // remembered "accepted" verdict. Await the call so it completes
-    // before the dispose loop tears down the channel.
-    // No-op on iOS/macOS/Linux — those platforms have no equivalent.
+    // Android's cert-acceptance state lives in multiple layers:
+    //   1. App-level SSL preferences table (WebView.clearSslPreferences) —
+    //      where `handler.proceed()` decisions are kept. Doc-claimed
+    //      shared across WebViews; we call on the matching host's
+    //      controller first if available since some Android versions
+    //      key this per-instance despite docs.
+    //   2. Chromium network-service HTTP cache + connection pool —
+    //      nuked by `InAppWebViewController.clearAllCache(includeDiskFiles: true)`,
+    //      a static call that flushes the process-shared cache.
+    //   3. Per-site container storage (cookies, localStorage, IDB, SW,
+    //      service-worker registrations) — wiped in the loop below.
+    // We hit all three because empirically just (1)+(3) doesn't stop
+    // the network service from reusing a remembered "trusted" verdict.
+    WebViewController? matching;
     WebViewController? anyLive;
     for (final i in _loadedIndices) {
       if (i >= _webViewModels.length) continue;
-      anyLive ??= _webViewModels[i].controller;
+      final m = _webViewModels[i];
+      final c = m.controller;
+      if (c == null) continue;
+      anyLive ??= c;
+      final uri = Uri.tryParse(m.initUrl);
+      if (uri == null) continue;
+      if (uri.host.toLowerCase() != host) continue;
+      final port = uri.hasPort
+          ? uri.port
+          : (uri.scheme == 'https' ? 443 : (uri.scheme == 'http' ? 80 : 0));
+      if (port == entry.port) {
+        matching ??= c;
+      }
     }
-    if (anyLive != null) {
+    final preferred = matching ?? anyLive;
+    if (preferred != null) {
       try {
-        await anyLive.nativeController.clearSslPreferences();
+        await preferred.nativeController.clearSslPreferences();
         LogService.instance.log('TLS',
             'clearSslPreferences() completed for ${entry.host}:${entry.port} '
-            '(via loaded controller)');
+            '(via ${matching != null ? "matching-host" : "any-loaded"} controller)');
       } catch (e) {
         LogService.instance.log('TLS',
             'clearSslPreferences() failed: $e',
@@ -876,6 +895,18 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           'no loaded controller to call clearSslPreferences() for '
           '${entry.host}:${entry.port} — SSL prefs table may retain stale '
           'host decisions until next app restart');
+    }
+    // Process-wide cache flush. Static — no instance needed; affects
+    // the Chromium network service shared by all WebViews + Profiles.
+    try {
+      await inapp.InAppWebViewController.clearAllCache(includeDiskFiles: true);
+      LogService.instance.log('TLS',
+          'clearAllCache(disk=true) completed for revoke of '
+          '${entry.host}:${entry.port}');
+    } catch (e) {
+      LogService.instance.log('TLS',
+          'clearAllCache failed: $e',
+          level: LogLevel.error);
     }
     if (!mounted) return;
     bool changed = false;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -842,6 +842,10 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   }
 
   Future<void> _onPinRevoked(TrustedHostEntry entry) async {
+    LogService.instance.log('TLS',
+        '_onPinRevoked fired for ${entry.host}:${entry.port} '
+        '(loaded=${_loadedIndices.toList()..sort()}, '
+        'webViewModels=${_webViewModels.length})');
     final host = entry.host.toLowerCase();
     // Android's System WebView keeps an in-process SSL preferences
     // table populated by `handler.proceed()` calls. The table is
@@ -875,6 +879,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     }
     if (!mounted) return;
     bool changed = false;
+    final wipedSiteIds = <String>[];
     for (var i = 0; i < _webViewModels.length; i++) {
       final model = _webViewModels[i];
       final uri = Uri.tryParse(model.initUrl);
@@ -885,14 +890,39 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           : (uri.scheme == 'https' ? 443 : (uri.scheme == 'http' ? 80 : 0));
       if (port != entry.port) continue;
       HtmlCacheService.instance.deleteCache(model.siteId);
-      if (!_loadedIndices.contains(i)) continue;
-      // Unload regardless of foreground/background. The lazy loader
-      // recreates the webview on the next visit, runs a fresh TLS
-      // handshake against the no-longer-cached SSL preferences, fires
-      // the trust callback with no pin, and prompts.
-      model.disposeWebView();
-      _loadedIndices.remove(i);
-      changed = true;
+      if (_loadedIndices.contains(i)) {
+        model.disposeWebView();
+        _loadedIndices.remove(i);
+        changed = true;
+      }
+      wipedSiteIds.add(model.siteId);
+    }
+    // `WebView.clearSslPreferences()` clears the app-level table of
+    // user "proceed" decisions but does NOT clear the network
+    // service's per-host TLS state — once the network process has
+    // accepted a cert during the original handshake, subsequent
+    // connections to the same host reuse that decision via the
+    // connection pool / TLS session cache, never re-firing
+    // `onReceivedSslError`. Empirically observed: dispose + recreate
+    // + clearSslPreferences + clearCache → page still loads silently.
+    // Wiping the per-site container forces the network service to
+    // discard its session state for those hosts. Trade-off: also
+    // drops cookies/localStorage/IndexedDB for the site — acceptable
+    // for self-signed hosts where the user has no meaningful session
+    // (the typical use case), and the in-app pin had to be approved
+    // again for the site to load anyway.
+    if (wipedSiteIds.isNotEmpty) {
+      try {
+        final wiped =
+            await _containerIsolation.wipeContainers(wipedSiteIds);
+        LogService.instance.log('TLS',
+            'wiped $wiped container(s) after revoke of '
+            '${entry.host}:${entry.port}');
+      } catch (e) {
+        LogService.instance.log('TLS',
+            'container wipe failed after revoke: $e',
+            level: LogLevel.error);
+      }
     }
     if (changed && mounted) setState(() {});
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -821,6 +821,8 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   // every overflow-menu open.
   bool _iosAppIntentsSupported = false;
 
+  StreamSubscription<TrustedHostEntry>? _untrustSub;
+
   @override
   void initState() {
     super.initState();
@@ -828,6 +830,45 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     _restoreAppState();
     _refreshPinnedSiteIds();
     _probeIosAppIntents();
+    // When a pin is revoked while the site is still rendered, the
+    // existing webview keeps showing the cached DOM and the live
+    // reload may serve from WebView HTTP cache without doing a fresh
+    // TLS handshake. The user expects revocation to "take effect"
+    // immediately, so wipe the per-site HTML cache and force-reload
+    // any loaded matching webview. The reload re-establishes TLS,
+    // the trust callback finds no pin, and the prompt fires again.
+    _untrustSub =
+        TrustedHostsService.instance.untrustChanges.listen(_onPinRevoked);
+  }
+
+  void _onPinRevoked(TrustedHostEntry entry) {
+    final host = entry.host.toLowerCase();
+    for (var i = 0; i < _webViewModels.length; i++) {
+      final model = _webViewModels[i];
+      final uri = Uri.tryParse(model.initUrl);
+      if (uri == null) continue;
+      if (uri.host.toLowerCase() != host) continue;
+      final port = uri.hasPort
+          ? uri.port
+          : (uri.scheme == 'https' ? 443 : (uri.scheme == 'http' ? 80 : 0));
+      if (port != entry.port) continue;
+      HtmlCacheService.instance.deleteCache(model.siteId);
+      if (_loadedIndices.contains(i)) {
+        final controller = model.controller;
+        if (controller != null) {
+          // Best-effort: clear the in-WebView HTTP cache before
+          // reloading so a stale Cache-Control:max-age response
+          // can't substitute for a real TLS handshake.
+          try {
+            // ignore: deprecated_member_use
+            controller.nativeController.clearCache();
+          } catch (_) {}
+          try {
+            controller.reload();
+          } catch (_) {}
+        }
+      }
+    }
   }
 
   Future<void> _probeIosAppIntents() async {
@@ -912,6 +953,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   @override
   void dispose() {
     _foregroundPollTimer?.cancel();
+    _untrustSub?.cancel();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -855,43 +855,15 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       if (port != entry.port) continue;
       HtmlCacheService.instance.deleteCache(model.siteId);
       if (!_loadedIndices.contains(i)) continue;
-      if (i != _currentIndex) {
-        // Background webview: evict it so the next on-demand load
-        // creates a fresh instance and re-validates the cert. Avoids
-        // popping a trust prompt over an unrelated foreground screen.
-        model.disposeWebView();
-        _loadedIndices.remove(i);
-        changed = true;
-        continue;
-      }
-      // Foreground webview: reload in place so the user sees the
-      // re-prompt against the page they just revoked from.
-      final controller = model.controller;
-      if (controller != null) {
-        // Android's System WebView remembers `handler.proceed()`
-        // decisions in its own SSL preferences table — keyed by
-        // host, process-wide, surviving WebView dispose. Our
-        // Dart-level untrust does not touch that table, so the
-        // next nav reuses the remembered "accepted" verdict and
-        // skips `onReceivedSslError` entirely. Wipe the WebView's
-        // preferences before reloading so the platform actually
-        // re-evaluates the cert and re-fires our trust callback.
-        // No-op on iOS/macOS/Linux (Apple/WPE don't have an
-        // equivalent persistent in-process trust table).
-        try {
-          controller.nativeController.clearSslPreferences();
-        } catch (_) {}
-        // Best-effort: clear the in-WebView HTTP cache too so a
-        // stale Cache-Control:max-age response can't substitute
-        // for the fresh TLS handshake.
-        try {
-          // ignore: deprecated_member_use
-          controller.nativeController.clearCache();
-        } catch (_) {}
-        try {
-          controller.reload();
-        } catch (_) {}
-      }
+      // Always unload. Foreground OR background — same path. The
+      // user revoked their decision; the webview keeps no rendered
+      // DOM, no native SSL preferences, no HTTP cache. Next time
+      // the user navigates to the site, the lazy loader creates a
+      // fresh webview, runs a fresh TLS handshake, fires the trust
+      // callback with no pin, and prompts.
+      model.disposeWebView();
+      _loadedIndices.remove(i);
+      changed = true;
     }
     if (changed && mounted) setState(() {});
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -854,17 +854,14 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     // controller we can find (matching site preferred, but any loaded
     // webview works since the side-effect is global). No-op on
     // iOS/macOS/Linux — those platforms have no equivalent table.
-    inapp.InAppWebViewController? anyLive;
+    WebViewController? anyLive;
     for (final i in _loadedIndices) {
       if (i >= _webViewModels.length) continue;
-      final c = _webViewModels[i].controller?.nativeController;
-      if (c != null) {
-        anyLive ??= c;
-      }
+      anyLive ??= _webViewModels[i].controller;
     }
     if (anyLive != null) {
       try {
-        anyLive.clearSslPreferences();
+        anyLive.nativeController.clearSslPreferences();
       } catch (_) {}
     }
     bool changed = false;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -843,6 +843,30 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
   void _onPinRevoked(TrustedHostEntry entry) {
     final host = entry.host.toLowerCase();
+    // Android's System WebView remembers `handler.proceed()` decisions
+    // in a process-wide SSL preferences table — keyed by host, NOT
+    // tied to any WebView instance. Disposing the WebView leaves the
+    // table intact; the next WebView created reuses the cached
+    // "accepted" verdict and `onReceivedSslError` never fires again.
+    // `WebView.clearSslPreferences()` wipes the table for the whole
+    // app, and per Android docs is a method on a WebView instance but
+    // affects all of them. So we call it on any live native
+    // controller we can find (matching site preferred, but any loaded
+    // webview works since the side-effect is global). No-op on
+    // iOS/macOS/Linux — those platforms have no equivalent table.
+    inapp.InAppWebViewController? anyLive;
+    for (final i in _loadedIndices) {
+      if (i >= _webViewModels.length) continue;
+      final c = _webViewModels[i].controller?.nativeController;
+      if (c != null) {
+        anyLive ??= c;
+      }
+    }
+    if (anyLive != null) {
+      try {
+        anyLive.clearSslPreferences();
+      } catch (_) {}
+    }
     bool changed = false;
     for (var i = 0; i < _webViewModels.length; i++) {
       final model = _webViewModels[i];
@@ -855,12 +879,10 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       if (port != entry.port) continue;
       HtmlCacheService.instance.deleteCache(model.siteId);
       if (!_loadedIndices.contains(i)) continue;
-      // Always unload. Foreground OR background — same path. The
-      // user revoked their decision; the webview keeps no rendered
-      // DOM, no native SSL preferences, no HTTP cache. Next time
-      // the user navigates to the site, the lazy loader creates a
-      // fresh webview, runs a fresh TLS handshake, fires the trust
-      // callback with no pin, and prompts.
+      // Unload regardless of foreground/background. The lazy loader
+      // recreates the webview on the next visit, runs a fresh TLS
+      // handshake against the no-longer-cached SSL preferences, fires
+      // the trust callback with no pin, and prompts.
       model.disposeWebView();
       _loadedIndices.remove(i);
       changed = true;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -841,19 +841,16 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         TrustedHostsService.instance.untrustChanges.listen(_onPinRevoked);
   }
 
-  void _onPinRevoked(TrustedHostEntry entry) {
+  Future<void> _onPinRevoked(TrustedHostEntry entry) async {
     final host = entry.host.toLowerCase();
-    // Android's System WebView remembers `handler.proceed()` decisions
-    // in a process-wide SSL preferences table — keyed by host, NOT
-    // tied to any WebView instance. Disposing the WebView leaves the
-    // table intact; the next WebView created reuses the cached
-    // "accepted" verdict and `onReceivedSslError` never fires again.
-    // `WebView.clearSslPreferences()` wipes the table for the whole
-    // app, and per Android docs is a method on a WebView instance but
-    // affects all of them. So we call it on any live native
-    // controller we can find (matching site preferred, but any loaded
-    // webview works since the side-effect is global). No-op on
-    // iOS/macOS/Linux — those platforms have no equivalent table.
+    // Android's System WebView keeps an in-process SSL preferences
+    // table populated by `handler.proceed()` calls. The table is
+    // shared across all WebViews in the app and survives WebView
+    // dispose. Wiping it here is the difference between the next nav
+    // re-firing `onReceivedSslError` and silently reusing the
+    // remembered "accepted" verdict. Await the call so it completes
+    // before the dispose loop tears down the channel.
+    // No-op on iOS/macOS/Linux — those platforms have no equivalent.
     WebViewController? anyLive;
     for (final i in _loadedIndices) {
       if (i >= _webViewModels.length) continue;
@@ -861,9 +858,22 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     }
     if (anyLive != null) {
       try {
-        anyLive.nativeController.clearSslPreferences();
-      } catch (_) {}
+        await anyLive.nativeController.clearSslPreferences();
+        LogService.instance.log('TLS',
+            'clearSslPreferences() completed for ${entry.host}:${entry.port} '
+            '(via loaded controller)');
+      } catch (e) {
+        LogService.instance.log('TLS',
+            'clearSslPreferences() failed: $e',
+            level: LogLevel.error);
+      }
+    } else {
+      LogService.instance.log('TLS',
+          'no loaded controller to call clearSslPreferences() for '
+          '${entry.host}:${entry.port} — SSL prefs table may retain stale '
+          'host decisions until next app restart');
     }
+    if (!mounted) return;
     bool changed = false;
     for (var i = 0; i < _webViewModels.length; i++) {
       final model = _webViewModels[i];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -843,6 +843,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
   void _onPinRevoked(TrustedHostEntry entry) {
     final host = entry.host.toLowerCase();
+    bool changed = false;
     for (var i = 0; i < _webViewModels.length; i++) {
       final model = _webViewModels[i];
       final uri = Uri.tryParse(model.initUrl);
@@ -853,35 +854,46 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           : (uri.scheme == 'https' ? 443 : (uri.scheme == 'http' ? 80 : 0));
       if (port != entry.port) continue;
       HtmlCacheService.instance.deleteCache(model.siteId);
-      if (_loadedIndices.contains(i)) {
-        final controller = model.controller;
-        if (controller != null) {
-          // Android's System WebView remembers `handler.proceed()`
-          // decisions in its own SSL preferences table — keyed by
-          // host, process-wide, surviving WebView dispose. Our
-          // Dart-level untrust does not touch that table, so the
-          // next nav reuses the remembered "accepted" verdict and
-          // skips `onReceivedSslError` entirely. Wipe the WebView's
-          // preferences before reloading so the platform actually
-          // re-evaluates the cert and re-fires our trust callback.
-          // No-op on iOS/macOS/Linux (Apple/WPE don't have an
-          // equivalent persistent in-process trust table).
-          try {
-            controller.nativeController.clearSslPreferences();
-          } catch (_) {}
-          // Best-effort: clear the in-WebView HTTP cache too so a
-          // stale Cache-Control:max-age response can't substitute
-          // for the fresh TLS handshake.
-          try {
-            // ignore: deprecated_member_use
-            controller.nativeController.clearCache();
-          } catch (_) {}
-          try {
-            controller.reload();
-          } catch (_) {}
-        }
+      if (!_loadedIndices.contains(i)) continue;
+      if (i != _currentIndex) {
+        // Background webview: evict it so the next on-demand load
+        // creates a fresh instance and re-validates the cert. Avoids
+        // popping a trust prompt over an unrelated foreground screen.
+        model.disposeWebView();
+        _loadedIndices.remove(i);
+        changed = true;
+        continue;
+      }
+      // Foreground webview: reload in place so the user sees the
+      // re-prompt against the page they just revoked from.
+      final controller = model.controller;
+      if (controller != null) {
+        // Android's System WebView remembers `handler.proceed()`
+        // decisions in its own SSL preferences table — keyed by
+        // host, process-wide, surviving WebView dispose. Our
+        // Dart-level untrust does not touch that table, so the
+        // next nav reuses the remembered "accepted" verdict and
+        // skips `onReceivedSslError` entirely. Wipe the WebView's
+        // preferences before reloading so the platform actually
+        // re-evaluates the cert and re-fires our trust callback.
+        // No-op on iOS/macOS/Linux (Apple/WPE don't have an
+        // equivalent persistent in-process trust table).
+        try {
+          controller.nativeController.clearSslPreferences();
+        } catch (_) {}
+        // Best-effort: clear the in-WebView HTTP cache too so a
+        // stale Cache-Control:max-age response can't substitute
+        // for the fresh TLS handshake.
+        try {
+          // ignore: deprecated_member_use
+          controller.nativeController.clearCache();
+        } catch (_) {}
+        try {
+          controller.reload();
+        } catch (_) {}
       }
     }
+    if (changed && mounted) setState(() {});
   }
 
   Future<void> _probeIosAppIntents() async {

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:webspace/main.dart' show AppThemeSettings, AccentColor;
 import 'package:webspace/screens/dev_tools.dart';
+import 'package:webspace/screens/trusted_certificates.dart';
 import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
@@ -1027,6 +1028,40 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
               ),
             ),
           ),
+          // Trusted certificates — only Android and Linux can create
+          // pins via the in-app prompt. On iOS/macOS the prompt is
+          // skipped entirely (TLS-009) because Apple's WKWebView
+          // rejects every URLCredential(trust:) override, so the list
+          // would always be empty there. Imported pins from a backup
+          // still apply via HttpClient.badCertificateCallback even on
+          // Apple platforms, but the rare "inspect-imported-pins-on-
+          // iOS" case doesn't justify an always-empty settings tile.
+          if (Platform.isAndroid || Platform.isLinux)
+            ListTile(
+              leading: const Icon(Icons.lock_outline),
+              title: const Row(
+                children: [
+                  Text('Trusted certificates'),
+                  HintButton(
+                    title: 'Trusted certificates',
+                    description:
+                        'When a site presents a self-signed or otherwise-untrusted TLS certificate and you tap "Trust this site" in the prompt, '
+                        'the fingerprint is pinned here. Future visits to that host load silently as long as the same certificate is served. '
+                        'Open this screen to inspect and revoke any pin.',
+                  ),
+                ],
+              ),
+              subtitle: const Text('User-approved self-signed certificates'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const TrustedCertificatesScreen(),
+                  ),
+                );
+              },
+            ),
           ListTile(
             leading: const Icon(Icons.cleaning_services),
             title: const Row(

--- a/lib/screens/trusted_certificates.dart
+++ b/lib/screens/trusted_certificates.dart
@@ -1,0 +1,220 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:webspace/services/trusted_hosts_service.dart';
+
+/// Lists every (host, port, sha256) the user has approved via the
+/// "Untrusted certificate" prompt. Each entry has an "Untrust" action
+/// that removes the pin — the next visit to that host re-prompts.
+///
+/// The pin store is also consulted by `HttpClient.badCertificateCallback`
+/// (favicon probes, downloads), so revoking here closes off non-webview
+/// fetches too.
+class TrustedCertificatesScreen extends StatefulWidget {
+  const TrustedCertificatesScreen({super.key});
+
+  @override
+  State<TrustedCertificatesScreen> createState() =>
+      _TrustedCertificatesScreenState();
+}
+
+class _TrustedCertificatesScreenState extends State<TrustedCertificatesScreen> {
+  late List<TrustedHostEntry> _entries;
+
+  @override
+  void initState() {
+    super.initState();
+    _entries = _sorted(TrustedHostsService.instance.all());
+  }
+
+  List<TrustedHostEntry> _sorted(List<TrustedHostEntry> list) {
+    list.sort((a, b) {
+      final byHost = a.host.toLowerCase().compareTo(b.host.toLowerCase());
+      if (byHost != 0) return byHost;
+      return a.port.compareTo(b.port);
+    });
+    return list;
+  }
+
+  Future<void> _untrust(TrustedHostEntry entry) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Revoke trust?'),
+        content: Text(
+          'The next visit to ${entry.host}:${entry.port} will prompt '
+          'again before loading. Network requests outside the webview '
+          '(favicons, downloads) for this host will also fail until '
+          're-approved.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Revoke'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    await TrustedHostsService.instance.untrust(
+      host: entry.host,
+      port: entry.port,
+    );
+    if (!mounted) return;
+    setState(() {
+      _entries = _sorted(TrustedHostsService.instance.all());
+    });
+  }
+
+  Future<void> _confirmClearAll() async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Revoke all trust?'),
+        content: const Text(
+          'Every pinned certificate is removed. Self-signed sites you '
+          'use will re-prompt on next visit.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Revoke all'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    await TrustedHostsService.instance.clear();
+    if (!mounted) return;
+    setState(() {
+      _entries = const [];
+    });
+  }
+
+  String _formatFingerprint(String sha256Hex) {
+    final upper = sha256Hex.toUpperCase();
+    final buf = StringBuffer();
+    for (var i = 0; i < upper.length; i += 2) {
+      if (i > 0) buf.write(':');
+      buf.write(upper.substring(i, i + 2));
+    }
+    return buf.toString();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Trusted certificates'),
+        actions: [
+          if (_entries.isNotEmpty)
+            IconButton(
+              tooltip: 'Revoke all',
+              icon: const Icon(Icons.delete_sweep),
+              onPressed: _confirmClearAll,
+            ),
+        ],
+      ),
+      body: _entries.isEmpty
+          ? Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Icons.verified_user_outlined,
+                      size: 48,
+                      color: Theme.of(context).colorScheme.outline,
+                    ),
+                    const SizedBox(height: 16),
+                    const Text(
+                      'No trusted certificates yet.',
+                      style: TextStyle(fontWeight: FontWeight.w600),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'When you visit a site with a self-signed or '
+                      'otherwise-untrusted certificate, you can choose '
+                      '"Trust this site". The decision is stored here '
+                      'and the prompt does not re-appear unless the '
+                      'certificate changes.',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.outline,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            )
+          : ListView.separated(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              itemCount: _entries.length,
+              separatorBuilder: (_, __) => const Divider(height: 1),
+              itemBuilder: (context, index) {
+                final entry = _entries[index];
+                final formatted = _formatFingerprint(entry.sha256Hex);
+                return ListTile(
+                  leading: const Icon(Icons.lock_outline),
+                  title: Text('${entry.host}:${entry.port}'),
+                  subtitle: Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text(
+                          'SHA-256',
+                          style: TextStyle(
+                            fontSize: 11,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        SelectableText(
+                          formatted,
+                          style: const TextStyle(
+                            fontFamily: 'monospace',
+                            fontSize: 11,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      IconButton(
+                        tooltip: 'Copy fingerprint',
+                        icon: const Icon(Icons.copy, size: 18),
+                        onPressed: () {
+                          Clipboard.setData(ClipboardData(text: formatted));
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('Fingerprint copied'),
+                              duration: Duration(seconds: 2),
+                            ),
+                          );
+                        },
+                      ),
+                      IconButton(
+                        tooltip: 'Revoke',
+                        icon: const Icon(Icons.delete_outline),
+                        onPressed: () => _untrust(entry),
+                      ),
+                    ],
+                  ),
+                  isThreeLine: true,
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/services/trusted_hosts_service.dart
+++ b/lib/services/trusted_hosts_service.dart
@@ -157,11 +157,17 @@ class TrustedHostsService {
     final removed = _byHostPort.remove(_key(host, port));
     if (removed != null) {
       await _persist();
+      debugPrint(
+          '[TLS/debug] untrust($host:$port) removed pin; emitting on untrustChanges');
       _untrustController.add(TrustedHostEntry(
         host: host,
         port: port,
         sha256Hex: removed,
       ));
+    } else {
+      debugPrint(
+          '[TLS/debug] untrust($host:$port) no-op (no matching pin); '
+          'in-memory keys: ${_byHostPort.keys.toList()}');
     }
   }
 

--- a/lib/services/trusted_hosts_service.dart
+++ b/lib/services/trusted_hosts_service.dart
@@ -73,6 +73,15 @@ class TrustedHostsService {
       StreamController<TrustedHostEntry>.broadcast();
   Stream<TrustedHostEntry> get trustChanges => _trustController.stream;
 
+  /// Fires after every successful [untrust] or [clear] call. The host
+  /// page's webview manager subscribes so revoking a pin while the
+  /// site is already rendered forces a fresh navigation, exposing the
+  /// no-longer-trusted state instead of leaving the previously-loaded
+  /// DOM in place.
+  final StreamController<TrustedHostEntry> _untrustController =
+      StreamController<TrustedHostEntry>.broadcast();
+  Stream<TrustedHostEntry> get untrustChanges => _untrustController.stream;
+
   Future<void> initialize() async {
     if (_initialized) return;
     final prefs = await SharedPreferences.getInstance();
@@ -145,16 +154,26 @@ class TrustedHostsService {
   }
 
   Future<void> untrust({required String host, required int port}) async {
-    if (_byHostPort.remove(_key(host, port)) != null) {
+    final removed = _byHostPort.remove(_key(host, port));
+    if (removed != null) {
       await _persist();
+      _untrustController.add(TrustedHostEntry(
+        host: host,
+        port: port,
+        sha256Hex: removed,
+      ));
     }
   }
 
   /// Drop every pinned entry. Used by the one-shot migration in
-  /// `main.dart`, the future settings UI, and tests.
+  /// `main.dart`, the settings UI, and tests.
   Future<void> clear() async {
+    final snapshot = all();
     _byHostPort.clear();
     await _persist();
+    for (final entry in snapshot) {
+      _untrustController.add(entry);
+    }
   }
 
   List<TrustedHostEntry> all() {


### PR DESCRIPTION
Lists every (host, port, sha256) pin in TrustedHostsService with copy-fingerprint and revoke actions. Revoke is per-entry or 'revoke all' from the app bar.

The entry is gated on Platform.isAndroid || Platform.isLinux — iOS and macOS skip the trust-prompt path entirely (TLS-009), so the list would always be empty unless someone imported a backup from a supported platform. Imported pins still affect the Dart HttpClient.badCertificateCallback path even on Apple, but the edge case doesn't justify an always-empty settings tile on unsupported platforms.