### PR TITLE
fix(webview): recover from renderer death on resume

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1348,6 +1348,21 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       if (!_webViewModels[_currentIndex!].effectiveNotificationsEnabled) {
         await _webViewModels[_currentIndex!].resumeFromAppLifecycle();
       }
+      // Android-only: nudge the active WebView's renderer to issue a paint
+      // after the platform view's surface has been re-attached on activity
+      // restart. Without this nudge, the hybrid-composition surface can
+      // come back blank — the page is still alive (taps, scrolls, JS all
+      // work), but the user sees a black rectangle until something forces
+      // a layout pass. Reading `document.body.offsetHeight` is a no-op
+      // that triggers a synchronous layout, which schedules a paint.
+      // See issue #333. Fire-and-forget; failure is benign.
+      if (Platform.isAndroid) {
+        final ctrl = _webViewModels[_currentIndex!].controller;
+        if (ctrl != null) {
+          unawaited(ctrl.evaluateJavascript(
+              'void (document.body && document.body.offsetHeight);'));
+        }
+      }
     }
     // Re-apply fullscreen system UI mode after resume
     if (_isFullscreen) {

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -486,6 +486,14 @@ class WebViewConfig {
   )? onUntrustedCertificate;
   /// Optional pull-to-refresh controller for enabling pull-to-refresh gesture.
   final inapp.PullToRefreshController? pullToRefreshController;
+  /// Fires when the underlying renderer terminates unexpectedly. On Android
+  /// this maps to `WebView.onRenderProcessGone` — the OS sometimes kills the
+  /// renderer to reclaim memory after the app has been backgrounded for a
+  /// while, leaving the WebView's surface in an unusable "black screen"
+  /// state until it's destroyed and recreated. The host is expected to drop
+  /// the controller and rebuild the widget. If unset, the WebView is left
+  /// in its post-crash state (visible to the user as a black rectangle).
+  final void Function(bool didCrash)? onRendererGone;
   /// Per-site geolocation mode. [LocationMode.spoof] injects a shim that
   /// overrides `navigator.geolocation` with [spoofLatitude]/[spoofLongitude].
   final LocationMode locationMode;
@@ -557,6 +565,7 @@ class WebViewConfig {
     this.onExternalSchemeUrl,
     this.onUntrustedCertificate,
     this.pullToRefreshController,
+    this.onRendererGone,
     this.locationMode = LocationMode.off,
     this.spoofLatitude,
     this.spoofLongitude,
@@ -3096,6 +3105,35 @@ class WebViewFactory {
       },
       onReceivedServerTrustAuthRequest: (controller, challenge) =>
           _handleServerTrust(controller, challenge, config.onUntrustedCertificate),
+      // Android `WebView.onRenderProcessGone`: the OS can kill the renderer
+      // process while the app is backgrounded to reclaim memory. Coming back
+      // to a renderer-gone WebView shows a black surface because the view is
+      // alive but has no renderer driving it. Android docs require the host
+      // to destroy and rebuild the WebView — we hand the event up to the
+      // owning model, which clears `webview`/`controller` and triggers a
+      // setState so the IndexedStack child rebuilds at the same `currentUrl`.
+      // Fixes issue #333.
+      onRenderProcessGone: (controller, detail) {
+        LogService.instance.log(
+          'WebView',
+          'onRenderProcessGone: siteId=${config.siteId} didCrash=${detail.didCrash} '
+              'priority=${detail.rendererPriorityAtExit}',
+          level: LogLevel.warning,
+        );
+        config.onRendererGone?.call(detail.didCrash);
+      },
+      // iOS/macOS parity for `onRenderProcessGone`: WKWebView raises this
+      // when the web content process is killed (OS memory pressure during
+      // backgrounding, or a page-induced crash). Same recovery path —
+      // throw the WebView away and let the host rebuild.
+      onWebContentProcessDidTerminate: (controller) {
+        LogService.instance.log(
+          'WebView',
+          'onWebContentProcessDidTerminate: siteId=${config.siteId}',
+          level: LogLevel.warning,
+        );
+        config.onRendererGone?.call(true);
+      },
     );
   }
 

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -968,6 +968,7 @@ class WebViewModel {
           onHtmlLoaded: onHtmlLoaded,
           shouldFetchHtml: shouldFetchHtml,
           initialHtml: initialHtml,
+          onRendererGone: (didCrash) => handleRendererGone(didCrash: didCrash),
           onConsoleMessage: (message, level) {
             consoleLogs.add(ConsoleLogEntry(
               timestamp: DateTime.now(),
@@ -1074,6 +1075,25 @@ class WebViewModel {
     if (incognito) return; // Don't capture cookies for incognito sites
     final url = Uri.parse(currentUrl.isNotEmpty ? currentUrl : initUrl);
     cookies = await cookieManager.getCookies(url: url);
+  }
+
+  /// Drop the cached webview widget and controller, then ask the host to
+  /// rebuild. Used when the renderer process is killed (Android `onRender-
+  /// ProcessGone`, iOS/macOS `onWebContentProcessDidTerminate`) — the view
+  /// is alive but has no renderer driving it, which paints as a black
+  /// surface on resume from background (issue #333). Recreation is the only
+  /// supported recovery per Android docs; the native WebView cannot recover
+  /// in place. The user loses the live JS heap and DOM, which is unavoidable
+  /// since the process holding them is gone — `currentUrl` is reloaded so
+  /// the back-/forward stack is the only thing dropped.
+  void handleRendererGone({required bool didCrash}) {
+    LogService.instance.log(
+      'WebView',
+      'Renderer gone for "$name" (siteId: $siteId, didCrash: $didCrash) — recreating',
+    );
+    webview = null;
+    controller = null;
+    stateSetterF?.call();
   }
 
   /// Per-instance pause for site switches.

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -95,6 +95,21 @@ The system SHALL pause both the active webview and process-global JS timers when
 **And** `resumeFromAppLifecycle()` is called on the active webview
 **And** the controller receives `resume()` followed by `resumeAllJsTimers()`
 
+#### Scenario: Android — paint nudge after activity restart
+
+**Given** the user backgrounds the app, switches to another app, then returns
+**And** the platform view's surface was torn down and recreated by the activity restart
+**When** `AppLifecycleState.resumed` fires and `_resumeAfterLifecyclePause()` runs
+**Then** after `resumeFromAppLifecycle()` resolves, the active webview receives a
+no-op `evaluateJavascript` (`void (document.body && document.body.offsetHeight);`)
+**Because** Android's hybrid-composition pipeline can leave the freshly re-attached
+surface blank until something forces a layout pass. Reading `offsetHeight`
+synchronously triggers layout, which schedules a paint, which fills the surface
+with the page's pixels. The page itself is never paused-stuck — taps and JS still
+work — but without the nudge the user sees a black rectangle. iOS/macOS use the
+WebKit content process model and don't exhibit this; the nudge is gated on
+`Platform.isAndroid`. Fire-and-forget; failure is benign.
+
 ---
 
 ### Requirement: PAUSE-003 — API Separation Is Documented at the Type Level

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -387,6 +387,48 @@ The two systems are complementary: HTML cache provides instant first-paint of th
 
 ---
 
+### Requirement: PAUSE-013 — Renderer-Gone Recovery
+
+The system SHALL recover from renderer-process termination by destroying and rebuilding the affected webview at its `currentUrl`. When the OS kills the WebView's renderer (Android `onRenderProcessGone`, iOS/macOS `onWebContentProcessDidTerminate`) — typically to reclaim memory after the app has been backgrounded for a while — the native WebView is alive but has no renderer driving it. Visually this paints as a **black surface** that does not recover on its own; per Android docs the WebView object is unusable and must be destroyed.
+
+Recovery runs entirely in the host (`WebViewModel`), not in the engine:
+
+- `WebViewModel.handleRendererGone({required bool didCrash})` drops the cached widget (`webview = null`) and controller (`controller = null`), then invokes `stateSetterF`.
+- The host `setState` rebuild calls `getWebView()`, which sees `webview == null` and constructs a fresh `InAppWebView` with `initialUrlRequest` pointing at `currentUrl`.
+- The live JS heap and DOM are unavoidably lost — the process holding them is gone. Back/forward stack is dropped too (no `saveState()` is possible after the renderer is dead); the user lands on the URL they were on.
+
+The wrapper exposes a single `WebViewConfig.onRendererGone(bool didCrash)` callback fed by both platform events. `didCrash` is forwarded as-is for logging, but the recovery path is identical for `didCrash=true` (renderer crashed) and `didCrash=false` (renderer killed by the system) — the WebView object is equally unusable in both cases.
+
+#### Scenario: Android renderer killed after app is backgrounded
+
+**Given** the user is on site A in the foreground
+**And** they background the app and switch to another app for several minutes
+**And** the Android OS kills the WebView renderer process to reclaim memory
+**When** the user switches back to our app
+**Then** `WebView.onRenderProcessGone` fires with `didCrash=false`
+**And** `WebViewConfig.onRendererGone(false)` is invoked on the owning model
+**And** `model.webview` and `model.controller` are set to null
+**And** `stateSetterF` is called, triggering a parent rebuild
+**And** the IndexedStack child reconstructs the `InAppWebView` at `currentUrl`
+**And** the user sees the page reload instead of a stuck black screen
+
+#### Scenario: iOS web content process terminates
+
+**Given** site A is loaded on iOS
+**When** WKWebView raises `onWebContentProcessDidTerminate` (page-induced crash or OS reclaim)
+**Then** `WebViewConfig.onRendererGone(true)` is invoked (treated as a hard termination)
+**And** the same destroy-and-rebuild path runs — the WebView is reconstructed at `currentUrl`
+
+#### Scenario: Recovery is safe when `stateSetterF` is unset
+
+**Given** a `WebViewModel` constructed without a `stateSetterF` (e.g. test fixtures, pre-mount initialisation)
+**When** `handleRendererGone` runs
+**Then** `webview` and `controller` are cleared
+**And** no exception is thrown
+**Because** the null-aware `stateSetterF?.call()` makes the host hook optional. The next time the model is wired into a tree, the caller assigns `stateSetterF` and any subsequent rebuild reconstructs the WebView.
+
+---
+
 ### Requirement: PAUSE-004 — Null-Safe Controller Access
 
 `pauseWebView()`, `resumeWebView()`, `pauseForAppLifecycle()`, and `resumeFromAppLifecycle()` SHALL be no-ops when the underlying controller has not yet been initialized or has been disposed.

--- a/test/webview_renderer_gone_test.dart
+++ b/test/webview_renderer_gone_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/webview.dart';
+import 'package:webspace/web_view_model.dart';
+
+class _StubController extends Fake implements WebViewController {}
+
+void main() {
+  group('WebViewModel.handleRendererGone', () {
+    test('clears cached webview + controller and triggers a rebuild', () {
+      var rebuilds = 0;
+      final model = WebViewModel(
+        initUrl: 'https://example.com',
+        stateSetterF: () => rebuilds++,
+      );
+      model.webview = const SizedBox.shrink();
+      model.controller = _StubController();
+
+      model.handleRendererGone(didCrash: true);
+
+      expect(model.webview, isNull,
+          reason: 'Cached widget must be cleared so the next getWebView call '
+              'constructs a fresh InAppWebView.');
+      expect(model.controller, isNull,
+          reason: 'The dead controller is unusable — keep it and the next '
+              'pause/resume/setSettings call hits a torn-down platform view.');
+      expect(rebuilds, 1,
+          reason: 'Host must rebuild so the IndexedStack child reconstructs.');
+    });
+
+    test('handles a null stateSetterF without throwing', () {
+      final model = WebViewModel(initUrl: 'https://example.com');
+      model.webview = const SizedBox.shrink();
+      model.controller = _StubController();
+
+      expect(() => model.handleRendererGone(didCrash: false), returnsNormally);
+      expect(model.webview, isNull);
+      expect(model.controller, isNull);
+    });
+
+    test('didCrash=false (OS-killed renderer) still recreates', () {
+      // Per Android docs: when didCrash is false the renderer was killed by
+      // the system to reclaim memory. The recovery is the same as a hard
+      // crash — the WebView object is unusable either way.
+      var rebuilds = 0;
+      final model = WebViewModel(
+        initUrl: 'https://example.com',
+        stateSetterF: () => rebuilds++,
+      );
+      model.webview = const SizedBox.shrink();
+      model.controller = _StubController();
+
+      model.handleRendererGone(didCrash: false);
+
+      expect(model.webview, isNull);
+      expect(model.controller, isNull);
+      expect(rebuilds, 1);
+    });
+  });
+}


### PR DESCRIPTION
Android can kill the WebView renderer process while the app is
backgrounded to reclaim memory. The view stays alive but has no renderer
driving it, painting as a black surface that does not recover on its own.
Wire onRenderProcessGone (Android) / onWebContentProcessDidTerminate
(iOS/macOS) to drop the cached widget + controller and trigger a host
rebuild so the IndexedStack child reconstructs the InAppWebView at
currentUrl. Fixes #333.