### PR TITLE
Android authenticated proxy via loopback relay

### DIFF
--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -20,6 +20,7 @@ class MainActivity: FlutterActivity() {
     private var locationPlugin: LocationPlugin? = null
     private var webSpaceContainerPlugin: WebSpaceContainerPlugin? = null
     private var backgroundTaskPlugin: BackgroundTaskAndroidPlugin? = null
+    private var proxyRelayPlugin: ProxyRelayPlugin? = null
     private var pendingShareUrl: String? = null
     private var pendingShareHtml: HtmlPayload? = null
 
@@ -47,6 +48,7 @@ class MainActivity: FlutterActivity() {
         locationPlugin = LocationPlugin(this, flutterEngine)
         webSpaceContainerPlugin = WebSpaceContainerPlugin(flutterEngine)
         backgroundTaskPlugin = BackgroundTaskAndroidPlugin(applicationContext, flutterEngine)
+        proxyRelayPlugin = ProxyRelayPlugin(flutterEngine)
         captureSharePayload(intent)
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, SHARE_CHANNEL).setMethodCallHandler { call, result ->
             when (call.method) {
@@ -256,6 +258,8 @@ class MainActivity: FlutterActivity() {
     override fun cleanUpFlutterEngine(flutterEngine: FlutterEngine) {
         backgroundTaskPlugin?.dispose()
         backgroundTaskPlugin = null
+        proxyRelayPlugin?.dispose()
+        proxyRelayPlugin = null
         super.cleanUpFlutterEngine(flutterEngine)
     }
 

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/ProxyRelayPlugin.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/ProxyRelayPlugin.kt
@@ -1,5 +1,7 @@
 package org.codeberg.theoden8.webspace
 
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
@@ -20,7 +22,17 @@ import org.codeberg.theoden8.webspace.proxy.ProxyRelay
  */
 class ProxyRelayPlugin(flutterEngine: FlutterEngine) {
     private val channel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
-    private val relay = ProxyRelay { msg -> Log.i(TAG, msg) }
+    private val mainHandler = Handler(Looper.getMainLooper())
+    // Forward every relay event to the Dart side so it surfaces in the
+    // in-app Logs tab next to the proxy-apply events — critical for the
+    // container-reach diagnostic (zero accepted connections during a
+    // proxied page load = ProxyController not reaching the container).
+    private val relay = ProxyRelay { msg ->
+        Log.i(TAG, msg)
+        mainHandler.post {
+            runCatching { channel.invokeMethod("logEvent", mapOf("msg" to msg)) }
+        }
+    }
 
     init {
         channel.setMethodCallHandler { call, result ->

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/ProxyRelayPlugin.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/ProxyRelayPlugin.kt
@@ -1,0 +1,82 @@
+package org.codeberg.theoden8.webspace
+
+import android.util.Log
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+import org.codeberg.theoden8.webspace.proxy.ProxyRelay
+
+/**
+ * Method-channel surface for the local authenticating proxy relay.
+ *
+ * The relay solves Android WebView's missing proxy-auth: Dart starts it
+ * with the upstream credentials, gets back a loopback port, and points
+ * `ProxyController` at `127.0.0.1:<port>` with no credentials. The relay
+ * itself ([ProxyRelay]) holds no `android.*` deps so it is JVM-unit-tested;
+ * this class is the thin Android wrapper.
+ *
+ * The relay runs on daemon JVM threads in the app process, independent of
+ * the Flutter engine lifecycle, so it keeps serving while the engine is
+ * paused (background notification-refresh sites still proxy correctly).
+ */
+class ProxyRelayPlugin(flutterEngine: FlutterEngine) {
+    private val channel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
+    private val relay = ProxyRelay { msg -> Log.i(TAG, msg) }
+
+    init {
+        channel.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "start" -> {
+                    val typeStr = call.argument<String>("type")
+                    val host = call.argument<String>("host")
+                    val port = call.argument<Int>("port")
+                    if (typeStr == null || host == null || port == null) {
+                        result.error("INVALID_ARGS", "type, host and port are required", null)
+                        return@setMethodCallHandler
+                    }
+                    val type = when (typeStr.lowercase()) {
+                        "http" -> ProxyRelay.UpstreamType.HTTP
+                        "https" -> ProxyRelay.UpstreamType.HTTPS
+                        "socks5" -> ProxyRelay.UpstreamType.SOCKS5
+                        else -> {
+                            result.error("INVALID_TYPE", "unsupported upstream type: $typeStr", null)
+                            return@setMethodCallHandler
+                        }
+                    }
+                    try {
+                        val localPort = relay.start(
+                            ProxyRelay.UpstreamConfig(
+                                type = type,
+                                host = host,
+                                port = port,
+                                username = call.argument<String>("username"),
+                                password = call.argument<String>("password"),
+                            )
+                        )
+                        result.success(localPort)
+                    } catch (e: Exception) {
+                        // Bind failure: report it so Dart can fail closed
+                        // rather than clearing the override (which would
+                        // leak a direct connection).
+                        result.error("RELAY_START_FAILED", e.message, null)
+                    }
+                }
+                "stop" -> {
+                    relay.stop()
+                    result.success(true)
+                }
+                "isRunning" -> result.success(relay.isRunning())
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    fun dispose() {
+        relay.stop()
+        channel.setMethodCallHandler(null)
+    }
+
+    companion object {
+        private const val TAG = "ProxyRelayPlugin"
+        const val CHANNEL = "org.codeberg.theoden8.webspace/proxy_relay"
+    }
+}

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/proxy/ProxyRelay.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/proxy/ProxyRelay.kt
@@ -209,9 +209,11 @@ class ProxyRelay(private val logger: ((String) -> Unit)? = null) {
         val out = s.getOutputStream()
         val ins = s.getInputStream()
 
-        // Greeting: offer user/pass auth only when we actually have creds.
+        // Greeting: when the user explicitly configured credentials,
+        // insist on RFC 1929 user/pass — offering no-auth alongside lets
+        // the server silently skip the credentials the user provided.
         if (cfg.hasCredentials) {
-            out.write(byteArrayOf(0x05, 0x02, 0x00, 0x02))
+            out.write(byteArrayOf(0x05, 0x01, 0x02))
         } else {
             out.write(byteArrayOf(0x05, 0x01, 0x00))
         }

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/proxy/ProxyRelay.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/proxy/ProxyRelay.kt
@@ -1,0 +1,442 @@
+package org.codeberg.theoden8.webspace.proxy
+
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.URI
+import java.util.concurrent.Executors
+import javax.net.ssl.SSLSocketFactory
+
+/**
+ * A loopback HTTP proxy that fronts an authenticated upstream proxy.
+ *
+ * Android's `ProxyController` has no proxy-authentication primitive: a
+ * proxy rule with embedded `user:pass@` userinfo is rejected by Chromium
+ * and the WebView silently falls back to a direct connection (the user's
+ * real IP). This relay is the standard workaround — WebView points at
+ * `127.0.0.1:<ephemeral>` with *no* credentials, and the relay injects the
+ * upstream credentials itself (HTTP `Proxy-Authorization` or the SOCKS5
+ * username/password handshake, RFC 1929).
+ *
+ * Fail-closed by construction: the relay only ever connects to the
+ * configured upstream. If the upstream is unreachable or rejects auth, the
+ * client gets a `502` and the connection closes — the relay never opens a
+ * direct connection to the origin, so a failed proxy cannot leak the IP.
+ *
+ * Deliberately free of `android.*` imports so it runs under plain JVM
+ * JUnit (no Robolectric). The lifecycle wrapper / method channel lives in
+ * [ProxyRelayPlugin].
+ */
+class ProxyRelay(private val logger: ((String) -> Unit)? = null) {
+
+    enum class UpstreamType { HTTP, HTTPS, SOCKS5 }
+
+    data class UpstreamConfig(
+        val type: UpstreamType,
+        val host: String,
+        val port: Int,
+        val username: String?,
+        val password: String?,
+    ) {
+        val hasCredentials: Boolean
+            get() = !username.isNullOrEmpty() && !password.isNullOrEmpty()
+    }
+
+    @Volatile
+    private var serverSocket: ServerSocket? = null
+    @Volatile
+    private var config: UpstreamConfig? = null
+    @Volatile
+    private var boundPort: Int = -1
+    private var acceptThread: Thread? = null
+
+    private val pool = Executors.newCachedThreadPool { r ->
+        Thread(r, "proxy-relay-worker").apply { isDaemon = true }
+    }
+
+    val port: Int
+        get() = boundPort
+
+    @Synchronized
+    fun isRunning(): Boolean = serverSocket?.isClosed == false
+
+    /**
+     * Start (or reconfigure) the relay. Returns the loopback port the
+     * caller should hand to `ProxyController`. Binds a fresh ephemeral
+     * port on every (re)start; the port is never persisted.
+     *
+     * Idempotent for an unchanged config: returns the existing port
+     * without rebinding.
+     */
+    @Synchronized
+    fun start(cfg: UpstreamConfig): Int {
+        if (isRunning() && cfg == config) {
+            return boundPort
+        }
+        stop()
+        val socket = ServerSocket()
+        socket.reuseAddress = true
+        // Loopback-only bind; port 0 lets the OS pick a free ephemeral port.
+        socket.bind(InetSocketAddress(InetAddress.getLoopbackAddress(), 0), BACKLOG)
+        serverSocket = socket
+        config = cfg
+        boundPort = socket.localPort
+        val t = Thread({ acceptLoop(socket) }, "proxy-relay-accept").apply { isDaemon = true }
+        acceptThread = t
+        t.start()
+        log("started on 127.0.0.1:$boundPort (upstream type=${cfg.type})")
+        return boundPort
+    }
+
+    @Synchronized
+    fun stop() {
+        serverSocket?.let { runCatching { it.close() } }
+        serverSocket = null
+        config = null
+        boundPort = -1
+        acceptThread = null
+    }
+
+    private fun acceptLoop(socket: ServerSocket) {
+        while (!socket.isClosed) {
+            val client = try {
+                socket.accept()
+            } catch (e: Exception) {
+                break // socket closed by stop()
+            }
+            val cfg = config
+            if (cfg == null) {
+                runCatching { client.close() }
+                continue
+            }
+            pool.execute {
+                try {
+                    handle(client, cfg)
+                } catch (e: Exception) {
+                    log("client handling failed: ${e.javaClass.simpleName}")
+                } finally {
+                    runCatching { client.close() }
+                }
+            }
+        }
+    }
+
+    private fun handle(client: Socket, cfg: UpstreamConfig) {
+        client.soTimeout = HANDSHAKE_TIMEOUT_MS
+        val cin = client.getInputStream()
+        val cout = client.getOutputStream()
+
+        val preamble = readPreamble(cin) ?: return
+        val requestLine = preamble.first
+        val headers = preamble.second
+        val parts = requestLine.split(" ")
+        if (parts.size < 3) {
+            writeStatus(cout, 400, "Bad Request")
+            return
+        }
+        val method = parts[0].uppercase()
+        val target = parts[1]
+        val isConnect = method == "CONNECT"
+
+        val (host, hostPort) = if (isConnect) {
+            parseAuthority(target, 443)
+        } else {
+            val uri = runCatching { URI(target) }.getOrNull()
+            if (uri?.host == null) {
+                writeStatus(cout, 400, "Bad Request")
+                return
+            }
+            val p = if (uri.port != -1) uri.port else if (uri.scheme == "https") 443 else 80
+            Pair(uri.host, p)
+        }
+        if (host.isEmpty()) {
+            writeStatus(cout, 400, "Bad Request")
+            return
+        }
+
+        val upstream: Socket = try {
+            when (cfg.type) {
+                UpstreamType.SOCKS5 -> openViaSocks5(cfg, host, hostPort)
+                UpstreamType.HTTP, UpstreamType.HTTPS ->
+                    openViaHttpProxy(cfg, host, hostPort, isConnect)
+            }
+        } catch (e: Exception) {
+            log("upstream connect failed: ${e.message}")
+            writeStatus(cout, 502, "Bad Gateway")
+            return
+        }
+
+        try {
+            if (isConnect) {
+                // Tunnel established at the upstream; tell the WebView the
+                // CONNECT succeeded and splice raw bytes both ways.
+                cout.write("HTTP/1.1 200 Connection Established\r\n\r\n".toByteArray(Charsets.ISO_8859_1))
+                cout.flush()
+            } else {
+                // Forward mode: replay the (rewritten) request preamble to
+                // the upstream, then splice. SOCKS gives an origin tunnel
+                // (origin-form path, no proxy auth header); an HTTP proxy
+                // wants the absolute-form line plus Proxy-Authorization.
+                val rewritten = if (cfg.type == UpstreamType.SOCKS5) {
+                    rewriteForOriginTunnel(requestLine, target, headers)
+                } else {
+                    rewriteForHttpProxy(requestLine, headers, cfg)
+                }
+                upstream.getOutputStream().write(rewritten.toByteArray(Charsets.ISO_8859_1))
+                upstream.getOutputStream().flush()
+            }
+            // Switch to indefinite blocking for the splice phase.
+            client.soTimeout = 0
+            upstream.soTimeout = 0
+            pump(client, upstream)
+        } finally {
+            runCatching { upstream.close() }
+        }
+    }
+
+    // --- Upstream: SOCKS5 (with optional RFC 1929 username/password) ---
+
+    private fun openViaSocks5(cfg: UpstreamConfig, host: String, port: Int): Socket {
+        val s = Socket()
+        s.connect(InetSocketAddress(cfg.host, cfg.port), CONNECT_TIMEOUT_MS)
+        s.soTimeout = HANDSHAKE_TIMEOUT_MS
+        val out = s.getOutputStream()
+        val ins = s.getInputStream()
+
+        // Greeting: offer user/pass auth only when we actually have creds.
+        if (cfg.hasCredentials) {
+            out.write(byteArrayOf(0x05, 0x02, 0x00, 0x02))
+        } else {
+            out.write(byteArrayOf(0x05, 0x01, 0x00))
+        }
+        out.flush()
+        val method = byteArrayOf(0, 0)
+        readFully(ins, method)
+        if (method[0].toInt() != 0x05) throw IllegalStateException("bad socks version")
+        when (method[1].toInt() and 0xFF) {
+            0x00 -> { /* no auth */ }
+            0x02 -> {
+                if (!cfg.hasCredentials) throw IllegalStateException("socks requires auth, none configured")
+                val u = cfg.username!!.toByteArray(Charsets.UTF_8)
+                val p = cfg.password!!.toByteArray(Charsets.UTF_8)
+                val buf = ByteArray(3 + u.size + p.size)
+                buf[0] = 0x01
+                buf[1] = u.size.toByte()
+                System.arraycopy(u, 0, buf, 2, u.size)
+                buf[2 + u.size] = p.size.toByte()
+                System.arraycopy(p, 0, buf, 3 + u.size, p.size)
+                out.write(buf)
+                out.flush()
+                val authReply = byteArrayOf(0, 0)
+                readFully(ins, authReply)
+                if (authReply[1].toInt() != 0x00) throw IllegalStateException("socks auth rejected")
+            }
+            else -> throw IllegalStateException("no acceptable socks auth method")
+        }
+
+        // CONNECT command, ATYP=domain so the upstream resolves DNS (no
+        // local DNS leak).
+        val hostBytes = host.toByteArray(Charsets.US_ASCII)
+        if (hostBytes.size > 255) throw IllegalStateException("hostname too long")
+        val req = ByteArray(7 + hostBytes.size)
+        req[0] = 0x05; req[1] = 0x01; req[2] = 0x00; req[3] = 0x03
+        req[4] = hostBytes.size.toByte()
+        System.arraycopy(hostBytes, 0, req, 5, hostBytes.size)
+        req[5 + hostBytes.size] = ((port shr 8) and 0xFF).toByte()
+        req[6 + hostBytes.size] = (port and 0xFF).toByte()
+        out.write(req)
+        out.flush()
+
+        val reply = ByteArray(4)
+        readFully(ins, reply)
+        if (reply[1].toInt() != 0x00) throw IllegalStateException("socks connect failed rep=${reply[1].toInt()}")
+        // Consume the bound address so the stream is positioned at the tunnel.
+        when (reply[3].toInt() and 0xFF) {
+            0x01 -> readFully(ins, ByteArray(4 + 2))
+            0x04 -> readFully(ins, ByteArray(16 + 2))
+            0x03 -> {
+                val len = ByteArray(1); readFully(ins, len)
+                readFully(ins, ByteArray((len[0].toInt() and 0xFF) + 2))
+            }
+            else -> throw IllegalStateException("bad socks atyp")
+        }
+        return s
+    }
+
+    // --- Upstream: HTTP / HTTPS proxy ---
+
+    private fun openViaHttpProxy(cfg: UpstreamConfig, host: String, port: Int, isConnect: Boolean): Socket {
+        var s = Socket()
+        s.connect(InetSocketAddress(cfg.host, cfg.port), CONNECT_TIMEOUT_MS)
+        s.soTimeout = HANDSHAKE_TIMEOUT_MS
+        if (cfg.type == UpstreamType.HTTPS) {
+            s = (SSLSocketFactory.getDefault() as SSLSocketFactory)
+                .createSocket(s, cfg.host, cfg.port, true)
+        }
+        if (isConnect) {
+            // Establish the CONNECT tunnel through the upstream proxy.
+            val authority = "$host:$port"
+            val sb = StringBuilder()
+            sb.append("CONNECT ").append(authority).append(" HTTP/1.1\r\n")
+            sb.append("Host: ").append(authority).append("\r\n")
+            credentialHeader(cfg)?.let { sb.append(it).append("\r\n") }
+            sb.append("\r\n")
+            s.getOutputStream().write(sb.toString().toByteArray(Charsets.ISO_8859_1))
+            s.getOutputStream().flush()
+            val resp = readPreamble(s.getInputStream())
+                ?: throw IllegalStateException("no CONNECT response")
+            val code = resp.first.split(" ").getOrNull(1)?.toIntOrNull() ?: 0
+            if (code != 200) throw IllegalStateException("CONNECT rejected: ${resp.first}")
+        }
+        // Forward (absolute-form) mode replays its rewritten preamble in
+        // handle(); nothing more to do here.
+        return s
+    }
+
+    private fun credentialHeader(cfg: UpstreamConfig): String? {
+        if (!cfg.hasCredentials) return null
+        val token = base64("${cfg.username}:${cfg.password}".toByteArray(Charsets.UTF_8))
+        return "Proxy-Authorization: Basic $token"
+    }
+
+    // --- Request rewriting (forward mode) ---
+
+    private fun rewriteForHttpProxy(requestLine: String, headers: List<String>, cfg: UpstreamConfig): String {
+        val sb = StringBuilder()
+        sb.append(requestLine).append("\r\n")
+        for (h in headers) {
+            if (h.startsWith("Proxy-Authorization:", true)) continue
+            if (h.startsWith("Proxy-Connection:", true)) continue
+            if (h.startsWith("Connection:", true)) continue
+            sb.append(h).append("\r\n")
+        }
+        credentialHeader(cfg)?.let { sb.append(it).append("\r\n") }
+        sb.append("Connection: close\r\n")
+        sb.append("\r\n")
+        return sb.toString()
+    }
+
+    private fun rewriteForOriginTunnel(requestLine: String, target: String, headers: List<String>): String {
+        // Convert absolute-form ("GET http://host/path HTTP/1.1") to
+        // origin-form ("GET /path HTTP/1.1") for the tunneled origin server.
+        val parts = requestLine.split(" ")
+        val uri = runCatching { URI(target) }.getOrNull()
+        val path = uri?.rawPath?.takeIf { it.isNotEmpty() } ?: "/"
+        val query = uri?.rawQuery?.let { "?$it" } ?: ""
+        val sb = StringBuilder()
+        sb.append(parts[0]).append(" ").append(path).append(query).append(" ")
+            .append(parts.getOrElse(2) { "HTTP/1.1" }).append("\r\n")
+        for (h in headers) {
+            if (h.startsWith("Proxy-Authorization:", true)) continue
+            if (h.startsWith("Proxy-Connection:", true)) continue
+            if (h.startsWith("Connection:", true)) continue
+            sb.append(h).append("\r\n")
+        }
+        sb.append("Connection: close\r\n")
+        sb.append("\r\n")
+        return sb.toString()
+    }
+
+    // --- Byte plumbing ---
+
+    private fun pump(a: Socket, b: Socket) {
+        val ab = pool.submit {
+            runCatching { copy(a.getInputStream(), b.getOutputStream()) }
+            runCatching { a.shutdownInput() }
+            runCatching { b.shutdownOutput() }
+        }
+        runCatching { copy(b.getInputStream(), a.getOutputStream()) }
+        runCatching { b.shutdownInput() }
+        runCatching { a.shutdownOutput() }
+        ab.get()
+    }
+
+    private fun copy(src: InputStream, dst: OutputStream) {
+        val buf = ByteArray(16 * 1024)
+        while (true) {
+            val n = src.read(buf)
+            if (n < 0) break
+            dst.write(buf, 0, n)
+            dst.flush()
+        }
+    }
+
+    private fun readPreamble(ins: InputStream): Pair<String, List<String>>? {
+        val raw = StringBuilder()
+        var last4 = 0
+        var count = 0
+        while (count < MAX_PREAMBLE) {
+            val b = ins.read()
+            if (b < 0) break
+            raw.append(b.toChar())
+            count++
+            last4 = ((last4 shl 8) or b) and 0xFFFFFFFF.toInt()
+            if (last4 == 0x0D0A0D0A) break // \r\n\r\n
+        }
+        if (raw.isEmpty()) return null
+        val lines = raw.toString().split("\r\n").filter { it.isNotEmpty() }
+        if (lines.isEmpty()) return null
+        return Pair(lines[0], lines.drop(1))
+    }
+
+    private fun parseAuthority(authority: String, defaultPort: Int): Pair<String, Int> {
+        val idx = authority.lastIndexOf(':')
+        return if (idx > 0) {
+            Pair(authority.substring(0, idx), authority.substring(idx + 1).toIntOrNull() ?: defaultPort)
+        } else {
+            Pair(authority, defaultPort)
+        }
+    }
+
+    private fun writeStatus(out: OutputStream, code: Int, reason: String) {
+        runCatching {
+            out.write("HTTP/1.1 $code $reason\r\nConnection: close\r\n\r\n".toByteArray(Charsets.ISO_8859_1))
+            out.flush()
+        }
+    }
+
+    private fun readFully(ins: InputStream, buf: ByteArray) {
+        var off = 0
+        while (off < buf.size) {
+            val n = ins.read(buf, off, buf.size - off)
+            if (n < 0) throw IllegalStateException("eof during read")
+            off += n
+        }
+    }
+
+    private fun log(msg: String) {
+        logger?.invoke(msg)
+    }
+
+    companion object {
+        private const val BACKLOG = 64
+        private const val CONNECT_TIMEOUT_MS = 15_000
+        private const val HANDSHAKE_TIMEOUT_MS = 20_000
+        private const val MAX_PREAMBLE = 64 * 1024
+
+        private const val B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+        // Hand-rolled so the relay works below API 26 (java.util.Base64)
+        // without pulling in android.util.Base64 (which JVM unit tests stub
+        // to a no-op under returnDefaultValues).
+        fun base64(data: ByteArray): String {
+            val sb = StringBuilder()
+            var i = 0
+            while (i < data.size) {
+                val b0 = data[i].toInt() and 0xFF
+                val b1 = if (i + 1 < data.size) data[i + 1].toInt() and 0xFF else 0
+                val b2 = if (i + 2 < data.size) data[i + 2].toInt() and 0xFF else 0
+                val n = (b0 shl 16) or (b1 shl 8) or b2
+                sb.append(B64[(n shr 18) and 0x3F])
+                sb.append(B64[(n shr 12) and 0x3F])
+                sb.append(if (i + 1 < data.size) B64[(n shr 6) and 0x3F] else '=')
+                sb.append(if (i + 2 < data.size) B64[n and 0x3F] else '=')
+                i += 3
+            }
+            return sb.toString()
+        }
+    }
+}

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/proxy/ProxyRelay.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/proxy/ProxyRelay.kt
@@ -112,6 +112,7 @@ class ProxyRelay(private val logger: ((String) -> Unit)? = null) {
                 runCatching { client.close() }
                 continue
             }
+            log("accepted connection from ${client.inetAddress.hostAddress}:${client.port}")
             pool.execute {
                 try {
                     handle(client, cfg)
@@ -157,6 +158,7 @@ class ProxyRelay(private val logger: ((String) -> Unit)? = null) {
             return
         }
 
+        log("upstream connecting via ${cfg.type} ${cfg.host}:${cfg.port} for ${if (isConnect) "CONNECT" else method} $host:$hostPort")
         val upstream: Socket = try {
             when (cfg.type) {
                 UpstreamType.SOCKS5 -> openViaSocks5(cfg, host, hostPort)
@@ -164,10 +166,11 @@ class ProxyRelay(private val logger: ((String) -> Unit)? = null) {
                     openViaHttpProxy(cfg, host, hostPort, isConnect)
             }
         } catch (e: Exception) {
-            log("upstream connect failed: ${e.message}")
+            log("upstream connect FAILED for $host:$hostPort via ${cfg.type}: ${e.javaClass.simpleName}: ${e.message} — sending 502")
             writeStatus(cout, 502, "Bad Gateway")
             return
         }
+        log("upstream connected for $host:$hostPort")
 
         try {
             if (isConnect) {

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/proxy/ProxyRelay.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/proxy/ProxyRelay.kt
@@ -79,15 +79,20 @@ class ProxyRelay(private val logger: ((String) -> Unit)? = null) {
         stop()
         val socket = ServerSocket()
         socket.reuseAddress = true
-        // Loopback-only bind; port 0 lets the OS pick a free ephemeral port.
-        socket.bind(InetSocketAddress(InetAddress.getLoopbackAddress(), 0), BACKLOG)
+        // Pin to IPv4 loopback (127.0.0.1) explicitly. InetAddress
+        // .getLoopbackAddress() can return ::1 on dual-stack JVMs, which
+        // is unreachable from the http://127.0.0.1:<port> rule we hand to
+        // ProxyController — Chromium gets ERR_PROXY_CONNECTION_FAILED
+        // without ever opening a TCP connection to our listener.
+        val bindAddr = InetAddress.getByName("127.0.0.1")
+        socket.bind(InetSocketAddress(bindAddr, 0), BACKLOG)
         serverSocket = socket
         config = cfg
         boundPort = socket.localPort
         val t = Thread({ acceptLoop(socket) }, "proxy-relay-accept").apply { isDaemon = true }
         acceptThread = t
         t.start()
-        log("started on 127.0.0.1:$boundPort (upstream type=${cfg.type})")
+        log("started on ${bindAddr.hostAddress}:$boundPort (upstream type=${cfg.type})")
         return boundPort
     }
 
@@ -105,7 +110,12 @@ class ProxyRelay(private val logger: ((String) -> Unit)? = null) {
             val client = try {
                 socket.accept()
             } catch (e: Exception) {
-                break // socket closed by stop()
+                // socket.close() from stop() throws SocketException here
+                // and we exit cleanly. Any other exception is worth seeing.
+                if (!socket.isClosed) {
+                    log("accept loop ended with ${e.javaClass.simpleName}: ${e.message}")
+                }
+                break
             }
             val cfg = config
             if (cfg == null) {

--- a/android/app/src/test/kotlin/org/codeberg/theoden8/webspace/proxy/ProxyRelayTest.kt
+++ b/android/app/src/test/kotlin/org/codeberg/theoden8/webspace/proxy/ProxyRelayTest.kt
@@ -1,0 +1,241 @@
+package org.codeberg.theoden8.webspace.proxy
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.InputStream
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * JVM unit tests for [ProxyRelay] — no Android framework, no emulator.
+ * Each test stands up a fake upstream (HTTP proxy / SOCKS5) and a fake
+ * origin on loopback, drives a client through the relay, and asserts the
+ * upstream saw the right credentials.
+ */
+class ProxyRelayTest {
+
+    @Test
+    fun base64_matchesKnownVectors() {
+        assertEquals("", ProxyRelay.base64("".toByteArray()))
+        assertEquals("Zg==", ProxyRelay.base64("f".toByteArray()))
+        assertEquals("Zm8=", ProxyRelay.base64("fo".toByteArray()))
+        assertEquals("Zm9v", ProxyRelay.base64("foo".toByteArray()))
+        assertEquals("dXNlcjpwYXNz", ProxyRelay.base64("user:pass".toByteArray()))
+    }
+
+    @Test
+    fun randomPort_distinctInstancesGetIndependentLoopbackPorts() {
+        val a = ProxyRelay()
+        val b = ProxyRelay()
+        try {
+            val cfg = ProxyRelay.UpstreamConfig(ProxyRelay.UpstreamType.HTTP, "127.0.0.1", 1, null, null)
+            val pa = a.start(cfg)
+            val pb = b.start(cfg)
+            assertTrue("port must be a real ephemeral port", pa in 1..65535)
+            assertTrue(pb in 1..65535)
+            assertNotEquals("two relays must not share a port", pa, pb)
+            assertTrue(a.isRunning())
+            // Idempotent: same config returns the same port without rebinding.
+            assertEquals(pa, a.start(cfg))
+        } finally {
+            a.stop(); b.stop()
+        }
+    }
+
+    @Test
+    fun httpProxyUpstream_connectInjectsProxyAuthorization() {
+        val origin = fakeOrigin("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi")
+        val seenAuth = AtomicReference<String?>(null)
+        val proxy = fakeServer { sock ->
+            val req = readPreamble(sock.getInputStream())
+            seenAuth.set(req.headers.firstOrNull { it.startsWith("Proxy-Authorization:", true) })
+            sock.getOutputStream().write("HTTP/1.1 200 Connection Established\r\n\r\n".toByteArray())
+            sock.getOutputStream().flush()
+            spliceTo(sock, origin.localPort)
+        }
+        val relay = ProxyRelay()
+        try {
+            val port = relay.start(
+                ProxyRelay.UpstreamConfig(
+                    ProxyRelay.UpstreamType.HTTP, "127.0.0.1", proxy.localPort, "user", "pass",
+                )
+            )
+            val body = clientConnectThenGet(port, "example.com", 443)
+            assertTrue("origin response should reach the client", body.contains("hi"))
+            assertEquals(
+                "Proxy-Authorization: Basic ${ProxyRelay.base64("user:pass".toByteArray())}",
+                seenAuth.get(),
+            )
+        } finally {
+            relay.stop(); proxy.close(); origin.close()
+        }
+    }
+
+    @Test
+    fun socks5Upstream_performsUsernamePasswordHandshake() {
+        val origin = fakeOrigin("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+        val seenUser = AtomicReference<String?>(null)
+        val seenPass = AtomicReference<String?>(null)
+        val socks = fakeServer { sock ->
+            val ins = sock.getInputStream()
+            val out = sock.getOutputStream()
+            // Greeting.
+            val ver = ins.read(); val nm = ins.read()
+            val methods = ByteArray(nm); readFully(ins, methods)
+            assertEquals(0x05, ver)
+            assertTrue("client must offer user/pass auth", methods.any { it.toInt() == 0x02 })
+            out.write(byteArrayOf(0x05, 0x02)); out.flush()
+            // RFC 1929 auth.
+            assertEquals(0x01, ins.read())
+            val ul = ins.read(); val ub = ByteArray(ul); readFully(ins, ub)
+            val pl = ins.read(); val pb = ByteArray(pl); readFully(ins, pb)
+            seenUser.set(String(ub)); seenPass.set(String(pb))
+            out.write(byteArrayOf(0x01, 0x00)); out.flush()
+            // CONNECT request.
+            val head = ByteArray(4); readFully(ins, head)
+            assertEquals(0x01, head[1].toInt()) // CMD=connect
+            val hl = ins.read(); readFully(ins, ByteArray(hl)); readFully(ins, ByteArray(2))
+            out.write(byteArrayOf(0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0)); out.flush()
+            spliceTo(sock, origin.localPort)
+        }
+        val relay = ProxyRelay()
+        try {
+            val port = relay.start(
+                ProxyRelay.UpstreamConfig(
+                    ProxyRelay.UpstreamType.SOCKS5, "127.0.0.1", socks.localPort, "alice", "s3cret",
+                )
+            )
+            val body = clientConnectThenGet(port, "example.com", 443)
+            assertTrue(body.contains("ok"))
+            assertEquals("alice", seenUser.get())
+            assertEquals("s3cret", seenPass.get())
+        } finally {
+            relay.stop(); socks.close(); origin.close()
+        }
+    }
+
+    @Test
+    fun failClosed_unreachableUpstreamYields502NotDirect() {
+        // Upstream points at a closed port: the relay must answer 502 and
+        // never open a direct connection to the origin.
+        val deadPort = ServerSocket(0).use { it.localPort }
+        val relay = ProxyRelay()
+        try {
+            val port = relay.start(
+                ProxyRelay.UpstreamConfig(
+                    ProxyRelay.UpstreamType.HTTP, "127.0.0.1", deadPort, "user", "pass",
+                )
+            )
+            Socket().use { c ->
+                c.connect(InetSocketAddress("127.0.0.1", port), 2000)
+                c.getOutputStream().write(
+                    "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n".toByteArray()
+                )
+                c.getOutputStream().flush()
+                val status = readPreamble(c.getInputStream()).requestLine
+                assertTrue("expected 502, got: $status", status.contains("502"))
+            }
+        } finally {
+            relay.stop()
+        }
+    }
+
+    // --- helpers ---
+
+    private data class Preamble(val requestLine: String, val headers: List<String>)
+
+    private fun readPreamble(ins: InputStream): Preamble {
+        val sb = StringBuilder()
+        var last4 = 0
+        while (true) {
+            val b = ins.read()
+            if (b < 0) break
+            sb.append(b.toChar())
+            last4 = (last4 shl 8) or b
+            if (last4 == 0x0D0A0D0A) break
+        }
+        val lines = sb.toString().split("\r\n").filter { it.isNotEmpty() }
+        return Preamble(lines.firstOrNull() ?: "", lines.drop(1))
+    }
+
+    private fun readFully(ins: InputStream, buf: ByteArray) {
+        var off = 0
+        while (off < buf.size) {
+            val n = ins.read(buf, off, buf.size - off)
+            if (n < 0) throw IllegalStateException("eof")
+            off += n
+        }
+    }
+
+    private fun clientConnectThenGet(relayPort: Int, host: String, port: Int): String {
+        Socket().use { c ->
+            c.connect(InetSocketAddress("127.0.0.1", relayPort), 3000)
+            val out = c.getOutputStream()
+            out.write("CONNECT $host:$port HTTP/1.1\r\nHost: $host:$port\r\n\r\n".toByteArray())
+            out.flush()
+            val established = readPreamble(c.getInputStream())
+            assertTrue("CONNECT should succeed: ${established.requestLine}", established.requestLine.contains("200"))
+            out.write("GET / HTTP/1.1\r\nHost: $host\r\nConnection: close\r\n\r\n".toByteArray())
+            out.flush()
+            return c.getInputStream().readBytes().toString(Charsets.ISO_8859_1)
+        }
+    }
+
+    private fun fakeOrigin(response: String): ServerSocket {
+        val server = ServerSocket()
+        server.bind(InetSocketAddress(InetAddress.getLoopbackAddress(), 0))
+        Thread {
+            while (!server.isClosed) {
+                val s = try { server.accept() } catch (e: Exception) { break }
+                Thread {
+                    try {
+                        readPreamble(s.getInputStream())
+                        s.getOutputStream().write(response.toByteArray())
+                        s.getOutputStream().flush()
+                    } catch (e: Exception) {
+                    } finally { runCatching { s.close() } }
+                }.apply { isDaemon = true }.start()
+            }
+        }.apply { isDaemon = true }.start()
+        return server
+    }
+
+    private fun fakeServer(handler: (Socket) -> Unit): ServerSocket {
+        val server = ServerSocket()
+        server.bind(InetSocketAddress(InetAddress.getLoopbackAddress(), 0))
+        Thread {
+            while (!server.isClosed) {
+                val s = try { server.accept() } catch (e: Exception) { break }
+                Thread {
+                    try { handler(s) } catch (e: Exception) { } finally { runCatching { s.close() } }
+                }.apply { isDaemon = true }.start()
+            }
+        }.apply { isDaemon = true }.start()
+        return server
+    }
+
+    private fun spliceTo(client: Socket, originPort: Int) {
+        val origin = Socket()
+        origin.connect(InetSocketAddress("127.0.0.1", originPort), 3000)
+        val latch = CountDownLatch(2)
+        Thread {
+            runCatching { client.getInputStream().copyTo(origin.getOutputStream()); origin.getOutputStream().flush() }
+            runCatching { origin.shutdownOutput() }
+            latch.countDown()
+        }.apply { isDaemon = true }.start()
+        Thread {
+            runCatching { origin.getInputStream().copyTo(client.getOutputStream()); client.getOutputStream().flush() }
+            runCatching { client.shutdownOutput() }
+            latch.countDown()
+        }.apply { isDaemon = true }.start()
+        latch.await(10, TimeUnit.SECONDS)
+        runCatching { origin.close() }
+    }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3196,6 +3196,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
             '${loadedWebViewModels.length} site(s); '
             '$sitesWithCustomProxy site(s) have a non-DEFAULT per-site proxy',
         level: LogLevel.info,
+        sensitivity: LogSensitivity.sensitive,
       );
 
       // Load cookies from secure storage (keyed by siteId or legacy domain)

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -297,12 +297,14 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
         'Outbound proxy changed; resetting all loaded webviews so the new '
             'value is applied on next render',
         level: LogLevel.info,
+        sensitivity: LogSensitivity.sensitive,
       );
       widget.onOutboundProxyChanged?.call();
     } else {
       LogService.instance.log(
         'Proxy',
         'Outbound proxy save invoked but settings unchanged; skipping webview reset',
+        sensitivity: LogSensitivity.sensitive,
       );
     }
     if (mounted && changed) {

--- a/lib/services/proxy_relay.dart
+++ b/lib/services/proxy_relay.dart
@@ -1,0 +1,60 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/services.dart';
+
+import 'package:webspace/settings/proxy.dart';
+
+/// Dart side of the Android local authenticating proxy relay.
+///
+/// Android's `ProxyController` cannot carry proxy credentials, so for a
+/// credentialed upstream we start a native loopback relay
+/// ([`ProxyRelayPlugin`]) and point WebView at `127.0.0.1:<port>` with no
+/// credentials; the relay injects them upstream. Android-only — iOS/macOS
+/// bind credentials to the per-site data store, and Linux/WebKit accepts a
+/// credentialed proxy URI directly.
+class ProxyRelay {
+  static const MethodChannel _channel =
+      MethodChannel('org.codeberg.theoden8.webspace/proxy_relay');
+
+  static final ProxyRelay instance = ProxyRelay._();
+  ProxyRelay._();
+
+  /// Start or reconfigure the relay for [upstream]. Returns the loopback
+  /// port to hand to `ProxyController`, or `null` if it could not bind (the
+  /// caller MUST then fail closed, never clearing the override).
+  Future<int?> start(UserProxySettings upstream) async {
+    if (!Platform.isAndroid) return null;
+    final address = upstream.address;
+    if (address == null) return null;
+    final parts = address.split(':');
+    if (parts.length != 2) return null;
+    final port = int.tryParse(parts[1]);
+    if (port == null) return null;
+    final type = switch (upstream.type) {
+      ProxyType.HTTPS => 'https',
+      ProxyType.SOCKS5 => 'socks5',
+      _ => 'http',
+    };
+    try {
+      return await _channel.invokeMethod<int>('start', {
+        'type': type,
+        'host': parts[0],
+        'port': port,
+        'username': upstream.username,
+        'password': upstream.password,
+      });
+    } on PlatformException {
+      return null;
+    }
+  }
+
+  /// Stop the relay if running. Safe to call when not running.
+  Future<void> stop() async {
+    if (!Platform.isAndroid) return;
+    try {
+      await _channel.invokeMethod('stop');
+    } on PlatformException {
+      // Already stopped / channel unavailable.
+    }
+  }
+}

--- a/lib/services/proxy_relay.dart
+++ b/lib/services/proxy_relay.dart
@@ -2,6 +2,7 @@ import 'dart:io' show Platform;
 
 import 'package:flutter/services.dart';
 
+import 'package:webspace/services/log_service.dart';
 import 'package:webspace/settings/proxy.dart';
 
 /// Dart side of the Android local authenticating proxy relay.
@@ -17,7 +18,24 @@ class ProxyRelay {
       MethodChannel('org.codeberg.theoden8.webspace/proxy_relay');
 
   static final ProxyRelay instance = ProxyRelay._();
-  ProxyRelay._();
+  ProxyRelay._() {
+    // The native side posts every relay event (accept, upstream connect
+    // attempt/result, 502, start/stop) over this channel so they land in
+    // the in-app Logs tab alongside the `Proxy` events.
+    _channel.setMethodCallHandler((call) async {
+      if (call.method == 'logEvent') {
+        final msg = (call.arguments as Map?)?['msg']?.toString();
+        if (msg != null) {
+          LogService.instance.log(
+            'ProxyRelay',
+            msg,
+            sensitivity: LogSensitivity.sensitive,
+          );
+        }
+      }
+      return null;
+    });
+  }
 
   /// Start or reconfigure the relay for [upstream]. Returns the loopback
   /// port to hand to `ProxyController`, or `null` if it could not bind (the

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -243,8 +243,11 @@ class ProxyManager {
 
   Future<void> setProxySettings(UserProxySettings settings) async {
     if (!PlatformInfo.isProxySupported) {
-      LogService.instance.log('Proxy',
-          'setProxySettings: platform does not support proxy override; no-op');
+      LogService.instance.log(
+        'Proxy',
+        'setProxySettings: platform does not support proxy override; no-op',
+        sensitivity: LogSensitivity.sensitive,
+      );
       return;
     }
 
@@ -255,8 +258,11 @@ class ProxyManager {
     // per-site proxy require the WebView to be rebuilt by the caller (see
     // [WebViewModel.updateProxySettings]).
     if (Platform.isIOS || Platform.isMacOS) {
-      LogService.instance.log('Proxy',
-          'setProxySettings: iOS/macOS bind proxy at WebView construction; no-op here');
+      LogService.instance.log(
+        'Proxy',
+        'setProxySettings: iOS/macOS bind proxy at WebView construction; no-op here',
+        sensitivity: LogSensitivity.sensitive,
+      );
       return;
     }
 
@@ -276,6 +282,7 @@ class ProxyManager {
         'Proxy',
         'Clearing proxy override (per-site=DEFAULT, no global proxy set)',
         level: LogLevel.info,
+        sensitivity: LogSensitivity.sensitive,
       );
       final sw = Stopwatch()..start();
       await controller.clearProxyOverride();
@@ -283,6 +290,7 @@ class ProxyManager {
         'Proxy',
         'Cleared proxy override (native call took ${sw.elapsedMilliseconds}ms)',
         level: LogLevel.info,
+        sensitivity: LogSensitivity.sensitive,
       );
       return;
     }
@@ -416,6 +424,7 @@ class ProxyManager {
       'Proxy',
       'Cleared proxy override via clearProxy() (native call took ${sw.elapsedMilliseconds}ms)',
       level: LogLevel.info,
+      sensitivity: LogSensitivity.sensitive,
     );
   }
 }

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -12,6 +12,7 @@ import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/do_not_track_shim.dart';
 import 'package:webspace/services/language_shim.dart';
 import 'package:webspace/services/launch_nonce.dart';
+import 'package:webspace/services/proxy_relay.dart';
 import 'package:webspace/services/theme_color_scheme_shim.dart';
 import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
@@ -225,7 +226,11 @@ enum WebViewTheme { light, dark, system }
 ///     singleton override (`PROXY_OVERRIDE` WebViewFeature). Per-site config
 ///     in the data model is fictional under container mode: with multiple
 ///     same-base-domain sites loaded concurrently, the last applied proxy
-///     wins for every WebView. See PROXY-008.
+///     wins for every WebView. See PROXY-008. Credentialed upstreams cannot
+///     be expressed to `ProxyController` (Chromium rejects userinfo in a
+///     proxy rule), so they are fronted by a native loopback relay
+///     ([`ProxyRelay`]) that injects the credentials; WebView points at
+///     `127.0.0.1:<ephemeral>` with none. See PROXY-010.
 ///   * **iOS 17+ / macOS 14+.** Genuine per-site proxy via
 ///     `WKWebsiteDataStore.proxyConfigurations` on the per-container data
 ///     store, created by the WebSpace fork's `preWKWebViewConfiguration`
@@ -266,6 +271,7 @@ class ProxyManager {
         effective.type != ProxyType.DEFAULT;
 
     if (effective.type == ProxyType.DEFAULT) {
+      if (Platform.isAndroid) await ProxyRelay.instance.stop();
       LogService.instance.log(
         'Proxy',
         'Clearing proxy override (per-site=DEFAULT, no global proxy set)',
@@ -317,13 +323,54 @@ class ProxyManager {
       _ => 'http',
     };
 
+    // Android's ProxyController has no proxy-auth primitive: a rule with
+    // embedded `user:pass@` userinfo is rejected by Chromium and the
+    // WebView silently goes direct (leaking the real IP). Route a
+    // credentialed upstream through the native loopback relay and point
+    // WebView at it with NO credentials; the relay injects them upstream.
+    // iOS/macOS never reach here; Linux/WebKit accepts a credentialed
+    // proxy URI directly, so it keeps the inline-credential path below.
+    if (Platform.isAndroid && effective.hasCredentials) {
+      final localPort = await ProxyRelay.instance.start(effective);
+      if (localPort == null) {
+        LogService.instance.log(
+          'Proxy',
+          'Auth proxy relay failed to start; refusing to fall back to a '
+              'direct connection. Effective: ${effective.describeForLogs()}',
+          level: LogLevel.error,
+          sensitivity: LogSensitivity.sensitive,
+        );
+        throw Exception('Proxy relay failed to start');
+      }
+      LogService.instance.log(
+        'Proxy',
+        'Applying Android proxy override via auth relay (upstream scheme=$scheme'
+            '${fellThrough ? ', via DEFAULT->global fallthrough' : ''}, '
+            'effective: ${effective.describeForLogs()})',
+        level: LogLevel.info,
+        sensitivity: LogSensitivity.sensitive,
+      );
+      await controller.setProxyOverride(
+        settings: inapp.ProxySettings(
+          proxyRules: [inapp.ProxyRule(url: 'http://127.0.0.1:$localPort')],
+          bypassRules: ['<local>'],
+        ),
+      );
+      return;
+    }
+
+    // No credentials (or Linux): point ProxyController straight at the
+    // upstream. Stop any relay left over from a previous credentialed
+    // config so its loopback port isn't left listening.
+    if (Platform.isAndroid) await ProxyRelay.instance.stop();
+
     final proxyUrl = effective.hasCredentials
         ? '$scheme://${Uri.encodeComponent(effective.username!)}:${Uri.encodeComponent(effective.password!)}@$host:$port'
         : '$scheme://$host:$port';
 
     LogService.instance.log(
       'Proxy',
-      'Applying Android proxy override (scheme=$scheme'
+      'Applying proxy override (scheme=$scheme'
           '${fellThrough ? ', via DEFAULT->global fallthrough' : ''}, '
           'effective: ${effective.describeForLogs()})',
       level: LogLevel.info,
@@ -340,6 +387,7 @@ class ProxyManager {
   Future<void> clearProxy() async {
     if (!PlatformInfo.isProxySupported) return;
     if (Platform.isIOS || Platform.isMacOS) return;
+    if (Platform.isAndroid) await ProxyRelay.instance.stop();
     await inapp.ProxyController.instance().clearProxyOverride();
   }
 }

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -277,7 +277,13 @@ class ProxyManager {
         'Clearing proxy override (per-site=DEFAULT, no global proxy set)',
         level: LogLevel.info,
       );
+      final sw = Stopwatch()..start();
       await controller.clearProxyOverride();
+      LogService.instance.log(
+        'Proxy',
+        'Cleared proxy override (native call took ${sw.elapsedMilliseconds}ms)',
+        level: LogLevel.info,
+      );
       return;
     }
 
@@ -350,11 +356,19 @@ class ProxyManager {
         level: LogLevel.info,
         sensitivity: LogSensitivity.sensitive,
       );
+      final sw = Stopwatch()..start();
       await controller.setProxyOverride(
         settings: inapp.ProxySettings(
           proxyRules: [inapp.ProxyRule(url: 'http://127.0.0.1:$localPort')],
           bypassRules: ['<local>'],
         ),
+      );
+      LogService.instance.log(
+        'Proxy',
+        'Applied proxy override via relay (native call took ${sw.elapsedMilliseconds}ms, '
+            'relay port=$localPort)',
+        level: LogLevel.info,
+        sensitivity: LogSensitivity.sensitive,
       );
       return;
     }
@@ -376,11 +390,19 @@ class ProxyManager {
       level: LogLevel.info,
       sensitivity: LogSensitivity.sensitive,
     );
+    final sw = Stopwatch()..start();
     await controller.setProxyOverride(
       settings: inapp.ProxySettings(
         proxyRules: [inapp.ProxyRule(url: proxyUrl)],
         bypassRules: ['<local>'],
       ),
+    );
+    LogService.instance.log(
+      'Proxy',
+      'Applied proxy override (native call took ${sw.elapsedMilliseconds}ms, '
+          'scheme=$scheme)',
+      level: LogLevel.info,
+      sensitivity: LogSensitivity.sensitive,
     );
   }
 
@@ -388,7 +410,13 @@ class ProxyManager {
     if (!PlatformInfo.isProxySupported) return;
     if (Platform.isIOS || Platform.isMacOS) return;
     if (Platform.isAndroid) await ProxyRelay.instance.stop();
+    final sw = Stopwatch()..start();
     await inapp.ProxyController.instance().clearProxyOverride();
+    LogService.instance.log(
+      'Proxy',
+      'Cleared proxy override via clearProxy() (native call took ${sw.elapsedMilliseconds}ms)',
+      level: LogLevel.info,
+    );
   }
 }
 
@@ -2826,6 +2854,11 @@ class WebViewFactory {
       // and LocalCDN replacement are both handled by the native
       // FastSubresourceInterceptor attached via WebInterceptNative.
       onLoadStart: (controller, url) async {
+        LogService.instance.log(
+          'WebViewLifecycle',
+          'onLoadStart siteId=${config.siteId} url=$url',
+          sensitivity: LogSensitivity.sensitive,
+        );
         // Snapshot the navigation generation BEFORE any await — if a
         // later `shouldOverrideUrlLoading` advances the counter while
         // we're between IPCs, the previous frame is being torn down and
@@ -2893,6 +2926,11 @@ class WebViewFactory {
         }
       },
       onLoadStop: (controller, url) async {
+        LogService.instance.log(
+          'WebViewLifecycle',
+          'onLoadStop siteId=${config.siteId} url=$url',
+          sensitivity: LogSensitivity.sensitive,
+        );
         // End pull-to-refresh animation
         config.pullToRefreshController?.endRefreshing();
         // Notify the call site that this navigation finished loading
@@ -3059,6 +3097,13 @@ class WebViewFactory {
         config.onConsoleMessage?.call(consoleMessage.message, consoleMessage.messageLevel);
       },
       onReceivedError: (controller, request, error) async {
+        LogService.instance.log(
+          'WebViewLifecycle',
+          'onReceivedError siteId=${config.siteId} url=${request.url} '
+              'type=${error.type} desc=${error.description}',
+          level: LogLevel.warning,
+          sensitivity: LogSensitivity.sensitive,
+        );
         // For non-internal schemes (intent://, custom app schemes) Android
         // sometimes hands the URL straight to onReceivedError without
         // calling shouldOverrideUrlLoading first — observed every time on

--- a/openspec/changes/android-auth-proxy-relay/proposal.md
+++ b/openspec/changes/android-auth-proxy-relay/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+Authenticated proxies do not work on Android. The data model accepts a
+username/password, and `ProxyManager.setProxySettings` embedded them in the
+proxy URL handed to `inapp.ProxyController` as
+`scheme://user:pass@host:port`. Android's WebView `ProxyController` has no
+proxy-authentication primitive, and Chromium rejects a proxy rule that
+carries userinfo — so the rule is dropped and the WebView **silently falls
+back to a direct connection**, leaking the user's real IP (the exact
+opposite of what the user asked for). The failure was swallowed in
+`_applyProxySettings`, so there was no surfaced error either.
+
+This is a platform gap, not user error: Chrome's own WebView cannot do
+authenticated proxies via `ProxyController`. The established fix (used by
+e.g. Alibaba's HTTPDNS WebView integration) is a local loopback proxy that
+fronts the authenticated upstream: WebView talks to `127.0.0.1` with no
+credentials, and the relay injects them on the way out.
+
+iOS 17+/macOS 14+ already carry credentials on the per-site
+`WKWebsiteDataStore.proxyConfigurations`; Linux/WebKit accepts a
+credentialed proxy URI directly. Only Android needs the relay.
+
+## What Changes
+
+- **Native loopback relay (`ProxyRelay`, Kotlin).** A small HTTP proxy that
+  binds a random ephemeral port on `127.0.0.1` and forwards to the
+  configured upstream, injecting credentials: HTTP `Proxy-Authorization:
+  Basic` for HTTP/HTTPS upstreams, the SOCKS5 username/password handshake
+  (RFC 1929) for SOCKS5. Handles `CONNECT` tunnels (HTTPS, the common case)
+  and absolute-form HTTP. Deliberately free of `android.*` imports so it is
+  unit-tested on the JVM (`ProxyRelayTest`) — no emulator.
+- **Fail-closed by construction.** The relay only ever connects to the
+  configured upstream; an unreachable upstream or rejected auth yields a
+  `502` to the client, never a direct connection. Random port is
+  re-bound on every (re)start and never persisted; the listener binds to
+  loopback only.
+- **`ProxyRelayPlugin` + method channel** (`.../proxy_relay`) with
+  `start` / `stop` / `isRunning`. Runs on daemon JVM threads in the app
+  process, independent of the Flutter engine lifecycle, so background
+  notification-refresh sites keep proxying.
+- **Dart wiring.** On Android, when the effective proxy has credentials,
+  `ProxyManager.setProxySettings` starts the relay (`ProxyRelay` in
+  `lib/services/proxy_relay.dart`) and points `ProxyController` at
+  `http://127.0.0.1:<port>` with no credentials. If the relay cannot bind,
+  it throws rather than clearing the override (no direct-connection leak).
+  Unauthenticated proxies and Linux keep the direct `ProxyController` path.
+- **CI.** Add a JVM unit-test lane (`./gradlew testDebugUnitTest`) so the
+  relay (and the existing `src/test/kotlin` suites) run on every push.
+
+## Out of Scope
+
+- iOS/macOS/Linux proxy auth (already supported natively).
+- Confirming whether per-site container profiles honor the global
+  `ProxyController` override: documented contract says the override applies
+  to all WebViews app-wide, and the relay sits underneath `ProxyController`
+  either way. An on-device egress-IP check is tracked as a verification
+  task, not a code change.

--- a/openspec/changes/android-auth-proxy-relay/specs/ip-leakage/spec.md
+++ b/openspec/changes/android-auth-proxy-relay/specs/ip-leakage/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: LEAK-008 - Android webview auth-proxy fail-closed
+
+On Android, applying a credentialed proxy to the WebView SHALL NOT degrade
+to a direct connection on failure. Credentials SHALL NOT be embedded in the
+`inapp.ProxyController` proxy rule (Chromium rejects userinfo and silently
+goes direct); they SHALL instead be injected by the native loopback relay
+(see PROXY-010 / PROXY-011), which only ever connects to the configured
+upstream. Credentials SHALL travel to the relay only over the loopback
+method channel and SHALL NOT appear in any `ProxyController` rule or on any
+non-loopback socket from the app. If the relay cannot be established, the
+webview proxy application SHALL fail closed (no override cleared, no direct
+fallback) consistent with the SOCKS5 fail-closed posture in LEAK-003.
+
+#### Scenario: Credentialed Android proxy never sets a userinfo rule
+
+- **GIVEN** the app runs on Android with a credentialed effective proxy
+- **WHEN** the proxy is applied
+- **THEN** the `ProxyController` rule is `http://127.0.0.1:<port>` with no userinfo
+- **AND** the username and password are present only in the relay's upstream connection
+
+#### Scenario: Relay failure does not leak the IP
+
+- **GIVEN** a credentialed Android proxy whose relay cannot start
+- **WHEN** the proxy is applied
+- **THEN** no direct-connection override is left active for that site's traffic
+- **AND** the failure is logged at error level

--- a/openspec/changes/android-auth-proxy-relay/specs/proxy/spec.md
+++ b/openspec/changes/android-auth-proxy-relay/specs/proxy/spec.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+### Requirement: PROXY-010 - Android authenticated proxy via local relay
+
+On Android, a proxy whose effective settings carry credentials SHALL be
+served through a native loopback relay rather than by embedding credentials
+in the `inapp.ProxyController` proxy rule. Android WebView's
+`ProxyController` has no proxy-authentication primitive and Chromium rejects
+a proxy rule containing userinfo, which silently degrades to a direct
+connection. The relay ([`ProxyRelay`](../../../../android/app/src/main/kotlin/org/codeberg/theoden8/webspace/proxy/ProxyRelay.kt))
+SHALL accept HTTP proxy traffic on `127.0.0.1`, forward it to the configured
+upstream, and inject the upstream credentials — HTTP `Proxy-Authorization:
+Basic` for HTTP/HTTPS upstreams, the RFC 1929 username/password handshake
+for SOCKS5. WebView SHALL be pointed at `http://127.0.0.1:<port>` with no
+credentials in the rule.
+
+The relay SHALL bind a fresh random ephemeral port chosen by the OS on every
+(re)start, SHALL bind to the loopback interface only, and SHALL NOT persist
+the port. Unauthenticated Android proxies, and all non-Android platforms,
+SHALL continue to use the direct `ProxyController` / native per-store path
+and SHALL NOT start the relay.
+
+#### Scenario: Authenticated HTTP proxy routes through the relay
+
+- **GIVEN** the app runs on Android
+- **AND** a site's effective proxy is `HTTP proxy.example.com:8080` with a username and password
+- **WHEN** the proxy is applied
+- **THEN** the native relay is started for that upstream
+- **AND** `ProxyController` is set to `http://127.0.0.1:<ephemeral-port>` with no credentials
+- **AND** the relay forwards `CONNECT` requests to the upstream with a `Proxy-Authorization: Basic` header derived from the credentials
+
+#### Scenario: Authenticated SOCKS5 proxy performs RFC 1929 handshake
+
+- **GIVEN** the app runs on Android
+- **AND** a site's effective proxy is `SOCKS5 proxy.example.com:1080` with a username and password
+- **WHEN** a request is made through the relay
+- **THEN** the relay performs the SOCKS5 greeting offering username/password auth
+- **AND** completes the RFC 1929 username/password sub-negotiation with the configured credentials before issuing the SOCKS CONNECT
+
+#### Scenario: Unauthenticated proxy bypasses the relay
+
+- **GIVEN** the app runs on Android
+- **AND** a site's effective proxy has no credentials
+- **WHEN** the proxy is applied
+- **THEN** `ProxyController` is pointed directly at the upstream
+- **AND** any relay started for a previous credentialed config is stopped
+
+#### Scenario: Each start binds an independent loopback port
+
+- **WHEN** the relay is started
+- **THEN** the bound port is an OS-assigned ephemeral port on the loopback interface
+- **AND** the port is not written to persistent storage
+
+---
+
+### Requirement: PROXY-011 - Auth proxy relay fails closed
+
+The Android authenticated-proxy relay SHALL never open a direct connection
+to an origin on behalf of a client; it SHALL only connect to the configured
+upstream. When the upstream is unreachable or rejects authentication, the
+relay SHALL return an error status (HTTP `502`) to the client and close the
+connection. When the relay cannot bind its listener at all,
+`ProxyManager.setProxySettings` SHALL throw and SHALL NOT clear the existing
+proxy override — clearing it would let traffic flow directly and leak the
+user's IP.
+
+#### Scenario: Unreachable upstream does not leak direct
+
+- **GIVEN** the relay is configured with an upstream that is unreachable
+- **WHEN** a client opens a `CONNECT` request through the relay
+- **THEN** the relay responds with `502`
+- **AND** the relay does not connect the client directly to the requested origin
+
+#### Scenario: Bind failure does not fall back to direct
+
+- **GIVEN** applying a credentialed Android proxy
+- **WHEN** the relay cannot bind a loopback port
+- **THEN** `setProxySettings` throws
+- **AND** the existing proxy override is left intact rather than cleared

--- a/openspec/changes/android-auth-proxy-relay/tasks.md
+++ b/openspec/changes/android-auth-proxy-relay/tasks.md
@@ -1,0 +1,31 @@
+## 1. Native relay (Kotlin)
+
+- [x] 1.1 `ProxyRelay` in `android/app/src/main/kotlin/.../proxy/ProxyRelay.kt` — loopback HTTP proxy, random ephemeral port, `android.*`-free. `CONNECT` tunnel + absolute-form forward.
+- [x] 1.2 HTTP/HTTPS upstream: inject `Proxy-Authorization: Basic`. HTTPS upstream wrapped in TLS.
+- [x] 1.3 SOCKS5 upstream: greeting + RFC 1929 username/password auth + domain-ATYP CONNECT (no local DNS leak).
+- [x] 1.4 Fail-closed: only ever connect to the configured upstream; `502` on failure; never direct.
+- [x] 1.5 Hand-rolled Base64 (no `android.util.Base64`, no API-26 `java.util.Base64`).
+
+## 2. Native plugin
+
+- [x] 2.1 `ProxyRelayPlugin` method channel (`.../proxy_relay`) with `start` / `stop` / `isRunning`.
+- [x] 2.2 Register + dispose in `MainActivity`.
+
+## 3. Dart wiring
+
+- [x] 3.1 `ProxyRelay` client in `lib/services/proxy_relay.dart` (Android-only).
+- [x] 3.2 `ProxyManager.setProxySettings`: credentialed Android proxy → start relay, point `ProxyController` at `127.0.0.1:<port>` (no creds); throw (fail closed) on relay-start failure.
+- [x] 3.3 Stop the relay on the DEFAULT/clear path, the unauthenticated path, and `clearProxy()`.
+- [x] 3.4 Preserve the inline-credential URL on the non-Android (Linux) path.
+
+## 4. Tests
+
+- [x] 4.1 `ProxyRelayTest` (JVM): Base64 vectors, distinct random ports, HTTP `Proxy-Authorization` injection (fake upstream), SOCKS5 RFC 1929 handshake (fake upstream), fail-closed `502`. Verified passing via standalone `kotlinc` + JUnit.
+- [x] 4.2 CI: the existing `Run JVM unit tests` step (`gradle :app:testFdroidDebugUnitTest`, build-and-test.yml) auto-discovers `src/test/kotlin` and runs `ProxyRelayTest` — no workflow change needed.
+- [ ] 4.3 On-device egress-IP verification: with a plain (unauthenticated) proxy under containers, confirm egress IP changes — settles whether container profiles honor the global `ProxyController`. Manual / instrumentation; not automatable in the current CI.
+
+## 5. Specs
+
+- [x] 5.1 PROXY-010 / PROXY-011, LEAK-008 deltas.
+- [x] 5.2 `openspec validate android-auth-proxy-relay --no-interactive` clean.
+- [ ] 5.3 On apply: fold the relay note into `openspec/specs/proxy/spec.md` Android row and the `ProxyManager` docstring (done in code) + ip-leakage coverage matrix.


### PR DESCRIPTION
Android's `ProxyController` has no proxy-authentication primitive and Chromium rejects a proxy rule with embedded userinfo, causing a silent fallback to a direct connection. This change implements a native loopback relay that fronts authenticated upstreams, injecting credentials on behalf of the WebView.

**Key changes:**

- **`ProxyRelay` (Kotlin):** Loopback HTTP proxy binding a random ephemeral port on `127.0.0.1`. Forwards traffic to the configured upstream (HTTP, HTTPS, or SOCKS5) and injects credentials: `Proxy-Authorization: Basic` for HTTP/HTTPS upstreams, RFC 1929 username/password handshake for SOCKS5. Handles `CONNECT` tunnels and absolute-form HTTP requests. Deliberately free of `android.*` imports for JVM unit testing.

- **`ProxyRelayPlugin` (Kotlin):** Method channel (`org.codeberg.theoden8.webspace/proxy_relay`) exposing `start`, `stop`, and `isRunning` operations. Runs on daemon threads independent of the Flutter engine lifecycle.

- **`ProxyRelay` (Dart):** Android-only client in `lib/services/proxy_relay.dart` that starts the relay and returns the loopback port.

- **`ProxyManager` integration:** When applying a credentialed proxy on Android, starts the relay and points `ProxyController` at `http://127.0.0.1:<port>` with no credentials. Stops the relay when clearing the proxy or applying an unauthenticated upstream. Fails closed (throws) if the relay cannot bind, preventing a silent fallback to direct.

- **Tests:** `ProxyRelayTest` (JVM) validates Base64 encoding, distinct port allocation, credential injection for HTTP and SOCKS5 upstreams, and fail-closed behavior.

**Implementation notes:**

- Hand-rolled Base64 encoding (no `android.util.Base64`, compatible with API <26).
- SOCKS5 uses domain-ATYP for the CONNECT request to avoid local DNS leaks.
- Relay only ever connects to the configured upstream; unreachable upstream or rejected auth yields HTTP 502 to the client.
- Port is re-bound on every start and never persisted.

https://claude.ai/code/session_016d8Mc7aBFGWSXUA4jjxa58