### PR TITLE
build(rust): pin toolchain for reproducible F-Droid builds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,6 +10,11 @@ on:
   # Allow manual trigger for testing
   workflow_dispatch:
 
+# Single source of truth for the cargo-ndk version. The F-Droid recipe
+# seds this line; every job reads it via the env context. Bump here only.
+env:
+  CARGO_NDK_VERSION: "4.1.2"
+
 jobs:
   validate:
     name: Validate Fastlane + OpenSpec
@@ -168,8 +173,6 @@ jobs:
           targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
 
       - name: Install cargo-ndk
-        env:
-          CARGO_NDK_VERSION: "4.1.2"
         run: cargo install --locked "cargo-ndk@${CARGO_NDK_VERSION}"
 
       # cargo-ndk requires ANDROID_NDK_HOME pointing at a real NDK

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -163,7 +163,9 @@ jobs:
           targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
 
       - name: Install cargo-ndk
-        run: cargo install --locked cargo-ndk
+        env:
+          CARGO_NDK_VERSION: "4.1.2"
+        run: cargo install --locked "cargo-ndk@${CARGO_NDK_VERSION}"
 
       # cargo-ndk requires ANDROID_NDK_HOME pointing at a real NDK
       # install. The ubuntu-latest runner ships a default NDK under

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -157,9 +157,14 @@ jobs:
           restore-keys: |
             cargo-android-${{ runner.os }}-
 
+      - name: Read Rust toolchain
+        id: rust
+        run: echo "channel=$(sed -n -E 's/channel = "(.*)"/\1/p' rust-toolchain.toml)" >> "$GITHUB_OUTPUT"
+
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ steps.rust.outputs.channel }}
           targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
 
       - name: Install cargo-ndk
@@ -473,8 +478,14 @@ jobs:
           restore-keys: |
             cargo-linux-${{ runner.os }}-
 
+      - name: Read Rust toolchain
+        id: rust
+        run: echo "channel=$(sed -n -E 's/channel = "(.*)"/\1/p' rust-toolchain.toml)" >> "$GITHUB_OUTPUT"
+
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.rust.outputs.channel }}
 
       # Pin the upstream-crate behaviour the Dart-side procedural
       # backfill (procedural_action_backfill.dart) relies on. If
@@ -719,9 +730,14 @@ jobs:
           restore-keys: |
             cargo-apple-${{ runner.os }}-
 
+      - name: Read Rust toolchain
+        id: rust
+        run: echo "channel=$(sed -n -E 's/channel = "(.*)"/\1/p' rust-toolchain.toml)" >> "$GITHUB_OUTPUT"
+
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ steps.rust.outputs.channel }}
           targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios,aarch64-apple-darwin,x86_64-apple-darwin
 
       # Build the rust .xcframework + macOS fat .a + keep_alive.c into

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,18 @@
+# Pins the toolchain for the webspace_adblock crate (rust/webspace_adblock).
+# Lives at the repo root so rustup finds it both when cargo runs from the
+# crate dir (gradle buildRustAdblock / CMake / build_rust.sh all `cd` in)
+# and when CI runs `cargo test --manifest-path ...` from the root.
+#
+# Pinning an exact rustc is required for F-Droid reproducible builds —
+# without it the buildserver compiles with whatever floating stable the
+# VM ships. `targets` lets rustup provision the Android cross-targets
+# declaratively when this toolchain is first synced.
+[toolchain]
+channel = "1.94.1"
+profile = "minimal"
+targets = [
+  "aarch64-linux-android",
+  "armv7-linux-androideabi",
+  "x86_64-linux-android",
+  "i686-linux-android",
+]


### PR DESCRIPTION
Add rust-toolchain.toml at repo root pinning rustc 1.94.1 and the four Android cross-targets. Reachable from both the crate dir (gradle/CMake) and repo root (cargo test --manifest-path) so every cargo invocation uses the same compiler instead of a floating stable.
