### PR TITLE
fix(ios-ul): bypass GET redirects following a form POST

### DIFF
--- a/lib/services/ios_universal_link_bypass.dart
+++ b/lib/services/ios_universal_link_bypass.dart
@@ -17,12 +17,17 @@
 /// redirects without a tap origin, pushState) don't activate AASA
 /// in the first place and are passed through without interception.
 ///
-/// `.formSubmitted` is intentionally NOT bypassed. `loadUrl` is a
-/// GET, so reissuing a form submit drops the POST body, which
-/// breaks credentialed flows (login, search, payments). Form POSTs
-/// to AASA-matching endpoints are exceedingly rare; apps publish
-/// AASA for content URLs (profile pages, map locations), not POST
-/// handlers.
+/// A `.formSubmitted` action whose HTTP method carries a body (POST,
+/// PUT, PATCH) is NOT bypassed. `loadUrl` is a GET, so reissuing it
+/// drops the body and breaks credentialed flows (login, search,
+/// payments). But WKWebView also tags a *server redirect that
+/// follows* a form POST as `.formSubmitted`, and that hop is
+/// re-fetched as a bodyless GET (302/303 → GET). Those are eligible:
+/// reissuing a GET via `loadUrl` is lossless, and it is exactly the
+/// hop that lets Google Maps' `consent.google.com/save → maps.google.com`
+/// redirect escape into the native app. So `.formSubmitted` is
+/// bypassed only when the request method is GET/HEAD; POST/PUT/PATCH
+/// pass through with the body intact.
 ///
 /// No domain/path list. iOS exposes no public API to ask "does this
 /// URL match an installed app's AASA?", so the bypass treats every
@@ -35,19 +40,33 @@ class IosUniversalLinkBypass {
   IosUniversalLinkBypass();
 
   /// Webview-side gate: is this navigation eligible for the AASA
-  /// bypass? Returns true only for main-frame http(s) navigations
-  /// rooted in a user tap on a link. Form POSTs are intentionally
-  /// excluded — see the class doc for why.
+  /// bypass? Returns true for main-frame http(s) navigations rooted
+  /// in a user tap on a link, and for form-submit navigations whose
+  /// HTTP method has no body (a server redirect following a form POST
+  /// is re-issued by WebKit as a GET but still tagged `.formSubmitted`).
+  /// Body-carrying form submits (POST/PUT/PATCH) are excluded — see
+  /// the class doc for why.
   ///
-  /// Caller passes `isLinkActivated = navigationAction.navigationType
-  /// == NavigationType.LINK_ACTIVATED` to keep this predicate free of
+  /// Caller passes `isLinkActivated` / `isFormSubmitted` derived from
+  /// `navigationAction.navigationType` and `httpMethod` from
+  /// `navigationAction.request.method` to keep this predicate free of
   /// flutter_inappwebview imports (and unit-testable from pure Dart).
   static bool isEligibleNavigation({
     required bool isMainFrame,
     required String url,
     required bool isLinkActivated,
+    bool isFormSubmitted = false,
+    String? httpMethod,
   }) {
-    return isMainFrame && url.startsWith('http') && isLinkActivated;
+    if (!isMainFrame || !url.startsWith('http')) return false;
+    if (isLinkActivated) return true;
+    if (isFormSubmitted) {
+      // Only reissue when we positively know the method is bodyless.
+      // Unknown method → pass through (preserve a possible POST body).
+      final m = httpMethod?.toUpperCase();
+      return m == 'GET' || m == 'HEAD';
+    }
+    return false;
   }
 
   /// Per-WebView memo: URL → timestamp of the cancel-and-reissue.

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -2617,14 +2617,17 @@ class WebViewFactory {
         // reissued nav fires `shouldOverrideUrlLoading` again; the
         // per-URL memo passes that second pass through.
         //
-        // Scoped to LINK_ACTIVATED only — FORM_SUBMITTED is
-        // intentionally passed through. Reissuing a form submit via
-        // `loadUrl` would drop the POST body (loadUrl is GET), which
-        // breaks every credentialed form on the web (logins, search,
-        // payments). LinkedIn's `/checkpoint/lg/login-submit` was the
-        // canonical 404 case. Form POSTs to AASA-matching endpoints
-        // are exceedingly rare; apps publish AASA for content URLs
-        // (profile pages, map locations), not POST handlers.
+        // Scoped to LINK_ACTIVATED plus bodyless (GET/HEAD)
+        // FORM_SUBMITTED. A body-carrying form POST is passed through:
+        // reissuing it via `loadUrl` (a GET) would drop the POST body
+        // and break every credentialed form on the web (logins, search,
+        // payments) — LinkedIn's `/checkpoint/lg/login-submit` was the
+        // canonical 404 case. But WKWebView also tags the server
+        // redirect that *follows* a form POST as FORM_SUBMITTED, and
+        // that hop is re-fetched as a GET (302/303 → GET). That hop is
+        // exactly the one that lets Google Maps'
+        // `consent.google.com/save → maps.google.com` redirect escape
+        // into the native app, so a GET/HEAD FORM_SUBMITTED is eligible.
         //
         // Pure programmatic navigations (initial nav, server
         // redirects without a tap origin, pushState) carry no user
@@ -2636,6 +2639,9 @@ class WebViewFactory {
               url: url,
               isLinkActivated: navigationAction.navigationType ==
                   inapp.NavigationType.LINK_ACTIVATED,
+              isFormSubmitted: navigationAction.navigationType ==
+                  inapp.NavigationType.FORM_SUBMITTED,
+              httpMethod: navigationAction.request.method,
             )) {
           if (iosUlBypass.shouldCancelAndReissue(url)) {
             LogService.instance.log(

--- a/openspec/specs/ios-universal-link-bypass/spec.md
+++ b/openspec/specs/ios-universal-link-bypass/spec.md
@@ -30,9 +30,11 @@ Universal Link routing happens **after** `decidePolicyForNavigationAction:decisi
 
 ## Solution
 
-Generic prophylactic bypass: on iOS, treat **every main-frame http(s) navigation whose `navigationType` is `.linkActivated` (user tap on a link)** as at-risk. Cancel the navigation, then reissue the same URL via `controller.loadUrl`. WebKit treats programmatic loads as navigation type `.other` and **does not match them against AASA**, so the URL renders inside the webview regardless of which apps are installed.
+Generic prophylactic bypass: on iOS, treat **every main-frame http(s) navigation whose `navigationType` is `.linkActivated` (user tap on a link)**, plus **bodyless (`GET`/`HEAD`) `.formSubmitted` navigations**, as at-risk. Cancel the navigation, then reissue the same URL via `controller.loadUrl`. WebKit treats programmatic loads as navigation type `.other` and **does not match them against AASA**, so the URL renders inside the webview regardless of which apps are installed.
 
-`.formSubmitted` is intentionally excluded. `loadUrl` is a GET, so reissuing a form submit would drop the POST body and break every credentialed form (logins, search, payments) — LinkedIn's `/checkpoint/lg/login-submit` 404ing under the broader filter was the prompt to narrow the scope. AASA matches on POST endpoints are vanishingly rare in practice; apps publish AASA for content URLs, not form handlers.
+A `.formSubmitted` action whose request method carries a body (`POST`/`PUT`/`PATCH`) is excluded. `loadUrl` is a GET, so reissuing it would drop the body and break every credentialed form (logins, search, payments) — LinkedIn's `/checkpoint/lg/login-submit` 404ing under the broader filter was the prompt to narrow the scope. AASA matches on POST endpoints are vanishingly rare in practice; apps publish AASA for content URLs, not form handlers.
+
+The catch is that WKWebView also tags the **server redirect that follows a form POST** as `.formSubmitted`, and that hop is re-fetched as a bodyless `GET` (302/303 → GET). That hop is exactly the one that escaped the original `.linkActivated`-only filter: the user-reported Google Maps chain ends with `consent.google.com/save` (a POST) 302ing to `www.google.com/maps`, which the device then routes into the native Maps app. Because the redirect target is a `GET`, reissuing it via `loadUrl` is lossless, so `.formSubmitted` navigations are bypassed when — and only when — the request method is `GET`/`HEAD`. An unknown/unreported method passes through unchanged (conservative: we can't rule out a POST body).
 
 Pure programmatic navigations (initial nav from `initialUrlRequest`, server redirects without a tap origin, pushState SPA navs) carry no user gesture and don't activate AASA in the first place. Those are passed through without interception, so the bypass adds no overhead to the common case.
 
@@ -54,7 +56,7 @@ This is consistent with WebSpace's overall posture (webview-first, opt-in extern
 
 ### Requirement: IOS-UL-001 - Cancel-and-Reissue Tap-Rooted Navigations
 
-The system SHALL cancel main-frame http(s) navigations whose `WKNavigationAction.navigationType` is `.linkActivated` and reissue the same URL via `controller.loadUrl` with the original headers preserved.
+The system SHALL cancel main-frame http(s) navigations whose `WKNavigationAction.navigationType` is `.linkActivated`, or whose `navigationType` is `.formSubmitted` with a bodyless request method (`GET`/`HEAD`), and reissue the same URL via `controller.loadUrl` with the original headers preserved.
 
 #### Scenario: User taps a link to a URL that matches an installed app's AASA
 
@@ -66,21 +68,30 @@ The system SHALL cancel main-frame http(s) navigations whose `WKNavigationAction
 **And** the page renders inside the webview
 **And** the native app does NOT open
 
+#### Scenario: GET redirect following a form POST is bypassed
+
+**Given** the device has the Google Maps app installed
+**And** the user accepts the cookie consent banner, which POSTs to `consent.google.com/save`
+**When** the server 302-redirects to `https://www.google.com/maps` and WKWebView fires `decidePolicyForNavigationAction` with `navigationType == .formSubmitted` and `request.method == "GET"`
+**Then** the navigation is cancelled and reissued via `controller.loadUrl`
+**And** the maps page renders inside the webview
+**And** the native Google Maps app does NOT open
+
 #### Scenario: Form POST is passed through unchanged
 
-**Given** the user submits a credentialed form (login, search, payment) via POST
-**When** WKWebView fires `decidePolicyForNavigationAction` with `navigationType == .formSubmitted`
+**Given** the user submits a credentialed form (login, payment) via POST
+**When** WKWebView fires `decidePolicyForNavigationAction` with `navigationType == .formSubmitted` and `request.method == "POST"`
 **Then** the bypass does NOT fire
 **And** the navigation is allowed through with the POST body intact
 **And** the server receives the POST and responds normally (e.g. LinkedIn's `/checkpoint/lg/login-submit` accepts the credentials instead of 404ing a GET)
 
-Rationale: `loadUrl` is a GET. Reissuing a `.formSubmitted` action would drop the POST body and break every credentialed form on the web. Form POSTs to AASA-matching endpoints are exceedingly rare in practice — apps publish AASA for content URLs (profile pages, map locations), not POST handlers — so passing them through trades a rare false-negative for a critical false-positive that broke logins on major sites.
+Rationale: `loadUrl` is a GET. Reissuing a body-carrying `.formSubmitted` action would drop the POST body and break every credentialed form on the web. The discriminator is the request method: a server redirect that follows a form POST is re-fetched as a bodyless GET (and still tagged `.formSubmitted`), so it is safe to reissue and is exactly the hop that escaped the original `.linkActivated`-only filter. A reported/known POST method is passed through; an unknown method is also passed through (conservative — we can't rule out a body).
 
 ---
 
 ### Requirement: IOS-UL-002 - Pass Through Programmatic Navigations
 
-The system SHALL NOT intercept navigations whose `navigationType` is anything other than `.linkActivated` (including `.formSubmitted`, `.other`, `.backForward`, `.reload`).
+The system SHALL NOT intercept navigations whose `navigationType` is `.other`, `.backForward`, or `.reload`, nor `.formSubmitted` navigations carrying a body (`POST`/`PUT`/`PATCH` or an unreported method).
 
 #### Scenario: Initial site load
 
@@ -207,9 +218,15 @@ The class is the entire URL-matching surface: no domain or path filter. The webv
 
 ```dart
 if (Platform.isIOS &&
-    isMainFrame &&
-    url.startsWith('http') &&
-    navigationAction.navigationType == inapp.NavigationType.LINK_ACTIVATED) {
+    IosUniversalLinkBypass.isEligibleNavigation(
+      isMainFrame: isMainFrame,
+      url: url,
+      isLinkActivated:
+          navigationAction.navigationType == inapp.NavigationType.LINK_ACTIVATED,
+      isFormSubmitted:
+          navigationAction.navigationType == inapp.NavigationType.FORM_SUBMITTED,
+      httpMethod: navigationAction.request.method,
+    )) {
   if (iosUlBypass.shouldCancelAndReissue(url)) {
     final originalUrl = navigationAction.request.url;
     final originalHeaders = navigationAction.request.headers;
@@ -224,7 +241,7 @@ if (Platform.isIOS &&
 return inapp.NavigationActionPolicy.ALLOW;
 ```
 
-`LINK_ACTIVATED` is the eligibility filter: iOS routes both `.linkActivated` and `.formSubmitted` through AASA, but reissuing `.formSubmitted` via `loadUrl` (a GET) would drop the POST body. The narrower filter accepts the rare false-negative (form POST whose response would have UL-matched) in exchange for not breaking every credentialed login form.
+iOS routes both `.linkActivated` and `.formSubmitted` through AASA. `.linkActivated` is always eligible. `.formSubmitted` is eligible only when `request.method` is `GET`/`HEAD`: that covers the server redirect that follows a form POST (re-fetched as a bodyless GET, still tagged `.formSubmitted`) — the hop that launched the native Maps app — without reissuing a real `POST` as a body-dropping GET and breaking credentialed login forms.
 
 ### Why the bypass runs after all other policy checks
 

--- a/test/ios_universal_link_bypass_test.dart
+++ b/test/ios_universal_link_bypass_test.dart
@@ -114,6 +114,56 @@ void main() {
           isMainFrame: true,
           url: 'https://www.linkedin.com/checkpoint/lg/login-submit?_l=de_DE',
           isLinkActivated: false,
+          isFormSubmitted: true,
+          httpMethod: 'POST',
+        ),
+        isFalse,
+      );
+    });
+
+    test('GET redirect following a form POST IS eligible', () {
+      // The user-reported Google Maps case: tapping "accept cookies" on
+      // consent.google.com POSTs to /save, which 302s to maps.google.com.
+      // WKWebView tags that redirect hop .formSubmitted, but it is
+      // re-fetched as a bodyless GET. Reissuing a GET via loadUrl is
+      // lossless and is what keeps the native Maps app from launching.
+      expect(
+        IosUniversalLinkBypass.isEligibleNavigation(
+          isMainFrame: true,
+          url: 'https://maps.google.com/maps',
+          isLinkActivated: false,
+          isFormSubmitted: true,
+          httpMethod: 'GET',
+        ),
+        isTrue,
+      );
+    });
+
+    test('GET-method form submit (search box) IS eligible', () {
+      // A GET form (e.g. a search box) has its params in the query
+      // string, no body to drop, so reissuing via loadUrl is safe.
+      expect(
+        IosUniversalLinkBypass.isEligibleNavigation(
+          isMainFrame: true,
+          url: 'https://maps.google.com/maps?q=cafe',
+          isLinkActivated: false,
+          isFormSubmitted: true,
+          httpMethod: 'get',
+        ),
+        isTrue,
+      );
+    });
+
+    test('form submit with unknown method is NOT eligible', () {
+      // Conservative default: if the platform doesn't report a method,
+      // we can't rule out a POST body, so pass through unchanged.
+      expect(
+        IosUniversalLinkBypass.isEligibleNavigation(
+          isMainFrame: true,
+          url: 'https://maps.google.com/maps',
+          isLinkActivated: false,
+          isFormSubmitted: true,
+          httpMethod: null,
         ),
         isFalse,
       );


### PR DESCRIPTION
The Google Maps consent flow ends with consent.google.com/save (POST)
302ing to maps.google.com; WKWebView tags that redirect hop
.formSubmitted, which the LINK_ACTIVATED-only bypass skipped, so iOS
routed it into the native Maps app. Reissue .formSubmitted navs too
when the request method is GET/HEAD (bodyless, lossless to reissue);
real POST/PUT/PATCH still pass through with the body intact.

https://claude.ai/code/session_01KskuXdepTKjxM9b29qH9BH