### PR TITLE
Simplify uBO resources setting description

### DIFF
--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -1370,11 +1370,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
             subtitle: Text(
               !ContentBlockerService.instance.rustEngineSupportedOnPlatform
                   ? 'Native adblock library not available on this platform.'
-                  : 'Returns uBO\'s stub bodies (noop.js, 1x1.gif, '
-                      'neutered tracker shims) for \$redirect= rule '
-                      'matches. Improves compatibility with sites that '
-                      'break when their tracker script returns empty. '
-                      'Off → \$redirect= rules drop the request.',
+                  : 'Return stub bodies for \$redirect= rules instead of dropping the request',
             ),
             value: ContentBlockerService.instance.useUboResources,
             onChanged: ContentBlockerService.instance


### PR DESCRIPTION
Shorten the subtitle text for the uBO resources toggle in app settings to be more concise and user-friendly.

The description was verbose and technical, explaining implementation details about stub bodies, noop.js, tracker shims, and the behavior difference between on and off states. Replaced with a single clear statement of the feature's purpose: returning stub bodies for $redirect= rules instead of dropping the request.

This improves readability in the settings UI without losing the essential meaning of what the toggle does.

https://claude.ai/code/session_012yjxPhMGbGh4m3XfGWWNqo