### PR TITLE
Add protected-content (Widevine/EME) permission handling

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3584,6 +3584,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           webRtcPolicy: webRtcPolicy,
           userScripts: userScripts,
           onConfirmScriptFetch: _confirmScriptFetch,
+          onProtectedMediaRequest: _promptProtectedMedia,
           onShowUrlBarChanged: (show) async {
             if (!mounted) return;
             setState(() {
@@ -3635,6 +3636,37 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           TextButton(
             onPressed: () => Navigator.pop(ctx, false),
             child: const Text('Deny'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Allow'),
+          ),
+        ],
+      ),
+    );
+    return result ?? false;
+  }
+
+  /// Stable callback for the protected-content (Widevine/EME) permission
+  /// popup. Shown the first time a site requests `PROTECTED_MEDIA_ID` (e.g.
+  /// the Spotify web player). The per-site decision is remembered by the
+  /// caller (the parent webview persists it on the `WebViewModel`; nested
+  /// webviews remember it in-memory), so this only collects user intent.
+  Future<bool> _promptProtectedMedia(String origin) async {
+    if (!mounted) return false;
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Play protected content?'),
+        content: Text(
+          '$origin wants to play protected (DRM) content.\n\n'
+          'Allowing this lets the site provision a device identifier to '
+          'decrypt the media. Your choice is remembered for this site.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Block'),
           ),
           TextButton(
             onPressed: () => Navigator.pop(ctx, true),
@@ -5884,6 +5916,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                                         }(),
                                   isActive: () => _currentIndex == index,
                                   onConfirmScriptFetch: _confirmScriptFetch,
+                                  onProtectedMediaRequest: _promptProtectedMedia,
                                   onUntrustedCertificate: _promptUntrustedCertificate,
                                   onExternalSchemeUrl: (url, info) async {
                                     if (!mounted) return;

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -45,6 +45,11 @@ class InAppWebViewScreen extends StatefulWidget {
   /// working when the user follows an outbound link into a nested screen.
   final List<UserScriptConfig> userScripts;
   final Future<bool> Function(String url)? onConfirmScriptFetch;
+  /// Protected-content (Widevine/EME) permission popup, forwarded from the
+  /// parent so a DRM site followed through an outbound link prompts the
+  /// same way. The decision is remembered in-memory for this screen only
+  /// (nested screens have no persisted `WebViewModel`).
+  final Future<bool> Function(String origin)? onProtectedMediaRequest;
   /// Invoked when the user toggles the URL bar from this nested screen's
   /// popup menu. Threaded back to `_WebSpacePageState` so the change
   /// updates the same global preference shown in the parent menu.
@@ -79,6 +84,7 @@ class InAppWebViewScreen extends StatefulWidget {
     this.webRtcPolicy = WebRtcPolicy.defaultPolicy,
     this.userScripts = const [],
     this.onConfirmScriptFetch,
+    this.onProtectedMediaRequest,
     this.onShowUrlBarChanged,
     UserProxySettings? proxySettings,
     this.notificationsEnabled = false,
@@ -95,6 +101,14 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
   String? title;
   late String _currentUrl;
   late final inapp.PullToRefreshController? _pullToRefreshController;
+
+  /// In-memory protected-content (Widevine/EME) decision for this nested
+  /// screen. null = ask, true/false = remembered grant/deny. Nested screens
+  /// are transient and have no persisted model, so the choice only lives
+  /// for the lifetime of this screen. [_protectedMediaInFlight] coalesces a
+  /// burst of `PROTECTED_MEDIA_ID` requests onto one popup.
+  bool? _protectedContentAllowed;
+  Future<bool>? _protectedMediaInFlight;
 
   /// Cached InAppWebView widget. Built once in initState and reused on
   /// every build() so setState calls (URL bar updates, find results,
@@ -187,6 +201,24 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
         proxySettings: widget.proxySettings,
         userScripts: widget.userScripts,
         onConfirmScriptFetch: widget.onConfirmScriptFetch,
+        onProtectedMediaRequest: widget.onProtectedMediaRequest == null
+            ? null
+            : (origin) async {
+                if (_protectedContentAllowed != null) {
+                  return _protectedContentAllowed!;
+                }
+                _protectedMediaInFlight ??= () async {
+                  final granted =
+                      await widget.onProtectedMediaRequest!(origin);
+                  _protectedContentAllowed = granted;
+                  return granted;
+                }();
+                try {
+                  return await _protectedMediaInFlight!;
+                } finally {
+                  _protectedMediaInFlight = null;
+                }
+              },
         notificationsEnabled: widget.notificationsEnabled,
         pullToRefreshController: _pullToRefreshController,
         onUrlChanged: (url) {

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -136,6 +136,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late bool _fullscreenMode;
   late bool _htmlCachingEnabled;
   late bool _notificationsEnabled;
+  bool? _protectedContentAllowed;
   String? _selectedLanguage;
   bool _obscureProxyPassword = true;
   bool _showProxyCredentials = false;
@@ -216,6 +217,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         'fullscreenMode': _fullscreenMode,
         'htmlCachingEnabled': _htmlCachingEnabled,
         'notificationsEnabled': _notificationsEnabled,
+        'protectedContentAllowed': _protectedContentAllowed,
         'selectedLanguage': _selectedLanguage,
         'latitude': _latitudeController.text,
         'longitude': _longitudeController.text,
@@ -297,6 +299,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _fullscreenMode = m.fullscreenMode;
     _htmlCachingEnabled = m.htmlCachingEnabled;
     _notificationsEnabled = m.notificationsEnabled;
+    _protectedContentAllowed = m.protectedContentAllowed;
     _selectedLanguage = m.language;
     _latitudeController.text = m.spoofLatitude?.toString() ?? '';
     _longitudeController.text = m.spoofLongitude?.toString() ?? '';
@@ -471,6 +474,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       widget.webViewModel.fullscreenMode = _fullscreenMode;
       widget.webViewModel.htmlCachingEnabled = _htmlCachingEnabled;
       widget.webViewModel.notificationsEnabled = _notificationsEnabled;
+      widget.webViewModel.protectedContentAllowed = _protectedContentAllowed;
       widget.webViewModel.language = _selectedLanguage;
       // locationMode is derived from the UI state:
       // - `_isLiveLocation` → live (real device GPS forwarded through the shim)
@@ -1537,6 +1541,38 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       },
               );
             }),
+          if (Platform.isAndroid)
+            ListTile(
+              title: Row(
+                children: const [
+                  Flexible(child: Text('Protected content (DRM)')),
+                  HintButton(
+                    title: 'Protected content (DRM)',
+                    description:
+                        'Controls whether this site may play DRM-protected '
+                        'media (Widevine/EME), e.g. the Spotify web player.\n\n'
+                        'Ask (default): a popup asks the first time the site '
+                        'requests it, then remembers your choice.\n'
+                        'Always allow / Always block: skip the popup.\n\n'
+                        'Allowing lets the site provision a device identifier '
+                        'to decrypt media. Android only — other platforms '
+                        'cannot play Widevine content.',
+                  ),
+                ],
+              ),
+              trailing: DropdownButton<bool?>(
+                value: _protectedContentAllowed,
+                onChanged: (v) =>
+                    setState(() => _protectedContentAllowed = v),
+                items: const <DropdownMenuItem<bool?>>[
+                  DropdownMenuItem<bool?>(value: null, child: Text('Ask')),
+                  DropdownMenuItem<bool?>(
+                      value: true, child: Text('Always allow')),
+                  DropdownMenuItem<bool?>(
+                      value: false, child: Text('Always block')),
+                ],
+              ),
+            ),
           ..._buildLocationSection(),
           DomainClaimsEditor(
             model: widget.webViewModel,

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -531,6 +531,12 @@ class WebViewConfig {
   ///   the app-global outbound proxy.
   final UserProxySettings? proxySettings;
   final bool notificationsEnabled;
+  /// Prompt fired when the page requests protected-media (Widevine/EME)
+  /// permission (`PROTECTED_MEDIA_ID`). Returns true to grant, false to
+  /// deny. When null, the handler is not installed and the platform's
+  /// default applies (Android denies). Only meaningful on Android — iOS/
+  /// macOS WKWebView has no EME/Widevine and never issues the request.
+  final Future<bool> Function(String origin)? onProtectedMediaRequest;
 
   WebViewConfig({
     this.key,
@@ -576,6 +582,7 @@ class WebViewConfig {
     this.webRtcPolicy = WebRtcPolicy.defaultPolicy,
     this.proxySettings,
     this.notificationsEnabled = false,
+    this.onProtectedMediaRequest,
   });
 }
 
@@ -2070,6 +2077,36 @@ class WebViewFactory {
       pullToRefreshController: config.pullToRefreshController,
       initialUserScripts: UnmodifiableListView(userScripts),
       initialSettings: settings,
+      // Protected-media (Widevine/EME) permission. Only installed on
+      // Android, where `PROTECTED_MEDIA_ID` exists and the no-handler
+      // default is deny; granting it lets the origin run EME license
+      // requests (e.g. the Spotify web player). The handler grants ONLY
+      // the protected-media resource and returns PROMPT for anything else
+      // (camera/mic) so it never widens permissions beyond DRM. Left null
+      // off-Android so iOS/macOS keep their native PROMPT default.
+      onPermissionRequest:
+          (Platform.isAndroid && config.onProtectedMediaRequest != null)
+              ? (controller, request) async {
+                  final wantsProtectedMedia = request.resources.contains(
+                      inapp.PermissionResourceType.PROTECTED_MEDIA_ID);
+                  if (wantsProtectedMedia) {
+                    final granted = await config.onProtectedMediaRequest!(
+                        request.origin.toString());
+                    return inapp.PermissionResponse(
+                      resources: [
+                        inapp.PermissionResourceType.PROTECTED_MEDIA_ID
+                      ],
+                      action: granted
+                          ? inapp.PermissionResponseAction.GRANT
+                          : inapp.PermissionResponseAction.DENY,
+                    );
+                  }
+                  return inapp.PermissionResponse(
+                    resources: request.resources,
+                    action: inapp.PermissionResponseAction.PROMPT,
+                  );
+                }
+              : null,
       onWebViewCreated: (controller) async {
         final wrappedController = _WebViewController(controller);
         onControllerCreated(wrappedController);

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -313,6 +313,14 @@ class WebViewModel {
   /// the foreground poll timer so it can detect new content and fire
   /// notifications even when the user isn't looking at it.
   bool notificationsEnabled;
+  /// Remembered per-site decision for protected (DRM/Widevine EME) content,
+  /// e.g. the Spotify web player. null = not yet decided (the webview shows
+  /// an Allow/Block popup on the first `PROTECTED_MEDIA_ID` permission
+  /// request); true = grant silently; false = deny silently. Granting lets
+  /// the origin provision a Widevine device identifier, so the default is
+  /// "ask" rather than always-on. Android-only: WKWebView (iOS/macOS) has no
+  /// EME/Widevine support and never issues this request.
+  bool? protectedContentAllowed;
   List<UserScriptConfig> userScripts; // Per-site user scripts
   /// IDs of global user scripts opted into for this site. Global scripts
   /// are stored once in app state (shared source/URL) and each site
@@ -406,11 +414,24 @@ class WebViewModel {
   bool get effectiveHtmlCachingEnabled =>
       isArchiveTier ? false : htmlCachingEnabled;
 
+  /// Effective protected-content (Widevine/EME) decision. Archive-tier
+  /// sites never grant DRM regardless of stored value: a grant provisions
+  /// a per-container Widevine device identifier on disk and the prompt is
+  /// OS-level UI, both of which ARCH-006 forbids for archive sites. They
+  /// deny without prompting (false, never null = never "ask").
+  bool? get effectiveProtectedContentAllowed =>
+      isArchiveTier ? false : protectedContentAllowed;
+
   final List<ConsoleLogEntry> consoleLogs = [];
   static const _maxConsoleLogs = 500;
   VoidCallback? onConsoleLogChanged;
 
   String? defaultUserAgent;
+  /// In-flight protected-content decision. A page can fire several
+  /// `PROTECTED_MEDIA_ID` requests in a burst while EME initializes; this
+  /// coalesces them onto a single Allow/Block popup instead of stacking
+  /// dialogs. Cleared once [protectedContentAllowed] is recorded.
+  Future<bool>? _protectedMediaDecisionInFlight;
   Function? stateSetterF;
   FindMatchesResult findMatches = FindMatchesResult();
   WebViewTheme _currentTheme = WebViewTheme.light;
@@ -442,6 +463,7 @@ class WebViewModel {
     this.fullscreenMode = false,
     this.htmlCachingEnabled = false,
     this.notificationsEnabled = false,
+    this.protectedContentAllowed,
     List<UserScriptConfig>? userScripts,
     Set<String>? enabledGlobalScriptIds,
     Set<BlockedCookie>? blockedCookies,
@@ -628,6 +650,7 @@ class WebViewModel {
       inapp.SslCertificate? certificate,
     )? onUntrustedCertificate,
     Future<void> Function(String url, ExternalUrlInfo info)? onExternalSchemeUrl,
+    Future<bool> Function(String origin)? onProtectedMediaRequest,
     List<UserScriptConfig> globalUserScripts = const [],
   }) {
     if (webview == null) {
@@ -726,6 +749,27 @@ class WebViewModel {
           onConfirmScriptFetch: onConfirmScriptFetch,
           onUntrustedCertificate: onUntrustedCertificate,
           onExternalSchemeUrl: onExternalSchemeUrl,
+          onProtectedMediaRequest: onProtectedMediaRequest == null
+              ? null
+              : (origin) async {
+                  // Archive-tier sites deny without prompting; otherwise a
+                  // previously remembered Allow/Block decision short-circuits
+                  // the popup.
+                  final remembered = effectiveProtectedContentAllowed;
+                  if (remembered != null) return remembered;
+                  // Coalesce a burst of requests onto one popup.
+                  _protectedMediaDecisionInFlight ??= () async {
+                    final granted = await onProtectedMediaRequest(origin);
+                    protectedContentAllowed = granted;
+                    await saveFunc();
+                    return granted;
+                  }();
+                  try {
+                    return await _protectedMediaDecisionInFlight!;
+                  } finally {
+                    _protectedMediaDecisionInFlight = null;
+                  }
+                },
           pullToRefreshController: pullToRefreshController,
           onWindowRequested: onWindowRequested,
           shouldOverrideUrlLoading: (url, hasGesture) {
@@ -1412,6 +1456,8 @@ class WebViewModel {
         'fullscreenMode': fullscreenMode,
         'htmlCachingEnabled': htmlCachingEnabled,
         'notificationsEnabled': notificationsEnabled,
+        if (protectedContentAllowed != null)
+          'protectedContentAllowed': protectedContentAllowed,
         'userScripts': userScripts.map((s) => s.toJson()).toList(),
         if (enabledGlobalScriptIds.isNotEmpty)
           'enabledGlobalScriptIds': enabledGlobalScriptIds.toList(),
@@ -1474,6 +1520,7 @@ class WebViewModel {
           (json['notificationsEnabled'] as bool?) ??
               (json['backgroundPoll'] as bool?) ??
               false,
+      protectedContentAllowed: json['protectedContentAllowed'] as bool?,
       userScripts: (json['userScripts'] as List<dynamic>?)
           ?.map((e) => UserScriptConfig.fromJson(e as Map<String, dynamic>))
           .toList(),

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -81,6 +81,30 @@ This directory contains HTML test files for automated testing of WebSpace featur
 - **Usage**: Import this file via "Import HTML file" on the Add Site screen, then use the buttons to exercise each notification requirement. Enable/disable the per-site notification toggle and background-active toggle to test different scenarios.
 - **Note**: This is for manual testing. The fixture logs all events with timestamps in an on-page log panel.
 
+## Protected Content (DRM) Tests
+
+### `protected_content_test.html`
+- **Feature**: Per-site protected-content (Widevine/EME) permission popup
+- **Purpose**: Manual verification on a real Android device/emulator that a
+  DRM site (e.g. the Spotify web player) triggers the `PROTECTED_MEDIA_ID`
+  permission and that the per-site Allow/Block decision is honored and
+  remembered. EME is a native path — jsdom has no EME and CI WebViews
+  usually lack a Widevine CDM, so this is not an automated test.
+- **Tests**:
+  - EME API availability (`navigator.requestMediaKeySystemAccess`)
+  - Widevine probe (`com.widevine.alpha`) — fires the Allow/Block popup on
+    first request, auto-run on page load to mimic a DRM player startup
+  - ClearKey control (`org.w3.clearkey`) — should resolve with no popup
+- **Usage**: Import via "Import HTML file" on the Add Site screen (or host it
+  and add the URL), then on Android:
+  1. First load → expect the "Play protected content?" popup. Tap Allow → the
+     Widevine result turns green and a CDM is created.
+  2. Reload → no second popup (the grant is remembered per-site).
+  3. Set the site's "Protected content (DRM)" dropdown to **Always block** and
+     reload → the probe fails with no popup.
+  4. On iOS/macOS the EME API is unavailable, so every probe fails — expected.
+- **Note**: For manual testing. The fixture logs all events with timestamps.
+
 ## General Test Page
 
 ### `test_page.html`

--- a/test/fixtures/protected_content_test.html
+++ b/test/fixtures/protected_content_test.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Protected Content (Widevine/EME) Test Fixture</title>
+  <style>
+    body { font-family: -apple-system, sans-serif; padding: 16px; max-width: 540px; }
+    button { display: block; width: 100%; padding: 12px; margin: 8px 0; font-size: 16px; border-radius: 8px; border: 1px solid #ccc; cursor: pointer; }
+    button:active { opacity: 0.7; }
+    .section { margin: 16px 0; padding: 12px; border: 1px solid #ddd; border-radius: 8px; }
+    .section h3 { margin-top: 0; }
+    #log { font-family: monospace; font-size: 12px; white-space: pre-wrap; background: #f5f5f5; padding: 8px; border-radius: 4px; max-height: 300px; overflow-y: auto; }
+    .pass { color: green; }
+    .fail { color: red; }
+    .info { color: #666; }
+    .result { font-weight: 700; padding: 2px 8px; border-radius: 4px; }
+    .result.pass { background: #cef4d8; color: #186; }
+    .result.fail { background: #fde0e0; color: #a22; }
+    .result.pending { background: #fff3c4; color: #976; }
+  </style>
+</head>
+<body>
+  <h2>Protected Content (Widevine/EME) Test Fixture</h2>
+  <p class="info">
+    Exercises the Encrypted Media Extensions path that DRM web players (e.g.
+    Spotify) use. On Android, the first Widevine probe triggers WebSpace's
+    "Play protected content?" popup (the <code>PROTECTED_MEDIA_ID</code>
+    permission). Your Allow/Block choice is remembered per-site.
+  </p>
+
+  <div class="section">
+    <h3>EME API availability</h3>
+    <p><code>navigator.requestMediaKeySystemAccess</code>:
+      <span id="emeAvail" class="result pending">checking...</span></p>
+    <p class="info">If unavailable, the platform has no EME support (expected
+      on iOS/macOS WKWebView) and nothing below can succeed.</p>
+  </div>
+
+  <div class="section">
+    <h3>Widevine (triggers the DRM popup)</h3>
+    <p>Result: <span id="widevineResult" class="result pending">not run</span></p>
+    <button onclick="probe('com.widevine.alpha', 'optional', 'widevineResult')">
+      Probe Widevine</button>
+    <button onclick="probe('com.widevine.alpha', 'required', 'widevineResult')">
+      Probe Widevine (require device identifier)</button>
+    <p class="info">
+      First run on Android: expect the Allow/Block popup. After Allow, the
+      promise resolves and a CDM is created. Reload the page — there should be
+      NO second popup (decision remembered). Set the site's "Protected content
+      (DRM)" dropdown to Block and reload — the probe should fail with no popup.
+    </p>
+  </div>
+
+  <div class="section">
+    <h3>ClearKey (control — should NOT trigger the popup)</h3>
+    <p>Result: <span id="clearKeyResult" class="result pending">not run</span></p>
+    <button onclick="probe('org.w3.clearkey', 'optional', 'clearKeyResult')">
+      Probe ClearKey</button>
+    <p class="info">ClearKey needs no CDM or device identifier, so it should
+      resolve without any popup. If a popup appears here, the permission
+      handler is granting more than protected media.</p>
+  </div>
+
+  <div class="section">
+    <h3>Event Log</h3>
+    <button onclick="clearLog()">Clear Log</button>
+    <div id="log"></div>
+  </div>
+
+  <script>
+    var logEl = document.getElementById('log');
+
+    function log(msg, cls) {
+      var ts = new Date().toLocaleTimeString();
+      var line = document.createElement('div');
+      line.className = cls || 'info';
+      line.textContent = '[' + ts + '] ' + msg;
+      logEl.appendChild(line);
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+
+    function clearLog() { logEl.innerHTML = ''; }
+
+    function setResult(id, text, cls) {
+      var el = document.getElementById(id);
+      el.textContent = text;
+      el.className = 'result ' + cls;
+    }
+
+    function emeConfig(distinctiveIdentifier) {
+      return [{
+        initDataTypes: ['cenc'],
+        distinctiveIdentifier: distinctiveIdentifier,
+        persistentState: 'optional',
+        videoCapabilities: [
+          { contentType: 'video/mp4; codecs="avc1.42E01E"' }
+        ],
+        audioCapabilities: [
+          { contentType: 'audio/mp4; codecs="mp4a.40.2"' }
+        ]
+      }];
+    }
+
+    function checkEmeAvailable() {
+      var ok = typeof navigator.requestMediaKeySystemAccess === 'function';
+      setResult('emeAvail', ok ? 'available' : 'unavailable', ok ? 'pass' : 'fail');
+      log('EME API ' + (ok ? 'available' : 'unavailable'), ok ? 'pass' : 'fail');
+      return ok;
+    }
+
+    function probe(keySystem, distinctiveIdentifier, resultId) {
+      if (!checkEmeAvailable()) {
+        setResult(resultId, 'EME unavailable', 'fail');
+        return;
+      }
+      setResult(resultId, 'requesting...', 'pending');
+      log('requestMediaKeySystemAccess("' + keySystem + '", distinctiveIdentifier=' +
+        distinctiveIdentifier + ') ...');
+      navigator.requestMediaKeySystemAccess(keySystem, emeConfig(distinctiveIdentifier))
+        .then(function(access) {
+          log(keySystem + ': access GRANTED (keySystem=' + access.keySystem + ')', 'pass');
+          return access.createMediaKeys();
+        })
+        .then(function() {
+          log(keySystem + ': MediaKeys created — CDM is usable', 'pass');
+          setResult(resultId, 'available', 'pass');
+        })
+        .catch(function(err) {
+          log(keySystem + ': REJECTED — ' + err.name + ': ' + err.message, 'fail');
+          setResult(resultId, 'blocked / unsupported', 'fail');
+        });
+    }
+
+    // Auto-probe Widevine on load, the way a real DRM player does, so the
+    // popup fires without any tap.
+    checkEmeAvailable();
+    window.setTimeout(function() {
+      log('Auto-probing Widevine on load (mimics a DRM player startup)...');
+      probe('com.widevine.alpha', 'optional', 'widevineResult');
+    }, 500);
+  </script>
+</body>
+</html>

--- a/test/web_view_model_test.dart
+++ b/test/web_view_model_test.dart
@@ -375,6 +375,48 @@ void main() {
       expect(restored.notificationsEnabled, isTrue);
     });
 
+    test('protectedContentAllowed defaults to null (ask) and toJson omits it',
+        () {
+      final model = WebViewModel(initUrl: 'https://example.com');
+      expect(model.protectedContentAllowed, isNull);
+      expect(model.toJson().containsKey('protectedContentAllowed'), isFalse);
+
+      final restored = WebViewModel.fromJson(model.toJson(), null);
+      expect(restored.protectedContentAllowed, isNull);
+    });
+
+    test('protectedContentAllowed allow/block round-trips through JSON', () {
+      for (final decision in [true, false]) {
+        final model = WebViewModel(
+          initUrl: 'https://example.com',
+          protectedContentAllowed: decision,
+        );
+        final json = model.toJson();
+        expect(json['protectedContentAllowed'], equals(decision));
+        final restored = WebViewModel.fromJson(json, null);
+        expect(restored.protectedContentAllowed, equals(decision));
+      }
+    });
+
+    test('effectiveProtectedContentAllowed forces deny for archive-tier (ARCH-006)',
+        () {
+      final allowed = WebViewModel(
+        initUrl: 'https://example.com',
+        protectedContentAllowed: true,
+        isArchiveTier: true,
+      );
+      // Stored value is preserved, but the effective value never grants
+      // DRM for archive sites.
+      expect(allowed.protectedContentAllowed, isTrue);
+      expect(allowed.effectiveProtectedContentAllowed, isFalse);
+
+      final appTier = WebViewModel(
+        initUrl: 'https://example.com',
+        protectedContentAllowed: true,
+      );
+      expect(appTier.effectiveProtectedContentAllowed, isTrue);
+    });
+
     test('legacy backgroundPoll JSON migrates to notificationsEnabled', () {
       // Sites stored under the previous schema (separate backgroundPoll
       // toggle, notifications off) should still be polled and able to


### PR DESCRIPTION
Adds per-site DRM/Widevine EME permission control for Android, allowing sites like Spotify to play protected media when explicitly granted by the user.

Key changes:
- `WebViewModel.protectedContentAllowed` stores the per-site decision (null = ask, true/false = remembered grant/deny). Archive-tier sites always deny via `effectiveProtectedContentAllowed` (ARCH-006 forbids device identifier provisioning and OS-level prompts).
- `_protectedMediaDecisionInFlight` coalesces burst `PROTECTED_MEDIA_ID` requests onto a single Allow/Block popup instead of stacking dialogs.
- `WebViewConfig.onProtectedMediaRequest` callback wired through `WebViewFactory` to Android's `onPermissionRequest`, filtering for `PROTECTED_MEDIA_ID` only and returning PROMPT for other resources (camera/mic) to avoid permission widening.
- Settings UI (Android-only) with three-state dropdown: Ask (default), Always allow, Always block.
- `_promptProtectedMedia` dialog in `_WebSpacePageState` and forwarded to nested `InAppWebViewScreen` for consistent UX across parent and outbound-link screens.
- JSON serialization omits null values to preserve backward compatibility.
- Tests verify null default, round-trip persistence, and archive-tier denial.

Implementation notes:
- iOS/macOS WKWebView has no EME/Widevine support and never issues the request, so the handler is Android-only.
- Granting provisions a per-container Widevine device identifier on disk; the decision is remembered to avoid re-prompting.
- Nested screens remember the choice in-memory only (no persisted model).

https://claude.ai/code/session_01Y3CrJdZDpVKJfwbLrKRYHd