### PR TITLE
Expand live location granularity from binary to three-tier model

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2970,7 +2970,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     double spoofAccuracy = 50.0,
     String? spoofTimezone,
     bool spoofTimezoneFromLocation = false,
-    LocationGranularity liveLocationGranularity = LocationGranularity.fine,
+    LocationGranularity liveLocationGranularity = LocationGranularity.gps,
     WebRtcPolicy webRtcPolicy = WebRtcPolicy.defaultPolicy,
     required List<UserScriptConfig> userScripts,
     UserProxySettings? proxySettings,

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -75,7 +75,7 @@ class InAppWebViewScreen extends StatefulWidget {
     this.spoofAccuracy = 50.0,
     this.spoofTimezone,
     this.spoofTimezoneFromLocation = false,
-    this.liveLocationGranularity = LocationGranularity.fine,
+    this.liveLocationGranularity = LocationGranularity.gps,
     this.webRtcPolicy = WebRtcPolicy.defaultPolicy,
     this.userScripts = const [],
     this.onConfirmScriptFetch,

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -151,7 +151,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   // the page. Only meaningful when `_isLiveLocation` is true; persists
   // across switches between segments so the user's preference isn't lost
   // when they toggle Off → Live again.
-  LocationGranularity _liveLocationGranularity = LocationGranularity.fine;
+  LocationGranularity _liveLocationGranularity = LocationGranularity.gps;
   late WebRtcPolicy _webRtcPolicy;
 
   /// Snapshot of every form field captured after [_loadFromModel] (and again
@@ -592,14 +592,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
           'Function.prototype.toString — so timezone override and WebRTC '
           'policy still apply, but the coordinates are real and current.\n\n'
           'In Live mode, pick a granularity:\n'
-          'Fine: real device coordinates and accuracy. Use when the site '
-          'needs metre-level positioning (turn-by-turn navigation, AR, '
-          'hyper-local search).\n'
-          'Coarse: lat/lng snapped to a ~1.1 km grid and accuracy '
-          'inflated to match. Use for sites that only need your general '
-          'area (regional weather, "stores nearby"). The OS still hands '
-          'the app the high-precision fix; the shim fuzzes it before the '
-          'site sees anything.',
+          'GPS: real device coordinates and accuracy via the GPS '
+          'provider. Use when the site needs metre-level positioning '
+          '(turn-by-turn navigation, AR, hyper-local search).\n'
+          'Approximate: still uses the GPS provider so a fix actually '
+          'arrives, then the shim snaps lat/lng to a ~110 m grid before '
+          'the page sees it. Use when the site needs your general area '
+          'with reasonable speed (weather, "stores nearby", traffic).\n'
+          'GSM: cell-tower / Wi-Fi positioning only — no GPS chip and '
+          'no fine-location permission. Result snapped to a ~1.1 km '
+          'grid. Most privacy-respectful but may return nothing on '
+          'devices without a Network Location Provider (some de-Googled '
+          'phones).',
     );
 
     // Derive the active segment from current state. `Static` is selected
@@ -688,14 +692,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 child: SegmentedButton<LocationGranularity>(
                   segments: const [
                     ButtonSegment(
-                      value: LocationGranularity.fine,
+                      value: LocationGranularity.gps,
                       icon: Icon(Icons.gps_fixed),
-                      label: Text('Fine'),
+                      label: Text('GPS'),
                     ),
                     ButtonSegment(
-                      value: LocationGranularity.coarse,
+                      value: LocationGranularity.approximate,
                       icon: Icon(Icons.gps_not_fixed),
-                      label: Text('Coarse'),
+                      label: Text('Approx'),
+                    ),
+                    ButtonSegment(
+                      value: LocationGranularity.gsm,
+                      icon: Icon(Icons.cell_tower),
+                      label: Text('GSM'),
                     ),
                   ],
                   selected: {_liveLocationGranularity},
@@ -706,12 +715,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
               const SizedBox(height: 4),
               Text(
-                _liveLocationGranularity == LocationGranularity.fine
-                    ? 'Fine: real device coordinates and accuracy. Use for '
-                        'turn-by-turn navigation or hyper-local search.'
-                    : 'Coarse: lat/lng snapped to a ~1.1 km grid and '
-                        'reported accuracy inflated to match. Use when the '
-                        'site only needs your general area.',
+                switch (_liveLocationGranularity) {
+                  LocationGranularity.gps =>
+                    'GPS: real device coordinates and accuracy. Use for '
+                        'turn-by-turn navigation or hyper-local search.',
+                  LocationGranularity.approximate =>
+                    'Approximate: GPS provider, lat/lng snapped to a ~110 '
+                        'm grid before the page sees it. Fast and works '
+                        'on devices without a network-location backend.',
+                  LocationGranularity.gsm =>
+                    'GSM: network provider only (cell-tower / Wi-Fi), no '
+                        'GPS chip, result snapped to a ~1.1 km grid. May '
+                        'fail on devices without an NLP backend.',
+                },
                 style: const TextStyle(fontSize: 11),
               ),
             ],

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -152,6 +152,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
   // across switches between segments so the user's preference isn't lost
   // when they toggle Off → Live again.
   LocationGranularity _liveLocationGranularity = LocationGranularity.gps;
+  // Sticky preference for the "Approximate" sub-switch under the GPS
+  // segment. Derived from the granularity on load (true iff approximate)
+  // and remembered across GPS↔GSM segment toggles so flipping to GSM
+  // and back doesn't silently drop the user's snap preference.
+  bool _liveGpsApproximate = false;
   late WebRtcPolicy _webRtcPolicy;
 
   /// Snapshot of every form field captured after [_loadFromModel] (and again
@@ -300,6 +305,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _spoofTimezoneFromLocation = m.spoofTimezoneFromLocation;
     _isLiveLocation = m.locationMode == LocationMode.live;
     _liveLocationGranularity = m.liveLocationGranularity;
+    _liveGpsApproximate =
+        m.liveLocationGranularity == LocationGranularity.approximate;
     _webRtcPolicy = m.webRtcPolicy;
     _showProxyCredentials = _proxySettings.hasCredentials;
   }
@@ -591,19 +598,20 @@ class _SettingsScreenState extends State<SettingsScreen> {
           'overrides Geolocation.prototype and hides the patch from '
           'Function.prototype.toString — so timezone override and WebRTC '
           'policy still apply, but the coordinates are real and current.\n\n'
-          'In Live mode, pick a granularity:\n'
-          'GPS: real device coordinates and accuracy via the GPS '
-          'provider. Use when the site needs metre-level positioning '
-          '(turn-by-turn navigation, AR, hyper-local search).\n'
-          'Approximate: still uses the GPS provider so a fix actually '
-          'arrives, then the shim snaps lat/lng to a ~110 m grid before '
-          'the page sees it. Use when the site needs your general area '
-          'with reasonable speed (weather, "stores nearby", traffic).\n'
+          'In Live mode, pick a provider:\n'
+          'GPS: real device coordinates via the GPS provider. Use when '
+          'the site needs metre-level positioning (turn-by-turn '
+          'navigation, AR, hyper-local search).\n'
           'GSM: cell-tower / Wi-Fi positioning only — no GPS chip and '
           'no fine-location permission. Result snapped to a ~1.1 km '
           'grid. Most privacy-respectful but may return nothing on '
           'devices without a Network Location Provider (some de-Googled '
-          'phones).',
+          'phones).\n\n'
+          'Under GPS, toggle "Approximate" to have the shim snap the '
+          'lat/lng to a ~110 m grid before the page sees it — same '
+          'provider speed, fuzzier result. Use when the site needs '
+          'your general area but not your exact position (weather, '
+          '"stores nearby", traffic).',
     );
 
     // Derive the active segment from current state. `Static` is selected
@@ -687,42 +695,74 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 style: TextStyle(fontSize: 12),
               ),
               const SizedBox(height: 8),
+              // Two-tier picker: GPS vs GSM at the top (provider), with an
+              // "Approximate" sub-switch that only applies under GPS — both
+              // share the same OS-level provider, the switch just toggles
+              // whether the JS shim snaps the result. GSM is a different
+              // provider entirely (NETWORK only) and has no sub-toggle.
               SizedBox(
                 width: double.infinity,
-                child: SegmentedButton<LocationGranularity>(
+                child: SegmentedButton<_LiveProvider>(
                   segments: const [
                     ButtonSegment(
-                      value: LocationGranularity.gps,
+                      value: _LiveProvider.gps,
                       icon: Icon(Icons.gps_fixed),
                       label: Text('GPS'),
                     ),
                     ButtonSegment(
-                      value: LocationGranularity.approximate,
-                      icon: Icon(Icons.gps_not_fixed),
-                      label: Text('Approx'),
-                    ),
-                    ButtonSegment(
-                      value: LocationGranularity.gsm,
+                      value: _LiveProvider.gsm,
                       icon: Icon(Icons.cell_tower),
                       label: Text('GSM'),
                     ),
                   ],
-                  selected: {_liveLocationGranularity},
-                  onSelectionChanged: (vs) => setState(
-                      () => _liveLocationGranularity = vs.first),
+                  selected: {
+                    _liveLocationGranularity == LocationGranularity.gsm
+                        ? _LiveProvider.gsm
+                        : _LiveProvider.gps,
+                  },
+                  onSelectionChanged: (vs) => setState(() {
+                    // Preserve the user's approximate preference across
+                    // GPS↔GSM segment toggles: when they leave GPS the
+                    // saved-approximate hint lives in the local switch
+                    // below; coming back to GPS we read its state.
+                    if (vs.first == _LiveProvider.gsm) {
+                      _liveLocationGranularity = LocationGranularity.gsm;
+                    } else {
+                      _liveLocationGranularity = _liveGpsApproximate
+                          ? LocationGranularity.approximate
+                          : LocationGranularity.gps;
+                    }
+                  }),
                   showSelectedIcon: false,
                 ),
               ),
               const SizedBox(height: 4),
+              if (_liveLocationGranularity != LocationGranularity.gsm)
+                SwitchListTile(
+                  contentPadding: EdgeInsets.zero,
+                  dense: true,
+                  title: const Text('Approximate'),
+                  subtitle: const Text(
+                    'Snap lat/lng to a ~110 m grid before the page sees it.',
+                    style: TextStyle(fontSize: 11),
+                  ),
+                  value: _liveGpsApproximate,
+                  onChanged: (v) => setState(() {
+                    _liveGpsApproximate = v;
+                    _liveLocationGranularity = v
+                        ? LocationGranularity.approximate
+                        : LocationGranularity.gps;
+                  }),
+                ),
               Text(
                 switch (_liveLocationGranularity) {
                   LocationGranularity.gps =>
                     'GPS: real device coordinates and accuracy. Use for '
                         'turn-by-turn navigation or hyper-local search.',
                   LocationGranularity.approximate =>
-                    'Approximate: GPS provider, lat/lng snapped to a ~110 '
-                        'm grid before the page sees it. Fast and works '
-                        'on devices without a network-location backend.',
+                    'GPS provider, lat/lng snapped to a ~110 m grid '
+                        'before the page sees it. Fast and works on '
+                        'devices without a network-location backend.',
                   LocationGranularity.gsm =>
                     'GSM: network provider only (cell-tower / Wi-Fi), no '
                         'GPS chip, result snapped to a ~1.1 km grid. May '
@@ -1633,4 +1673,10 @@ Future<void> maybeShowBackgroundNotificationLimitsDialog(
 ///   live   -> LocationMode.live    (real device GPS via the shim's
 ///                                   getRealLocation handler)
 enum _LocationSegment { off, staticCoords, live }
+
+/// Provider tier shown by the live-mode segment picker. GPS and GSM are
+/// the two OS-level provider strategies; the "Approximate" switch
+/// rendered under GPS modulates whether the JS shim snaps the result,
+/// so it is not a separate provider — see [LocationGranularity].
+enum _LiveProvider { gps, gsm }
 

--- a/lib/services/location_spoof_service.dart
+++ b/lib/services/location_spoof_service.dart
@@ -29,7 +29,7 @@ class LocationSpoofService {
     required double? spoofLongitude,
     required double spoofAccuracy,
     required String? spoofTimezone,
-    LocationGranularity liveLocationGranularity = LocationGranularity.fine,
+    LocationGranularity liveLocationGranularity = LocationGranularity.gps,
     required WebRtcPolicy webRtcPolicy,
   }) {
     final spoofLocation = locationMode == LocationMode.spoof &&
@@ -52,13 +52,23 @@ class LocationSpoofService {
       WebRtcPolicy.disabled => '"off"',
       WebRtcPolicy.defaultPolicy => '"default"',
     };
-    final coarseLive = liveLocation &&
-        liveLocationGranularity == LocationGranularity.coarse;
+    // Snap step (degrees) and accuracy floor (metres) chosen per tier.
+    // 0.001° ≈ 110 m at the equator; 0.01° ≈ 1100 m. GPS=no snap. The
+    // longitude step is derived from cos(snappedLat) at runtime so cells
+    // stay roughly square at higher latitudes (see snapFix below).
+    final (snapStepDeg, snapMinAccM) = !liveLocation
+        ? (0.0, 0.0)
+        : switch (liveLocationGranularity) {
+            LocationGranularity.gps => (0.0, 0.0),
+            LocationGranularity.approximate => (0.001, 110.0),
+            LocationGranularity.gsm => (0.01, 1100.0),
+          };
 
     return _template
         .replaceAll('__STATIC_LOC__', spoofLocation ? 'true' : 'false')
         .replaceAll('__LIVE_LOC__', liveLocation ? 'true' : 'false')
-        .replaceAll('__LIVE_COARSE__', coarseLive ? 'true' : 'false')
+        .replaceAll('__SNAP_STEP_DEG__', snapStepDeg.toString())
+        .replaceAll('__SNAP_MIN_ACC_M__', snapMinAccM.toString())
         .replaceAll('__LAT__', lat.toString())
         .replaceAll('__LNG__', lng.toString())
         .replaceAll('__ACC__', acc.toString())
@@ -74,24 +84,23 @@ const String _template = r'''
 
   var STATIC_LOC = __STATIC_LOC__;
   var LIVE_LOC = __LIVE_LOC__;
-  var LIVE_COARSE = __LIVE_COARSE__;
+  // Grid step in degrees applied to the live fix before the page sees it.
+  // 0 = no snap (GPS tier), ~0.001 = approximate (~110 m), ~0.01 = GSM
+  // (~1.1 km). The longitude step is divided by cos(snappedLat) so cells
+  // stay roughly square as we approach the poles. SNAP_MIN_ACC_M is the
+  // floor for reported accuracy — sites that refuse low-accuracy fixes
+  // will skip the call, which is the intended trade-off.
+  var SNAP_STEP_DEG = __SNAP_STEP_DEG__;
+  var SNAP_MIN_ACC_M = __SNAP_MIN_ACC_M__;
   var LAT = __LAT__;
   var LNG = __LNG__;
   var ACC = __ACC__;
   var TZ = __TZ__;
   var WRTC = __WRTC__;
 
-  // Grid cell size for coarse live location. 0.01 degrees latitude is
-  // ~1.11 km on the WGS-84 ellipsoid; the longitude step is divided by
-  // cos(lat) so cells stay roughly square as we approach the poles.
-  // Reported accuracy is inflated to the cell's diagonal half-extent so
-  // the page sees an honest "this is approximate" value — sites that
-  // refuse to use low-accuracy fixes will skip the call, which is the
-  // intended trade-off.
-  var COARSE_STEP_DEG = 0.01;
-  var COARSE_MIN_ACC_M = 1100;
-  function coarsenFix(lat, lng, acc) {
-    var latStep = COARSE_STEP_DEG;
+  function snapFix(lat, lng, acc) {
+    if (!(SNAP_STEP_DEG > 0)) return { lat: lat, lng: lng, acc: acc };
+    var latStep = SNAP_STEP_DEG;
     var snappedLat = Math.round(lat / latStep) * latStep;
     // Compute the longitude step from the SNAPPED latitude, not the raw
     // one. If we used the raw lat, two adjacent fixes inside the same
@@ -103,7 +112,7 @@ const String _template = r'''
     var cosLat = Math.cos(snappedLat * Math.PI / 180);
     var lngStep = latStep / Math.max(Math.abs(cosLat), 1e-6);
     var snappedLng = Math.round(lng / lngStep) * lngStep;
-    var inflated = Math.max(acc || 0, COARSE_MIN_ACC_M);
+    var inflated = Math.max(acc || 0, SNAP_MIN_ACC_M);
     return { lat: snappedLat, lng: snappedLng, acc: inflated };
   }
 
@@ -187,20 +196,18 @@ const String _template = r'''
     // mode is `live`; if it's missing here we still defensively fail
     // closed so a legacy/no-handler page doesn't hang forever.
     //
-    // When LIVE_COARSE is true, the platform fix is snapped to a ~1.1 km
-    // grid before being handed to makePositionFrom — sub-meter jitter
-    // applied below sits well inside the grid cell so the page can't
-    // distinguish a stationary device from one moving a few metres, but
-    // watchPosition still doesn't return byte-identical frames.
+    // When SNAP_STEP_DEG > 0 (approximate or GSM tier), the platform fix
+    // is snapped to a grid before being handed to makePositionFrom —
+    // sub-meter jitter applied below sits well inside the grid cell so
+    // the page can't distinguish a stationary device from one moving a
+    // few metres within the same cell, but watchPosition still doesn't
+    // return byte-identical frames.
     function getLiveFix() {
       if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
         return window.flutter_inappwebview.callHandler('getRealLocation').then(function(res) {
           if (res && res.status === 'ok') {
-            if (LIVE_COARSE) {
-              var c = coarsenFix(res.latitude, res.longitude, res.accuracy);
-              return { ok: true, lat: c.lat, lng: c.lng, acc: c.acc };
-            }
-            return { ok: true, lat: res.latitude, lng: res.longitude, acc: res.accuracy };
+            var c = snapFix(res.latitude, res.longitude, res.accuracy);
+            return { ok: true, lat: c.lat, lng: c.lng, acc: c.acc };
           }
           return { ok: false, payload: res };
         }, function() {

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -494,8 +494,9 @@ class WebViewConfig {
   /// through to no-timezone-spoof.
   final bool spoofTimezoneFromLocation;
   /// Granularity of the fix reported to the page in [LocationMode.live].
-  /// Fine (default) reveals the real device coordinates; coarse snaps
-  /// to a ~1.1 km grid and inflates accuracy. Ignored when
+  /// GPS (default) reveals the real device coordinates; Approximate uses
+  /// the GPS provider but snaps to a ~110 m grid; GSM uses the network
+  /// provider only and snaps to a ~1.1 km grid. Ignored when
   /// [locationMode] is not [LocationMode.live].
   final LocationGranularity liveLocationGranularity;
   /// WebRTC policy — prevents real-IP leak that bypasses HTTP(S)/SOCKS proxies.
@@ -553,7 +554,7 @@ class WebViewConfig {
     this.spoofAccuracy = 50.0,
     this.spoofTimezone,
     this.spoofTimezoneFromLocation = false,
-    this.liveLocationGranularity = LocationGranularity.fine,
+    this.liveLocationGranularity = LocationGranularity.gps,
     this.webRtcPolicy = WebRtcPolicy.defaultPolicy,
     this.proxySettings,
     this.notificationsEnabled = false,
@@ -2055,14 +2056,16 @@ class WebViewFactory {
         // getCurrentPosition / watchPosition. The handler returns a
         // serialisable map matching CurrentLocationService's JSON shape.
         if (config.locationMode == LocationMode.live) {
-          // Coarse-granularity sites get their fixes from the platform's
+          // GSM-granularity sites get their fixes from the platform's
           // network-positioning provider only (Android NETWORK_PROVIDER /
           // iOS kCLLocationAccuracyKilometer). The OS never escalates to
           // the fine-location permission and never powers up the GPS
-          // chip — the JS shim's grid-snapping is then layered on top
-          // for an extra ~1.1 km of consistency across consecutive fixes.
+          // chip. Approximate still uses the GPS provider so a fix
+          // actually arrives on devices without an NLP backend — the JS
+          // shim's grid-snapping is layered on top to fuzz the result
+          // before the page sees it.
           final requestAccuracy =
-              config.liveLocationGranularity == LocationGranularity.coarse
+              config.liveLocationGranularity == LocationGranularity.gsm
                   ? LocationAccuracy.coarse
                   : LocationAccuracy.fine;
           controller.addJavaScriptHandler(

--- a/lib/settings/location.dart
+++ b/lib/settings/location.dart
@@ -10,27 +10,39 @@
 ///   change as the device moves.
 enum LocationMode { off, spoof, live }
 
-/// Granularity of the fix surfaced by [LocationMode.live]. The platform
-/// always hands back the highest-precision fix it has (the OS-level
-/// fine/coarse permission split is for native callers, not the WebView).
-/// This enum controls what the JS shim reveals to the page after the fact:
+/// Granularity of the fix surfaced by [LocationMode.live]. Three tiers
+/// trade off precision for permission posture and OS resource use:
 ///
-/// - [fine]: the real device coordinates and accuracy, jittered by ~2 m
-///   like the spoof path so `watchPosition` doesn't return byte-identical
-///   frames. Use when the site genuinely needs metre-level positioning
+/// - [gps]: native GPS provider preferred (Android `ACCESS_FINE_LOCATION`
+///   with GPS + NETWORK + PASSIVE, iOS `kCLLocationAccuracyBest`). The
+///   page sees the real coordinates and accuracy with only sub-meter
+///   jitter so `watchPosition` doesn't return byte-identical frames.
+///   Best precision, may spin up the GPS chip, needs sky view to lock.
+///   Use when the site genuinely needs metre-level positioning
 ///   (turn-by-turn navigation, hyper-local search, AR overlays).
-/// - [coarse]: lat/lng snapped to a ~1.1 km grid (0.01° in latitude,
-///   `0.01° / cos(lat)` in longitude so cells stay roughly square at
-///   higher latitudes) and the reported `accuracy` inflated to at least
-///   ~1100 m so the page knows the fix is approximate. Use when the site
-///   just needs the user's general area (regional weather, "find stores
-///   nearby", "drive on the highway" geofences). The grid is recomputed
-///   on every call, so a stationary device returns the same cell and a
-///   moving device crosses cell boundaries with the actual displacement.
+/// - [approximate]: same OS-level provider as [gps] (fastest fix wins,
+///   GPS or NETWORK) so it actually returns a location even on devices
+///   where the NETWORK_PROVIDER backend (NLP / GSM-only) is not
+///   configured, then the shim snaps lat/lng to a ~110 m grid before
+///   the page sees anything. The reported `accuracy` is inflated to at
+///   least ~110 m so the page knows the fix is rounded. This is the
+///   middle ground: real GPS-quality fix, fuzzed before exposure. Use
+///   for weather, "stores nearby", traffic info — anything that doesn't
+///   need exact coordinates but does need a fix that arrives.
+/// - [gsm]: Android `ACCESS_COARSE_LOCATION` only with `NETWORK_PROVIDER`
+///   only (cell-tower / Wi-Fi triangulation, never GPS), iOS
+///   `kCLLocationAccuracyKilometer` so CoreLocation does not power up
+///   the GPS chip even under full Precise authorization. The returned
+///   fix is then snapped to a ~1.1 km grid and the reported `accuracy`
+///   is inflated to at least 1100 m. Privacy-paranoid: the app never
+///   even asks for fine-location permission. Note that this tier can
+///   return nothing on devices without a Network Location Provider
+///   backend (de-Googled phones without microG/UnifiedNlp); use
+///   [approximate] for a working middle ground.
 ///
 /// Static [LocationMode.spoof] coordinates are user-supplied and not
 /// rounded — the user already chose the precision they want to expose.
-enum LocationGranularity { fine, coarse }
+enum LocationGranularity { gps, approximate, gsm }
 
 /// Per-site WebRTC policy. HTTP(S)/SOCKS5 proxies only tunnel TCP — WebRTC
 /// UDP candidates leak the real client IP even with proxy enabled. This

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -335,10 +335,12 @@ class WebViewModel {
   /// loadable polygon dataset that may not be present.
   bool spoofTimezoneFromLocation;
   /// Granularity applied to the real GPS fix surfaced by
-  /// [LocationMode.live]. Default [LocationGranularity.fine] preserves
-  /// the existing pre-feature behavior; [LocationGranularity.coarse]
-  /// snaps the lat/lng to a ~1.1 km grid and inflates the reported
-  /// accuracy. Ignored for [LocationMode.off] / [LocationMode.spoof].
+  /// [LocationMode.live]. [LocationGranularity.gps] (default) reports
+  /// the raw device coords. [LocationGranularity.approximate] snaps to
+  /// a ~110 m grid while still using the GPS provider so a fix actually
+  /// arrives. [LocationGranularity.gsm] uses the network provider only
+  /// and snaps to a ~1.1 km grid. Ignored for [LocationMode.off] and
+  /// [LocationMode.spoof].
   LocationGranularity liveLocationGranularity;
   WebRtcPolicy webRtcPolicy;
 
@@ -419,7 +421,7 @@ class WebViewModel {
     this.spoofAccuracy = 50.0,
     this.spoofTimezone,
     this.spoofTimezoneFromLocation = false,
-    this.liveLocationGranularity = LocationGranularity.fine,
+    this.liveLocationGranularity = LocationGranularity.gps,
     this.webRtcPolicy = WebRtcPolicy.defaultPolicy,
     this.domainClaims,
     this.stateSetterF,
@@ -1302,7 +1304,7 @@ class WebViewModel {
         'spoofAccuracy': spoofAccuracy,
         if (spoofTimezone != null) 'spoofTimezone': spoofTimezone,
         if (spoofTimezoneFromLocation) 'spoofTimezoneFromLocation': true,
-        if (liveLocationGranularity != LocationGranularity.fine)
+        if (liveLocationGranularity != LocationGranularity.gps)
           'liveLocationGranularity': liveLocationGranularity.name,
         'webRtcPolicy': webRtcPolicy.name,
         if (domainClaims != null && domainClaims!.isNotEmpty)
@@ -1368,10 +1370,8 @@ class WebViewModel {
       spoofTimezone: json['spoofTimezone'] as String?,
       spoofTimezoneFromLocation:
           json['spoofTimezoneFromLocation'] as bool? ?? false,
-      liveLocationGranularity: LocationGranularity.values.firstWhere(
-        (g) => g.name == json['liveLocationGranularity'],
-        orElse: () => LocationGranularity.fine,
-      ),
+      liveLocationGranularity: _decodeLiveLocationGranularity(
+          json['liveLocationGranularity']),
       webRtcPolicy: WebRtcPolicy.values.firstWhere(
         (p) => p.name == json['webRtcPolicy'],
         orElse: () => WebRtcPolicy.defaultPolicy,
@@ -1382,4 +1382,19 @@ class WebViewModel {
       stateSetterF: stateSetterF,
     )..pageTitle = dropUrl ? null : json['pageTitle'];
   }
+}
+
+/// Legacy enum values written before the three-tier rename are migrated:
+/// `"fine"` (pre-#326 default = raw GPS) → [LocationGranularity.gps],
+/// `"coarse"` (pre-#326 cell-tower-only) → [LocationGranularity.gsm].
+/// Anything unrecognised or absent falls through to [LocationGranularity.gps].
+LocationGranularity _decodeLiveLocationGranularity(Object? raw) {
+  if (raw is String) {
+    if (raw == 'fine') return LocationGranularity.gps;
+    if (raw == 'coarse') return LocationGranularity.gsm;
+    for (final v in LocationGranularity.values) {
+      if (v.name == raw) return v;
+    }
+  }
+  return LocationGranularity.gps;
 }

--- a/openspec/specs/per-site-location/spec.md
+++ b/openspec/specs/per-site-location/spec.md
@@ -114,16 +114,17 @@ The spoof SHALL resist trivial detection by:
 
 When `locationMode = live`, the JS shim SHALL forward `navigator.geolocation.getCurrentPosition` and `navigator.geolocation.watchPosition` calls to the platform's native location service via a `flutter_inappwebview` JavaScript handler named `getRealLocation`. Each call returns a fresh fix; coordinates change as the device moves. The same shim hardening as `spoof` mode applies (prototype overrides, toString native reporting, Permissions API → granted).
 
-The shape of the fix surfaced to the page in live mode is controlled by a per-site `liveLocationGranularity` field with two values:
+The shape of the fix surfaced to the page in live mode is controlled by a per-site `liveLocationGranularity` field with three values, named after the OS-level provider strategy the user is opting into:
 
-- `fine` (default): the real device coordinates and accuracy, jittered by ~2 m like the spoof path. Use when the site genuinely needs metre-level positioning.
-- `coarse`: the platform fix is requested at the OS-level coarse tier — Android `ACCESS_COARSE_LOCATION` only with `NETWORK_PROVIDER` only (cell-tower / Wi-Fi triangulation, never GPS), iOS `kCLLocationAccuracyKilometer` so CoreLocation does not power up the GPS chip even under full Precise authorization. The returned fix is then snapped to a ~1.1 km grid before being handed to the page — latitude rounds to the nearest `0.01°`, longitude rounds to the nearest `0.01° / cos(snappedLat)` so cells stay roughly square at higher latitudes, and the reported `accuracy` is inflated to at least 1100 m (or the platform-reported accuracy, whichever is larger — a NETWORK-only 5 km fix must not be silently sharpened by coarse mode). The longitude step is derived from the snapped (not raw) latitude so two fixes that round into the same cell row share an identical step and re-snap to the same column.
+- `gps` (default): the platform fix is requested at the OS-level fine tier — Android `ACCESS_FINE_LOCATION` with `GPS_PROVIDER` + `NETWORK_PROVIDER` (fastest fix wins), iOS `kCLLocationAccuracyBest`. The shim returns the real device coordinates and accuracy with only ~2 m sub-meter jitter so `watchPosition` doesn't return byte-identical frames. Use when the site genuinely needs metre-level positioning.
+- `approximate`: the platform fix is requested at the same OS-level fine tier as `gps` (so a fix actually arrives on devices without a Network Location Provider backend, where pure `NETWORK_PROVIDER` returns nothing), then the shim snaps lat/lng to a ~110 m grid before the page sees it — latitude rounds to the nearest `0.001°`, longitude rounds to the nearest `0.001° / cos(snappedLat)` so cells stay roughly square at higher latitudes. The reported `accuracy` is inflated to at least 110 m (or the platform-reported accuracy, whichever is larger). The longitude step is derived from the snapped (not raw) latitude so two fixes that round into the same cell row share an identical step. This is the privacy-preserving middle ground: the OS still serves a real GPS fix, but the page sees a fuzzed result.
+- `gsm`: the platform fix is requested at the OS-level coarse tier — Android `ACCESS_COARSE_LOCATION` only with `NETWORK_PROVIDER` only (cell-tower / Wi-Fi triangulation, never GPS), iOS `kCLLocationAccuracyKilometer` so CoreLocation does not power up the GPS chip even under full Precise authorization. The returned fix is then snapped to a ~1.1 km grid before being handed to the page (latitude rounds to `0.01°`, longitude rounds to `0.01° / cos(snappedLat)`) and the reported `accuracy` is inflated to at least 1100 m (or the platform-reported accuracy, whichever is larger — a NETWORK-only 5 km fix must not be silently sharpened by GSM mode). Note that this tier may return nothing on devices without an NLP backend (de-Googled phones without microG/UnifiedNlp); `approximate` is the right choice when the user needs a fix that actually arrives.
 
-Granularity is `fine` by default for backwards compatibility — existing sites that read live location keep their metre-level precision until the user opts into coarse for that site. The fine/coarse selection threads through to the platform plugin via a `'accuracy'` arg on the `getCurrentLocation` method-channel call (string `'fine'` or `'coarse'`); a coarse-only site therefore never escalates the app's permission posture or causes the OS prompt to offer the Precise toggle for that call.
+Granularity is `gps` by default for backwards compatibility — existing sites that read live location keep their metre-level precision until the user opts into `approximate` or `gsm` for that site. The granularity threads through to the platform plugin via an `'accuracy'` arg on the `getCurrentLocation` method-channel call: `gps` and `approximate` both pass `'fine'` (the OS provider strategy is identical), while `gsm` passes `'coarse'`. A GSM-only site therefore never escalates the app's permission posture or causes the OS prompt to offer the Precise toggle for that call.
 
-`liveLocationGranularity` SHALL round-trip through `WebViewModel.toJson` / `fromJson`. The default `fine` value SHALL be omitted from JSON so on-disk and QR-payload sizes stay byte-stable for users who never opt into coarse. Older backups predating the field SHALL rehydrate as `fine`.
+`liveLocationGranularity` SHALL round-trip through `WebViewModel.toJson` / `fromJson`. The default `gps` value SHALL be omitted from JSON so on-disk and QR-payload sizes stay byte-stable for users who never opt into `approximate` / `gsm`. Older backups predating the field SHALL rehydrate as `gps`. Backups written under the previous two-tier scheme (`fine` / `coarse`) SHALL migrate as `fine` → `gps` and `coarse` → `gsm`, since those were the OS-level provider tiers those values mapped to.
 
-The shim variable controlling the static-coordinates path SHALL be named `STATIC_LOC` (not `SPOOF_LOC`) for clarity, since both `spoof` and `live` are technically "spoofs" of `navigator.geolocation` — `STATIC_LOC` specifically gates the path that returns hardcoded coords. The shim variable gating coarse live granularity SHALL be named `LIVE_COARSE`.
+The shim variable controlling the static-coordinates path SHALL be named `STATIC_LOC` (not `SPOOF_LOC`) for clarity, since both `spoof` and `live` are technically "spoofs" of `navigator.geolocation` — `STATIC_LOC` specifically gates the path that returns hardcoded coords. The shim variables driving the live-fix grid SHALL be named `SNAP_STEP_DEG` (degrees per grid cell, `0` for `gps`) and `SNAP_MIN_ACC_M` (accuracy floor in metres, `0` for `gps`).
 
 The Dart-side handler for `getRealLocation` SHALL be registered in `webview.dart`'s `onWebViewCreated` only when `config.locationMode == LocationMode.live`. The handler delegates to `CurrentLocationService.getCurrentLocation()` (Android `LocationManager` / iOS `CLLocationManager`, no Google Play Services). The platform permission prompt fires the first time the page actually calls `getCurrentPosition` — not at app launch, not at site activation.
 
@@ -157,45 +158,61 @@ The Dart-side handler for `getRealLocation` SHALL be registered in `webview.dart
 **Then** `Intl` reports `'Asia/Tokyo'` (the timezone override is unaffected by live mode)
 **And** `RTCPeerConnection` is neutered per the policy
 
-#### Scenario: Fine granularity preserves platform precision
+#### Scenario: GPS granularity preserves platform precision
 
-**Given** site "Acme" has `locationMode = live`, `liveLocationGranularity = fine`
+**Given** site "Acme" has `locationMode = live`, `liveLocationGranularity = gps`
 **And** the platform fix is `(35.6762, 139.6503)` with accuracy 12 m
 **When** the site calls `navigator.geolocation.getCurrentPosition(cb)`
 **Then** `cb` is invoked with `coords.latitude ≈ 35.6762`, `coords.longitude ≈ 139.6503` (within ~2 m of sub-meter jitter)
 **And** `coords.accuracy == 12` (the platform-reported value, unchanged)
 
-#### Scenario: Coarse granularity snaps to a ~1.1 km grid
+#### Scenario: Approximate granularity snaps to a ~110 m grid via the GPS provider
 
-**Given** site "Acme" has `locationMode = live`, `liveLocationGranularity = coarse`
+**Given** site "Acme" has `locationMode = live`, `liveLocationGranularity = approximate`
+**And** the platform fix is `(35.6762, 139.6503)` with accuracy 12 m
+**When** the site calls `navigator.geolocation.getCurrentPosition(cb)`
+**Then** the underlying method-channel call carries `'accuracy': 'fine'`, so the OS still uses the GPS provider (a NETWORK-only failure does NOT block this tier)
+**And** `cb` is invoked with coords snapped so `coords.latitude` rounds to a multiple of `0.001°` and `coords.longitude` rounds to a multiple of `0.001° / cos(snappedLat)` (each modulo the ~2 m jitter applied on top)
+**And** `coords.accuracy >= 110` (inflated to reflect the grid extent)
+
+#### Scenario: GSM granularity snaps to a ~1.1 km grid
+
+**Given** site "Acme" has `locationMode = live`, `liveLocationGranularity = gsm`
 **And** the platform fix is `(35.6762, 139.6503)` with accuracy 12 m
 **When** the site calls `navigator.geolocation.getCurrentPosition(cb)`
 **Then** `cb` is invoked with coords snapped so `coords.latitude` rounds to a multiple of `0.01°` and `coords.longitude` rounds to a multiple of `0.01° / cos(snappedLat)` (each modulo the ~2 m jitter applied on top)
 **And** `coords.accuracy >= 1100` (inflated to reflect the grid extent)
 
-#### Scenario: Coarse granularity does not sharpen an already-coarse fix
+#### Scenario: Snap granularity does not sharpen an already-coarse fix
 
-**Given** site "Acme" has `locationMode = live`, `liveLocationGranularity = coarse`
+**Given** site "Acme" has `locationMode = live` and any snapping granularity (`approximate` or `gsm`)
 **And** the platform fix is `(35.6762, 139.6503)` with accuracy 5000 m (NETWORK provider)
 **When** the site calls `navigator.geolocation.getCurrentPosition(cb)`
-**Then** `coords.accuracy == 5000` (the coarse path uses `max(real, 1100)`, never sharpens a less-accurate fix)
+**Then** `coords.accuracy == 5000` (the snap path uses `max(real, floor)`, never sharpens a less-accurate fix)
 
-#### Scenario: Coarse granularity never requests fine-location permission
+#### Scenario: GSM granularity never requests fine-location permission
 
-**Given** site "Acme" has `locationMode = live`, `liveLocationGranularity = coarse`
+**Given** site "Acme" has `locationMode = live`, `liveLocationGranularity = gsm`
 **And** the app holds neither `ACCESS_FINE_LOCATION` nor `ACCESS_COARSE_LOCATION` (Android), or `notDetermined` authorization (iOS)
 **When** the site calls `navigator.geolocation.getCurrentPosition(cb)` for the first time
 **Then** the OS permission prompt requests only `ACCESS_COARSE_LOCATION` on Android (the system "Precise" toggle is not offered for this call)
-**And** on Android the fix is sourced exclusively from `LocationManager.NETWORK_PROVIDER`; the `GPS_PROVIDER` is not started even if it is enabled and even if the app already held `ACCESS_FINE_LOCATION` from a previous fine-mode call
+**And** on Android the fix is sourced exclusively from `LocationManager.NETWORK_PROVIDER`; the `GPS_PROVIDER` is not started even if it is enabled and even if the app already held `ACCESS_FINE_LOCATION` from a previous GPS-mode call
 **And** on iOS `CLLocationManager.desiredAccuracy = kCLLocationAccuracyKilometer` is set before `requestLocation()`, so CoreLocation serves the fix from cell-tower / Wi-Fi positioning rather than powering up the GPS chip
 
-#### Scenario: Coarse granularity hides sub-cell movement
+#### Scenario: Snap granularity hides sub-cell movement
 
-**Given** site "Acme" has `locationMode = live`, `liveLocationGranularity = coarse`
-**And** two consecutive platform fixes 100 m apart inside the same grid cell
+**Given** site "Acme" has `locationMode = live` and any snapping granularity (`approximate` or `gsm`)
+**And** two consecutive platform fixes within the same grid cell (~100 m for `approximate`, ~1 km for `gsm`)
 **When** the site calls `watchPosition(cb)` and receives both fixes
 **Then** the two reported `(latitude, longitude)` values are within sub-meter jitter of each other
 **And** the cell row's longitude step is derived from the snapped latitude (not the raw one), so two neighbouring real latitudes that round into the same row never produce different snapped longitudes for the same cell
+
+#### Scenario: Legacy "fine"/"coarse" backups migrate to gps/gsm
+
+**Given** a settings backup written before the three-tier rename, where one site has `"liveLocationGranularity": "fine"` and another has `"liveLocationGranularity": "coarse"`
+**When** the user restores the backup
+**Then** the first site's `liveLocationGranularity` rehydrates as `gps` (same OS-level provider, same lack of snapping)
+**And** the second site's `liveLocationGranularity` rehydrates as `gsm` (same NETWORK-only provider, same ~1.1 km snap)
 
 ---
 

--- a/test/js/location_spoof_shim.test.js
+++ b/test/js/location_spoof_shim.test.js
@@ -122,11 +122,11 @@ function loadLiveShim(fixtureRelPath, fakeFix) {
   return dom;
 }
 
-test('live_fine: getCurrentPosition returns the platform fix unchanged (modulo sub-meter jitter)', async () => {
-  // The platform fix is 35.6762, 139.6503 with 12 m accuracy. Fine
+test('live_gps: getCurrentPosition returns the platform fix unchanged (modulo sub-meter jitter)', async () => {
+  // The platform fix is 35.6762, 139.6503 with 12 m accuracy. GPS
   // granularity must not snap to a grid; only the ~2 m jitter in
   // makeCoordsFrom is allowed to perturb the values.
-  const dom = loadLiveShim('location_spoof/live_fine.js', {
+  const dom = loadLiveShim('location_spoof/live_gps.js', {
     lat: 35.6762, lng: 139.6503, acc: 12,
   });
   const pos = await new Promise((resolve, reject) => {
@@ -134,94 +134,106 @@ test('live_fine: getCurrentPosition returns the platform fix unchanged (modulo s
   });
   assert.ok(Math.abs(pos.coords.latitude - 35.6762) < 0.0001);
   assert.ok(Math.abs(pos.coords.longitude - 139.6503) < 0.0001);
-  // Fine reports the platform-provided accuracy (no inflation).
+  // GPS reports the platform-provided accuracy (no inflation).
   assert.equal(pos.coords.accuracy, 12);
 });
 
-test('live_coarse: getCurrentPosition snaps lat/lng to a ~1.1km grid', async () => {
-  // Latitude rounds to the nearest 0.01° (~1.1 km). Longitude step is
-  // divided by cos(snappedLat) so cells stay roughly square. Sub-meter
-  // jitter is applied on top of the snapped value, so the reported
-  // coords differ from the grid cell origin by less than 2 m.
-  const dom = loadLiveShim('location_spoof/live_coarse.js', {
-    lat: 35.6762, lng: 139.6503, acc: 12,
-  });
-  const pos = await new Promise((resolve, reject) => {
-    dom.window.navigator.geolocation.getCurrentPosition(resolve, reject);
-  });
-  // Mirror the shim's coarsening: snap latitude first, then derive the
-  // longitude step from the snapped latitude (not the raw one — see the
-  // shim comment for why).
-  const latStep = 0.01;
-  const expectedLat = Math.round(35.6762 / latStep) * latStep;
-  const cosSnappedLat = Math.cos(expectedLat * Math.PI / 180);
-  const lngStep = latStep / cosSnappedLat;
-  const expectedLng = Math.round(139.6503 / lngStep) * lngStep;
-  assert.ok(Math.abs(pos.coords.latitude - expectedLat) < 0.0001,
-    `lat ${pos.coords.latitude} not within jitter of grid cell ${expectedLat}`);
-  assert.ok(Math.abs(pos.coords.longitude - expectedLng) < 0.0001,
-    `lng ${pos.coords.longitude} not within jitter of grid cell ${expectedLng}`);
-});
+// Parameterise the snap-tier scenarios so the GSM and Approximate tiers
+// share the same correctness contract, only the grid step / accuracy
+// floor differ. A regression on either tier fails its own row without
+// false-positives on the other.
+const SNAP_TIERS = [
+  { name: 'approximate', fixture: 'location_spoof/live_approximate.js',
+    latStep: 0.001, accFloor: 110 },
+  { name: 'gsm',         fixture: 'location_spoof/live_gsm.js',
+    latStep: 0.01,  accFloor: 1100 },
+];
 
-test('live_coarse: reported accuracy is inflated to at least 1100 m', async () => {
-  // Platform-reported 12 m accuracy must not flow through unchanged —
-  // coarse mode must report an accuracy that matches the grid extent so
-  // pages know the fix is approximate.
-  const dom = loadLiveShim('location_spoof/live_coarse.js', {
-    lat: 35.6762, lng: 139.6503, acc: 12,
+for (const tier of SNAP_TIERS) {
+  test(`live_${tier.name}: getCurrentPosition snaps lat/lng to the tier grid`, async () => {
+    // Latitude rounds to the nearest tier.latStep. Longitude step is
+    // divided by cos(snappedLat) so cells stay roughly square. Sub-meter
+    // jitter is applied on top of the snapped value, so the reported
+    // coords differ from the grid cell origin by less than 2 m.
+    const dom = loadLiveShim(tier.fixture, {
+      lat: 35.6762, lng: 139.6503, acc: 12,
+    });
+    const pos = await new Promise((resolve, reject) => {
+      dom.window.navigator.geolocation.getCurrentPosition(resolve, reject);
+    });
+    // Mirror the shim: snap latitude first, then derive the longitude
+    // step from the snapped latitude (not the raw one — see shim comment).
+    const expectedLat = Math.round(35.6762 / tier.latStep) * tier.latStep;
+    const cosSnappedLat = Math.cos(expectedLat * Math.PI / 180);
+    const lngStep = tier.latStep / cosSnappedLat;
+    const expectedLng = Math.round(139.6503 / lngStep) * lngStep;
+    assert.ok(Math.abs(pos.coords.latitude - expectedLat) < 0.0001,
+      `lat ${pos.coords.latitude} not within jitter of grid cell ${expectedLat}`);
+    assert.ok(Math.abs(pos.coords.longitude - expectedLng) < 0.0001,
+      `lng ${pos.coords.longitude} not within jitter of grid cell ${expectedLng}`);
   });
-  const pos = await new Promise((resolve, reject) => {
-    dom.window.navigator.geolocation.getCurrentPosition(resolve, reject);
-  });
-  assert.ok(pos.coords.accuracy >= 1100,
-    `accuracy ${pos.coords.accuracy} should be >=1100m in coarse mode`);
-});
 
-test('live_coarse: a fix already coarser than the floor keeps its accuracy', async () => {
-  // If the platform already reports 5000 m (low-accuracy NETWORK
-  // provider), coarse mode must not silently lower the reported accuracy
-  // to 1100. Use max(real, floor) not just floor.
-  const dom = loadLiveShim('location_spoof/live_coarse.js', {
-    lat: 35.6762, lng: 139.6503, acc: 5000,
+  test(`live_${tier.name}: reported accuracy is inflated to at least the tier floor`, async () => {
+    // A precise 12 m platform fix must not flow through unchanged —
+    // snap tiers report an accuracy that matches the grid extent so
+    // pages know the fix is approximate.
+    const dom = loadLiveShim(tier.fixture, {
+      lat: 35.6762, lng: 139.6503, acc: 12,
+    });
+    const pos = await new Promise((resolve, reject) => {
+      dom.window.navigator.geolocation.getCurrentPosition(resolve, reject);
+    });
+    assert.ok(pos.coords.accuracy >= tier.accFloor,
+      `accuracy ${pos.coords.accuracy} should be >=${tier.accFloor}m in ${tier.name} mode`);
   });
-  const pos = await new Promise((resolve, reject) => {
-    dom.window.navigator.geolocation.getCurrentPosition(resolve, reject);
-  });
-  assert.equal(pos.coords.accuracy, 5000);
-});
 
-test('live_coarse: nearby fixes inside the same grid cell snap to the same coords', async () => {
-  // The whole point of coarse mode is that small movements don't leak.
-  // Two fixes 100 m apart inside the same ~1.1 km cell must produce the
-  // same snapped lat/lng (modulo the 2 m jitter, which is well below
-  // grid-cell resolution).
-  const fix1 = { lat: 35.6760, lng: 139.6500, acc: 12 };
-  const fix2 = { lat: 35.6765, lng: 139.6505, acc: 12 };
-  let nextFix = fix1;
-  const { loadShim: load } = require('./helpers/load_shim');
-  const dom = load('location_spoof/live_coarse.js');
-  dom.window.flutter_inappwebview = {
-    callHandler(name) {
-      if (name !== 'getRealLocation') return Promise.resolve(null);
-      const f = nextFix;
-      return Promise.resolve({
-        status: 'ok', latitude: f.lat, longitude: f.lng, accuracy: f.acc,
-      });
-    },
-  };
-  const pos1 = await new Promise((resolve, reject) => {
-    dom.window.navigator.geolocation.getCurrentPosition(resolve, reject);
+  test(`live_${tier.name}: a fix already coarser than the floor keeps its accuracy`, async () => {
+    // If the platform already reports 5000 m (low-accuracy NETWORK
+    // provider), snap mode must not silently lower the reported accuracy.
+    // Use max(real, floor) not just floor.
+    const dom = loadLiveShim(tier.fixture, {
+      lat: 35.6762, lng: 139.6503, acc: 5000,
+    });
+    const pos = await new Promise((resolve, reject) => {
+      dom.window.navigator.geolocation.getCurrentPosition(resolve, reject);
+    });
+    assert.equal(pos.coords.accuracy, 5000);
   });
-  nextFix = fix2;
-  const pos2 = await new Promise((resolve, reject) => {
-    dom.window.navigator.geolocation.getCurrentPosition(resolve, reject);
+
+  test(`live_${tier.name}: nearby fixes inside the same grid cell snap to the same coords`, async () => {
+    // The whole point of snapping is that small movements don't leak.
+    // Two fixes inside the same cell must produce the same snapped
+    // lat/lng (modulo the 2 m jitter, which is well below the
+    // grid-cell resolution for both tiers).
+    const cell = tier.latStep / 4;   // safely inside one cell
+    const fix1 = { lat: 35.6760, lng: 139.6500, acc: 12 };
+    const fix2 = { lat: 35.6760 + cell, lng: 139.6500 + cell, acc: 12 };
+    let nextFix = fix1;
+    const { loadShim: load } = require('./helpers/load_shim');
+    const dom = load(tier.fixture);
+    dom.window.flutter_inappwebview = {
+      callHandler(name) {
+        if (name !== 'getRealLocation') return Promise.resolve(null);
+        const f = nextFix;
+        return Promise.resolve({
+          status: 'ok', latitude: f.lat, longitude: f.lng, accuracy: f.acc,
+        });
+      },
+    };
+    const pos1 = await new Promise((resolve, reject) => {
+      dom.window.navigator.geolocation.getCurrentPosition(resolve, reject);
+    });
+    nextFix = fix2;
+    const pos2 = await new Promise((resolve, reject) => {
+      dom.window.navigator.geolocation.getCurrentPosition(resolve, reject);
+    });
+    // Both fixes round into the same cell, so the snapped components are
+    // identical. ~2 m jitter is well below tier.latStep, so a tight
+    // tolerance catches a regression where the grid step changed.
+    assert.ok(Math.abs(pos1.coords.latitude - pos2.coords.latitude) < 0.0001);
+    assert.ok(Math.abs(pos1.coords.longitude - pos2.coords.longitude) < 0.0001);
   });
-  // Both fixes round into the same cell, so the snapped components are
-  // identical. ~2 m jitter is well below 0.0001°, so a tight tolerance
-  // catches a regression where the grid step changed.
-  assert.ok(Math.abs(pos1.coords.latitude - pos2.coords.latitude) < 0.0001);
-  assert.ok(Math.abs(pos1.coords.longitude - pos2.coords.longitude) < 0.0001);
-});
+}
 
 test('full_combo: all four overrides install in the same realm', () => {
   // Smoke test that the combined shim doesn't fail to install one

--- a/test/js_fixtures/location_spoof/full_combo.js
+++ b/test/js_fixtures/location_spoof/full_combo.js
@@ -4,24 +4,23 @@
 
   var STATIC_LOC = true;
   var LIVE_LOC = false;
-  var LIVE_COARSE = false;
+  // Grid step in degrees applied to the live fix before the page sees it.
+  // 0 = no snap (GPS tier), ~0.001 = approximate (~110 m), ~0.01 = GSM
+  // (~1.1 km). The longitude step is divided by cos(snappedLat) so cells
+  // stay roughly square as we approach the poles. SNAP_MIN_ACC_M is the
+  // floor for reported accuracy — sites that refuse low-accuracy fixes
+  // will skip the call, which is the intended trade-off.
+  var SNAP_STEP_DEG = 0.0;
+  var SNAP_MIN_ACC_M = 0.0;
   var LAT = 48.8566;
   var LNG = 2.3522;
   var ACC = 30.0;
   var TZ = "Europe/Paris";
   var WRTC = "relay";
 
-  // Grid cell size for coarse live location. 0.01 degrees latitude is
-  // ~1.11 km on the WGS-84 ellipsoid; the longitude step is divided by
-  // cos(lat) so cells stay roughly square as we approach the poles.
-  // Reported accuracy is inflated to the cell's diagonal half-extent so
-  // the page sees an honest "this is approximate" value — sites that
-  // refuse to use low-accuracy fixes will skip the call, which is the
-  // intended trade-off.
-  var COARSE_STEP_DEG = 0.01;
-  var COARSE_MIN_ACC_M = 1100;
-  function coarsenFix(lat, lng, acc) {
-    var latStep = COARSE_STEP_DEG;
+  function snapFix(lat, lng, acc) {
+    if (!(SNAP_STEP_DEG > 0)) return { lat: lat, lng: lng, acc: acc };
+    var latStep = SNAP_STEP_DEG;
     var snappedLat = Math.round(lat / latStep) * latStep;
     // Compute the longitude step from the SNAPPED latitude, not the raw
     // one. If we used the raw lat, two adjacent fixes inside the same
@@ -33,7 +32,7 @@
     var cosLat = Math.cos(snappedLat * Math.PI / 180);
     var lngStep = latStep / Math.max(Math.abs(cosLat), 1e-6);
     var snappedLng = Math.round(lng / lngStep) * lngStep;
-    var inflated = Math.max(acc || 0, COARSE_MIN_ACC_M);
+    var inflated = Math.max(acc || 0, SNAP_MIN_ACC_M);
     return { lat: snappedLat, lng: snappedLng, acc: inflated };
   }
 
@@ -117,20 +116,18 @@
     // mode is `live`; if it's missing here we still defensively fail
     // closed so a legacy/no-handler page doesn't hang forever.
     //
-    // When LIVE_COARSE is true, the platform fix is snapped to a ~1.1 km
-    // grid before being handed to makePositionFrom — sub-meter jitter
-    // applied below sits well inside the grid cell so the page can't
-    // distinguish a stationary device from one moving a few metres, but
-    // watchPosition still doesn't return byte-identical frames.
+    // When SNAP_STEP_DEG > 0 (approximate or GSM tier), the platform fix
+    // is snapped to a grid before being handed to makePositionFrom —
+    // sub-meter jitter applied below sits well inside the grid cell so
+    // the page can't distinguish a stationary device from one moving a
+    // few metres within the same cell, but watchPosition still doesn't
+    // return byte-identical frames.
     function getLiveFix() {
       if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
         return window.flutter_inappwebview.callHandler('getRealLocation').then(function(res) {
           if (res && res.status === 'ok') {
-            if (LIVE_COARSE) {
-              var c = coarsenFix(res.latitude, res.longitude, res.accuracy);
-              return { ok: true, lat: c.lat, lng: c.lng, acc: c.acc };
-            }
-            return { ok: true, lat: res.latitude, lng: res.longitude, acc: res.accuracy };
+            var c = snapFix(res.latitude, res.longitude, res.accuracy);
+            return { ok: true, lat: c.lat, lng: c.lng, acc: c.acc };
           }
           return { ok: false, payload: res };
         }, function() {

--- a/test/js_fixtures/location_spoof/live_approximate.js
+++ b/test/js_fixtures/location_spoof/live_approximate.js
@@ -4,24 +4,23 @@
 
   var STATIC_LOC = false;
   var LIVE_LOC = true;
-  var LIVE_COARSE = false;
+  // Grid step in degrees applied to the live fix before the page sees it.
+  // 0 = no snap (GPS tier), ~0.001 = approximate (~110 m), ~0.01 = GSM
+  // (~1.1 km). The longitude step is divided by cos(snappedLat) so cells
+  // stay roughly square as we approach the poles. SNAP_MIN_ACC_M is the
+  // floor for reported accuracy — sites that refuse low-accuracy fixes
+  // will skip the call, which is the intended trade-off.
+  var SNAP_STEP_DEG = 0.001;
+  var SNAP_MIN_ACC_M = 110.0;
   var LAT = 0.0;
   var LNG = 0.0;
   var ACC = 50.0;
   var TZ = null;
   var WRTC = "default";
 
-  // Grid cell size for coarse live location. 0.01 degrees latitude is
-  // ~1.11 km on the WGS-84 ellipsoid; the longitude step is divided by
-  // cos(lat) so cells stay roughly square as we approach the poles.
-  // Reported accuracy is inflated to the cell's diagonal half-extent so
-  // the page sees an honest "this is approximate" value — sites that
-  // refuse to use low-accuracy fixes will skip the call, which is the
-  // intended trade-off.
-  var COARSE_STEP_DEG = 0.01;
-  var COARSE_MIN_ACC_M = 1100;
-  function coarsenFix(lat, lng, acc) {
-    var latStep = COARSE_STEP_DEG;
+  function snapFix(lat, lng, acc) {
+    if (!(SNAP_STEP_DEG > 0)) return { lat: lat, lng: lng, acc: acc };
+    var latStep = SNAP_STEP_DEG;
     var snappedLat = Math.round(lat / latStep) * latStep;
     // Compute the longitude step from the SNAPPED latitude, not the raw
     // one. If we used the raw lat, two adjacent fixes inside the same
@@ -33,7 +32,7 @@
     var cosLat = Math.cos(snappedLat * Math.PI / 180);
     var lngStep = latStep / Math.max(Math.abs(cosLat), 1e-6);
     var snappedLng = Math.round(lng / lngStep) * lngStep;
-    var inflated = Math.max(acc || 0, COARSE_MIN_ACC_M);
+    var inflated = Math.max(acc || 0, SNAP_MIN_ACC_M);
     return { lat: snappedLat, lng: snappedLng, acc: inflated };
   }
 
@@ -117,20 +116,18 @@
     // mode is `live`; if it's missing here we still defensively fail
     // closed so a legacy/no-handler page doesn't hang forever.
     //
-    // When LIVE_COARSE is true, the platform fix is snapped to a ~1.1 km
-    // grid before being handed to makePositionFrom — sub-meter jitter
-    // applied below sits well inside the grid cell so the page can't
-    // distinguish a stationary device from one moving a few metres, but
-    // watchPosition still doesn't return byte-identical frames.
+    // When SNAP_STEP_DEG > 0 (approximate or GSM tier), the platform fix
+    // is snapped to a grid before being handed to makePositionFrom —
+    // sub-meter jitter applied below sits well inside the grid cell so
+    // the page can't distinguish a stationary device from one moving a
+    // few metres within the same cell, but watchPosition still doesn't
+    // return byte-identical frames.
     function getLiveFix() {
       if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
         return window.flutter_inappwebview.callHandler('getRealLocation').then(function(res) {
           if (res && res.status === 'ok') {
-            if (LIVE_COARSE) {
-              var c = coarsenFix(res.latitude, res.longitude, res.accuracy);
-              return { ok: true, lat: c.lat, lng: c.lng, acc: c.acc };
-            }
-            return { ok: true, lat: res.latitude, lng: res.longitude, acc: res.accuracy };
+            var c = snapFix(res.latitude, res.longitude, res.accuracy);
+            return { ok: true, lat: c.lat, lng: c.lng, acc: c.acc };
           }
           return { ok: false, payload: res };
         }, function() {

--- a/test/js_fixtures/location_spoof/live_gps.js
+++ b/test/js_fixtures/location_spoof/live_gps.js
@@ -4,24 +4,23 @@
 
   var STATIC_LOC = false;
   var LIVE_LOC = true;
-  var LIVE_COARSE = true;
+  // Grid step in degrees applied to the live fix before the page sees it.
+  // 0 = no snap (GPS tier), ~0.001 = approximate (~110 m), ~0.01 = GSM
+  // (~1.1 km). The longitude step is divided by cos(snappedLat) so cells
+  // stay roughly square as we approach the poles. SNAP_MIN_ACC_M is the
+  // floor for reported accuracy — sites that refuse low-accuracy fixes
+  // will skip the call, which is the intended trade-off.
+  var SNAP_STEP_DEG = 0.0;
+  var SNAP_MIN_ACC_M = 0.0;
   var LAT = 0.0;
   var LNG = 0.0;
   var ACC = 50.0;
   var TZ = null;
   var WRTC = "default";
 
-  // Grid cell size for coarse live location. 0.01 degrees latitude is
-  // ~1.11 km on the WGS-84 ellipsoid; the longitude step is divided by
-  // cos(lat) so cells stay roughly square as we approach the poles.
-  // Reported accuracy is inflated to the cell's diagonal half-extent so
-  // the page sees an honest "this is approximate" value — sites that
-  // refuse to use low-accuracy fixes will skip the call, which is the
-  // intended trade-off.
-  var COARSE_STEP_DEG = 0.01;
-  var COARSE_MIN_ACC_M = 1100;
-  function coarsenFix(lat, lng, acc) {
-    var latStep = COARSE_STEP_DEG;
+  function snapFix(lat, lng, acc) {
+    if (!(SNAP_STEP_DEG > 0)) return { lat: lat, lng: lng, acc: acc };
+    var latStep = SNAP_STEP_DEG;
     var snappedLat = Math.round(lat / latStep) * latStep;
     // Compute the longitude step from the SNAPPED latitude, not the raw
     // one. If we used the raw lat, two adjacent fixes inside the same
@@ -33,7 +32,7 @@
     var cosLat = Math.cos(snappedLat * Math.PI / 180);
     var lngStep = latStep / Math.max(Math.abs(cosLat), 1e-6);
     var snappedLng = Math.round(lng / lngStep) * lngStep;
-    var inflated = Math.max(acc || 0, COARSE_MIN_ACC_M);
+    var inflated = Math.max(acc || 0, SNAP_MIN_ACC_M);
     return { lat: snappedLat, lng: snappedLng, acc: inflated };
   }
 
@@ -117,20 +116,18 @@
     // mode is `live`; if it's missing here we still defensively fail
     // closed so a legacy/no-handler page doesn't hang forever.
     //
-    // When LIVE_COARSE is true, the platform fix is snapped to a ~1.1 km
-    // grid before being handed to makePositionFrom — sub-meter jitter
-    // applied below sits well inside the grid cell so the page can't
-    // distinguish a stationary device from one moving a few metres, but
-    // watchPosition still doesn't return byte-identical frames.
+    // When SNAP_STEP_DEG > 0 (approximate or GSM tier), the platform fix
+    // is snapped to a grid before being handed to makePositionFrom —
+    // sub-meter jitter applied below sits well inside the grid cell so
+    // the page can't distinguish a stationary device from one moving a
+    // few metres within the same cell, but watchPosition still doesn't
+    // return byte-identical frames.
     function getLiveFix() {
       if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
         return window.flutter_inappwebview.callHandler('getRealLocation').then(function(res) {
           if (res && res.status === 'ok') {
-            if (LIVE_COARSE) {
-              var c = coarsenFix(res.latitude, res.longitude, res.accuracy);
-              return { ok: true, lat: c.lat, lng: c.lng, acc: c.acc };
-            }
-            return { ok: true, lat: res.latitude, lng: res.longitude, acc: res.accuracy };
+            var c = snapFix(res.latitude, res.longitude, res.accuracy);
+            return { ok: true, lat: c.lat, lng: c.lng, acc: c.acc };
           }
           return { ok: false, payload: res };
         }, function() {

--- a/test/js_fixtures/location_spoof/live_gsm.js
+++ b/test/js_fixtures/location_spoof/live_gsm.js
@@ -2,19 +2,19 @@
   if (window.__wsLocShimInstalled) return;
   window.__wsLocShimInstalled = true;
 
-  var STATIC_LOC = true;
-  var LIVE_LOC = false;
+  var STATIC_LOC = false;
+  var LIVE_LOC = true;
   // Grid step in degrees applied to the live fix before the page sees it.
   // 0 = no snap (GPS tier), ~0.001 = approximate (~110 m), ~0.01 = GSM
   // (~1.1 km). The longitude step is divided by cos(snappedLat) so cells
   // stay roughly square as we approach the poles. SNAP_MIN_ACC_M is the
   // floor for reported accuracy — sites that refuse low-accuracy fixes
   // will skip the call, which is the intended trade-off.
-  var SNAP_STEP_DEG = 0.0;
-  var SNAP_MIN_ACC_M = 0.0;
-  var LAT = 35.6762;
-  var LNG = 139.6503;
-  var ACC = 25.0;
+  var SNAP_STEP_DEG = 0.01;
+  var SNAP_MIN_ACC_M = 1100.0;
+  var LAT = 0.0;
+  var LNG = 0.0;
+  var ACC = 50.0;
   var TZ = null;
   var WRTC = "default";
 

--- a/test/js_fixtures/location_spoof/timezone_only_tokyo.js
+++ b/test/js_fixtures/location_spoof/timezone_only_tokyo.js
@@ -4,24 +4,23 @@
 
   var STATIC_LOC = false;
   var LIVE_LOC = false;
-  var LIVE_COARSE = false;
+  // Grid step in degrees applied to the live fix before the page sees it.
+  // 0 = no snap (GPS tier), ~0.001 = approximate (~110 m), ~0.01 = GSM
+  // (~1.1 km). The longitude step is divided by cos(snappedLat) so cells
+  // stay roughly square as we approach the poles. SNAP_MIN_ACC_M is the
+  // floor for reported accuracy — sites that refuse low-accuracy fixes
+  // will skip the call, which is the intended trade-off.
+  var SNAP_STEP_DEG = 0.0;
+  var SNAP_MIN_ACC_M = 0.0;
   var LAT = 0.0;
   var LNG = 0.0;
   var ACC = 50.0;
   var TZ = "Asia/Tokyo";
   var WRTC = "default";
 
-  // Grid cell size for coarse live location. 0.01 degrees latitude is
-  // ~1.11 km on the WGS-84 ellipsoid; the longitude step is divided by
-  // cos(lat) so cells stay roughly square as we approach the poles.
-  // Reported accuracy is inflated to the cell's diagonal half-extent so
-  // the page sees an honest "this is approximate" value — sites that
-  // refuse to use low-accuracy fixes will skip the call, which is the
-  // intended trade-off.
-  var COARSE_STEP_DEG = 0.01;
-  var COARSE_MIN_ACC_M = 1100;
-  function coarsenFix(lat, lng, acc) {
-    var latStep = COARSE_STEP_DEG;
+  function snapFix(lat, lng, acc) {
+    if (!(SNAP_STEP_DEG > 0)) return { lat: lat, lng: lng, acc: acc };
+    var latStep = SNAP_STEP_DEG;
     var snappedLat = Math.round(lat / latStep) * latStep;
     // Compute the longitude step from the SNAPPED latitude, not the raw
     // one. If we used the raw lat, two adjacent fixes inside the same
@@ -33,7 +32,7 @@
     var cosLat = Math.cos(snappedLat * Math.PI / 180);
     var lngStep = latStep / Math.max(Math.abs(cosLat), 1e-6);
     var snappedLng = Math.round(lng / lngStep) * lngStep;
-    var inflated = Math.max(acc || 0, COARSE_MIN_ACC_M);
+    var inflated = Math.max(acc || 0, SNAP_MIN_ACC_M);
     return { lat: snappedLat, lng: snappedLng, acc: inflated };
   }
 
@@ -117,20 +116,18 @@
     // mode is `live`; if it's missing here we still defensively fail
     // closed so a legacy/no-handler page doesn't hang forever.
     //
-    // When LIVE_COARSE is true, the platform fix is snapped to a ~1.1 km
-    // grid before being handed to makePositionFrom — sub-meter jitter
-    // applied below sits well inside the grid cell so the page can't
-    // distinguish a stationary device from one moving a few metres, but
-    // watchPosition still doesn't return byte-identical frames.
+    // When SNAP_STEP_DEG > 0 (approximate or GSM tier), the platform fix
+    // is snapped to a grid before being handed to makePositionFrom —
+    // sub-meter jitter applied below sits well inside the grid cell so
+    // the page can't distinguish a stationary device from one moving a
+    // few metres within the same cell, but watchPosition still doesn't
+    // return byte-identical frames.
     function getLiveFix() {
       if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
         return window.flutter_inappwebview.callHandler('getRealLocation').then(function(res) {
           if (res && res.status === 'ok') {
-            if (LIVE_COARSE) {
-              var c = coarsenFix(res.latitude, res.longitude, res.accuracy);
-              return { ok: true, lat: c.lat, lng: c.lng, acc: c.acc };
-            }
-            return { ok: true, lat: res.latitude, lng: res.longitude, acc: res.accuracy };
+            var c = snapFix(res.latitude, res.longitude, res.accuracy);
+            return { ok: true, lat: c.lat, lng: c.lng, acc: c.acc };
           }
           return { ok: false, payload: res };
         }, function() {

--- a/test/js_fixtures/location_spoof/webrtc_disabled.js
+++ b/test/js_fixtures/location_spoof/webrtc_disabled.js
@@ -4,24 +4,23 @@
 
   var STATIC_LOC = false;
   var LIVE_LOC = false;
-  var LIVE_COARSE = false;
+  // Grid step in degrees applied to the live fix before the page sees it.
+  // 0 = no snap (GPS tier), ~0.001 = approximate (~110 m), ~0.01 = GSM
+  // (~1.1 km). The longitude step is divided by cos(snappedLat) so cells
+  // stay roughly square as we approach the poles. SNAP_MIN_ACC_M is the
+  // floor for reported accuracy — sites that refuse low-accuracy fixes
+  // will skip the call, which is the intended trade-off.
+  var SNAP_STEP_DEG = 0.0;
+  var SNAP_MIN_ACC_M = 0.0;
   var LAT = 0.0;
   var LNG = 0.0;
   var ACC = 50.0;
   var TZ = null;
   var WRTC = "off";
 
-  // Grid cell size for coarse live location. 0.01 degrees latitude is
-  // ~1.11 km on the WGS-84 ellipsoid; the longitude step is divided by
-  // cos(lat) so cells stay roughly square as we approach the poles.
-  // Reported accuracy is inflated to the cell's diagonal half-extent so
-  // the page sees an honest "this is approximate" value — sites that
-  // refuse to use low-accuracy fixes will skip the call, which is the
-  // intended trade-off.
-  var COARSE_STEP_DEG = 0.01;
-  var COARSE_MIN_ACC_M = 1100;
-  function coarsenFix(lat, lng, acc) {
-    var latStep = COARSE_STEP_DEG;
+  function snapFix(lat, lng, acc) {
+    if (!(SNAP_STEP_DEG > 0)) return { lat: lat, lng: lng, acc: acc };
+    var latStep = SNAP_STEP_DEG;
     var snappedLat = Math.round(lat / latStep) * latStep;
     // Compute the longitude step from the SNAPPED latitude, not the raw
     // one. If we used the raw lat, two adjacent fixes inside the same
@@ -33,7 +32,7 @@
     var cosLat = Math.cos(snappedLat * Math.PI / 180);
     var lngStep = latStep / Math.max(Math.abs(cosLat), 1e-6);
     var snappedLng = Math.round(lng / lngStep) * lngStep;
-    var inflated = Math.max(acc || 0, COARSE_MIN_ACC_M);
+    var inflated = Math.max(acc || 0, SNAP_MIN_ACC_M);
     return { lat: snappedLat, lng: snappedLng, acc: inflated };
   }
 
@@ -117,20 +116,18 @@
     // mode is `live`; if it's missing here we still defensively fail
     // closed so a legacy/no-handler page doesn't hang forever.
     //
-    // When LIVE_COARSE is true, the platform fix is snapped to a ~1.1 km
-    // grid before being handed to makePositionFrom — sub-meter jitter
-    // applied below sits well inside the grid cell so the page can't
-    // distinguish a stationary device from one moving a few metres, but
-    // watchPosition still doesn't return byte-identical frames.
+    // When SNAP_STEP_DEG > 0 (approximate or GSM tier), the platform fix
+    // is snapped to a grid before being handed to makePositionFrom —
+    // sub-meter jitter applied below sits well inside the grid cell so
+    // the page can't distinguish a stationary device from one moving a
+    // few metres within the same cell, but watchPosition still doesn't
+    // return byte-identical frames.
     function getLiveFix() {
       if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
         return window.flutter_inappwebview.callHandler('getRealLocation').then(function(res) {
           if (res && res.status === 'ok') {
-            if (LIVE_COARSE) {
-              var c = coarsenFix(res.latitude, res.longitude, res.accuracy);
-              return { ok: true, lat: c.lat, lng: c.lng, acc: c.acc };
-            }
-            return { ok: true, lat: res.latitude, lng: res.longitude, acc: res.accuracy };
+            var c = snapFix(res.latitude, res.longitude, res.accuracy);
+            return { ok: true, lat: c.lat, lng: c.lng, acc: c.acc };
           }
           return { ok: false, payload: res };
         }, function() {

--- a/test/js_fixtures/location_spoof/webrtc_relay.js
+++ b/test/js_fixtures/location_spoof/webrtc_relay.js
@@ -4,24 +4,23 @@
 
   var STATIC_LOC = false;
   var LIVE_LOC = false;
-  var LIVE_COARSE = false;
+  // Grid step in degrees applied to the live fix before the page sees it.
+  // 0 = no snap (GPS tier), ~0.001 = approximate (~110 m), ~0.01 = GSM
+  // (~1.1 km). The longitude step is divided by cos(snappedLat) so cells
+  // stay roughly square as we approach the poles. SNAP_MIN_ACC_M is the
+  // floor for reported accuracy — sites that refuse low-accuracy fixes
+  // will skip the call, which is the intended trade-off.
+  var SNAP_STEP_DEG = 0.0;
+  var SNAP_MIN_ACC_M = 0.0;
   var LAT = 0.0;
   var LNG = 0.0;
   var ACC = 50.0;
   var TZ = null;
   var WRTC = "relay";
 
-  // Grid cell size for coarse live location. 0.01 degrees latitude is
-  // ~1.11 km on the WGS-84 ellipsoid; the longitude step is divided by
-  // cos(lat) so cells stay roughly square as we approach the poles.
-  // Reported accuracy is inflated to the cell's diagonal half-extent so
-  // the page sees an honest "this is approximate" value — sites that
-  // refuse to use low-accuracy fixes will skip the call, which is the
-  // intended trade-off.
-  var COARSE_STEP_DEG = 0.01;
-  var COARSE_MIN_ACC_M = 1100;
-  function coarsenFix(lat, lng, acc) {
-    var latStep = COARSE_STEP_DEG;
+  function snapFix(lat, lng, acc) {
+    if (!(SNAP_STEP_DEG > 0)) return { lat: lat, lng: lng, acc: acc };
+    var latStep = SNAP_STEP_DEG;
     var snappedLat = Math.round(lat / latStep) * latStep;
     // Compute the longitude step from the SNAPPED latitude, not the raw
     // one. If we used the raw lat, two adjacent fixes inside the same
@@ -33,7 +32,7 @@
     var cosLat = Math.cos(snappedLat * Math.PI / 180);
     var lngStep = latStep / Math.max(Math.abs(cosLat), 1e-6);
     var snappedLng = Math.round(lng / lngStep) * lngStep;
-    var inflated = Math.max(acc || 0, COARSE_MIN_ACC_M);
+    var inflated = Math.max(acc || 0, SNAP_MIN_ACC_M);
     return { lat: snappedLat, lng: snappedLng, acc: inflated };
   }
 
@@ -117,20 +116,18 @@
     // mode is `live`; if it's missing here we still defensively fail
     // closed so a legacy/no-handler page doesn't hang forever.
     //
-    // When LIVE_COARSE is true, the platform fix is snapped to a ~1.1 km
-    // grid before being handed to makePositionFrom — sub-meter jitter
-    // applied below sits well inside the grid cell so the page can't
-    // distinguish a stationary device from one moving a few metres, but
-    // watchPosition still doesn't return byte-identical frames.
+    // When SNAP_STEP_DEG > 0 (approximate or GSM tier), the platform fix
+    // is snapped to a grid before being handed to makePositionFrom —
+    // sub-meter jitter applied below sits well inside the grid cell so
+    // the page can't distinguish a stationary device from one moving a
+    // few metres within the same cell, but watchPosition still doesn't
+    // return byte-identical frames.
     function getLiveFix() {
       if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
         return window.flutter_inappwebview.callHandler('getRealLocation').then(function(res) {
           if (res && res.status === 'ok') {
-            if (LIVE_COARSE) {
-              var c = coarsenFix(res.latitude, res.longitude, res.accuracy);
-              return { ok: true, lat: c.lat, lng: c.lng, acc: c.acc };
-            }
-            return { ok: true, lat: res.latitude, lng: res.longitude, acc: res.accuracy };
+            var c = snapFix(res.latitude, res.longitude, res.accuracy);
+            return { ok: true, lat: c.lat, lng: c.lng, acc: c.acc };
           }
           return { ok: false, payload: res };
         }, function() {

--- a/test/location_spoof_test.dart
+++ b/test/location_spoof_test.dart
@@ -149,10 +149,10 @@ void main() {
       expect(script, contains("'granted'"));
     });
 
-    test('live mode without granularity defaults to fine', () {
+    test('live mode without granularity defaults to gps (no snap)', () {
       // Backwards-compat: callers that omit `liveLocationGranularity`
-      // must still build a live shim that does NOT coarsen — coarsening
-      // is opt-in only.
+      // must still build a live shim that does NOT snap — snapping is
+      // opt-in only via approximate/gsm.
       final script = LocationSpoofService.buildScript(
         locationMode: LocationMode.live,
         spoofLatitude: null,
@@ -163,44 +163,63 @@ void main() {
       );
       expect(script, isNotNull);
       expect(script, contains('var LIVE_LOC = true'));
-      expect(script, contains('var LIVE_COARSE = false'));
+      expect(script, contains('var SNAP_STEP_DEG = 0.0'));
+      expect(script, contains('var SNAP_MIN_ACC_M = 0.0'));
     });
 
-    test('live mode with coarse granularity flips LIVE_COARSE', () {
+    test('live mode with approximate granularity snaps to a ~110 m grid', () {
       final script = LocationSpoofService.buildScript(
         locationMode: LocationMode.live,
         spoofLatitude: null,
         spoofLongitude: null,
         spoofAccuracy: 50.0,
         spoofTimezone: null,
-        liveLocationGranularity: LocationGranularity.coarse,
+        liveLocationGranularity: LocationGranularity.approximate,
         webRtcPolicy: WebRtcPolicy.defaultPolicy,
       );
       expect(script, isNotNull);
       expect(script, contains('var LIVE_LOC = true'));
-      expect(script, contains('var LIVE_COARSE = true'));
+      expect(script, contains('var SNAP_STEP_DEG = 0.001'));
+      expect(script, contains('var SNAP_MIN_ACC_M = 110.0'));
       // Grid snapping logic must be present in the live-mode shim.
-      expect(script, contains('coarsenFix'));
-      expect(script, contains('COARSE_STEP_DEG'));
+      expect(script, contains('snapFix'));
+    });
+
+    test('live mode with gsm granularity snaps to a ~1.1 km grid', () {
+      final script = LocationSpoofService.buildScript(
+        locationMode: LocationMode.live,
+        spoofLatitude: null,
+        spoofLongitude: null,
+        spoofAccuracy: 50.0,
+        spoofTimezone: null,
+        liveLocationGranularity: LocationGranularity.gsm,
+        webRtcPolicy: WebRtcPolicy.defaultPolicy,
+      );
+      expect(script, isNotNull);
+      expect(script, contains('var LIVE_LOC = true'));
+      expect(script, contains('var SNAP_STEP_DEG = 0.01'));
+      expect(script, contains('var SNAP_MIN_ACC_M = 1100.0'));
+      expect(script, contains('snapFix'));
     });
 
     test('granularity is ignored for spoof mode (static coords are user-chosen)', () {
       // Static spoof coords reflect what the user typed/picked; the
-      // builder must not flip LIVE_COARSE when the mode isn't live, even
-      // if the caller passes coarse.
+      // builder must not flip on snapping when the mode isn't live, even
+      // if the caller passes gsm.
       final script = LocationSpoofService.buildScript(
         locationMode: LocationMode.spoof,
         spoofLatitude: 35.6762,
         spoofLongitude: 139.6503,
         spoofAccuracy: 25.0,
         spoofTimezone: null,
-        liveLocationGranularity: LocationGranularity.coarse,
+        liveLocationGranularity: LocationGranularity.gsm,
         webRtcPolicy: WebRtcPolicy.defaultPolicy,
       );
       expect(script, isNotNull);
       expect(script, contains('var STATIC_LOC = true'));
       expect(script, contains('var LIVE_LOC = false'));
-      expect(script, contains('var LIVE_COARSE = false'));
+      expect(script, contains('var SNAP_STEP_DEG = 0.0'));
+      expect(script, contains('var SNAP_MIN_ACC_M = 0.0'));
     });
 
     test('installs only once via window flag', () {

--- a/test/web_view_model_test.dart
+++ b/test/web_view_model_test.dart
@@ -401,12 +401,12 @@ void main() {
       expect(model.spoofLongitude, isNull);
       expect(model.spoofAccuracy, equals(50.0));
       expect(model.spoofTimezone, isNull);
-      expect(model.liveLocationGranularity, equals(LocationGranularity.fine));
+      expect(model.liveLocationGranularity, equals(LocationGranularity.gps));
       expect(model.webRtcPolicy, equals(WebRtcPolicy.defaultPolicy));
     });
 
     test('liveLocationGranularity round-trips when non-default', () {
-      // Default fine: omitted from JSON so on-disk size stays the same
+      // Default gps: omitted from JSON so on-disk size stays the same
       // for users who never touch live mode.
       final defaultModel = WebViewModel(
         initUrl: 'https://example.com',
@@ -414,24 +414,34 @@ void main() {
       );
       final defaultJson = defaultModel.toJson();
       expect(defaultJson.containsKey('liveLocationGranularity'), isFalse,
-          reason: 'fine is the default; omit to keep on-disk JSON byte-stable '
-              'for users who never opt into coarse');
+          reason: 'gps is the default; omit to keep on-disk JSON byte-stable '
+              'for users who never opt into approximate/gsm');
 
-      final coarseModel = WebViewModel(
+      final gsmModel = WebViewModel(
         initUrl: 'https://example.com',
         locationMode: LocationMode.live,
-        liveLocationGranularity: LocationGranularity.coarse,
+        liveLocationGranularity: LocationGranularity.gsm,
       );
-      final coarseJson = coarseModel.toJson();
-      expect(coarseJson['liveLocationGranularity'], equals('coarse'));
+      final gsmJson = gsmModel.toJson();
+      expect(gsmJson['liveLocationGranularity'], equals('gsm'));
 
-      final restored = WebViewModel.fromJson(coarseJson, null);
+      final restored = WebViewModel.fromJson(gsmJson, null);
       expect(restored.liveLocationGranularity,
-          equals(LocationGranularity.coarse));
+          equals(LocationGranularity.gsm));
+
+      final approxModel = WebViewModel(
+        initUrl: 'https://example.com',
+        locationMode: LocationMode.live,
+        liveLocationGranularity: LocationGranularity.approximate,
+      );
+      final approxJson = approxModel.toJson();
+      expect(approxJson['liveLocationGranularity'], equals('approximate'));
+      expect(WebViewModel.fromJson(approxJson, null).liveLocationGranularity,
+          equals(LocationGranularity.approximate));
     });
 
-    test('liveLocationGranularity defaults to fine when absent from JSON', () {
-      // Older backups predate the field — they must rehydrate as fine.
+    test('liveLocationGranularity defaults to gps when absent from JSON', () {
+      // Older backups predate the field — they must rehydrate as gps.
       final json = {
         'initUrl': 'https://example.com',
         'currentUrl': 'https://example.com',
@@ -443,7 +453,30 @@ void main() {
         'locationMode': 'live',
       };
       final model = WebViewModel.fromJson(json, null);
-      expect(model.liveLocationGranularity, equals(LocationGranularity.fine));
+      expect(model.liveLocationGranularity, equals(LocationGranularity.gps));
+    });
+
+    test('legacy "fine"/"coarse" JSON values migrate to gps/gsm', () {
+      // Backups written before #326 used the old enum names. Reading
+      // them must map "fine" → gps and "coarse" → gsm so existing users
+      // don't silently land on the wrong tier on upgrade.
+      Map<String, dynamic> base(String value) => {
+            'initUrl': 'https://example.com',
+            'currentUrl': 'https://example.com',
+            'cookies': [],
+            'proxySettings': {'type': 0, 'address': null},
+            'javascriptEnabled': true,
+            'userAgent': '',
+            'thirdPartyCookiesEnabled': false,
+            'locationMode': 'live',
+            'liveLocationGranularity': value,
+          };
+      expect(
+          WebViewModel.fromJson(base('fine'), null).liveLocationGranularity,
+          equals(LocationGranularity.gps));
+      expect(
+          WebViewModel.fromJson(base('coarse'), null).liveLocationGranularity,
+          equals(LocationGranularity.gsm));
     });
 
     test('location spoof fields round-trip through JSON', () {

--- a/tool/dump_shim_js.dart
+++ b/tool/dump_shim_js.dart
@@ -65,7 +65,7 @@ Map<String, String> buildAllFixtures() {
     spoofTimezone: null,
     webRtcPolicy: WebRtcPolicy.defaultPolicy,
   )!;
-  fixtures['location_spoof/live_fine.js'] =
+  fixtures['location_spoof/live_gps.js'] =
       LocationSpoofService.buildScript(
     locationMode: LocationMode.live,
     spoofLatitude: null,
@@ -74,14 +74,24 @@ Map<String, String> buildAllFixtures() {
     spoofTimezone: null,
     webRtcPolicy: WebRtcPolicy.defaultPolicy,
   )!;
-  fixtures['location_spoof/live_coarse.js'] =
+  fixtures['location_spoof/live_approximate.js'] =
       LocationSpoofService.buildScript(
     locationMode: LocationMode.live,
     spoofLatitude: null,
     spoofLongitude: null,
     spoofAccuracy: 50.0,
     spoofTimezone: null,
-    liveLocationGranularity: LocationGranularity.coarse,
+    liveLocationGranularity: LocationGranularity.approximate,
+    webRtcPolicy: WebRtcPolicy.defaultPolicy,
+  )!;
+  fixtures['location_spoof/live_gsm.js'] =
+      LocationSpoofService.buildScript(
+    locationMode: LocationMode.live,
+    spoofLatitude: null,
+    spoofLongitude: null,
+    spoofAccuracy: 50.0,
+    spoofTimezone: null,
+    liveLocationGranularity: LocationGranularity.gsm,
     webRtcPolicy: WebRtcPolicy.defaultPolicy,
   )!;
   fixtures['location_spoof/timezone_only_tokyo.js'] =


### PR DESCRIPTION
Replaces the binary `fine`/`coarse` location granularity enum with a three-tier model (`gps`, `approximate`, `gsm`) that maps to distinct OS-level provider strategies and grid-snapping behaviors.

**Changes:**

- Rename `LocationGranularity.fine` → `LocationGranularity.gps` (no snapping, GPS provider preferred)
- Add `LocationGranularity.approximate` (0.001° grid snap ≈110 m, still uses GPS provider)
- Rename `LocationGranularity.coarse` → `LocationGranularity.gsm` (0.01° grid snap ≈1.1 km, network provider only)
- Refactor JS shim to use parameterized `SNAP_STEP_DEG` and `SNAP_MIN_ACC_M` instead of hardcoded `LIVE_COARSE` boolean, enabling per-tier configuration
- Rename `coarsenFix()` → `snapFix()` and update grid-snapping logic to work with any step size
- Update all fixture files (`live_gps.js`, `live_approximate.js`, `live_gsm.js`) to reflect new parameter names
- Parameterize JS tests to run the same grid-snapping contract against both approximate and GSM tiers
- Update settings UI help text and model documentation to explain the three tiers and their use cases
- Change default from `fine` to `gps` (preserves existing behavior; omit from JSON for backward-compat)

The refactor decouples grid granularity from the binary on/off toggle, allowing sites to opt into intermediate precision (approximate) without jumping to full network-only mode (GSM).

https://claude.ai/code/session_01SHtSbHY66JAMAHFetMSD1y