### PR TITLE
fix(webgl): fold Android WebGL kill-switch under tracking protection

### DIFF
--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -1218,14 +1218,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       'Umbrella per-site Enhanced Tracking Protection. When on, '
                       'forces ClearURLs, DNS Blocklist, and Content Blocker to be '
                       'active for this site, AND injects an anti-fingerprinting '
-                      'shim that randomizes Canvas, WebGL, audio, font metrics, '
+                      'shim that randomizes Canvas, audio, font metrics, '
                       'screen dimensions, hardware concurrency, plugins, battery, '
                       'speech voices, high-resolution timers, and bounding-box '
                       'measurements. The fingerprint stays stable per site across '
                       'launches but differs between sites and between users. '
                       'When Incognito is also enabled for this site, the '
                       'fingerprint is rerolled on every app launch so the '
-                      'site cannot re-identify you across cold restarts.',
+                      'site cannot re-identify you across cold restarts. '
+                      'WebGL is disabled entirely while this is on; turn it off '
+                      'for sites that need WebGL (maps, 3D viewers).',
                 ),
               ],
             ),

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1310,22 +1310,29 @@ class WebViewFactory {
 
     final userScripts = <inapp.UserScript>[];
 
-    // WebGL kill-switch (Android). LinkedIn's `protechts.net`
-    // fingerprint script (and other sites) try to create a WebGL
-    // context on every page; on this device's WebView build that
-    // walks a chromium code path with a dangling-raw_ptr regression
-    // and SIGTRAPs the renderer at `partition_alloc_support.cc:770`.
-    // `hardwareAcceleration: false` does NOT prevent this — chromium
-    // still walks the WebGL blocklist code path even with software
-    // compositing — and there's no `disableWebGL` flag in
-    // InAppWebViewSettings. The only mechanism that actually works
-    // is shimming the JS API so getContext() returns null for WebGL
-    // types, which means JS never asks for the context and chromium
-    // never enters the blocklist cleanup path.
+    // WebGL kill-switch (Android), folded under tracking protection.
+    // LinkedIn's `protechts.net` fingerprint script (and other sites)
+    // try to create a WebGL context on every page; on this device's
+    // WebView build that walks a chromium code path with a
+    // dangling-raw_ptr regression and SIGTRAPs the renderer at
+    // `partition_alloc_support.cc:770`. `hardwareAcceleration: false`
+    // does NOT prevent this (chromium still walks the WebGL blocklist
+    // code path even with software compositing), and there's no
+    // `disableWebGL` flag in InAppWebViewSettings. The only mechanism
+    // that actually works is shimming the JS API so getContext()
+    // returns null for WebGL types, so JS never asks for the context
+    // and chromium never enters the blocklist cleanup path.
+    //
+    // Stripping the entire WebGL surface is also the strongest answer
+    // to WebGL fingerprinting, so it rides the per-site tracking
+    // protection toggle. ETP-on sites get no WebGL at all (the
+    // anti-fingerprinting shim's vendor/renderer masking is moot here);
+    // turning tracking protection off for a site restores WebGL2 for
+    // legitimate uses like maps and 3D viewers (issue #391, gpx.studio).
     //
     // iOS/macOS WebKit doesn't have the regression, so leave WebGL
     // alone there.
-    if (Platform.isAndroid) {
+    if (Platform.isAndroid && config.trackingProtectionEnabled) {
       userScripts.add(inapp.UserScript(
         groupName: 'webgl_kill_switch',
         source: '$_webGlKillSwitchScript\n;null;',

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1310,29 +1310,27 @@ class WebViewFactory {
 
     final userScripts = <inapp.UserScript>[];
 
-    // WebGL kill-switch (Android), folded under tracking protection.
-    // LinkedIn's `protechts.net` fingerprint script (and other sites)
-    // try to create a WebGL context on every page; on this device's
-    // WebView build that walks a chromium code path with a
-    // dangling-raw_ptr regression and SIGTRAPs the renderer at
-    // `partition_alloc_support.cc:770`. `hardwareAcceleration: false`
-    // does NOT prevent this (chromium still walks the WebGL blocklist
-    // code path even with software compositing), and there's no
-    // `disableWebGL` flag in InAppWebViewSettings. The only mechanism
-    // that actually works is shimming the JS API so getContext()
-    // returns null for WebGL types, so JS never asks for the context
-    // and chromium never enters the blocklist cleanup path.
+    // WebGL kill-switch, folded under tracking protection. Stripping the
+    // entire WebGL surface is the strongest answer to WebGL
+    // fingerprinting, so it rides the per-site tracking protection
+    // toggle on every platform: ETP-on sites get no WebGL at all (the
+    // anti-fingerprinting shim's vendor/renderer masking is moot once
+    // the constructors are gone), while turning tracking protection off
+    // for a site restores WebGL2 for legitimate uses like maps and 3D
+    // viewers (issue #391, gpx.studio).
     //
-    // Stripping the entire WebGL surface is also the strongest answer
-    // to WebGL fingerprinting, so it rides the per-site tracking
-    // protection toggle. ETP-on sites get no WebGL at all (the
-    // anti-fingerprinting shim's vendor/renderer masking is moot here);
-    // turning tracking protection off for a site restores WebGL2 for
-    // legitimate uses like maps and 3D viewers (issue #391, gpx.studio).
-    //
-    // iOS/macOS WebKit doesn't have the regression, so leave WebGL
-    // alone there.
-    if (Platform.isAndroid && config.trackingProtectionEnabled) {
+    // On Android it doubles as a crash workaround: LinkedIn's
+    // `protechts.net` fingerprint script (and others) try to create a
+    // WebGL context on every page, and on this device's WebView build
+    // that walks a chromium code path with a dangling-raw_ptr regression
+    // and SIGTRAPs the renderer at `partition_alloc_support.cc:770`.
+    // `hardwareAcceleration: false` does NOT prevent this (chromium
+    // still walks the WebGL blocklist code path even with software
+    // compositing), and there's no `disableWebGL` flag in
+    // InAppWebViewSettings. Shimming the JS API so getContext() returns
+    // null for WebGL types means JS never asks for the context and
+    // chromium never enters the blocklist cleanup path.
+    if (config.trackingProtectionEnabled) {
       userScripts.add(inapp.UserScript(
         groupName: 'webgl_kill_switch',
         source: '$_webGlKillSwitchScript\n;null;',


### PR DESCRIPTION
The kill-switch deleted WebGLRenderingContext/WebGL2RenderingContext on
every Android site unconditionally, breaking legitimate WebGL2 sites
(issue #391, gpx.studio). Gate it on the per-site tracking protection
toggle so disabling ETP for a site restores WebGL.