### PR TITLE
Fix site data clear sequencing for container mode

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3513,20 +3513,46 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   /// back to in-model cookie deletion + reload (the most that can be
   /// scoped to a single site when localStorage / IDB / SW are
   /// app-global).
+  ///
+  /// Container-mode sequencing matters: the fork's `deleteContainer`
+  /// no-ops on an in-use container (see container_native.dart), and
+  /// `model.disposeWebView()` only nulls the Dart-side controller /
+  /// widget cache — the native platform-view (WKWebView / AndroidView /
+  /// WebKitWebView) stays alive and bound to the container until the
+  /// IndexedStack rebuild unmounts the InAppWebView element. So phase
+  /// 1 wraps the drop in setState + endOfFrame to force tear-down,
+  /// phase 2 wipes against the now-unbound container, phase 3 re-adds
+  /// the index so the lazy creation path binds a fresh widget to the
+  /// freshly-empty container (without phase 3 the active tab stays
+  /// blank until the user navigates away and back).
   Future<void> _clearSiteData(int index) async {
     if (index < 0 || index >= _webViewModels.length) return;
     final model = _webViewModels[index];
     final plan = SiteDataClearEngine.planClear(useContainers: _useContainers);
+
     if (plan.disposeWebView) {
       _evictCacheIfOnline(model.siteId);
-      model.disposeWebView();
     }
-    if (plan.dropFromLoadedIndices) {
-      _loadedIndices.remove(index);
+
+    if (plan.disposeWebView ||
+        plan.dropFromLoadedIndices ||
+        plan.clearInModelCookies) {
+      setState(() {
+        if (plan.disposeWebView) {
+          model.disposeWebView();
+        }
+        if (plan.dropFromLoadedIndices) {
+          _loadedIndices.remove(index);
+        }
+        if (plan.clearInModelCookies) {
+          model.cookies = const [];
+        }
+      });
+      if (plan.dropFromLoadedIndices) {
+        await WidgetsBinding.instance.endOfFrame;
+      }
     }
-    if (plan.clearInModelCookies) {
-      model.cookies = const [];
-    }
+
     if (plan.wipeContainer) {
       await _containerIsolation.wipeContainers([model.siteId]);
     }
@@ -3535,7 +3561,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     }
     await _saveWebViewModels();
     if (!mounted) return;
-    if (plan.userDrivenReload) {
+    if (plan.dropFromLoadedIndices) {
+      setState(() {
+        _loadedIndices.add(index);
+      });
+    } else if (plan.userDrivenReload) {
       await _refreshCurrentSite();
     } else {
       setState(() {});

--- a/lib/services/container_isolation_engine.dart
+++ b/lib/services/container_isolation_engine.dart
@@ -92,12 +92,21 @@ class ContainerIsolationEngine {
     return deleted;
   }
 
-  /// Deletes the named containers and recreates them empty. Used at
-  /// app startup to wipe localStorage / IndexedDB / ServiceWorker cache
-  /// / HTTP cache for incognito sites — without this, on-disk container
-  /// data outlives the process and the next launch reads back stale
-  /// session state (issue #298). Idempotent and safe before any
-  /// webview binds: containers are materialized lazily on first bind.
+  /// Deletes the named containers and recreates them empty. Two call
+  /// sites:
+  ///
+  ///   - App startup, for incognito sites, so on-disk container data
+  ///     doesn't outlive the process and feed stale session state into
+  ///     the next launch (issue #298).
+  ///   - User-driven "Clear Site Data" (`_clearSiteData`), so cookies +
+  ///     localStorage + IDB + SW + HTTP cache go away in one call.
+  ///
+  /// Caller MUST ensure no live webview is bound to [siteIds] — the
+  /// fork's `deleteContainer` no-ops on an in-use container, so the
+  /// IndexedStack rebuild that drops the InAppWebView widget has to
+  /// complete before this runs (`await WidgetsBinding.instance.endOfFrame`
+  /// at the call site). Idempotent and safe before any webview binds:
+  /// containers are materialized lazily on first bind.
   Future<int> wipeContainers(Iterable<String> siteIds) async {
     if (!await containerNative.isSupported()) return 0;
     int wiped = 0;
@@ -108,7 +117,7 @@ class ContainerIsolationEngine {
     if (wiped > 0) {
       LogService.instance.log(
         'Container',
-        'Wiped $wiped incognito container(s) on startup',
+        'Wiped $wiped container(s)',
       );
     }
     return wiped;

--- a/lib/services/site_data_clear_engine.dart
+++ b/lib/services/site_data_clear_engine.dart
@@ -15,14 +15,24 @@
 /// nuclear option, [`ContainerIsolationEngine.wipeContainers`], but it
 /// was wired only to the share-into-incognito flow.
 class SiteDataClearPlan {
-  /// Dispose the live webview before the wipe so the named container
-  /// isn't bound when `deleteContainer` runs (native impl no-ops on an
-  /// in-use container — see [container_native.dart:deleteContainer]).
+  /// Null the Dart-side controller / cached widget on the model before
+  /// the wipe. Required but not sufficient for container mode: a Dart
+  /// null-out alone leaves the native platform-view alive and bound to
+  /// the container, so the wipe still no-ops — see
+  /// [dropFromLoadedIndices] for the rest of the dance.
   final bool disposeWebView;
 
   /// Drop the index from `_loadedIndices` so the IndexedStack rebuild
-  /// re-runs the lazy webview creation path with a fresh empty
-  /// container.
+  /// renders `SizedBox.shrink()` for it, unmounts the InAppWebView
+  /// element, and tears down the native platform-view (WKWebView /
+  /// AndroidView / WebKitWebView). Executor MUST wrap the drop in
+  /// setState + `await WidgetsBinding.instance.endOfFrame` before the
+  /// wipe — without the rebuild yield, `deleteContainer` races the
+  /// still-bound webview and silently no-ops (see container_native.dart
+  /// line 71-74). Executor MUST also re-add the index after the wipe
+  /// so the lazy creation path binds a fresh widget to the now-empty
+  /// container; otherwise the active tab stays blank until the user
+  /// navigates away and back.
   final bool dropFromLoadedIndices;
 
   /// Wipe the per-site native container — drops cookies, localStorage,


### PR DESCRIPTION
Restructure `_clearSiteData` to properly sequence the three phases required for container-mode cleanup: dispose the webview, unmount the widget via IndexedStack rebuild, wipe the container, then re-add the index to trigger lazy recreation.

The native `deleteContainer` no-ops on an in-use container (see container_native.dart). The previous code disposed the Dart-side controller but left the native platform-view (WKWebView / AndroidView / WebKitWebView) bound to the container, so the wipe silently failed. The fix wraps the dispose and index drop in `setState` + `await WidgetsBinding.instance.endOfFrame` to force the IndexedStack rebuild and unmount the InAppWebView element before wiping. After the wipe, re-add the index so the lazy creation path binds a fresh widget to the now-empty container.

Key changes:
- Wrap `disposeWebView()`, `_loadedIndices.remove()`, and cookie clear in `setState` with `endOfFrame` yield after the drop
- Move container wipe to after the rebuild completes
- Re-add the index to `_loadedIndices` after the wipe (phase 3) so the active tab doesn't stay blank
- Update `SiteDataClearPlan` and `ContainerIsolationEngine.wipeContainers` docstrings to document the sequencing requirement and dual call sites (startup + user-driven clear)
- Simplify container wipe log message to cover both startup and user-driven cases

https://claude.ai/code/session_01TLc3zWJhvhu4BTbfiu4jgi