### PR TITLE
Add per-site HTML caching toggle

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4991,20 +4991,24 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                                           // once the cached parse settles. file:// imports skip
                                           // the swap (no live to fetch); offline cold starts skip
                                           // the swap inside the factory's `pendingLiveReload`
-                                          // gate. Online cold starts get cache-then-live.
+                                          // gate.
                                           //
-                                          // The previous version of this code gated cached-HTML
-                                          // render on `lastKnownOnline == false` to avoid a
-                                          // chromium dangling-raw_ptr crash on the swap. Later
-                                          // minidump analysis (see `unretained_dangling_ptr_guide.md`)
-                                          // showed that crash is gated by chromium's own
-                                          // `PartitionAllocUnretainedDanglingPtr` debug feature
-                                          // — enabled only on AOSP userdebug builds, off in
-                                          // production Stable WebView. The gate was paying a
-                                          // cold-start UX cost for *every* online user to
-                                          // protect *userdebug developers* from a chromium
-                                          // self-test, which is the wrong trade.
-                                          final cached = webViewModel.initUrl.startsWith('file://')
+                                          // Per-site `htmlCachingEnabled` gates the cached-read
+                                          // for URL sites: off (default) means the cache is only
+                                          // consulted when the device is offline at construction
+                                          // time, so online cold starts go straight to live and
+                                          // never show stale content. On = cache-then-live for
+                                          // instant first paint. file:// imports ignore the
+                                          // toggle — they have no live to fetch, so the cached
+                                          // bytes are the only thing to render.
+                                          final isFileImport =
+                                              webViewModel.initUrl.startsWith('file://');
+                                          if (!isFileImport &&
+                                              !webViewModel.htmlCachingEnabled &&
+                                              (ConnectivityService.instance.lastKnownOnline ?? true)) {
+                                            return null;
+                                          }
+                                          final cached = isFileImport
                                               ? HtmlImportStorage.instance.getHtmlSync(webViewModel.siteId)
                                               : HtmlCacheService.instance.getHtmlSync(webViewModel.siteId);
                                           if (cached == null) return null;

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -134,6 +134,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late bool _localCdnEnabled;
   late bool _blockAutoRedirects;
   late bool _fullscreenMode;
+  late bool _htmlCachingEnabled;
   late bool _notificationsEnabled;
   String? _selectedLanguage;
   bool _obscureProxyPassword = true;
@@ -208,6 +209,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         'localCdnEnabled': _localCdnEnabled,
         'blockAutoRedirects': _blockAutoRedirects,
         'fullscreenMode': _fullscreenMode,
+        'htmlCachingEnabled': _htmlCachingEnabled,
         'notificationsEnabled': _notificationsEnabled,
         'selectedLanguage': _selectedLanguage,
         'latitude': _latitudeController.text,
@@ -288,6 +290,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _localCdnEnabled = m.localCdnEnabled;
     _blockAutoRedirects = m.blockAutoRedirects;
     _fullscreenMode = m.fullscreenMode;
+    _htmlCachingEnabled = m.htmlCachingEnabled;
     _notificationsEnabled = m.notificationsEnabled;
     _selectedLanguage = m.language;
     _latitudeController.text = m.spoofLatitude?.toString() ?? '';
@@ -457,6 +460,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       widget.webViewModel.localCdnEnabled = _localCdnEnabled;
       widget.webViewModel.blockAutoRedirects = _blockAutoRedirects;
       widget.webViewModel.fullscreenMode = _fullscreenMode;
+      widget.webViewModel.htmlCachingEnabled = _htmlCachingEnabled;
       widget.webViewModel.notificationsEnabled = _notificationsEnabled;
       widget.webViewModel.language = _selectedLanguage;
       // locationMode is derived from the UI state:
@@ -1381,6 +1385,36 @@ class _SettingsScreenState extends State<SettingsScreen> {
             onChanged: (bool value) {
               setState(() {
                 _fullscreenMode = value;
+              });
+            },
+          ),
+          SwitchListTile(
+            title: Row(
+              children: const [
+                Flexible(child: Text('HTML caching')),
+                HintButton(
+                  title: 'HTML Caching',
+                  description:
+                      'Render this site from a cached HTML snapshot for '
+                      'instant first paint on cold start, then swap to the '
+                      'live page once the cached parse settles.\n\n'
+                      'Off (default): the cache is only consulted when the '
+                      'device is offline, so an online cold start always '
+                      'goes straight to live and never shows stale content. '
+                      'Snapshots are still saved in the background so the '
+                      'offline fallback works on the next launch.\n\n'
+                      'On: trades a momentary glimpse of stale content for '
+                      'a faster first paint on every cold start.',
+                ),
+              ],
+            ),
+            subtitle: const Text(
+              'Show cached page on cold start (offline fallback always on)',
+            ),
+            value: _htmlCachingEnabled,
+            onChanged: (bool value) {
+              setState(() {
+                _htmlCachingEnabled = value;
               });
             },
           ),

--- a/lib/services/site_settings_qr_codec.dart
+++ b/lib/services/site_settings_qr_codec.dart
@@ -43,6 +43,7 @@ class SiteSettingsQrCodec {
     'localCdnEnabled',
     'blockAutoRedirects',
     'fullscreenMode',
+    'htmlCachingEnabled',
     'notificationsEnabled',
     'locationMode',
     'spoofLatitude',

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -300,6 +300,13 @@ class WebViewModel {
   bool localCdnEnabled; // Serve CDN resources from local cache for privacy
   bool blockAutoRedirects; // Block script-initiated cross-domain navigations
   bool fullscreenMode; // Auto-enter fullscreen when this site is selected
+  /// When true, the cached HTML snapshot is rendered as `initialData` for
+  /// instant first paint on construction, then swapped to a live load
+  /// once the cached parse settles. When false, the cached snapshot is
+  /// only used as a fallback when the device is offline at construction
+  /// time — online cold starts go straight to live. Saves to the cache
+  /// happen regardless so the offline fallback keeps working.
+  bool htmlCachingEnabled;
   /// Allow this site to show system notifications. Implies background
   /// polling: the site is auto-loaded on startup, kept resident across
   /// site switches and app-lifecycle pauses, and reloaded periodically by
@@ -401,6 +408,7 @@ class WebViewModel {
     this.localCdnEnabled = true,
     this.blockAutoRedirects = true,
     this.fullscreenMode = false,
+    this.htmlCachingEnabled = false,
     this.notificationsEnabled = false,
     List<UserScriptConfig>? userScripts,
     Set<String>? enabledGlobalScriptIds,
@@ -1208,6 +1216,7 @@ class WebViewModel {
         'localCdnEnabled': localCdnEnabled,
         'blockAutoRedirects': blockAutoRedirects,
         'fullscreenMode': fullscreenMode,
+        'htmlCachingEnabled': htmlCachingEnabled,
         'notificationsEnabled': notificationsEnabled,
         'userScripts': userScripts.map((s) => s.toJson()).toList(),
         if (enabledGlobalScriptIds.isNotEmpty)
@@ -1261,6 +1270,7 @@ class WebViewModel {
       localCdnEnabled: json['localCdnEnabled'] ?? true,
       blockAutoRedirects: json['blockAutoRedirects'] ?? true,
       fullscreenMode: json['fullscreenMode'] ?? false,
+      htmlCachingEnabled: json['htmlCachingEnabled'] as bool? ?? false,
       notificationsEnabled:
           (json['notificationsEnabled'] as bool?) ??
               (json['backgroundPoll'] as bool?) ??

--- a/test/site_settings_qr_codec_test.dart
+++ b/test/site_settings_qr_codec_test.dart
@@ -25,6 +25,7 @@ void main() {
         localCdnEnabled: false,
         blockAutoRedirects: false,
         fullscreenMode: true,
+        htmlCachingEnabled: true,
         notificationsEnabled: true,
         locationMode: LocationMode.spoof,
         spoofLatitude: 51.5074,
@@ -68,6 +69,7 @@ void main() {
       expect(hydrated.localCdnEnabled, source.localCdnEnabled);
       expect(hydrated.blockAutoRedirects, source.blockAutoRedirects);
       expect(hydrated.fullscreenMode, source.fullscreenMode);
+      expect(hydrated.htmlCachingEnabled, source.htmlCachingEnabled);
       expect(hydrated.notificationsEnabled, source.notificationsEnabled);
       expect(hydrated.locationMode, source.locationMode);
       expect(hydrated.spoofLatitude, source.spoofLatitude);

--- a/test/web_view_model_test.dart
+++ b/test/web_view_model_test.dart
@@ -26,6 +26,7 @@ void main() {
       expect(model.trackingProtectionEnabled, isTrue);
       expect(model.localCdnEnabled, isTrue);
       expect(model.fullscreenMode, isFalse);
+      expect(model.htmlCachingEnabled, isFalse);
       expect(model.notificationsEnabled, isFalse);
     });
 
@@ -316,6 +317,34 @@ void main() {
 
       final restored = WebViewModel.fromJson(json, null);
       expect(restored.fullscreenMode, isTrue);
+    });
+
+    test('htmlCachingEnabled defaults to false when missing from JSON', () {
+      final json = {
+        'initUrl': 'https://example.com',
+        'currentUrl': 'https://example.com',
+        'cookies': [],
+        'proxySettings': {'type': 0, 'address': null},
+        'javascriptEnabled': true,
+        'userAgent': '',
+        'thirdPartyCookiesEnabled': false,
+      };
+
+      final model = WebViewModel.fromJson(json, null);
+      expect(model.htmlCachingEnabled, isFalse);
+    });
+
+    test('htmlCachingEnabled true is preserved through serialization', () {
+      final model = WebViewModel(
+        initUrl: 'https://example.com',
+        htmlCachingEnabled: true,
+      );
+
+      final json = model.toJson();
+      expect(json['htmlCachingEnabled'], equals(true));
+
+      final restored = WebViewModel.fromJson(json, null);
+      expect(restored.htmlCachingEnabled, isTrue);
     });
 
     test('notificationsEnabled defaults to false when missing from JSON', () {


### PR DESCRIPTION
Adds a new `htmlCachingEnabled` per-site setting to control whether cached HTML snapshots are rendered on cold start.

When disabled (default), the cached snapshot is only consulted when offline at construction time — online cold starts go straight to live and never show stale content. When enabled, the cached HTML is rendered as `initialData` for instant first paint, then swapped to the live page once the cached parse settles.

Changes:
- Add `htmlCachingEnabled` boolean field to `WebViewModel` with default `false`
- Persist setting through serialization (toJson/fromJson) and QR codec
- Add UI toggle in settings screen with explanatory hint text
- Update cold-start cache-read logic in `_WebSpacePageState` to gate cached-HTML render on the per-site toggle for URL sites (file:// imports ignore the toggle since they have no live to fetch)
- Update tests to cover the new field and its serialization behavior

File imports continue to use cached bytes unconditionally since they have no live source to fetch.

https://claude.ai/code/session_01CufkQQiMA4ZMJhDVnS1esv