### PR TITLE
fix(webview): probe renderer on activation to kill black-screen on shortcut

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -876,6 +876,10 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   bool _isBackHandling = false;
   bool _isFindVisible = false;
   bool _isFullscreen = false; // Runtime fullscreen state (hides appBar, tabStrip, system UI)
+  // Toggled by _nudgeSurfaceRepaint to apply a transient 1px inset that
+  // forces Android hybrid-composition platform views to recomposite after
+  // the activity is recreated (shortcut/resume). Always false in steady state.
+  bool _repaintNudge = false;
   /// When true, a full-screen opaque mask covers every webview so the
   /// OS task-switcher / recents snapshot doesn't capture archive-tier
   /// content (ARCH-009). Set on `inactive`/`paused` when at least one
@@ -1350,6 +1354,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       }
       unawaited(_probeRendererAndRecover(_webViewModels[_currentIndex!]));
     }
+    // Force a relayout in case the activity was recreated while backgrounded
+    // and the platform-view surface came back blank.
+    _nudgeSurfaceRepaint();
     // Re-apply fullscreen system UI mode after resume
     if (_isFullscreen) {
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
@@ -1395,6 +1402,33 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     }
   }
 
+  /// Android only: after the activity is recreated (a pinned-shortcut tap, or
+  /// a resume that recreated the activity) the Flutter base surface and the
+  /// hybrid-composition webview SurfaceView can come back without a paint —
+  /// the page area and the strip behind the edge-to-edge status bar render
+  /// black even though the page is alive. A relayout fixes it: that is what a
+  /// device rotation / lock-unlock / tab switch does, all of which the user
+  /// confirmed recover the screen. A JS `offsetHeight` read does not, because
+  /// it relayouts web content, not the Android surface.
+  ///
+  /// Toggle a 1px body inset a few times over ~0.5s: each setState repaints
+  /// the Flutter surface (status-bar strip, chrome) and each size flip forces
+  /// the webview platform view to recomposite. Spread across several frames
+  /// because the new surface may not be attached on the first frame after
+  /// resume, which is why a single rebuild (e.g. the one in _setCurrentIndex)
+  /// is not enough on its own.
+  void _nudgeSurfaceRepaint() {
+    if (!Platform.isAndroid) return;
+    var ticks = 0;
+    void tick() {
+      if (!mounted || ticks >= 6) return;
+      ticks++;
+      setState(() => _repaintNudge = !_repaintNudge);
+      Future.delayed(const Duration(milliseconds: 100), tick);
+    }
+    tick();
+  }
+
   Future<void> _handleShortcutIntent() async {
     final siteId = await ShortcutService.getLaunchSiteId();
     if (!mounted) return;
@@ -1407,6 +1441,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           if (!mounted) return;
         }
         setState(() {});
+        // The shortcut tap can recreate the activity; force a relayout so the
+        // activated site doesn't land on a blank platform-view surface.
+        _nudgeSurfaceRepaint();
         await _saveWebViewModels();
       }
     }
@@ -5939,7 +5976,14 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                 if (_loadedIndices.isNotEmpty)
                   Offstage(
                     offstage: _currentIndex == null || _currentIndex! >= _webViewModels.length,
-                    child: IndexedStack(
+                    // The 1px inset is toggled by _nudgeSurfaceRepaint after
+                    // the activity is recreated (shortcut/resume) to force the
+                    // hybrid-composition webview SurfaceView to recomposite —
+                    // otherwise it can come back black on Android. No-op
+                    // (zero inset) in steady state.
+                    child: Padding(
+                      padding: EdgeInsets.only(bottom: _repaintNudge ? 1.0 : 0.0),
+                      child: IndexedStack(
                       index: _currentIndex ?? 0,
                       children: _webViewModels.asMap().entries.map<Widget>((entry) {
                         final index = entry.key;
@@ -6041,6 +6085,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                           ),
                         );
                       }).toList(),
+                      ),
                     ),
                   ),
                 // Fullscreen exit zone: touch target at the top edge with a

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1348,25 +1348,50 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       if (!_webViewModels[_currentIndex!].effectiveNotificationsEnabled) {
         await _webViewModels[_currentIndex!].resumeFromAppLifecycle();
       }
-      // Android-only: nudge the active WebView's renderer to issue a paint
-      // after the platform view's surface has been re-attached on activity
-      // restart. Without this nudge, the hybrid-composition surface can
-      // come back blank — the page is still alive (taps, scrolls, JS all
-      // work), but the user sees a black rectangle until something forces
-      // a layout pass. Reading `document.body.offsetHeight` is a no-op
-      // that triggers a synchronous layout, which schedules a paint.
-      // See issue #333. Fire-and-forget; failure is benign.
-      if (Platform.isAndroid) {
-        final ctrl = _webViewModels[_currentIndex!].controller;
-        if (ctrl != null) {
-          unawaited(ctrl.evaluateJavascript(
-              'void (document.body && document.body.offsetHeight);'));
-        }
-      }
+      unawaited(_probeRendererAndRecover(_webViewModels[_currentIndex!]));
     }
     // Re-apply fullscreen system UI mode after resume
     if (_isFullscreen) {
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+    }
+  }
+
+  /// Probe a just-resumed / just-activated webview's renderer and recreate it
+  /// if the renderer process is gone. Covers the two memory-reclaim outcomes
+  /// the user hits most when returning to a backgrounded site (typically via
+  /// a pinned shortcut, which can recreate the activity and re-attach every
+  /// platform-view surface):
+  ///
+  ///   - iOS: WKWebView's content process was jettisoned while this webview
+  ///     was offscreen. `onWebContentProcessDidTerminate` does not reliably
+  ///     fire for a webview that was not on screen at termination, so the
+  ///     event-driven recovery (PAUSE-013) never runs — the page comes back
+  ///     blank with no signal. `evaluateJavascript` against a dead content
+  ///     process throws, surfaced here as a null probe result.
+  ///   - Android: the renderer is alive but the hybrid-composition surface
+  ///     re-attached blank after an activity restart. Reading
+  ///     `document.body.offsetHeight` forces a synchronous layout that
+  ///     schedules the missing paint; the probe returns a number, so no
+  ///     recreate happens — the read alone fixes the blank surface.
+  ///
+  /// A live renderer returns a number (0 / -1 / positive); only null means
+  /// gone. Fire-and-forget; no-op when the model has no controller (a fresh
+  /// first-load whose controller hasn't been created yet).
+  Future<void> _probeRendererAndRecover(WebViewModel model) async {
+    final controller = model.controller;
+    if (controller == null) return;
+    final result = await controller
+        .evaluateJavascriptReturning('document.body ? document.body.offsetHeight : -1');
+    if (!mounted) return;
+    // identical() guard: a concurrent recreate may have already swapped the
+    // controller out from under us — don't null a fresh one.
+    if (rendererProbeIndicatesGone(result) && identical(model.controller, controller)) {
+      LogService.instance.log(
+        'WebView',
+        'Renderer probe failed for "${model.name}" (siteId: ${model.siteId}) — recreating',
+        level: LogLevel.warning,
+      );
+      model.handleRendererGone(didCrash: false);
     }
   }
 
@@ -2806,6 +2831,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
     // Resume the newly active webview
     await _webViewModels[index].resumeWebView();
+
+    // A site that sat offscreen while the OS reclaimed memory can come back
+    // with a dead renderer (iOS content-process jettison whose termination
+    // delegate never fired) or a blank surface (Android hybrid-composition).
+    // Probe and recover so a shortcut tap or tab switch doesn't land on a
+    // black/blank page. See PAUSE-013.
+    unawaited(_probeRendererAndRecover(target));
 
     // Defensive sweep: pause every other loaded webview so background
     // sites don't run animations / GPS listeners / non-throttled

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1324,13 +1324,10 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         setState(() => _maskBackground = false);
       }
       _startForegroundPollTimer();
-      // Await any in-flight pause before resuming to prevent ordering inversion
-      _resumeAfterLifecyclePause();
-      _handleShortcutIntent();
-      _handleShareIntent();
-      // Pinned shortcuts may have been added (via the launcher's pin dialog)
-      // or removed (by the user from the launcher) while we were backgrounded.
-      _refreshPinnedSiteIds();
+      // Resume + shortcut + share are sequenced in _onResumed: the
+      // app-lifecycle resume must finish before a shortcut intent switches
+      // sites, or the two race over _currentIndex and webview pause/resume.
+      unawaited(_onResumed());
       // Release the iOS grace-period background task. Foregrounded again,
       // so we don't need the extension; iOS auto-ends after the expiration
       // handler fires, but explicit end is cleaner.
@@ -1340,6 +1337,38 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       // be torn down; if any are still loaded the schedule submission
       // is a no-op.
       unawaited(_updateBackgroundRefreshSchedule());
+    }
+  }
+
+  bool _isResuming = false;
+
+  /// Run the resume sequence in a fixed order. The app-lifecycle resume
+  /// (drains the in-flight `pauseForAppLifecycle`, resumes process-global JS
+  /// timers and the active site) MUST complete before a pinned-shortcut
+  /// intent is handled: both mutate `_currentIndex` and pause/resume
+  /// webviews, and the previous fire-and-forget pair let the shortcut's site
+  /// switch race the resume. Sequencing also lets a single surface repaint
+  /// run once, against the final visible site, instead of two `_repaintNudge`
+  /// loops interleaving. Re-entry guarded in case `resumed` fires twice.
+  Future<void> _onResumed() async {
+    if (_isResuming) return;
+    _isResuming = true;
+    try {
+      await _resumeAfterLifecyclePause();
+      if (!mounted) return;
+      await _handleShortcutIntent();
+      if (!mounted) return;
+      await _handleShareIntent();
+      if (!mounted) return;
+      // Pinned shortcuts may have been added (via the launcher's pin dialog)
+      // or removed (by the user from the launcher) while we were backgrounded.
+      _refreshPinnedSiteIds();
+      // One relayout against the now-final visible site, in case the activity
+      // was recreated and the platform-view surface came back blank. See
+      // PAUSE-015.
+      _nudgeSurfaceRepaint();
+    } finally {
+      _isResuming = false;
     }
   }
 
@@ -1354,9 +1383,6 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       }
       unawaited(_probeRendererAndRecover(_webViewModels[_currentIndex!]));
     }
-    // Force a relayout in case the activity was recreated while backgrounded
-    // and the platform-view surface came back blank.
-    _nudgeSurfaceRepaint();
     // Re-apply fullscreen system UI mode after resume
     if (_isFullscreen) {
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
@@ -1441,9 +1467,6 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           if (!mounted) return;
         }
         setState(() {});
-        // The shortcut tap can recreate the activity; force a relayout so the
-        // activated site doesn't land on a blank platform-view surface.
-        _nudgeSurfaceRepaint();
         await _saveWebViewModels();
       }
     }

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -1218,10 +1218,17 @@ class WebViewModel {
   /// background we want every loaded webview's JS frozen, not just the active
   /// one. Pair with [resumeFromAppLifecycle] on resume.
   Future<void> pauseForAppLifecycle() async {
-    if (controller == null) return;
+    // Bind both calls to one local controller: disposeWebView() only nulls
+    // the `controller` field (the native webview stays alive until the next
+    // widget rebuild), so a concurrent dispose landing between these awaits
+    // would, if we re-read `controller!`, throw and skip the process-global
+    // pauseAllJsTimers — stranding every webview's JS timers. The local keeps
+    // both calls on the same still-live controller.
+    final c = controller;
+    if (c == null) return;
     try {
-      await controller!.pause();
-      await controller!.pauseAllJsTimers();
+      await c.pause();
+      await c.pauseAllJsTimers();
       LogService.instance.log(
         'WebView',
         'App-lifecycle paused webview for "$name" (siteId: $siteId)',
@@ -1234,10 +1241,13 @@ class WebViewModel {
 
   /// Inverse of [pauseForAppLifecycle].
   Future<void> resumeFromAppLifecycle() async {
-    if (controller == null) return;
+    // See [pauseForAppLifecycle]: bind both calls to one local controller so a
+    // concurrent dispose can't strand the process-global resumeAllJsTimers.
+    final c = controller;
+    if (c == null) return;
     try {
-      await controller!.resume();
-      await controller!.resumeAllJsTimers();
+      await c.resume();
+      await c.resumeAllJsTimers();
       LogService.instance.log(
         'WebView',
         'App-lifecycle resumed webview for "$name" (siteId: $siteId)',

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -276,6 +276,15 @@ class BlockedCookie {
       BlockedCookie(name: json['name'] as String, domain: json['domain'] as String);
 }
 
+/// Interpret a renderer-health probe result. The probe reads
+/// `document.body.offsetHeight`: a live renderer returns a number — `0`
+/// (about:blank), `-1` (document/body not built yet, still loading), or a
+/// positive height. A dead renderer (iOS content-process jettisoned,
+/// Android renderer killed) makes `evaluateJavascript` throw, surfaced as a
+/// `null` result by [WebViewController.evaluateJavascriptReturning]. Only
+/// `null` means gone; every numeric value is alive.
+bool rendererProbeIndicatesGone(Object? probeResult) => probeResult == null;
+
 class WebViewModel {
   final String siteId; // Unique ID for per-site cookie isolation
   String initUrl; // Made non-final to allow URL editing

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -446,12 +446,12 @@ The wrapper exposes a single `WebViewConfig.onRendererGone(bool didCrash)` callb
 
 ### Requirement: PAUSE-014 — Proactive Renderer Probe on Activation
 
-The event-driven recovery in PAUSE-013 is not sufficient on its own, because the platform terminations it listens for do not reliably surface for a webview that was **offscreen** when its renderer died:
+The system SHALL probe the renderer of a webview when it becomes active and recreate it if the renderer is gone. This is required because the event-driven recovery in PAUSE-013 does not reliably fire for a webview that was **offscreen** when its renderer died:
 
 - **iOS**: when WKWebView's web content process is jettisoned for a webview that is not in the visible view hierarchy, `onWebContentProcessDidTerminate` frequently does not fire. The webview then comes back blank with no event to drive recovery. This is the dominant render-death the user reports when returning to a backgrounded site via a pinned shortcut (the shortcut activates a site that was offscreen).
 - **Android**: the renderer can be alive but the hybrid-composition surface re-attaches blank after an activity restart, which emits no event at all.
 
-The system SHALL therefore probe the renderer of a webview when it becomes active and recreate it if the renderer is gone. The host runs the probe `_probeRendererAndRecover(model)`:
+The host runs the probe `_probeRendererAndRecover(model)`:
 
 - After resuming the active site on app resume (`_resumeAfterLifecyclePause`).
 - After resuming the newly-activated site on every site switch (`_setCurrentIndex`), which is the path a pinned-shortcut tap funnels through.
@@ -491,9 +491,9 @@ On Android the probe doubles as the surface paint nudge: reading `offsetHeight` 
 
 ### Requirement: PAUSE-015 — Android Surface Repaint After Activity Restart
 
-On Android, tapping a pinned shortcut (or otherwise resuming) can recreate the activity. When it does, the Flutter base surface and the hybrid-composition webview `SurfaceView` can re-attach without receiving a paint: the renderer is alive (taps, scroll, JS all work) but the **web page area renders black, and the strip behind the edge-to-edge status bar renders black too** — distinct from a dead renderer (PAUSE-013/PAUSE-014), which a JS probe cannot detect because the renderer is healthy. The blank surface clears the moment a relayout occurs (device rotation, lock/unlock, or a tab switch).
+On Android, the system SHALL force a relayout on the activity-restart paths (`_resumeAfterLifecyclePause`, `_handleShortcutIntent`) to repaint a platform-view surface that re-attached blank. When the activity is recreated (e.g. a pinned-shortcut tap), the Flutter base surface and the hybrid-composition webview `SurfaceView` can re-attach without receiving a paint: the renderer is alive (taps, scroll, JS all work) but the **web page area renders black, and the strip behind the edge-to-edge status bar renders black too** — distinct from a dead renderer (PAUSE-013/PAUSE-014), which a JS probe cannot detect because the renderer is healthy. The blank surface clears the moment a relayout occurs (device rotation, lock/unlock, or a tab switch).
 
-The system SHALL force a relayout on the activity-restart paths (`_resumeAfterLifecyclePause`, `_handleShortcutIntent`) via `_nudgeSurfaceRepaint`:
+`_nudgeSurfaceRepaint` implements this:
 
 - Toggle a transient 1px body inset around the IndexedStack several times over ~0.5s.
 - Each `setState` repaints the Flutter base surface (status-bar strip and chrome); each size flip resizes the webview platform view, forcing its `SurfaceView` to recomposite.

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -491,11 +491,11 @@ On Android the probe doubles as the surface paint nudge: reading `offsetHeight` 
 
 ### Requirement: PAUSE-015 — Android Surface Repaint After Activity Restart
 
-On Android, the system SHALL force a relayout on the activity-restart paths (`_resumeAfterLifecyclePause`, `_handleShortcutIntent`) to repaint a platform-view surface that re-attached blank. When the activity is recreated (e.g. a pinned-shortcut tap), the Flutter base surface and the hybrid-composition webview `SurfaceView` can re-attach without receiving a paint: the renderer is alive (taps, scroll, JS all work) but the **web page area renders black, and the strip behind the edge-to-edge status bar renders black too** — distinct from a dead renderer (PAUSE-013/PAUSE-014), which a JS probe cannot detect because the renderer is healthy. The blank surface clears the moment a relayout occurs (device rotation, lock/unlock, or a tab switch).
+On Android, the system SHALL force a relayout once the resume sequence (`_onResumed`) has settled the active site, to repaint a platform-view surface that re-attached blank. When the activity is recreated (e.g. a pinned-shortcut tap), the Flutter base surface and the hybrid-composition webview `SurfaceView` can re-attach without receiving a paint: the renderer is alive (taps, scroll, JS all work) but the **web page area renders black, and the strip behind the edge-to-edge status bar renders black too** — distinct from a dead renderer (PAUSE-013/PAUSE-014), which a JS probe cannot detect because the renderer is healthy. The blank surface clears the moment a relayout occurs (device rotation, lock/unlock, or a tab switch).
 
-`_nudgeSurfaceRepaint` implements this:
+The resume sequence is ordered so the repaint is deterministic. `_onResumed` SHALL run the app-lifecycle resume (`_resumeAfterLifecyclePause`) to completion, then handle any pinned-shortcut and share intents, and only then fire `_nudgeSurfaceRepaint` once — against the final `_currentIndex`. Running the lifecycle resume and the shortcut switch concurrently (the previous fire-and-forget pair) raced over `_currentIndex` and webview pause/resume, and let two repaint loops interleave on the shared `_repaintNudge`. `_nudgeSurfaceRepaint` then:
 
-- Toggle a transient 1px body inset around the IndexedStack several times over ~0.5s.
+- Toggles a transient 1px body inset around the IndexedStack several times over ~0.5s.
 - Each `setState` repaints the Flutter base surface (status-bar strip and chrome); each size flip resizes the webview platform view, forcing its `SurfaceView` to recomposite.
 - The nudge is spread across multiple frames because the recreated surface may not be attached on the first frame after resume — a single rebuild (the one already in `_setCurrentIndex`) fires too early to help.
 - The inset is always 0 in steady state and the nudge is a no-op on non-Android platforms.
@@ -507,10 +507,18 @@ This is complementary to PAUSE-014: the probe recreates a *dead* renderer; the s
 **Given** a normal (non-fullscreen) site loaded in the background
 **And** the user taps its pinned shortcut, which recreates the Android activity
 **And** the webview platform-view surface re-attaches without a paint (page area and status-bar strip are black, page is alive)
-**When** `_handleShortcutIntent` activates the site
-**Then** `_nudgeSurfaceRepaint` toggles the 1px inset across several frames
+**When** `_onResumed` finishes the lifecycle resume, then `_handleShortcutIntent` activates the site, then fires `_nudgeSurfaceRepaint`
+**Then** `_nudgeSurfaceRepaint` toggles the 1px inset across several frames against the activated site
 **And** the Flutter surface repaints and the webview `SurfaceView` recomposites
 **And** the page and status-bar strip become visible without the user rotating or locking the device
+
+#### Scenario: Shortcut switch does not race the lifecycle resume
+
+**Given** the app is resuming from background via a pinned-shortcut tap
+**When** `_onResumed` runs
+**Then** `_resumeAfterLifecyclePause` completes (the in-flight `pauseForAppLifecycle` is drained and process-global JS timers are resumed) before `_handleShortcutIntent` switches `_currentIndex`
+**And** only one `_nudgeSurfaceRepaint` runs, after the final site is active
+**And** re-entry is guarded so a second `resumed` event does not start an overlapping sequence
 
 #### Scenario: Nudge is inert off Android and in steady state
 

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -77,7 +77,7 @@ calls, so the active site is never left paused.
 
 ### Requirement: PAUSE-002 — Process-Global Pause Only at App Lifecycle
 
-The system SHALL pause both the active webview and process-global JS timers when the app goes to background, so every loaded webview's JS halts.
+The system SHALL pause both the active webview and process-global JS timers when the app goes to background, so every loaded webview's JS halts. The per-instance and process-global calls SHALL be bound to a single captured controller so a concurrent `disposeWebView()` cannot strand the global half.
 
 #### Scenario: App goes to background
 
@@ -91,24 +91,17 @@ The system SHALL pause both the active webview and process-global JS timers when
 
 **Given** the app was backgrounded via `pauseForAppLifecycle`
 **When** `AppLifecycleState.resumed` fires
-**Then** `_resumeAfterLifecyclePause()` awaits the pending pause Future to prevent ordering inversion
+**Then** `_onResumed` awaits `_resumeAfterLifecyclePause()` (which awaits the pending pause Future to prevent ordering inversion) before handling any shortcut/share intent
 **And** `resumeFromAppLifecycle()` is called on the active webview
 **And** the controller receives `resume()` followed by `resumeAllJsTimers()`
 
-#### Scenario: Android — paint nudge after activity restart
+#### Scenario: Concurrent dispose does not strand process-global timers
 
-**Given** the user backgrounds the app, switches to another app, then returns
-**And** the platform view's surface was torn down and recreated by the activity restart
-**When** `AppLifecycleState.resumed` fires and `_resumeAfterLifecyclePause()` runs
-**Then** after `resumeFromAppLifecycle()` resolves, the active webview receives a
-no-op `evaluateJavascript` (`void (document.body && document.body.offsetHeight);`)
-**Because** Android's hybrid-composition pipeline can leave the freshly re-attached
-surface blank until something forces a layout pass. Reading `offsetHeight`
-synchronously triggers layout, which schedules a paint, which fills the surface
-with the page's pixels. The page itself is never paused-stuck — taps and JS still
-work — but without the nudge the user sees a black rectangle. iOS/macOS use the
-WebKit content process model and don't exhibit this; the nudge is gated on
-`Platform.isAndroid`. Fire-and-forget; failure is benign.
+**Given** `pauseForAppLifecycle()` / `resumeFromAppLifecycle()` is mid-flight on the active webview
+**And** a concurrent path calls `disposeWebView()` on that model (which only nulls the Dart `webview`/`controller` references — the native webview stays alive until the next widget rebuild)
+**When** the dispose lands between the per-instance `pause()`/`resume()` and the process-global `pauseAllJsTimers()`/`resumeAllJsTimers()`
+**Then** the global call still runs against the captured-local controller rather than throwing on a re-read `controller!`
+**Because** skipping `resumeAllJsTimers()` would leave every webview's JS timers frozen process-wide with no other path re-issuing the call — the page would be up but dead. The Android surface repaint and renderer recovery live in PAUSE-015 and PAUSE-014 respectively.
 
 ---
 

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -489,6 +489,38 @@ On Android the probe doubles as the surface paint nudge: reading `offsetHeight` 
 
 ---
 
+### Requirement: PAUSE-015 — Android Surface Repaint After Activity Restart
+
+On Android, tapping a pinned shortcut (or otherwise resuming) can recreate the activity. When it does, the Flutter base surface and the hybrid-composition webview `SurfaceView` can re-attach without receiving a paint: the renderer is alive (taps, scroll, JS all work) but the **web page area renders black, and the strip behind the edge-to-edge status bar renders black too** — distinct from a dead renderer (PAUSE-013/PAUSE-014), which a JS probe cannot detect because the renderer is healthy. The blank surface clears the moment a relayout occurs (device rotation, lock/unlock, or a tab switch).
+
+The system SHALL force a relayout on the activity-restart paths (`_resumeAfterLifecyclePause`, `_handleShortcutIntent`) via `_nudgeSurfaceRepaint`:
+
+- Toggle a transient 1px body inset around the IndexedStack several times over ~0.5s.
+- Each `setState` repaints the Flutter base surface (status-bar strip and chrome); each size flip resizes the webview platform view, forcing its `SurfaceView` to recomposite.
+- The nudge is spread across multiple frames because the recreated surface may not be attached on the first frame after resume — a single rebuild (the one already in `_setCurrentIndex`) fires too early to help.
+- The inset is always 0 in steady state and the nudge is a no-op on non-Android platforms.
+
+This is complementary to PAUSE-014: the probe recreates a *dead* renderer; the surface nudge repaints a *live* renderer whose surface came back blank. A JS `offsetHeight` read addresses neither the Flutter base surface nor the Android `SurfaceView` composition, which is why it is insufficient on its own.
+
+#### Scenario: Blank surface after shortcut recreates the activity
+
+**Given** a normal (non-fullscreen) site loaded in the background
+**And** the user taps its pinned shortcut, which recreates the Android activity
+**And** the webview platform-view surface re-attaches without a paint (page area and status-bar strip are black, page is alive)
+**When** `_handleShortcutIntent` activates the site
+**Then** `_nudgeSurfaceRepaint` toggles the 1px inset across several frames
+**And** the Flutter surface repaints and the webview `SurfaceView` recomposites
+**And** the page and status-bar strip become visible without the user rotating or locking the device
+
+#### Scenario: Nudge is inert off Android and in steady state
+
+**Given** the app is running on iOS/macOS/Linux, or no activity restart occurred
+**When** `_nudgeSurfaceRepaint` would run
+**Then** it is a no-op on non-Android platforms
+**And** `_repaintNudge` remains false so the body inset stays 0 — no visible jitter during normal use
+
+---
+
 ### Requirement: PAUSE-004 — Null-Safe Controller Access
 
 `pauseWebView()`, `resumeWebView()`, `pauseForAppLifecycle()`, and `resumeFromAppLifecycle()` SHALL be no-ops when the underlying controller has not yet been initialized or has been disposed.

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -444,6 +444,51 @@ The wrapper exposes a single `WebViewConfig.onRendererGone(bool didCrash)` callb
 
 ---
 
+### Requirement: PAUSE-014 — Proactive Renderer Probe on Activation
+
+The event-driven recovery in PAUSE-013 is not sufficient on its own, because the platform terminations it listens for do not reliably surface for a webview that was **offscreen** when its renderer died:
+
+- **iOS**: when WKWebView's web content process is jettisoned for a webview that is not in the visible view hierarchy, `onWebContentProcessDidTerminate` frequently does not fire. The webview then comes back blank with no event to drive recovery. This is the dominant render-death the user reports when returning to a backgrounded site via a pinned shortcut (the shortcut activates a site that was offscreen).
+- **Android**: the renderer can be alive but the hybrid-composition surface re-attaches blank after an activity restart, which emits no event at all.
+
+The system SHALL therefore probe the renderer of a webview when it becomes active and recreate it if the renderer is gone. The host runs the probe `_probeRendererAndRecover(model)`:
+
+- After resuming the active site on app resume (`_resumeAfterLifecyclePause`).
+- After resuming the newly-activated site on every site switch (`_setCurrentIndex`), which is the path a pinned-shortcut tap funnels through.
+
+The probe evaluates `document.body ? document.body.offsetHeight : -1` via `evaluateJavascriptReturning`. A live renderer returns a number; a dead renderer (whose `evaluateJavascript` throws) is surfaced as a `null` result. `rendererProbeIndicatesGone(result)` returns true only for `null` — every numeric value (`0`, `-1`, positive height) is treated as alive, so a healthy or still-loading page is never recreated. When the probe indicates gone, the host calls `handleRendererGone(didCrash: false)`, joining the same destroy-and-rebuild path as PAUSE-013. The probe is fire-and-forget and a no-op when the model has no controller (a fresh first-load).
+
+On Android the probe doubles as the surface paint nudge: reading `offsetHeight` forces a synchronous layout that schedules the missing paint, so a blank-but-alive surface is fixed by the probe itself without a recreate.
+
+#### Scenario: iOS content process jettisoned while offscreen, recovered on shortcut tap
+
+**Given** site A is loaded but offscreen (the user was on a different site, or the app was backgrounded)
+**And** iOS jettisons site A's web content process to reclaim memory
+**And** `onWebContentProcessDidTerminate` does not fire because site A was not on screen
+**When** the user taps the pinned shortcut for site A, routing through `_setCurrentIndex`
+**Then** `_probeRendererAndRecover` evaluates the probe against the dead content process
+**And** `evaluateJavascriptReturning` returns null (the call threw on the dead process)
+**And** `rendererProbeIndicatesGone(null)` is true
+**And** `handleRendererGone(didCrash: false)` recreates the webview at `currentUrl`
+**And** the user sees the page reload instead of a blank screen
+
+#### Scenario: Live renderer is not recreated
+
+**Given** a webview whose renderer is alive (probe returns `0`, `-1`, or a positive height)
+**When** `_probeRendererAndRecover` runs on activation
+**Then** `rendererProbeIndicatesGone` returns false
+**And** `handleRendererGone` is not called
+**And** the existing webview, its JS heap, and its back/forward stack are preserved
+
+#### Scenario: Probe skips a fresh first-load
+
+**Given** a site being activated for the first time whose `controller` has not yet been created
+**When** `_probeRendererAndRecover` is invoked
+**Then** it returns immediately without evaluating any JS
+**Because** there is no renderer to probe yet; the about-to-be-built controller starts alive.
+
+---
+
 ### Requirement: PAUSE-004 — Null-Safe Controller Access
 
 `pauseWebView()`, `resumeWebView()`, `pauseForAppLifecycle()`, and `resumeFromAppLifecycle()` SHALL be no-ops when the underlying controller has not yet been initialized or has been disposed.

--- a/test/webview_renderer_gone_test.dart
+++ b/test/webview_renderer_gone_test.dart
@@ -57,4 +57,22 @@ void main() {
       expect(rebuilds, 1);
     });
   });
+
+  group('rendererProbeIndicatesGone', () {
+    test('null result means the renderer process is gone', () {
+      // evaluateJavascriptReturning maps a dead-process throw to null
+      // (iOS WebContentProcessTerminated, Android renderer killed).
+      expect(rendererProbeIndicatesGone(null), isTrue);
+    });
+
+    test('numeric results mean the renderer is alive', () {
+      // Positive height (painted), 0 (about:blank), and -1 (document/body
+      // not built yet, still loading) are all live renderers — recreating
+      // on these would reload-loop a healthy page.
+      expect(rendererProbeIndicatesGone(640), isFalse);
+      expect(rendererProbeIndicatesGone(0), isFalse);
+      expect(rendererProbeIndicatesGone(-1), isFalse);
+      expect(rendererProbeIndicatesGone(12.5), isFalse);
+    });
+  });
 }


### PR DESCRIPTION
Returning to a backgrounded site via a pinned shortcut often lands on a
black/blank page. The event-driven renderer recovery (PAUSE-013) misses
it because the platform terminations don't fire for an offscreen webview:
on iOS onWebContentProcessDidTerminate frequently never fires when the
content process is jettisoned while the webview is off screen, and the
Android blank-surface case emits no event at all.

Probe the renderer on resume and on every site switch (the path a
shortcut tap funnels through) by reading document.body.offsetHeight; a
dead process surfaces as a null result and triggers the same destroy-
and-rebuild recovery. The read also forces the Android paint nudge,
subsuming the previous Android-only hack.