### PR TITLE
Fix App Shortcuts deduplication on iOS by using stringLiteral

### DIFF
--- a/ios/Runner/WebSpaceAppIntents.swift
+++ b/ios/Runner/WebSpaceAppIntents.swift
@@ -27,8 +27,14 @@ struct SiteEntity: AppEntity {
     TypeDisplayRepresentation(name: "Site")
   }
 
+  // String interpolation inside `DisplayRepresentation(title:)` is read as a
+  // LocalizedStringResource template, so iOS materializes every parameterized
+  // App Shortcut with the unresolved "%@" placeholder and then dedupes the
+  // identical titles in Shortcuts.app down to a single visible entry. The
+  // `stringLiteral:` initializer skips localization and uses `name` as-is, so
+  // every site gets a distinct materialized shortcut.
   var displayRepresentation: DisplayRepresentation {
-    DisplayRepresentation(title: "\(name)")
+    DisplayRepresentation(stringLiteral: name)
   }
 
   static var defaultQuery = SiteEntityQuery()

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -138,6 +138,13 @@ Only available on iOS 16+. On older iOS the intent type is compiled but never re
 **When** the user opens the Shortcuts app and adds the "Open Site" action from WebSpace
 **Then** the action shows a "Site" parameter whose picker lists every site currently in WebSpace by name
 
+#### Scenario: Every site appears as a discoverable App Shortcut
+
+**Given** the user has multiple sites in WebSpace on iOS 16 or later
+**When** the user opens the Shortcuts app and views the WebSpace section
+**Then** every site materializes as its own "Open <site name> in WebSpace" entry (subject to the iOS-imposed App Shortcuts cap)
+**And** the entries are not collapsed to a single placeholder (e.g. "Open %@ in WebSpace") regardless of how many sites are synced
+
 #### Scenario: Shortcut launches WebSpace to the chosen site
 
 **Given** the user has added a Shortcut wired to `OpenSiteIntent` with a specific site selected
@@ -297,7 +304,7 @@ Methods:
 
 `ios/Runner/WebSpaceAppIntents.swift` defines (all `@available(iOS 16, *)`):
 
-- `SiteEntity: AppEntity` — one synced site with `id: String` (siteId) and `name: String`.
+- `SiteEntity: AppEntity` — one synced site with `id: String` (siteId) and `name: String`. `displayRepresentation` MUST use `DisplayRepresentation(stringLiteral: name)`, not `DisplayRepresentation(title: "\(name)")`: the latter is parsed as a `LocalizedStringResource` template whose `%@` placeholder is never resolved at materialization time, so iOS dedupes the materialized parameterized App Shortcuts (one per entity) down to a single visible entry in Shortcuts.app.
 - `SiteEntityQuery: EntityQuery` — reads the synced site list from App Group UserDefaults under `shortcut_sites` so Shortcuts.app's parameter picker shows real WebSpace sites.
 - `OpenSiteIntent: AppIntent, OpenIntent` — parameterized on `SiteEntity`. `openAppWhenRun = true` foregrounds WebSpace; `perform()` writes the chosen siteId to App Group UserDefaults under `pending_shortcut_site_id`.
 - `WebSpaceShortcuts: AppShortcutsProvider` — declares the discoverable "Open Site" App Shortcut with phrase template `"Open \(\.$target) in WebSpace"`.

--- a/test/shortcut_service_test.dart
+++ b/test/shortcut_service_test.dart
@@ -124,4 +124,27 @@ void main() {
       await ShortcutService.removeShortcut('a');
     });
   });
+
+  // The iOS App Shortcuts materialization (HS-008) collapses every entity
+  // down to a single visible "Open %@ in WebSpace" row when SiteEntity's
+  // displayRepresentation uses string interpolation: iOS treats the
+  // interpolated form as a LocalizedStringResource template whose %@ is never
+  // bound at materialization time. The fix is `DisplayRepresentation(
+  // stringLiteral: name)`. Guard the Swift source so a future refactor can't
+  // silently revert it.
+  group('WebSpaceAppIntents.swift — SiteEntity displayRepresentation', () {
+    test('uses stringLiteral, not LocalizedStringResource interpolation', () {
+      final source =
+          File('ios/Runner/WebSpaceAppIntents.swift').readAsStringSync();
+      expect(source, contains('DisplayRepresentation(stringLiteral: name)'),
+          reason: 'SiteEntity.displayRepresentation must use the '
+              '`stringLiteral:` initializer so each site materializes as its '
+              'own App Shortcut entry. See HS-008 / openspec spec.');
+      expect(source, isNot(contains(r'DisplayRepresentation(title: "\(name)")')),
+          reason: 'String interpolation inside DisplayRepresentation(title:) '
+              'is parsed as a LocalizedStringResource template, which '
+              'collapses every materialized App Shortcut to a single %@ '
+              'placeholder row in Shortcuts.app.');
+    });
+  });
 }


### PR DESCRIPTION
SiteEntity's displayRepresentation was using string interpolation inside DisplayRepresentation(title:), which iOS parses as a LocalizedStringResource template. At materialization time, the %@ placeholder is never resolved, causing iOS to dedupe all parameterized App Shortcuts down to a single visible entry in Shortcuts.app.

Changed displayRepresentation to use DisplayRepresentation(stringLiteral: name) instead, which skips localization and uses the site name as-is, ensuring each site materializes as its own discoverable shortcut entry.

Changes:
- ios/Runner/WebSpaceAppIntents.swift: replaced DisplayRepresentation(title: "\(name)") with DisplayRepresentation(stringLiteral: name) and added explanatory comment
- openspec/specs/home-shortcut/spec.md: added scenario documenting that every site appears as a discoverable App Shortcut, and clarified the SiteEntity displayRepresentation requirement in the implementation section
- test/shortcut_service_test.dart: added test guarding the Swift source to prevent silent reversion of the fix (HS-008)

https://claude.ai/code/session_01Mrt83kyNCuTAQwq2B62pmP