### PR TITLE
Release log stripping; optional extra sections in settings backup

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -108,6 +108,12 @@ android {
             if (keystorePropertiesFile.exists()) {
                 signingConfig signingConfigs.release
             }
+            // R8 in optimize-only mode (shrink + obfuscate disabled in
+            // proguard-rules.pro). The sole effect is dropping
+            // android.util.Log.d/.v calls so debug-level log lines don't
+            // reach release logcat. shrinkResources stays off.
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,14 @@
+# R8 runs in optimize-only mode for release builds: shrinking and
+# obfuscation are disabled so no class is removed or renamed (keeps
+# reflection and JNI entry points intact across the native plugins).
+# The only observable effect is that android.util.Log.d / .v calls are
+# treated as side-effect-free and dropped during the optimize pass, so
+# debug-level log lines (including ones inherited from upstream webview
+# code) don't reach release logcat.
+-dontshrink
+-dontobfuscate
+
+-assumenosideeffects class android.util.Log {
+    public static int d(...);
+    public static int v(...);
+}

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -12,3 +12,13 @@
     public static int d(...);
     public static int v(...);
 }
+
+# Flutter's embedding references Play Store deferred-components and
+# split-install classes that aren't bundled (the fdroid flavor ships no
+# Play services). They're referenced on a code path this app never
+# takes, so suppress R8's missing-class verification rather than pull in
+# the dependency. Same for javax.lang.model, reachable only through
+# compile-time errorprone annotations.
+-dontwarn com.google.android.play.core.**
+-dontwarn javax.lang.model.**
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3926,6 +3926,44 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     // match what a user with zero archives would produce.
     final appTierModels =
         _webViewModels.where((m) => !m.isArchiveTier).toList();
+
+    // When archives are open, offer to bundle them into the backup as
+    // opaque encrypted sections. The prompt only appears while archives
+    // are open (their content is already visible in the switcher at
+    // that point); a backup with none open is byte-identical to one
+    // produced without the feature.
+    List<String>? extraSections;
+    final open = _archive.openArchives;
+    if (open.isNotEmpty) {
+      final include = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('Include open archives?'),
+          content: Text(
+            'You have ${open.length} archive(s) open. Include them in this '
+            'backup? They stay encrypted, but the file will reveal that '
+            'archived data exists.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Exclude'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Include'),
+            ),
+          ],
+        ),
+      );
+      if (!mounted) return;
+      if (include == true) {
+        extraSections = [
+          for (final h in open) await _archive.exportSection(h),
+        ];
+      }
+    }
+
     await SettingsBackupService.exportAndSave(
       context,
       webViewModels: appTierModels,
@@ -3946,6 +3984,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       // themselves stay machine state; the user re-downloads after import.
       dnsBlockLevel: DnsBlockService.instance.level,
       contentBlockerLists: ContentBlockerService.instance.exportListSelection(),
+      extraSections: extraSections,
     );
   }
 
@@ -4180,6 +4219,39 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
               ? 'Settings imported successfully'
               : 'Settings imported. ${hints.join(' ')}'),
           duration: Duration(seconds: hints.isEmpty ? 4 : 6),
+        ),
+      );
+    }
+
+    // If the backup carries encrypted sections, offer to restore them
+    // by passphrase. Each prompt restores the section(s) matching the
+    // entered passphrase; remaining ones can be restored by entering
+    // another passphrase, or skipped by cancelling.
+    final sections = backup.extraSections;
+    if (sections != null && sections.isNotEmpty && mounted) {
+      await _restoreBackupSections(sections);
+    }
+  }
+
+  Future<void> _restoreBackupSections(List<String> sections) async {
+    var remaining = List<String>.from(sections);
+    while (remaining.isNotEmpty && mounted) {
+      final passphrase = await _showPassphraseDialog(
+        title: 'Restore archived data',
+        hint: 'Passphrase (cancel to skip)',
+        submitLabel: 'Restore',
+      );
+      if (passphrase == null || passphrase.isEmpty) break;
+      final before = remaining.length;
+      final unmatched = await _archive.importSections(passphrase, remaining);
+      if (!mounted) return;
+      final restored = before - unmatched.length;
+      remaining = unmatched;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(restored > 0
+              ? 'Restored $restored archived section(s)'
+              : 'No section matched that passphrase'),
         ),
       );
     }

--- a/lib/services/archive.dart
+++ b/lib/services/archive.dart
@@ -189,6 +189,84 @@ class Archive {
     }
   }
 
+  /// Restores self-contained sections produced by [exportSection] into
+  /// the slot pool. Tries [passphrase] against each base64 blob; a blob
+  /// that decrypts is written to its archive's slot (existing slot for
+  /// that key, or a fresh one). Restored archives are written to disk
+  /// but NOT opened. Returns the blobs that did not decrypt under this
+  /// passphrase, so the caller can prompt again for a different one.
+  Future<List<String>> importSections(
+    String passphrase,
+    List<String> base64Sections,
+  ) async {
+    final key = await ArchiveKeyDerivation.derive(passphrase);
+    try {
+      return await importSectionsWithKey(key, base64Sections);
+    } finally {
+      ArchiveCrypto.zeroize(key);
+    }
+  }
+
+  /// Key-based core of [importSections]. Does not consume or zeroize
+  /// [key] (the caller owns its lifetime). Exposed for tests so they
+  /// can exercise section round-tripping without the per-call Argon2id
+  /// cost; derivation itself is covered by the crypto tests.
+  Future<List<String>> importSectionsWithKey(
+    Uint8List key,
+    List<String> base64Sections,
+  ) async {
+    await ensureInitialized();
+    final unmatched = <String>[];
+    for (final b64 in base64Sections) {
+      Uint8List wire;
+      try {
+        wire = Uint8List.fromList(base64.decode(b64));
+      } catch (_) {
+        unmatched.add(b64);
+        continue;
+      }
+      final plaintext = await ArchiveCrypto.open(key, wire);
+      if (plaintext == null) {
+        unmatched.add(b64);
+        continue;
+      }
+      final stateJson =
+          jsonDecode(utf8.decode(plaintext)) as Map<String, dynamic>;
+      await _writeState(key, ArchiveState.fromJson(stateJson));
+    }
+    return unmatched;
+  }
+
+  /// Seals an archive's state into a self-contained base64 blob (no
+  /// slot AAD) that [importSections] can later restore under the same
+  /// passphrase-derived key.
+  Future<String> exportSection(ArchiveHandle handle) async {
+    final plaintext =
+        Uint8List.fromList(utf8.encode(jsonEncode(handle.state.toJson())));
+    final wire = await ArchiveCrypto.seal(handle.key, plaintext);
+    return base64.encode(wire);
+  }
+
+  Future<void> _writeState(Uint8List key, ArchiveState state) async {
+    final match = await _scanSlots(key);
+    final int slotIndex;
+    if (match != null) {
+      slotIndex = match.slotIndex;
+    } else {
+      final claimed = <int>{for (final h in _openHandles) h.slotIndex};
+      slotIndex = _storage.pickRandomUnclaimedSlot(claimed);
+    }
+    // Build a transient handle over a private copy of the key just to
+    // persist; never registered as open, zeroed immediately after.
+    final handle = ArchiveHandle._(
+      key: Uint8List.fromList(key),
+      slotIndex: slotIndex,
+      state: state,
+    );
+    await _persist(handle);
+    handle._zeroizeAndMarkClosed();
+  }
+
   Future<_SlotMatch?> _scanSlots(Uint8List key) async {
     final slots = await _storage.readAllSlots();
     for (var i = 0; i < slots.length; i++) {

--- a/lib/services/settings_backup.dart
+++ b/lib/services/settings_backup.dart
@@ -29,6 +29,12 @@ class SettingsBackup {
   final DateTime exportedAt;
   final List<Map<String, dynamic>>? suggestedSites;
   final List<Map<String, dynamic>>? globalUserScripts;
+  /// Optional opaque encrypted sections the user chose to bundle into
+  /// the backup. Each entry is a base64 self-decrypting blob; only
+  /// present when the user opted in at export time. Omitted entirely
+  /// otherwise, so a default export is byte-identical to one produced
+  /// without the feature.
+  final List<String>? extraSections;
 
   /// Chosen DNS blocklist severity level (0-5). User intent; the
   /// downloaded domain blob is never part of a backup. Null when the
@@ -57,6 +63,7 @@ class SettingsBackup {
     this.globalUserScripts,
     this.dnsBlockLevel,
     this.contentBlockerLists,
+    this.extraSections,
   }) : globalPrefs = _normalizePrefs(
           globalPrefs,
           showUrlBar: showUrlBar,
@@ -83,6 +90,8 @@ class SettingsBackup {
         if (dnsBlockLevel != null) 'dnsBlockLevel': dnsBlockLevel,
         if (contentBlockerLists != null)
           'contentBlockerLists': contentBlockerLists,
+        if (extraSections != null && extraSections!.isNotEmpty)
+          'extraSections': extraSections,
       };
 
   factory SettingsBackup.fromJson(Map<String, dynamic> json) {
@@ -120,6 +129,9 @@ class SettingsBackup {
       dnsBlockLevel: json['dnsBlockLevel'] as int?,
       contentBlockerLists: (json['contentBlockerLists'] as List<dynamic>?)
           ?.map((e) => Map<String, dynamic>.from(e as Map))
+          .toList(),
+      extraSections: (json['extraSections'] as List<dynamic>?)
+          ?.map((e) => e as String)
           .toList(),
     );
   }
@@ -168,6 +180,7 @@ class SettingsBackupService {
     List<Map<String, dynamic>>? globalUserScripts,
     int? dnsBlockLevel,
     List<Map<String, dynamic>>? contentBlockerLists,
+    List<String>? extraSections,
   }) {
     // Convert sites to JSON. `model.toJson` already omits the proxy
     // password (per PWD-005); we still need to strip secure cookies here.
@@ -205,6 +218,7 @@ class SettingsBackupService {
       globalUserScripts: globalUserScripts,
       dnsBlockLevel: dnsBlockLevel,
       contentBlockerLists: contentBlockerLists,
+      extraSections: extraSections,
     );
   }
 
@@ -226,6 +240,7 @@ class SettingsBackupService {
     List<Map<String, dynamic>>? globalUserScripts,
     int? dnsBlockLevel,
     List<Map<String, dynamic>>? contentBlockerLists,
+    List<String>? extraSections,
   }) async {
     try {
       final backup = createBackup(
@@ -239,6 +254,7 @@ class SettingsBackupService {
         globalUserScripts: globalUserScripts,
         dnsBlockLevel: dnsBlockLevel,
         contentBlockerLists: contentBlockerLists,
+        extraSections: extraSections,
       );
 
       final jsonString = exportToJson(backup);

--- a/openspec/specs/archive/spec.md
+++ b/openspec/specs/archive/spec.md
@@ -41,11 +41,18 @@ their membership rides the archive's own encrypted state and is
 re-captured on close. Reopening restores the grouping; closing falls
 back to the "All" view if the user was inside an archive collection.
 
-**Deferred from v1:**
-
-- **ARCH-010 (export tick):** exports remain app-tier-only with no
-  opt-in switch. Adding the tick later is additive and won't break the
-  existing on-device invariant.
+**ARCH-010 (export opt-in):** when one or more archives are open, the
+settings export prompts whether to bundle them. Each open archive is
+sealed into a self-contained base64 section (`Archive.exportSection`,
+AES-256-GCM under the passphrase-derived key, no slot AAD) stored under
+the optional `extraSections` key in the backup JSON. The prompt only
+appears while archives are open — at which point their content is
+already visible in the switcher — so a backup taken with none open is
+byte-identical to one produced without the feature (the key is omitted
+entirely). Import detects `extraSections` and prompts for a passphrase
+per round (`Archive.importSections`); sections that decrypt are written
+to the slot pool (not opened); the rest can be restored by entering
+another passphrase, or skipped.
 
 ## Purpose
 

--- a/openspec/specs/archive/spec.md
+++ b/openspec/specs/archive/spec.md
@@ -527,12 +527,13 @@ These tests run in CI and are the regression-prevention spine of ARCH-001.
 - **Slot size cap.** Archives larger than 256 KiB of packed state (typically: cookies + webspace JSON for ~50 sites) currently fail at write with a clear error to the user. v1 does not split archives across slots.
 - **Per-site browser state beyond cookies does not migrate on move-to-archive.** Cookies are captured from the running container and pushed into the new opaque container on next webview build. `localStorage`, `IndexedDB`, `ServiceWorker` registrations, and `HTTP cache` are not — the new container is a fresh slate. Sites that store user preferences (theme, language, layout) in `localStorage` will revert to defaults the first time they're opened from an archive after a move. The move-to-archive snackbar warns the user. Mitigation would require fork-side API to read/write per-container `localStorage`; tracked but out of scope for v1.
 - **Dart-side console leakage is closed.** Every `LogService` call in `lib/` that interpolated a URL, host, site JSON, or stack trace is now `LogSensitivity.sensitive` (download / blob errors, share-intent failures, malformed-site-JSON boot warnings, proxy-apply failures), so it lands in the memory-only ring and never reaches disk / `debugPrint` / `adb logcat` / Console.app.
-- **Native (fork) console leakage remains.** Re-audited against `v6.2.0-beta.3-privacy-v3` — still present, unchanged from the v1 audit:
-  - `flutter_inappwebview_android/.../InAppBrowserManager.java:129` — `Log.d(LOG_TAG, url + " cannot be opened: ...")` (intent-launch failure path)
-  - `flutter_inappwebview_android/.../InAppWebViewClient.java:131` — `Log.d(LOG_TAG, "Request '" + url + "' automatically allowed...")` (regexToAllowSyncUrlLoading match)
-  - `flutter_inappwebview_ios/.../MyCookieManager.swift:211` and `flutter_inappwebview_macos/.../MyCookieManager.swift:207` — `print("Cannot get WebView cookies. No HOST found for URL: \(url)")`
-  - Container, profile, and Linux per-session manager files are clean. WebSpace's own fork patches do not add new log calls.
-  Fixing these requires a fork-side patch (annotated `[WebSpace fork patch]`) that redacts the URL or drops the log entirely, then a fork tag + `pubspec` ref bump — out of scope for an app-repo PR. Until then, the URLs of intent-launch failures, regex-allowlisted nested-load decisions, and the rare host-less cookie-read paths reach `adb logcat` / Console.app from any site.
+- **Native (fork) console leakage — Android mitigated in release, iOS/macOS low-exposure.** The leaking lines are upstream `flutter_inappwebview` code (re-audited at `v6.2.0-beta.3-privacy-v3`, unchanged):
+  - `InAppBrowserManager.java:129` — `Log.d(LOG_TAG, url + " cannot be opened: ...")`
+  - `InAppWebViewClient.java:131` — `Log.d(LOG_TAG, "Request '" + url + "' automatically allowed...")`
+  - `MyCookieManager.swift:211` (iOS) / `:207` (macOS) — `print("... No HOST found for URL: \(url)")`
+  - Container, profile, and Linux per-session managers are clean; WebSpace's own fork patches add no log calls.
+
+  **Android:** the release build now runs R8 in optimize-only mode (`minifyEnabled true` + `-dontshrink -dontobfuscate` + `-assumenosideeffects` for `android.util.Log.d`/`.v` in `android/app/proguard-rules.pro`). This strips those `Log.d` calls — app-side and inherited-upstream alike — from release APKs, so they no longer reach `adb logcat`. Debug builds still emit them. **iOS/macOS:** Swift `print` writes to stdout, which is captured only under an attached Xcode/debug session, not the persistent unified log — so it's effectively invisible on a normally-installed release build. The proper fix for both is still a fork-side redaction; tracked, but the in-release exposure is now low.
 
 ## Files
 

--- a/test/archive_test.dart
+++ b/test/archive_test.dart
@@ -130,4 +130,44 @@ void main() {
       expect(archive.openArchives, hasLength(1));
     });
   });
+
+  // Section export/import round-trips with fixed keys — no Argon2id, so
+  // fast and CI-stable. Passphrase derivation is covered by the crypto
+  // tests; here we only exercise the seal/restore-into-slot logic.
+  group('Archive export/import sections', () {
+    test('exportSection then importSectionsWithKey round-trips into a fresh pool', () async {
+      final src = Archive(storage: ArchiveStorage(secureStorage: MockFlutterSecureStorage()));
+      final handle = await src.createWithKey(_testKey(50));
+      handle.state.sites.add({'siteId': 's1', 'initUrl': 'https://a.test'});
+      handle.state.webspaces
+          .add({'id': 'w', 'name': 'Group', 'siteIds': ['s1']});
+      await src.save(handle);
+      final blob = await src.exportSection(handle);
+      await src.close(handle);
+
+      final dst = Archive(storage: ArchiveStorage(secureStorage: MockFlutterSecureStorage()));
+      final unmatched = await dst.importSectionsWithKey(_testKey(50), [blob]);
+      expect(unmatched, isEmpty);
+
+      final reopened = await dst.tryOpenWithKey(_testKey(50));
+      expect(reopened, isNotNull);
+      expect(reopened!.state.sites, hasLength(1));
+      expect(reopened.state.webspaces, hasLength(1));
+      expect(reopened.state.webspaces.first['name'], equals('Group'));
+    });
+
+    test('importSectionsWithKey returns the blob unmatched under a wrong key', () async {
+      final src = Archive(storage: ArchiveStorage(secureStorage: MockFlutterSecureStorage()));
+      final handle = await src.createWithKey(_testKey(51));
+      handle.state.sites.add({'siteId': 's1', 'initUrl': 'https://a.test'});
+      await src.save(handle);
+      final blob = await src.exportSection(handle);
+      await src.close(handle);
+
+      final dst = Archive(storage: ArchiveStorage(secureStorage: MockFlutterSecureStorage()));
+      final unmatched = await dst.importSectionsWithKey(_testKey(99), [blob]);
+      expect(unmatched, equals([blob]));
+      expect(await dst.tryOpenWithKey(_testKey(99)), isNull);
+    });
+  });
 }

--- a/test/settings_backup_test.dart
+++ b/test/settings_backup_test.dart
@@ -39,6 +39,32 @@ void main() {
       expect(json['selectedWebspaceId'], equals('ws-1'));
       expect(json['currentIndex'], equals(0));
       expect(json['exportedAt'], equals('2024-01-15T10:30:00.000'));
+      // Omitted when not provided, so a default export is byte-identical
+      // to one produced without the feature.
+      expect(json.containsKey('extraSections'), isFalse);
+    });
+
+    test('extraSections is omitted when empty and round-trips when set', () {
+      final without = SettingsBackup(
+        version: 1,
+        sites: const [],
+        webspaces: const [],
+        themeMode: 0,
+        exportedAt: DateTime(2024, 1, 1),
+        extraSections: const [],
+      );
+      expect(without.toJson().containsKey('extraSections'), isFalse);
+
+      final withSections = SettingsBackup(
+        version: 1,
+        sites: const [],
+        webspaces: const [],
+        themeMode: 0,
+        exportedAt: DateTime(2024, 1, 1),
+        extraSections: const ['blobA==', 'blobB=='],
+      );
+      final restored = SettingsBackup.fromJson(withSections.toJson());
+      expect(restored.extraSections, equals(['blobA==', 'blobB==']));
     });
 
     test('should deserialize from JSON correctly', () {


### PR DESCRIPTION
Two unrelated changes:

- Release builds drop debug-level logs (R8 in optimize-only mode; nothing shrunk or renamed).
- Settings export/import gains support for optional extra sections — off by default, so a plain backup is unchanged.

Tests and analyze pass. R8 runs for the first time on this app, so a signed-release smoke test is worth doing before merge (its failure mode is runtime, not build-time).