### PR TITLE
fix(navigation): trust canGoBack on Android, skip URL-comparison fallback

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4980,16 +4980,30 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
             return;
           }
           // Webview is visible - try to go back in its history.
-          // Don't trust canGoBack(): it can return false for pushState
-          // entries on some webview versions. Instead, always attempt
-          // goBack() (which is a no-op when there's no history) and
-          // check whether the URL actually changed.
           final controller = getController();
           if (controller == null) {
             LogService.instance.log('Navigation', 'Back gesture: no controller, opening drawer');
             scaffoldState?.openDrawer();
             return;
           }
+          // Android's canGoBack() is reliable (including for pushState/SPA
+          // entries on Chromium). Trust it directly: URL-comparison can
+          // false-positive when goBack() succeeds but the navigation
+          // hasn't propagated within the timeout, causing the drawer to
+          // open instead of navigating back.
+          if (Platform.isAndroid) {
+            if (await controller.canGoBack()) {
+              await controller.goBack();
+              LogService.instance.log('Navigation', 'Back gesture: navigated back (canGoBack)');
+            } else {
+              LogService.instance.log('Navigation', 'Back gesture: no history, opening drawer');
+              scaffoldState?.openDrawer();
+            }
+            return;
+          }
+          // iOS/macOS: canGoBack() can return false for pushState entries,
+          // so attempt goBack() unconditionally and use URL comparison as
+          // the authoritative check.
           final urlBefore = (await controller.getUrl())?.toString();
           await controller.goBack();
           // Give the native webview time to process the navigation

--- a/openspec/specs/navigation/spec.md
+++ b/openspec/specs/navigation/spec.md
@@ -79,21 +79,38 @@ The system back gesture (Android back button, iOS edge swipe via PopScope) SHALL
 
 ---
 
-### Requirement: NAV-002 - PopScope canGoBack Distrust
+### Requirement: NAV-002 - PopScope canGoBack Distrust (iOS/macOS)
 
-The PopScope back handler SHALL NOT trust `canGoBack()` for determining back navigation capability. It SHALL use URL comparison as the authoritative check.
+On iOS and macOS, the PopScope back handler SHALL NOT trust `canGoBack()` for determining back navigation capability. It SHALL use URL comparison as the authoritative check.
 
-**Rationale:** `canGoBack()` can return `false` for `history.pushState()` entries on iOS. Trusting it would prevent back navigation in SPAs.
+On Android, the PopScope back handler SHALL trust `canGoBack()` directly. Chromium reports `pushState` entries correctly, so URL comparison adds no information and its 150ms window can false-positive when a slow `goBack()` (e.g. BFCache miss) leaves the URL unchanged at the time of the post-delay sample — which incorrectly opens the drawer instead of letting the navigation complete.
 
-#### Scenario: SPA with pushState history
+**Rationale:** `canGoBack()` can return `false` for `history.pushState()` entries on iOS WKWebView. Trusting it would prevent back navigation in SPAs. Android System WebView (Chromium) does not have this bug.
 
-**Given** a single-page app has navigated via `history.pushState()`
+#### Scenario: SPA with pushState history (iOS)
+
+**Given** a single-page app has navigated via `history.pushState()` on iOS
 **And** `canGoBack()` returns `false`
 **When** the user triggers the system back gesture
 **Then** `goBack()` is called regardless
 **And** the URL is compared before/after with a 150ms delay
 **And** if the URL changed, back navigation succeeded
 **And** if the URL did NOT change, the drawer opens as fallback
+
+#### Scenario: Slow back navigation (Android)
+
+**Given** a webview is visible on Android with back history
+**And** `canGoBack()` returns `true`
+**When** the user triggers the system back gesture
+**Then** `goBack()` is called
+**And** the drawer does NOT open, even if the new page takes longer than 150ms to update its URL
+
+#### Scenario: No back history (Android)
+
+**Given** a webview is visible on Android
+**And** `canGoBack()` returns `false`
+**When** the user triggers the system back gesture
+**Then** the drawer opens as the exit-warning fallback
 
 ---
 
@@ -284,7 +301,11 @@ System back gesture received
   │
   ├─ No controller? ───────────── open drawer
   │
-  └─ Has controller:
+  ├─ Android && has controller:
+  │   ├─ canGoBack()? ─────────── goBack()
+  │   └─ else ─────────────────── open drawer
+  │
+  └─ iOS/macOS && has controller:
       ├─ urlBefore = getUrl()
       ├─ goBack()
       ├─ wait 150ms


### PR DESCRIPTION
The 150ms URL-comparison window false-positives when goBack() succeeds
but the navigation hasn't propagated yet (BFCache miss, slow nav), so
a back swipe with real history would open the drawer instead of going
back. Android System WebView's canGoBack() handles pushState correctly,
so trust it directly — the iOS WKWebView pushState quirk that motivated
the URL-comparison fallback doesn't apply.