### PR TITLE
Add defensive deserialization for boot-time JSON parsing

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1834,11 +1834,22 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   Future<void> _loadGlobalUserScripts() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     final json = prefs.getStringList('globalUserScripts');
-    if (json != null) {
-      _globalUserScripts = json
-          .map((s) => UserScriptConfig.fromJson(jsonDecode(s) as Map<String, dynamic>))
-          .toList();
+    if (json == null) return;
+    final loaded = <UserScriptConfig>[];
+    for (var i = 0; i < json.length; i++) {
+      try {
+        loaded.add(UserScriptConfig.fromJson(
+          jsonDecode(json[i]) as Map<String, dynamic>,
+        ));
+      } catch (e) {
+        LogService.instance.log(
+          'Boot',
+          'Skipped malformed global user script at index $i: $e',
+          level: LogLevel.warning,
+        );
+      }
     }
+    _globalUserScripts = loaded;
   }
 
   /// Migrate pre-opt-in data: older builds ran every enabled global script
@@ -2378,9 +2389,18 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     List<String>? webspacesJson = prefs.getStringList('webspaces');
 
     if (webspacesJson != null) {
-      List<Webspace> loadedWebspaces = webspacesJson
-          .map((webspaceJson) => Webspace.fromJson(jsonDecode(webspaceJson)))
-          .toList();
+      final loadedWebspaces = <Webspace>[];
+      for (var i = 0; i < webspacesJson.length; i++) {
+        try {
+          loadedWebspaces.add(Webspace.fromJson(jsonDecode(webspacesJson[i])));
+        } catch (e) {
+          LogService.instance.log(
+            'Boot',
+            'Skipped malformed webspace at index $i: $e',
+            level: LogLevel.warning,
+          );
+        }
+      }
 
       setState(() {
         _webspaces.addAll(loadedWebspaces);
@@ -2430,24 +2450,33 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       final secureProxyPasswords = await _proxyPasswordStorage.loadAll();
       final legacyMigrations = <String, String>{};
       final cleanedJsonStrings = <String>[];
-      for (final raw in webViewModelsJson) {
-        final decoded = jsonDecode(raw) as Map<String, dynamic>;
-        final proxy = decoded['proxySettings'];
-        if (proxy is Map<String, dynamic>) {
-          final pwd = proxy['password'];
-          if (pwd is String && pwd.isNotEmpty) {
-            final siteId = decoded['siteId'];
-            if (siteId is String && siteId.isNotEmpty) {
-              // Don't overwrite an existing secure-storage entry — the
-              // secure value wins on conflict (it's newer by definition).
-              if (!(secureProxyPasswords[siteId]?.isNotEmpty ?? false)) {
-                legacyMigrations[siteId] = pwd;
+      for (var i = 0; i < webViewModelsJson.length; i++) {
+        final raw = webViewModelsJson[i];
+        try {
+          final decoded = jsonDecode(raw) as Map<String, dynamic>;
+          final proxy = decoded['proxySettings'];
+          if (proxy is Map<String, dynamic>) {
+            final pwd = proxy['password'];
+            if (pwd is String && pwd.isNotEmpty) {
+              final siteId = decoded['siteId'];
+              if (siteId is String && siteId.isNotEmpty) {
+                // Don't overwrite an existing secure-storage entry — the
+                // secure value wins on conflict (it's newer by definition).
+                if (!(secureProxyPasswords[siteId]?.isNotEmpty ?? false)) {
+                  legacyMigrations[siteId] = pwd;
+                }
+                proxy.remove('password');
               }
-              proxy.remove('password');
             }
           }
+          cleanedJsonStrings.add(jsonEncode(decoded));
+        } catch (e) {
+          LogService.instance.log(
+            'Boot',
+            'Dropped unparseable site JSON at index $i: $e',
+            level: LogLevel.warning,
+          );
         }
-        cleanedJsonStrings.add(jsonEncode(decoded));
       }
       if (legacyMigrations.isNotEmpty) {
         final merged = <String, String?>{
@@ -2464,9 +2493,21 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         );
       }
 
-      List<WebViewModel> loadedWebViewModels = cleanedJsonStrings
-          .map((webViewModelJson) => WebViewModel.fromJson(jsonDecode(webViewModelJson), (){ setState((){}); _updateCanGoBack(); }))
-          .toList();
+      final loadedWebViewModels = <WebViewModel>[];
+      for (var i = 0; i < cleanedJsonStrings.length; i++) {
+        try {
+          loadedWebViewModels.add(WebViewModel.fromJson(
+            jsonDecode(cleanedJsonStrings[i]),
+            () { setState((){}); _updateCanGoBack(); },
+          ));
+        } catch (e) {
+          LogService.instance.log(
+            'Boot',
+            'Skipped malformed site at index $i: $e',
+            level: LogLevel.warning,
+          );
+        }
+      }
 
       // Hydrate per-site proxy passwords from secure storage.
       var hydratedCount = 0;

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -1253,9 +1253,10 @@ class WebViewModel {
       name: json['name'],
       cookies: isIncognito
           ? const <Cookie>[]
-          : (json['cookies'] as List<dynamic>)
-              .map((dynamic e) => cookieFromJson(e))
-              .toList(),
+          : (json['cookies'] as List<dynamic>?)
+                  ?.map((dynamic e) => cookieFromJson(e))
+                  .toList() ??
+              const <Cookie>[],
       proxySettings: UserProxySettings.fromJson(json['proxySettings']),
       javascriptEnabled: json['javascriptEnabled'],
       userAgent: json['userAgent'],

--- a/lib/webspace_model.dart
+++ b/lib/webspace_model.dart
@@ -26,9 +26,11 @@ class Webspace {
 
   factory Webspace.fromJson(Map<String, dynamic> json) {
     return Webspace(
-      id: json['id'],
-      name: json['name'],
-      siteIndices: (json['siteIndices'] as List<dynamic>).map((e) => e as int).toList(),
+      id: json['id'] as String?,
+      name: json['name'] as String? ?? 'Untitled',
+      siteIndices: (json['siteIndices'] as List<dynamic>?)
+          ?.whereType<int>()
+          .toList(),
     );
   }
 

--- a/test/web_view_model_test.dart
+++ b/test/web_view_model_test.dart
@@ -667,6 +667,38 @@ void main() {
         expect(json['cookies'], isEmpty);
       });
     });
+
+    // Defensive deserialization: malformed prefs blobs from partial writes
+    // or external backups must not crash boot. Pairs with the per-entry
+    // try/catch in `_loadWebViewModels`.
+    group('fromJson tolerates missing/null fields', () {
+      Map<String, dynamic> baseJson() => {
+            'initUrl': 'https://example.com',
+            'name': 'Example',
+            'proxySettings': {'type': 0},
+            'javascriptEnabled': true,
+            'userAgent': '',
+            'thirdPartyCookiesEnabled': false,
+            'incognito': false,
+            'clearUrlEnabled': true,
+            'dnsBlockEnabled': true,
+            'contentBlockEnabled': true,
+            'blockAutoRedirects': true,
+          };
+
+      test('missing cookies key falls back to empty list', () {
+        final json = baseJson();
+        // No 'cookies' key at all.
+        final model = WebViewModel.fromJson(json, null);
+        expect(model.cookies, isEmpty);
+      });
+
+      test('null cookies value falls back to empty list', () {
+        final json = baseJson()..['cookies'] = null;
+        final model = WebViewModel.fromJson(json, null);
+        expect(model.cookies, isEmpty);
+      });
+    });
   });
 
   group('extractDomain', () {

--- a/test/webspace_model_test.dart
+++ b/test/webspace_model_test.dart
@@ -212,5 +212,41 @@ void main() {
       // Should preserve negative indices (cleanup happens elsewhere)
       expect(restored.siteIndices, [-1, 0, 1]);
     });
+
+    // Defensive deserialization: malformed prefs blobs (partial writes,
+    // legacy schemas, external backups) must not crash boot. Pairs with
+    // the per-entry try/catch in `_loadWebspaces` so a single bad entry
+    // is dropped rather than fatal.
+    test('fromJson tolerates missing siteIndices (defaults to empty)', () {
+      final webspace = Webspace.fromJson({'id': 'x', 'name': 'NoIndices'});
+      expect(webspace.id, 'x');
+      expect(webspace.name, 'NoIndices');
+      expect(webspace.siteIndices, isEmpty);
+    });
+
+    test('fromJson tolerates null siteIndices (defaults to empty)', () {
+      final webspace =
+          Webspace.fromJson({'id': 'x', 'name': 'NullIndices', 'siteIndices': null});
+      expect(webspace.siteIndices, isEmpty);
+    });
+
+    test('fromJson tolerates missing id (generates a fresh one)', () {
+      final webspace = Webspace.fromJson({'name': 'NoId', 'siteIndices': [1, 2]});
+      expect(webspace.id, isNotEmpty);
+      expect(webspace.name, 'NoId');
+      expect(webspace.siteIndices, [1, 2]);
+    });
+
+    test('fromJson tolerates missing name (defaults to Untitled)', () {
+      final webspace = Webspace.fromJson({'id': 'x', 'siteIndices': []});
+      expect(webspace.name, 'Untitled');
+    });
+
+    test('fromJson on an empty map yields a usable, non-crashing Webspace', () {
+      final webspace = Webspace.fromJson(<String, dynamic>{});
+      expect(webspace.id, isNotEmpty);
+      expect(webspace.name, 'Untitled');
+      expect(webspace.siteIndices, isEmpty);
+    });
   });
 }


### PR DESCRIPTION
Wrap all boot-time JSON deserialization in try-catch blocks to prevent a single malformed preference entry from crashing app startup. Malformed entries are logged at warning level and skipped; valid entries load normally.

Key changes:
- `_loadGlobalUserScripts()`: iterate with index, catch per-entry, log skipped scripts
- `_loadWebspaces()`: iterate with index, catch per-entry, log skipped webspaces
- `_loadWebViewModels()`: iterate with index, catch per-entry during both legacy proxy-password migration and final deserialization, log skipped sites
- `Webspace.fromJson()`: add null-coalescing defaults (id generation, name → "Untitled", siteIndices → empty list) and filter non-int list elements
- `WebViewModel.fromJson()`: handle missing or null cookies list, default to empty

Pairs with per-entry try-catch so a single corrupted blob (partial write, legacy schema, external backup) is dropped rather than fatal. Tests added for edge cases: missing fields, null values, empty maps.

https://claude.ai/code/session_01HLDBuwMUot83E93Fmg9tQR