### PR TITLE
build(android): respect -Ptarget-platform in buildRustAdblock

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -132,10 +132,12 @@ flutter {
 }
 
 // =====================================================================
-// Rust adblock-rust auto-build. Runs `scripts/build_rust.sh android-all`
-// before Gradle merges jniLibs, dropping the per-ABI .so into
-// android/app/src/main/jniLibs/<abi>/. Up-to-date checks key on the
-// crate's Cargo.lock + every src file, so unchanged builds are a no-op.
+// Rust adblock-rust auto-build. Runs `scripts/build_rust.sh android <abi>`
+// for each ABI Flutter targets (via -Ptarget-platform) before Gradle merges
+// jniLibs, dropping the per-ABI .so into android/app/src/main/jniLibs/<abi>/.
+// A single-ABI build (e.g. F-Droid's per-arch split) compiles only that ABI;
+// a universal/plain build compiles all. Up-to-date checks key on the crate's
+// Cargo.lock + every src file, so unchanged builds are a no-op.
 //
 // Hard prerequisites:
 //   * `cargo` on PATH (rustup recommended)
@@ -154,15 +156,34 @@ def rustScript   = file("${rootProject.projectDir}/../scripts/build_rust.sh")
 def jniLibsRoot  = file("${projectDir}/src/main/jniLibs")
 def abis         = ["arm64-v8a", "armeabi-v7a", "x86_64", "x86"]
 
+// Flutter passes -Ptarget-platform=android-arm[,android-arm64,...] to say
+// which ABIs this invocation targets (per-ABI split, --target-platform, or
+// the default 3-ABI universal set). Mirror that selection so a single-ABI
+// build compiles only its own Rust .so instead of all four. No property
+// (plain gradlew / IDE indexing) falls back to every ABI.
+def platformToAbi = [
+    "android-arm"  : "armeabi-v7a",
+    "android-arm64": "arm64-v8a",
+    "android-x64"  : "x86_64",
+    "android-x86"  : "x86",
+]
+def targetPlatform = project.findProperty("target-platform")?.toString()
+def selectedAbis = (targetPlatform
+    ? targetPlatform.split(",").collect { platformToAbi[it.trim()] }.findAll { it != null }
+    : abis)
+if (selectedAbis.isEmpty()) {
+    selectedAbis = abis
+}
+
 tasks.register("buildRustAdblock", Exec) {
-    description = "Build webspace_adblock Rust library for every Android ABI"
+    description = "Build webspace_adblock Rust library for the target Android ABIs"
     group = "build"
 
     inputs.file rustScript
     inputs.file new File(rustCrateDir, "Cargo.toml")
     inputs.file new File(rustCrateDir, "Cargo.lock")
     inputs.dir new File(rustCrateDir, "src")
-    abis.each { abi ->
+    selectedAbis.each { abi ->
         outputs.file new File(jniLibsRoot, "${abi}/libwebspace_adblock.so")
     }
     onlyIf {
@@ -175,8 +196,8 @@ tasks.register("buildRustAdblock", Exec) {
     }
 
     workingDir rootProject.projectDir.parentFile
-    executable "bash"
-    args "scripts/build_rust.sh", "android-all"
+    commandLine "bash", "-c",
+        "set -e; for abi in ${selectedAbis.join(' ')}; do scripts/build_rust.sh android \"\$abi\"; done"
 
     // Resolve ANDROID_NDK_HOME from env, then fall back to the NDK
     // sub-directory of the SDK declared in local.properties. cargo-ndk


### PR DESCRIPTION
## Summary

- `buildRustAdblock` hardcoded `scripts/build_rust.sh android-all`, so every Android build compiled the adblock `.so` for **all four** ABIs regardless of what the build actually targeted.
- It now reads Flutter's `-Ptarget-platform` and compiles only the requested ABI(s). Absent the property (plain `gradlew` / IDE indexing) it still builds every ABI.
- Outputs are narrowed to the selected ABIs so the up-to-date check stays correct.

## Why

F-Droid ships one APK per arch via `flutter build apk --flavor fdroid --split-per-abi --target-platform=android-arm` (one entry per ABI). With the old task, each of those single-arch builds still cross-compiled the Rust lib **4×** (LTO + `opt-level=z`), 3 of which were then discarded at packaging. That's ~4× the Rust build time per arch on the buildserver, for nothing.

## Behavior

| Invocation | `-Ptarget-platform` | ABIs built (before → after) |
|---|---|---|
| F-Droid per-arch split | `android-arm` | 4 → **1** |
| `flutter build apk` (universal) | default 3 (`arm`,`arm64`,`x64`) | 4 → **3** |
| `flutter build apk --split-per-abi` | default 3 | 4 → **3** |
| plain `gradlew` / IDE | _absent_ | 4 → 4 (unchanged) |

No shipped-APK change: Flutter's default target set excludes `x86`, so the 4th `.so` was built but never packaged — this just stops building it.

## Test plan

- [ ] `flutter build apk --flavor fdroid --split-per-abi --target-platform=android-arm` → only `jniLibs/armeabi-v7a/libwebspace_adblock.so` is (re)built; no `arm64-v8a`/`x86_64`/`x86` Rust compile.
- [ ] `flutter build apk --release --flavor fdroid` (universal) still produces a working APK with the arm64/armv7/x64 libs (matches current CI job).
- [ ] `./gradlew :app:assembleFdroidRelease` with no `-Ptarget-platform` builds all ABIs as before.

Note: the `target-platform` gradle-property name is Flutter's documented mechanism for passing the target ABIs to Gradle; worth confirming the narrowing fires on a real build in CI.
