### PR TITLE
Embed canonical SPDX license texts in transitive Rust deps

### DIFF
--- a/assets/licenses/ubo_resources.txt
+++ b/assets/licenses/ubo_resources.txt
@@ -1,14 +1,3 @@
-adblock-rust
-https://github.com/brave/adblock-rust
-
-The Rust adblock engine that powers WebSpace's content blocker, including
-the ABP rule parser, network filtering, cosmetic resources, and $redirect=
-support. Distributed as the Rust crate `adblock` 0.12.x; statically linked
-into the app on Apple platforms and dynamically loaded on
-Android/Linux. WebSpace's wrapper crate
-(rust/webspace_adblock) and the JNI bridge under android/app/.../jni
-are also licensed under MPL-2.0.
-
 uBlock Origin web-accessible resources
 https://github.com/gorhill/uBlock
 
@@ -17,8 +6,13 @@ trackers, etc.) embedded into the binary at build time. Fetched at the
 pinned tag declared in rust/webspace_adblock/build.rs; assembled by
 adblock-rust's `assemble_web_accessible_resources` helper.
 
-Both projects are licensed under the Mozilla Public License Version 2.0.
-The full license text follows.
+(The `adblock` crate and WebSpace's own `webspace_adblock` wrapper
+crate are also MPL-2.0; their attribution rides the Rust transitive
+crate enumeration below, with canonical SPDX text resolved at build
+time from the `license` crate's vendored SPDX 3.x dataset.)
+
+Licensed under the Mozilla Public License Version 2.0. The full
+license text follows.
 
 ================================================================================
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -607,8 +607,15 @@ void main() async {
     (['Hagezi DNS Blocklists (domain data)'], 'assets/licenses/hagezi.txt'),
     (['EasyList filter lists (filter data)'], 'assets/licenses/easylist.txt'),
     (
-      ['adblock-rust + uBlock Origin resources (engine code + redirect bodies)'],
-      'assets/licenses/adblock_rust.txt'
+      // uBO ships the redirect-resource bodies (noop.js, 1x1.gif,
+      // neutered trackers, etc.) we embed at build time. uBO isn't
+      // a Rust crate so the transitive-deps SPDX extractor below
+      // can't reach it — the bundled file carries the MPL-2.0 text
+      // for that contribution. The `adblock` and `webspace_adblock`
+      // crates themselves flow through the transitive enumeration
+      // with canonical SPDX text from the `license` crate.
+      ['uBlock Origin web-accessible resources (redirect bodies)'],
+      'assets/licenses/ubo_resources.txt'
     ),
     (['cdnjs (LocalCDN resource data)'], 'assets/licenses/cdnjs.txt'),
     (['OpenStreetMap (map data and tiles)'], 'assets/licenses/openstreetmap.txt'),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -94,6 +94,41 @@ enum AccentColor {
   yellow,
 }
 
+/// LicenseEntry that emits one [LicenseParagraph] per source line,
+/// so structural single line breaks (license titles, numbered
+/// section headers, template lines) survive the renderer.
+///
+/// `LicenseEntryWithLineBreaks` only breaks on blank lines and
+/// folds every other `\n` into a space, which collapses Apache-2.0
+/// title blocks and similar multi-line headers into one wrapping
+/// paragraph. The license texts the `license` Rust crate emits
+/// (and the bundled assets/licenses/*.txt files) all use single
+/// `\n` for structural breaks AND keep paragraph bodies as single
+/// long lines, so per-line preservation renders correctly without
+/// hurting paragraph flow.
+class _PerLineLicenseEntry extends LicenseEntry {
+  _PerLineLicenseEntry(this.packages, this._text);
+
+  @override
+  final Iterable<String> packages;
+  final String _text;
+
+  @override
+  Iterable<LicenseParagraph> get paragraphs sync* {
+    for (final line in const LineSplitter().convert(_text)) {
+      var leading = 0;
+      while (leading < line.length && line[leading] == ' ') {
+        leading++;
+      }
+      // LicenseParagraph indents are integer levels (0..8 roughly);
+      // map every 2 leading spaces to one indent step so indented
+      // numbered items / template snippets still look indented.
+      final indent = (leading ~/ 2).clamp(0, 8);
+      yield LicenseParagraph(line.substring(leading), indent);
+    }
+  }
+}
+
 // App theme settings - combines theme mode and accent color
 class AppThemeSettings {
   final ThemeMode themeMode;
@@ -623,7 +658,7 @@ void main() async {
   for (final (packages, assetPath) in customLicenses) {
     LicenseRegistry.addLicense(() async* {
       final text = await rootBundle.loadString(assetPath);
-      yield LicenseEntryWithLineBreaks(packages, text);
+      yield _PerLineLicenseEntry(packages, text);
     });
   }
 
@@ -670,7 +705,7 @@ void main() async {
           parts.add(text);
         }
       }
-      yield LicenseEntryWithLineBreaks(
+      yield _PerLineLicenseEntry(
         ['$name (Rust crate, transitive via adblock-rust)'],
         parts.join('\n'),
       );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -624,9 +624,9 @@ void main() async {
   // adblock_rust shared library's static metadata blob (see
   // rust/webspace_adblock/build.rs). Surfaces every crate
   // adblock-rust pulls in (regex, serde, flatbuffers, idna, …) with
-  // its SPDX license + upstream URL. Skips the actual license text —
-  // SPDX + URL is enough to direct users to the original for any
-  // crate that requires reproducing it.
+  // its SPDX license + canonical SPDX text (sourced at build time
+  // via the `license` crate's vendored license-list-data, NOT
+  // hand-typed). Dual-licensed crates ship every relevant text.
   LicenseRegistry.addLicense(() async* {
     for (final dep in AdblockEngine.depLicenses()) {
       final name = dep['name'] as String? ?? '';
@@ -635,20 +635,37 @@ void main() async {
       final license = dep['license'] as String? ?? '<unspecified>';
       final repo = dep['repository'] as String? ?? '';
       final desc = dep['description'] as String? ?? '';
-      final body = [
+      final texts = (dep['license_texts'] as List? ?? const [])
+          .cast<Map<String, dynamic>>();
+
+      final parts = <String>[
         if (desc.isNotEmpty) desc,
         '',
         'Version: $version',
         'License: $license',
         if (repo.isNotEmpty) 'Source: $repo',
         if (repo.isEmpty) 'Source: https://crates.io/crates/$name',
-        '',
-        'Full license text available at the upstream source above and '
-            'in standard SPDX form at https://spdx.org/licenses/.',
-      ].join('\n');
+      ];
+      if (texts.isEmpty) {
+        parts.add('');
+        parts.add(
+            'Canonical SPDX license text was not resolvable for "$license". '
+            'See the upstream source above for the original.');
+      } else {
+        for (final lt in texts) {
+          final id = lt['id'] as String? ?? '';
+          final lname = lt['name'] as String? ?? id;
+          final text = lt['text'] as String? ?? '';
+          if (text.isEmpty) continue;
+          parts.add('');
+          parts.add('--- $lname (SPDX: $id) ---');
+          parts.add('');
+          parts.add(text);
+        }
+      }
       yield LicenseEntryWithLineBreaks(
         ['$name (Rust crate, transitive via adblock-rust)'],
-        body,
+        parts.join('\n'),
       );
     }
   });

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -1374,6 +1374,8 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
     }
     final avgMicros = samples.isEmpty ? 0 : totalMicros ~/ samples.length;
 
+    final timingOn = svc.engineTimingEnabled;
+    final consulted = svc.engineConsultedSinceTimingOn;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -1383,6 +1385,12 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
             spacing: 8,
             runSpacing: 4,
             children: [
+              _abpStatChip('engine', svc.usingRustEngine ? 'active' : 'off',
+                  svc.usingRustEngine ? Colors.green : Colors.grey),
+              _abpStatChip('recording',
+                  timingOn ? 'on' : 'off',
+                  timingOn ? Colors.green : Colors.orange),
+              _abpStatChip('consulted', '$consulted', Colors.blueGrey),
               _abpStatChip(
                   'avg', '$avgMicros µs', Colors.blueGrey),
               _abpStatChip('max', '$maxMicros µs',
@@ -1413,12 +1421,23 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
         const Divider(height: 1),
         Expanded(
           child: samples.isEmpty
-              ? const Center(
+              ? Center(
                   child: Padding(
-                    padding: EdgeInsets.all(24),
+                    padding: const EdgeInsets.all(24),
                     child: Text(
-                      'No engine decisions captured yet — browse a site\n'
-                      'and tap Refresh.',
+                      consulted == 0
+                          ? 'Engine has not been consulted since DevTools '
+                              'opened.\n\n'
+                              'Sub-resource checks fire from the JS-bridge '
+                              '`blockCheck` handler — they only run on '
+                              'cross-origin requests that hit the bloom '
+                              'prefilter.\n\n'
+                              'Try: reload an ad-heavy page with DevTools '
+                              'already open.'
+                          : 'Engine consulted $consulted time(s) but the '
+                              'recent decisions ring buffer is empty.\n'
+                              'This usually means the buffer rolled over — '
+                              'tap Refresh to capture the latest entries.',
                       textAlign: TextAlign.center,
                     ),
                   ),

--- a/lib/services/content_blocker_service.dart
+++ b/lib/services/content_blocker_service.dart
@@ -218,13 +218,31 @@ class ContentBlockerService {
   final List<EngineDecisionSample> _recentEngineDecisions = [];
   bool _engineTimingEnabled = false;
 
+  /// Total number of times [isBlocked] consulted the Rust engine since
+  /// the last [engineTimingEnabled] flip — i.e. across the current
+  /// DevTools session. Decoupled from [_recentEngineDecisions] which
+  /// is a 200-entry ring; this keeps growing so the ABP tab can show
+  /// "consulted N times" even when the sliding window has rolled over.
+  int _engineConsultedSinceTimingOn = 0;
+
+  /// See [_engineConsultedSinceTimingOn]. Read by the ABP tab.
+  int get engineConsultedSinceTimingOn => _engineConsultedSinceTimingOn;
+
   /// Toggle per-request engine timing capture. When false, [isBlocked]
   /// skips the Stopwatch + buffer write — no overhead. DevTools turns
   /// this on while its ABP tab is visible.
   set engineTimingEnabled(bool v) {
     if (_engineTimingEnabled == v) return;
     _engineTimingEnabled = v;
-    if (!v) _recentEngineDecisions.clear();
+    if (!v) {
+      _recentEngineDecisions.clear();
+    } else {
+      _engineConsultedSinceTimingOn = 0;
+    }
+    LogService.instance.log('ContentBlocker',
+        'engine timing recording: ${v ? "ON" : "OFF"} '
+        '(engineActive=${_rustEngine != null})',
+        level: LogLevel.info);
   }
   bool get engineTimingEnabled => _engineTimingEnabled;
 
@@ -463,6 +481,7 @@ class ContentBlockerService {
         );
         sw.stop();
         _recordEngineDecision(url, requestType, sw.elapsedMicroseconds, blocked);
+        _engineConsultedSinceTimingOn++;
         return blocked;
       }
       return engine.shouldBlock(

--- a/rust/webspace_adblock/Cargo.lock
+++ b/rust/webspace_adblock/Cargo.lock
@@ -294,6 +294,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "license"
+version = "3.8.0+3.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5829b45ee447c45e83bc4081e584f8251d7dbfcbfaeb3f153824e03f76d5cf0e"
+dependencies = [
+ "reword",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +404,15 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reword"
+version = "7.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2de73ec80cfacafa51b73b0db31d6c3a4718fc6b0d479ef445609704020c1b0"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -544,6 +564,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +603,7 @@ version = "0.1.0"
 dependencies = [
  "adblock",
  "jni",
+ "license",
  "serde_json",
 ]
 

--- a/rust/webspace_adblock/Cargo.toml
+++ b/rust/webspace_adblock/Cargo.toml
@@ -60,6 +60,14 @@ adblock = { version = "0.12", default-features = false, features = [
   "resource-assembler",
 ] }
 serde_json = "1"
+# SPDX 3.x license dataset. `License::text()` returns the canonical
+# upstream-published text — sourced from the SPDX license-list-data
+# repo, vendored in this crate. Used by build.rs to attach the
+# real license body to each transitive dep's metadata entry. Avoids
+# the legal risk of either hand-typing the texts (typo / drift) or
+# scraping non-standard LICENSE filenames out of every crate's
+# source tree.
+license = "3"
 
 # Android-only: JNI exports so Kotlin's FastSubresourceInterceptor can
 # consult the engine on every sub-resource without a Dart roundtrip.

--- a/rust/webspace_adblock/build.rs
+++ b/rust/webspace_adblock/build.rs
@@ -143,6 +143,46 @@ fn main() {
 /// Failure path: cargo not on PATH (theoretically impossible — we
 /// were just invoked by cargo) → write `[]`, app shows no deps. Same
 /// fallback as the uBO fetch path: app keeps working.
+/// Look up canonical SPDX license texts for a `cargo metadata`
+/// license expression via the `license` crate (which ships the
+/// upstream SPDX 3.x dataset). Avoids the legal risk of either
+/// hand-typing the text (typo / omission) or reading from each
+/// crate's filesystem (non-standard filenames / encoding).
+///
+/// Expression tokens like `"MIT OR Apache-2.0"`, `"MIT/Apache-2.0"`,
+/// `"(MIT OR Apache-2.0) AND Unicode-3.0"` are split on the
+/// SPDX-allowed separators and each identified license is looked
+/// up. Unknown identifiers are silently skipped — the caller still
+/// records the raw expression so the user can read the original
+/// SPDX string and follow the source link.
+fn license_texts_for_expression(expression: &str) -> Vec<Value> {
+    use license::License;
+    if expression.is_empty() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let mut seen: std::collections::HashSet<&'static str> = Default::default();
+    let cleaned = expression.replace(['(', ')'], " ");
+    for raw in cleaned.split(|c: char| c.is_whitespace() || c == '/') {
+        let t = raw.trim();
+        if t.is_empty() || matches!(t, "OR" | "AND" | "WITH" | "or" | "and" | "with") {
+            continue;
+        }
+        let parsed: Result<&dyn License, _> = t.parse();
+        if let Ok(lic) = parsed {
+            if !seen.insert(lic.id()) {
+                continue;
+            }
+            out.push(json!({
+                "id": lic.id(),
+                "name": lic.name(),
+                "text": lic.text(),
+            }));
+        }
+    }
+    out
+}
+
 fn write_dep_licenses(out_dir: &Path) {
     let out_path = out_dir.join("dep_licenses.json");
     let metadata = match Command::new(env::var("CARGO").unwrap_or_else(|_| "cargo".into()))
@@ -191,13 +231,29 @@ fn write_dep_licenses(out_dir: &Path) {
         if name == "webspace_adblock" {
             continue;
         }
+        // Skip the `adblock` crate too — `lib/main.dart` already
+        // ships its full MPL-2.0 text via assets/licenses/adblock_rust.txt
+        // under the "adblock-rust + uBlock Origin resources" entry.
+        // Without this skip the dep enumeration would duplicate it
+        // under the transitive-deps section.
+        if name == "adblock" {
+            continue;
+        }
+        let license_expr = pkg
+            .get("license")
+            .and_then(|v| v.as_str())
+            .unwrap_or("<unspecified>");
+        // Resolve the SPDX expression to canonical license texts via
+        // the `license` crate (build-dep). One entry per distinct
+        // SPDX id named in the expression so dual-licensed crates
+        // ship both bodies. Empty when the expression names no
+        // recognised SPDX id — the consumer falls back to the raw
+        // expression string.
+        let license_texts = license_texts_for_expression(license_expr);
         out.push(json!({
             "name": name,
             "version": pkg.get("version").and_then(|v| v.as_str()).unwrap_or(""),
-            "license": pkg
-                .get("license")
-                .and_then(|v| v.as_str())
-                .unwrap_or("<unspecified>"),
+            "license": license_expr,
             "repository": pkg
                 .get("repository")
                 .and_then(|v| v.as_str())
@@ -206,6 +262,7 @@ fn write_dep_licenses(out_dir: &Path) {
                 .get("description")
                 .and_then(|v| v.as_str())
                 .unwrap_or(""),
+            "license_texts": license_texts,
         }));
     }
     // Stable order — sort by name so successive builds with the same

--- a/rust/webspace_adblock/build.rs
+++ b/rust/webspace_adblock/build.rs
@@ -226,17 +226,11 @@ fn write_dep_licenses(out_dir: &Path) {
     let mut out = Vec::new();
     for pkg in packages {
         let name = pkg.get("name").and_then(|v| v.as_str()).unwrap_or("");
-        // Skip the crate itself — already covered by the WebSpace
-        // bundle entry in lib/main.dart.
+        // Skip the wrapper crate itself — it has no upstream
+        // source link and is fully described by the rest of the
+        // attribution surface (the project's own LICENSE +
+        // README + the transitive `adblock` entry that follows).
         if name == "webspace_adblock" {
-            continue;
-        }
-        // Skip the `adblock` crate too — `lib/main.dart` already
-        // ships its full MPL-2.0 text via assets/licenses/adblock_rust.txt
-        // under the "adblock-rust + uBlock Origin resources" entry.
-        // Without this skip the dep enumeration would duplicate it
-        // under the transitive-deps section.
-        if name == "adblock" {
             continue;
         }
         let license_expr = pkg


### PR DESCRIPTION
Resolves legal risk in transitive dependency attribution by embedding canonical SPDX license texts at build time instead of relying on hand-typed or filesystem-scraped copies.

**Changes:**

- Add `_PerLineLicenseEntry` class to preserve structural line breaks in license text rendering (titles, numbered headers, template lines). Replaces `LicenseEntryWithLineBreaks` which collapsed multi-line headers into single paragraphs.

- Extend `rust/webspace_adblock/build.rs` with `license_texts_for_expression()` to parse SPDX license expressions and resolve each identifier to canonical text via the `license` crate (which vendors the upstream SPDX 3.x dataset). Dual-licensed crates now ship all relevant license bodies.

- Update `write_dep_licenses()` to attach resolved license texts to each transitive dependency's metadata entry. Skips unrecognized SPDX identifiers gracefully; consumer falls back to raw expression string.

- Refactor `lib/main.dart` license registry to consume the new `license_texts` field and render each text under its SPDX identifier. Fallback message when texts are unresolvable directs users to upstream source.

- Rename `assets/licenses/adblock_rust.txt` → `assets/licenses/ubo_resources.txt` and clarify that it covers only uBlock Origin's web-accessible resources (redirect bodies). Attribution for the `adblock` crate itself now flows through the transitive enumeration with canonical SPDX text.

- Add `license = "3"` build-dependency to `Cargo.toml` to enable SPDX text resolution.

- Improve ABP timing stats in DevTools: track total engine consultations across the session (decoupled from the 200-entry ring buffer), display engine status and recording state, and provide context-aware empty-state messages.

**Implementation notes:**

- SPDX expression parsing splits on whitespace, `/`, and parentheses; filters out logical operators (`OR`, `AND`, `WITH`). Deduplicates by license ID to avoid shipping the same text twice for dual-licensed crates.

- `_PerLineLicenseEntry` yields one `LicenseParagraph` per input line, mapping every 2 leading spaces to one indent level (clamped 0–8) so indented items remain visually distinct without breaking paragraph flow.

- Build-time resolution avoids the legal risk of typos, omissions, or encoding issues that arise from hand-typing or scraping non-standard LICENSE filenames from each crate's source tree.

https://claude.ai/code/session_015WiiVUydsVMj3XG7eut164