### PR TITLE
fix: revert Stop button to Refresh after canceling reload

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3306,6 +3306,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await _webViewModels[_currentIndex!].userDrivenReload();
   }
 
+  Future<void> _stopCurrentSiteLoading() async {
+    if (_currentIndex == null || _currentIndex! >= _webViewModels.length) return;
+    await _webViewModels[_currentIndex!].userStopLoading();
+  }
+
   /// Update _canGoBack from the current webview's controller.
   /// Used on iOS to enable drawer edge-swipe when there's no back history.
   /// Note: canGoBack() can return false for pushState/SPA navigations even
@@ -3591,7 +3596,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                           onPressed: () {
                             Navigator.pop(context);
                             if (loading) {
-                              getController()?.stopLoading();
+                              _stopCurrentSiteLoading();
                             } else {
                               _refreshCurrentSite();
                             }
@@ -3950,7 +3955,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                     onPressed: () {
                       Navigator.pop(context);
                       if (loading) {
-                        getController()?.stopLoading();
+                        _stopCurrentSiteLoading();
                       } else {
                         _refreshCurrentSite();
                       }

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -1100,6 +1100,28 @@ class WebViewModel {
     }
   }
 
+  /// User tapped the Stop button. Cancels the in-flight load and
+  /// eagerly clears [isLoading] so the URL-bar action button flips
+  /// back to Refresh on the next rebuild. `onLoadStop` is not
+  /// guaranteed to fire after `stopLoading()` on every engine
+  /// (WebKit in particular can swallow it when the cancel races a
+  /// commit), which leaves the menu stuck on the Stop icon. The
+  /// guard in [onLoadingChanged] suppresses the duplicate rebuild
+  /// when the callback does fire.
+  Future<void> userStopLoading() async {
+    if (controller != null) {
+      try {
+        await controller!.stopLoading();
+      } catch (_) {
+        // Controller may have been disposed while the cancel was in flight.
+      }
+    }
+    if (isLoading) {
+      isLoading = false;
+      stateSetterF?.call();
+    }
+  }
+
   /// Capture the WebView's navigation state as bytes. Returns null
   /// when there's nothing to save (controller is null, page never
   /// navigated, or the platform refused). Pair with the matching


### PR DESCRIPTION
controller.stopLoading() was fire-and-forget; the loading state only
flipped via onLoadStop, which WebKit can swallow when the cancel races
a commit. The popup menu then stayed on the Stop icon on the next open.
Route through userStopLoading() which eagerly clears isLoading.