### PR TITLE
feat(log-service): add sensitivity dimension for per-site identifiers

### DIFF
--- a/audit_notes.md
+++ b/audit_notes.md
@@ -1,0 +1,48 @@
+# Native-side log audit
+
+Scope: in-repo native code only. Upstream flutter_inappwebview fork logs are enumerated at the bottom but NOT patched here.
+
+## Android (`android/app/src/main/kotlin/`)
+
+All native Log calls live in `AdblockEngineNative.kt` and report only engine state (load probe, build, dispose, teardown). None include per-site identifiers, container names, cookie hostnames, URLs, page titles, or proxy credentials. Left as-is.
+
+- `AdblockEngineNative.kt:47` `Log.i(TAG, "webspace_adblock JNI loaded")`
+- `AdblockEngineNative.kt:49` `Log.w(TAG, "webspace_adblock loaded but probe returned false")`
+- `AdblockEngineNative.kt:55` `Log.i(TAG, "webspace_adblock JNI not loaded: ${t.message}")` — JNI load error, no site data.
+- `AdblockEngineNative.kt:81` `Log.i(TAG, "engine torn down")`
+- `AdblockEngineNative.kt:86` `Log.i(TAG, "engine built (...)")` — rule-byte count only.
+- `AdblockEngineNative.kt:128` `Log.i(TAG, "engine disposed")`
+
+## iOS (`ios/Runner/`)
+
+`AppDelegate.swift` had 8 `NSLog` calls that printed inbound share URLs verbatim to the iOS console. Each one is now wrapped in `#if DEBUG / #endif` so release builds compile them out. The signals are useful while developing the share-extension path but must not reach a shipped app's `os_log` stream.
+
+Other native NSLog callers reviewed and left alone (no per-site data):
+
+- `ShortcutsPlugin.swift:77` — App Group unavailable warning; static config.
+- `BackgroundTaskPlugin.swift:99` — `BGAppRefreshTask` schedule error; iOS error message only.
+- `WebSpaceAppIntents.swift:94` — App Group unavailable warning; static config.
+
+## Linux (`linux/`)
+
+`my_application.cc` has two `g_warning` calls; both are generic GLib/Flutter response/registration errors with no per-site data. Left as-is.
+
+- `my_application.cc:62` `g_warning("Failed to send share-intent response: %s", error->message);`
+- `my_application.cc:158` `g_warning("Failed to register: %s", error->message);`
+
+## Upstream fork (`~/.pub-cache/git/flutter_inappwebview-*/`)
+
+Not patched per instructions. There are ~89 `Log.*` / `NSLog` / `os_log` calls across the fork's plugin packages (Android, iOS, macOS, Linux). Most are upstream library code that predates our fork patches; common sites:
+
+- `flutter_inappwebview_android/.../MyCookieManager.java` — generic error logs (no cookie host).
+- `flutter_inappwebview_android/.../Util.java` — error helper.
+- `flutter_inappwebview_android/.../InAppBrowserActivity.java` — file/menu errors.
+- Many platform plugins log error stack traces only.
+
+A pass to silence these on release builds upstream would be welcome but is out of scope for this branch.
+
+Reproduce with:
+
+```sh
+grep -rn 'Log\.d\|Log\.i\|Log\.w\|Log\.e\|Log\.v\|NSLog\|os_log' ~/.pub-cache/git/flutter_inappwebview-*/
+```

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -48,7 +48,9 @@ import UserNotifications
     open url: URL,
     options: [UIApplication.OpenURLOptionsKey: Any] = [:]
   ) -> Bool {
+    #if DEBUG
     NSLog("[WebSpace] application(_:open:) url=\(url.absoluteString)")
+    #endif
     capturePendingShareUrl(from: url)
     drainAppGroupPendingUrl()
     return super.application(app, open: url, options: options)
@@ -63,7 +65,9 @@ import UserNotifications
         self.drainAppGroupPendingUrl()
         let url = self.pendingShareUrl
         self.pendingShareUrl = nil
+        #if DEBUG
         NSLog("[WebSpace] consumeLaunchUrl returning: \(url ?? "nil")")
+        #endif
         result(url)
       case "consumeLaunchHtml":
         // LIR-012: iOS Share Extension HTML delivery isn't wired yet
@@ -79,7 +83,9 @@ import UserNotifications
 
   private func capturePendingShareUrl(from url: URL) {
     guard url.scheme?.lowercased() == "webspace" else {
+      #if DEBUG
       NSLog("[WebSpace] ignoring non-webspace scheme: \(url.scheme ?? "nil")")
+      #endif
       return
     }
     let host = url.host?.lowercased()
@@ -90,7 +96,9 @@ import UserNotifications
     // form is preserved below for back-compat.
     if host == "open" {
       pendingShareUrl = url.absoluteString
+      #if DEBUG
       NSLog("[WebSpace] captured open URL: \(url.absoluteString)")
+      #endif
     } else if host == "share" {
       guard
         let inner = URLComponents(url: url, resolvingAgainstBaseURL: false)?
@@ -98,18 +106,26 @@ import UserNotifications
         let httpScheme = URL(string: inner)?.scheme?.lowercased(),
         httpScheme == "http" || httpScheme == "https"
       else {
+        #if DEBUG
         NSLog("[WebSpace] share URL has no valid http(s) inner: \(url.absoluteString)")
+        #endif
         return
       }
       pendingShareUrl = inner
+      #if DEBUG
       NSLog("[WebSpace] captured share inner URL: \(inner)")
+      #endif
     } else if host == "qr" {
       // Pass the original webspace:// URL through; Dart routes it to the
       // QR-apply path by scheme.
       pendingShareUrl = url.absoluteString
+      #if DEBUG
       NSLog("[WebSpace] captured qr URL")
+      #endif
     } else {
+      #if DEBUG
       NSLog("[WebSpace] unrecognized webspace host: \(host ?? "nil")")
+      #endif
     }
   }
 
@@ -121,7 +137,9 @@ import UserNotifications
     if let stored = defaults.string(forKey: pendingUrlKey), !stored.isEmpty {
       pendingShareUrl = stored
       defaults.removeObject(forKey: pendingUrlKey)
+      #if DEBUG
       NSLog("[WebSpace] drained pending URL from app group: \(stored)")
+      #endif
     }
   }
 }

--- a/lib/demo_data.dart
+++ b/lib/demo_data.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webspace/services/log_service.dart';
 import 'package:webspace/web_view_model.dart';
 import 'package:webspace/webspace_model.dart';
 
@@ -20,14 +21,16 @@ bool isDemoMode = false;
 /// - null (default): Use per-site settings or system default
 /// - 'en', 'es', etc.: Override all sites with this language
 Future<void> seedDemoData({String theme = 'system', String? language}) async {
-  print('========================================');
-  print('SEEDING DEMO DATA');
-  print('========================================');
+  void log(String msg) =>
+      LogService.instance.log('DemoData', msg, level: LogLevel.info);
+
+  log('========================================');
+  log('SEEDING DEMO DATA');
+  log('========================================');
 
   final prefs = await SharedPreferences.getInstance();
 
-  // Clear existing data
-  print('Clearing existing data...');
+  log('Clearing existing data...');
   await prefs.remove('webViewModels');
   await prefs.remove('webspaces');
   await prefs.remove('selectedWebspaceId');
@@ -79,9 +82,9 @@ Future<void> seedDemoData({String theme = 'system', String? language}) async {
     ),
   ];
 
-  print('Created ${sites.length} sites');
+  log('Created ${sites.length} sites');
   for (var i = 0; i < sites.length; i++) {
-    print('  Site $i: ${sites[i].name} - ${sites[i].initUrl}');
+    log('  Site $i: ${sites[i].name} - ${sites[i].initUrl}');
   }
 
   // Create sample webspaces
@@ -104,14 +107,13 @@ Future<void> seedDemoData({String theme = 'system', String? language}) async {
     ),
   ];
 
-  print('Created ${webspaces.length} webspaces');
+  log('Created ${webspaces.length} webspaces');
   for (var i = 0; i < webspaces.length; i++) {
     final ws = webspaces[i];
-    print('  Webspace $i: ${ws.name} (${ws.siteIndices.length} sites)');
+    log('  Webspace $i: ${ws.name} (${ws.siteIndices.length} sites)');
   }
 
-  // Serialize and save
-  print('Saving to SharedPreferences...');
+  log('Saving to SharedPreferences...');
   final sitesJson = sites.map((s) => jsonEncode(s.toJson())).toList();
   final webspacesJson = webspaces.map((w) => jsonEncode(w.toJson())).toList();
 
@@ -131,30 +133,27 @@ Future<void> seedDemoData({String theme = 'system', String? language}) async {
   await prefs.setInt('themeSettings', themeSettingsIndex);
   await prefs.setBool('showUrlBar', false);
 
-  print('Data saved successfully!');
-  print('');
-  print('Verifying saved data...');
+  log('Data saved successfully!');
+  log('Verifying saved data...');
 
   // Verify
   final savedSites = prefs.getStringList('webViewModels');
   final savedWebspaces = prefs.getStringList('webspaces');
   final selectedId = prefs.getString('selectedWebspaceId');
 
-  print('webViewModels: ${savedSites?.length} items');
-  print('webspaces: ${savedWebspaces?.length} items');
-  print('selectedWebspaceId: $selectedId');
+  log('webViewModels: ${savedSites?.length} items');
+  log('webspaces: ${savedWebspaces?.length} items');
+  log('selectedWebspaceId: $selectedId');
 
   if (savedSites != null && savedSites.isNotEmpty) {
-    print('First site: ${savedSites[0].substring(0, savedSites[0].length < 100 ? savedSites[0].length : 100)}...');
+    log('First site: ${savedSites[0].substring(0, savedSites[0].length < 100 ? savedSites[0].length : 100)}...');
   }
 
-  print('');
-  print('========================================');
-  print('DEMO DATA SEEDING COMPLETE');
-  print('========================================');
-  print('The app will load with ${sites.length} sites in ${webspaces.length} webspaces.');
+  log('========================================');
+  log('DEMO DATA SEEDING COMPLETE');
+  log('========================================');
+  log('The app will load with ${sites.length} sites in ${webspaces.length} webspaces.');
 
-  // Enable demo mode to prevent any further saves during the session
   isDemoMode = true;
-  print('Demo mode enabled - changes will NOT be persisted to storage');
+  log('Demo mode enabled - changes will NOT be persisted to storage');
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -933,10 +933,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   }
 
   Future<void> _onPinRevoked(TrustedHostEntry entry) async {
-    LogService.instance.log('TLS',
-        '_onPinRevoked fired for ${entry.host}:${entry.port} '
-        '(loaded=${_loadedIndices.toList()..sort()}, '
-        'webViewModels=${_webViewModels.length})');
+    LogService.instance.log(
+      'TLS',
+      '_onPinRevoked fired for ${entry.host}:${entry.port} '
+          '(loaded=${_loadedIndices.toList()..sort()}, '
+          'webViewModels=${_webViewModels.length})',
+      sensitivity: LogSensitivity.sensitive,
+    );
     final host = entry.host.toLowerCase();
     // Android's cert-acceptance state lives in multiple layers:
     //   1. App-level SSL preferences table (WebView.clearSslPreferences) —
@@ -973,27 +976,36 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     if (preferred != null) {
       try {
         await preferred.nativeController.clearSslPreferences();
-        LogService.instance.log('TLS',
-            'clearSslPreferences() completed for ${entry.host}:${entry.port} '
-            '(via ${matching != null ? "matching-host" : "any-loaded"} controller)');
+        LogService.instance.log(
+          'TLS',
+          'clearSslPreferences() completed for ${entry.host}:${entry.port} '
+              '(via ${matching != null ? "matching-host" : "any-loaded"} controller)',
+          sensitivity: LogSensitivity.sensitive,
+        );
       } catch (e) {
         LogService.instance.log('TLS',
             'clearSslPreferences() failed: $e',
             level: LogLevel.error);
       }
     } else {
-      LogService.instance.log('TLS',
-          'no loaded controller to call clearSslPreferences() for '
-          '${entry.host}:${entry.port} — SSL prefs table may retain stale '
-          'host decisions until next app restart');
+      LogService.instance.log(
+        'TLS',
+        'no loaded controller to call clearSslPreferences() for '
+            '${entry.host}:${entry.port} — SSL prefs table may retain stale '
+            'host decisions until next app restart',
+        sensitivity: LogSensitivity.sensitive,
+      );
     }
     // Process-wide cache flush. Static — no instance needed; affects
     // the Chromium network service shared by all WebViews + Profiles.
     try {
       await inapp.InAppWebViewController.clearAllCache(includeDiskFiles: true);
-      LogService.instance.log('TLS',
-          'clearAllCache(disk=true) completed for revoke of '
-          '${entry.host}:${entry.port}');
+      LogService.instance.log(
+        'TLS',
+        'clearAllCache(disk=true) completed for revoke of '
+            '${entry.host}:${entry.port}',
+        sensitivity: LogSensitivity.sensitive,
+      );
     } catch (e) {
       LogService.instance.log('TLS',
           'clearAllCache failed: $e',
@@ -1037,9 +1049,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       try {
         final wiped =
             await _containerIsolation.wipeContainers(wipedSiteIds);
-        LogService.instance.log('TLS',
-            'wiped $wiped container(s) after revoke of '
-            '${entry.host}:${entry.port}');
+        LogService.instance.log(
+          'TLS',
+          'wiped $wiped container(s) after revoke of '
+              '${entry.host}:${entry.port}',
+          sensitivity: LogSensitivity.sensitive,
+        );
       } catch (e) {
         LogService.instance.log('TLS',
             'container wipe failed after revoke: $e',
@@ -1191,6 +1206,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         'Memory pressure — promoting site $victim "${model.name}": '
             '${from.name} → ${to.name}',
         level: LogLevel.warning,
+        sensitivity: LogSensitivity.sensitive,
       );
 
       switch (to) {
@@ -1326,8 +1342,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
               'HTML share dropped (link handling disabled)');
           return;
         }
-        LogService.instance.log('LinkIntent',
-            'HTML share received (${html.content.length} bytes, title=${html.title})');
+        LogService.instance.log(
+          'LinkIntent',
+          'HTML share received (${html.content.length} bytes, title=${html.title})',
+          sensitivity: LogSensitivity.sensitive,
+        );
         await _dispatchInbound(InboundHtml(
           content: html.content,
           suggestedTitle: html.title,
@@ -1342,27 +1361,41 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         LogService.instance.log('LinkIntent', 'poll: no pending URL');
         return;
       }
-      LogService.instance.log('LinkIntent', 'received: $raw');
+      LogService.instance.log(
+        'LinkIntent',
+        'received: $raw',
+        sensitivity: LogSensitivity.sensitive,
+      );
       if (raw.startsWith('webspace://qr/')) {
         final decoded = SiteSettingsQrCodec.decode(raw);
         if (decoded != null) {
           _addSite(qrSettings: decoded);
         } else {
-          LogService.instance.log('LinkIntent',
-              'QR payload failed to decode: $raw',
-              level: LogLevel.warning);
+          LogService.instance.log(
+            'LinkIntent',
+            'QR payload failed to decode: $raw',
+            level: LogLevel.warning,
+            sensitivity: LogSensitivity.sensitive,
+          );
         }
         return;
       }
       if (!_linkHandlingEnabled) {
-        LogService.instance.log('LinkIntent',
-            'Share dropped (link handling disabled): $raw');
+        LogService.instance.log(
+          'LinkIntent',
+          'Share dropped (link handling disabled): $raw',
+          sensitivity: LogSensitivity.sensitive,
+        );
         return;
       }
       final parsed = Uri.tryParse(raw);
       if (parsed == null) {
-        LogService.instance.log('LinkIntent', 'unparseable URL: $raw',
-            level: LogLevel.warning);
+        LogService.instance.log(
+          'LinkIntent',
+          'unparseable URL: $raw',
+          level: LogLevel.warning,
+          sensitivity: LogSensitivity.sensitive,
+        );
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Unsupported URL')),
         );
@@ -1394,6 +1427,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     LogService.instance.log(
       'LinkIntent',
       'dispatch ${inboundUri ?? '(html payload)'} -> ${_describeDispatchAction(action)}',
+      sensitivity: LogSensitivity.sensitive,
     );
     await _executeDispatchAction(action, inboundUri);
   }
@@ -1504,6 +1538,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         'LinkIntent',
         'OpenInMain bailed: site ${a.siteId} not found',
         level: LogLevel.warning,
+        sensitivity: LogSensitivity.sensitive,
       );
       return;
     }
@@ -1536,8 +1571,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       LogService.instance.log(
         'LinkIntent',
         'OpenInMain: controller not yet ready for "${model.name}" '
-        '(siteId: ${model.siteId}); ${a.url} may queue until first frame',
+            '(siteId: ${model.siteId}); ${a.url} may queue until first frame',
         level: LogLevel.warning,
+        sensitivity: LogSensitivity.sensitive,
       );
       return;
     }
@@ -2021,8 +2057,16 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
     final target = _webViewModels[index];
 
-    LogService.instance.log('CookieIsolation', 'Switching to site $index: "${target.name}" (siteId: ${target.siteId})');
-    LogService.instance.log('CookieIsolation', 'Target domain: ${getBaseDomain(target.initUrl)}');
+    LogService.instance.log(
+      'CookieIsolation',
+      'Switching to site $index: "${target.name}" (siteId: ${target.siteId})',
+      sensitivity: LogSensitivity.sensitive,
+    );
+    LogService.instance.log(
+      'CookieIsolation',
+      'Target domain: ${getBaseDomain(target.initUrl)}',
+      sensitivity: LogSensitivity.sensitive,
+    );
     LogService.instance.log('CookieIsolation', 'Currently loaded indices: $_loadedIndices');
 
     // Mark this site as activation-in-flight so concurrent OS memory
@@ -2047,6 +2091,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           'WebViewState',
           'Queued ${bytes.length} restore bytes for "${target.name}" '
               '(siteId: ${target.siteId})',
+          sensitivity: LogSensitivity.sensitive,
         );
       }
       target.lifecycleState = SiteLifecycleState.resident;
@@ -2072,6 +2117,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           'CookieIsolation',
           'CONFLICT! Unloading site $conflictIndex: "${_webViewModels[conflictIndex].name}"',
           level: LogLevel.warning,
+          sensitivity: LogSensitivity.sensitive,
         );
         await _unloadSiteForDomainSwitch(conflictIndex);
         if (version != _setCurrentIndexVersion) return;
@@ -2094,6 +2140,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         'SiteUnload',
         'Proxy mismatch — unloading site $i: "${_webViewModels[i].name}"',
         level: LogLevel.warning,
+        sensitivity: LogSensitivity.sensitive,
       );
       await _unloadSiteForOtherReason(i);
       if (version != _setCurrentIndexVersion) return;
@@ -2120,6 +2167,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       LogService.instance.log(
         'SiteUnload',
         'LRU cap (>$kMaxLoadedSites) — unloading site $i: "${_webViewModels[i].name}"',
+        sensitivity: LogSensitivity.sensitive,
       );
       await _unloadSiteForOtherReason(i);
       if (version != _setCurrentIndexVersion) return;
@@ -2153,6 +2201,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         'SiteUnload',
         'Proactive cacheClear (>$kMaxResidentSites resident) — '
             'clearing cache for site $i: "${_webViewModels[i].name}"',
+        sensitivity: LogSensitivity.sensitive,
       );
       await _webViewModels[i].clearWebViewCache();
       if (version != _setCurrentIndexVersion) return;
@@ -2234,7 +2283,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       _exitFullscreen();
     }
 
-    LogService.instance.log('CookieIsolation', 'After switch, loaded indices: $_loadedIndices');
+    LogService.instance.log('CookieIsolation', 'After switch, loaded indices: $_loadedIndices', sensitivity: LogSensitivity.sensitive);
     // _loadedIndices may have changed (LRU eviction, conflict unload,
     // first-load of target), so re-evaluate the background refresh
     // schedule. No-op on non-iOS / non-Android.
@@ -2306,6 +2355,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     LogService.instance.log(
       'WebViewState',
       'Captured ${bytes.length} bytes for "${model.name}" (siteId: ${model.siteId})',
+      sensitivity: LogSensitivity.sensitive,
     );
     return true;
   }
@@ -2338,7 +2388,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   Future<void> _showPopupWindow(int windowId, String url) async {
     if (!mounted) return;
 
-    LogService.instance.log('PopupWindow', 'Opening popup window with id: $windowId, url: $url');
+    LogService.instance.log(
+      'PopupWindow',
+      'Opening popup window with id: $windowId, url: $url',
+      sensitivity: LogSensitivity.sensitive,
+    );
 
     await showDialog(
       context: context,
@@ -2805,10 +2859,19 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   void _onNotificationTapped(String siteId) {
     final index = _webViewModels.indexWhere((m) => m.siteId == siteId);
     if (index < 0) {
-      LogService.instance.log('Notification', 'Tap for unknown siteId: $siteId', level: LogLevel.warning);
+      LogService.instance.log(
+        'Notification',
+        'Tap for unknown siteId: $siteId',
+        level: LogLevel.warning,
+        sensitivity: LogSensitivity.sensitive,
+      );
       return;
     }
-    LogService.instance.log('Notification', 'Tap routing to site $index: "${_webViewModels[index].name}"');
+    LogService.instance.log(
+      'Notification',
+      'Tap routing to site $index: "${_webViewModels[index].name}"',
+      sensitivity: LogSensitivity.sensitive,
+    );
     _setCurrentIndex(index);
     if (mounted) setState(() {});
   }
@@ -3148,7 +3211,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
             if (!mounted || version != _selectWebspaceVersion) return;
             _webViewModels[index].disposeWebView();
             _loadedIndices.remove(index);
-            LogService.instance.log('WebspaceSwitch', 'Unloaded site $index: "${_webViewModels[index].name}"');
+            LogService.instance.log(
+              'WebspaceSwitch',
+              'Unloaded site $index: "${_webViewModels[index].name}"',
+              sensitivity: LogSensitivity.sensitive,
+            );
           }
         }
       } else {
@@ -5181,10 +5248,18 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           if (!mounted) return;
           final urlAfter = (await controller.getUrl())?.toString();
           if (urlBefore == urlAfter) {
-            LogService.instance.log('Navigation', 'Back gesture: URL unchanged ($urlAfter), opening drawer');
+            LogService.instance.log(
+              'Navigation',
+              'Back gesture: URL unchanged ($urlAfter), opening drawer',
+              sensitivity: LogSensitivity.sensitive,
+            );
             scaffoldState?.openDrawer();
           } else {
-            LogService.instance.log('Navigation', 'Back gesture: navigated back from $urlBefore to $urlAfter');
+            LogService.instance.log(
+              'Navigation',
+              'Back gesture: navigated back from $urlBefore to $urlAfter',
+              sensitivity: LogSensitivity.sensitive,
+            );
             if (Platform.isIOS && _currentIndex != null && _currentIndex! < _webViewModels.length) {
               // After a successful goBack(), if we've landed on the home URL,
               // synchronously clear _canGoBack so the drawer edge-swipe is

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -164,6 +164,13 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   bool _isFetchingHtml = false;
   final Set<LogLevel> _activeFilters = LogLevel.values.toSet();
 
+  /// Runtime-only toggle: when true, the App Logs tab shows
+  /// [LogSensitivity.sensitive] entries (siteId, hostnames, page URLs,
+  /// proxy host:port, …) merged with normal entries. Resets on every
+  /// cold launch — `LogService._sensitiveEntries` is process-local and
+  /// the toggle is not persisted to SharedPreferences.
+  bool _showSensitive = false;
+
   final ScrollController _consoleScrollController = ScrollController();
   final ScrollController _logScrollController = ScrollController();
 
@@ -1510,7 +1517,9 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   // ── App Logs Tab ──
 
   Widget _buildAppLogsTab() {
-    final allEntries = LogService.instance.entries;
+    final allEntries = _showSensitive
+        ? LogService.instance.allEntriesMerged
+        : LogService.instance.entries;
     var filtered = _activeFilters.length == LogLevel.values.length
         ? allEntries
         : allEntries.where((e) => _activeFilters.contains(e.level)).toList();
@@ -1524,6 +1533,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
       children: [
         _buildLogActions(filtered),
         _buildLogFilters(),
+        _buildSensitiveToggle(),
         Expanded(
           child: filtered.isEmpty
               ? Center(child: Text(_searchQuery.isEmpty ? 'No log entries' : 'No matches'))
@@ -1537,6 +1547,29 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
                 ),
         ),
       ],
+    );
+  }
+
+  Widget _buildSensitiveToggle() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12.0),
+      child: Row(
+        children: [
+          Switch(
+            value: _showSensitive,
+            onChanged: (v) => setState(() => _showSensitive = v),
+          ),
+          const SizedBox(width: 4),
+          Expanded(
+            child: Text(
+              _showSensitive
+                  ? 'Showing sensitive entries (siteId, URLs, hostnames). Resets on app restart.'
+                  : 'Show sensitive entries (siteId, URLs, hostnames)',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+        ],
+      ),
     );
   }
 
@@ -1619,10 +1652,19 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
       default:
         color = Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white;
     }
-    return Padding(
+    final isSensitive = entry.sensitivity == LogSensitivity.sensitive;
+    final prefix = isSensitive ? '[SENSITIVE] ' : '';
+    return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 1.0),
+      decoration: isSensitive
+          ? BoxDecoration(
+              border: Border(
+                left: BorderSide(color: Colors.deepOrange.shade400, width: 3),
+              ),
+            )
+          : null,
       child: SelectableText(
-        '[${_formatTime(entry.timestamp)}] [${entry.tag}] ${entry.message}',
+        '[${_formatTime(entry.timestamp)}] $prefix[${entry.tag}] ${entry.message}',
         style: TextStyle(fontFamily: 'monospace', fontSize: 11, color: color),
       ),
     );

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -722,6 +722,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
           'Cookie inspector via ContainerCookieManager: '
               'siteId=${widget.host!.siteId} url=$url '
               'count=${cookies.length}',
+          sensitivity: LogSensitivity.sensitive,
         );
       } else {
         cookies = await widget.cookieManager.getCookies(url: Uri.parse(url));
@@ -731,6 +732,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
               'siteId=${widget.host!.siteId} url=$url '
               'count=${cookies.length} '
               '(container=${container != null} ctrl=${controller != null})',
+          sensitivity: LogSensitivity.sensitive,
         );
       }
       if (mounted) {

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp
     show PullToRefreshController, PullToRefreshSettings, SslCertificate;

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -305,9 +305,11 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
   Future<void> _showPopupWindow(int windowId, String url) async {
     if (!mounted) return;
 
-    if (kDebugMode) {
-      debugPrint('[PopupWindow] Opening popup window with id: $windowId, url: $url');
-    }
+    LogService.instance.log(
+      'PopupWindow',
+      'Opening popup window with id: $windowId, url: $url',
+      sensitivity: LogSensitivity.sensitive,
+    );
 
     await showDialog(
       context: context,
@@ -350,9 +352,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
       },
     );
 
-    if (kDebugMode) {
-      debugPrint('[PopupWindow] Popup window closed');
-    }
+    LogService.instance.log('PopupWindow', 'Popup window closed');
   }
 
   @override
@@ -397,12 +397,18 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
           final urlAfter = (await controller.getUrl())?.toString();
           if (!mounted) return;
           if (urlBefore == urlAfter) {
-            LogService.instance.log('Navigation',
-                'Nested back gesture: no history ($urlAfter), exiting nested');
+            LogService.instance.log(
+              'Navigation',
+              'Nested back gesture: no history ($urlAfter), exiting nested',
+              sensitivity: LogSensitivity.sensitive,
+            );
             navigator.pop();
           } else {
-            LogService.instance.log('Navigation',
-                'Nested back gesture: navigated $urlBefore -> $urlAfter');
+            LogService.instance.log(
+              'Navigation',
+              'Nested back gesture: navigated $urlBefore -> $urlAfter',
+              sensitivity: LogSensitivity.sensitive,
+            );
           }
         } finally {
           _isBackHandling = false;

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -429,6 +429,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           'Saving per-site proxy for siteId=${widget.webViewModel.siteId}: '
               '${_proxySettings.describeForLogs()}',
           level: LogLevel.info,
+          sensitivity: LogSensitivity.sensitive,
         );
 
         // Apply proxy settings immediately
@@ -441,6 +442,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           'Proxy',
           'Per-site proxy unsupported on this platform; forcing DEFAULT for '
               'siteId=${widget.webViewModel.siteId}',
+          sensitivity: LogSensitivity.sensitive,
         );
         await widget.webViewModel.updateProxySettings(defaultProxy);
       }

--- a/lib/services/container_cookie_manager.dart
+++ b/lib/services/container_cookie_manager.dart
@@ -57,6 +57,7 @@ class ContainerCookieManager {
         'ContainerCookieManager',
         'getCookies($siteId, ${url.host}) failed: $e',
         level: LogLevel.error,
+        sensitivity: LogSensitivity.sensitive,
       );
       return const [];
     }
@@ -91,6 +92,7 @@ class ContainerCookieManager {
         'deleteCookie($name@${domain ?? url.host}, siteId=$siteId) '
             'failed: $e',
         level: LogLevel.error,
+        sensitivity: LogSensitivity.sensitive,
       );
     }
   }

--- a/lib/services/container_isolation_engine.dart
+++ b/lib/services/container_isolation_engine.dart
@@ -34,6 +34,7 @@ class ContainerIsolationEngine {
         'Container',
         'ensureContainer($siteId) failed: $e',
         level: LogLevel.error,
+        sensitivity: LogSensitivity.sensitive,
       );
     }
   }
@@ -51,6 +52,7 @@ class ContainerIsolationEngine {
     LogService.instance.log(
       'Container',
       'Bound container ws-$siteId to $bound webview(s)',
+      sensitivity: LogSensitivity.sensitive,
     );
     return bound;
   }
@@ -60,7 +62,11 @@ class ContainerIsolationEngine {
   Future<void> onSiteDeleted(String siteId) async {
     if (!await containerNative.isSupported()) return;
     await containerNative.deleteContainer(siteId);
-    LogService.instance.log('Container', 'Deleted container ws-$siteId');
+    LogService.instance.log(
+      'Container',
+      'Deleted container ws-$siteId',
+      sensitivity: LogSensitivity.sensitive,
+    );
   }
 
   /// Sweeps containers whose owning site no longer exists in

--- a/lib/services/container_native.dart
+++ b/lib/services/container_native.dart
@@ -169,6 +169,7 @@ class _ContainerNative implements ContainerNative {
         'Container',
         'deleteContainer($siteId) failed: $e',
         level: LogLevel.error,
+        sensitivity: LogSensitivity.sensitive,
       );
     }
   }

--- a/lib/services/content_blocker_service.dart
+++ b/lib/services/content_blocker_service.dart
@@ -346,7 +346,8 @@ class ContentBlockerService {
         '${hides.length} hide(s), ${exceptions.length} exception(s)'
         '${genericHide ? ", generichide" : ""}'
         '${procedural.isNotEmpty ? ", ${procedural.length} procedural" : ""}',
-        level: LogLevel.debug);
+        level: LogLevel.debug,
+        sensitivity: LogSensitivity.sensitive);
     return entry;
   }
 
@@ -366,7 +367,8 @@ class ContentBlockerService {
         'getEarlyCssScript($pageUrl): '
         '${ctx.hides.length} hide(s) '
         '→ ${script == null ? "no script" : "${script.length} bytes"}',
-        level: LogLevel.debug);
+        level: LogLevel.debug,
+        sensitivity: LogSensitivity.sensitive);
     return script;
   }
 
@@ -390,7 +392,8 @@ class ContentBlockerService {
       LogService.instance.log('ContentBlocker',
           'engine.hiddenClassIdSelectors($pageUrl) skipped — '
           'page has \$generichide allowlist',
-          level: LogLevel.debug);
+          level: LogLevel.debug,
+          sensitivity: LogSensitivity.sensitive);
       return const [];
     }
     final mergedExceptions =
@@ -406,7 +409,8 @@ class ContentBlockerService {
         'engine.hiddenClassIdSelectors($pageUrl): '
         '${classes.length} class(es), ${ids.length} id(s) → '
         '${result.length} selector(s)',
-        level: LogLevel.debug);
+        level: LogLevel.debug,
+        sensitivity: LogSensitivity.sensitive);
     return result;
   }
 

--- a/lib/services/cookie_isolation.dart
+++ b/lib/services/cookie_isolation.dart
@@ -51,6 +51,7 @@ class CookieIsolationEngine {
     LogService.instance.log(
       'CookieIsolation',
       'Unloading site $index: "${model.name}" (siteId: ${model.siteId})',
+      sensitivity: LogSensitivity.sensitive,
     );
 
     if (!model.incognito) {
@@ -69,11 +70,16 @@ class CookieIsolationEngine {
       LogService.instance.log(
         'CookieIsolation',
         'Captured ${model.cookies.length} cookies for site $index: "${model.name}"',
+        sensitivity: LogSensitivity.sensitive,
       );
     }
 
     model.disposeWebView();
-    LogService.instance.log('CookieIsolation', 'Disposed webview for site $index');
+    LogService.instance.log(
+      'CookieIsolation',
+      'Disposed webview for site $index',
+      sensitivity: LogSensitivity.sensitive,
+    );
     loadedIndices.remove(index);
   }
 
@@ -157,6 +163,7 @@ class CookieIsolationEngine {
     LogService.instance.log(
       'CookieIsolation',
       'Restoring ${cookies.length} cookies for site $index: "${model.name}" (siteId: ${model.siteId})',
+      sensitivity: LogSensitivity.sensitive,
     );
 
     await _setCookies(model, cookies);

--- a/lib/services/cookie_secure_storage.dart
+++ b/lib/services/cookie_secure_storage.dart
@@ -182,7 +182,12 @@ class CookieSecureStorage {
     }
 
     await saveCookies(allCookies);
-    LogService.instance.log('CookieStorage', 'Removed orphaned cookies for siteIds: $siteIdsToRemove', level: LogLevel.info);
+    LogService.instance.log(
+      'CookieStorage',
+      'Removed orphaned cookies for siteIds: $siteIdsToRemove',
+      level: LogLevel.info,
+      sensitivity: LogSensitivity.sensitive,
+    );
   }
 
   /// Clears all stored cookies from both secure storage and fallback.

--- a/lib/services/html_cache_service.dart
+++ b/lib/services/html_cache_service.dart
@@ -163,17 +163,32 @@ class HtmlCacheService {
               } else {
                 // Invalid format - discard
                 await entity.delete();
-                LogService.instance.log('HtmlCache', 'Discarded invalid cache file: ${entity.path}', level: LogLevel.warning);
+                LogService.instance.log(
+                  'HtmlCache',
+                  'Discarded invalid cache file: ${entity.path}',
+                  level: LogLevel.warning,
+                  sensitivity: LogSensitivity.sensitive,
+                );
               }
             } else {
               // Decryption failed - discard (key may have changed)
               await entity.delete();
-              LogService.instance.log('HtmlCache', 'Discarded undecryptable cache file: ${entity.path}', level: LogLevel.warning);
+              LogService.instance.log(
+                'HtmlCache',
+                'Discarded undecryptable cache file: ${entity.path}',
+                level: LogLevel.warning,
+                sensitivity: LogSensitivity.sensitive,
+              );
             }
           } catch (e) {
             // File read/decrypt error - discard
             await entity.delete();
-            LogService.instance.log('HtmlCache', 'Discarded corrupted cache file: ${entity.path} ($e)', level: LogLevel.warning);
+            LogService.instance.log(
+              'HtmlCache',
+              'Discarded corrupted cache file: ${entity.path} ($e)',
+              level: LogLevel.warning,
+              sensitivity: LogSensitivity.sensitive,
+            );
           }
         }
       }
@@ -312,7 +327,12 @@ class HtmlCacheService {
 
     // Skip if HTML is too large
     if (html.length > _maxHtmlSize) {
-      LogService.instance.log('HtmlCache', 'Skipping save for $siteId - HTML too large (${html.length} bytes > $_maxHtmlSize)', level: LogLevel.warning);
+      LogService.instance.log(
+        'HtmlCache',
+        'Skipping save for $siteId - HTML too large (${html.length} bytes > $_maxHtmlSize)',
+        level: LogLevel.warning,
+        sensitivity: LogSensitivity.sensitive,
+      );
       return;
     }
 
@@ -331,7 +351,11 @@ class HtmlCacheService {
       // cache to drop this site, and committing now would silently
       // resurrect the stale bytes the user just told us to forget.
       if ((_evictionGen[siteId] ?? 0) != genAtEntry) {
-        LogService.instance.log('HtmlCache', 'Skipping save for $siteId - evicted before write');
+        LogService.instance.log(
+          'HtmlCache',
+          'Skipping save for $siteId - evicted before write',
+          sensitivity: LogSensitivity.sensitive,
+        );
         return;
       }
 
@@ -344,7 +368,11 @@ class HtmlCacheService {
         try {
           if (await file.exists()) await file.delete();
         } catch (_) {}
-        LogService.instance.log('HtmlCache', 'Rolled back save for $siteId - evicted during write');
+        LogService.instance.log(
+          'HtmlCache',
+          'Rolled back save for $siteId - evicted during write',
+          sensitivity: LogSensitivity.sensitive,
+        );
         return;
       }
 
@@ -352,9 +380,18 @@ class HtmlCacheService {
       _memoryCache[siteId] = html;
       _lastSaveAt[siteId] = DateTime.now();
 
-      LogService.instance.log('HtmlCache', 'Saved ${html.length} bytes for site $siteId (encrypted)');
+      LogService.instance.log(
+        'HtmlCache',
+        'Saved ${html.length} bytes for site $siteId (encrypted)',
+        sensitivity: LogSensitivity.sensitive,
+      );
     } catch (e) {
-      LogService.instance.log('HtmlCache', 'Error saving HTML for $siteId: $e', level: LogLevel.error);
+      LogService.instance.log(
+        'HtmlCache',
+        'Error saving HTML for $siteId: $e',
+        level: LogLevel.error,
+        sensitivity: LogSensitivity.sensitive,
+      );
     }
   }
 
@@ -377,11 +414,20 @@ class HtmlCacheService {
       final url = decrypted.substring(0, newlineIndex);
       final html = decrypted.substring(newlineIndex + 1);
 
-      LogService.instance.log('HtmlCache', 'Loaded ${html.length} bytes for site $siteId (decrypted)');
+      LogService.instance.log(
+        'HtmlCache',
+        'Loaded ${html.length} bytes for site $siteId (decrypted)',
+        sensitivity: LogSensitivity.sensitive,
+      );
 
       return (url, html);
     } catch (e) {
-      LogService.instance.log('HtmlCache', 'Error loading HTML for $siteId: $e', level: LogLevel.error);
+      LogService.instance.log(
+        'HtmlCache',
+        'Error loading HTML for $siteId: $e',
+        level: LogLevel.error,
+        sensitivity: LogSensitivity.sensitive,
+      );
       return null;
     }
   }
@@ -420,7 +466,12 @@ class HtmlCacheService {
         if (!activeSiteIds.contains(siteId)) {
           evictInMemory(siteId);
           await entity.delete();
-          LogService.instance.log('HtmlCache', 'Removed orphaned cache for $siteId', level: LogLevel.info);
+          LogService.instance.log(
+            'HtmlCache',
+            'Removed orphaned cache for $siteId',
+            level: LogLevel.info,
+            sensitivity: LogSensitivity.sensitive,
+          );
         }
       }
     }

--- a/lib/services/html_import_storage.dart
+++ b/lib/services/html_import_storage.dart
@@ -121,15 +121,30 @@ class HtmlImportStorage {
                 // the AES key is recoverable (e.g. flutter_secure_storage
                 // returns the original key on a later launch after a
                 // transient Android Keystore read failure).
-                LogService.instance.log('HtmlImport', 'Skipping invalid import file (kept on disk): ${entity.path}', level: LogLevel.warning);
+                LogService.instance.log(
+                  'HtmlImport',
+                  'Skipping invalid import file (kept on disk): ${entity.path}',
+                  level: LogLevel.warning,
+                  sensitivity: LogSensitivity.sensitive,
+                );
                 skipped++;
               }
             } else {
-              LogService.instance.log('HtmlImport', 'Skipping undecryptable import file (kept on disk): ${entity.path}', level: LogLevel.warning);
+              LogService.instance.log(
+                'HtmlImport',
+                'Skipping undecryptable import file (kept on disk): ${entity.path}',
+                level: LogLevel.warning,
+                sensitivity: LogSensitivity.sensitive,
+              );
               skipped++;
             }
           } catch (e) {
-            LogService.instance.log('HtmlImport', 'Skipping unreadable import file (kept on disk): ${entity.path} ($e)', level: LogLevel.warning);
+            LogService.instance.log(
+              'HtmlImport',
+              'Skipping unreadable import file (kept on disk): ${entity.path} ($e)',
+              level: LogLevel.warning,
+              sensitivity: LogSensitivity.sensitive,
+            );
             skipped++;
           }
         }
@@ -157,7 +172,12 @@ class HtmlImportStorage {
     if (_storageDirectory == null || _encrypter == null) return;
 
     if (html.length > _maxHtmlSize) {
-      LogService.instance.log('HtmlImport', 'Skipping save for $siteId - HTML too large (${html.length} bytes > $_maxHtmlSize)', level: LogLevel.warning);
+      LogService.instance.log(
+        'HtmlImport',
+        'Skipping save for $siteId - HTML too large (${html.length} bytes > $_maxHtmlSize)',
+        level: LogLevel.warning,
+        sensitivity: LogSensitivity.sensitive,
+      );
       return;
     }
 
@@ -170,9 +190,18 @@ class HtmlImportStorage {
       await file.writeAsString(encrypted);
       _memoryStore[siteId] = html;
 
-      LogService.instance.log('HtmlImport', 'Saved ${html.length} bytes for site $siteId (encrypted)');
+      LogService.instance.log(
+        'HtmlImport',
+        'Saved ${html.length} bytes for site $siteId (encrypted)',
+        sensitivity: LogSensitivity.sensitive,
+      );
     } catch (e) {
-      LogService.instance.log('HtmlImport', 'Error saving HTML for $siteId: $e', level: LogLevel.error);
+      LogService.instance.log(
+        'HtmlImport',
+        'Error saving HTML for $siteId: $e',
+        level: LogLevel.error,
+        sensitivity: LogSensitivity.sensitive,
+      );
     }
   }
 
@@ -195,7 +224,12 @@ class HtmlImportStorage {
 
       return (url, html);
     } catch (e) {
-      LogService.instance.log('HtmlImport', 'Error loading HTML for $siteId: $e', level: LogLevel.error);
+      LogService.instance.log(
+        'HtmlImport',
+        'Error loading HTML for $siteId: $e',
+        level: LogLevel.error,
+        sensitivity: LogSensitivity.sensitive,
+      );
       return null;
     }
   }
@@ -226,7 +260,12 @@ class HtmlImportStorage {
         if (!activeSiteIds.contains(siteId)) {
           await entity.delete();
           _memoryStore.remove(siteId);
-          LogService.instance.log('HtmlImport', 'Removed orphaned import for $siteId', level: LogLevel.info);
+          LogService.instance.log(
+            'HtmlImport',
+            'Removed orphaned import for $siteId',
+            level: LogLevel.info,
+            sensitivity: LogSensitivity.sensitive,
+          );
         }
       }
     }

--- a/lib/services/icon_service.dart
+++ b/lib/services/icon_service.dart
@@ -148,8 +148,11 @@ void wireFaviconTrustInvalidation() {
     }
     if (hits.isEmpty) return;
     LogService.instance.log(
-        'Icon', 'Trust granted for ${entry.host}:${entry.port} — '
-            'invalidating ${hits.length} cached favicon(s)');
+      'Icon',
+      'Trust granted for ${entry.host}:${entry.port} — '
+          'invalidating ${hits.length} cached favicon(s)',
+      sensitivity: LogSensitivity.sensitive,
+    );
     for (final key in hits) {
       invalidateFaviconFor(key);
     }
@@ -257,8 +260,11 @@ Future<bool> _isSvgColored(String svgUrl, UserProxySettings proxy) async {
     for (var styleMatch in styleBlockPattern.allMatches(svgContent)) {
       final styleContent = styleMatch.group(1) ?? '';
       if (RegExp(r'display\s*:\s*none').hasMatch(styleContent)) {
-        LogService.instance.log('Icon',
-            'SVG uses CSS visibility switching, treating as low quality: $svgUrl');
+        LogService.instance.log(
+          'Icon',
+          'SVG uses CSS visibility switching, treating as low quality: $svgUrl',
+          sensitivity: LogSensitivity.sensitive,
+        );
         return false;
       }
     }
@@ -271,7 +277,11 @@ Future<bool> _isSvgColored(String svgUrl, UserProxySettings proxy) async {
     for (var match in attrMatches) {
       final color = match.group(1)!.toLowerCase();
       if (_isRealColor(color)) {
-        LogService.instance.log('Icon', 'Found colored SVG with attr color #$color: $svgUrl');
+        LogService.instance.log(
+          'Icon',
+          'Found colored SVG with attr color #$color: $svgUrl',
+          sensitivity: LogSensitivity.sensitive,
+        );
         return true;
       }
     }
@@ -295,19 +305,31 @@ Future<bool> _isSvgColored(String svgUrl, UserProxySettings proxy) async {
       for (var match in cssMatches) {
         final color = match.group(1)!.toLowerCase();
         if (_isRealColor(color)) {
-          LogService.instance.log('Icon', 'Found colored SVG with CSS color #$color: $svgUrl');
+          LogService.instance.log(
+            'Icon',
+            'Found colored SVG with CSS color #$color: $svgUrl',
+            sensitivity: LogSensitivity.sensitive,
+          );
           return true;
         }
       }
 
       // Check for rgb/hsl
       if (withoutMedia.contains('rgb(') || withoutMedia.contains('hsl(')) {
-        LogService.instance.log('Icon', 'Found colored SVG with rgb/hsl: $svgUrl');
+        LogService.instance.log(
+          'Icon',
+          'Found colored SVG with rgb/hsl: $svgUrl',
+          sensitivity: LogSensitivity.sensitive,
+        );
         return true;
       }
     }
 
-    LogService.instance.log('Icon', 'SVG appears monochrome: $svgUrl');
+    LogService.instance.log(
+      'Icon',
+      'SVG appears monochrome: $svgUrl',
+      sensitivity: LogSensitivity.sensitive,
+    );
     return false;
   } catch (e) {
     LogService.instance.log('Icon', 'Failed to check SVG color: $e', level: LogLevel.error);
@@ -350,7 +372,11 @@ int _compareFavicons(Favicon a, Favicon b, Map<String, bool> svgColorCache) {
 // ignore: unused_element
 Future<Favicon?> _findBestIcon(String url, UserProxySettings proxy) async {
   final favicons = await FaviconFinder.getAll(url, proxy: proxy);
-  LogService.instance.log('Icon', 'Favicons: ${favicons.map((f) => '${f.url} (width: ${f.width}, height: ${f.height})').join(', ')}');
+  LogService.instance.log(
+    'Icon',
+    'Favicons: ${favicons.map((f) => '${f.url} (width: ${f.width}, height: ${f.height})').join(', ')}',
+    sensitivity: LogSensitivity.sensitive,
+  );
   if (favicons.isEmpty) return null;
 
   final svgColorCache = <String, bool>{};
@@ -377,26 +403,42 @@ Future<Favicon?> _findBestIcon(String url, UserProxySettings proxy) async {
 Future<String?> getFaviconUrl(String url, {UserProxySettings? proxy}) async {
   // Check cache first
   if (_faviconCache.containsKey(url)) {
-    LogService.instance.log('Icon', 'Using cached icon for $url');
+    LogService.instance.log(
+      'Icon',
+      'Using cached icon for $url',
+      sensitivity: LogSensitivity.sensitive,
+    );
     return _faviconCache[url];
   }
 
   // Queue management to limit concurrent requests
   if (_activeRequests >= _maxConcurrentRequests) {
-    LogService.instance.log('Icon', 'Queueing request for $url (active: $_activeRequests)');
+    LogService.instance.log(
+      'Icon',
+      'Queueing request for $url (active: $_activeRequests)',
+      sensitivity: LogSensitivity.sensitive,
+    );
     final completer = Completer<void>();
     _requestQueue.add(completer);
     await completer.future;
   }
 
   _activeRequests++;
-  LogService.instance.log('Icon', 'Starting request for $url (active: $_activeRequests, queued: ${_requestQueue.length})');
+  LogService.instance.log(
+    'Icon',
+    'Starting request for $url (active: $_activeRequests, queued: ${_requestQueue.length})',
+    sensitivity: LogSensitivity.sensitive,
+  );
 
   try {
     return await _fetchFaviconUrlInternal(url, _resolve(proxy));
   } finally {
     _activeRequests--;
-    LogService.instance.log('Icon', 'Finished request for $url (active: $_activeRequests, queued: ${_requestQueue.length})');
+    LogService.instance.log(
+      'Icon',
+      'Finished request for $url (active: $_activeRequests, queued: ${_requestQueue.length})',
+      sensitivity: LogSensitivity.sensitive,
+    );
 
     // Process next queued request
     if (_requestQueue.isNotEmpty) {
@@ -431,7 +473,11 @@ Stream<IconUpdate> getFaviconUrlStream(String url, {UserProxySettings? proxy}) a
   if (_faviconCache.containsKey(url) && _faviconCache[url] != null) {
     final cachedUrl = _faviconCache[url]!;
     final cachedQuality = _faviconQualityCache[url] ?? 100;
-    LogService.instance.log('Icon', 'Stream: Using cached icon for $url (quality: $cachedQuality)');
+    LogService.instance.log(
+      'Icon',
+      'Stream: Using cached icon for $url (quality: $cachedQuality)',
+      sensitivity: LogSensitivity.sensitive,
+    );
     yield IconUpdate(cachedUrl, cachedQuality, isFinal: true);
     return;
   }
@@ -439,7 +485,11 @@ Stream<IconUpdate> getFaviconUrlStream(String url, {UserProxySettings? proxy}) a
   // Check if we should use public icon services (skip for http:// and IP addresses)
   final usePublicServices = _shouldUsePublicIconServices(uri);
 
-  LogService.instance.log('Icon', 'Stream: Starting progressive fetch for $url (domain: $domain, usePublicServices: $usePublicServices)');
+  LogService.instance.log(
+    'Icon',
+    'Stream: Starting progressive fetch for $url (domain: $domain, usePublicServices: $usePublicServices)',
+    sensitivity: LogSensitivity.sensitive,
+  );
 
   // Phase 1 & 2: Public icon services (only for HTTPS + non-IP addresses)
   if (usePublicServices) {
@@ -491,7 +541,11 @@ Stream<IconUpdate> getFaviconUrlStream(String url, {UserProxySettings? proxy}) a
   _faviconCache[url] = bestUrl;
   _faviconQualityCache[url] = bestQuality;
 
-  LogService.instance.log('Icon', 'Stream: Completed for $url, best quality: $bestQuality');
+  LogService.instance.log(
+    'Icon',
+    'Stream: Completed for $url, best quality: $bestQuality',
+    sensitivity: LogSensitivity.sensitive,
+  );
 }
 
 Future<String?> _fetchFaviconUrlInternal(String url, UserProxySettings proxy) async {
@@ -504,7 +558,11 @@ Future<String?> _fetchFaviconUrlInternal(String url, UserProxySettings proxy) as
   String domain = _applyDomainSubstitution(uri.host);
   final usePublicServices = _shouldUsePublicIconServices(uri);
 
-  LogService.instance.log('Icon', 'Fetching icon for $url (domain: $domain, usePublicServices: $usePublicServices)');
+  LogService.instance.log(
+    'Icon',
+    'Fetching icon for $url (domain: $domain, usePublicServices: $usePublicServices)',
+    sensitivity: LogSensitivity.sensitive,
+  );
 
   final List<_IconCandidate> candidates = [];
 
@@ -532,7 +590,12 @@ Future<String?> _fetchFaviconUrlInternal(String url, UserProxySettings proxy) as
 
     candidates.addAll(results.whereType<_IconCandidate>());
   } catch (e) {
-    LogService.instance.log('Icon', 'Error fetching icons for $url: $e', level: LogLevel.error);
+    LogService.instance.log(
+      'Icon',
+      'Error fetching icons for $url: $e',
+      level: LogLevel.error,
+      sensitivity: LogSensitivity.sensitive,
+    );
   }
 
   if (candidates.isEmpty) {
@@ -543,7 +606,11 @@ Future<String?> _fetchFaviconUrlInternal(String url, UserProxySettings proxy) as
   // Sort by quality (highest first)
   candidates.sort((a, b) => b.quality.compareTo(a.quality));
 
-  LogService.instance.log('Icon', 'Candidates: ${candidates.map((c) => '${c.url} (quality: ${c.quality})').join(', ')}');
+  LogService.instance.log(
+    'Icon',
+    'Candidates: ${candidates.map((c) => '${c.url} (quality: ${c.quality})').join(', ')}',
+    sensitivity: LogSensitivity.sensitive,
+  );
 
   // Return first valid candidate
   for (var candidate in candidates) {
@@ -565,11 +632,20 @@ Future<String?> _tryGoogleFavicon(String domain, int size, UserProxySettings pro
   try {
     final googleUrl = 'https://www.google.com/s2/favicons?domain=$domain&sz=$size';
     if (await _verifyIconUrl(googleUrl, proxy)) {
-      LogService.instance.log('Icon', 'Found Google favicon at ${size}px for $domain');
+      LogService.instance.log(
+        'Icon',
+        'Found Google favicon at ${size}px for $domain',
+        sensitivity: LogSensitivity.sensitive,
+      );
       return googleUrl;
     }
   } catch (e) {
-    LogService.instance.log('Icon', 'Google ${size}px failed for $domain: $e', level: LogLevel.error);
+    LogService.instance.log(
+      'Icon',
+      'Google ${size}px failed for $domain: $e',
+      level: LogLevel.error,
+      sensitivity: LogSensitivity.sensitive,
+    );
   }
   return null;
 }
@@ -578,11 +654,20 @@ Future<String?> _tryDuckDuckGo(String domain, UserProxySettings proxy) async {
   try {
     final ddgUrl = 'https://icons.duckduckgo.com/ip3/$domain.ico';
     if (await _verifyIconUrl(ddgUrl, proxy)) {
-      LogService.instance.log('Icon', 'Found DuckDuckGo favicon for $domain');
+      LogService.instance.log(
+        'Icon',
+        'Found DuckDuckGo favicon for $domain',
+        sensitivity: LogSensitivity.sensitive,
+      );
       return ddgUrl;
     }
   } catch (e) {
-    LogService.instance.log('Icon', 'DuckDuckGo failed for $domain: $e', level: LogLevel.error);
+    LogService.instance.log(
+      'Icon',
+      'DuckDuckGo failed for $domain: $e',
+      level: LogLevel.error,
+      sensitivity: LogSensitivity.sensitive,
+    );
   }
   return null;
 }
@@ -600,7 +685,11 @@ Future<_IconCandidate?> _tryFaviconPackage(String url, UserProxySettings proxy) 
     final favicons = await FaviconFinder.getAll(url, proxy: proxy).timeout(Duration(seconds: 15));
     if (favicons.isEmpty) return null;
 
-    LogService.instance.log('Icon', 'Favicons: ${favicons.map((f) => '${f.url} (width: ${f.width}, height: ${f.height})').join(', ')}');
+    LogService.instance.log(
+      'Icon',
+      'Favicons: ${favicons.map((f) => '${f.url} (width: ${f.width}, height: ${f.height})').join(', ')}',
+      sensitivity: LogSensitivity.sensitive,
+    );
 
     final svgColorCache = <String, bool>{};
 
@@ -625,11 +714,20 @@ Future<_IconCandidate?> _tryFaviconPackage(String url, UserProxySettings proxy) 
         quality = (best.width > 0) ? best.width : 50;
       }
 
-      LogService.instance.log('Icon', 'Found favicon via package for $url (quality: $quality) ${best.url}');
+      LogService.instance.log(
+        'Icon',
+        'Found favicon via package for $url (quality: $quality) ${best.url}',
+        sensitivity: LogSensitivity.sensitive,
+      );
       return _IconCandidate(best.url, quality);
     }
   } catch (e) {
-    LogService.instance.log('Icon', 'FaviconFinder failed for $url: $e', level: LogLevel.error);
+    LogService.instance.log(
+      'Icon',
+      'FaviconFinder failed for $url: $e',
+      level: LogLevel.error,
+      sensitivity: LogSensitivity.sensitive,
+    );
   }
   return null;
 }

--- a/lib/services/log_service.dart
+++ b/lib/services/log_service.dart
@@ -2,17 +2,26 @@ import 'package:flutter/foundation.dart';
 
 enum LogLevel { debug, info, warning, error }
 
+/// Whether an entry may carry per-site identifiers (siteId, container
+/// names, cookie hostnames, URLs, page titles, proxy passwords, etc.).
+/// `sensitive` entries are kept in a memory-only ring, never written
+/// to disk, never piped to `debugPrint`, and only surfaced in the
+/// in-app dev-tools log view when the runtime toggle is on.
+enum LogSensitivity { normal, sensitive }
+
 class LogEntry {
   final DateTime timestamp;
   final String tag;
   final String message;
   final LogLevel level;
+  final LogSensitivity sensitivity;
 
   LogEntry({
     required this.timestamp,
     required this.tag,
     required this.message,
     required this.level,
+    this.sensitivity = LogSensitivity.normal,
   });
 }
 
@@ -21,27 +30,59 @@ class LogService extends ChangeNotifier {
   LogService._();
 
   final List<LogEntry> _entries = [];
+  final List<LogEntry> _sensitiveEntries = [];
   static const maxEntries = 2000;
 
-  void log(String tag, String message, {LogLevel level = LogLevel.debug}) {
+  @visibleForTesting
+  void resetForTest() {
+    _entries.clear();
+    _sensitiveEntries.clear();
+    notifyListeners();
+  }
+
+  void log(
+    String tag,
+    String message, {
+    LogLevel level = LogLevel.debug,
+    LogSensitivity sensitivity = LogSensitivity.normal,
+  }) {
     final entry = LogEntry(
       timestamp: DateTime.now(),
       tag: tag,
       message: message,
       level: level,
+      sensitivity: sensitivity,
     );
-    _entries.add(entry);
-    if (_entries.length > maxEntries) {
-      _entries.removeAt(0);
-    }
-    if (kDebugMode) {
-      debugPrint('[${entry.tag}/${entry.level.name}] ${entry.message}');
+    if (sensitivity == LogSensitivity.sensitive) {
+      _sensitiveEntries.add(entry);
+      if (_sensitiveEntries.length > maxEntries) {
+        _sensitiveEntries.removeAt(0);
+      }
+    } else {
+      _entries.add(entry);
+      if (_entries.length > maxEntries) {
+        _entries.removeAt(0);
+      }
+      if (kDebugMode) {
+        debugPrint('[${entry.tag}/${entry.level.name}] ${entry.message}');
+      }
     }
     notifyListeners();
   }
 
   List<LogEntry> get entries => List.unmodifiable(_entries);
+  List<LogEntry> get sensitiveEntries => List.unmodifiable(_sensitiveEntries);
 
+  /// Combined view of normal + sensitive entries, ordered by timestamp.
+  /// Used by the dev-tools UI when the "show sensitive" toggle is on.
+  List<LogEntry> get allEntriesMerged {
+    final combined = <LogEntry>[..._entries, ..._sensitiveEntries];
+    combined.sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    return List.unmodifiable(combined);
+  }
+
+  /// Export only ships normal entries; sensitive entries never reach
+  /// a file the user can share or that ends up syncing off-device.
   String export() {
     final buffer = StringBuffer();
     for (final entry in _entries) {
@@ -55,6 +96,7 @@ class LogService extends ChangeNotifier {
 
   void clear() {
     _entries.clear();
+    _sensitiveEntries.clear();
     notifyListeners();
   }
 }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -96,7 +96,11 @@ class NotificationService {
       final data = jsonDecode(response.payload!);
       final siteId = data['siteId'] as String?;
       if (siteId != null) {
-        LogService.instance.log('Notification', 'Tapped notification for siteId: $siteId');
+        LogService.instance.log(
+          'Notification',
+          'Tapped notification for siteId: $siteId',
+          sensitivity: LogSensitivity.sensitive,
+        );
         onNotificationTapped?.call(siteId);
       }
     } catch (e) {
@@ -119,7 +123,12 @@ class NotificationService {
     if (!_initialized) await init();
     await _ensurePermission();
     if (_permissionGranted != true) {
-      LogService.instance.log('Notification', 'Skipped "$title" — OS notification permission denied', level: LogLevel.warning);
+      LogService.instance.log(
+        'Notification',
+        'Skipped "$title" — OS notification permission denied',
+        level: LogLevel.warning,
+        sensitivity: LogSensitivity.sensitive,
+      );
       return;
     }
 
@@ -148,7 +157,11 @@ class NotificationService {
     final id = siteId.hashCode ^ title.hashCode;
 
     await _plugin.show(id: id, title: title, body: body.isNotEmpty ? body : null, notificationDetails: details, payload: payload);
-    LogService.instance.log('Notification', 'Showed notification: "$title" for siteId: $siteId');
+    LogService.instance.log(
+      'Notification',
+      'Showed notification: "$title" for siteId: $siteId',
+      sensitivity: LogSensitivity.sensitive,
+    );
   }
 
   Future<bool> requestPermission() async {

--- a/lib/services/proxy_password_secure_storage.dart
+++ b/lib/services/proxy_password_secure_storage.dart
@@ -130,6 +130,7 @@ class ProxyPasswordSecureStorage {
         'ProxyPwdStore',
         'Removed orphaned proxy passwords for keys: $removed',
         level: LogLevel.info,
+        sensitivity: LogSensitivity.sensitive,
       );
     }
   }
@@ -166,6 +167,7 @@ class ProxyPasswordSecureStorage {
       'ProxyPwdStore',
       'Migrated legacy plaintext password from prefs[$prefsKey] -> secure[$secureKey]',
       level: LogLevel.info,
+      sensitivity: LogSensitivity.sensitive,
     );
     return true;
   }

--- a/lib/services/settings_backup.dart
+++ b/lib/services/settings_backup.dart
@@ -5,6 +5,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import 'package:webspace/services/log_service.dart';
 import 'package:webspace/web_view_model.dart';
 import 'package:webspace/webspace_model.dart';
 
@@ -248,7 +249,11 @@ class SettingsBackupService {
       }
       return true;
     } catch (e, stack) {
-      debugPrint('Export failed: $e\n$stack');
+      LogService.instance.log(
+        'SettingsBackup',
+        'Export failed: $e\n$stack',
+        level: LogLevel.error,
+      );
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Export failed: $e')),

--- a/lib/services/trusted_hosts_service.dart
+++ b/lib/services/trusted_hosts_service.dart
@@ -6,6 +6,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:webspace/services/log_service.dart';
+
 /// SharedPreferences key holding the encoded trusted-cert pin list.
 /// Round-tripped through settings export/import via [kExportedAppPrefs].
 const String kTrustedHostsKey = 'trustedHosts';
@@ -157,17 +159,23 @@ class TrustedHostsService {
     final removed = _byHostPort.remove(_key(host, port));
     if (removed != null) {
       await _persist();
-      debugPrint(
-          '[TLS/debug] untrust($host:$port) removed pin; emitting on untrustChanges');
+      LogService.instance.log(
+        'TLS',
+        'untrust($host:$port) removed pin; emitting on untrustChanges',
+        sensitivity: LogSensitivity.sensitive,
+      );
       _untrustController.add(TrustedHostEntry(
         host: host,
         port: port,
         sha256Hex: removed,
       ));
     } else {
-      debugPrint(
-          '[TLS/debug] untrust($host:$port) no-op (no matching pin); '
-          'in-memory keys: ${_byHostPort.keys.toList()}');
+      LogService.instance.log(
+        'TLS',
+        'untrust($host:$port) no-op (no matching pin); '
+            'in-memory keys: ${_byHostPort.keys.toList()}',
+        sensitivity: LogSensitivity.sensitive,
+      );
     }
   }
 

--- a/lib/services/user_script_service.dart
+++ b/lib/services/user_script_service.dart
@@ -112,11 +112,19 @@ class UserScriptService {
     for (final script in _scripts) {
       final src = _buildSource(script);
       if (!script.enabled || src.isEmpty) {
-        LogService.instance.log('UserScript', 'Skipping "${script.name}" (enabled=${script.enabled}, empty=${src.isEmpty})');
+        LogService.instance.log(
+          'UserScript',
+          'Skipping "${script.name}" (enabled=${script.enabled}, empty=${src.isEmpty})',
+          sensitivity: LogSensitivity.sensitive,
+        );
         continue;
       }
       final time = script.injectionTime == UserScriptInjectionTime.atDocumentStart ? 'DOCUMENT_START' : 'DOCUMENT_END';
-      LogService.instance.log('UserScript', 'Adding to initialUserScripts: "${script.name}" at $time (${src.length} chars, url=${script.url ?? "none"})');
+      LogService.instance.log(
+        'UserScript',
+        'Adding to initialUserScripts: "${script.name}" at $time (${src.length} chars, url=${script.url ?? "none"})',
+        sensitivity: LogSensitivity.sensitive,
+      );
       result.add(inapp.UserScript(
         groupName: 'user_scripts',
         source: '${_guarded(script.id, src)}\n;null;',
@@ -153,21 +161,37 @@ class UserScriptService {
       final url = args[0] as String;
       final status = classifyScriptFetchUrl(url);
       if (status == ScriptFetchUrlStatus.blocked) {
-        LogService.instance.log('UserScript', 'Blocked script fetch: $url');
+        LogService.instance.log(
+          'UserScript',
+          'Blocked script fetch: $url',
+          sensitivity: LogSensitivity.sensitive,
+        );
         return false;
       }
       if (status == ScriptFetchUrlStatus.requiresConfirmation) {
         if (_onConfirmScriptFetch == null) {
-          LogService.instance.log('UserScript', 'Blocked non-whitelisted URL (no confirmation handler): $url');
+          LogService.instance.log(
+            'UserScript',
+            'Blocked non-whitelisted URL (no confirmation handler): $url',
+            sensitivity: LogSensitivity.sensitive,
+          );
           return false;
         }
         final approved = await _onConfirmScriptFetch!(url);
         if (!approved) {
-          LogService.instance.log('UserScript', 'User denied script fetch: $url');
+          LogService.instance.log(
+            'UserScript',
+            'User denied script fetch: $url',
+            sensitivity: LogSensitivity.sensitive,
+          );
           return false;
         }
       }
-      LogService.instance.log('UserScript', 'Fetching external script: $url');
+      LogService.instance.log(
+        'UserScript',
+        'Fetching external script: $url',
+        sensitivity: LogSensitivity.sensitive,
+      );
       final clientResult = outboundHttp.clientFor(resolveEffectiveProxy(_proxy));
       if (clientResult is OutboundClientBlocked) {
         LogService.instance.log(
@@ -217,7 +241,11 @@ class UserScriptService {
       final url = args[0] as String;
       final status = classifyScriptFetchUrl(url);
       if (status == ScriptFetchUrlStatus.blocked) {
-        LogService.instance.log('UserScript', 'Blocked resource fetch: $url');
+        LogService.instance.log(
+          'UserScript',
+          'Blocked resource fetch: $url',
+          sensitivity: LogSensitivity.sensitive,
+        );
         return {'status': 403};
       }
       final clientResult = outboundHttp.clientFor(resolveEffectiveProxy(_proxy));
@@ -276,7 +304,11 @@ class UserScriptService {
       final src = _buildSource(script);
       if (src.isEmpty) continue;
       if (script.injectionTime == UserScriptInjectionTime.atDocumentStart) {
-        LogService.instance.log('UserScript', 'onLoadStart: re-injecting "${script.name}" (${src.length} chars)');
+        LogService.instance.log(
+          'UserScript',
+          'onLoadStart: re-injecting "${script.name}" (${src.length} chars)',
+          sensitivity: LogSensitivity.sensitive,
+        );
         await _safeEval(controller, _guarded(script.id, src));
       }
     }
@@ -294,7 +326,11 @@ class UserScriptService {
       final src = _buildSource(script);
       if (src.isEmpty) continue;
       if (script.injectionTime == UserScriptInjectionTime.atDocumentEnd) {
-        LogService.instance.log('UserScript', 'onLoadStop: re-injecting "${script.name}" (${src.length} chars)');
+        LogService.instance.log(
+          'UserScript',
+          'onLoadStop: re-injecting "${script.name}" (${src.length} chars)',
+          sensitivity: LogSensitivity.sensitive,
+        );
         await _safeEval(controller, _guarded(script.id, src));
       }
     }
@@ -311,7 +347,11 @@ class UserScriptService {
     if (!hasScripts) return;
     for (final script in _scripts) {
       if (!script.enabled || script.source.isEmpty) continue;
-      LogService.instance.log('UserScript', 'SPA nav: re-running "${script.name}" source (${script.source.length} chars)');
+      LogService.instance.log(
+        'UserScript',
+        'SPA nav: re-running "${script.name}" source (${script.source.length} chars)',
+        sensitivity: LogSensitivity.sensitive,
+      );
       final safeName = script.name.replaceAll('"', '\\"');
       await _safeEval(controller, 'console.log("__ws: SPA re-inject: $safeName");\n${script.source}');
     }

--- a/lib/services/web_intercept_native.dart
+++ b/lib/services/web_intercept_native.dart
@@ -37,7 +37,13 @@ class WebInterceptNative {
           if (args is Map) {
             final tag = (args['tag'] as String?) ?? 'WebIntercept';
             final message = (args['message'] as String?) ?? '';
-            LogService.instance.log(tag, message);
+            // Native bridge messages may carry per-site hosts / URLs.
+            // Treat as sensitive so they stay out of adb logcat.
+            LogService.instance.log(
+              tag,
+              message,
+              sensitivity: LogSensitivity.sensitive,
+            );
           }
           break;
       }
@@ -204,8 +210,11 @@ class WebInterceptNative {
       final count = await _channel.invokeMethod('attachToWebViews', {
         if (siteId != null) 'siteId': siteId,
       });
-      LogService.instance.log('WebIntercept',
-          'Attached native interceptor to $count webviews (siteId: $siteId)');
+      LogService.instance.log(
+        'WebIntercept',
+        'Attached native interceptor to $count webviews (siteId: $siteId)',
+        sensitivity: LogSensitivity.sensitive,
+      );
       return count as int;
     } catch (e) {
       LogService.instance.log('WebIntercept',

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -281,6 +281,7 @@ class ProxyManager {
         'Effective proxy missing address; aborting setProxyOverride. '
             'Effective: ${effective.describeForLogs()}',
         level: LogLevel.error,
+        sensitivity: LogSensitivity.sensitive,
       );
       throw Exception('Proxy address is required');
     }
@@ -292,6 +293,7 @@ class ProxyManager {
         'Effective proxy address malformed (expected host:port). '
             'Effective: ${effective.describeForLogs()}',
         level: LogLevel.error,
+        sensitivity: LogSensitivity.sensitive,
       );
       throw Exception('Proxy address must be in format host:port');
     }
@@ -304,6 +306,7 @@ class ProxyManager {
         'Effective proxy port is not numeric. '
             'Effective: ${effective.describeForLogs()}',
         level: LogLevel.error,
+        sensitivity: LogSensitivity.sensitive,
       );
       throw Exception('Invalid port number');
     }
@@ -324,6 +327,7 @@ class ProxyManager {
           '${fellThrough ? ', via DEFAULT->global fallthrough' : ''}, '
           'effective: ${effective.describeForLogs()})',
       level: LogLevel.info,
+      sensitivity: LogSensitivity.sensitive,
     );
     await controller.setProxyOverride(
       settings: inapp.ProxySettings(
@@ -1964,7 +1968,11 @@ class WebViewFactory {
         ? _userProxyToInappProxy(resolveEffectiveProxy(config.proxySettings!))
         : null;
 
-    LogService.instance.log('DnsBlock', 'Creating webview: siteId=${config.siteId} dnsBlock=${config.dnsBlockEnabled} hasBlocklist=${DnsBlockService.instance.hasBlocklist} isAndroid=${Platform.isAndroid} url=${config.initialUrl} containerId=$containerId proxySettings=${inappProxy != null}');
+    LogService.instance.log(
+      'DnsBlock',
+      'Creating webview: siteId=${config.siteId} dnsBlock=${config.dnsBlockEnabled} hasBlocklist=${DnsBlockService.instance.hasBlocklist} isAndroid=${Platform.isAndroid} url=${config.initialUrl} containerId=$containerId proxySettings=${inappProxy != null}',
+      sensitivity: LogSensitivity.sensitive,
+    );
 
     final settings = inapp.InAppWebViewSettings(
       containerId: containerId,
@@ -2231,6 +2239,7 @@ class WebViewFactory {
                       '${classes.length} class / ${ids.length} id → '
                       '${selectors.length} hide(s): [$preview${selectors.length > 8 ? ", …" : ""}]',
                   level: LogLevel.debug,
+                  sensitivity: LogSensitivity.sensitive,
                 );
               }
               return selectors;
@@ -2310,7 +2319,11 @@ class WebViewFactory {
                 DownloadsService.instance.fail(taskId, e.message);
               }
             } catch (e, stack) {
-              debugPrint('Blob download error: $e\n$stack');
+              LogService.instance.log(
+                'WebView',
+                'Blob download error: $e\n$stack',
+                level: LogLevel.error,
+              );
               if (taskId.isNotEmpty) {
                 DownloadsService.instance.fail(taskId, e.toString());
               }
@@ -2401,6 +2414,7 @@ class WebViewFactory {
             'requesting native interceptor attach: siteId=${config.siteId} '
                 'initialUrl=${config.initialUrl}',
             level: LogLevel.debug,
+            sensitivity: LogSensitivity.sensitive,
           );
           Future.microtask(() => WebInterceptNative.attachToWebViews(siteId: config.siteId));
         }
@@ -2426,9 +2440,12 @@ class WebViewFactory {
         // onReceivedError handles recovery.
         final externalInfo = ExternalUrlParser.parse(url);
         if (externalInfo != null) {
-          LogService.instance.log('WebView',
-              'External scheme intercepted: scheme=${externalInfo.scheme} '
-              'package=${externalInfo.package} fallback=${externalInfo.fallbackUrl} url=$url');
+          LogService.instance.log(
+            'WebView',
+            'External scheme intercepted: scheme=${externalInfo.scheme} '
+                'package=${externalInfo.package} fallback=${externalInfo.fallbackUrl} url=$url',
+            sensitivity: LogSensitivity.sensitive,
+          );
           // intent:// with a resolvable web URL: route the fallback
           // through the standard same-domain / cross-domain path, no
           // confirmation prompt. We are the browser; handing the user
@@ -2441,8 +2458,11 @@ class WebViewFactory {
           if (externalInfo.scheme == 'intent') {
             final resolved = ExternalUrlParser.intentToWebUrl(externalInfo);
             if (resolved != null) {
-              LogService.instance.log('WebView',
-                  'intent fallback resolved → $resolved (from $url)');
+              LogService.instance.log(
+                'WebView',
+                'intent fallback resolved → $resolved (from $url)',
+                sensitivity: LogSensitivity.sensitive,
+              );
               bool allow = true;
               if (config.shouldOverrideUrlLoading != null) {
                 final hasGesture = _hasUserGesture(navigationAction);
@@ -2517,9 +2537,12 @@ class WebViewFactory {
           final rewritten = ContentBlockerService.instance
               .rewrittenUrl(url, requestType: 'document');
           if (rewritten != null && rewritten != url) {
-            LogService.instance.log('ContentBlocker',
-                '\$removeparam= rewrote $url → $rewritten',
-                level: LogLevel.debug);
+            LogService.instance.log(
+              'ContentBlocker',
+              '\$removeparam= rewrote $url → $rewritten',
+              level: LogLevel.debug,
+              sensitivity: LogSensitivity.sensitive,
+            );
             controller.loadUrl(
                 urlRequest: inapp.URLRequest(url: inapp.WebUri(rewritten)));
             return inapp.NavigationActionPolicy.CANCEL;
@@ -2575,8 +2598,11 @@ class WebViewFactory {
             url.startsWith('http') &&
             _hasUserGesture(navigationAction)) {
           if (iosUlBypass.shouldCancelAndReissue(url)) {
-            LogService.instance.log('WebView',
-                '  -> CANCEL (iOS UL bypass: reissuing programmatically) $url');
+            LogService.instance.log(
+              'WebView',
+              '  -> CANCEL (iOS UL bypass: reissuing programmatically) $url',
+              sensitivity: LogSensitivity.sensitive,
+            );
             // Forward original headers so per-site Accept-Language
             // survives the reissue. POST body is dropped — POSTs
             // that match AASA are rare and the existing flow lost
@@ -2590,16 +2616,22 @@ class WebViewFactory {
             ));
             return inapp.NavigationActionPolicy.CANCEL;
           }
-          LogService.instance.log('WebView',
-              '  -> ALLOW (iOS UL bypass: reissued nav passing through)');
+          LogService.instance.log(
+            'WebView',
+            '  -> ALLOW (iOS UL bypass: reissued nav passing through)',
+            sensitivity: LogSensitivity.sensitive,
+          );
         }
         return inapp.NavigationActionPolicy.ALLOW;
       },
       onCreateWindow: (controller, createWindowAction) async {
         final url = createWindowAction.request.url?.toString() ?? '';
         final windowId = createWindowAction.windowId;
-        LogService.instance.log('WebView',
-            'onCreateWindow: url=$url windowId=$windowId');
+        LogService.instance.log(
+          'WebView',
+          'onCreateWindow: url=$url windowId=$windowId',
+          sensitivity: LogSensitivity.sensitive,
+        );
 
         // Show popup dialog for Cloudflare challenges (captcha verification).
         if (isCaptchaChallenge(url)) {
@@ -2615,14 +2647,20 @@ class WebViewFactory {
         // the same confirmation path as direct navigations.
         final externalInfo = ExternalUrlParser.parse(url);
         if (externalInfo != null) {
-          LogService.instance.log('WebView',
-              'External scheme intercepted (onCreateWindow): '
-              'scheme=${externalInfo.scheme} package=${externalInfo.package} url=$url');
+          LogService.instance.log(
+            'WebView',
+            'External scheme intercepted (onCreateWindow): '
+                'scheme=${externalInfo.scheme} package=${externalInfo.package} url=$url',
+            sensitivity: LogSensitivity.sensitive,
+          );
           if (externalInfo.scheme == 'intent') {
             final resolved = ExternalUrlParser.intentToWebUrl(externalInfo);
             if (resolved != null) {
-              LogService.instance.log('WebView',
-                  'intent fallback resolved (onCreateWindow) → $resolved (from $url)');
+              LogService.instance.log(
+                'WebView',
+                'intent fallback resolved (onCreateWindow) → $resolved (from $url)',
+                sensitivity: LogSensitivity.sensitive,
+              );
               bool allow = true;
               if (config.shouldOverrideUrlLoading != null) {
                 final hasGesture = _hasUserGesture(createWindowAction);
@@ -2858,9 +2896,12 @@ class WebViewFactory {
               if (liveUrl == urlStr) {
                 config.onHtmlLoaded!(urlStr, html);
               } else {
-                LogService.instance.log('WebView',
-                    'Skipping cache save: URL changed during getHtml() '
-                    '($urlStr -> $liveUrl)');
+                LogService.instance.log(
+                  'WebView',
+                  'Skipping cache save: URL changed during getHtml() '
+                      '($urlStr -> $liveUrl)',
+                  sensitivity: LogSensitivity.sensitive,
+                );
               }
             }
           } catch (_) {
@@ -2914,8 +2955,11 @@ class WebViewFactory {
         // to the OS and the OS rejected. Show the user prompt; on
         // approval pin the cached cert and reload.
         if (_isSslError(error.type)) {
-          LogService.instance.log('TLS',
-              'onReceivedError ssl: type=${error.type} url=$reqUrl description="${error.description}"');
+          LogService.instance.log(
+            'TLS',
+            'onReceivedError ssl: type=${error.type} url=$reqUrl description="${error.description}"',
+            sensitivity: LogSensitivity.sensitive,
+          );
           final handled = await _handleSslLoadError(
             controller: controller,
             url: reqUrl,
@@ -2926,8 +2970,11 @@ class WebViewFactory {
         final externalInfo = ExternalUrlParser.parse(reqUrl);
         if (externalInfo == null) return;
         if (ExternalUrlSuppressor.isSuppressedInfo(externalInfo)) {
-          LogService.instance.log('WebView',
-              'onReceivedError: suppressed — loading about:blank to clear error commit (url=$reqUrl)');
+          LogService.instance.log(
+            'WebView',
+            'onReceivedError: suppressed — loading about:blank to clear error commit (url=$reqUrl)',
+            sensitivity: LogSensitivity.sensitive,
+          );
           // The fallback page actually loaded (HtmlCache shows
           // multi-MB saves); Android then painted chrome-error://
           // chromewebdata over it because the page's JS retried the
@@ -2949,8 +2996,11 @@ class WebViewFactory {
           final resolved = ExternalUrlParser.intentToWebUrl(externalInfo);
           if (resolved != null) {
             ExternalUrlSuppressor.mark(externalInfo);
-            LogService.instance.log('WebView',
-                'onReceivedError: intent fallback resolved → $resolved (from $reqUrl)');
+            LogService.instance.log(
+              'WebView',
+              'onReceivedError: intent fallback resolved → $resolved (from $reqUrl)',
+              sensitivity: LogSensitivity.sensitive,
+            );
             Future.microtask(() async {
               try {
                 bool allow = true;
@@ -2974,16 +3024,22 @@ class WebViewFactory {
           // user can still choose to launch the target app.
         }
         if (config.onExternalSchemeUrl != null) {
-          LogService.instance.log('WebView',
-              'onReceivedError: type=${error.type} url=$reqUrl '
-              '— routing to external-scheme dialog');
+          LogService.instance.log(
+            'WebView',
+            'onReceivedError: type=${error.type} url=$reqUrl '
+                '— routing to external-scheme dialog',
+            sensitivity: LogSensitivity.sensitive,
+          );
           config.onExternalSchemeUrl!(reqUrl, externalInfo);
           return;
         }
         final recovery = lastStableUrl ?? config.initialUrl;
-        LogService.instance.log('WebView',
-            'onReceivedError: type=${error.type} url=$reqUrl '
-            '— no host UI, scheduling reload of $recovery');
+        LogService.instance.log(
+          'WebView',
+          'onReceivedError: type=${error.type} url=$reqUrl '
+              '— no host UI, scheduling reload of $recovery',
+          sensitivity: LogSensitivity.sensitive,
+        );
         Future.microtask(() async {
           try {
             await controller.loadUrl(
@@ -3082,22 +3138,31 @@ class WebViewFactory {
       fingerprint: fingerprint,
     )) {
       LogService.instance.log(
-          'TLS', 'pinned cert accepted for $host:$port (sha256=$fingerprint)');
+        'TLS',
+        'pinned cert accepted for $host:$port (sha256=$fingerprint)',
+        sensitivity: LogSensitivity.sensitive,
+      );
       return inapp.ServerTrustAuthResponse(
           action: inapp.ServerTrustAuthResponseAction.PROCEED);
     }
     // Post-failure platforms (Android, Linux): the OS already rejected
     // the chain. Prompt the user now.
     if (prompt == null) {
-      LogService.instance.log('TLS',
-          'untrusted cert for $host:$port and no host UI — cancelling load');
+      LogService.instance.log(
+        'TLS',
+        'untrusted cert for $host:$port and no host UI — cancelling load',
+        sensitivity: LogSensitivity.sensitive,
+      );
       return inapp.ServerTrustAuthResponse(
           action: inapp.ServerTrustAuthResponseAction.CANCEL);
     }
     final approved = await prompt(host, port, cert);
     if (!approved) {
       LogService.instance.log(
-          'TLS', 'user rejected untrusted cert for $host:$port');
+        'TLS',
+        'user rejected untrusted cert for $host:$port',
+        sensitivity: LogSensitivity.sensitive,
+      );
       return inapp.ServerTrustAuthResponse(
           action: inapp.ServerTrustAuthResponseAction.CANCEL);
     }
@@ -3107,11 +3172,17 @@ class WebViewFactory {
         port: port,
         fingerprint: fingerprint,
       );
-      LogService.instance.log('TLS',
-          'user trusted cert for $host:$port (pinned sha256=$fingerprint)');
+      LogService.instance.log(
+        'TLS',
+        'user trusted cert for $host:$port (pinned sha256=$fingerprint)',
+        sensitivity: LogSensitivity.sensitive,
+      );
     } else {
-      LogService.instance.log('TLS',
-          'user trusted cert for $host:$port (no DER from platform — not pinned)');
+      LogService.instance.log(
+        'TLS',
+        'user trusted cert for $host:$port (no DER from platform — not pinned)',
+        sensitivity: LogSensitivity.sensitive,
+      );
     }
     // Android's SslErrorHandler (and WPE's TLS-error proxy) may have
     // been invalidated during the async prompt — the WebView gives up
@@ -3220,13 +3291,19 @@ class WebViewFactory {
       fingerprint: fingerprint,
     )) {
       if (!_claimReloadGuard(key)) {
-        LogService.instance.log('TLS',
-            'ignoring further ssl errors for $host:$port — reload already in flight');
+        LogService.instance.log(
+          'TLS',
+          'ignoring further ssl errors for $host:$port — reload already in flight',
+          sensitivity: LogSensitivity.sensitive,
+        );
         return true;
       }
-      LogService.instance.log('TLS',
-          'pin matches but iOS reported error for $host:$port — reloading once '
-          '(os: ${Platform.operatingSystem} ${Platform.operatingSystemVersion})');
+      LogService.instance.log(
+        'TLS',
+        'pin matches but iOS reported error for $host:$port — reloading once '
+            '(os: ${Platform.operatingSystem} ${Platform.operatingSystemVersion})',
+        sensitivity: LogSensitivity.sensitive,
+      );
       Future.microtask(() async {
         try {
           await controller.loadUrl(
@@ -3242,12 +3319,18 @@ class WebViewFactory {
       final approved = await prompt(host, port, cert);
       if (!approved) {
         LogService.instance.log(
-            'TLS', 'user rejected untrusted cert for $host:$port');
+          'TLS',
+          'user rejected untrusted cert for $host:$port',
+          sensitivity: LogSensitivity.sensitive,
+        );
         return false;
       }
       if (fingerprint == null) {
-        LogService.instance.log('TLS',
-            'user trusted cert for $host:$port but DER missing — cannot pin, load will fail again');
+        LogService.instance.log(
+          'TLS',
+          'user trusted cert for $host:$port but DER missing — cannot pin, load will fail again',
+          sensitivity: LogSensitivity.sensitive,
+        );
         return false;
       }
       await TrustedHostsService.instance.trust(
@@ -3255,8 +3338,11 @@ class WebViewFactory {
         port: port,
         fingerprint: fingerprint,
       );
-      LogService.instance.log('TLS',
-          'user trusted cert for $host:$port (pinned sha256=$fingerprint) — reloading');
+      LogService.instance.log(
+        'TLS',
+        'user trusted cert for $host:$port (pinned sha256=$fingerprint) — reloading',
+        sensitivity: LogSensitivity.sensitive,
+      );
       try {
         await controller.loadUrl(
           urlRequest: inapp.URLRequest(url: inapp.WebUri(url)),
@@ -3343,7 +3429,11 @@ class WebViewFactory {
     } on DownloadException catch (e) {
       DownloadsService.instance.fail(task.id, e.message);
     } catch (e, stack) {
-      debugPrint('Download error: $e\n$stack');
+      LogService.instance.log(
+        'Download',
+        'Download error: $e\n$stack',
+        level: LogLevel.error,
+      );
       DownloadsService.instance.fail(task.id, e.toString());
     }
   }
@@ -3372,7 +3462,11 @@ class WebViewFactory {
     } on DownloadException catch (e) {
       DownloadsService.instance.fail(task.id, e.message);
     } catch (e, stack) {
-      debugPrint('Data-URI download error: $e\n$stack');
+      LogService.instance.log(
+        'Download',
+        'Data-URI download error: $e\n$stack',
+        level: LogLevel.error,
+      );
       DownloadsService.instance.fail(task.id, e.toString());
     }
   }
@@ -3396,7 +3490,11 @@ class WebViewFactory {
     try {
       await controller.evaluateJavascript(source: script);
     } catch (e, stack) {
-      debugPrint('Blob download eval error: $e\n$stack');
+      LogService.instance.log(
+        'Download',
+        'Blob download eval error: $e\n$stack',
+        level: LogLevel.error,
+      );
       DownloadsService.instance.fail(task.id, e.toString());
     }
   }

--- a/lib/services/webview_state_secure_storage.dart
+++ b/lib/services/webview_state_secure_storage.dart
@@ -172,12 +172,14 @@ class SecureWebViewStateStorage implements WebViewStateStorage {
       LogService.instance.log(
         'WebViewState',
         'Saved ${state.length} bytes for site $siteId (encrypted)',
+        sensitivity: LogSensitivity.sensitive,
       );
     } catch (e) {
       LogService.instance.log(
         'WebViewState',
         'Error saving state for $siteId: $e',
         level: LogLevel.error,
+        sensitivity: LogSensitivity.sensitive,
       );
     }
   }
@@ -200,6 +202,7 @@ class SecureWebViewStateStorage implements WebViewStateStorage {
         'WebViewState',
         'Error loading state for $siteId: $e',
         level: LogLevel.error,
+        sensitivity: LogSensitivity.sensitive,
       );
       // Corrupt entry — defensive: remove so a re-save can succeed
       // and we don't keep failing loads in a hot loop.
@@ -224,6 +227,7 @@ class SecureWebViewStateStorage implements WebViewStateStorage {
         'WebViewState',
         'Error deleting state for $siteId: $e',
         level: LogLevel.error,
+        sensitivity: LogSensitivity.sensitive,
       );
     }
   }

--- a/lib/settings/global_outbound_proxy.dart
+++ b/lib/settings/global_outbound_proxy.dart
@@ -71,6 +71,7 @@ class GlobalOutboundProxy {
       'Proxy',
       'GlobalOutboundProxy initialized: ${_current.describeForLogs()}',
       level: LogLevel.info,
+      sensitivity: LogSensitivity.sensitive,
     );
   }
 
@@ -87,6 +88,7 @@ class GlobalOutboundProxy {
       'Proxy',
       'GlobalOutboundProxy updated: ${settings.describeForLogs()}',
       level: LogLevel.info,
+      sensitivity: LogSensitivity.sensitive,
     );
   }
 

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -592,9 +592,20 @@ class WebViewModel {
     if (webview == null) {
       // Use this.language directly to ensure we get the current value from WebViewModel
       final effectiveLanguage = this.language;
-      LogService.instance.log('WebView', 'Creating webview for "$name" (siteId: $siteId, initUrl: $initUrl)');
-      LogService.instance.log('WebView', 'Language: $effectiveLanguage (param: $language)');
-      LogService.instance.log('WebView', 'Using cached HTML: ${initialHtml != null} (${initialHtml?.length ?? 0} bytes)');
+      LogService.instance.log(
+        'WebView',
+        'Creating webview for "$name" (siteId: $siteId, initUrl: $initUrl)',
+        sensitivity: LogSensitivity.sensitive,
+      );
+      LogService.instance.log(
+        'WebView',
+        'Language: $effectiveLanguage (param: $language)',
+      );
+      LogService.instance.log(
+        'WebView',
+        'Using cached HTML: ${initialHtml != null} (${initialHtml?.length ?? 0} bytes)',
+        sensitivity: LogSensitivity.sensitive,
+      );
       final bool isMobile = Platform.isIOS || Platform.isAndroid;
       final pullToRefreshController = isMobile ? inapp.PullToRefreshController(
         settings: inapp.PullToRefreshSettings(enabled: true),
@@ -676,7 +687,11 @@ class WebViewModel {
           pullToRefreshController: pullToRefreshController,
           onWindowRequested: onWindowRequested,
           shouldOverrideUrlLoading: (url, hasGesture) {
-            LogService.instance.log('WebView', 'shouldOverrideUrlLoading: site="$name" (siteId: $siteId) initUrl=$initUrl request=$url hasGesture=$hasGesture');
+            LogService.instance.log(
+              'WebView',
+              'shouldOverrideUrlLoading: site="$name" (siteId: $siteId) initUrl=$initUrl request=$url hasGesture=$hasGesture',
+              sensitivity: LogSensitivity.sensitive,
+            );
             final result = NavigationDecisionEngine.decideShouldOverrideUrlLoading(
               targetUrl: url,
               initUrl: initUrl,
@@ -698,16 +713,32 @@ class WebViewModel {
             }
             switch (result.decision) {
               case NavigationDecision.allow:
-                LogService.instance.log('WebView', '  -> ALLOW');
+                LogService.instance.log(
+                  'WebView',
+                  '  -> ALLOW',
+                  sensitivity: LogSensitivity.sensitive,
+                );
                 return true;
               case NavigationDecision.blockSilent:
-                LogService.instance.log('WebView', '  -> CANCEL (auto-redirect blocked, no user gesture)');
+                LogService.instance.log(
+                  'WebView',
+                  '  -> CANCEL (auto-redirect blocked, no user gesture)',
+                  sensitivity: LogSensitivity.sensitive,
+                );
                 return false;
               case NavigationDecision.blockSuppressed:
-                LogService.instance.log('WebView', '  -> CANCEL (background site, suppressing nested webview)');
+                LogService.instance.log(
+                  'WebView',
+                  '  -> CANCEL (background site, suppressing nested webview)',
+                  sensitivity: LogSensitivity.sensitive,
+                );
                 return false;
               case NavigationDecision.blockOpenNested:
-                LogService.instance.log('WebView', '  -> CANCEL (opening nested webview)');
+                LogService.instance.log(
+                  'WebView',
+                  '  -> CANCEL (opening nested webview)',
+                  sensitivity: LogSensitivity.sensitive,
+                );
                 launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, localCdnEnabled: localCdnEnabled, trackingProtectionEnabled: trackingProtectionEnabled, language: this.language, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, liveLocationGranularity: liveLocationGranularity, webRtcPolicy: webRtcPolicy, userScripts: combineUserScripts(globalUserScripts), proxySettings: proxySettings, notificationsEnabled: notificationsEnabled);
                 return false;
             }
@@ -770,13 +801,25 @@ class WebViewModel {
                 handled.decision != NavigationDecision.allow) {
               switch (handled.decision!) {
                 case NavigationDecision.blockSilent:
-                  LogService.instance.log('WebView', 'onUrlChanged: cross-domain redirect blocked: $url (expected domain: $initDomain)');
+                  LogService.instance.log(
+                    'WebView',
+                    'onUrlChanged: cross-domain redirect blocked: $url (expected domain: $initDomain)',
+                    sensitivity: LogSensitivity.sensitive,
+                  );
                   return;
                 case NavigationDecision.blockSuppressed:
-                  LogService.instance.log('WebView', 'onUrlChanged: cross-domain redirect suppressed (background site): $url');
+                  LogService.instance.log(
+                    'WebView',
+                    'onUrlChanged: cross-domain redirect suppressed (background site): $url',
+                    sensitivity: LogSensitivity.sensitive,
+                  );
                   return;
                 case NavigationDecision.blockOpenNested:
-                  LogService.instance.log('WebView', 'onUrlChanged: cross-domain redirect detected: $url (expected domain: $initDomain)');
+                  LogService.instance.log(
+                    'WebView',
+                    'onUrlChanged: cross-domain redirect detected: $url (expected domain: $initDomain)',
+                    sensitivity: LogSensitivity.sensitive,
+                  );
                   if (handled.launchNestedUrl != null) {
                     launchUrlFunc(handled.launchNestedUrl!, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, localCdnEnabled: localCdnEnabled, trackingProtectionEnabled: trackingProtectionEnabled, language: this.language, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, liveLocationGranularity: liveLocationGranularity, webRtcPolicy: webRtcPolicy, userScripts: combineUserScripts(globalUserScripts), proxySettings: proxySettings, notificationsEnabled: notificationsEnabled);
                   }
@@ -896,7 +939,11 @@ class WebViewModel {
           },
         ),
         onControllerCreated: (ctrl) {
-          LogService.instance.log('WebView', 'onControllerCreated for "$name" (siteId: $siteId)');
+          LogService.instance.log(
+            'WebView',
+            'onControllerCreated for "$name" (siteId: $siteId)',
+            sensitivity: LogSensitivity.sensitive,
+          );
           controller = ctrl;
           setController();
           // Apply any state queued by the activation flow when this
@@ -918,8 +965,11 @@ class WebViewModel {
             unawaited(() async {
               try {
                 final ok = await ctrl.restoreState(pending);
-                LogService.instance.log('WebView',
-                    'restoreState for "$name" (siteId: $siteId): $ok');
+                LogService.instance.log(
+                  'WebView',
+                  'restoreState for "$name" (siteId: $siteId): $ok',
+                  sensitivity: LogSensitivity.sensitive,
+                );
               } catch (_) {
                 // Restore is best-effort; on failure the page is
                 // already loading from `currentUrl` — user just loses
@@ -1005,7 +1055,11 @@ class WebViewModel {
     if (notificationsEnabled) return;
     try {
       await controller!.pause();
-      LogService.instance.log('WebView', 'Paused webview for "$name" (siteId: $siteId)');
+      LogService.instance.log(
+        'WebView',
+        'Paused webview for "$name" (siteId: $siteId)',
+        sensitivity: LogSensitivity.sensitive,
+      );
     } catch (_) {
       // Controller may have been disposed
     }
@@ -1016,7 +1070,11 @@ class WebViewModel {
     if (controller == null) return;
     try {
       await controller!.resume();
-      LogService.instance.log('WebView', 'Resumed webview for "$name" (siteId: $siteId)');
+      LogService.instance.log(
+        'WebView',
+        'Resumed webview for "$name" (siteId: $siteId)',
+        sensitivity: LogSensitivity.sensitive,
+      );
     } catch (_) {
       // Controller may have been disposed
     }
@@ -1032,7 +1090,11 @@ class WebViewModel {
     try {
       await controller!.pause();
       await controller!.pauseAllJsTimers();
-      LogService.instance.log('WebView', 'App-lifecycle paused webview for "$name" (siteId: $siteId)');
+      LogService.instance.log(
+        'WebView',
+        'App-lifecycle paused webview for "$name" (siteId: $siteId)',
+        sensitivity: LogSensitivity.sensitive,
+      );
     } catch (_) {
       // Controller may have been disposed
     }
@@ -1044,7 +1106,11 @@ class WebViewModel {
     try {
       await controller!.resume();
       await controller!.resumeAllJsTimers();
-      LogService.instance.log('WebView', 'App-lifecycle resumed webview for "$name" (siteId: $siteId)');
+      LogService.instance.log(
+        'WebView',
+        'App-lifecycle resumed webview for "$name" (siteId: $siteId)',
+        sensitivity: LogSensitivity.sensitive,
+      );
     } catch (_) {
       // Controller may have been disposed
     }
@@ -1053,7 +1119,11 @@ class WebViewModel {
   /// Dispose the webview and controller to release resources.
   /// Used when unloading a site due to domain conflict.
   void disposeWebView() {
-    LogService.instance.log('WebView', 'disposeWebView called for "$name" (siteId: $siteId)');
+    LogService.instance.log(
+      'WebView',
+      'disposeWebView called for "$name" (siteId: $siteId)',
+      sensitivity: LogSensitivity.sensitive,
+    );
     webview = null;
     controller = null;
   }
@@ -1067,8 +1137,11 @@ class WebViewModel {
     if (controller == null) return;
     try {
       await controller!.clearCache();
-      LogService.instance.log('WebView',
-          'Cleared in-memory cache for "$name" (siteId: $siteId)');
+      LogService.instance.log(
+        'WebView',
+        'Cleared in-memory cache for "$name" (siteId: $siteId)',
+        sensitivity: LogSensitivity.sensitive,
+      );
     } catch (_) {
       // Controller may have been disposed mid-call.
     }

--- a/lib/widgets/external_url_prompt.dart
+++ b/lib/widgets/external_url_prompt.dart
@@ -103,6 +103,7 @@ Future<void> confirmAndLaunchExternalUrl(
     LogService.instance.log(
       'ExternalUrl',
       'suppressed (recently handled): ${info.url}',
+      sensitivity: LogSensitivity.sensitive,
     );
     return;
   }
@@ -117,17 +118,34 @@ Future<void> confirmAndLaunchExternalUrl(
     LogService.instance.log(
       'ExternalUrl',
       'prompt: scheme=${info.scheme} package=${info.package} '
-      'clearUrlsLoaded=$hasRules urlCleaned=$urlChanged '
-      'fallbackCleaned=$fallbackChanged',
+          'clearUrlsLoaded=$hasRules urlCleaned=$urlChanged '
+          'fallbackCleaned=$fallbackChanged',
+      sensitivity: LogSensitivity.sensitive,
     );
-    LogService.instance.log('ExternalUrl', '  rawUrl=${info.url}');
+    LogService.instance.log(
+      'ExternalUrl',
+      '  rawUrl=${info.url}',
+      sensitivity: LogSensitivity.sensitive,
+    );
     if (urlChanged) {
-      LogService.instance.log('ExternalUrl', '  cleanedUrl=$cleanedLaunchUrl');
+      LogService.instance.log(
+        'ExternalUrl',
+        '  cleanedUrl=$cleanedLaunchUrl',
+        sensitivity: LogSensitivity.sensitive,
+      );
     }
     if (info.fallbackUrl != null) {
-      LogService.instance.log('ExternalUrl', '  rawFallback=${info.fallbackUrl}');
+      LogService.instance.log(
+        'ExternalUrl',
+        '  rawFallback=${info.fallbackUrl}',
+        sensitivity: LogSensitivity.sensitive,
+      );
       if (fallbackChanged) {
-        LogService.instance.log('ExternalUrl', '  cleanedFallback=$cleanedFallback');
+        LogService.instance.log(
+          'ExternalUrl',
+          '  cleanedFallback=$cleanedFallback',
+          sensitivity: LogSensitivity.sensitive,
+        );
       }
     }
 
@@ -184,7 +202,11 @@ Future<void> confirmAndLaunchExternalUrl(
         ExternalUrlSuppressor.mark(info);
         return;
       case _ExternalUrlChoice.openInBrowser:
-        LogService.instance.log('ExternalUrl', 'user chose: open in browser → $cleanedFallback');
+        LogService.instance.log(
+          'ExternalUrl',
+          'user chose: open in browser → $cleanedFallback',
+          sensitivity: LogSensitivity.sensitive,
+        );
         ExternalUrlSuppressor.mark(info);
         // We are the browser. Load the fallback inside our own webview
         // so per-site settings (cookie isolation, proxy, content blocker
@@ -196,8 +218,11 @@ Future<void> confirmAndLaunchExternalUrl(
           try {
             await loadInWebView.loadUrl(cleanedFallback);
           } catch (e) {
-            LogService.instance.log('ExternalUrl',
-                'in-app loadUrl failed ($e), falling back to external launch');
+            LogService.instance.log(
+              'ExternalUrl',
+              'in-app loadUrl failed ($e), falling back to external launch',
+              sensitivity: LogSensitivity.sensitive,
+            );
             await _launchExternally(cleanedFallback, label: 'browser fallback');
           }
         } else {
@@ -205,7 +230,11 @@ Future<void> confirmAndLaunchExternalUrl(
         }
         return;
       case _ExternalUrlChoice.openInApp:
-        LogService.instance.log('ExternalUrl', 'user chose: open in app → $cleanedLaunchUrl');
+        LogService.instance.log(
+          'ExternalUrl',
+          'user chose: open in app → $cleanedLaunchUrl',
+          sensitivity: LogSensitivity.sensitive,
+        );
         ExternalUrlSuppressor.mark(info);
         await _launchInApp(cleanedLaunchUrl, cleanedFallback, info.scheme);
         return;
@@ -222,7 +251,11 @@ Future<void> confirmAndLaunchExternalUrl(
 Future<bool> _launchExternally(String url, {required String label}) async {
   final uri = Uri.tryParse(url);
   if (uri == null) {
-    LogService.instance.log('ExternalUrl', '$label: invalid URL, cannot launch — $url');
+    LogService.instance.log(
+      'ExternalUrl',
+      '$label: invalid URL, cannot launch — $url',
+      sensitivity: LogSensitivity.sensitive,
+    );
     return false;
   }
   try {
@@ -230,7 +263,11 @@ Future<bool> _launchExternally(String url, {required String label}) async {
       uri,
       mode: url_launcher.LaunchMode.externalApplication,
     );
-    LogService.instance.log('ExternalUrl', '$label: external launch result=$launched url=$url');
+    LogService.instance.log(
+      'ExternalUrl',
+      '$label: external launch result=$launched url=$url',
+      sensitivity: LogSensitivity.sensitive,
+    );
     if (!launched) {
       rootScaffoldMessengerKey.currentState?.showSnackBar(
         SnackBar(content: Text('No app available to open: $url')),
@@ -238,7 +275,11 @@ Future<bool> _launchExternally(String url, {required String label}) async {
     }
     return launched;
   } catch (e) {
-    LogService.instance.log('ExternalUrl', '$label: external launch threw — $e');
+    LogService.instance.log(
+      'ExternalUrl',
+      '$label: external launch threw — $e',
+      sensitivity: LogSensitivity.sensitive,
+    );
     rootScaffoldMessengerKey.currentState?.showSnackBar(
       SnackBar(content: Text('Could not open: $url')),
     );

--- a/test/log_no_siteid_leak_test.dart
+++ b/test/log_no_siteid_leak_test.dart
@@ -1,0 +1,209 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/log_service.dart';
+
+/// Mirrors `_generateSiteId` in `lib/web_view_model.dart` so tests
+/// exercise the same surface a real session would use. Format:
+/// `<microseconds-base36>-<rand-base36>`.
+String _generateSiteId() {
+  final now = DateTime.now().microsecondsSinceEpoch;
+  final random = Random().nextInt(999999);
+  return '${now.toRadixString(36)}-${random.toRadixString(36)}';
+}
+
+/// Captures any `print()` call inside [body], including the implicit
+/// pipe inside `debugPrint`. Returns the captured lines.
+Future<List<String>> _captureZonePrint(FutureOr<void> Function() body) async {
+  final captured = <String>[];
+  final completer = Completer<void>();
+  runZoned(
+    () async {
+      try {
+        await body();
+        completer.complete();
+      } catch (e, st) {
+        completer.completeError(e, st);
+      }
+    },
+    zoneSpecification: ZoneSpecification(
+      print: (self, parent, zone, line) {
+        captured.add(line);
+      },
+    ),
+  );
+  await completer.future;
+  return captured;
+}
+
+void main() {
+  setUp(() {
+    LogService.instance.resetForTest();
+  });
+
+  test('sensitive logs never appear in zone print stream', () async {
+    final siteId = _generateSiteId();
+    final url = 'https://example.org/private?token=abc123';
+
+    final captured = await _captureZonePrint(() async {
+      // Simulate a representative session: site creation, navigation,
+      // cookie capture, switch. Every per-site log call must already be
+      // tagged sensitive in production code; this asserts the contract
+      // holds end-to-end.
+      LogService.instance.log(
+        'WebView',
+        'Creating webview for "$siteId" (siteId: $siteId)',
+        sensitivity: LogSensitivity.sensitive,
+      );
+      LogService.instance.log(
+        'WebView',
+        'onUrlChanged: $url',
+        sensitivity: LogSensitivity.sensitive,
+      );
+      LogService.instance.log(
+        'Container',
+        'Bound container ws-$siteId to 1 webview(s)',
+        sensitivity: LogSensitivity.sensitive,
+      );
+      LogService.instance.log(
+        'CookieIsolation',
+        'Restoring cookies for siteId: $siteId',
+        sensitivity: LogSensitivity.sensitive,
+      );
+
+      // Normal logs are also fine — they should NOT carry siteId/URLs.
+      LogService.instance.log('App', 'Application started');
+    });
+
+    // Site identifier must never appear in adb logcat / iOS console
+    // (which is what zone `print` simulates here).
+    expect(
+      captured.where((l) => l.contains(siteId)),
+      isEmpty,
+      reason:
+          'siteId "$siteId" leaked through print() — sensitive entries must stay '
+          'memory-only. Captured: ${captured.length} line(s).',
+    );
+
+    // Container name format also must not appear.
+    expect(
+      captured.where((l) => l.contains('ws-$siteId')),
+      isEmpty,
+      reason: 'Container name leaked through print().',
+    );
+
+    // The per-site URL must not appear.
+    expect(
+      captured.where((l) => l.contains(url)),
+      isEmpty,
+      reason: 'Per-site URL leaked through print().',
+    );
+
+    // Per-site host must not appear either (broader regex).
+    expect(
+      captured.where((l) => l.contains('example.org')),
+      isEmpty,
+      reason: 'Per-site host leaked through print().',
+    );
+
+    // Sanity: the sensitive ring captured them.
+    final inSensitiveRing = LogService.instance.sensitiveEntries
+        .where((e) => e.message.contains(siteId))
+        .toList();
+    expect(inSensitiveRing, isNotEmpty,
+        reason: 'Sensitive entries should still reach the in-memory ring.');
+  });
+
+  test('export() never contains siteId-shaped substrings, even from sensitive logs',
+      () async {
+    final ids = [for (var i = 0; i < 5; i++) _generateSiteId()];
+
+    for (final id in ids) {
+      LogService.instance.log(
+        'WebView',
+        'siteId=$id',
+        sensitivity: LogSensitivity.sensitive,
+      );
+    }
+    // One normal log to confirm export() still works.
+    LogService.instance.log('App', 'started');
+
+    final exported = LogService.instance.export();
+    expect(exported, contains('started'));
+    for (final id in ids) {
+      expect(
+        exported,
+        isNot(contains(id)),
+        reason: 'siteId $id leaked into export() text',
+      );
+    }
+  });
+
+  test('siteId-shaped values land in sensitive ring under realistic call shape',
+      () async {
+    // Generate a few siteIds; if any matches the radix-36 shape regex
+    // also leaks into print, the assertion below will catch it.
+    final siteIds = [for (var i = 0; i < 3; i++) _generateSiteId()];
+
+    final captured = await _captureZonePrint(() async {
+      for (final id in siteIds) {
+        // The audit guarantees these call sites are sensitive.
+        LogService.instance.log(
+          'WebView',
+          'shouldOverrideUrlLoading: site (siteId: $id)',
+          sensitivity: LogSensitivity.sensitive,
+        );
+      }
+    });
+
+    // The siteId pattern is `<base36>-<base36>` — at least 6 chars
+    // before the dash, at least 1 after. Calibrated to the actual
+    // _generateSiteId output.
+    final siteIdRegex = RegExp(r'[0-9a-z]{6,}-[0-9a-z]+');
+    for (final line in captured) {
+      expect(
+        siteIdRegex.hasMatch(line),
+        isFalse,
+        reason: 'Line "$line" matches siteId regex; sensitive logging contract '
+            'broken.',
+      );
+    }
+
+    // All explicit siteIds we passed in are still searchable in the
+    // sensitive ring (proves we actually emitted something).
+    for (final id in siteIds) {
+      final hits = LogService.instance.sensitiveEntries
+          .where((e) => e.message.contains(id))
+          .toList();
+      expect(hits, isNotEmpty,
+          reason: 'siteId $id must be visible to developers via the toggle');
+    }
+  });
+
+  test('debugPrint pipe is silent for sensitive entries even in debug mode',
+      () async {
+    // We can't override kDebugMode at runtime, but we CAN observe what
+    // debugPrint pipes to the zone. The contract: only normal entries
+    // ever call debugPrint. We assert by capturing the zone's print
+    // stream (which is what debugPrint defaults to) and checking the
+    // sensitive payload never shows up.
+    final siteId = _generateSiteId();
+    final captured = <String>[];
+    final original = debugPrint;
+    debugPrint = (String? message, {int? wrapWidth}) {
+      if (message != null) captured.add(message);
+    };
+    try {
+      LogService.instance.log(
+        'WebView',
+        'siteId=$siteId',
+        sensitivity: LogSensitivity.sensitive,
+      );
+    } finally {
+      debugPrint = original;
+    }
+    expect(captured.where((l) => l.contains(siteId)), isEmpty);
+  });
+}

--- a/test/log_service_test.dart
+++ b/test/log_service_test.dart
@@ -1,0 +1,155 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/log_service.dart';
+
+void main() {
+  setUp(() {
+    LogService.instance.resetForTest();
+  });
+
+  group('LogService normal entries', () {
+    test('reach the persisted entries sink', () {
+      LogService.instance.log('Test', 'hello');
+      expect(LogService.instance.entries, hasLength(1));
+      expect(LogService.instance.entries.first.message, 'hello');
+    });
+
+    test('appear in export()', () {
+      LogService.instance.log('Test', 'first');
+      LogService.instance.log('Test', 'second');
+      final out = LogService.instance.export();
+      expect(out, contains('first'));
+      expect(out, contains('second'));
+    });
+  });
+
+  group('LogService sensitive entries', () {
+    test('stay out of the normal entries sink', () {
+      LogService.instance.log(
+        'Test',
+        'secret-payload',
+        sensitivity: LogSensitivity.sensitive,
+      );
+      expect(LogService.instance.entries, isEmpty);
+      expect(LogService.instance.sensitiveEntries, hasLength(1));
+      expect(LogService.instance.sensitiveEntries.first.message,
+          'secret-payload');
+    });
+
+    test('never reach export() (memory-only contract)', () {
+      LogService.instance.log(
+        'Test',
+        'secret-payload',
+        sensitivity: LogSensitivity.sensitive,
+      );
+      final out = LogService.instance.export();
+      expect(out, isNot(contains('secret-payload')));
+    });
+
+    test('do NOT print to the zone print stream', () {
+      final captured = <String>[];
+      runZoned(
+        () {
+          LogService.instance.log(
+            'Test',
+            'secret-payload',
+            sensitivity: LogSensitivity.sensitive,
+          );
+        },
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            captured.add(line);
+          },
+        ),
+      );
+      expect(captured.where((l) => l.contains('secret-payload')), isEmpty);
+    });
+
+    test('show up in allEntriesMerged ordered by timestamp', () async {
+      LogService.instance.log('Test', 'first-normal');
+      await Future<void>.delayed(const Duration(milliseconds: 2));
+      LogService.instance.log(
+        'Test',
+        'sensitive-mid',
+        sensitivity: LogSensitivity.sensitive,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 2));
+      LogService.instance.log('Test', 'last-normal');
+
+      final merged = LogService.instance.allEntriesMerged;
+      expect(merged.map((e) => e.message), [
+        'first-normal',
+        'sensitive-mid',
+        'last-normal',
+      ]);
+    });
+
+    test('are cleared on simulated process restart (resetForTest)', () {
+      LogService.instance.log(
+        'Test',
+        'pre-restart',
+        sensitivity: LogSensitivity.sensitive,
+      );
+      expect(LogService.instance.sensitiveEntries, hasLength(1));
+
+      // Simulate a cold launch: the in-memory ring is wiped, the toggle
+      // would reset to off (UI concern), and the singleton is reused.
+      LogService.instance.resetForTest();
+
+      expect(LogService.instance.sensitiveEntries, isEmpty);
+      expect(LogService.instance.entries, isEmpty);
+    });
+
+    test('clear() wipes both rings', () {
+      LogService.instance.log('Test', 'normal-1');
+      LogService.instance.log(
+        'Test',
+        'sensitive-1',
+        sensitivity: LogSensitivity.sensitive,
+      );
+      LogService.instance.clear();
+      expect(LogService.instance.entries, isEmpty);
+      expect(LogService.instance.sensitiveEntries, isEmpty);
+    });
+
+    test('respect the per-ring maxEntries cap', () {
+      for (var i = 0; i < LogService.maxEntries + 50; i++) {
+        LogService.instance.log(
+          'Test',
+          'sensitive-$i',
+          sensitivity: LogSensitivity.sensitive,
+        );
+      }
+      expect(LogService.instance.sensitiveEntries,
+          hasLength(LogService.maxEntries));
+      // The oldest entries should have rolled off.
+      expect(
+        LogService.instance.sensitiveEntries.first.message,
+        'sensitive-50',
+      );
+    });
+  });
+
+  group('LogEntry shape', () {
+    test('default sensitivity is normal', () {
+      LogService.instance.log('Test', 'message');
+      expect(
+        LogService.instance.entries.first.sensitivity,
+        LogSensitivity.normal,
+      );
+    });
+
+    test('sensitivity flag is preserved on the entry', () {
+      LogService.instance.log(
+        'Test',
+        'sec',
+        sensitivity: LogSensitivity.sensitive,
+      );
+      expect(
+        LogService.instance.sensitiveEntries.first.sensitivity,
+        LogSensitivity.sensitive,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Sensitive entries live in a memory-only ring, never written to disk,
never piped to debugPrint. Surfaced in the dev-tools log view only
when an explicit runtime toggle is on; the toggle resets on cold
launch.