### PR TITLE
Support inline script interception for DarkReader on Android

### DIFF
--- a/lib/services/user_script_service.dart
+++ b/lib/services/user_script_service.dart
@@ -2,202 +2,16 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
 
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/outbound_http.dart';
+import 'package:webspace/services/user_script_shim.dart';
 import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/settings/user_script.dart';
 
-/// JavaScript shim that intercepts <script> DOM insertions and provides
-/// a CORS-bypassing fetch function for user scripts.
-///
-/// Three interceptions:
-/// 1. `<script src="...">` for whitelisted CDN URLs — Dart fetches the URL
-///    and injects the body via evaluateJavascript (bypassing page CSP).
-/// 2. `<script>` with inline textContent (no `src`) — Dart receives the
-///    source and runs it via evaluateJavascript (bypassing page CSP).
-///    Required for libraries like DarkReader whose `injectProxy` does
-///    `head.append(scriptEl)` with inline text; Chromium WebView enforces
-///    CSP strictly on this pattern, WKWebView is more lenient.
-/// 3. `window.__wsFetch(url)` — CORS-bypassing fetch returning a Response.
-///
-/// Wrapped DOM entry points: `Node.prototype.appendChild`,
-/// `Node.prototype.insertBefore`, `Element.prototype.append`. DarkReader
-/// uses `append()` (not `appendChild`), so the `Element.append` wrapper
-/// is what unblocks it on Android.
-///
-/// Security:
-/// - Shim only installed on sites with user scripts enabled. The user has
-///   opted into running custom JS; bypassing CSP for inline scripts on
-///   that one site is in scope.
-/// - Handler names are randomized per webview instance (placeholders
-///   replaced at runtime) so page code cannot guess or call them.
-/// - callHandler reference is captured lazily on first use.
-/// - For `<script src>`, only whitelisted CDN URLs are intercepted; other
-///   URLs fall through to normal (CSP-governed) DOM behavior.
-const String _shimTemplate = r'''
-(function() {
-  if (window.__wsFetchShimInstalled) return;
-  window.__wsFetchShimInstalled = true;
-  var _origAppend = Node.prototype.appendChild;
-  var _origInsert = Node.prototype.insertBefore;
-  var _origElemAppend = Element.prototype.append;
-  var SCRIPT_HANDLER = '__SCRIPT_HANDLER_NAME__';
-  var FETCH_HANDLER = '__FETCH_HANDLER_NAME__';
-  var INLINE_SCRIPT_HANDLER = '__INLINE_SCRIPT_HANDLER_NAME__';
+// The shim JS template and [buildUserScriptShim] live in
+// `user_script_shim.dart` (pure Dart, no Flutter imports) so the fixture
+// dumper at `tool/dump_shim_js.dart` can reach them under `fvm dart run`.
+export 'package:webspace/services/user_script_shim.dart'
+    show buildUserScriptShim, userScriptShimTemplate;
 
-  // Lazily capture the bridge reference. At DOCUMENT_START the
-  // flutter_inappwebview bridge may not be injected yet. By the time
-  // user scripts actually call appendChild or __wsFetch (after the
-  // library <script> loads), the bridge will be available.
-  var _call = null;
-  function call() {
-    if (!_call) {
-      if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
-        _call = window.flutter_inappwebview.callHandler.bind(window.flutter_inappwebview);
-      }
-    }
-    if (!_call) return null;
-    return _call.apply(null, arguments);
-  }
-
-  var WHITELIST = __WHITELIST_JSON__;
-
-  function isFetchableUrl(url) {
-    if (typeof url !== 'string' || url.length === 0) return false;
-    var lower = url.toLowerCase();
-    return lower.indexOf('http://') === 0 || lower.indexOf('https://') === 0;
-  }
-
-  function isWhitelistedUrl(url) {
-    if (!isFetchableUrl(url)) return false;
-    try {
-      var host = new URL(url).hostname.toLowerCase();
-      for (var i = 0; i < WHITELIST.length; i++) {
-        if (host === WHITELIST[i] || host.endsWith('.' + WHITELIST[i])) return true;
-      }
-    } catch(e) {}
-    return false;
-  }
-
-  // Track URLs already fetched + injected to avoid double-loading
-  // when initialUserScripts and onLoadStop both run the same script.
-  var _loadedUrls = {};
-
-  function intercept(scriptEl) {
-    var url = scriptEl.src;
-    // Only intercept whitelisted CDN URLs. Site scripts (e.g.,
-    // platform.linkedin.com) fall through to normal DOM behavior.
-    if (!isWhitelistedUrl(url)) return null;
-    // If already loaded, just fire onload without re-fetching.
-    if (_loadedUrls[url]) {
-      var onload = scriptEl.onload;
-      if (onload) setTimeout(function() { try { onload.call(scriptEl); } catch(e) { console.error('__ws: dedup onload error:', e); } }, 0);
-      return scriptEl;
-    }
-    var result = call(SCRIPT_HANDLER, url);
-    if (!result) return null;
-    var onload = scriptEl.onload;
-    var onerror = scriptEl.onerror;
-    result.then(function(ok) {
-      if (ok) {
-        _loadedUrls[url] = true;
-        if (onload) try { onload.call(scriptEl); } catch(e) { console.error('__ws: onload error:', e); }
-      }
-      else { if (onerror) try { onerror.call(scriptEl, new Error('fetch failed')); } catch(e) { console.error('__ws: onerror error:', e); } }
-    }).catch(function(e) {
-      if (onerror) try { onerror.call(scriptEl, e); } catch(e2) {}
-    });
-    return scriptEl;
-  }
-
-  // Catch inline <script>{textContent} elements and route them through
-  // the privileged Dart bridge so they bypass the page's strict CSP.
-  // Returns the element (un-appended) on success, null to fall through.
-  function interceptInline(scriptEl) {
-    if (scriptEl.src) return null;
-    var inlineSource = scriptEl.text || scriptEl.textContent || '';
-    if (typeof inlineSource !== 'string' || inlineSource.length === 0) return null;
-    var c = call();
-    if (!c) return null;
-    c(INLINE_SCRIPT_HANDLER, inlineSource);
-    return scriptEl;
-  }
-
-  function interceptScript(scriptEl) {
-    if (!(scriptEl instanceof HTMLScriptElement)) return null;
-    if (scriptEl.src) return intercept(scriptEl);
-    return interceptInline(scriptEl);
-  }
-
-  Node.prototype.appendChild = function(child) {
-    var result = interceptScript(child);
-    if (result) return result;
-    return _origAppend.call(this, child);
-  };
-  Node.prototype.insertBefore = function(child, ref) {
-    var result = interceptScript(child);
-    if (result) return result;
-    return _origInsert.call(this, child, ref);
-  };
-  // Element.prototype.append accepts variadic Node|string args and does
-  // NOT call Node.prototype.appendChild internally — it's a separate path
-  // in the DOM impl. DarkReader's injectProxy uses
-  // `(document.head||document.documentElement).append(proxyScript)`, so
-  // without wrapping append() too, the inline-script intercept above
-  // never fires for DarkReader's pattern.
-  Element.prototype.append = function() {
-    var passthrough = [];
-    for (var i = 0; i < arguments.length; i++) {
-      var n = arguments[i];
-      if (interceptScript(n)) continue;
-      passthrough.push(n);
-    }
-    if (passthrough.length === 0) return undefined;
-    return _origElemAppend.apply(this, passthrough);
-  };
-
-  // CORS-bypassing fetch for user scripts. Returns a standard Response object.
-  // Usage: myLibrary.setFetchMethod(window.__wsFetch);
-  window.__wsFetch = function(url) {
-    var urlStr = typeof url === 'string' ? url : url.toString();
-    if (!isFetchableUrl(urlStr)) {
-      return Promise.reject(new Error('__wsFetch: only http/https URLs supported'));
-    }
-    var result = call(FETCH_HANDLER, urlStr);
-    if (!result) {
-      console.log('__wsFetch: bridge not available for ' + urlStr.substring(0, 80));
-      return Promise.reject(new Error('__wsFetch: bridge not available'));
-    }
-    return result.then(function(r) {
-      console.log('__wsFetch: ' + urlStr.substring(0, 60) + ' -> status=' + (r && r.status) + ' body=' + (r && r.body ? r.body.length + 'b' : 'none'));
-      if (r && r.body !== undefined) {
-        return new Response(r.body, {
-          status: r.status || 200,
-          headers: r.contentType ? { 'Content-Type': r.contentType } : {},
-        });
-      }
-      return new Response('', { status: 500 });
-    });
-  };
-
-  // Patch window.fetch to fall back to __wsFetch on CORS errors.
-  // Only catches TypeError (which browsers throw for CORS and network
-  // failures), not application errors like 404. This avoids breaking
-  // video/binary fetches that fail for non-CORS reasons.
-  var _origFetch = window.fetch.bind(window);
-  window.fetch = function(input, init) {
-    return _origFetch(input, init).catch(function(err) {
-      if (err instanceof TypeError) {
-        var url = typeof input === 'string' ? input : (input && input.url ? input.url : '');
-        if (isFetchableUrl(url)) {
-          return window.__wsFetch(url);
-        }
-      }
-      throw err;
-    });
-  };
-})();
-''';
-
-/// Max size for fetched resources (5 MB).
 const int _maxFetchBytes = 5 * 1024 * 1024;
 
 /// Evaluate JS without triggering "unsupported type" serialization errors.
@@ -258,12 +72,11 @@ class UserScriptService {
 
     String? shimScript;
     if (hasScripts) {
-      final whitelistJson = '[${scriptFetchWhitelist.map((d) => '"$d"').join(',')}]';
-      shimScript = _shimTemplate
-          .replaceAll('__SCRIPT_HANDLER_NAME__', scriptHandlerName)
-          .replaceAll('__FETCH_HANDLER_NAME__', fetchHandlerName)
-          .replaceAll('__INLINE_SCRIPT_HANDLER_NAME__', inlineScriptHandlerName)
-          .replaceAll('__WHITELIST_JSON__', whitelistJson);
+      shimScript = buildUserScriptShim(
+        scriptHandlerName: scriptHandlerName,
+        fetchHandlerName: fetchHandlerName,
+        inlineScriptHandlerName: inlineScriptHandlerName,
+      );
     }
 
     return UserScriptService._(

--- a/lib/services/user_script_service.dart
+++ b/lib/services/user_script_service.dart
@@ -5,32 +5,43 @@ import 'package:webspace/services/outbound_http.dart';
 import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/settings/user_script.dart';
 
-/// JavaScript shim that intercepts <script src="..."> DOM insertions and
-/// provides a CORS-bypassing fetch function for user scripts.
+/// JavaScript shim that intercepts <script> DOM insertions and provides
+/// a CORS-bypassing fetch function for user scripts.
 ///
-/// When user scripts create script elements with external sources, the browser
-/// would block them via CSP. This shim catches those insertions, sends the URL
-/// to Dart for fetching, and the content is injected natively via
-/// evaluateJavascript (which bypasses CSP).
+/// Three interceptions:
+/// 1. `<script src="...">` for whitelisted CDN URLs — Dart fetches the URL
+///    and injects the body via evaluateJavascript (bypassing page CSP).
+/// 2. `<script>` with inline textContent (no `src`) — Dart receives the
+///    source and runs it via evaluateJavascript (bypassing page CSP).
+///    Required for libraries like DarkReader whose `injectProxy` does
+///    `head.append(scriptEl)` with inline text; Chromium WebView enforces
+///    CSP strictly on this pattern, WKWebView is more lenient.
+/// 3. `window.__wsFetch(url)` — CORS-bypassing fetch returning a Response.
 ///
-/// Also exposes `window.__wsFetch(url)` which returns a `Response` object,
-/// useful for libraries that need a CORS-bypassing fetch (e.g. to read
-/// cross-origin stylesheets).
+/// Wrapped DOM entry points: `Node.prototype.appendChild`,
+/// `Node.prototype.insertBefore`, `Element.prototype.append`. DarkReader
+/// uses `append()` (not `appendChild`), so the `Element.append` wrapper
+/// is what unblocks it on Android.
 ///
 /// Security:
-/// - Handler names are randomized per webview instance (placeholders replaced
-///   at runtime) so page code cannot guess or call them.
+/// - Shim only installed on sites with user scripts enabled. The user has
+///   opted into running custom JS; bypassing CSP for inline scripts on
+///   that one site is in scope.
+/// - Handler names are randomized per webview instance (placeholders
+///   replaced at runtime) so page code cannot guess or call them.
 /// - callHandler reference is captured lazily on first use.
-/// - Only whitelisted CDN URLs are intercepted for script loading; other URLs
-///   fall through to normal (CSP-governed) DOM behavior.
+/// - For `<script src>`, only whitelisted CDN URLs are intercepted; other
+///   URLs fall through to normal (CSP-governed) DOM behavior.
 const String _shimTemplate = r'''
 (function() {
   if (window.__wsFetchShimInstalled) return;
   window.__wsFetchShimInstalled = true;
   var _origAppend = Node.prototype.appendChild;
   var _origInsert = Node.prototype.insertBefore;
+  var _origElemAppend = Element.prototype.append;
   var SCRIPT_HANDLER = '__SCRIPT_HANDLER_NAME__';
   var FETCH_HANDLER = '__FETCH_HANDLER_NAME__';
+  var INLINE_SCRIPT_HANDLER = '__INLINE_SCRIPT_HANDLER_NAME__';
 
   // Lazily capture the bridge reference. At DOCUMENT_START the
   // flutter_inappwebview bridge may not be injected yet. By the time
@@ -97,19 +108,50 @@ const String _shimTemplate = r'''
     return scriptEl;
   }
 
+  // Catch inline <script>{textContent} elements and route them through
+  // the privileged Dart bridge so they bypass the page's strict CSP.
+  // Returns the element (un-appended) on success, null to fall through.
+  function interceptInline(scriptEl) {
+    if (scriptEl.src) return null;
+    var inlineSource = scriptEl.text || scriptEl.textContent || '';
+    if (typeof inlineSource !== 'string' || inlineSource.length === 0) return null;
+    var c = call();
+    if (!c) return null;
+    c(INLINE_SCRIPT_HANDLER, inlineSource);
+    return scriptEl;
+  }
+
+  function interceptScript(scriptEl) {
+    if (!(scriptEl instanceof HTMLScriptElement)) return null;
+    if (scriptEl.src) return intercept(scriptEl);
+    return interceptInline(scriptEl);
+  }
+
   Node.prototype.appendChild = function(child) {
-    if (child instanceof HTMLScriptElement && child.src) {
-      var result = intercept(child);
-      if (result) return result;
-    }
+    var result = interceptScript(child);
+    if (result) return result;
     return _origAppend.call(this, child);
   };
   Node.prototype.insertBefore = function(child, ref) {
-    if (child instanceof HTMLScriptElement && child.src) {
-      var result = intercept(child);
-      if (result) return result;
-    }
+    var result = interceptScript(child);
+    if (result) return result;
     return _origInsert.call(this, child, ref);
+  };
+  // Element.prototype.append accepts variadic Node|string args and does
+  // NOT call Node.prototype.appendChild internally — it's a separate path
+  // in the DOM impl. DarkReader's injectProxy uses
+  // `(document.head||document.documentElement).append(proxyScript)`, so
+  // without wrapping append() too, the inline-script intercept above
+  // never fires for DarkReader's pattern.
+  Element.prototype.append = function() {
+    var passthrough = [];
+    for (var i = 0; i < arguments.length; i++) {
+      var n = arguments[i];
+      if (interceptScript(n)) continue;
+      passthrough.push(n);
+    }
+    if (passthrough.length === 0) return undefined;
+    return _origElemAppend.apply(this, passthrough);
   };
 
   // CORS-bypassing fetch for user scripts. Returns a standard Response object.
@@ -177,6 +219,7 @@ class UserScriptService {
   final String? shimScript;
   final String _scriptHandlerName;
   final String _fetchHandlerName;
+  final String _inlineScriptHandlerName;
   final bool hasScripts;
   final List<UserScriptConfig> _scripts;
   final Future<bool> Function(String url)? _onConfirmScriptFetch;
@@ -189,12 +232,14 @@ class UserScriptService {
     required this.shimScript,
     required String scriptHandlerName,
     required String fetchHandlerName,
+    required String inlineScriptHandlerName,
     required this.hasScripts,
     required List<UserScriptConfig> scripts,
     required Future<bool> Function(String url)? onConfirmScriptFetch,
     required UserProxySettings proxy,
   })  : _scriptHandlerName = scriptHandlerName,
         _fetchHandlerName = fetchHandlerName,
+        _inlineScriptHandlerName = inlineScriptHandlerName,
         _scripts = scripts,
         _onConfirmScriptFetch = onConfirmScriptFetch,
         _proxy = proxy;
@@ -209,6 +254,7 @@ class UserScriptService {
     final ts = DateTime.now().microsecondsSinceEpoch.toRadixString(36);
     final scriptHandlerName = '__ws_s_$ts';
     final fetchHandlerName = '__ws_f_$ts';
+    final inlineScriptHandlerName = '__ws_i_$ts';
 
     String? shimScript;
     if (hasScripts) {
@@ -216,6 +262,7 @@ class UserScriptService {
       shimScript = _shimTemplate
           .replaceAll('__SCRIPT_HANDLER_NAME__', scriptHandlerName)
           .replaceAll('__FETCH_HANDLER_NAME__', fetchHandlerName)
+          .replaceAll('__INLINE_SCRIPT_HANDLER_NAME__', inlineScriptHandlerName)
           .replaceAll('__WHITELIST_JSON__', whitelistJson);
     }
 
@@ -223,6 +270,7 @@ class UserScriptService {
       shimScript: shimScript,
       scriptHandlerName: scriptHandlerName,
       fetchHandlerName: fetchHandlerName,
+      inlineScriptHandlerName: inlineScriptHandlerName,
       hasScripts: hasScripts,
       scripts: scripts,
       onConfirmScriptFetch: onConfirmScriptFetch,
@@ -334,6 +382,18 @@ class UserScriptService {
         client.close();
       }
       return false;
+    });
+
+    // Inline-script handler: takes a captured <script>{textContent} source
+    // string and evaluates it via the privileged Dart bridge, bypassing
+    // page CSP. Fire-and-forget — the JS side doesn't await a result.
+    controller.addJavaScriptHandler(handlerName: _inlineScriptHandlerName, callback: (args) async {
+      if (args.isEmpty || args[0] is! String) return null;
+      final source = args[0] as String;
+      if (source.isEmpty) return null;
+      LogService.instance.log('UserScript', 'Inline script bridged (${source.length} bytes)');
+      await _safeEval(controller, source);
+      return null;
     });
 
     // Resource fetch handler: fetches URL and returns body as text.

--- a/lib/services/user_script_shim.dart
+++ b/lib/services/user_script_shim.dart
@@ -1,0 +1,214 @@
+import 'package:webspace/settings/user_script.dart';
+
+/// JavaScript shim that intercepts <script> DOM insertions and provides
+/// a CORS-bypassing fetch function for user scripts.
+///
+/// Three interceptions:
+/// 1. `<script src="...">` for whitelisted CDN URLs — Dart fetches the URL
+///    and injects the body via evaluateJavascript (bypassing page CSP).
+/// 2. `<script>` with inline textContent (no `src`) — Dart receives the
+///    source and runs it via evaluateJavascript (bypassing page CSP).
+///    Required for libraries like DarkReader whose `injectProxy` does
+///    `head.append(scriptEl)` with inline text; Chromium WebView enforces
+///    CSP strictly on this pattern, WKWebView is more lenient.
+/// 3. `window.__wsFetch(url)` — CORS-bypassing fetch returning a Response.
+///
+/// Wrapped DOM entry points: `Node.prototype.appendChild`,
+/// `Node.prototype.insertBefore`, `Element.prototype.append`. DarkReader
+/// uses `append()` (not `appendChild`), so the `Element.append` wrapper
+/// is what unblocks it on Android.
+///
+/// Lives in its own file (no Flutter imports) so the fixture dumper at
+/// `tool/dump_shim_js.dart` can call [buildUserScriptShim] under
+/// `fvm dart run` without pulling in the Flutter framework.
+///
+/// Security:
+/// - Shim only installed on sites with user scripts enabled. The user has
+///   opted into running custom JS; bypassing CSP for inline scripts on
+///   that one site is in scope.
+/// - Handler names are randomized per webview instance (placeholders
+///   replaced at runtime) so page code cannot guess or call them.
+/// - callHandler reference is captured lazily on first use.
+/// - For `<script src>`, only whitelisted CDN URLs are intercepted; other
+///   URLs fall through to normal (CSP-governed) DOM behavior.
+const String userScriptShimTemplate = r'''
+(function() {
+  if (window.__wsFetchShimInstalled) return;
+  window.__wsFetchShimInstalled = true;
+  var _origAppend = Node.prototype.appendChild;
+  var _origInsert = Node.prototype.insertBefore;
+  var _origElemAppend = Element.prototype.append;
+  var SCRIPT_HANDLER = '__SCRIPT_HANDLER_NAME__';
+  var FETCH_HANDLER = '__FETCH_HANDLER_NAME__';
+  var INLINE_SCRIPT_HANDLER = '__INLINE_SCRIPT_HANDLER_NAME__';
+
+  // Lazily capture the bridge reference. At DOCUMENT_START the
+  // flutter_inappwebview bridge may not be injected yet. By the time
+  // user scripts actually call appendChild or __wsFetch (after the
+  // library <script> loads), the bridge will be available.
+  var _call = null;
+  function call() {
+    if (!_call) {
+      if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
+        _call = window.flutter_inappwebview.callHandler.bind(window.flutter_inappwebview);
+      }
+    }
+    if (!_call) return null;
+    return _call.apply(null, arguments);
+  }
+
+  var WHITELIST = __WHITELIST_JSON__;
+
+  function isFetchableUrl(url) {
+    if (typeof url !== 'string' || url.length === 0) return false;
+    var lower = url.toLowerCase();
+    return lower.indexOf('http://') === 0 || lower.indexOf('https://') === 0;
+  }
+
+  function isWhitelistedUrl(url) {
+    if (!isFetchableUrl(url)) return false;
+    try {
+      var host = new URL(url).hostname.toLowerCase();
+      for (var i = 0; i < WHITELIST.length; i++) {
+        if (host === WHITELIST[i] || host.endsWith('.' + WHITELIST[i])) return true;
+      }
+    } catch(e) {}
+    return false;
+  }
+
+  // Track URLs already fetched + injected to avoid double-loading
+  // when initialUserScripts and onLoadStop both run the same script.
+  var _loadedUrls = {};
+
+  function intercept(scriptEl) {
+    var url = scriptEl.src;
+    // Only intercept whitelisted CDN URLs. Site scripts (e.g.,
+    // platform.linkedin.com) fall through to normal DOM behavior.
+    if (!isWhitelistedUrl(url)) return null;
+    // If already loaded, just fire onload without re-fetching.
+    if (_loadedUrls[url]) {
+      var onload = scriptEl.onload;
+      if (onload) setTimeout(function() { try { onload.call(scriptEl); } catch(e) { console.error('__ws: dedup onload error:', e); } }, 0);
+      return scriptEl;
+    }
+    var result = call(SCRIPT_HANDLER, url);
+    if (!result) return null;
+    var onload = scriptEl.onload;
+    var onerror = scriptEl.onerror;
+    result.then(function(ok) {
+      if (ok) {
+        _loadedUrls[url] = true;
+        if (onload) try { onload.call(scriptEl); } catch(e) { console.error('__ws: onload error:', e); }
+      }
+      else { if (onerror) try { onerror.call(scriptEl, new Error('fetch failed')); } catch(e) { console.error('__ws: onerror error:', e); } }
+    }).catch(function(e) {
+      if (onerror) try { onerror.call(scriptEl, e); } catch(e2) {}
+    });
+    return scriptEl;
+  }
+
+  // Catch inline <script>{textContent} elements and route them through
+  // the privileged Dart bridge so they bypass the page's strict CSP.
+  // Returns the element (un-appended) on success, null to fall through.
+  function interceptInline(scriptEl) {
+    if (scriptEl.src) return null;
+    var inlineSource = scriptEl.text || scriptEl.textContent || '';
+    if (typeof inlineSource !== 'string' || inlineSource.length === 0) return null;
+    var result = call(INLINE_SCRIPT_HANDLER, inlineSource);
+    if (!result) return null;
+    return scriptEl;
+  }
+
+  function interceptScript(scriptEl) {
+    if (!(scriptEl instanceof HTMLScriptElement)) return null;
+    if (scriptEl.src) return intercept(scriptEl);
+    return interceptInline(scriptEl);
+  }
+
+  Node.prototype.appendChild = function(child) {
+    var result = interceptScript(child);
+    if (result) return result;
+    return _origAppend.call(this, child);
+  };
+  Node.prototype.insertBefore = function(child, ref) {
+    var result = interceptScript(child);
+    if (result) return result;
+    return _origInsert.call(this, child, ref);
+  };
+  // Element.prototype.append accepts variadic Node|string args and does
+  // NOT call Node.prototype.appendChild internally — it's a separate path
+  // in the DOM impl. DarkReader's injectProxy uses
+  // `(document.head||document.documentElement).append(proxyScript)`, so
+  // without wrapping append() too, the inline-script intercept above
+  // never fires for DarkReader's pattern.
+  Element.prototype.append = function() {
+    var passthrough = [];
+    for (var i = 0; i < arguments.length; i++) {
+      var n = arguments[i];
+      if (interceptScript(n)) continue;
+      passthrough.push(n);
+    }
+    if (passthrough.length === 0) return undefined;
+    return _origElemAppend.apply(this, passthrough);
+  };
+
+  // CORS-bypassing fetch for user scripts. Returns a standard Response object.
+  // Usage: myLibrary.setFetchMethod(window.__wsFetch);
+  window.__wsFetch = function(url) {
+    var urlStr = typeof url === 'string' ? url : url.toString();
+    if (!isFetchableUrl(urlStr)) {
+      return Promise.reject(new Error('__wsFetch: only http/https URLs supported'));
+    }
+    var result = call(FETCH_HANDLER, urlStr);
+    if (!result) {
+      console.log('__wsFetch: bridge not available for ' + urlStr.substring(0, 80));
+      return Promise.reject(new Error('__wsFetch: bridge not available'));
+    }
+    return result.then(function(r) {
+      console.log('__wsFetch: ' + urlStr.substring(0, 60) + ' -> status=' + (r && r.status) + ' body=' + (r && r.body ? r.body.length + 'b' : 'none'));
+      if (r && r.body !== undefined) {
+        return new Response(r.body, {
+          status: r.status || 200,
+          headers: r.contentType ? { 'Content-Type': r.contentType } : {},
+        });
+      }
+      return new Response('', { status: 500 });
+    });
+  };
+
+  // Patch window.fetch to fall back to __wsFetch on CORS errors.
+  // Only catches TypeError (which browsers throw for CORS and network
+  // failures), not application errors like 404. This avoids breaking
+  // video/binary fetches that fail for non-CORS reasons.
+  var _origFetch = window.fetch.bind(window);
+  window.fetch = function(input, init) {
+    return _origFetch(input, init).catch(function(err) {
+      if (err instanceof TypeError) {
+        var url = typeof input === 'string' ? input : (input && input.url ? input.url : '');
+        if (isFetchableUrl(url)) {
+          return window.__wsFetch(url);
+        }
+      }
+      throw err;
+    });
+  };
+})();
+''';
+
+/// Build the user-script shim with explicit handler names. Production code
+/// uses [UserScriptService] which generates randomized names per webview
+/// instance; the fixture dumper (`tool/dump_shim_js.dart`) calls this
+/// directly with deterministic names so the on-disk fixture under
+/// `test/js_fixtures/user_script/` stays stable across runs.
+String buildUserScriptShim({
+  required String scriptHandlerName,
+  required String fetchHandlerName,
+  required String inlineScriptHandlerName,
+}) {
+  final whitelistJson = '[${scriptFetchWhitelist.map((d) => '"$d"').join(',')}]';
+  return userScriptShimTemplate
+      .replaceAll('__SCRIPT_HANDLER_NAME__', scriptHandlerName)
+      .replaceAll('__FETCH_HANDLER_NAME__', fetchHandlerName)
+      .replaceAll('__INLINE_SCRIPT_HANDLER_NAME__', inlineScriptHandlerName)
+      .replaceAll('__WHITELIST_JSON__', whitelistJson);
+}

--- a/openspec/specs/user-scripts/spec.md
+++ b/openspec/specs/user-scripts/spec.md
@@ -387,12 +387,37 @@ Scripts are added to the `initialUserScripts` list in `WebViewFactory.createWebV
 
 A shim is injected at `AT_DOCUMENT_START` before user scripts. It provides:
 
-1. **`appendChild`/`insertBefore` interception**: Catches `<script src="...">` DOM insertions for whitelisted CDN URLs and fetches them at the Dart level (bypassing CSP).
+1. **`appendChild` / `insertBefore` / `Element.append` interception**: Catches both `<script src="...">` insertions for whitelisted CDN URLs and inline `<script>{textContent}` insertions, routing both through Dart handlers that evaluate the source via `controller.evaluateJavascript` (bypassing CSP). `Element.prototype.append` is wrapped in addition to `Node.prototype.appendChild`/`insertBefore` because `ParentNode.append` does not invoke `appendChild` internally — libraries like DarkReader call `head.append(scriptEl)`, which `appendChild`-only wrappers miss.
 2. **`window.__wsFetch(url)`**: CORS-bypassing fetch that returns a standard `Response` object. User scripts can use this for libraries that need custom fetch methods (e.g. `MyLib.setFetchMethod(window.__wsFetch)`).
 3. **`window.fetch` CORS fallback**: Patches `window.fetch` to fall back to `__wsFetch` on TypeError (CORS/network failures).
 4. **Deduplication**: Tracks loaded URLs to avoid double-loading when both `initialUserScripts` and re-injection run.
 
 Handler names are randomized per webview instance for security.
+
+#### Inline Script Bridging (US-DR-001)
+
+Chromium WebView (Android System WebView) enforces CSP strictly on dynamically-created inline scripts: `document.createElement('script')` + `textContent` + `appendChild`/`append` is rejected on any site whose `Content-Security-Policy` lacks `'unsafe-inline'` or a matching hash. WebKit (iOS/macOS) is more lenient in practice on the same pattern. This asymmetry caused libraries like DarkReader to degrade on Android (initial CSS theming applies, but `injectProxy()` — needed for live stylesheet operations — is blocked, so dark mode silently regresses as the page renders).
+
+The shim closes the gap by catching inline `<script>` insertions in the same wrappers that handle `<script src>`:
+
+1. When `appendChild` / `insertBefore` / `Element.append` is called with an `HTMLScriptElement` whose `src` is empty but `text`/`textContent` is non-empty
+2. The shim sends the source string to a dedicated Dart handler (`__ws_i_<timestamp>`)
+3. Dart runs the source via `controller.evaluateJavascript` (privileged, CSP-bypassing on both engines)
+4. The native append is **skipped** — the script element is returned un-parented, so callers' `proxy.remove()` no-ops safely
+
+##### Scenario: DarkReader survives strict CSP on Android
+
+**Given** a user script enables DarkReader on a site whose CSP forbids `'unsafe-inline'` scripts (e.g. linkedin.com)
+**And** the site is loaded on Android
+**When** DarkReader's `injectProxy()` calls `(document.head || document.documentElement).append(proxyScript)` with inline text
+**Then** the shim's `Element.prototype.append` wrapper captures `proxyScript.text`, sends it to the inline-script handler, and Dart evaluates it via `controller.evaluateJavascript` — the proxy runs and dark mode persists as the page mutates
+
+##### Trade-offs (US-DR-002)
+
+- **CSP weakening is scoped to opted-in sites**: the shim is installed only on sites with at least one enabled user script (`hasScripts == true`). Sites with no user scripts retain full native CSP enforcement.
+- **Execution timing is async**: the bridge round-trip adds a microtask + IPC hop (typically <50ms on a warm bridge). DarkReader's proxy installs `Element.prototype` overrides used in later page lifecycle, so async timing does not break it. A user script that depends on a hard-synchronous execution guarantee for an inline script it appends would not be satisfied — there is no `eval`-based fast path because the page CSP also forbids `eval` in the policies that motivate this feature.
+- **All inline scripts on the page are bridged**, not just user-script-created ones. Distinguishing the two reliably from JS is not feasible. The opt-in scope (user has scripts on this site) is the security boundary.
+- **DocumentFragment-mediated insertion is not intercepted**: `frag.appendChild(scriptEl); parent.appendChild(frag)` moves the script into the parent in a single DOM op that does not pass through our `appendChild` wrapper a second time. The first `appendChild` (into the fragment) is caught — the bridged evaluation still runs — so user scripts that follow this pattern still execute their JS; the script element just never reaches the live DOM.
 
 ### External Dependency Resolution
 

--- a/test/js/user_script_shim.test.js
+++ b/test/js/user_script_shim.test.js
@@ -1,0 +1,179 @@
+// Replication tests for the user-script shim's CSP-bypass bridge.
+//
+// The motivating bug: DarkReader works on iOS but degrades on Android as
+// the page loads. Root cause: DarkReader's `injectProxy()` does
+//
+//   const proxy = document.createElement('script');
+//   proxy.append('(proxyInjectorCode)()');
+//   (document.head || document.documentElement).append(proxy);
+//   proxy.remove();
+//
+// On Android Chromium WebView, that inline-script append fails the page
+// CSP. The shim catches the script element before it reaches the live DOM
+// and ships its source string through the privileged Dart bridge instead,
+// where `controller.evaluateJavascript` bypasses page CSP on both engines.
+//
+// jsdom doesn't enforce CSP, so we can't replicate the *failure* here.
+// What we can replicate is the *interception*: after running the shim,
+// DarkReader's exact pattern must trigger a call to the inline-script
+// handler, and the script element must never enter the live DOM. Those
+// two facts together prove the bridge fires on the production code path.
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { makeDom, readFixture, runInDom } = require('./helpers/load_shim.js');
+
+const SHIM = readFixture('user_script/shim.js');
+const INLINE_HANDLER = '__ws_i_test';
+const SRC_HANDLER = '__ws_s_test';
+
+// Build a jsdom + install a callHandler stub before the shim runs, so
+// the shim's lazy bridge capture finds it. Returns { dom, calls } where
+// `calls` accumulates every callHandler invocation as [name, ...args].
+function setup({ html } = {}) {
+  const dom = makeDom({ url: 'https://linkedin.example/', html });
+  const calls = [];
+  // jsdom omits window.fetch. The shim's __wsFetch CORS-fallback layer
+  // does `window.fetch.bind(window)` at install time, so we need *some*
+  // function there. The body doesn't need to work; nothing in these
+  // tests exercises the fetch fallback path.
+  if (typeof dom.window.fetch !== 'function') {
+    dom.window.fetch = function unusedFetchStub() {
+      return Promise.reject(new Error('fetch stub not exercised'));
+    };
+  }
+  dom.window.flutter_inappwebview = {
+    callHandler(name, ...args) {
+      calls.push([name, ...args]);
+      // Return a thenable so the src-fetch branch (which awaits the
+      // result) doesn't blow up. The inline branch doesn't await.
+      return Promise.resolve(true);
+    },
+  };
+  runInDom(dom, SHIM);
+  return { dom, calls };
+}
+
+test('DarkReader injectProxy pattern is bridged through inline-script handler', () => {
+  const { dom, calls } = setup();
+  const { document } = dom.window;
+
+  // Verbatim copy of DarkReader's injectProxy logic.
+  const proxy = document.createElement('script');
+  const proxyCode = '(function(){window.__darkReaderProxyInstalled=true;})()';
+  proxy.append(proxyCode);
+  (document.head || document.documentElement).append(proxy);
+  proxy.remove();
+
+  const inlineCalls = calls.filter(c => c[0] === INLINE_HANDLER);
+  assert.strictEqual(inlineCalls.length, 1,
+    'expected exactly one inline-script bridge call, got ' + inlineCalls.length);
+  assert.strictEqual(inlineCalls[0][1], proxyCode,
+    'bridged source must match the proxy code DarkReader assembled');
+
+  // The script element must NOT have ended up in the live DOM. If it had,
+  // a real browser's CSP would have run (and blocked) it.
+  assert.strictEqual(document.head.querySelector('script'), null,
+    'inline script must not enter the live DOM — bridge handles execution');
+});
+
+test('inline script via appendChild is bridged too', () => {
+  const { dom, calls } = setup();
+  const { document } = dom.window;
+  const s = document.createElement('script');
+  s.textContent = 'window.__viaAppendChild = true;';
+  document.head.appendChild(s);
+
+  const inlineCalls = calls.filter(c => c[0] === INLINE_HANDLER);
+  assert.strictEqual(inlineCalls.length, 1);
+  assert.strictEqual(inlineCalls[0][1], 'window.__viaAppendChild = true;');
+  assert.strictEqual(s.parentNode, null,
+    'native append must be skipped — element stays unattached');
+});
+
+test('inline script via insertBefore is bridged too', () => {
+  const { dom, calls } = setup();
+  const { document } = dom.window;
+  // Need an existing reference child so insertBefore has a valid sibling.
+  const ref = document.createElement('meta');
+  document.head.appendChild(ref);
+
+  const s = document.createElement('script');
+  s.text = 'window.__viaInsertBefore = true;';
+  document.head.insertBefore(s, ref);
+
+  const inlineCalls = calls.filter(c => c[0] === INLINE_HANDLER);
+  assert.strictEqual(inlineCalls.length, 1);
+  assert.strictEqual(inlineCalls[0][1], 'window.__viaInsertBefore = true;');
+});
+
+test('script with empty content is NOT bridged (no source to evaluate)', () => {
+  const { dom, calls } = setup();
+  const { document } = dom.window;
+  const s = document.createElement('script');
+  // No textContent, no src — nothing to evaluate.
+  document.head.appendChild(s);
+
+  const inlineCalls = calls.filter(c => c[0] === INLINE_HANDLER);
+  assert.strictEqual(inlineCalls.length, 0);
+});
+
+test('whitelisted <script src> still routes through the src handler', () => {
+  const { dom, calls } = setup();
+  const { document } = dom.window;
+  const s = document.createElement('script');
+  s.src = 'https://cdn.jsdelivr.net/npm/darkreader/darkreader.min.js';
+  document.head.appendChild(s);
+
+  const srcCalls = calls.filter(c => c[0] === SRC_HANDLER);
+  const inlineCalls = calls.filter(c => c[0] === INLINE_HANDLER);
+  assert.strictEqual(srcCalls.length, 1, 'src-script must use the src handler');
+  assert.strictEqual(srcCalls[0][1], s.src);
+  assert.strictEqual(inlineCalls.length, 0,
+    'src-script must not be misrouted through the inline handler');
+});
+
+test('non-whitelisted <script src> from the page is NOT intercepted', () => {
+  // Page-authored remote scripts must keep their native CSP-governed path
+  // — only whitelisted CDN URLs go through the bridge.
+  const { dom, calls } = setup();
+  const { document } = dom.window;
+  const s = document.createElement('script');
+  s.src = 'https://platform.linkedin.com/some-tracker.js';
+  document.head.appendChild(s);
+
+  const srcCalls = calls.filter(c => c[0] === SRC_HANDLER);
+  assert.strictEqual(srcCalls.length, 0,
+    'non-whitelisted src must fall through to native (CSP-governed) append');
+  // The script element should be in the DOM, on the native path.
+  assert.strictEqual(s.parentNode, dom.window.document.head);
+});
+
+test('Element.prototype.append passes non-script args through to native', () => {
+  // The shim's append() wrapper iterates variadic args and only diverts
+  // <script> elements. Strings and other elements must reach the page DOM.
+  const { dom } = setup();
+  const { document } = dom.window;
+  const div = document.createElement('div');
+  document.body.append(div, 'tail-text');
+  assert.strictEqual(div.parentNode, document.body);
+  assert.strictEqual(document.body.lastChild.textContent, 'tail-text');
+});
+
+test('shim is idempotent — running it twice does not double-wrap', () => {
+  // The guard `if (window.__wsFetchShimInstalled) return;` matters because
+  // the shim re-runs at onLoadStart in production. A double-wrap would
+  // intercept twice per append.
+  const { dom, calls } = setup();
+  runInDom(dom, SHIM);
+
+  const { document } = dom.window;
+  const s = document.createElement('script');
+  s.textContent = 'noop;';
+  document.head.appendChild(s);
+
+  const inlineCalls = calls.filter(c => c[0] === INLINE_HANDLER);
+  assert.strictEqual(inlineCalls.length, 1,
+    're-installation must be a no-op, not a double-intercept');
+});

--- a/test/js_fixtures/user_script/shim.js
+++ b/test/js_fixtures/user_script/shim.js
@@ -1,0 +1,161 @@
+(function() {
+  if (window.__wsFetchShimInstalled) return;
+  window.__wsFetchShimInstalled = true;
+  var _origAppend = Node.prototype.appendChild;
+  var _origInsert = Node.prototype.insertBefore;
+  var _origElemAppend = Element.prototype.append;
+  var SCRIPT_HANDLER = '__ws_s_test';
+  var FETCH_HANDLER = '__ws_f_test';
+  var INLINE_SCRIPT_HANDLER = '__ws_i_test';
+
+  // Lazily capture the bridge reference. At DOCUMENT_START the
+  // flutter_inappwebview bridge may not be injected yet. By the time
+  // user scripts actually call appendChild or __wsFetch (after the
+  // library <script> loads), the bridge will be available.
+  var _call = null;
+  function call() {
+    if (!_call) {
+      if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
+        _call = window.flutter_inappwebview.callHandler.bind(window.flutter_inappwebview);
+      }
+    }
+    if (!_call) return null;
+    return _call.apply(null, arguments);
+  }
+
+  var WHITELIST = ["cdn.jsdelivr.net","unpkg.com","cdnjs.cloudflare.com","cdn.cloudflare.com","raw.githubusercontent.com","gist.githubusercontent.com","gitlab.com","ajax.googleapis.com","ajax.aspnetcdn.com","code.jquery.com","cdn.skypack.dev","esm.sh","ga.jspm.io"];
+
+  function isFetchableUrl(url) {
+    if (typeof url !== 'string' || url.length === 0) return false;
+    var lower = url.toLowerCase();
+    return lower.indexOf('http://') === 0 || lower.indexOf('https://') === 0;
+  }
+
+  function isWhitelistedUrl(url) {
+    if (!isFetchableUrl(url)) return false;
+    try {
+      var host = new URL(url).hostname.toLowerCase();
+      for (var i = 0; i < WHITELIST.length; i++) {
+        if (host === WHITELIST[i] || host.endsWith('.' + WHITELIST[i])) return true;
+      }
+    } catch(e) {}
+    return false;
+  }
+
+  // Track URLs already fetched + injected to avoid double-loading
+  // when initialUserScripts and onLoadStop both run the same script.
+  var _loadedUrls = {};
+
+  function intercept(scriptEl) {
+    var url = scriptEl.src;
+    // Only intercept whitelisted CDN URLs. Site scripts (e.g.,
+    // platform.linkedin.com) fall through to normal DOM behavior.
+    if (!isWhitelistedUrl(url)) return null;
+    // If already loaded, just fire onload without re-fetching.
+    if (_loadedUrls[url]) {
+      var onload = scriptEl.onload;
+      if (onload) setTimeout(function() { try { onload.call(scriptEl); } catch(e) { console.error('__ws: dedup onload error:', e); } }, 0);
+      return scriptEl;
+    }
+    var result = call(SCRIPT_HANDLER, url);
+    if (!result) return null;
+    var onload = scriptEl.onload;
+    var onerror = scriptEl.onerror;
+    result.then(function(ok) {
+      if (ok) {
+        _loadedUrls[url] = true;
+        if (onload) try { onload.call(scriptEl); } catch(e) { console.error('__ws: onload error:', e); }
+      }
+      else { if (onerror) try { onerror.call(scriptEl, new Error('fetch failed')); } catch(e) { console.error('__ws: onerror error:', e); } }
+    }).catch(function(e) {
+      if (onerror) try { onerror.call(scriptEl, e); } catch(e2) {}
+    });
+    return scriptEl;
+  }
+
+  // Catch inline <script>{textContent} elements and route them through
+  // the privileged Dart bridge so they bypass the page's strict CSP.
+  // Returns the element (un-appended) on success, null to fall through.
+  function interceptInline(scriptEl) {
+    if (scriptEl.src) return null;
+    var inlineSource = scriptEl.text || scriptEl.textContent || '';
+    if (typeof inlineSource !== 'string' || inlineSource.length === 0) return null;
+    var result = call(INLINE_SCRIPT_HANDLER, inlineSource);
+    if (!result) return null;
+    return scriptEl;
+  }
+
+  function interceptScript(scriptEl) {
+    if (!(scriptEl instanceof HTMLScriptElement)) return null;
+    if (scriptEl.src) return intercept(scriptEl);
+    return interceptInline(scriptEl);
+  }
+
+  Node.prototype.appendChild = function(child) {
+    var result = interceptScript(child);
+    if (result) return result;
+    return _origAppend.call(this, child);
+  };
+  Node.prototype.insertBefore = function(child, ref) {
+    var result = interceptScript(child);
+    if (result) return result;
+    return _origInsert.call(this, child, ref);
+  };
+  // Element.prototype.append accepts variadic Node|string args and does
+  // NOT call Node.prototype.appendChild internally — it's a separate path
+  // in the DOM impl. DarkReader's injectProxy uses
+  // `(document.head||document.documentElement).append(proxyScript)`, so
+  // without wrapping append() too, the inline-script intercept above
+  // never fires for DarkReader's pattern.
+  Element.prototype.append = function() {
+    var passthrough = [];
+    for (var i = 0; i < arguments.length; i++) {
+      var n = arguments[i];
+      if (interceptScript(n)) continue;
+      passthrough.push(n);
+    }
+    if (passthrough.length === 0) return undefined;
+    return _origElemAppend.apply(this, passthrough);
+  };
+
+  // CORS-bypassing fetch for user scripts. Returns a standard Response object.
+  // Usage: myLibrary.setFetchMethod(window.__wsFetch);
+  window.__wsFetch = function(url) {
+    var urlStr = typeof url === 'string' ? url : url.toString();
+    if (!isFetchableUrl(urlStr)) {
+      return Promise.reject(new Error('__wsFetch: only http/https URLs supported'));
+    }
+    var result = call(FETCH_HANDLER, urlStr);
+    if (!result) {
+      console.log('__wsFetch: bridge not available for ' + urlStr.substring(0, 80));
+      return Promise.reject(new Error('__wsFetch: bridge not available'));
+    }
+    return result.then(function(r) {
+      console.log('__wsFetch: ' + urlStr.substring(0, 60) + ' -> status=' + (r && r.status) + ' body=' + (r && r.body ? r.body.length + 'b' : 'none'));
+      if (r && r.body !== undefined) {
+        return new Response(r.body, {
+          status: r.status || 200,
+          headers: r.contentType ? { 'Content-Type': r.contentType } : {},
+        });
+      }
+      return new Response('', { status: 500 });
+    });
+  };
+
+  // Patch window.fetch to fall back to __wsFetch on CORS errors.
+  // Only catches TypeError (which browsers throw for CORS and network
+  // failures), not application errors like 404. This avoids breaking
+  // video/binary fetches that fail for non-CORS reasons.
+  var _origFetch = window.fetch.bind(window);
+  window.fetch = function(input, init) {
+    return _origFetch(input, init).catch(function(err) {
+      if (err instanceof TypeError) {
+        var url = typeof input === 'string' ? input : (input && input.url ? input.url : '');
+        if (isFetchableUrl(url)) {
+          return window.__wsFetch(url);
+        }
+      }
+      throw err;
+    });
+  };
+})();

--- a/test/user_script_test.dart
+++ b/test/user_script_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/user_script_service.dart';
 import 'package:webspace/settings/user_script.dart';
 import 'package:webspace/web_view_model.dart';
 
@@ -539,6 +540,49 @@ void main() {
       expect(restored.injectionTime, original.injectionTime);
       expect(restored.enabled, original.enabled);
       expect(restored.fullSource, original.fullSource);
+    });
+  });
+
+  group('UserScriptService shim', () {
+    // Drift guards: the inline-script bridge is what lets DarkReader
+    // (and any similar dynamic-injector) survive strict CSP on Android
+    // Chromium WebView. A refactor that drops any of these substrings
+    // silently reverts that fix.
+    test('shim wraps Node.appendChild, Node.insertBefore, and Element.append', () {
+      final service = UserScriptService(scripts: [
+        UserScriptConfig(name: 't', source: 'noop;', enabled: true),
+      ]);
+      final shim = service.shimScript;
+      expect(shim, isNotNull);
+      expect(shim, contains('Node.prototype.appendChild = function'));
+      expect(shim, contains('Node.prototype.insertBefore = function'));
+      expect(shim, contains('Element.prototype.append = function'));
+    });
+
+    test('shim intercepts inline <script>{textContent} via interceptInline', () {
+      final service = UserScriptService(scripts: [
+        UserScriptConfig(name: 't', source: 'noop;', enabled: true),
+      ]);
+      final shim = service.shimScript!;
+      expect(shim, contains('function interceptInline'));
+      expect(shim, contains('scriptEl.text || scriptEl.textContent'));
+    });
+
+    test('shim is omitted when no enabled scripts are configured', () {
+      final service = UserScriptService(scripts: [
+        UserScriptConfig(name: 't', source: 'noop;', enabled: false),
+      ]);
+      expect(service.shimScript, isNull);
+      expect(service.hasScripts, isFalse);
+    });
+
+    test('inline-script handler placeholder is replaced in the emitted shim', () {
+      final service = UserScriptService(scripts: [
+        UserScriptConfig(name: 't', source: 'noop;', enabled: true),
+      ]);
+      final shim = service.shimScript!;
+      expect(shim, isNot(contains('__INLINE_SCRIPT_HANDLER_NAME__')),
+          reason: 'placeholder must be substituted with a randomized name');
     });
   });
 

--- a/tool/dump_shim_js.dart
+++ b/tool/dump_shim_js.dart
@@ -29,6 +29,7 @@ import 'package:webspace/services/language_shim.dart';
 import 'package:webspace/services/location_spoof_service.dart';
 import 'package:webspace/services/theme_color_scheme_shim.dart';
 import 'package:webspace/services/user_agent_classifier.dart';
+import 'package:webspace/services/user_script_shim.dart';
 import 'package:webspace/settings/location.dart';
 
 /// Build every fixture this script knows about. Map keys are paths relative
@@ -262,6 +263,14 @@ Map<String, String> buildAllFixtures() {
     '{"selector":[{"type":"css-selector","arg":"div.fp_probe_proc_remove_attr[data-tracker]"}],"action":{"type":"remove-attr","arg":"data-tracker"}}',
     '{"selector":[{"type":"css-selector","arg":"div.fp_probe_proc_remove_class.fp_probe_remove_me"}],"action":{"type":"remove-class","arg":"fp_probe_remove_me"}}',
   ])!;
+
+  // User-script shim with deterministic handler names so jsdom tests can
+  // assert against fixed callHandler('__ws_i_test', ...) invocations.
+  fixtures['user_script/shim.js'] = buildUserScriptShim(
+    scriptHandlerName: '__ws_s_test',
+    fetchHandlerName: '__ws_f_test',
+    inlineScriptHandlerName: '__ws_i_test',
+  );
 
   return fixtures;
 }


### PR DESCRIPTION
Extends the user script shim to intercept and bridge inline `<script>{textContent}` insertions, closing a CSP enforcement gap on Chromium WebView (Android) where dynamically-created inline scripts are blocked even when `<script src>` interception works.

**Problem**: DarkReader's `injectProxy()` calls `head.append(scriptEl)` with inline text to install live stylesheet mutation handlers. On Android Chromium WebView with strict CSP (no `'unsafe-inline'`), this pattern is rejected, causing dark mode to degrade after initial CSS theming. WebKit (iOS/macOS) is more lenient, masking the issue.

**Solution**: Wrap three DOM entry points (`Node.prototype.appendChild`, `Node.prototype.insertBefore`, `Element.prototype.append`) to detect inline script insertions and route them through a privileged Dart handler that evaluates the source via `controller.evaluateJavascript` (CSP-bypassing). `Element.prototype.append` is wrapped separately because it does not invoke `appendChild` internally — DarkReader uses `append()`, not `appendChild`.

**Key changes**:
- Add `interceptInline()` function to detect and capture inline script source
- Add `interceptScript()` dispatcher to handle both `<script src>` and inline patterns
- Wrap `Element.prototype.append` in addition to existing `appendChild`/`insertBefore` wrappers
- Add `__INLINE_SCRIPT_HANDLER_NAME__` placeholder and randomized handler registration
- Implement inline-script Dart handler that calls `_safeEval()` with the captured source
- Add drift-guard tests to ensure shim wraps all three DOM methods and includes inline interception logic
- Update spec with detailed scenario (US-DR-001, US-DR-002) explaining CSP asymmetry, trade-offs, and edge cases (DocumentFragment, async timing)

**Security scope**: Shim is installed only on sites with at least one enabled user script; the user has opted into running custom JS on that site. Inline script bridging is scoped to that opt-in boundary.

https://claude.ai/code/session_01HLDBuwMUot83E93Fmg9tQR