### PR TITLE
fix: Clear Site Data wipes the container in container mode

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,6 +43,7 @@ import 'package:webspace/services/container_cookie_manager.dart';
 import 'package:webspace/services/navigation_engine.dart';
 import 'package:webspace/services/site_settings_qr_codec.dart';
 import 'package:webspace/services/site_activation_engine.dart';
+import 'package:webspace/services/site_data_clear_engine.dart';
 import 'package:webspace/services/site_lifecycle_engine.dart';
 import 'package:webspace/services/site_lifecycle_promotion_engine.dart';
 import 'package:webspace/services/site_retention_priority.dart';
@@ -3396,6 +3397,43 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await _webViewModels[_currentIndex!].userDrivenReload();
   }
 
+  /// User-driven full session wipe for a single site.
+  ///
+  /// Plan is computed by [SiteDataClearEngine.planClear]; this method is
+  /// the executor. Container mode wipes the named container and forces
+  /// webview recreation against a fresh empty one. Legacy mode falls
+  /// back to in-model cookie deletion + reload (the most that can be
+  /// scoped to a single site when localStorage / IDB / SW are
+  /// app-global).
+  Future<void> _clearSiteData(int index) async {
+    if (index < 0 || index >= _webViewModels.length) return;
+    final model = _webViewModels[index];
+    final plan = SiteDataClearEngine.planClear(useContainers: _useContainers);
+    if (plan.disposeWebView) {
+      _evictCacheIfOnline(model.siteId);
+      model.disposeWebView();
+    }
+    if (plan.dropFromLoadedIndices) {
+      _loadedIndices.remove(index);
+    }
+    if (plan.clearInModelCookies) {
+      model.cookies = const [];
+    }
+    if (plan.wipeContainer) {
+      await _containerIsolation.wipeContainers([model.siteId]);
+    }
+    if (plan.deleteKnownCookies) {
+      await model.deleteCookies(_cookieManager, _containerCookieManager);
+    }
+    await _saveWebViewModels();
+    if (!mounted) return;
+    if (plan.userDrivenReload) {
+      await _refreshCurrentSite();
+    } else {
+      setState(() {});
+    }
+  }
+
   Future<void> _stopCurrentSiteLoading() async {
     if (_currentIndex == null || _currentIndex! >= _webViewModels.length) return;
     await _webViewModels[_currentIndex!].userStopLoading();
@@ -3786,11 +3824,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                           _resetAllWebViews();
                         },
                         onScriptsChanged: _resetCurrentSiteWebView,
-                        onClearCookies: () {
-                          _webViewModels[_currentIndex!].deleteCookies(_cookieManager, _containerCookieManager);
-                          _saveWebViewModels();
-                          _refreshCurrentSite();
-                        },
+                        onClearCookies: () => _clearSiteData(_currentIndex!),
                         onSettingsSaved: _handlePerSiteSettingsSaved,
                       ),
                     ),
@@ -4145,11 +4179,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                     _resetAllWebViews();
                   },
                   onScriptsChanged: _resetCurrentSiteWebView,
-                  onClearCookies: () {
-                    _webViewModels[_currentIndex!].deleteCookies(_cookieManager, _containerCookieManager);
-                    _saveWebViewModels();
-                    _refreshCurrentSite();
-                  },
+                  onClearCookies: () => _clearSiteData(_currentIndex!),
                   onSettingsSaved: _handlePerSiteSettingsSaved,
                 ),
               ),

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -1457,38 +1457,47 @@ class _SettingsScreenState extends State<SettingsScreen> {
           if (widget.onClearCookies != null)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-              child: OutlinedButton.icon(
-                icon: Icon(Icons.cookie, color: Colors.red),
-                label: Text('Clear Cookies', style: TextStyle(color: Colors.red)),
-                style: OutlinedButton.styleFrom(side: BorderSide(color: Colors.red)),
-                onPressed: () async {
-                  final confirmed = await showDialog<bool>(
-                    context: context,
-                    builder: (context) => AlertDialog(
-                      title: Text('Clear Cookies'),
-                      content: Text('Are you sure you want to clear all cookies for this site?'),
-                      actions: [
-                        TextButton(
-                          onPressed: () => Navigator.pop(context, false),
-                          child: Text('Cancel'),
-                        ),
-                        TextButton(
-                          onPressed: () => Navigator.pop(context, true),
-                          child: Text('Clear', style: TextStyle(color: Colors.red)),
-                        ),
-                      ],
-                    ),
-                  );
-                  if (confirmed == true) {
-                    widget.onClearCookies!();
-                    if (mounted) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(content: Text('Cookies cleared')),
-                      );
+              child: Builder(builder: (context) {
+                final label = widget.useContainers ? 'Clear Site Data' : 'Clear Cookies';
+                final dialogBody = widget.useContainers
+                    ? 'This wipes cookies, localStorage, IndexedDB, '
+                        'ServiceWorkers, and the HTTP cache for this site. '
+                        'The site will reload with a fresh empty container.'
+                    : 'Are you sure you want to clear all cookies for this site?';
+                final snack = widget.useContainers ? 'Site data cleared' : 'Cookies cleared';
+                return OutlinedButton.icon(
+                  icon: Icon(Icons.cookie, color: Colors.red),
+                  label: Text(label, style: TextStyle(color: Colors.red)),
+                  style: OutlinedButton.styleFrom(side: BorderSide(color: Colors.red)),
+                  onPressed: () async {
+                    final confirmed = await showDialog<bool>(
+                      context: context,
+                      builder: (context) => AlertDialog(
+                        title: Text(label),
+                        content: Text(dialogBody),
+                        actions: [
+                          TextButton(
+                            onPressed: () => Navigator.pop(context, false),
+                            child: Text('Cancel'),
+                          ),
+                          TextButton(
+                            onPressed: () => Navigator.pop(context, true),
+                            child: Text('Clear', style: TextStyle(color: Colors.red)),
+                          ),
+                        ],
+                      ),
+                    );
+                    if (confirmed == true) {
+                      widget.onClearCookies!();
+                      if (mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(content: Text(snack)),
+                        );
+                      }
                     }
-                  }
-                },
-              ),
+                  },
+                );
+              }),
             ),
           // Imported file:// sites have no fetchable URL; sharing the
           // QR would only ship a synthetic file:///<name> handle that the

--- a/lib/services/site_data_clear_engine.dart
+++ b/lib/services/site_data_clear_engine.dart
@@ -1,0 +1,118 @@
+/// What `_WebSpacePageState._clearSiteData` must do when the user taps
+/// the per-site "Clear Site Data" / "Clear Cookies" button.
+///
+/// Pure value class so the plan can be unit-tested independently of the
+/// widget tree. Mirrors the `DispatchAction` pattern in
+/// [link_intent_dispatch_engine.dart]: the engine decides the steps,
+/// the executor in `main.dart` runs them.
+///
+/// The pre-refactor bug (0.2.3) was that the executor unconditionally
+/// ran `deleteCookies` + `reload()` regardless of engine mode. In
+/// container mode that left localStorage / IndexedDB / ServiceWorker /
+/// HTTP cache resident in the container and only deleted the cookies
+/// the in-model snapshot knew about — a reload from the same container
+/// then re-read all the stale state. The container engine has a
+/// nuclear option, [`ContainerIsolationEngine.wipeContainers`], but it
+/// was wired only to the share-into-incognito flow.
+class SiteDataClearPlan {
+  /// Dispose the live webview before the wipe so the named container
+  /// isn't bound when `deleteContainer` runs (native impl no-ops on an
+  /// in-use container — see [container_native.dart:deleteContainer]).
+  final bool disposeWebView;
+
+  /// Drop the index from `_loadedIndices` so the IndexedStack rebuild
+  /// re-runs the lazy webview creation path with a fresh empty
+  /// container.
+  final bool dropFromLoadedIndices;
+
+  /// Wipe the per-site native container — drops cookies, localStorage,
+  /// IndexedDB, ServiceWorker registrations, HTTP cache. The container
+  /// is materialized empty on the next webview bind.
+  final bool wipeContainer;
+
+  /// Reset the in-model `cookies` snapshot to empty. In container mode
+  /// the snapshot is otherwise unused for read-back, but legacy
+  /// isolation reads it during capture-nuke-restore — clearing it here
+  /// would corrupt that path.
+  final bool clearInModelCookies;
+
+  /// Iterate `WebViewModel.cookies` and call `deleteCookie` for each
+  /// entry through the active cookie manager. Legacy mode only — the
+  /// only scoped action available when there is no per-site partition.
+  final bool deleteKnownCookies;
+
+  /// User-driven reload after the clear. Container mode skips this:
+  /// `disposeWebView` + setState forces the widget tree to recreate the
+  /// webview, which loads from scratch against the new container.
+  final bool userDrivenReload;
+
+  const SiteDataClearPlan({
+    required this.disposeWebView,
+    required this.dropFromLoadedIndices,
+    required this.wipeContainer,
+    required this.clearInModelCookies,
+    required this.deleteKnownCookies,
+    required this.userDrivenReload,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      other is SiteDataClearPlan &&
+      other.disposeWebView == disposeWebView &&
+      other.dropFromLoadedIndices == dropFromLoadedIndices &&
+      other.wipeContainer == wipeContainer &&
+      other.clearInModelCookies == clearInModelCookies &&
+      other.deleteKnownCookies == deleteKnownCookies &&
+      other.userDrivenReload == userDrivenReload;
+
+  @override
+  int get hashCode => Object.hash(
+        disposeWebView,
+        dropFromLoadedIndices,
+        wipeContainer,
+        clearInModelCookies,
+        deleteKnownCookies,
+        userDrivenReload,
+      );
+
+  @override
+  String toString() =>
+      'SiteDataClearPlan(disposeWebView=$disposeWebView, '
+      'dropFromLoadedIndices=$dropFromLoadedIndices, '
+      'wipeContainer=$wipeContainer, '
+      'clearInModelCookies=$clearInModelCookies, '
+      'deleteKnownCookies=$deleteKnownCookies, '
+      'userDrivenReload=$userDrivenReload)';
+}
+
+class SiteDataClearEngine {
+  SiteDataClearEngine._();
+
+  /// Plan the per-site clear for the active isolation engine.
+  ///
+  /// Container mode (Android System WebView 110+ / iOS 17+ / macOS 14+ /
+  /// Linux WPE 2.40+) takes the full dispose + wipe + recreate path so
+  /// every byte of partitioned state is dropped. Legacy mode falls back
+  /// to in-model cookie deletion + reload because there is no per-site
+  /// partition to recreate and localStorage / IDB / SW are app-global.
+  static SiteDataClearPlan planClear({required bool useContainers}) {
+    if (useContainers) {
+      return const SiteDataClearPlan(
+        disposeWebView: true,
+        dropFromLoadedIndices: true,
+        wipeContainer: true,
+        clearInModelCookies: true,
+        deleteKnownCookies: false,
+        userDrivenReload: false,
+      );
+    }
+    return const SiteDataClearPlan(
+      disposeWebView: false,
+      dropFromLoadedIndices: false,
+      wipeContainer: false,
+      clearInModelCookies: false,
+      deleteKnownCookies: true,
+      userDrivenReload: true,
+    );
+  }
+}

--- a/test/site_data_clear_engine_test.dart
+++ b/test/site_data_clear_engine_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/site_data_clear_engine.dart';
+
+/// Regression coverage for the 0.2.3 "Clear Site Data" bug: the executor
+/// in `_WebSpacePageState` used to call `deleteCookies` + `reload()`
+/// regardless of isolation engine. In container mode that left
+/// localStorage / IndexedDB / ServiceWorker / HTTP cache intact in the
+/// per-site container and only dropped the cookies the in-model
+/// snapshot already knew about. The plan asserted below pins the
+/// dispose + wipe + recreate dance that the container path now takes.
+///
+/// If this test ever flips back to the legacy plan under
+/// `useContainers: true`, the per-site "Clear Site Data" button is
+/// silently broken for every user on a container-capable platform
+/// (Android System WebView 110+ / iOS 17+ / macOS 14+ / Linux WPE 2.40+).
+void main() {
+  group('SiteDataClearEngine.planClear', () {
+    test('container mode wipes the container and forces recreation', () {
+      final plan = SiteDataClearEngine.planClear(useContainers: true);
+
+      expect(plan.disposeWebView, isTrue,
+          reason: 'container is in-use until the webview is gone; '
+              'deleteContainer no-ops on an in-use container');
+      expect(plan.dropFromLoadedIndices, isTrue,
+          reason: 'IndexedStack must rebuild against the fresh container');
+      expect(plan.wipeContainer, isTrue,
+          reason: 'only wipeContainers drops localStorage / IDB / SW / cache');
+      expect(plan.clearInModelCookies, isTrue,
+          reason: 'in-model snapshot must not resurrect cookies on next save');
+      expect(plan.deleteKnownCookies, isFalse,
+          reason: 'pre-wipe deleteCookie pass is redundant and races the '
+              'wipe; the bug it replaced left non-snapshot cookies behind');
+      expect(plan.userDrivenReload, isFalse,
+          reason: 'reload on the SAME disposed controller is a no-op; '
+              'lazy recreation from setState is what loads the page');
+    });
+
+    test('legacy mode keeps cookie-iteration + reload', () {
+      final plan = SiteDataClearEngine.planClear(useContainers: false);
+
+      expect(plan.disposeWebView, isFalse);
+      expect(plan.dropFromLoadedIndices, isFalse);
+      expect(plan.wipeContainer, isFalse,
+          reason: 'no per-site container exists in legacy mode');
+      expect(plan.clearInModelCookies, isFalse,
+          reason: 'capture-nuke-restore in CookieIsolationEngine reads '
+              'this snapshot; nulling it here would corrupt that flow');
+      expect(plan.deleteKnownCookies, isTrue,
+          reason: 'only scoped action available against the shared jar');
+      expect(plan.userDrivenReload, isTrue,
+          reason: 'controller is still alive; reload picks up the delete');
+    });
+
+    test('the two plans are not equal — the engine MUST branch', () {
+      final container = SiteDataClearEngine.planClear(useContainers: true);
+      final legacy = SiteDataClearEngine.planClear(useContainers: false);
+      expect(container, isNot(equals(legacy)),
+          reason: 'a single un-branched plan is the original 0.2.3 bug');
+    });
+  });
+}


### PR DESCRIPTION
The per-site clear button iterated the in-model cookie snapshot and
reload()ed the same controller against the same container, leaving
localStorage / IndexedDB / ServiceWorker / HTTP cache resident and
missing any cookie the snapshot hadn't captured. Route through
ContainerIsolationEngine.wipeContainers so the container is deleted
and recreated empty on the next bind; legacy mode keeps the prior
deleteCookies + reload path. Plan extracted into a pure-Dart engine
so the branching is unit-tested.