### PR TITLE
Pin Runner DEBUG_INFORMATION_FORMAT=dwarf so archive validation skips dSYMs

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -133,6 +133,17 @@ post_install do |installer|
         needed = '-Wl,-needed_framework,webspace_adblock'
         ldflags << needed unless ldflags.include?(needed)
         config.build_settings['OTHER_LDFLAGS'] = ldflags
+        # Same dSYM-format pin as on the pod targets — archive
+        # validation runs against Runner's own setting, so until we
+        # set it here too Xcode still expects a dSYM for every linked
+        # framework (including objective_c.framework, which ships
+        # without one) and the archive refuses to distribute with
+        # "The archive did not include a dSYM for the
+        # objective_c.framework ...". Debug info now lives inline in
+        # Runner's binary; no separate Runner.app.dSYM is emitted.
+        # Crash reports symbolicate against Runner approximately;
+        # Dart stacks use the embedded VM symbol map regardless.
+        config.build_settings['DEBUG_INFORMATION_FORMAT'] = 'dwarf'
       end
     end
     aggregate.user_project.save

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -107,6 +107,9 @@ post_install do |installer|
         needed = '-Wl,-needed_framework,webspace_adblock'
         ldflags << needed unless ldflags.include?(needed)
         config.build_settings['OTHER_LDFLAGS'] = ldflags
+        # See ios/Podfile — archive validation runs against Runner's
+        # own setting, not just the pods'.
+        config.build_settings['DEBUG_INFORMATION_FORMAT'] = 'dwarf'
       end
     end
     aggregate.user_project.save


### PR DESCRIPTION
## Symptom

Archiving on iOS/macOS for App Store distribution fails validation:

```
The archive did not include a dSYM for the objective_c.framework
with the UUIDs [D89C9A0E-27BB-3C9B-A876-40DB0981F9C4]. Ensure that
the archive's dSYM folder includes a DWARF file for
objective_c.framework with the expected UUIDs.
```

`objective_c` is a transitive Flutter dep (pulled in via `path_provider` / similar) and ships its precompiled `.framework` without a `.dSYM` companion. Xcode's archive validation step refuses to distribute when any linked framework is missing a dSYM.

## Why PR #363's fix wasn't enough

That PR set `DEBUG_INFORMATION_FORMAT = dwarf` on **pod** targets, which stops the pod project from emitting separate dSYMs. But the archive validation step inspects **Runner**'s settings and Runner still defaults to `dwarf-with-dsym`, so Xcode still requests dSYMs for every linked framework.

## Fix

Apply the same `DEBUG_INFORMATION_FORMAT = dwarf` to Runner's build configurations via the existing post_install hook in `ios/Podfile` and `macos/Podfile`. Runner's debug info is then inlined in its binary rather than emitted as a separate `Runner.app.dSYM`; Xcode no longer expects dSYMs for any linked framework and the archive validates.

## Trade-off

Crash reports against Runner code symbolicate approximately. Dart stack traces are unaffected — they resolve against the embedded VM symbol map regardless of dSYM presence.

## How to verify

```
git checkout claude/fix-objective-c-dsym-archive
rm -rf ios/Pods ios/Podfile.lock
fvm flutter clean && fvm flutter pub get
fvm flutter build ios --release
```

Then Archive → Distribute in Xcode. Validation completes without the `objective_c.framework` dSYM complaint.