### PR TITLE
fix(ios-ul-bypass): pass through .formSubmitted to keep POST body intact

### DIFF
--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -65,10 +65,10 @@ String generateRandomUserAgent() {
     'Android 16; Mobile', // Add an Android platform
   ];
 
-  String geckoVersion = '147.0';
+  String geckoVersion = '151.0';
   String geckoTrail = '20100101';
   String appName = 'Firefox';
-  String appVersion = '147.0';
+  String appVersion = '151.0';
 
   String platform = platforms[Random().nextInt(platforms.length)];
   return 'Mozilla/5.0 ($platform; rv:$geckoVersion) Gecko/$geckoTrail $appName/$appVersion';

--- a/lib/services/ios_universal_link_bypass.dart
+++ b/lib/services/ios_universal_link_bypass.dart
@@ -7,15 +7,22 @@
 /// without a prompt, and even when the user explicitly added the
 /// site to WebSpace and is using the webview on purpose.
 ///
-/// Generic fix: on iOS, for every main-frame http(s) navigation that
-/// has a user gesture (`.linkActivated` / `.formSubmitted`), cancel
-/// the navigation and reissue it via `controller.loadUrl`. WebKit
-/// treats programmatic loads as navigation type `.other` and skips
-/// AASA matching, so the URL renders inside the webview regardless
-/// of which apps are installed. Pure programmatic navigations
-/// (initial nav, server redirects without a tap origin, pushState)
-/// don't activate AASA in the first place and are passed through
-/// without interception.
+/// Generic fix: on iOS, for every main-frame http(s) navigation
+/// whose `WKNavigationAction.navigationType` is `.linkActivated`
+/// (user tap), cancel the navigation and reissue it via
+/// `controller.loadUrl`. WebKit treats programmatic loads as
+/// navigation type `.other` and skips AASA matching, so the URL
+/// renders inside the webview regardless of which apps are
+/// installed. Pure programmatic navigations (initial nav, server
+/// redirects without a tap origin, pushState) don't activate AASA
+/// in the first place and are passed through without interception.
+///
+/// `.formSubmitted` is intentionally NOT bypassed. `loadUrl` is a
+/// GET, so reissuing a form submit drops the POST body, which
+/// breaks credentialed flows (login, search, payments). Form POSTs
+/// to AASA-matching endpoints are exceedingly rare; apps publish
+/// AASA for content URLs (profile pages, map locations), not POST
+/// handlers.
 ///
 /// No domain/path list. iOS exposes no public API to ask "does this
 /// URL match an installed app's AASA?", so the bypass treats every
@@ -26,6 +33,22 @@
 /// separately via `ExternalUrlParser`.
 class IosUniversalLinkBypass {
   IosUniversalLinkBypass();
+
+  /// Webview-side gate: is this navigation eligible for the AASA
+  /// bypass? Returns true only for main-frame http(s) navigations
+  /// rooted in a user tap on a link. Form POSTs are intentionally
+  /// excluded — see the class doc for why.
+  ///
+  /// Caller passes `isLinkActivated = navigationAction.navigationType
+  /// == NavigationType.LINK_ACTIVATED` to keep this predicate free of
+  /// flutter_inappwebview imports (and unit-testable from pure Dart).
+  static bool isEligibleNavigation({
+    required bool isMainFrame,
+    required String url,
+    required bool isLinkActivated,
+  }) {
+    return isMainFrame && url.startsWith('http') && isLinkActivated;
+  }
 
   /// Per-WebView memo: URL → timestamp of the cancel-and-reissue.
   /// After we reissue programmatically the same URL fires

--- a/lib/services/user_agent_classifier.dart
+++ b/lib/services/user_agent_classifier.dart
@@ -82,10 +82,10 @@ String navigatorPlatformFor(DesktopUaPlatform p) {
 /// Firefox; the rendered shape matches the project's existing
 /// `generateRandomUserAgent()` output.
 const String firefoxLinuxDesktopUserAgent =
-    'Mozilla/5.0 (X11; Linux x86_64; rv:147.0) Gecko/20100101 Firefox/147.0';
+    'Mozilla/5.0 (X11; Linux x86_64; rv:151.0) Gecko/20100101 Firefox/151.0';
 const String firefoxMacosDesktopUserAgent =
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7; rv:147.0) '
-    'Gecko/20100101 Firefox/147.0';
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7; rv:151.0) '
+    'Gecko/20100101 Firefox/151.0';
 const String firefoxWindowsDesktopUserAgent =
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:147.0) '
-    'Gecko/20100101 Firefox/147.0';
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) '
+    'Gecko/20100101 Firefox/151.0';

--- a/lib/services/user_agent_metadata_builder.dart
+++ b/lib/services/user_agent_metadata_builder.dart
@@ -120,7 +120,7 @@ List<BrandVersion>? _brandVersionListFor(String ua) {
 
 /// `Sec-CH-UA-Full-Version-List` carries 4-segment versions
 /// (e.g. `137.0.6943.137`). UA strings often only carry the major (Firefox
-/// emits `147.0`, Chrome sometimes emits `137.0.0.0`); pad to four so we
+/// emits `151.0`, Chrome sometimes emits `137.0.0.0`); pad to four so we
 /// don't ship a suspiciously short value.
 String _padFullVersion(String version) {
   final parts = version.split('.');

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -2584,33 +2584,40 @@ class WebViewFactory {
         // native app for URLs whose host matches an installed app's
         // AASA — even when the user explicitly added the site to
         // WebSpace. iOS exposes no public API to detect AASA matches,
-        // so the bypass treats every gesture-rooted main-frame
-        // http(s) navigation as at-risk: cancel + reissue via
-        // `loadUrl`. WebKit treats programmatic loads as navigation
-        // type `.other` and skips AASA matching, keeping the page
-        // inside the webview regardless of which apps are installed.
-        // The reissued nav fires `shouldOverrideUrlLoading` again;
-        // the per-URL memo passes that second pass through.
+        // so the bypass treats every tap-rooted main-frame http(s)
+        // navigation as at-risk: cancel + reissue via `loadUrl`.
+        // WebKit treats programmatic loads as navigation type
+        // `.other` and skips AASA matching, keeping the page inside
+        // the webview regardless of which apps are installed. The
+        // reissued nav fires `shouldOverrideUrlLoading` again; the
+        // per-URL memo passes that second pass through.
+        //
+        // Scoped to LINK_ACTIVATED only — FORM_SUBMITTED is
+        // intentionally passed through. Reissuing a form submit via
+        // `loadUrl` would drop the POST body (loadUrl is GET), which
+        // breaks every credentialed form on the web (logins, search,
+        // payments). LinkedIn's `/checkpoint/lg/login-submit` was the
+        // canonical 404 case. Form POSTs to AASA-matching endpoints
+        // are exceedingly rare; apps publish AASA for content URLs
+        // (profile pages, map locations), not POST handlers.
         //
         // Pure programmatic navigations (initial nav, server
         // redirects without a tap origin, pushState) carry no user
         // gesture — they don't activate AASA in the first place and
         // are passed through here without interception.
         if (Platform.isIOS &&
-            isMainFrame &&
-            url.startsWith('http') &&
-            _hasUserGesture(navigationAction)) {
+            IosUniversalLinkBypass.isEligibleNavigation(
+              isMainFrame: isMainFrame,
+              url: url,
+              isLinkActivated: navigationAction.navigationType ==
+                  inapp.NavigationType.LINK_ACTIVATED,
+            )) {
           if (iosUlBypass.shouldCancelAndReissue(url)) {
             LogService.instance.log(
               'WebView',
               '  -> CANCEL (iOS UL bypass: reissuing programmatically) $url',
               sensitivity: LogSensitivity.sensitive,
             );
-            // Forward original headers so per-site Accept-Language
-            // survives the reissue. POST body is dropped — POSTs
-            // that match AASA are rare and the existing flow lost
-            // them anyway when iOS short-circuited to the native
-            // app.
             final originalUrl = navigationAction.request.url;
             final originalHeaders = navigationAction.request.headers;
             controller.loadUrl(urlRequest: inapp.URLRequest(

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -1123,7 +1123,7 @@ class WebViewModel {
   void disposeWebView() {
     LogService.instance.log(
       'WebView',
-      'disposeWebView called for "$name" (siteId: $siteId)',
+      'disposeWebView called for "$name" (siteId: $siteId)\n${StackTrace.current}',
       sensitivity: LogSensitivity.sensitive,
     );
     webview = null;

--- a/openspec/specs/ios-universal-link-bypass/spec.md
+++ b/openspec/specs/ios-universal-link-bypass/spec.md
@@ -30,7 +30,9 @@ Universal Link routing happens **after** `decidePolicyForNavigationAction:decisi
 
 ## Solution
 
-Generic prophylactic bypass: on iOS, treat **every gesture-rooted main-frame http(s) navigation** as at-risk. Cancel the navigation, then reissue the same URL via `controller.loadUrl`. WebKit treats programmatic loads as navigation type `.other` and **does not match them against AASA**, so the URL renders inside the webview regardless of which apps are installed.
+Generic prophylactic bypass: on iOS, treat **every main-frame http(s) navigation whose `navigationType` is `.linkActivated` (user tap on a link)** as at-risk. Cancel the navigation, then reissue the same URL via `controller.loadUrl`. WebKit treats programmatic loads as navigation type `.other` and **does not match them against AASA**, so the URL renders inside the webview regardless of which apps are installed.
+
+`.formSubmitted` is intentionally excluded. `loadUrl` is a GET, so reissuing a form submit would drop the POST body and break every credentialed form (logins, search, payments) — LinkedIn's `/checkpoint/lg/login-submit` 404ing under the broader filter was the prompt to narrow the scope. AASA matches on POST endpoints are vanishingly rare in practice; apps publish AASA for content URLs, not form handlers.
 
 Pure programmatic navigations (initial nav from `initialUrlRequest`, server redirects without a tap origin, pushState SPA navs) carry no user gesture and don't activate AASA in the first place. Those are passed through without interception, so the bypass adds no overhead to the common case.
 
@@ -50,9 +52,9 @@ This is consistent with WebSpace's overall posture (webview-first, opt-in extern
 
 ## Requirements
 
-### Requirement: IOS-UL-001 - Cancel-and-Reissue Gesture-Rooted Navigations
+### Requirement: IOS-UL-001 - Cancel-and-Reissue Tap-Rooted Navigations
 
-The system SHALL cancel main-frame http(s) navigations whose `WKNavigationAction.navigationType` is `.linkActivated` or `.formSubmitted` and reissue the same URL via `controller.loadUrl` with the original headers preserved.
+The system SHALL cancel main-frame http(s) navigations whose `WKNavigationAction.navigationType` is `.linkActivated` and reissue the same URL via `controller.loadUrl` with the original headers preserved.
 
 #### Scenario: User taps a link to a URL that matches an installed app's AASA
 
@@ -64,18 +66,21 @@ The system SHALL cancel main-frame http(s) navigations whose `WKNavigationAction
 **And** the page renders inside the webview
 **And** the native app does NOT open
 
-#### Scenario: Server redirect after form POST inherits the gesture
+#### Scenario: Form POST is passed through unchanged
 
-**Given** the user submits a form that 302-redirects to a UL-matching URL
-**When** WebKit reports the redirect navigation with `navigationType == .formSubmitted`
-**Then** the redirect URL is also cancelled and reissued
-**And** the page renders inside the webview
+**Given** the user submits a credentialed form (login, search, payment) via POST
+**When** WKWebView fires `decidePolicyForNavigationAction` with `navigationType == .formSubmitted`
+**Then** the bypass does NOT fire
+**And** the navigation is allowed through with the POST body intact
+**And** the server receives the POST and responds normally (e.g. LinkedIn's `/checkpoint/lg/login-submit` accepts the credentials instead of 404ing a GET)
+
+Rationale: `loadUrl` is a GET. Reissuing a `.formSubmitted` action would drop the POST body and break every credentialed form on the web. Form POSTs to AASA-matching endpoints are exceedingly rare in practice — apps publish AASA for content URLs (profile pages, map locations), not POST handlers — so passing them through trades a rare false-negative for a critical false-positive that broke logins on major sites.
 
 ---
 
 ### Requirement: IOS-UL-002 - Pass Through Programmatic Navigations
 
-The system SHALL NOT intercept navigations whose `navigationType` is `.other`, `.backForward`, `.reload`, or anything other than `.linkActivated` / `.formSubmitted`.
+The system SHALL NOT intercept navigations whose `navigationType` is anything other than `.linkActivated` (including `.formSubmitted`, `.other`, `.backForward`, `.reload`).
 
 #### Scenario: Initial site load
 
@@ -131,14 +136,6 @@ The system SHALL forward the original `URLRequest.headers` (e.g. per-site `Accep
 **And** the original navigation carried `Accept-Language: de` in its headers
 **When** the bypass reissues the URL via `loadUrl`
 **Then** the reissued request also carries `Accept-Language: de`
-
-#### Scenario: POST body is dropped (acknowledged limitation)
-
-**Given** a form POST navigation to a UL-matching URL
-**When** the bypass cancels and reissues
-**Then** the URL is reissued as a GET request
-**And** the POST body is lost
-**And** This is acknowledged as a rare-and-acceptable edge case — the prior behavior (iOS short-circuiting to the native app) lost the body anyway.
 
 ---
 
@@ -212,7 +209,7 @@ The class is the entire URL-matching surface: no domain or path filter. The webv
 if (Platform.isIOS &&
     isMainFrame &&
     url.startsWith('http') &&
-    _hasUserGesture(navigationAction)) {
+    navigationAction.navigationType == inapp.NavigationType.LINK_ACTIVATED) {
   if (iosUlBypass.shouldCancelAndReissue(url)) {
     final originalUrl = navigationAction.request.url;
     final originalHeaders = navigationAction.request.headers;
@@ -227,7 +224,7 @@ if (Platform.isIOS &&
 return inapp.NavigationActionPolicy.ALLOW;
 ```
 
-`_hasUserGesture(navigationAction)` already returns true exactly for `LINK_ACTIVATED` / `FORM_SUBMITTED` on iOS — the same set of types iOS routes via AASA. This is the single eligibility filter.
+`LINK_ACTIVATED` is the eligibility filter: iOS routes both `.linkActivated` and `.formSubmitted` through AASA, but reissuing `.formSubmitted` via `loadUrl` (a GET) would drop the POST body. The narrower filter accepts the rare false-negative (form POST whose response would have UL-matched) in exchange for not breaking every credentialed login form.
 
 ### Why the bypass runs after all other policy checks
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -319,8 +319,8 @@ packages:
     dependency: "direct main"
     description:
       path: flutter_inappwebview
-      ref: "v6.2.0-beta.3-privacy-v2"
-      resolved-ref: e0dd383ca98d9228fd9784fa2e4eb1a5cb911153
+      ref: "v6.2.0-beta.3-privacy-v3"
+      resolved-ref: "98e21077bea7abb8d26392d94244b8c8088a2aef"
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "6.2.0-beta.3"
@@ -328,8 +328,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_android
-      ref: "v6.2.0-beta.3-privacy-v2"
-      resolved-ref: e0dd383ca98d9228fd9784fa2e4eb1a5cb911153
+      ref: "v6.2.0-beta.3-privacy-v3"
+      resolved-ref: "98e21077bea7abb8d26392d94244b8c8088a2aef"
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.2.0-beta.3"
@@ -345,8 +345,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_ios
-      ref: "v6.2.0-beta.3-privacy-v2"
-      resolved-ref: e0dd383ca98d9228fd9784fa2e4eb1a5cb911153
+      ref: "v6.2.0-beta.3-privacy-v3"
+      resolved-ref: "98e21077bea7abb8d26392d94244b8c8088a2aef"
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.2.0-beta.3"
@@ -354,8 +354,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_linux
-      ref: "v6.2.0-beta.3-privacy-v2"
-      resolved-ref: e0dd383ca98d9228fd9784fa2e4eb1a5cb911153
+      ref: "v6.2.0-beta.3-privacy-v3"
+      resolved-ref: "98e21077bea7abb8d26392d94244b8c8088a2aef"
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "0.1.0-beta.2"
@@ -363,8 +363,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_macos
-      ref: "v6.2.0-beta.3-privacy-v2"
-      resolved-ref: e0dd383ca98d9228fd9784fa2e4eb1a5cb911153
+      ref: "v6.2.0-beta.3-privacy-v3"
+      resolved-ref: "98e21077bea7abb8d26392d94244b8c8088a2aef"
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.2.0-beta.3"
@@ -372,8 +372,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_platform_interface
-      ref: "v6.2.0-beta.3-privacy-v2"
-      resolved-ref: e0dd383ca98d9228fd9784fa2e4eb1a5cb911153
+      ref: "v6.2.0-beta.3-privacy-v3"
+      resolved-ref: "98e21077bea7abb8d26392d94244b8c8088a2aef"
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.4.0-beta.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -92,32 +92,32 @@ dependency_overrides:
   flutter_inappwebview:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-privacy-v2
+      ref: v6.2.0-beta.3-privacy-v3
       path: flutter_inappwebview
   flutter_inappwebview_android:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-privacy-v2
+      ref: v6.2.0-beta.3-privacy-v3
       path: flutter_inappwebview_android
   flutter_inappwebview_ios:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-privacy-v2
+      ref: v6.2.0-beta.3-privacy-v3
       path: flutter_inappwebview_ios
   flutter_inappwebview_macos:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-privacy-v2
+      ref: v6.2.0-beta.3-privacy-v3
       path: flutter_inappwebview_macos
   flutter_inappwebview_linux:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-privacy-v2
+      ref: v6.2.0-beta.3-privacy-v3
       path: flutter_inappwebview_linux
   flutter_inappwebview_platform_interface:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-privacy-v2
+      ref: v6.2.0-beta.3-privacy-v3
       path: flutter_inappwebview_platform_interface
 
 flutter:

--- a/test/ios_universal_link_bypass_test.dart
+++ b/test/ios_universal_link_bypass_test.dart
@@ -91,4 +91,79 @@ void main() {
           now: t.add(const Duration(milliseconds: 50))), isTrue);
     });
   });
+
+  group('IosUniversalLinkBypass.isEligibleNavigation', () {
+    test('user tap on http link is eligible', () {
+      expect(
+        IosUniversalLinkBypass.isEligibleNavigation(
+          isMainFrame: true,
+          url: 'https://maps.google.com/maps',
+          isLinkActivated: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('form POST is NOT eligible (loadUrl would drop the body)', () {
+      // Regression: LinkedIn's `/checkpoint/lg/login-submit` 404'd because
+      // the bypass cancelled the POST and reissued it as a GET. Form
+      // POSTs to AASA-matching endpoints are vanishingly rare; breaking
+      // every login form to catch them is not the right trade.
+      expect(
+        IosUniversalLinkBypass.isEligibleNavigation(
+          isMainFrame: true,
+          url: 'https://www.linkedin.com/checkpoint/lg/login-submit?_l=de_DE',
+          isLinkActivated: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('subframe navigation is NOT eligible', () {
+      // AASA only matches on top-level navigations; iframes never
+      // route to the native app.
+      expect(
+        IosUniversalLinkBypass.isEligibleNavigation(
+          isMainFrame: false,
+          url: 'https://maps.google.com/maps',
+          isLinkActivated: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('non-http(s) scheme is NOT eligible', () {
+      // intent://, tel:, mailto: etc. are handled by ExternalUrlParser.
+      expect(
+        IosUniversalLinkBypass.isEligibleNavigation(
+          isMainFrame: true,
+          url: 'intent://maps.google.com#Intent;...;end',
+          isLinkActivated: true,
+        ),
+        isFalse,
+      );
+      expect(
+        IosUniversalLinkBypass.isEligibleNavigation(
+          isMainFrame: true,
+          url: 'about:blank',
+          isLinkActivated: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('programmatic navigation (no link activation) is NOT eligible', () {
+      // Initial loads, server redirects without a tap origin, and
+      // pushState SPA navs all surface as `.other` — they don't
+      // activate AASA on iOS and don't need the bypass.
+      expect(
+        IosUniversalLinkBypass.isEligibleNavigation(
+          isMainFrame: true,
+          url: 'https://maps.google.com/maps',
+          isLinkActivated: false,
+        ),
+        isFalse,
+      );
+    });
+  });
 }

--- a/test/user_agent_classifier_test.dart
+++ b/test/user_agent_classifier_test.dart
@@ -13,8 +13,8 @@ void main() {
 
     test('Android Firefox UA is mobile', () {
       // The mobile end of generateRandomUserAgent's platform list.
-      const ua = 'Mozilla/5.0 (Android 16; Mobile; rv:147.0) '
-          'Gecko/20100101 Firefox/147.0';
+      const ua = 'Mozilla/5.0 (Android 16; Mobile; rv:151.0) '
+          'Gecko/20100101 Firefox/151.0';
       expect(isDesktopUserAgent(ua), isFalse);
     });
 
@@ -39,20 +39,20 @@ void main() {
     });
 
     test('Linux Firefox desktop is desktop', () {
-      const ua = 'Mozilla/5.0 (X11; Linux x86_64; rv:147.0) '
-          'Gecko/20100101 Firefox/147.0';
+      const ua = 'Mozilla/5.0 (X11; Linux x86_64; rv:151.0) '
+          'Gecko/20100101 Firefox/151.0';
       expect(isDesktopUserAgent(ua), isTrue);
     });
 
     test('macOS Firefox desktop is desktop', () {
-      const ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7; rv:147.0) '
-          'Gecko/20100101 Firefox/147.0';
+      const ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7; rv:151.0) '
+          'Gecko/20100101 Firefox/151.0';
       expect(isDesktopUserAgent(ua), isTrue);
     });
 
     test('Windows Firefox desktop is desktop', () {
-      const ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:147.0) '
-          'Gecko/20100101 Firefox/147.0';
+      const ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) '
+          'Gecko/20100101 Firefox/151.0';
       expect(isDesktopUserAgent(ua), isTrue);
     });
 
@@ -71,8 +71,8 @@ void main() {
 
   group('inferDesktopUaPlatform', () {
     test('detects macOS via "Macintosh"', () {
-      const ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7; rv:147.0) '
-          'Gecko/20100101 Firefox/147.0';
+      const ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7; rv:151.0) '
+          'Gecko/20100101 Firefox/151.0';
       expect(inferDesktopUaPlatform(ua), DesktopUaPlatform.macos);
     });
 
@@ -83,14 +83,14 @@ void main() {
     });
 
     test('detects Windows via "Windows NT"', () {
-      const ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:147.0) '
-          'Gecko/20100101 Firefox/147.0';
+      const ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) '
+          'Gecko/20100101 Firefox/151.0';
       expect(inferDesktopUaPlatform(ua), DesktopUaPlatform.windows);
     });
 
     test('detects Linux via "X11; Linux"', () {
-      const ua = 'Mozilla/5.0 (X11; Linux x86_64; rv:147.0) '
-          'Gecko/20100101 Firefox/147.0';
+      const ua = 'Mozilla/5.0 (X11; Linux x86_64; rv:151.0) '
+          'Gecko/20100101 Firefox/151.0';
       expect(inferDesktopUaPlatform(ua), DesktopUaPlatform.linux);
     });
 

--- a/test/user_agent_metadata_builder_test.dart
+++ b/test/user_agent_metadata_builder_test.dart
@@ -23,8 +23,8 @@ void main() {
       });
 
       test('Android Firefox UA → mobile=true', () {
-        const ua = 'Mozilla/5.0 (Android 16; Mobile; rv:147.0) '
-            'Gecko/20100101 Firefox/147.0';
+        const ua = 'Mozilla/5.0 (Android 16; Mobile; rv:151.0) '
+            'Gecko/20100101 Firefox/151.0';
         final m = buildUserAgentMetadata(ua);
         expect(m, isNotNull);
         expect(m!.mobile, isTrue);
@@ -85,7 +85,7 @@ void main() {
         // The actual brand entry must match the UA's Firefox version.
         final firefoxEntry =
             brands.firstWhere((b) => b.brand == 'Firefox');
-        expect(firefoxEntry.majorVersion, '147');
+        expect(firefoxEntry.majorVersion, '151');
       });
 
       test('Chrome UA → GREASE + Chromium + Google Chrome', () {
@@ -112,13 +112,13 @@ void main() {
 
       test('full version is padded to four segments', () {
         // `Sec-CH-UA-Full-Version-List` carries 4-segment versions.
-        // Firefox UAs only carry "147.0" — pad to "147.0.0.0" so we
+        // Firefox UAs only carry "151.0" — pad to "151.0.0.0" so we
         // don't ship a suspiciously short value.
         final m = buildUserAgentMetadata(firefoxLinuxDesktopUserAgent)!;
         final firefoxEntry =
             m.brandVersionList!.firstWhere((b) => b.brand == 'Firefox');
-        expect(firefoxEntry.fullVersion, '147.0.0.0');
-        expect(m.fullVersion, '147.0.0.0');
+        expect(firefoxEntry.fullVersion, '151.0.0.0');
+        expect(m.fullVersion, '151.0.0.0');
       });
     });
 
@@ -134,8 +134,8 @@ void main() {
       final firefoxBrand = brands.firstWhere(
         (b) => (b as Map)['brand'] == 'Firefox',
       ) as Map;
-      expect(firefoxBrand['majorVersion'], '147');
-      expect(firefoxBrand['fullVersion'], '147.0.0.0');
+      expect(firefoxBrand['majorVersion'], '151');
+      expect(firefoxBrand['fullVersion'], '151.0.0.0');
     });
 
     test('returned UserAgentMetadata is not const-equal across calls', () {


### PR DESCRIPTION
The cancel-and-reissue bypass dropped POST bodies because loadUrl is a
GET. LinkedIn's /checkpoint/lg/login-submit 404'd on every login. AASA
matches on form-submit endpoints are vanishingly rare; the broader
filter traded a critical false-positive for a hypothetical edge case.
Narrow the gate to LINK_ACTIVATED so credentialed forms survive.