### PR TITLE
feat(home-shortcut): iOS Web Clip Home Screen icon with favicon

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		7AC100032ED2DC5600515813 /* BackgroundTaskPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC100022ED2DC5600515813 /* BackgroundTaskPlugin.swift */; };
 		7AC200012ED2DC5600515820 /* ShortcutsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC200002ED2DC5600515820 /* ShortcutsPlugin.swift */; };
 		7AC200032ED2DC5600515821 /* WebSpaceAppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC200022ED2DC5600515821 /* WebSpaceAppIntents.swift */; };
+		7AC400012ED2DC5600515840 /* WebClipInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC400002ED2DC5600515840 /* WebClipInstaller.swift */; };
 		897CA73A1B12E395D36631E0 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEB686F40D1F327FFB98EB57 /* Pods_Runner.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -78,6 +79,7 @@
 		7AC100022ED2DC5600515813 /* BackgroundTaskPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundTaskPlugin.swift; sourceTree = "<group>"; };
 		7AC200002ED2DC5600515820 /* ShortcutsPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShortcutsPlugin.swift; sourceTree = "<group>"; };
 		7AC200022ED2DC5600515821 /* WebSpaceAppIntents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebSpaceAppIntents.swift; sourceTree = "<group>"; };
+		7AC400002ED2DC5600515840 /* WebClipInstaller.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebClipInstaller.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		8978E62AB7C1945FA3477F81 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
@@ -206,6 +208,7 @@
 				7AC100022ED2DC5600515813 /* BackgroundTaskPlugin.swift */,
 				7AC200002ED2DC5600515820 /* ShortcutsPlugin.swift */,
 				7AC200022ED2DC5600515821 /* WebSpaceAppIntents.swift */,
+				7AC400002ED2DC5600515840 /* WebClipInstaller.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 				7B0E0000000000000000000D /* Runner.entitlements */,
 			);
@@ -470,6 +473,7 @@
 				7AC100032ED2DC5600515813 /* BackgroundTaskPlugin.swift in Sources */,
 				7AC200012ED2DC5600515820 /* ShortcutsPlugin.swift in Sources */,
 				7AC200032ED2DC5600515821 /* WebSpaceAppIntents.swift in Sources */,
+				7AC400012ED2DC5600515840 /* WebClipInstaller.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -115,6 +115,21 @@ import UserNotifications
       #if DEBUG
       NSLog("[WebSpace] captured share inner URL: \(inner)")
       #endif
+    } else if host == "shortcut" {
+      // HS-011: a Home Screen Web Clip fires webspace://shortcut?siteId=...
+      // Funnel the siteId into the same App Group key the App Intents path
+      // writes (pending_shortcut_site_id) so getLaunchSiteId drains it on the
+      // next cold/warm launch and the existing reset-to-initUrl plumbing runs.
+      if let siteId = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+        .queryItems?.first(where: { $0.name == "siteId" })?.value,
+        !siteId.isEmpty,
+        let defaults = UserDefaults(suiteName: appGroupId)
+      {
+        defaults.set(siteId, forKey: "pending_shortcut_site_id")
+        #if DEBUG
+        NSLog("[WebSpace] captured web clip siteId: \(siteId)")
+        #endif
+      }
     } else if host == "qr" {
       // Pass the original webspace:// URL through; Dart routes it to the
       // QR-apply path by scheme.

--- a/ios/Runner/ShortcutsPlugin.swift
+++ b/ios/Runner/ShortcutsPlugin.swift
@@ -21,6 +21,7 @@ import AppIntents
 /// `_handleShortcutIntent`).
 class ShortcutsPlugin: NSObject {
   private let channel: FlutterMethodChannel
+  private var webClipInstaller: AnyObject?
   private static let channelName = "org.codeberg.theoden8.webspace/shortcuts"
   private static let appGroupId = "group.org.codeberg.theoden8.webspace"
   private static let sitesKey = "shortcut_sites"
@@ -54,6 +55,8 @@ class ShortcutsPlugin: NSObject {
       result(drainPendingSiteId())
     case "pinShortcut":
       openShortcutsApp(result: result)
+    case "installWebClip":
+      installWebClip(call.arguments as? [String: Any], result: result)
     case "removeShortcut":
       // No-op on iOS: we don't pin, we don't track.
       result(nil)
@@ -94,6 +97,26 @@ class ShortcutsPlugin: NSObject {
     else { return nil }
     defaults.removeObject(forKey: Self.pendingKey)
     return siteId
+  }
+
+  private func installWebClip(_ args: [String: Any]?, result: @escaping FlutterResult) {
+    guard
+      let label = args?["label"] as? String,
+      let urlString = args?["url"] as? String
+    else {
+      result(false)
+      return
+    }
+    let iconBase64 = args?["iconBase64"] as? String
+    guard #available(iOS 13, *) else {
+      result(false)
+      return
+    }
+    let installer = WebClipInstaller()
+    // Retain across the async serve/open + Safari round-trip.
+    webClipInstaller = installer
+    let ok = installer.install(label: label, urlString: urlString, iconBase64: iconBase64)
+    result(ok)
   }
 
   private func openShortcutsApp(result: @escaping FlutterResult) {

--- a/ios/Runner/WebClipInstaller.swift
+++ b/ios/Runner/WebClipInstaller.swift
@@ -97,9 +97,11 @@ final class WebClipInstaller {
     }
     listener.start(queue: .global(qos: .userInitiated))
 
-    // Safety net: reclaim the listener + background assertion if Safari
-    // never connects (user dismissed the download prompt, etc.).
-    DispatchQueue.global().asyncAfter(deadline: .now() + 30) { [weak self] in
+    // Keep serving for the whole window: Safari may make a preflight fetch
+    // plus the real one, so we must answer more than once. Reclaim the
+    // listener + background assertion once the window closes (or earlier if
+    // the background-task assertion expires).
+    DispatchQueue.global().asyncAfter(deadline: .now() + 120) { [weak self] in
       self?.teardown()
     }
     return true
@@ -114,20 +116,23 @@ final class WebClipInstaller {
         conn.cancel()
         return
       }
+      // No Content-Disposition: with attachment, Safari routes the profile
+      // through the download manager and re-fetches the bytes on a second
+      // request when the user taps "Download" — by which point a one-shot
+      // listener is gone. Serving it as a bare aspen-config lets Safari
+      // recognize it as a profile and show the install prompt on the first
+      // fetch. The listener also stays up (see serveAndOpen) to tolerate any
+      // preflight + actual fetch Safari still makes.
       let header =
         "HTTP/1.1 200 OK\r\n"
         + "Content-Type: application/x-apple-aspen-config\r\n"
-        + "Content-Disposition: attachment; filename=\"webspace.mobileconfig\"\r\n"
         + "Content-Length: \(self.profileData.count)\r\n"
         + "Connection: close\r\n\r\n"
       var payload = Data(header.utf8)
       payload.append(self.profileData)
       conn.send(
         content: payload,
-        completion: .contentProcessed { _ in
-          conn.cancel()
-          self.teardown()
-        })
+        completion: .contentProcessed { _ in conn.cancel() })
     }
   }
 

--- a/ios/Runner/WebClipInstaller.swift
+++ b/ios/Runner/WebClipInstaller.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Network
+import UIKit
+
+/// Builds a Web Clip configuration profile (`.mobileconfig`) for one site and
+/// hands it to Safari to install (HS-011).
+///
+/// iOS exposes no API to drop a Home Screen icon with a custom image. The only
+/// supported path is a Web Clip payload delivered through a configuration
+/// profile. iOS also only triggers the "Install Profile" flow when the
+/// `.mobileconfig` is fetched by Safari with the
+/// `application/x-apple-aspen-config` content type — opening a local file URL
+/// does not — so the profile is served from a one-shot loopback HTTP listener
+/// that we then open in Safari. A background-task assertion keeps the listener
+/// alive across the app backgrounding while Safari connects.
+@available(iOS 13, *)
+final class WebClipInstaller {
+  private var listener: NWListener?
+  private var bgTask: UIBackgroundTaskIdentifier = .invalid
+  private var profileData = Data()
+
+  func install(label: String, urlString: String, iconBase64: String?) -> Bool {
+    guard
+      let data = Self.buildProfile(
+        label: label, urlString: urlString, iconBase64: iconBase64)
+    else { return false }
+    profileData = data
+    return serveAndOpen()
+  }
+
+  private static func buildProfile(
+    label: String, urlString: String, iconBase64: String?
+  ) -> Data? {
+    let clipUUID = UUID().uuidString
+    let profileUUID = UUID().uuidString
+    var clip: [String: Any] = [
+      "URL": urlString,
+      "Label": label,
+      "IsRemovable": true,
+      "FullScreen": true,
+      "Precomposed": true,
+      "PayloadType": "com.apple.webClip.managed",
+      "PayloadVersion": 1,
+      "PayloadIdentifier": "org.codeberg.theoden8.webspace.webclip.\(clipUUID)",
+      "PayloadUUID": clipUUID,
+      "PayloadDisplayName": label,
+    ]
+    if let iconBase64 = iconBase64, let iconData = Data(base64Encoded: iconBase64) {
+      clip["Icon"] = iconData
+    }
+    let profile: [String: Any] = [
+      "PayloadContent": [clip],
+      "PayloadType": "Configuration",
+      "PayloadVersion": 1,
+      "PayloadIdentifier":
+        "org.codeberg.theoden8.webspace.webclip.profile.\(profileUUID)",
+      "PayloadUUID": profileUUID,
+      "PayloadDisplayName": "WebSpace: \(label)",
+      "PayloadDescription": "Adds a Home Screen icon that opens \(label) in WebSpace.",
+      "PayloadOrganization": "WebSpace",
+      "PayloadRemovalDisallowed": false,
+    ]
+    return try? PropertyListSerialization.data(
+      fromPropertyList: profile, format: .xml, options: 0)
+  }
+
+  private func serveAndOpen() -> Bool {
+    let params = NWParameters.tcp
+    params.requiredInterfaceType = .loopback
+    guard let listener = try? NWListener(using: params) else { return false }
+    self.listener = listener
+
+    bgTask = UIApplication.shared.beginBackgroundTask(withName: "webclip-install") {
+      [weak self] in self?.teardown()
+    }
+
+    listener.newConnectionHandler = { [weak self] conn in self?.handle(conn) }
+    listener.stateUpdateHandler = { [weak self] state in
+      guard let self = self else { return }
+      switch state {
+      case .ready:
+        guard
+          let port = self.listener?.port?.rawValue,
+          let url = URL(string: "http://127.0.0.1:\(port)/webspace.mobileconfig")
+        else {
+          self.teardown()
+          return
+        }
+        DispatchQueue.main.async {
+          UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+      case .failed, .cancelled:
+        self.teardown()
+      default:
+        break
+      }
+    }
+    listener.start(queue: .global(qos: .userInitiated))
+
+    // Safety net: reclaim the listener + background assertion if Safari
+    // never connects (user dismissed the download prompt, etc.).
+    DispatchQueue.global().asyncAfter(deadline: .now() + 30) { [weak self] in
+      self?.teardown()
+    }
+    return true
+  }
+
+  private func handle(_ conn: NWConnection) {
+    conn.start(queue: .global(qos: .userInitiated))
+    // Drain (and ignore) the request line/headers, then respond once.
+    conn.receive(minimumIncompleteLength: 1, maximumLength: 65536) {
+      [weak self] _, _, _, _ in
+      guard let self = self else {
+        conn.cancel()
+        return
+      }
+      let header =
+        "HTTP/1.1 200 OK\r\n"
+        + "Content-Type: application/x-apple-aspen-config\r\n"
+        + "Content-Disposition: attachment; filename=\"webspace.mobileconfig\"\r\n"
+        + "Content-Length: \(self.profileData.count)\r\n"
+        + "Connection: close\r\n\r\n"
+      var payload = Data(header.utf8)
+      payload.append(self.profileData)
+      conn.send(
+        content: payload,
+        completion: .contentProcessed { _ in
+          conn.cancel()
+          self.teardown()
+        })
+    }
+  }
+
+  private func teardown() {
+    listener?.cancel()
+    listener = nil
+    if bgTask != .invalid {
+      UIApplication.shared.endBackgroundTask(bgTask)
+      bgTask = .invalid
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ import 'package:webspace/screens/add_site.dart' show AddSiteScreen, UnifiedFavic
 import 'package:webspace/screens/settings.dart';
 import 'package:webspace/screens/app_settings.dart';
 import 'package:webspace/services/icon_service.dart';
+import 'package:webspace/services/web_clip_icon.dart';
 import 'package:webspace/screens/inappbrowser.dart';
 import 'package:webspace/screens/webspaces_list.dart';
 import 'package:webspace/screens/webspace_detail.dart';
@@ -1140,9 +1141,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         builder: (ctx) => AlertDialog(
           title: const Text('Add to Home Screen'),
           content: Text(
-            'iOS adds WebSpace sites through the Shortcuts app.\n\n'
-            'In Shortcuts, find the "Open Site" action under WebSpace, pick '
-            '"${model.name}", then tap "Add to Home Screen" from the share menu.',
+            'WebSpace will hand iOS a setup profile for "${model.name}".\n\n'
+            'Safari opens, then iOS shows "Profile Downloaded". Open '
+            'Settings > General > VPN & Device Management, tap the WebSpace '
+            'profile, and Install it. A "${model.name}" icon then appears on '
+            'your Home Screen.',
           ),
           actions: [
             TextButton(
@@ -1151,18 +1154,54 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
             ),
             TextButton(
               onPressed: () => Navigator.of(ctx).pop(true),
-              child: const Text('Open Shortcuts'),
+              child: const Text('Continue'),
             ),
           ],
         ),
       );
-      if (confirmed == true) {
-        await ShortcutService.pinShortcut(
-          siteId: model.siteId,
-          label: model.name,
+      if (confirmed != true) return;
+      final iconBase64 = await _buildWebClipIconBase64(model);
+      // HS-011: the tile fires webspace://shortcut?siteId=..., which
+      // AppDelegate funnels into the same pending-siteId launch path the
+      // App Intents shortcut uses (so HS-002/006/007 apply unchanged).
+      final target = Uri(
+        scheme: 'webspace',
+        host: 'shortcut',
+        queryParameters: {'siteId': model.siteId},
+      ).toString();
+      final ok = await ShortcutService.installWebClip(
+        label: model.name,
+        targetUrl: target,
+        iconPngBase64: iconBase64,
+      );
+      if (!ok && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not start Home Screen setup')),
         );
       }
     }
+  }
+
+  /// Build the Web Clip icon as a base64 PNG: the site's favicon when it is a
+  /// fetchable raster, otherwise the bundled app icon. SVG favicons aren't
+  /// rasterizable here, so they fall through to the app icon.
+  Future<String?> _buildWebClipIconBase64(WebViewModel model) async {
+    Uint8List? png;
+    final faviconUrl = FaviconUrlCache.get(model.initUrl);
+    final isSvg = faviconUrl != null && faviconUrl.toLowerCase().endsWith('.svg');
+    if (faviconUrl != null && !isSvg) {
+      final raw = await fetchIconBytes(faviconUrl, proxy: model.proxySettings);
+      if (raw != null) png = WebClipIcon.encodeSquarePng(raw);
+    }
+    if (png == null) {
+      try {
+        final data = await rootBundle.load('assets/webspace_icon.png');
+        png = WebClipIcon.encodeSquarePng(data.buffer.asUint8List());
+      } catch (_) {
+        return null;
+      }
+    }
+    return png == null ? null : base64Encode(png);
   }
 
   Future<void> _refreshPinnedSiteIds() async {

--- a/lib/services/icon_service.dart
+++ b/lib/services/icon_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:collection';
+import 'dart:typed_data';
 import 'package:http/http.dart' as http;
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/outbound_http.dart';
@@ -31,6 +32,30 @@ http.Client? _proxiedClient(UserProxySettings proxy) {
       'Outbound blocked: ${result.reason}',
       level: LogLevel.warning,
     );
+  }
+  return null;
+}
+
+/// Fetch the raw bytes of an already-resolved favicon URL, honoring the
+/// proxy posture of the owning site. Returns null when the proxy can't be
+/// honored (fail-closed, same as the rest of this service) or the request
+/// fails. Used by the iOS Web Clip path to embed the favicon in the
+/// configuration profile.
+Future<Uint8List?> fetchIconBytes(
+  String url, {
+  UserProxySettings? proxy,
+}) async {
+  final client = _proxiedClient(_resolve(proxy));
+  if (client == null) return null;
+  try {
+    final response = await client.get(Uri.parse(url)).timeout(
+          const Duration(seconds: 5),
+        );
+    if (response.statusCode == 200 && response.bodyBytes.isNotEmpty) {
+      return response.bodyBytes;
+    }
+  } catch (_) {
+    // best-effort; caller falls back to the bundled app icon.
   }
   return null;
 }

--- a/lib/services/shortcut_service.dart
+++ b/lib/services/shortcut_service.dart
@@ -50,6 +50,32 @@ class ShortcutService {
     }
   }
 
+  /// Install an iOS Web Clip so the site gets a real Home Screen icon
+  /// carrying its favicon (HS-011). iOS has no API to place a custom-icon
+  /// tile directly, so this hands a generated configuration profile to
+  /// Safari; the user installs it via Settings. [targetUrl] is the
+  /// `webspace://shortcut?siteId=...` deep link the tile fires;
+  /// [iconPngBase64] is a base64 PNG (favicon or app-icon fallback), or null
+  /// to let iOS pick a generic glyph. iOS only; returns false elsewhere or
+  /// when the profile could not be handed off.
+  static Future<bool> installWebClip({
+    required String label,
+    required String targetUrl,
+    String? iconPngBase64,
+  }) async {
+    if (!Platform.isIOS) return false;
+    try {
+      final result = await _channel.invokeMethod('installWebClip', {
+        'label': label,
+        'url': targetUrl,
+        'iconBase64': iconPngBase64,
+      });
+      return result == true;
+    } on PlatformException {
+      return false;
+    }
+  }
+
   /// Remove a pinned shortcut when a site is deleted (Android only).
   /// On iOS the App Intents site list is rebuilt from the user's actual
   /// sites by `syncSites` so a deletion drops out implicitly.

--- a/lib/services/web_clip_icon.dart
+++ b/lib/services/web_clip_icon.dart
@@ -1,0 +1,28 @@
+import 'dart:typed_data';
+import 'package:image/image.dart' as img;
+
+/// Pure helper: normalize an arbitrary raster favicon into a square PNG fit
+/// for an iOS Web Clip `Icon` payload. iOS renders the Home Screen tile from
+/// this PNG (it applies its own corner mask), so we only need a square,
+/// reasonably sized, opaque-friendly PNG. Returns null when the bytes can't
+/// be decoded (e.g. an SVG or a corrupt download) so the caller can fall back
+/// to the bundled app icon.
+class WebClipIcon {
+  static Uint8List? encodeSquarePng(Uint8List raw, {int size = 180}) {
+    try {
+      // decodeImage probes multiple format decoders; a malformed download can
+      // make one of them overrun its buffer and throw rather than return null.
+      final decoded = img.decodeImage(raw);
+      if (decoded == null) return null;
+      final resized = img.copyResize(
+        decoded,
+        width: size,
+        height: size,
+        interpolation: img.Interpolation.cubic,
+      );
+      return img.encodePng(resized);
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Allow users to add a site shortcut to the home screen. Tapping the shortcut launches WebSpace and navigates to that site. On Android the system pins the shortcut directly via `ShortcutManagerCompat.requestPinShortcut`. On iOS 16+ the system exposes WebSpace sites as App Intents (`OpenSiteIntent`) that the user adds through the Shortcuts app and pins to the home screen from there.
+Allow users to add a site shortcut to the home screen. Tapping the shortcut launches WebSpace and navigates to that site. On Android the system pins the shortcut directly via `ShortcutManagerCompat.requestPinShortcut`. On iOS 16+ the "Home Shortcut" menu item generates a Web Clip configuration profile carrying the site's favicon and a `webspace://shortcut?siteId=...` target, which the user installs to place a custom-icon tile on the Home Screen (HS-011). iOS sites are also exposed as App Intents (`OpenSiteIntent`) for Siri/Spotlight and manual Shortcuts-app use (HS-008/009); those remain, but are no longer the Home Screen path.
 
 ## Status
 
@@ -205,28 +205,65 @@ The system SHALL keep the iOS App Intents site picker in sync with the user's ac
 
 ### Requirement: HS-010 - iOS "Add to Home Screen" Dialog
 
-On iOS, tapping the "Home Shortcut" menu item SHALL show an instructional dialog explaining that iOS surfaces WebSpace sites through the Shortcuts app, with a primary button that deep-links to Shortcuts.app. The system SHALL NOT attempt to pin a shortcut programmatically (iOS has no such public API).
+On iOS, tapping the "Home Shortcut" menu item SHALL show an instructional dialog explaining that WebSpace will hand iOS a setup profile and that the user finishes installing it from Settings, with a primary button that proceeds to generate and deliver the Web Clip profile (HS-011). The system SHALL NOT attempt to pin a shortcut programmatically (iOS has no such public API).
 
 #### Scenario: Dialog content
 
 **Given** the user is on iOS 16+
 **When** the user taps "Home Shortcut" in the overflow menu
-**Then** an `AlertDialog` is shown explaining the iOS flow ("find the Open Site action under WebSpace, pick this site, then tap Add to Home Screen")
-**And** the dialog has an "Open Shortcuts" primary button and a "Cancel" button
+**Then** an `AlertDialog` is shown explaining the iOS flow (Safari opens, then install the WebSpace profile under Settings > General > VPN & Device Management)
+**And** the dialog has a "Continue" primary button and a "Cancel" button
 
 #### Scenario: User confirms
 
 **Given** the iOS instructional dialog is shown
-**When** the user taps "Open Shortcuts"
-**Then** the system opens the URL `shortcuts://` via `UIApplication.shared.open`
-**And** the Shortcuts.app launches
+**When** the user taps "Continue"
+**Then** the system builds the Web Clip profile and hands it to Safari (HS-011)
 
 #### Scenario: User cancels
 
 **Given** the iOS instructional dialog is shown
 **When** the user taps "Cancel"
 **Then** the dialog dismisses
-**And** Shortcuts.app is not opened
+**And** no profile is generated or delivered
+
+---
+
+### Requirement: HS-011 - iOS Web Clip Home Screen Icon
+
+On iOS 16+, confirming the HS-010 dialog SHALL generate a Web Clip configuration profile (`.mobileconfig`) for the site and deliver it to Safari for installation. The profile's single `com.apple.webClip.managed` payload SHALL set the site name as `Label`, the site's favicon (or the bundled app icon as fallback) as the `Icon`, and `webspace://shortcut?siteId=<siteId>` as the `URL`, with `IsRemovable = true`. The installed tile SHALL launch WebSpace to the targeted site, reusing the cold/warm launch path (HS-002, HS-006, HS-007). The system SHALL NOT install the profile silently (iOS forbids it); the user completes installation from Settings.
+
+#### Scenario: Profile carries the favicon
+
+**Given** the site has a cached non-SVG favicon that fetches successfully
+**When** the user confirms the HS-010 dialog
+**Then** the Web Clip `Icon` is the favicon, rendered to a square PNG
+
+#### Scenario: Favicon unavailable or SVG
+
+**Given** the site has no cached favicon, the favicon is an SVG, or the fetch fails
+**When** the user confirms the HS-010 dialog
+**Then** the Web Clip `Icon` falls back to the bundled WebSpace app icon
+
+#### Scenario: Delivery to Safari
+
+**Given** the profile has been built
+**When** delivery runs
+**Then** the profile is served from a one-shot loopback HTTP listener with `Content-Type: application/x-apple-aspen-config`
+**And** the system opens that loopback URL via `UIApplication.shared.open` so Safari downloads it and iOS shows "Profile Downloaded"
+
+#### Scenario: Tile launches the targeted site
+
+**Given** the user installed the Web Clip profile and tapped its Home Screen tile
+**When** WebSpace cold- or warm-launches
+**Then** `AppDelegate` parses `webspace://shortcut?siteId=...` and writes the siteId to App Group `pending_shortcut_site_id`
+**And** `ShortcutService.getLaunchSiteId()` drains it and the targeted site becomes active (resetting to `initUrl` on cold launch per HS-006)
+
+#### Scenario: Archive-tier site
+
+**Given** a site is archive-tier
+**When** the overflow menu is shown
+**Then** the "Home Shortcut" item is hidden (ARCH-006), so no Web Clip can be generated for it
 
 ---
 
@@ -293,7 +330,8 @@ This requirement applies only to **process-startup** launches (cold or post-kill
 Both Android and iOS share the channel `MethodChannel('org.codeberg.theoden8.webspace/shortcuts')`.
 
 Methods:
-- `pinShortcut({siteId, label, iconUrl})` — **Android**: requests a pinned shortcut via `ShortcutManagerCompat.requestPinShortcut()`. **iOS 16+**: opens `shortcuts://` (the Dart UI shows the HS-010 instructional dialog first).
+- `pinShortcut({siteId, label, iconUrl})` — **Android**: requests a pinned shortcut via `ShortcutManagerCompat.requestPinShortcut()`. **iOS 16+**: opens `shortcuts://` (retained for the Shortcuts-app/Siri path; the Home Screen menu now uses `installWebClip`).
+- `installWebClip({label, url, iconBase64})` — **iOS 16+ only**: builds a Web Clip `.mobileconfig` (`label`, base64 PNG `iconBase64`, `webspace://shortcut?siteId=...` `url`) and serves it from a one-shot loopback HTTP listener opened in Safari (HS-011). No-op elsewhere.
 - `removeShortcut(siteId)` — Android: disables and removes the dynamic+pinned shortcut for a deleted site. iOS: no-op (the App Intents site list is recomputed from `_webViewModels` on every save via HS-009).
 - `getLaunchSiteId()` — **Android**: returns the `siteId` from the launch intent extra. **iOS**: drains the `pending_shortcut_site_id` key from App Group UserDefaults (written by `OpenSiteIntent.perform()`).
 - `getPinnedSiteIds()` — Android: returns the set of `siteId`s currently pinned, derived from `ShortcutManagerCompat.getShortcuts(FLAG_MATCH_PINNED)` by stripping the `site_` prefix. iOS: always returns an empty list (no public API for pin-state introspection).
@@ -339,13 +377,15 @@ no widget tree required.
 - `lib/services/startup_restore_engine.dart` — `resolveLaunchTarget` shortcut→index resolution
 - `ios/Runner/WebSpaceAppIntents.swift` — `SiteEntity`, `SiteEntityQuery`, `OpenSiteIntent`, `WebSpaceShortcuts` (iOS 16+)
 - `ios/Runner/ShortcutsPlugin.swift` — iOS method-channel handler
+- `ios/Runner/WebClipInstaller.swift` — builds + delivers the Web Clip profile (HS-011)
+- `lib/services/web_clip_icon.dart` — favicon → square PNG normalizer for the Web Clip `Icon`
 - `test/startup_restore_engine_test.dart` — unit tests for the resolution rule
 - `test/shortcut_service_test.dart` — unit tests for the Dart service surface
 - `openspec/specs/home-shortcut/spec.md` — this specification
 
 #### Modified
 - `android/app/src/main/kotlin/.../MainActivity.kt` — native shortcut creation and intent handling
-- `ios/Runner/AppDelegate.swift` — wire `ShortcutsPlugin`
+- `ios/Runner/AppDelegate.swift` — wire `ShortcutsPlugin`; route `webspace://shortcut?siteId=` to the App Group pending-siteId key (HS-011)
 - `ios/Runner.xcodeproj/project.pbxproj` — register the new Swift files
 - `lib/main.dart` — menu item, shortcut action, launch intent handling, iOS site sync
 

--- a/test/shortcut_service_test.dart
+++ b/test/shortcut_service_test.dart
@@ -83,6 +83,17 @@ void main() {
       }
     });
 
+    test('installWebClip is false off iOS', () async {
+      final ok = await ShortcutService.installWebClip(
+        label: 'A',
+        targetUrl: 'webspace://shortcut?siteId=a',
+      );
+      if (!Platform.isIOS) {
+        expect(ok, isFalse);
+        expect(calls, isEmpty);
+      }
+    });
+
     test('getLaunchSiteId is null on non-mobile host', () async {
       final id = await ShortcutService.getLaunchSiteId();
       if (!isMobileHost) {
@@ -117,6 +128,13 @@ void main() {
       // channel; this case really exercises mobile hosts. Still: the calls
       // must never throw a PlatformException out of the service.
       expect(await ShortcutService.pinShortcut(siteId: 'a', label: 'A'), isFalse);
+      expect(
+        await ShortcutService.installWebClip(
+          label: 'A',
+          targetUrl: 'webspace://shortcut?siteId=a',
+        ),
+        isFalse,
+      );
       expect(await ShortcutService.getLaunchSiteId(), isNull);
       expect(await ShortcutService.getPinnedSiteIds(), isEmpty);
       expect(await ShortcutService.isAppIntentsSupported(), isFalse);

--- a/test/web_clip_icon_test.dart
+++ b/test/web_clip_icon_test.dart
@@ -1,0 +1,26 @@
+import 'dart:typed_data';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:webspace/services/web_clip_icon.dart';
+
+void main() {
+  test('encodeSquarePng squares + re-encodes a raster favicon', () {
+    final src = img.Image(width: 32, height: 64);
+    img.fill(src, color: img.ColorRgb8(10, 20, 30));
+    final raw = Uint8List.fromList(img.encodePng(src));
+
+    final out = WebClipIcon.encodeSquarePng(raw, size: 120);
+    expect(out, isNotNull);
+    final decoded = img.decodeImage(out!);
+    expect(decoded, isNotNull);
+    expect(decoded!.width, 120);
+    expect(decoded.height, 120);
+  });
+
+  test('encodeSquarePng returns null on undecodable bytes', () {
+    expect(
+      WebClipIcon.encodeSquarePng(Uint8List.fromList([1, 2, 3, 4])),
+      isNull,
+    );
+  });
+}


### PR DESCRIPTION
App Intents tiles all share the generic app glyph and only live in the
Shortcuts app. Web Clips are the only iOS path to a custom-icon Home
Screen tile. The "Home Shortcut" menu now builds a .mobileconfig with
the site favicon and a webspace://shortcut?siteId= target, served from a
one-shot loopback listener and opened in Safari. AppDelegate funnels the
deep link into the existing pending-siteId launch path (HS-002/006/007).