### PR TITLE
Export DNS level and content-blocker selection in settings backup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3941,6 +3941,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           .map((s) => {'name': s.name, 'url': s.url, 'domain': s.domain})
           .toList(),
       globalUserScripts: _globalUserScripts.map((s) => s.toJson()).toList(),
+      // User intent for the downloaded-data blockers: the chosen DNS
+      // severity level and the content-blocker list selection. The blobs
+      // themselves stay machine state; the user re-downloads after import.
+      dnsBlockLevel: DnsBlockService.instance.level,
+      contentBlockerLists: ContentBlockerService.instance.exportListSelection(),
     );
   }
 
@@ -4076,6 +4081,16 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     // address/username without an app restart.
     final reloadedPrefs = await SharedPreferences.getInstance();
     await GlobalOutboundProxy.update(readGlobalOutboundProxy(reloadedPrefs));
+    // Restore the downloaded-data blockers' user intent. Both carry only
+    // the selection (DNS level / list URLs + enabled), never the blob —
+    // the user re-downloads from App Settings to activate blocking.
+    if (backup.dnsBlockLevel != null) {
+      await DnsBlockService.instance.applyImportedLevel(backup.dnsBlockLevel!);
+    }
+    if (backup.contentBlockerLists != null) {
+      await ContentBlockerService.instance
+          .importListSelection(backup.contentBlockerLists!);
+    }
     await _saveWebViewModels();
     await _saveWebspaces();
     await _saveThemeSettings();
@@ -4144,13 +4159,27 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       } catch (_) {/* malformed global proxy entry → no hint */}
       final globalProxyAuth = hasProxyUsername(globalProxyJson);
       final stripped = perSiteProxyAuth || globalProxyAuth;
+      // Blocklist/filter-list blobs aren't in the backup — only the
+      // selection. Hint the user to re-download if they had either set.
+      final needsBlocklistRedownload =
+          (backup.dnsBlockLevel ?? 0) > 0 ||
+              (backup.contentBlockerLists
+                      ?.any((e) => e['enabled'] == true) ??
+                  false);
+      final hints = <String>[
+        if (stripped)
+          'Proxy passwords aren\'t included in backups — re-enter them in '
+              'site / app settings.',
+        if (needsBlocklistRedownload)
+          'Re-download DNS / content blocker lists in App Settings to '
+              'activate blocking.',
+      ];
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text(stripped
-              ? 'Settings imported. Proxy passwords aren\'t included in '
-                  'backups — re-enter them in site / app settings.'
-              : 'Settings imported successfully'),
-          duration: Duration(seconds: stripped ? 6 : 4),
+          content: Text(hints.isEmpty
+              ? 'Settings imported successfully'
+              : 'Settings imported. ${hints.join(' ')}'),
+          duration: Duration(seconds: hints.isEmpty ? 4 : 6),
         ),
       );
     }

--- a/lib/services/content_blocker_service.dart
+++ b/lib/services/content_blocker_service.dart
@@ -724,6 +724,53 @@ class ContentBlockerService {
     return count;
   }
 
+  /// User-intent slice of the filter-list configuration for settings
+  /// export: which lists exist, their source URLs, and whether they're
+  /// enabled. Download-side metadata (rule counts, last-updated, skipped
+  /// counts) is deliberately omitted — it's machine state tied to a blob
+  /// the backup doesn't carry. See content-blocker spec CB-011.
+  List<Map<String, dynamic>> exportListSelection() => _lists
+      .map((l) => <String, dynamic>{
+            'id': l.id,
+            'name': l.name,
+            'url': l.url,
+            'enabled': l.enabled,
+          })
+      .toList();
+
+  /// Restore a filter-list selection from a settings backup. Replaces the
+  /// current list set with the imported one and rebuilds the engine.
+  ///
+  /// Download metadata is unknown until the user re-downloads, except
+  /// where an imported id matches a list that was already present (its
+  /// cache file may still be on disk): the prior counts/timestamp are
+  /// kept so the engine rebuild reuses the existing blob and the UI shows
+  /// accurate counts without a re-download. Entries missing id/name/url
+  /// are skipped.
+  Future<void> importListSelection(List<Map<String, dynamic>> entries) async {
+    final priorById = {for (final l in _lists) l.id: l};
+    final restored = <FilterList>[];
+    for (final e in entries) {
+      final id = e['id'] as String?;
+      final name = e['name'] as String?;
+      final url = e['url'] as String?;
+      if (id == null || name == null || url == null) continue;
+      final prior = priorById[id];
+      restored.add(FilterList(
+        id: id,
+        name: name,
+        url: url,
+        enabled: e['enabled'] == true,
+        ruleCount: prior?.ruleCount ?? 0,
+        skippedCount: prior?.skippedCount ?? 0,
+        lastUpdated: prior?.lastUpdated,
+      ));
+    }
+    _lists = restored;
+    await _saveLists();
+    await _rebuildEngine();
+  }
+
   Future<void> _saveLists() async {
     final prefs = await SharedPreferences.getInstance();
     final json = jsonEncode(_lists.map((l) => l.toJson()).toList());

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -575,6 +575,38 @@ class DnsBlockService {
     return result;
   }
 
+  /// Apply a DNS severity level restored from a settings backup.
+  ///
+  /// A backup carries only the chosen level (user intent), never the
+  /// downloaded domain blob. This persists the level so the App Settings
+  /// slider reflects the user's choice; the user re-downloads from there
+  /// to repopulate `_blockedDomains`. When the imported level differs
+  /// from the level the on-disk cache was downloaded at, that cache is
+  /// dropped: `dns_blocklist.txt` is not level-tagged, so keeping a stale
+  /// blob under a new level number would make [level] lie about what
+  /// [blockedDomains] actually contains. Out-of-range levels are ignored.
+  Future<void> applyImportedLevel(int level) async {
+    if (level < 0 || level > 5) return;
+    if (level == _level) return;
+    _blockedDomains = {};
+    _bloomFilter = null;
+    try {
+      final file = await _getCacheFile();
+      if (await file.exists()) {
+        await file.delete();
+      }
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setInt(_levelKey, level);
+      await prefs.remove(_lastUpdatedKey);
+    } catch (e) {
+      LogService.instance.log('DnsBlock',
+          'Error applying imported level: $e', level: LogLevel.error);
+    }
+    _level = level;
+    await _clearDomainCache();
+    _notifyBlocklistChanged();
+  }
+
   /// Get the last time the blocklist was downloaded, or null if never.
   Future<DateTime?> getLastUpdated() async {
     final prefs = await SharedPreferences.getInstance();

--- a/lib/services/settings_backup.dart
+++ b/lib/services/settings_backup.dart
@@ -30,6 +30,17 @@ class SettingsBackup {
   final List<Map<String, dynamic>>? suggestedSites;
   final List<Map<String, dynamic>>? globalUserScripts;
 
+  /// Chosen DNS blocklist severity level (0-5). User intent; the
+  /// downloaded domain blob is never part of a backup. Null when the
+  /// backup predates this field.
+  final int? dnsBlockLevel;
+
+  /// Content-blocker filter-list selection: `{id, name, url, enabled}`
+  /// per list. User intent only — rule counts / timestamps (machine
+  /// state tied to a downloaded blob) are not carried. Null when the
+  /// backup predates this field.
+  final List<Map<String, dynamic>>? contentBlockerLists;
+
   SettingsBackup({
     required this.version,
     required this.sites,
@@ -44,6 +55,8 @@ class SettingsBackup {
     required this.exportedAt,
     this.suggestedSites,
     this.globalUserScripts,
+    this.dnsBlockLevel,
+    this.contentBlockerLists,
   }) : globalPrefs = _normalizePrefs(
           globalPrefs,
           showUrlBar: showUrlBar,
@@ -67,6 +80,9 @@ class SettingsBackup {
         'exportedAt': exportedAt.toIso8601String(),
         if (suggestedSites != null) 'suggestedSites': suggestedSites,
         if (globalUserScripts != null) 'globalUserScripts': globalUserScripts,
+        if (dnsBlockLevel != null) 'dnsBlockLevel': dnsBlockLevel,
+        if (contentBlockerLists != null)
+          'contentBlockerLists': contentBlockerLists,
       };
 
   factory SettingsBackup.fromJson(Map<String, dynamic> json) {
@@ -100,6 +116,10 @@ class SettingsBackup {
           .toList(),
       globalUserScripts: (json['globalUserScripts'] as List<dynamic>?)
           ?.map((e) => e as Map<String, dynamic>)
+          .toList(),
+      dnsBlockLevel: json['dnsBlockLevel'] as int?,
+      contentBlockerLists: (json['contentBlockerLists'] as List<dynamic>?)
+          ?.map((e) => Map<String, dynamic>.from(e as Map))
           .toList(),
     );
   }
@@ -146,6 +166,8 @@ class SettingsBackupService {
     int? currentIndex,
     List<Map<String, dynamic>>? suggestedSites,
     List<Map<String, dynamic>>? globalUserScripts,
+    int? dnsBlockLevel,
+    List<Map<String, dynamic>>? contentBlockerLists,
   }) {
     // Convert sites to JSON. `model.toJson` already omits the proxy
     // password (per PWD-005); we still need to strip secure cookies here.
@@ -181,6 +203,8 @@ class SettingsBackupService {
       exportedAt: DateTime.now(),
       suggestedSites: suggestedSites,
       globalUserScripts: globalUserScripts,
+      dnsBlockLevel: dnsBlockLevel,
+      contentBlockerLists: contentBlockerLists,
     );
   }
 
@@ -200,6 +224,8 @@ class SettingsBackupService {
     int? currentIndex,
     List<Map<String, dynamic>>? suggestedSites,
     List<Map<String, dynamic>>? globalUserScripts,
+    int? dnsBlockLevel,
+    List<Map<String, dynamic>>? contentBlockerLists,
   }) async {
     try {
       final backup = createBackup(
@@ -211,6 +237,8 @@ class SettingsBackupService {
         currentIndex: currentIndex,
         suggestedSites: suggestedSites,
         globalUserScripts: globalUserScripts,
+        dnsBlockLevel: dnsBlockLevel,
+        contentBlockerLists: contentBlockerLists,
       );
 
       final jsonString = exportToJson(backup);

--- a/openspec/specs/content-blocker/spec.md
+++ b/openspec/specs/content-blocker/spec.md
@@ -454,6 +454,22 @@ The system SHALL gate `adblock-rust`'s uBO web_accessible_resources/ pool behind
 
 The `useUboResources` preference SHALL round-trip through settings export/import via the `kExportedAppPrefs` registry. The retired `useRustAdblockEngine` toggle SHALL NOT round-trip.
 
+The filter-list selection SHALL also round-trip, as user intent: each
+list's `id`, `name`, `url`, and `enabled` flag ride a dedicated
+`contentBlockerLists` backup field. Download-side metadata (rule counts,
+skipped counts, last-updated timestamps) and the cached rule blobs SHALL
+NOT be exported — they are machine state, repopulated by re-downloading
+after import. The selection rides a dedicated field rather than the
+`kExportedAppPrefs` registry because applying it on import must run
+through `ContentBlockerService` (replacing `_lists` and rebuilding the
+engine), which the registry's blind pref-write path cannot do.
+
+`exportListSelection()` produces the export entries;
+`importListSelection(entries)` applies them, preserving prior
+download metadata for any imported `id` that matches a list already
+present (its cache file may still be on disk) so the engine rebuild
+reuses the existing blob.
+
 #### Scenario: useUboResources preserved across devices
 
 **Given** the user has flipped the toggle off
@@ -468,6 +484,20 @@ The `useUboResources` preference SHALL round-trip through settings export/import
 **Then** the key is silently ignored
 **And** the engine is loaded as the unconditional default
 **And** no warning is required (forward-compat shape: unknown keys ignore)
+
+#### Scenario: Filter-list selection round-trips
+
+**Given** the user has EasyList enabled and a custom list disabled
+**When** they export settings and restore on another device
+**Then** both lists appear with their enabled/disabled state preserved
+**And** the engine rebuilds from whatever cache files are present (none on a
+fresh device, so the user re-downloads to activate blocking)
+
+#### Scenario: Download metadata excluded from export
+
+**Given** a filter list has a rule count and a last-updated timestamp
+**When** settings are exported
+**Then** its exported entry contains only `{id, name, url, enabled}`
 
 ---
 

--- a/openspec/specs/dns-blocklist/spec.md
+++ b/openspec/specs/dns-blocklist/spec.md
@@ -375,6 +375,48 @@ Existing sites without `dnsBlockEnabled` in their stored JSON SHALL default to `
 
 ---
 
+### Requirement: DNS-018 - Severity Level in Settings Backup
+
+The chosen DNS severity level SHALL round-trip through settings
+export/import as user intent. The downloaded domain blob, last-updated
+timestamp, and domain decision cache SHALL NOT be exported — they are
+machine state and are repopulated by re-downloading after import.
+
+Import SHALL apply the restored level through `DnsBlockService` (not by
+writing the `dns_block_level` pref directly), so the persisted level
+stays coherent with the on-disk blob: `dns_blocklist.txt` is not
+level-tagged, so when the imported level differs from the level the
+cached blob was downloaded at, that stale blob is dropped.
+
+#### Scenario: Level exported
+
+**Given** the user has DNS level "Pro" (3) configured
+**When** settings are exported
+**Then** the backup includes `"dnsBlockLevel": 3`
+**And** the backup does not include the domain blob, timestamp, or domain cache
+
+#### Scenario: Level restored on fresh install
+
+**Given** a backup with `dnsBlockLevel: 3`
+**When** the user imports it on a device with no blocklist downloaded
+**Then** the persisted level becomes 3 and the slider reflects it
+**And** `hasBlocklist` remains false until the user re-downloads
+
+#### Scenario: Imported level supersedes a mismatched cached blob
+
+**Given** the importing device has a "Ultimate" (5) blob cached
+**When** a backup with `dnsBlockLevel: 3` is imported
+**Then** the stale level-5 blob is dropped
+**And** the level becomes 3 with `hasBlocklist` false until re-download
+
+#### Scenario: Out-of-range level ignored
+
+**Given** a tampered backup with `dnsBlockLevel: 9`
+**When** the user imports it
+**Then** the level is left unchanged
+
+---
+
 ### Requirement: DNS-012 - Per-Site DNS Statistics
 
 The system SHALL track allowed and blocked DNS request counts per site at runtime, with a log of recent queries. Recording happens regardless of whether the per-site DNS blocking toggle is on or off — stats always record when a blocklist is loaded.

--- a/openspec/specs/settings-backup/spec.md
+++ b/openspec/specs/settings-backup/spec.md
@@ -83,6 +83,53 @@ Backups SHALL include all settings, with cookies filtered by security flag.
 | Current site index | Yes | Last viewed site |
 | Non-secure cookies | Yes | Cookies with `isSecure=false` |
 | **Secure cookies** | **No** | `isSecure=true` never exported |
+| DNS blocklist level | Yes | Chosen severity (0-5); blob re-downloaded after import |
+| Content-blocker list selection | Yes | Per-list `{id, name, url, enabled}`; rule blob re-downloaded after import |
+| **DNS / filter rule blobs** | **No** | Downloaded domain lists + adblock rules are machine state |
+| **DNS / filter download metadata** | **No** | Rule counts, last-updated timestamps, domain cache |
+
+---
+
+### Requirement: BACKUP-009 - Downloaded-Data Blocker Preferences
+
+Backups SHALL carry the user-intent portion of the DNS blocklist and
+content-blocker configuration (the chosen DNS severity level and the
+content-blocker filter-list selection) while excluding the downloaded
+blobs and their machine-state metadata. After import the selection is
+restored, but the user re-downloads the blocklists to activate blocking.
+
+The DNS level and content-blocker list selection ride dedicated backup
+fields (`dnsBlockLevel`, `contentBlockerLists`), not the
+`kExportedAppPrefs` registry, because applying them on import must run
+through the owning service to keep the persisted level/selection coherent
+with whatever blob the importing device already has on disk.
+
+#### Scenario: DNS severity level restored
+
+**Given** a backup was taken on a device with DNS level "Pro++" (4)
+**When** the user imports it on a fresh install
+**Then** the App Settings DNS slider shows level 4
+**And** no domain blob is loaded (`hasBlocklist` is false) until the user re-downloads
+
+#### Scenario: Content-blocker selection restored without rule blobs
+
+**Given** a backup contains filter lists EasyList (enabled) and a custom list (disabled)
+**When** the user imports it
+**Then** both lists appear in App Settings with their enabled/disabled state
+**And** rule counts show as unknown until the user re-downloads
+
+#### Scenario: Download metadata never exported
+
+**Given** a content-blocker list has a rule count and last-updated timestamp
+**When** settings are exported
+**Then** the exported list entry contains only `{id, name, url, enabled}`
+**And** rule counts, skipped counts, and timestamps are excluded
+
+#### Scenario: Re-download hint after import
+
+**Given** an imported backup had a non-zero DNS level or any enabled filter list
+**When** the import completes
+**Then** the snackbar advises re-downloading DNS / content blocker lists in App Settings
 
 ---
 
@@ -170,9 +217,22 @@ Import/Export options SHALL only appear when on the webspaces list screen.
   "showUrlBar": false,
   "selectedWebspaceId": "__all_webspace__",
   "currentIndex": null,
-  "exportedAt": "2024-01-15T10:30:00.000Z"
+  "exportedAt": "2024-01-15T10:30:00.000Z",
+  "dnsBlockLevel": 3,
+  "contentBlockerLists": [
+    {
+      "id": "easylist",
+      "name": "EasyList",
+      "url": "https://easylist.to/easylist/easylist.txt",
+      "enabled": true
+    }
+  ]
 }
 ```
+
+`dnsBlockLevel` and `contentBlockerLists` are omitted entirely when the
+source device had no such configuration; importers treat their absence as
+"no change" (older backups simply lack the keys).
 
 ---
 

--- a/test/settings_backup_test.dart
+++ b/test/settings_backup_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/settings_backup.dart';
 import 'package:webspace/settings/app_prefs.dart';
 import 'package:webspace/settings/global_outbound_proxy.dart';
@@ -843,6 +844,92 @@ void main() {
       expect(backup.showUrlBar, equals(true));
       expect(backup.showTabStrip, equals(true));
       expect(backup.showStatsBanner, equals(false));
+    });
+  });
+
+  group('Downloaded-data blocker prefs', () {
+    test('DNS level and content-blocker selection round-trip through JSON', () {
+      final backup = SettingsBackupService.createBackup(
+        webViewModels: [],
+        webspaces: [Webspace.all()],
+        themeMode: 0,
+        dnsBlockLevel: 4,
+        contentBlockerLists: [
+          {
+            'id': 'easylist',
+            'name': 'EasyList',
+            'url': 'https://easylist.to/easylist/easylist.txt',
+            'enabled': true,
+          },
+          {
+            'id': 'custom_1',
+            'name': 'My List',
+            'url': 'https://example.com/list.txt',
+            'enabled': false,
+          },
+        ],
+      );
+
+      final restored = SettingsBackupService.importFromJson(
+        SettingsBackupService.exportToJson(backup),
+      )!;
+
+      expect(restored.dnsBlockLevel, equals(4));
+      expect(restored.contentBlockerLists, hasLength(2));
+      expect(restored.contentBlockerLists![0]['id'], equals('easylist'));
+      expect(restored.contentBlockerLists![0]['enabled'], isTrue);
+      expect(restored.contentBlockerLists![1]['url'],
+          equals('https://example.com/list.txt'));
+      expect(restored.contentBlockerLists![1]['enabled'], isFalse);
+    });
+
+    test('fields are absent when not provided (backward compatible)', () {
+      final backup = SettingsBackupService.createBackup(
+        webViewModels: [],
+        webspaces: [Webspace.all()],
+        themeMode: 0,
+      );
+
+      final json = backup.toJson();
+      expect(json.containsKey('dnsBlockLevel'), isFalse);
+      expect(json.containsKey('contentBlockerLists'), isFalse);
+
+      // Older backups without these keys deserialize to null, not a throw.
+      final restored = SettingsBackup.fromJson({
+        'version': 1,
+        'sites': [],
+        'webspaces': [],
+        'themeMode': 0,
+      });
+      expect(restored.dnsBlockLevel, isNull);
+      expect(restored.contentBlockerLists, isNull);
+    });
+
+    test('exportListSelection omits download metadata', () {
+      final service = ContentBlockerService.instance;
+      addTearDown(service.reset);
+      service.setLists([
+        FilterList(
+          id: 'easylist',
+          name: 'EasyList',
+          url: 'https://easylist.to/easylist/easylist.txt',
+          enabled: true,
+          ruleCount: 99999,
+          skippedCount: 42,
+          lastUpdated: DateTime(2024, 1, 1),
+        ),
+      ]);
+
+      final selection = service.exportListSelection();
+
+      expect(selection, hasLength(1));
+      expect(
+        selection[0].keys.toSet(),
+        equals({'id', 'name', 'url', 'enabled'}),
+        reason: 'download metadata (ruleCount/skippedCount/lastUpdated) '
+            'must not appear in the exported selection',
+      );
+      expect(selection[0]['enabled'], isTrue);
     });
   });
 


### PR DESCRIPTION
Carry user intent for downloaded-data blockers (DNS severity level and content-blocker filter-list selection) through settings export/import, while excluding the downloaded blobs and their machine-state metadata. After import, the selection is restored but the user re-downloads the blocklists to activate blocking.

Key changes:
- Add `dnsBlockLevel` and `contentBlockerLists` fields to `SettingsBackup` and serialize/deserialize them in JSON
- Implement `DnsBlockService.applyImportedLevel()` to restore the chosen DNS severity level, dropping stale cached blobs when the imported level differs from the cached one
- Implement `ContentBlockerService.exportListSelection()` to export only user-intent fields (`id`, `name`, `url`, `enabled`), omitting download metadata (rule counts, timestamps, skipped counts)
- Implement `ContentBlockerService.importListSelection()` to restore filter-list selection, preserving prior download metadata for any imported id that matches an existing list (so the engine rebuild reuses cached blobs if present)
- Update `_WebSpacePageState` to include DNS level and content-blocker selection when exporting, and apply them through their respective services on import
- Update import snackbar to hint users to re-download DNS/content blocker lists if the backup contained a non-zero DNS level or any enabled filter list
- Add comprehensive test coverage for round-trip serialization, backward compatibility with older backups, and metadata exclusion
- Document the feature in openspec with scenarios for level restoration, list selection restoration, metadata exclusion, and re-download hints

The DNS level and content-blocker selection ride dedicated backup fields rather than `kExportedAppPrefs` because applying them on import must run through their owning services to keep the persisted configuration coherent with whatever blob the importing device already has on disk.

https://claude.ai/code/session_016ZPVKueHstJarvVzEXrRhM