### PR TITLE
Add Save Icon as PNG to Developer Tools

### DIFF
--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -9,11 +9,14 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart' show ConsoleMess
 import 'package:share_plus/share_plus.dart';
 
 import 'package:webspace/web_view_model.dart';
+import 'package:webspace/screens/add_site.dart' show FaviconUrlCache;
 import 'package:webspace/services/container_cookie_manager.dart';
 import 'package:webspace/services/webview.dart';
+import 'package:webspace/services/icon_png_export.dart';
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
+import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/settings/user_script.dart';
 
 typedef VoidAsyncCallback = Future<void> Function();
@@ -32,6 +35,11 @@ abstract class DevToolsHost {
   String get name;
   String? get siteId;
   String get currentUrl;
+  /// URL used as the favicon cache key for this host (the site's stable
+  /// `initUrl` for top-level sites; the current URL for nested webviews).
+  String get iconUrl;
+  /// Per-site proxy the favicon must be fetched through, or null for global.
+  UserProxySettings? get proxy;
   WebViewController? get controller;
   List<ConsoleLogEntry> get consoleLogs;
   set onConsoleLogChanged(VoidCallback? cb);
@@ -53,6 +61,10 @@ class WebViewModelDevToolsHost implements DevToolsHost {
   String? get siteId => model.siteId;
   @override
   String get currentUrl => model.currentUrl;
+  @override
+  String get iconUrl => model.initUrl;
+  @override
+  UserProxySettings? get proxy => model.proxySettings;
   @override
   WebViewController? get controller => model.controller;
   @override
@@ -99,6 +111,11 @@ class NestedDevToolsHost implements DevToolsHost {
   @override
   String get currentUrl => _currentUrl;
   set currentUrl(String value) => _currentUrl = value;
+
+  @override
+  String get iconUrl => _currentUrl;
+  @override
+  UserProxySettings? get proxy => null;
 
   @override
   WebViewController? get controller => _controller;
@@ -162,6 +179,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   bool _loadingCookies = false;
   String? _exportedHtml;
   bool _isFetchingHtml = false;
+  bool _isSavingIcon = false;
   final Set<LogLevel> _activeFilters = LogLevel.values.toSet();
 
   /// Runtime-only toggle: when true, the App Logs tab shows
@@ -319,6 +337,12 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
                 icon: const Icon(Icons.share, size: 20),
                 tooltip: 'Share HTML',
                 onPressed: _showShareSheet,
+              ),
+            if (_hasHost)
+              IconButton(
+                icon: const Icon(Icons.image_outlined, size: 20),
+                tooltip: 'Save icon as PNG',
+                onPressed: _isSavingIcon ? null : _saveIconAsPng,
               ),
             IconButton(
               icon: Icon(_isSearchVisible ? Icons.search_off : Icons.search),
@@ -1188,6 +1212,60 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('HTML copied to clipboard')),
       );
+    }
+  }
+
+  // ── Save Icon as PNG ──
+
+  Future<void> _saveIconAsPng() async {
+    if (_isSavingIcon) return;
+    setState(() => _isSavingIcon = true);
+    final host = widget.host!;
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.showSnackBar(
+      const SnackBar(content: Text('Preparing icon...')),
+    );
+    try {
+      final png = await exportIconAsPng(
+        host.iconUrl,
+        resolvedIconUrl: FaviconUrlCache.get(host.iconUrl),
+        proxy: host.proxy,
+      );
+      if (!mounted) return;
+      if (png == null) {
+        messenger.showSnackBar(
+          const SnackBar(content: Text('No icon available to save')),
+        );
+        return;
+      }
+
+      final domain = extractDomain(host.currentUrl);
+      final fileName = '${domain}_icon.png';
+      final bool isMobile = !kIsWeb && (Platform.isIOS || Platform.isAndroid);
+      final outputPath = await FilePicker.saveFile(
+        dialogTitle: 'Save icon',
+        fileName: fileName,
+        bytes: isMobile ? png : null,
+      );
+
+      if (outputPath != null && !isMobile) {
+        final filePath = outputPath.endsWith('.png') ? outputPath : '$outputPath.png';
+        await File(filePath).writeAsBytes(png);
+      }
+
+      if (mounted && outputPath != null) {
+        messenger.showSnackBar(
+          const SnackBar(content: Text('Icon saved')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        messenger.showSnackBar(
+          SnackBar(content: Text('Save failed: $e')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isSavingIcon = false);
     }
   }
 

--- a/lib/services/icon_png_export.dart
+++ b/lib/services/icon_png_export.dart
@@ -1,0 +1,89 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:image/image.dart' as img;
+
+import 'package:webspace/services/icon_service.dart';
+import 'package:webspace/services/log_service.dart';
+import 'package:webspace/settings/proxy.dart';
+
+bool _isSvgUrl(String url) {
+  final lower = url.toLowerCase();
+  return lower.endsWith('.svg') || lower.contains('.svg?');
+}
+
+/// Resolve, fetch, and normalize a site's favicon to PNG bytes.
+///
+/// The favicon a site serves may be a PNG, an ICO (DuckDuckGo), or an SVG.
+/// This always returns a valid PNG: raster sources are decoded and
+/// re-encoded; SVG sources are rasterized at [size]x[size]. Returns null when
+/// no icon can be resolved/fetched (e.g. proxy fail-closed) or decoding fails.
+///
+/// Pass [resolvedIconUrl] when the caller already knows the favicon URL (e.g.
+/// from `FaviconUrlCache`) to skip a network round-trip resolving it.
+/// [proxy] is the per-site proxy of the site the icon belongs to.
+Future<Uint8List?> exportIconAsPng(
+  String siteUrl, {
+  String? resolvedIconUrl,
+  UserProxySettings? proxy,
+  int size = 256,
+}) async {
+  final iconUrl = resolvedIconUrl ?? await _resolveIconUrl(siteUrl, proxy);
+  if (iconUrl == null) return null;
+
+  try {
+    if (_isSvgUrl(iconUrl)) {
+      final svg = await getSvgContent(iconUrl, proxy: proxy);
+      if (svg == null) return null;
+      return await _rasterizeSvg(svg, size);
+    }
+    final bytes = await fetchIconBytes(iconUrl, proxy: proxy);
+    if (bytes == null) return null;
+    final decoded = img.decodeImage(bytes);
+    if (decoded == null) return null;
+    return Uint8List.fromList(img.encodePng(decoded));
+  } catch (e) {
+    LogService.instance.log('Icon', 'PNG export failed: $e', level: LogLevel.error);
+    return null;
+  }
+}
+
+Future<String?> _resolveIconUrl(String siteUrl, UserProxySettings? proxy) async {
+  String? best;
+  await for (final update in getFaviconUrlStream(siteUrl, proxy: proxy)) {
+    best = update.url;
+    if (update.isFinal) break;
+  }
+  return best;
+}
+
+Future<Uint8List?> _rasterizeSvg(String svg, int size) async {
+  final info = await vg.loadPicture(SvgStringLoader(svg), null);
+  try {
+    final srcW = info.size.width > 0 ? info.size.width : size.toDouble();
+    final srcH = info.size.height > 0 ? info.size.height : size.toDouble();
+    final scale = size / (srcW > srcH ? srcW : srcH);
+    final outW = (srcW * scale).round();
+    final outH = (srcH * scale).round();
+
+    final recorder = ui.PictureRecorder();
+    final canvas = ui.Canvas(recorder);
+    canvas.scale(scale);
+    canvas.drawPicture(info.picture);
+    final scaled = recorder.endRecording();
+    try {
+      final image = await scaled.toImage(outW, outH);
+      try {
+        final data = await image.toByteData(format: ui.ImageByteFormat.png);
+        return data?.buffer.asUint8List();
+      } finally {
+        image.dispose();
+      }
+    } finally {
+      scaled.dispose();
+    }
+  } finally {
+    info.picture.dispose();
+  }
+}

--- a/lib/services/icon_service.dart
+++ b/lib/services/icon_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:collection';
+import 'dart:typed_data';
 import 'package:http/http.dart' as http;
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/outbound_http.dart';
@@ -94,6 +95,29 @@ Future<String?> getSvgContent(
     }
   } catch (e) {
     LogService.instance.log('Icon', 'Failed to fetch SVG content: $e', level: LogLevel.error);
+  } finally {
+    client.close();
+  }
+  return null;
+}
+
+/// Fetch the raw bytes of an icon at [iconUrl] through the proxy-aware
+/// client. Returns null when the proxy cannot be honored (fail-closed, same
+/// as every other favicon fetch) or the request fails. [proxy] is the
+/// per-site proxy of the site the icon belongs to; null means the app-global
+/// outbound proxy applies.
+Future<Uint8List?> fetchIconBytes(String iconUrl, {UserProxySettings? proxy}) async {
+  final client = _proxiedClient(_resolve(proxy));
+  if (client == null) return null;
+  try {
+    final response = await client.get(Uri.parse(iconUrl)).timeout(
+      const Duration(seconds: 10),
+    );
+    if (response.statusCode == 200) {
+      return response.bodyBytes;
+    }
+  } catch (e) {
+    LogService.instance.log('Icon', 'Failed to fetch icon bytes: $e', level: LogLevel.error);
   } finally {
     client.close();
   }

--- a/openspec/specs/developer-tools/spec.md
+++ b/openspec/specs/developer-tools/spec.md
@@ -140,6 +140,42 @@ The app SHALL allow sharing, saving, or copying the current page's HTML source v
 
 ---
 
+### Requirement: DEVTOOLS-009 - Save Icon as PNG
+
+The app SHALL allow saving the current site's favicon as a PNG file via an
+AppBar action button, regardless of the source format the site serves.
+
+The favicon SHALL be fetched through the same proxy-aware client as all other
+favicon requests (per-site proxy, fail-closed when it cannot be honored), so
+the action never leaks the device IP.
+
+Because a site's favicon may be a PNG, an ICO (DuckDuckGo), or an SVG, the
+output SHALL always be a valid PNG: raster sources are decoded and re-encoded,
+and SVG sources are rasterized.
+
+#### Scenario: Save favicon to a PNG file
+
+**Given** a site is loaded with a resolvable favicon
+**When** the user taps the image icon in the AppBar
+**Then** the favicon is resolved (preferring the `FaviconUrlCache` entry for
+the site's `initUrl`) and fetched through the site's proxy
+**And** it is normalized to PNG bytes
+**And** a file save dialog appears with filename `{domain}_icon.png`
+
+#### Scenario: SVG favicon is rasterized
+
+**Given** the resolved favicon is an SVG
+**When** the user saves it
+**Then** the SVG is rasterized to a square PNG before the save dialog appears
+
+#### Scenario: No icon available
+
+**Given** the site has no resolvable favicon (or the proxy fails closed)
+**When** the user taps the image icon
+**Then** a snackbar reports that no icon is available and no file dialog appears
+
+---
+
 ### Requirement: DEVTOOLS-004 - App Logs
 
 The app SHALL maintain a ring buffer of app-level log entries accessible from both Developer Tools and App Settings, with live streaming updates and auto-scroll.
@@ -246,6 +282,7 @@ The reduced mode SHALL show:
 - Console tab (capture, filter, copy, clear, JS eval).
 - App Logs tab.
 - Share HTML AppBar action.
+- Save Icon as PNG AppBar action.
 
 The reduced mode SHALL NOT show Cookies, DNS, or Scripts surfaces. Cookies
 and scripts belong to the parent site (the nested webview reuses the
@@ -331,7 +368,8 @@ The app SHALL provide a JavaScript evaluation input in the Console tab, allowing
 | File | Role |
 |------|------|
 | `lib/services/log_service.dart` | LogService singleton, LogEntry, LogLevel enum |
-| `lib/screens/dev_tools.dart` | DevToolsScreen plus DevToolsHost abstraction (WebViewModelDevToolsHost, NestedDevToolsHost). Tabs/actions are gated on `host != null` (Console, Share HTML) and `host.blockedCookies != null` (Cookies, DNS, Scripts). |
+| `lib/screens/dev_tools.dart` | DevToolsScreen plus DevToolsHost abstraction (WebViewModelDevToolsHost, NestedDevToolsHost). Tabs/actions are gated on `host != null` (Console, Share HTML, Save Icon) and `host.blockedCookies != null` (Cookies, DNS, Scripts). |
+| `lib/services/icon_png_export.dart` | Resolves a site favicon, fetches it via the proxy-aware icon client, and normalizes any source (PNG/ICO/JPEG/SVG) to PNG bytes (`exportIconAsPng`). |
 | `lib/screens/inappbrowser.dart` | InAppWebViewScreen owns a NestedDevToolsHost: forwards onConsoleMessage / onUrlChanged / onControllerCreated and exposes a "Developer Tools" entry in the popup menu. |
 
 ### Data Models
@@ -370,6 +408,7 @@ class ConsoleLogEntry {
 3. **Console tab**: verify messages appear color-coded with timestamps
 4. **Cookies tab**: verify cookies listed with security chips; delete a cookie and confirm removal
 5. **Share HTML** (AppBar share icon): tap and verify bottom sheet with Share/Save/Copy options; test each option
+5a. **Save Icon as PNG** (AppBar image icon): tap and verify a save dialog with `{domain}_icon.png`; save and confirm the file opens as a PNG. Test on a site with an SVG favicon (e.g. codeberg) and one with an ICO favicon to confirm both rasterize/convert correctly
 6. **Scripts** (AppBar code icon): tap and verify bottom sheet shows user scripts (or "no scripts" message); expand a script and copy its source
 7. **App Logs tab**: verify app log entries appear; use filter chips; tap "Copy" and paste — verify only filtered entries are copied
 8. **Filtered copy**: on each tab, enter a search query, tap Copy, and verify clipboard contains only the matching entries (not all)


### PR DESCRIPTION
Implements DEVTOOLS-009: allow saving a site's favicon as PNG via an AppBar action button, regardless of source format (PNG, ICO, SVG).

Key changes:
- New `lib/services/icon_png_export.dart` exports `exportIconAsPng()`, which resolves a favicon URL, fetches it through the proxy-aware icon client (fail-closed), and normalizes any source to PNG bytes. SVG sources are rasterized to a square PNG at the requested size; raster sources (PNG, ICO, JPEG) are decoded and re-encoded.
- `lib/services/icon_service.dart` adds `fetchIconBytes()` to fetch raw icon bytes through the proxy-aware client, mirroring the existing favicon resolution and proxy handling.
- `lib/screens/dev_tools.dart` extends `DevToolsHost` with `iconUrl` (the site's stable `initUrl` for top-level sites, current URL for nested webviews) and `proxy` (per-site proxy settings). Adds "Save icon as PNG" AppBar button (image icon) that resolves the favicon, fetches and normalizes it, then opens a file save dialog with filename `{domain}_icon.png`. Uses `FaviconUrlCache` to skip redundant resolution when available.
- `openspec/specs/developer-tools/spec.md` documents DEVTOOLS-009 with scenarios for normal save, SVG rasterization, and missing favicon handling. Updates test checklist and file role table.

The implementation reuses existing icon resolution and proxy infrastructure, ensuring the favicon fetch never leaks the device IP and respects per-site proxy settings.

https://claude.ai/code/session_01DEzn8Yj76bFzB11Mr9mKTH