### PR TITLE
Restore collection grouping on archive open; tidy error logs

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1471,7 +1471,8 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     } catch (e, st) {
       LogService.instance.log(
           'LinkIntent', 'share intent handler threw: $e\n$st',
-          level: LogLevel.error);
+          level: LogLevel.error,
+          sensitivity: LogSensitivity.sensitive);
     } finally {
       _handlingShareIntent = false;
     }
@@ -3104,6 +3105,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
             'Boot',
             'Dropped unparseable site JSON at index $i: $e',
             level: LogLevel.warning,
+            // The exception text can echo the malformed site JSON, which
+            // includes initUrl / name — per-site identifiers. Memory ring.
+            sensitivity: LogSensitivity.sensitive,
           );
         }
       }
@@ -3134,6 +3138,8 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
             'Boot',
             'Skipped malformed site at index $i: $e',
             level: LogLevel.warning,
+            // Exception text can echo site JSON (initUrl / name). Memory ring.
+            sensitivity: LogSensitivity.sensitive,
           );
         }
       }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1857,11 +1857,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   }
 
   /// Materialises an open [ArchiveHandle]'s sites into [_webViewModels]
-  /// (appended at the end with `isArchiveTier=true`). The persistence
-  /// path in [_saveWebViewModels] filters by `isArchiveTier` so archive
-  /// sites never enter SharedPreferences. Webspaces inside the archive
-  /// state are ignored in v1 — archive sites appear in the "All" view.
-  /// Caller triggers setState.
+  /// (appended at the end with `isArchiveTier=true`) and its named
+  /// collections into [_webspaces] (marked `isArchiveTier`). Both
+  /// persistence paths ([_saveWebViewModels], [_saveWebspaces]) filter
+  /// by `isArchiveTier` so neither archive sites nor archive collections
+  /// enter SharedPreferences. Caller triggers setState.
   Future<void> _materialiseArchive(ArchiveHandle handle) async {
     final siteIds = <String>{};
     final containerIds = <String>{};
@@ -1890,9 +1890,20 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       _webViewModels.add(model);
       siteIds.add(model.siteId);
     }
+    // Restore the archive's own named collections (grouping). They carry
+    // siteId-keyed membership just like app-tier collections, marked
+    // isArchiveTier so `_saveWebspaces` keeps them out of app-tier
+    // persistence. Their runtime siteIndices view is rebuilt below.
+    final webspaceIds = <String>{};
+    for (final wsJson in handle.state.webspaces) {
+      final ws = Webspace.fromJson(Map<String, dynamic>.from(wsJson))
+        ..isArchiveTier = true;
+      _webspaces.add(ws);
+      webspaceIds.add(ws.id);
+    }
     _archiveSlices[handle] = _ArchiveSlice(
       siteIds: siteIds,
-      webspaceIds: const <String>{},
+      webspaceIds: webspaceIds,
       containerIds: containerIds,
     );
     _resolveWebspaceIndices();
@@ -1960,6 +1971,15 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     handle.state.sites
       ..clear()
       ..addAll(ownedSites.map((m) => m.toJson()));
+    // Capture this archive's collections back into its state so any
+    // rename / reorder / membership change made while open persists.
+    final ownedSpaces = [
+      for (final w in _webspaces)
+        if (slice.webspaceIds.contains(w.id)) w,
+    ];
+    handle.state.webspaces
+      ..clear()
+      ..addAll(ownedSpaces.map((w) => w.toJson()));
     await _archive.save(handle);
     await _archive.close(handle);
     // Dispose webviews owned by this archive before removing them from
@@ -2005,6 +2025,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     _loadedIndices
         .removeWhere((i) => i < _webViewModels.length && removedSet.contains(_webViewModels[i].siteId));
     _webViewModels.removeWhere((m) => removedSet.contains(m.siteId));
+    // Remove this archive's collections from the runtime list. If the
+    // user was viewing one, fall back to the synthetic "All" view.
+    if (slice.webspaceIds.contains(_selectedWebspaceId)) {
+      _selectedWebspaceId = kAllWebspaceId;
+      unawaited(_saveSelectedWebspaceId());
+    }
+    _webspaces.removeWhere((w) => slice.webspaceIds.contains(w.id));
     // Webspace.siteIndices is a derived view over _webViewModels;
     // archive sites just left the list, so positions of remaining
     // sites may have shifted and any webspace siteIds that previously
@@ -2538,7 +2565,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   Future<void> _saveWebspaces() async {
     if (isDemoMode) return; // Don't persist in demo mode
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    List<String> webspacesJson = _webspaces.map((webspace) => jsonEncode(webspace.toJson())).toList();
+    // Archive-tier collections live in `_webspaces` for rendering while
+    // open but must not enter app-tier persistence (their membership is
+    // carried in the archive's own encrypted state).
+    List<String> webspacesJson = _webspaces
+        .where((webspace) => !webspace.isArchiveTier)
+        .map((webspace) => jsonEncode(webspace.toJson()))
+        .toList();
     await prefs.setStringList('webspaces', webspacesJson);
   }
 

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -2350,6 +2350,7 @@ class WebViewFactory {
                 'WebView',
                 'Blob download error: $e\n$stack',
                 level: LogLevel.error,
+                sensitivity: LogSensitivity.sensitive,
               );
               if (taskId.isNotEmpty) {
                 DownloadsService.instance.fail(taskId, e.toString());
@@ -3496,6 +3497,7 @@ class WebViewFactory {
         'Download',
         'Download error: $e\n$stack',
         level: LogLevel.error,
+        sensitivity: LogSensitivity.sensitive,
       );
       DownloadsService.instance.fail(task.id, e.toString());
     }
@@ -3529,6 +3531,7 @@ class WebViewFactory {
         'Download',
         'Data-URI download error: $e\n$stack',
         level: LogLevel.error,
+        sensitivity: LogSensitivity.sensitive,
       );
       DownloadsService.instance.fail(task.id, e.toString());
     }
@@ -3557,6 +3560,7 @@ class WebViewFactory {
         'Download',
         'Blob download eval error: $e\n$stack',
         level: LogLevel.error,
+        sensitivity: LogSensitivity.sensitive,
       );
       DownloadsService.instance.fail(task.id, e.toString());
     }

--- a/lib/webspace_model.dart
+++ b/lib/webspace_model.dart
@@ -18,12 +18,18 @@ class Webspace {
   /// Recomputed by `_resolveWebspaceIndices` whenever `_webViewModels`
   /// changes. Never persisted; serialisation goes through [siteIds].
   List<int> siteIndices;
+  /// Runtime-only marker for collections materialised from an open
+  /// archive handle rather than app-tier SharedPreferences. Never
+  /// serialised; `_saveWebspaces` filters on it so archive-tier
+  /// collections never enter the app-tier persisted list.
+  bool isArchiveTier;
 
   Webspace({
     String? id,
     required this.name,
     List<String>? siteIds,
     List<int>? siteIndices,
+    this.isArchiveTier = false,
   })  : id = id ?? _uuid.v4(),
         siteIds = siteIds ?? <String>[],
         siteIndices = siteIndices ?? <int>[];
@@ -60,12 +66,14 @@ class Webspace {
     String? name,
     List<String>? siteIds,
     List<int>? siteIndices,
+    bool? isArchiveTier,
   }) {
     return Webspace(
       id: id ?? this.id,
       name: name ?? this.name,
       siteIds: siteIds ?? List<String>.from(this.siteIds),
       siteIndices: siteIndices ?? List<int>.from(this.siteIndices),
+      isArchiveTier: isArchiveTier ?? this.isArchiveTier,
     );
   }
 

--- a/openspec/specs/archive/spec.md
+++ b/openspec/specs/archive/spec.md
@@ -33,14 +33,19 @@ ARCH-001 through ARCH-009 are wired end-to-end:
   paints over the running tree on `inactive` / `paused` / `hidden` when
   at least one archive is open.
 
+**Archive-tier collections:** an open archive's named collections are
+materialised into `_webspaces` (marked `isArchiveTier`, a runtime-only
+flag) so a restored archive keeps its grouping. `_saveWebspaces`
+filters on the flag so they never enter app-tier SharedPreferences;
+their membership rides the archive's own encrypted state and is
+re-captured on close. Reopening restores the grouping; closing falls
+back to the "All" view if the user was inside an archive collection.
+
 **Deferred from v1:**
 
 - **ARCH-010 (export tick):** exports remain app-tier-only with no
   opt-in switch. Adding the tick later is additive and won't break the
   existing on-device invariant.
-- **Archive-tier webspaces** — sites inside an open archive appear in
-  the "All" view alongside app-tier sites; named-archive-webspace
-  support is a follow-up.
 
 ## Purpose
 
@@ -521,12 +526,13 @@ These tests run in CI and are the regression-prevention spine of ARCH-001.
 - **Live-device forensics is out of scope.** An adversary executing code inside the running app process while an archive is open can read `MK_arch` and the archive's plaintext from memory. There is no software-only mitigation at the app layer.
 - **Slot size cap.** Archives larger than 256 KiB of packed state (typically: cookies + webspace JSON for ~50 sites) currently fail at write with a clear error to the user. v1 does not split archives across slots.
 - **Per-site browser state beyond cookies does not migrate on move-to-archive.** Cookies are captured from the running container and pushed into the new opaque container on next webview build. `localStorage`, `IndexedDB`, `ServiceWorker` registrations, and `HTTP cache` are not — the new container is a fresh slate. Sites that store user preferences (theme, language, layout) in `localStorage` will revert to defaults the first time they're opened from an archive after a move. The move-to-archive snackbar warns the user. Mitigation would require fork-side API to read/write per-container `localStorage`; tracked but out of scope for v1.
-- **Upstream `flutter_inappwebview` logs a few sensitive identifiers via `print` / `Log.d` from native code paths that the WebSpace fork branch (`v6.2.0-beta.3-privacy-v1`) inherits unchanged.** Audit findings against the fork's pinned ref:
+- **Dart-side console leakage is closed.** Every `LogService` call in `lib/` that interpolated a URL, host, site JSON, or stack trace is now `LogSensitivity.sensitive` (download / blob errors, share-intent failures, malformed-site-JSON boot warnings, proxy-apply failures), so it lands in the memory-only ring and never reaches disk / `debugPrint` / `adb logcat` / Console.app.
+- **Native (fork) console leakage remains.** Re-audited against `v6.2.0-beta.3-privacy-v3` — still present, unchanged from the v1 audit:
   - `flutter_inappwebview_android/.../InAppBrowserManager.java:129` — `Log.d(LOG_TAG, url + " cannot be opened: ...")` (intent-launch failure path)
-  - `flutter_inappwebview_android/.../InAppWebViewClient.java:130` and `InAppWebViewClientCompat.java:130` — `Log.d(LOG_TAG, "Request '" + url + "' automatically allowed...")` (regexToAllowSyncUrlLoading match)
+  - `flutter_inappwebview_android/.../InAppWebViewClient.java:131` — `Log.d(LOG_TAG, "Request '" + url + "' automatically allowed...")` (regexToAllowSyncUrlLoading match)
   - `flutter_inappwebview_ios/.../MyCookieManager.swift:211` and `flutter_inappwebview_macos/.../MyCookieManager.swift:207` — `print("Cannot get WebView cookies. No HOST found for URL: \(url)")`
   - Container, profile, and Linux per-session manager files are clean. WebSpace's own fork patches do not add new log calls.
-  Fixing these requires a fork-side patch (annotated `[WebSpace fork patch]`) that redacts the URL or drops the log entirely; tracked as a follow-up. Until then, the URLs of intent-launch failures, regex-allowlisted nested-load decisions, and the rare host-less cookie-read paths reach `adb logcat` / Console.app from any site — app-tier and archive-tier alike.
+  Fixing these requires a fork-side patch (annotated `[WebSpace fork patch]`) that redacts the URL or drops the log entirely, then a fork tag + `pubspec` ref bump — out of scope for an app-repo PR. Until then, the URLs of intent-launch failures, regex-allowlisted nested-load decisions, and the rare host-less cookie-read paths reach `adb logcat` / Console.app from any site.
 
 ## Files
 

--- a/test/webspace_model_test.dart
+++ b/test/webspace_model_test.dart
@@ -155,6 +155,43 @@ void main() {
       expect(all.siteIds, isEmpty);
     });
 
+    group('isArchiveTier is a runtime-only marker', () {
+      test('defaults to false', () {
+        expect(Webspace(name: 'W').isArchiveTier, isFalse);
+      });
+
+      test('toJson never serialises it', () {
+        final ws = Webspace(name: 'W', siteIds: ['a'])..isArchiveTier = true;
+        expect(ws.toJson().containsKey('isArchiveTier'), isFalse);
+      });
+
+      test('fromJson always restores it as false', () {
+        final ws = Webspace(name: 'W', siteIds: ['a'])..isArchiveTier = true;
+        final restored = Webspace.fromJson(ws.toJson());
+        expect(restored.isArchiveTier, isFalse);
+      });
+
+      test('copyWith carries it through', () {
+        final ws = Webspace(name: 'W')..isArchiveTier = true;
+        expect(ws.copyWith(name: 'W2').isArchiveTier, isTrue);
+        expect(ws.copyWith(isArchiveTier: false).isArchiveTier, isFalse);
+      });
+
+      test('persistence filter drops archive-tier collections', () {
+        // Mirror of the filter in `_saveWebspaces`.
+        final spaces = [
+          Webspace(name: 'App A', siteIds: ['a']),
+          Webspace(name: 'Arch', siteIds: ['x'])..isArchiveTier = true,
+          Webspace(name: 'App B', siteIds: ['b']),
+        ];
+        final persisted = spaces
+            .where((w) => !w.isArchiveTier)
+            .map((w) => w.name)
+            .toList();
+        expect(persisted, ['App A', 'App B']);
+      });
+    });
+
     // Defensive deserialization: malformed prefs blobs from partial
     // writes, hand-edited backups, or schema drift across branches
     // must not crash boot. `_loadWebspaces` wraps each entry in


### PR DESCRIPTION
Two small independent changes:

- Restoring an archive now keeps its collection grouping, not just the flat site list. Runtime-only; doesn't change app-tier persistence.
- A few error logs that could carry a URL now go through the sensitive sink instead of normal output.

Tests + analyze pass.