### PR TITLE
openspec: propose outbound LIR routing for nested opens

### DIFF
--- a/openspec/changes/route-outbound-via-lir/design.md
+++ b/openspec/changes/route-outbound-via-lir/design.md
@@ -1,0 +1,196 @@
+## Context
+
+LIR currently handles **inbound** URLs (Android `ACTION_SEND`, iOS/macOS Share Extension, `webspace://`) by running them through `LinkRoutingService.resolve` and dispatching via `LinkIntentDispatchEngine`. The cross-domain **outbound** path inside a webview today bypasses LIR entirely:
+
+- `NavigationDecisionEngine.decideShouldOverrideUrlLoading` returns `blockOpenNested` for a gesture-driven cross-domain navigation.
+- `WebViewModel`'s callback invokes `launchUrlFunc(url, ...)` with **the source site's** siteId / cookies / container / settings.
+- The user lands on the destination domain inside the source's session.
+
+That's good for "open this article in the same private context as the search engine I'm using" but bad for "open this GitHub link in *my GitHub site* where I'm signed in". LIR has the data (per-site `domainClaims`) to make the latter choice; we just don't consult it on the outbound path.
+
+This change adds a second LIR entry point and threads it into the two existing nested-launch call sites in `web_view_model.dart`. The resolver itself does not change; the new logic is one layer above it (`resolveOutbound`) plus a new dispatch entry (`dispatchOutbound`).
+
+Constraints from the existing codebase:
+
+- Per-site settings MUST round-trip to nested webviews (CLAUDE.md). The destination-side `WebViewConfig` carrying destination cookies/container is already what `_executeOpenNested` (LIR-011) produces. Outbound reuses that primitive.
+- Logic engines are pure-Dart. The resolution layer goes in `link_routing_service.dart`; the dispatch decision goes in `link_intent_dispatch_engine.dart`; the executor lives in `_WebSpacePageState`.
+- The `LinkIntentDispatchEngine` already emits a `DispatchOpenNested` action used by the inbound LIR-011 cross-domain-share path. Outbound reuses that variant with a new `sourceIsParent` flag controlling whether `_maybeSwitchToAllForSite` runs.
+- Both legacy and container cookie engines must work. Container mode just opens the nested view with `containerId == destination.siteId`. Legacy mode pushes the nested view; the singleton CookieManager already has the destination's cookies installed via the source-of-truth replay in `WebViewFactory` when the nested view loads. No change to either engine.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Click on a GitHub link inside DDG lands in the user's GitHub site (cookies, container, login) when the user has opted DDG into launcher mode.
+- Source preference disambiguates multi-candidate cases (work-GitHub vs personal-GitHub) without showing a picker every time.
+- Silent fall-through to today's behaviour for: launcher mode off, no destination match, ambiguous without a learned source pref, target resolves to source itself.
+- Back-gesture from the hijacked nested view returns the user to the source site, in the same webspace they started in.
+
+**Non-Goals:**
+- Modifying `NavigationDecisionEngine` — it still owns "should this be nested at all". This change runs *after* `blockOpenNested` is decided.
+- Hijacking `window.open` / `target=_blank` popups (handled in `inappbrowser.dart`'s popup-window path).
+- Auto-creating a new site for an unmatched outbound URL.
+- Inbound LIR semantics — proposal, picker contents, and webspace-switch behaviour for shared URLs stay exactly as in `default-app-for-links`.
+
+## Decisions
+
+### D1. Outbound preference data shape
+
+Per-site additions to `WebViewModel`:
+
+```dart
+class OutboundPreference {
+  final DomainClaim claim;        // reused from link-intent-routing
+  final String targetSiteId;      // which site to route to
+}
+
+class WebViewModel {
+  bool routeOutboundLinks;                       // default false
+  List<OutboundPreference> outboundPreferences;  // default []
+  // ...
+}
+```
+
+`OutboundPreference` lives in `lib/services/outbound_preference.dart` (separate file to avoid the `web_view_model.dart` import cycle that already led to extracting `DomainClaim` into `lib/services/domain_claim.dart`).
+
+JSON shape on `WebViewModel`:
+
+```json
+{
+  "routeOutboundLinks": true,
+  "outboundPreferences": [
+    {"claim": {"kind": "exactHost", "value": "github.com"}, "targetSiteId": "work-github-abc123"},
+    {"claim": {"kind": "wildcardSubdomain", "value": "github.com"}, "targetSiteId": "work-github-abc123"}
+  ]
+}
+```
+
+`toJson` omits `routeOutboundLinks` when `false` and `outboundPreferences` when empty, keeping legacy on-disk output unchanged.
+
+**Alternative considered**: a single `Map<String, String>` keyed by destination host or baseDomain. Rejected — the user explicitly chose `DomainClaim` granularity. `wildcardSubdomain(google.com) → google-site` lets one entry cover `gmail.com`, `mail.google.com`, `drive.google.com` the same way LIR-001 claims already do. Reusing `DomainClaim` also means the existing canonicalisation + UI editor primitives carry over.
+
+**Alternative considered**: store outbound prefs as a global registry keyed by `(sourceSiteId, claim)` rather than per-site. Rejected — round-tripping per-site state through `WebViewModel.toJson` is the established pattern (settings-backup, site-editing), and a global registry would need its own GC + import/export plumbing for no gain.
+
+### D2. Resolution order
+
+`LinkRoutingService.resolveOutbound(targetUrl, sourcePrefs, allSites)` returns one of `OutboundResolution.preference(targetSite)`, `OutboundResolution.global(RoutingMatch)`, or `OutboundResolution.selfMatch()`:
+
+1. For each `OutboundPreference` in `sourcePrefs`, score against `targetUrl` using LIR-002's specificity table (`exactHost` 300, `wildcardSubdomain` 200, `baseDomain` 100). Pick the highest-scored entry whose `targetSiteId` still exists. Return `OutboundResolution.preference`.
+2. If no preference matches, call existing `resolve(targetUrl, allSites)` and return `OutboundResolution.global(...)` with the underlying `RoutingSingle` / `RoutingAmbiguous` / `RoutingNone`.
+3. **Self-match guard**: any resolved target whose `siteId == sourceSiteId` collapses to `OutboundResolution.selfMatch()`. This handles the edge case of a source site whose own claims cover the destination (DDG with `wildcardSubdomain(duckduckgo.com)` clicking a `links.duckduckgo.com` URL).
+
+**Source-preference-wins rule**: a preference at any score beats a global LIR winner at any score. Rationale: the user wrote the preference *from this source's context*; that is a more specific signal than the global claim graph. The picker remember-checkbox path (D4) is the only way preferences get populated implicitly.
+
+**Alternative considered**: tiebreaker semantics where global LIR wins when unambiguous and source prefs only break ties. Rejected — the user picked "source preference wins" up front, and the work-vs-personal-GitHub use case requires it.
+
+### D3. Dispatch shape
+
+`LinkIntentDispatchEngine.dispatchOutbound(...)` returns:
+
+| Resolution | Action | Notes |
+|------------|--------|-------|
+| `preference(site)` | `DispatchOpenNested(siteId, url, sourceIsParent: true)` | Silent. |
+| `global(RoutingSingle(site))` | `DispatchOpenNested(siteId, url, sourceIsParent: true)` | Silent. |
+| `global(RoutingAmbiguous(sites))` | `DispatchShowPicker(winnerSiteIds: sites, offerCreate: false, offerBind: false, source: sourceSiteId)` | Picker only fires when source has launcher mode on. |
+| `global(RoutingNone)` | `DispatchNestedFallback()` | Today's behaviour: source-settings nested. |
+| `selfMatch` | `DispatchNestedFallback()` | Today's behaviour. |
+| (launcher mode off) | `DispatchNestedFallback()` | Engine short-circuits before resolving. |
+
+The new `sourceIsParent` flag on `DispatchOpenNested` toggles `_executeOpenNested` to **skip** `_maybeSwitchToAllForSite`. For inbound LIR-011 the existing behaviour (switch to "All") is preserved by passing `sourceIsParent: false` from inbound callers.
+
+`DispatchShowPicker` gains:
+- `offerBind: bool` — `false` for outbound so the picker hides the "send {host} to {site}" row.
+- `offerCreate: bool` — already exists; outbound passes `false`.
+- `source: String?` — when present, the picker shows a "Always use this when opening links from {sourceName}" checkbox below the winners list. When the user picks a winner with the box ticked, the picker returns a `_DispatchChoiceOpen` plus an `outboundRememberSource: sourceSiteId` flag that the executor uses to call `LinkRoutingService.claimsToAdoptHost(host)` and append the resulting prefs (deduped) to source's `outboundPreferences`.
+
+`DispatchNestedFallback` is the sentinel "do exactly what `web_view_model.dart` would have done before this change". It carries no payload; the executor calls today's `launchUrl(...)` with source settings.
+
+**Alternative considered**: collapse `DispatchOpenNested` and `DispatchNestedFallback` into one variant with a `useSourceSettings` flag. Rejected — the destination-settings vs source-settings distinction is semantically important (it's the whole point of the change) and the action types in `LinkIntentDispatchEngine` are already sealed-class shaped for distinct semantics.
+
+### D4. Picker remember-checkbox writeback
+
+`_DispatchPickerSheet` already returns a `_DispatchChoice` value. For outbound mode (`source != null`), the sheet:
+
+1. Shows a `CheckboxListTile` "Always use this when opening links from {sourceName}" beneath the winners. Default checked (the user clicked a winner; remembering is the friction-reducing choice).
+2. On winner-row tap, returns `_DispatchChoiceOpen(site: chosen, rememberSource: source ?? null if unchecked)`.
+3. The executor branch in `_executeDispatchAction` (new `_executeOutboundDispatch`) writes back to source's `outboundPreferences` via `claimsToAdoptHost(targetHost)` filtered to entries not already present, persists `WebViewModel.toJson` via `_saveWebViewModels`, then proceeds with `DispatchOpenNested`.
+
+The bind ("send to {site}") and create rows are suppressed because outbound is not the right context to mutate destination claims (the user is mid-browse, not setting up routing) or to auto-spawn a site (surprising).
+
+### D5. Executor wiring in `_WebSpacePageState`
+
+New method `_executeOutboundDispatch(DispatchAction, Uri, WebViewModel source, ...sourceLaunchArgs)`:
+
+- `DispatchOpenNested(sourceIsParent: true)` → activate the destination's webview-config-shaped `launchUrl` call (using destination's `siteId`, `incognito`, `language`, `userScripts`, etc) but **skip** `_maybeSwitchToAllForSite`. The nested screen pushes; the drawer / current webspace is untouched.
+- `DispatchShowPicker(source: ...)` → reuse `_showDispatchPicker`, branch on `outboundRememberSource`, write back, then recurse into `_executeOutboundDispatch` with the user's choice.
+- `DispatchNestedFallback()` → call today's `launchUrl(...)` with source's args (identical to current `web_view_model.dart` behaviour). This is also the engine output when launcher mode is off, so the call sites in `web_view_model.dart` collapse to "always go through the engine".
+
+The two call sites in `web_view_model.dart` (`blockOpenNested` from `shouldOverrideUrlLoading`, and `blockOpenNested` from `onUrlChanged`) both shift from direct `launchUrlFunc(...)` to a new closure `outboundLaunchFunc(targetUrl)` injected via `WebViewModel.getController(...)`. The closure builds the inbound launch args from source's fields, calls `dispatchOutbound`, and routes the result through `_executeOutboundDispatch`.
+
+### D6. Webspace behaviour
+
+Outbound hijack uses `sourceIsParent: true` → `_maybeSwitchToAllForSite` skipped. Rationale: the user is mid-browse in webspace X; hijacking should not silently relocate them. Back-gesture from the nested view returns to source in webspace X exactly as it would without this change. This intentionally differs from inbound LIR-011, where the user came from outside the app and the "Switch to All" snackbar makes the destination's existence discoverable.
+
+### D7. Orphan GC for `targetSiteId`
+
+Mirroring cookie secure storage and proxy password orphan cleanup:
+
+- On startup, after `_loadWebViewModels`, walk every site's `outboundPreferences` and drop entries whose `targetSiteId` is not in `_webViewModels`.
+- After `_deleteSite(targetSite)`, walk every other site and drop preferences pointing at the deleted siteId.
+- After `_importSettings`, run the startup-style pass.
+
+Persist via `_saveWebViewModels` when entries are dropped. No user notification — orphaned prefs are silent state, not configuration the user should be alerted about.
+
+### D8. UI surface
+
+Per-site settings screen gains a section between "Privacy" and "Notifications":
+
+```
+Outbound link routing
+├─ [switch] Route outbound links to matching sites          (off by default)
+└─ Preferences                                              (shown only when switch is on)
+   ├─ [Claim chip editor] github.com → [▼ Work GitHub]
+   ├─ [Claim chip editor] *.github.com → [▼ Work GitHub]
+   └─ [+ Add preference]
+```
+
+The claim chip editor reuses `DomainClaimsEditor`'s row primitives. The target dropdown lists every other site (excluding `this`). Empty target dropdown disables the row.
+
+Subtitle when the switch is off: "When on, clicks to other domains can route into the site that claims that domain". When on with empty prefs: "Falls back to the global routing rule. Add a preference to override for a specific domain".
+
+### D9. Tests
+
+Pure-Dart, fast:
+
+- `test/link_routing_test.dart` (extend): `resolveOutbound` — source pref beats global single, source pref skipped if target site missing, global single returned when no source pref, ambiguous returned, self-match collapses to selfMatch.
+- `test/link_intent_dispatch_engine_test.dart` (extend): `dispatchOutbound` — emits `DispatchNestedFallback` when launcher mode off, `DispatchOpenNested(sourceIsParent: true)` on single resolution, `DispatchShowPicker(offerBind: false, offerCreate: false, source: ...)` on ambiguous, `DispatchNestedFallback` on self-match.
+- `test/web_view_model_test.dart` (extend): JSON round-trip of `routeOutboundLinks` and `outboundPreferences`; omission when default; legacy load without the fields.
+- `test/outbound_preference_gc_test.dart` (new): orphan cleanup after delete, after import, on startup.
+- `test/link_handling_settings_test.dart` (extend or sibling): `OutboundRoutingSection` widget — toggle gates editor visibility, dropdown lists only other sites, picker writeback round-trips through `_saveWebViewModels`.
+
+Manual: smoke test DDG launcher mode on Android (gesture click on `github.com` result lands in the user's GitHub site with login intact), back-gesture returns to DDG.
+
+## Risks / Trade-offs
+
+- **[Risk] User enables launcher mode on a site that legitimately needs same-session nested context** (e.g. a CMS where an outbound link to an embedded report should keep CMS cookies). Mitigation: opt-in per site; user can disable. Documenting in the "Outbound link routing" subtitle.
+- **[Risk] Source pref points at a deleted site between GC passes** (race: site deleted then immediate outbound click before persist). Mitigation: the engine's preference-lookup checks `targetSiteId` existence in the live `sites` list, not the persisted prefs; missing target falls through to global LIR.
+- **[Risk] Picker fires mid-browse and surprises the user** even with launcher mode on. Mitigation: picker only on ambiguous global LIR (multiple sites claim the same host); the remember checkbox + default-checked behaviour trains it away after one tap.
+- **[Risk] Back-stack semantics with nested-bound-to-destination feel off** when the user expects to be "in" their GitHub site after clicking a GitHub link. Mitigation: this is consistent with inbound LIR-011 cross-domain shares (they also open as nested with destination settings) and with how Android's "Open in app" handoff works. If users complain, a follow-on change can offer a "open in main view instead of nested" per-source setting.
+- **[Trade-off] Outbound prefs are directional (`source → destination`), so changing destination claims doesn't auto-propagate the inverse**. Acceptable — preferences point at `siteId`, not at claims, so renaming a destination site or editing its claims doesn't invalidate prefs.
+- **[Trade-off] Outbound resolution adds one resolver pass per cross-domain gesture**. Resolver is O(claims × sites); for the typical user (≤ 30 sites, ≤ 5 claims each) this is < 200 string comparisons per click. Not measured, not expected to matter; revisit if profiles show otherwise.
+
+## Migration Plan
+
+1. Data model + JSON migration (silent for users who never enable the toggle).
+2. `resolveOutbound` + `dispatchOutbound` engine entry points + pure-Dart tests.
+3. `_executeOutboundDispatch` executor + `outboundLaunchFunc` wiring in `web_view_model.dart`.
+4. Per-site settings UI (toggle + preferences editor).
+5. `_DispatchPickerSheet` source-mode + remember checkbox + writeback.
+6. Orphan GC at the three existing cleanup sites.
+
+Each step is independent. Rollback: data is preserved (the JSON fields stay in the model); the user-facing effect disappears when the toggle is removed from the settings screen.
+
+## Open Questions
+
+1. Should the per-site toggle be cloned on a *site-editing copy/duplicate*? Proposal: clone (the user's intent transfers with the source identity); revisit if it surprises in practice.
+2. Should ambiguity picker fire even when the source has launcher mode off but a preference matches the target? Proposal: no — the toggle gates the whole feature. Without it, outbound clicks are byte-identical to today.
+3. Should `outboundPreferences` round-trip via the QR-share / site-settings-qr flow? Proposal: yes for v1 — they're per-site state and the existing QR plumbing already serialises the full `WebViewModel.toJson`. Confirm against `site-settings-qr` spec at implementation time.

--- a/openspec/changes/route-outbound-via-lir/proposal.md
+++ b/openspec/changes/route-outbound-via-lir/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+Today, when the user clicks a cross-domain link inside a site (e.g. a GitHub link in DuckDuckGo's search results), `NavigationDecisionEngine` returns `blockOpenNested` and `web_view_model.dart` pushes an `InAppWebViewScreen` carrying the **source** site's settings — DDG's cookies, DDG's container, DDG's user scripts. The user lands on GitHub signed out, with a session scoped to DDG, even though they already have a configured GitHub site with their login.
+
+LIR (`link-intent-routing`) already classifies an arbitrary URL against per-site `domainClaims` for inbound shares; the same resolver could decide which existing site is the *right* container for an outbound link. This change wires the resolver into the cross-domain nested-open path so a click from a launcher-style site (DDG, Google, Kagi, HN frontpage) lands inside the user's claimed destination site instead of trapping in the source's session.
+
+UX has to be opt-in per source: nesting today is silent and back-gesture-reversible, so adding a mid-browse picker or even a snackbar on every outbound link would regress launcher-style flows. The toggle stays off by default; flipping it on DDG/Google is a one-time act.
+
+## What Changes
+
+- **Per-site outbound-routing toggle** (`WebViewModel.routeOutboundLinks`, default `false`). When `true`, cross-domain navigations originating from this site run through LIR before the existing nested-open path is invoked.
+- **Per-site outbound preferences** (`WebViewModel.outboundPreferences: List<OutboundPreference>`, where each entry is `(DomainClaim claim, String targetSiteId)`). Lets a source site override the global LIR resolver when the user has multiple sites that could match the same destination (e.g. work-GitHub vs personal-GitHub). Source preference wins over global LIR per the resolution order below.
+- **Outbound dispatch path on `LinkIntentDispatchEngine`** mirroring the inbound shape: a new entry point `dispatchOutbound({source, targetUrl, sites})` returns one of:
+  - `DispatchOpenNested(targetSiteId, url, sourceIsParent: true)` — silent hijack to the destination site's container, opened as a nested `InAppWebViewScreen` so back-gesture still returns to the source.
+  - `DispatchShowPicker(...)` — for ambiguous resolver results, only when the source has launcher mode on; reuses the LIR-010 sheet, gains a "Always use this from {source}" checkbox that writes back into source's `outboundPreferences`.
+  - `DispatchNestedFallback()` — the source site's existing nested launch, unchanged. Used for no-match, self-match (target resolves to source), and when launcher mode is off.
+- **Resolution order** when launcher mode is on:
+  1. Source's `outboundPreferences`, highest-specificity claim first (`exactHost` > `wildcardSubdomain` > `baseDomain`).
+  2. Global `LinkRoutingService.resolve(targetUrl, allSites)` — accepts only `RoutingSingle`.
+  3. Ambiguous → picker (with remember checkbox).
+  4. No match, or any match equal to the source site itself → `DispatchNestedFallback`.
+- **Picker writeback**: when the user picks "Open in {Site}" from the launcher-mode picker with the remember box ticked, an `OutboundPreference(claim: exactHost(host) + wildcardSubdomain(baseDomain), targetSiteId: site.siteId)` is appended to the source's prefs (deduplicated). The picker's "bind to site" and "create new site" options are suppressed in the outbound flow — outbound is not the right moment to mutate the destination site's claims or to spawn a brand-new site.
+- **No webspace switch on outbound hijack**: unlike inbound (WEBSPACE-011), an outbound hijack opens the destination as a nested screen without activating its webspace. Back-gesture returns the user to the source site in the webspace they started in.
+- **GC** of dangling `targetSiteId` entries in `outboundPreferences` at the three existing cleanup sites (`_deleteSite`, post-import settings, app startup). Mirrors the cookie-secure-storage orphan pattern.
+- **Per-site settings UI**: under each site, a "Outbound link routing" section with the master toggle and a `OutboundPreferencesEditor` (claim pattern via the existing `DomainClaimsEditor` widget + a target-site dropdown).
+- **Settings backup**: `routeOutboundLinks` and `outboundPreferences` ride `WebViewModel.toJson` automatically; no new entries in `kExportedAppPrefs`.
+
+### Explicitly out of scope
+
+- Auto-detecting launcher sites by `?q=`/`?query=` heuristics — the per-site toggle is honest and zero-config-after-flip.
+- Hijacking `window.open` / `target=_blank` / popup-window paths in `inappbrowser.dart`. v1 confines outbound hijacking to `NavigationDecisionEngine`'s `blockOpenNested` decisions (gesture-driven cross-domain) and the cross-domain `onUrlChanged` redirect path; everything else falls through to today's behaviour.
+- Auto-creating a new site for unmatched outbound URLs (LIR-010 option 3). Auto-spawning sites from a search-result click is surprising; the existing inbound flow remains the only path to create.
+- Per-host disable list ("hijack everything except this host"). The pref list already supports negative routing by claim specificity if the user really needs it.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `link-intent-routing`: adds LIR-013 (per-site outbound toggle + preferences), LIR-014 (outbound resolution order), LIR-015 (outbound dispatch executes as nested using destination settings, no webspace switch), LIR-016 (picker remember checkbox writes outbound preference back to source), LIR-017 (outbound preference GC on delete / import).
+
+No other capabilities are touched. `nested-url-blocking` is unaffected — `NavigationDecisionEngine` still owns the "should this be a nested open at all" decision; LIR only chooses *which* site the nested view is bound to.
+
+## Impact
+
+- **Flutter code**:
+  - `WebViewModel`: new `routeOutboundLinks: bool` and `outboundPreferences: List<OutboundPreference>` fields. JSON round-trip omits both when false / empty (legacy stable).
+  - `lib/services/outbound_preference.dart`: new pure-Dart value type `(DomainClaim claim, String targetSiteId)` with canonical serialization.
+  - `lib/services/link_intent_dispatch_engine.dart`: new static `dispatchOutbound(...)` plus result variants. Existing inbound entry points untouched.
+  - `lib/services/link_routing_service.dart`: new `resolveOutbound(targetUrl, sourcePrefs, allSites)` that layers source prefs over the existing `resolve`.
+  - `lib/web_view_model.dart`: the two `launchUrlFunc(...)` sites (`shouldOverrideUrlLoading` → `blockOpenNested` and `onUrlChanged` cross-domain redirect) call `dispatchOutbound` first; executor lives in `_WebSpacePageState` (`_executeOutboundDispatch`).
+  - Per-site settings screen: new `OutboundRoutingSection` widget composed of `SwitchListTile` + `OutboundPreferencesEditor`.
+  - `_WebSpacePageState`: GC routine extended to drop dangling `targetSiteId` entries.
+- **Specs touched**: only `link-intent-routing` (delta). No changes to `webspaces`, `nested-url-blocking`, `per-site-cookie-isolation`, or `per-site-containers`.
+- **Migration**: existing sites deserialize with `routeOutboundLinks=false` and empty `outboundPreferences`; serialization omits both. No user-visible change until the user flips the toggle.
+- **Tests**: unit tests for `resolveOutbound` (source-pref priority, self-match fall-through, ambiguity), engine tests for `dispatchOutbound` variants, widget test for picker writeback, GC test.
+- **Security**: outbound preferences carry only `siteId` references; no URLs, cookies, or secrets. Backup round-trips through normal `WebViewModel` JSON.
+- **Performance**: one extra resolver call per cross-domain navigation gesture. Resolver is O(claims × sites); negligible for typical site counts.

--- a/openspec/changes/route-outbound-via-lir/specs/link-intent-routing/spec.md
+++ b/openspec/changes/route-outbound-via-lir/specs/link-intent-routing/spec.md
@@ -1,0 +1,206 @@
+## ADDED Requirements
+
+### Requirement: LIR-013 - Per-Site Outbound Routing Toggle And Preferences
+
+Each site SHALL carry a `routeOutboundLinks` boolean (default `false`) and a `outboundPreferences` list of `(DomainClaim claim, String targetSiteId)` entries (default empty). When the boolean is `false`, the site's cross-domain navigation behaviour SHALL be byte-identical to the pre-change behaviour — `NavigationDecisionEngine`'s `blockOpenNested` decision opens a nested `InAppWebViewScreen` carrying the source site's siteId / cookies / container / settings. Serialization of `WebViewModel.toJson` SHALL omit `routeOutboundLinks` when `false` and `outboundPreferences` when empty so on-disk JSON for users who never enable the feature is unchanged.
+
+#### Scenario: Legacy site loads with defaults
+
+- **WHEN** a `WebViewModel` is deserialized from JSON that does not contain `routeOutboundLinks` or `outboundPreferences`
+- **THEN** `routeOutboundLinks` is `false`
+- **AND** `outboundPreferences` is `[]`
+- **AND** subsequent serialization omits both fields
+
+#### Scenario: Toggle off preserves today's nested behaviour
+
+- **GIVEN** site A has `routeOutboundLinks = false` and an outbound preference for `exactHost(github.com) → site B`
+- **WHEN** the user clicks a `github.com` link inside site A's webview
+- **THEN** the dispatch engine returns `DispatchNestedFallback`
+- **AND** the executor opens a nested webview with site A's settings (siteId, cookies, container, language, scripts, ...)
+- **AND** site B's container is not consulted
+
+#### Scenario: Preferences persist across restart
+
+- **GIVEN** the user saves `[(exactHost:github.com, work-gh), (wildcardSubdomain:github.com, work-gh)]` on a DDG site with `routeOutboundLinks = true`
+- **WHEN** the app is restarted
+- **THEN** the DDG site loads with both preferences and the toggle on
+
+---
+
+### Requirement: LIR-014 - Outbound Resolution Order
+
+When a source site has `routeOutboundLinks == true` and a cross-domain navigation would invoke the nested-launch path, the system SHALL resolve the target URL through `LinkRoutingService.resolveOutbound(targetUrl, sourceSiteId, sourcePrefs, allSites)`. The resolution SHALL apply the following order:
+
+1. **Source preferences**: score every `OutboundPreference` whose `targetSiteId` is currently present in `allSites` against `targetUrl` using LIR-002's specificity table (`exactHost` = 300, `wildcardSubdomain` = 200, `baseDomain` = 100). The highest-scored entry returns `OutboundResolution.preference(target)`. Source preferences SHALL win over any global LIR result, including unambiguous ones.
+2. **Global LIR**: when no source preference matches, the system SHALL fall back to `LinkRoutingService.resolve(targetUrl, allSites)` and wrap the result as `OutboundResolution.global(...)`.
+3. **Self-match collapse**: any resolution that targets the source site itself SHALL collapse to `OutboundResolution.selfMatch()`, regardless of whether it arrived via source preference or global LIR.
+
+#### Scenario: Source preference beats global single match
+
+- **GIVEN** the source has `OutboundPreference(exactHost:github.com, targetSiteId: work-gh)`
+- **AND** the global resolver would return `RoutingSingle(personal-gh)` for `https://github.com/x` because `personal-gh` claims `wildcardSubdomain:github.com`
+- **WHEN** `resolveOutbound` runs
+- **THEN** the result is `OutboundResolution.preference(work-gh)`
+
+#### Scenario: Source preference skipped when target site deleted
+
+- **GIVEN** the source has `OutboundPreference(exactHost:github.com, targetSiteId: work-gh)`
+- **AND** `work-gh` is no longer in `allSites`
+- **WHEN** `resolveOutbound` runs on `https://github.com/x`
+- **THEN** the preference is skipped
+- **AND** resolution falls through to global LIR
+
+#### Scenario: No source preference falls through to global
+
+- **GIVEN** the source has no preference covering `https://github.com/x`
+- **AND** the global resolver returns `RoutingSingle(work-gh)`
+- **WHEN** `resolveOutbound` runs
+- **THEN** the result is `OutboundResolution.global(RoutingSingle(work-gh))`
+
+#### Scenario: Self-match collapses regardless of path
+
+- **GIVEN** the source is the DuckDuckGo site, which claims `wildcardSubdomain:duckduckgo.com`
+- **WHEN** the user clicks `https://links.duckduckgo.com/help` from inside that site
+- **THEN** `resolveOutbound` returns `OutboundResolution.selfMatch()`
+- **AND** the executor SHALL invoke `DispatchNestedFallback`, leaving today's source-settings nested-open behaviour in place
+
+#### Scenario: Higher-specificity source preference wins among multiple
+
+- **GIVEN** the source has `[OutboundPreference(wildcardSubdomain:github.com, personal-gh), OutboundPreference(exactHost:github.com, work-gh)]`
+- **WHEN** `resolveOutbound` runs on `https://github.com/orgs/...`
+- **THEN** the result is `OutboundResolution.preference(work-gh)` (exactHost beats wildcardSubdomain)
+
+---
+
+### Requirement: LIR-015 - Outbound Dispatch Opens Destination As Nested Without Webspace Switch
+
+The dispatch engine SHALL emit `DispatchOpenNested(siteId: destinationSiteId, url: targetUrl, sourceIsParent: true)` for an outbound hijack. The executor SHALL invoke `launchUrl(...)` carrying the **destination** site's siteId, incognito flag, third-party cookies setting, ClearURL / DNS-block / content-block / LocalCDN / tracking-protection toggles, language, location settings, WebRTC policy, user scripts, proxy settings, and notifications flag. The executor SHALL **NOT** invoke `_maybeSwitchToAllForSite` for an outbound hijack — the user remains in the source's current webspace, and back-gesture from the pushed `InAppWebViewScreen` returns directly to the source site without an intermediate webspace transition.
+
+`DispatchNestedFallback` SHALL be the engine's output when (a) the source has `routeOutboundLinks == false`, (b) `resolveOutbound` returns `selfMatch`, or (c) `resolveOutbound` returns `global(RoutingNone)`. The executor SHALL implement `DispatchNestedFallback` by calling `launchUrl(...)` with the **source** site's args, byte-identical to the pre-change `launchUrlFunc(url, ...)` call site in `web_view_model.dart`.
+
+#### Scenario: Outbound hijack opens nested with destination settings
+
+- **GIVEN** source DDG has `routeOutboundLinks = true` and the resolver picks site `work-gh` for `https://github.com/x`
+- **WHEN** the user clicks the link inside DDG
+- **THEN** the executor pushes an `InAppWebViewScreen` with `siteId == work-gh`
+- **AND** the screen's `WebViewConfig` carries work-gh's container, cookies, language, user scripts, proxy settings, location, WebRTC policy, ClearURLs and blocking toggles
+- **AND** the current webspace is unchanged (no `_maybeSwitchToAllForSite` call)
+
+#### Scenario: Back gesture returns to source in the same webspace
+
+- **GIVEN** the user is on the DDG site in webspace "Personal" and clicks `https://github.com/x`
+- **AND** the resolver routes to `work-gh` (which lives in webspace "Work")
+- **WHEN** the nested view loads and the user presses the system Back button
+- **THEN** the nested screen pops
+- **AND** the active site is still DDG
+- **AND** the active webspace is still "Personal"
+
+#### Scenario: Launcher mode off uses fallback
+
+- **GIVEN** source DDG has `routeOutboundLinks = false`
+- **WHEN** the user clicks `https://github.com/x`
+- **THEN** the executor invokes `DispatchNestedFallback`
+- **AND** the nested `InAppWebViewScreen` carries DDG's siteId, cookies, container, and settings (today's behaviour)
+
+#### Scenario: Self-match uses fallback
+
+- **GIVEN** source DDG has `routeOutboundLinks = true`
+- **AND** the target URL resolves to DDG itself (self-claim or self-pref)
+- **WHEN** the user clicks the link
+- **THEN** the executor invokes `DispatchNestedFallback`
+- **AND** the nested view carries DDG's settings
+
+---
+
+### Requirement: LIR-016 - Picker Remember Checkbox Writes Outbound Preference Back To Source
+
+When `resolveOutbound` returns `OutboundResolution.global(RoutingAmbiguous(sites))`, the engine SHALL emit `DispatchShowPicker(winnerSiteIds: sites, offerBind: false, offerCreate: false, source: sourceSiteId)`. The picker SHALL render one row per winner candidate, suppress the "Send {host} to a site" row, suppress the "Create new site for {host}" row, and SHALL display a `CheckboxListTile` "Always use this when opening links from {sourceName}" beneath the candidate rows. The checkbox SHALL default to checked.
+
+When the user picks a winner with the checkbox in its checked state, the executor SHALL:
+
+1. Compute `claims = LinkRoutingService.claimsToAdoptHost(targetUrl.host)` — `[exactHost(host), wildcardSubdomain(getBaseDomain(host))]`.
+2. For each claim not already present in `source.outboundPreferences`, append `OutboundPreference(claim, chosenSiteId)`.
+3. Persist via `_saveWebViewModels()`.
+4. Continue with the outbound hijack as if the resolver had returned `OutboundResolution.preference(chosen)`.
+
+When the user picks a winner with the checkbox unchecked, the executor SHALL proceed with the outbound hijack for *this navigation only*, without mutating `outboundPreferences`.
+
+The remember writeback SHALL be idempotent — repeated picks of the same winner do not introduce duplicate preference entries.
+
+#### Scenario: Ambiguous resolution shows outbound-mode picker
+
+- **GIVEN** source DDG has `routeOutboundLinks = true` and no outbound preference for `github.com`
+- **AND** two sites both claim `exactHost:github.com`
+- **WHEN** the user clicks a `github.com` link inside DDG
+- **THEN** the picker is shown listing both sites
+- **AND** the "Send github.com to a site" row is hidden
+- **AND** the "Create new site" row is hidden
+- **AND** a "Always use this when opening links from DuckDuckGo" checkbox is shown, defaulted to checked
+
+#### Scenario: Remember writes outbound preference
+
+- **GIVEN** the outbound picker is showing for `https://github.com/x` from source DDG
+- **WHEN** the user taps "Open in Work GitHub" with the remember checkbox checked
+- **THEN** DDG's `outboundPreferences` gains `OutboundPreference(exactHost:github.com, work-gh)` and `OutboundPreference(wildcardSubdomain:github.com, work-gh)`
+- **AND** the state is persisted to disk
+- **AND** the GitHub URL opens nested with work-gh's settings
+- **AND** a subsequent `github.com` click from DDG resolves silently to work-gh without showing the picker
+
+#### Scenario: Unchecked remember does not mutate prefs
+
+- **GIVEN** the outbound picker is showing for `https://github.com/x` from source DDG
+- **WHEN** the user unticks the checkbox and taps "Open in Work GitHub"
+- **THEN** the GitHub URL opens nested with work-gh's settings
+- **AND** DDG's `outboundPreferences` is unchanged
+- **AND** the next `github.com` click from DDG shows the picker again
+
+#### Scenario: Repeated remember is idempotent
+
+- **GIVEN** DDG already has `OutboundPreference(exactHost:github.com, work-gh)` and `OutboundPreference(wildcardSubdomain:github.com, work-gh)`
+- **WHEN** the user manually invokes the outbound picker for `https://github.com/y` from DDG and re-picks Work GitHub with remember on
+- **THEN** the preference list is unchanged (no duplicates)
+
+#### Scenario: Picker is suppressed when launcher mode is off
+
+- **GIVEN** source DDG has `routeOutboundLinks = false`
+- **AND** two sites both claim `exactHost:github.com`
+- **WHEN** the user clicks a `github.com` link inside DDG
+- **THEN** the picker is not shown
+- **AND** the executor invokes `DispatchNestedFallback` (today's nested with DDG settings)
+
+---
+
+### Requirement: LIR-017 - Orphan Cleanup For Outbound Preferences
+
+The system SHALL drop any `OutboundPreference` entries whose `targetSiteId` is not present in `_webViewModels` at three points:
+
+1. After `_loadWebViewModels` during app startup.
+2. After `_deleteSite` removes a site.
+3. After `_importSettings` finishes restoring sites from a backup.
+
+The cleanup SHALL persist via `_saveWebViewModels` only when at least one entry was dropped. The cleanup SHALL NOT touch `outboundPreferences` entries whose target site is present, even if the target's claims no longer match the preference's claim — preferences remain valid as long as the target exists.
+
+The dispatch engine SHALL additionally guard against the race window between cleanups: `resolveOutbound` SHALL ignore any preference whose `targetSiteId` is not in the live `allSites` argument, even if the persisted preference list still contains it.
+
+#### Scenario: Site delete drops dangling preferences
+
+- **GIVEN** DDG has `OutboundPreference(exactHost:github.com, work-gh)`
+- **WHEN** the user deletes `work-gh`
+- **THEN** DDG's `outboundPreferences` list no longer contains the preference
+- **AND** the change is persisted to disk
+- **AND** no user-visible notification is shown
+
+#### Scenario: Import drops preferences whose target failed to re-import
+
+- **GIVEN** a backup file with two sites and a preference on site A pointing to site B
+- **WHEN** the user imports the backup but site B fails restore (e.g. duplicate ID conflict resolved by drop)
+- **THEN** after import completes, site A's preference list does not contain the dangling entry
+- **AND** the orphan cleanup runs as part of the import flow
+
+#### Scenario: Live race ignores not-yet-cleaned preference
+
+- **GIVEN** DDG has `OutboundPreference(exactHost:github.com, work-gh)` persisted
+- **AND** `work-gh` has been deleted but the cleanup has not yet run
+- **WHEN** the user clicks a `github.com` link inside DDG
+- **THEN** `resolveOutbound` ignores the preference (target missing in `allSites`)
+- **AND** resolution falls through to global LIR

--- a/openspec/changes/route-outbound-via-lir/tasks.md
+++ b/openspec/changes/route-outbound-via-lir/tasks.md
@@ -1,0 +1,87 @@
+## 1. Data model
+
+- [ ] 1.1 Add `OutboundPreference` value type in `lib/services/outbound_preference.dart` with `final DomainClaim claim`, `final String targetSiteId`, canonical equality, and `toJson` / `fromJson`. Mirror the file layout of `lib/services/domain_claim.dart` to avoid an import cycle with `web_view_model.dart`.
+- [ ] 1.2 Extend `WebViewModel` with `bool routeOutboundLinks` (default `false`) and `List<OutboundPreference> outboundPreferences` (default `[]`).
+- [ ] 1.3 `toJson` omits `routeOutboundLinks` when `false` and `outboundPreferences` when empty. `fromJson` defaults both when absent.
+- [ ] 1.4 Unit tests in `test/web_view_model_test.dart`: JSON round-trip with explicit values, omission of defaults, legacy-load without the fields, preservation across copy/duplicate.
+
+## 2. Resolver layer
+
+- [ ] 2.1 Add `OutboundResolution` sealed type to `lib/services/link_routing_service.dart` with variants `preference(RoutableSite target)`, `global(RoutingMatch underlying)`, `selfMatch()`.
+- [ ] 2.2 Implement `OutboundResolution resolveOutbound(Uri targetUrl, String sourceSiteId, List<OutboundPreference> sourcePrefs, List<RoutableSite> allSites)`:
+  - Score each `sourcePrefs[i].claim` against `targetUrl` using LIR-002's specificity table. Skip entries whose `targetSiteId` is not in `allSites`.
+  - Highest-scored matching pref returns `preference(target)` unless target == source → `selfMatch`.
+  - On no pref match, call existing `resolve(targetUrl, allSites)` and wrap as `global(...)`. Collapse `RoutingSingle` whose site == source to `selfMatch`.
+- [ ] 2.3 Unit tests in `test/link_routing_test.dart`:
+  - Source pref `exactHost(github.com) → work-gh` beats global `wildcardSubdomain(github.com) → personal-gh`.
+  - Source pref skipped when `targetSiteId` not in `allSites`.
+  - No pref → returns wrapped `RoutingAmbiguous` unchanged.
+  - Self-match collapses (both pref-self and global-self paths).
+  - Specificity ordering within `sourcePrefs` (multiple prefs match same URL).
+
+## 3. Dispatch engine
+
+- [ ] 3.1 Add `DispatchNestedFallback` variant to the sealed `DispatchAction` hierarchy in `lib/services/link_intent_dispatch_engine.dart`.
+- [ ] 3.2 Add `bool sourceIsParent` field to `DispatchOpenNested` (default `false` to keep inbound callers unchanged).
+- [ ] 3.3 Extend `DispatchShowPicker` with `bool offerBind` (default `true`), `bool offerCreate` (already exists), `String? source` (default `null`).
+- [ ] 3.4 Add `static DispatchAction dispatchOutbound({required Uri targetUrl, required DispatchableSite source, required List<OutboundPreference> sourcePrefs, required List<DispatchableSite> allSites, required bool routeOutboundLinks})`:
+  - If `!routeOutboundLinks` → `DispatchNestedFallback()`.
+  - Else call `resolveOutbound(...)`:
+    - `preference(t)` → `DispatchOpenNested(siteId: t.siteId, url: targetUrl.toString(), sourceIsParent: true)`.
+    - `global(RoutingSingle(t))` → same.
+    - `global(RoutingAmbiguous(sites))` → `DispatchShowPicker(winnerSiteIds: sites.map(siteId), offerBind: false, offerCreate: false, source: source.siteId)`.
+    - `global(RoutingNone)` → `DispatchNestedFallback()`.
+    - `selfMatch` → `DispatchNestedFallback()`.
+- [ ] 3.5 Engine tests in `test/link_intent_dispatch_engine_test.dart`: every branch above, plus the launcher-off short-circuit.
+
+## 4. Executor + wiring
+
+- [ ] 4.1 New executor `_executeOutboundDispatch(DispatchAction action, Uri targetUrl, WebViewModel source, _OutboundLaunchArgs sourceArgs)` in `_WebSpacePageState`:
+  - `DispatchOpenNested(sourceIsParent: true)` → look up destination model, call `launchUrl(...)` with destination's fields, **without** invoking `_maybeSwitchToAllForSite`.
+  - `DispatchShowPicker(source: src)` → reuse `_showDispatchPicker` with the picker reporting `outboundRememberSource: bool` alongside the choice; on remember, append `claimsToAdoptHost(targetUrl.host)` to `source.outboundPreferences` deduplicated, then `_saveWebViewModels()`, then recurse.
+  - `DispatchNestedFallback()` → call the existing `launchUrl(...)` with `sourceArgs` (source siteId / cookies / settings).
+- [ ] 4.2 Add `outboundLaunchFunc` typedef in `lib/web_view_model.dart` and thread it through `getController(...)` alongside `launchUrlFunc`. Build the closure in `_WebSpacePageState` so it captures the source model + executor.
+- [ ] 4.3 Replace the two `launchUrlFunc(url, ...)` call sites in `web_view_model.dart` (`shouldOverrideUrlLoading` → `blockOpenNested` and `onUrlChanged` → `blockOpenNested`) with `outboundLaunchFunc(url)`. The closure decides fallback vs hijack.
+- [ ] 4.4 Confirm both nested call sites end up at the same place in legacy and container modes (no engine-specific branching in the executor).
+
+## 5. Picker remember-checkbox
+
+- [ ] 5.1 Add `CheckboxListTile` to `_DispatchPickerSheet` shown only when `widget.source != null`. Label: "Always use this when opening links from {sourceName}". Default `true`.
+- [ ] 5.2 Change the sheet's return type from `_DispatchChoice` to `({_DispatchChoice choice, bool rememberSource})` (or a small sealed type) so the executor can branch.
+- [ ] 5.3 Suppress the "Send {host} to a site" row when `widget.offerBind == false` and the "Create new site" row when `widget.offerCreate == false`.
+- [ ] 5.4 Picker widget tests in `test/link_handling_settings_test.dart` (or sibling): outbound mode hides bind+create, checkbox toggles remember flag, returned tuple is wired correctly.
+
+## 6. UI surface
+
+- [ ] 6.1 `OutboundRoutingSection` widget in per-site settings (`lib/screens/settings.dart`): `SwitchListTile` + `OutboundPreferencesEditor` (visible only when toggle on).
+- [ ] 6.2 `OutboundPreferencesEditor` reuses `DomainClaimsEditor` for the claim row primitive, plus a `DropdownButton<String>` over `allSites.where((s) => s.siteId != currentSiteId)`.
+- [ ] 6.3 Empty-state copy: when toggle on with zero prefs, render "Falls back to global routing. Add a preference to override for a specific domain.". When toggle off, render "When on, clicks to other domains can route into the site that claims that domain.".
+- [ ] 6.4 Widget tests: toggle gates editor visibility, dropdown excludes self, save round-trips through `WebViewModel.toJson`.
+
+## 7. Orphan GC
+
+- [ ] 7.1 Add `_gcOutboundPreferences()` to `_WebSpacePageState`: walk every site, drop prefs whose `targetSiteId` is not in `{m.siteId for m in _webViewModels}`. Persist if anything dropped.
+- [ ] 7.2 Call at the three existing cleanup points: app startup (after `_loadWebViewModels`), post-`_deleteSite`, post-`_importSettings`.
+- [ ] 7.3 Unit test `test/outbound_preference_gc_test.dart`: builds a `_WebSpacePageState`-shaped fake, asserts dangling targets are dropped at each cleanup site and that no other prefs are touched.
+
+## 8. Backup / import alignment
+
+- [ ] 8.1 Confirm `routeOutboundLinks` and `outboundPreferences` ride `WebViewModel.toJson` automatically (no entry in `kExportedAppPrefs`). Update [test/settings_backup_test.dart](test/settings_backup_test.dart) only if a regression is observed.
+- [ ] 8.2 Manual: export a backup with prefs set, wipe install, import, verify prefs and toggle round-trip and that GC drops any prefs whose target site failed to re-import.
+
+## 9. Validation and CI
+
+- [ ] 9.1 `fvm flutter analyze` clean.
+- [ ] 9.2 `fvm flutter test` green (new + existing).
+- [ ] 9.3 `npx openspec validate route-outbound-via-lir --strict` passes.
+- [ ] 9.4 No unintended diffs in `openspec/specs/link-intent-routing/` until the change is archived.
+
+## 10. Manual smoke
+
+- [ ] 10.1 Android: create a GitHub site (logged in), enable launcher mode on DDG, click a `github.com` result, verify the nested view is logged in.
+- [ ] 10.2 Android: back-gesture returns to DDG in the same webspace.
+- [ ] 10.3 Two GitHub sites (work + personal): add an outbound pref on DDG for `exactHost(github.com) → work`, verify clicks land on work-GitHub even when both sites claim `github.com`.
+- [ ] 10.4 Launcher mode off: outbound clicks behave exactly as before (source-settings nested view).
+- [ ] 10.5 Self-match: from a Mastodon site, click a link to the same instance — no hijack, navigates in place.
+- [ ] 10.6 Delete the work-GitHub site, verify DDG's pref pointing at it is dropped without a snackbar.
+- [ ] 10.7 Ambiguous case: two sites claim `github.com`, click from DDG, picker fires; tick remember, repeat the click, verify no picker the second time.


### PR DESCRIPTION
Per-site routeOutboundLinks toggle + outboundPreferences let a launcher-style site (DDG, Google) hijack cross-domain gesture clicks into the user's claimed destination site, opened as a nested webview using the destination's settings. Resolution order is source preference > global LIR > self-match/no-match fallback to today's behaviour. Adds LIR-013..LIR-017.