### PR TITLE
Add option to keep tab strip visible in fullscreen mode

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -889,6 +889,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   bool _maskBackground = false;
   bool _showUrlBar = false;
   bool _showTabStrip = false;
+  bool _tabStripInFullscreen = false;
   bool _linkHandlingEnabled = true;
   bool _showStatsBanner = true;
 
@@ -2459,6 +2460,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await prefs.setBool('showTabStrip', _showTabStrip);
   }
 
+  Future<void> _saveTabStripInFullscreen() async {
+    if (isDemoMode) return;
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('tabStripInFullscreen', _tabStripInFullscreen);
+  }
+
   Future<void> _saveShowStatsBanner() async {
     if (isDemoMode) return;
     SharedPreferences prefs = await SharedPreferences.getInstance();
@@ -3362,6 +3369,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       }
       _showUrlBar = prefs.getBool('showUrlBar') ?? false;
       _showTabStrip = prefs.getBool('showTabStrip') ?? false;
+      _tabStripInFullscreen = prefs.getBool('tabStripInFullscreen') ?? false;
       _showStatsBanner = prefs.getBool('showStatsBanner') ?? true;
       _linkHandlingEnabled = prefs.getBool(kLinkHandlingEnabledKey) ?? true;
       widget.onThemeSettingsChanged(_themeSettings);
@@ -4198,6 +4206,8 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           backup.globalPrefs['showUrlBar'] as bool? ?? _showUrlBar;
       _showTabStrip =
           backup.globalPrefs['showTabStrip'] as bool? ?? _showTabStrip;
+      _tabStripInFullscreen =
+          backup.globalPrefs['tabStripInFullscreen'] as bool? ?? _tabStripInFullscreen;
       _showStatsBanner =
           backup.globalPrefs['showStatsBanner'] as bool? ?? _showStatsBanner;
 
@@ -4623,6 +4633,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                       });
                       _saveShowTabStrip();
                     },
+                    tabStripInFullscreen: _tabStripInFullscreen,
+                    onTabStripInFullscreenChanged: (value) {
+                      setState(() {
+                        _tabStripInFullscreen = value;
+                      });
+                      _saveTabStripInFullscreen();
+                    },
                     showStatsBanner: _showStatsBanner,
                     onShowStatsBannerChanged: (value) {
                       setState(() {
@@ -4848,7 +4865,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   /// Build the tab strip shown in bottomNavigationBar.
   /// This stays at the screen bottom and doesn't need to be above the keyboard.
   Widget? _buildTabStrip() {
-    if (_isFullscreen) return null;
+    if (_isFullscreen && !_tabStripInFullscreen) return null;
     if (_currentIndex == null || _currentIndex! >= _webViewModels.length) {
       return null;
     }
@@ -5959,7 +5976,10 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     // Input bar has its own SafeArea. Only apply body safe area when neither
     // is present (e.g. webspace list screen).
     final filteredIndices = _getFilteredSiteIndices();
-    final hasTabStrip = _currentIndex != null
+    // The tab strip is also rendered (in bottomNavigationBar) when kept in
+    // fullscreen, in which case it owns the bottom safe-area inset.
+    final hasTabStrip = (!_isFullscreen || _tabStripInFullscreen)
+        && _currentIndex != null
         && _currentIndex! < _webViewModels.length
         && _showTabStrip
         && filteredIndices.isNotEmpty;
@@ -5972,7 +5992,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       // it stays clear of any bars that persist; when they are truly hidden the
       // padding is ~0 and the webview still fills the screen. github #385
       top: _isFullscreen,
-      bottom: _isFullscreen || (!hasTabStrip && inputBar == null),
+      bottom: !hasTabStrip && inputBar == null,
       // Use Stack + Offstage so the IndexedStack (and its webview States)
       // stay mounted when showing the webspace list. Removing the
       // IndexedStack from the tree destroys webview States, losing

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -51,6 +51,8 @@ class AppSettingsScreen extends StatefulWidget {
   final VoidCallback? onCloseAllArchives;
   final bool showTabStrip;
   final ValueChanged<bool> onShowTabStripChanged;
+  final bool tabStripInFullscreen;
+  final ValueChanged<bool> onTabStripInFullscreenChanged;
   final bool showStatsBanner;
   final ValueChanged<bool> onShowStatsBannerChanged;
   /// LIR-008: master "Handle shared links" switch + entry into the
@@ -83,6 +85,8 @@ class AppSettingsScreen extends StatefulWidget {
     this.onCloseAllArchives,
     required this.showTabStrip,
     required this.onShowTabStripChanged,
+    required this.tabStripInFullscreen,
+    required this.onTabStripInFullscreenChanged,
     required this.showStatsBanner,
     required this.onShowStatsBannerChanged,
     required this.linkHandlingEnabled,
@@ -101,6 +105,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
     with SingleTickerProviderStateMixin {
   late AppThemeSettings _settings;
   late bool _showTabStrip;
+  late bool _tabStripInFullscreen;
   late bool _showStatsBanner;
   late TextEditingController _osmTileUrlController;
   bool _isDownloadingRules = false;
@@ -154,6 +159,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
     super.initState();
     _settings = widget.currentSettings;
     _showTabStrip = widget.showTabStrip;
+    _tabStripInFullscreen = widget.tabStripInFullscreen;
     _showStatsBanner = widget.showStatsBanner;
     _osmTileUrlController = TextEditingController();
     _loadOsmTileUrl();
@@ -721,6 +727,19 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
               });
               widget.onShowTabStripChanged(value);
             },
+          ),
+          SwitchListTile(
+            title: const Text('Keep Tab Strip in Full Screen'),
+            subtitle: const Text('Keep the tab bar visible in full screen while the top bar stays hidden'),
+            value: _tabStripInFullscreen,
+            onChanged: _showTabStrip
+                ? (value) {
+                    setState(() {
+                      _tabStripInFullscreen = value;
+                    });
+                    widget.onTabStripInFullscreenChanged(value);
+                  }
+                : null,
           ),
           SwitchListTile(
             title: const Text('Stats Bar'),

--- a/lib/settings/app_prefs.dart
+++ b/lib/settings/app_prefs.dart
@@ -23,6 +23,9 @@ import 'package:webspace/settings/global_outbound_proxy.dart';
 final Map<String, Object> kExportedAppPrefs = <String, Object>{
   'showUrlBar': false,
   'showTabStrip': false,
+  // Keep the site tab strip visible in fullscreen (top bar still hidden).
+  // Only meaningful when showTabStrip is on.
+  'tabStripInFullscreen': false,
   'showStatsBanner': true,
   // Tile URL used by the optional location picker map. Only queried after
   // the user explicitly taps "Load map" on the picker — no requests happen

--- a/openspec/specs/fullscreen-mode/spec.md
+++ b/openspec/specs/fullscreen-mode/spec.md
@@ -124,6 +124,31 @@ The system SHALL exit full screen when navigating to the webspaces list.
 
 ---
 
+### Requirement: FS-007 - Keep Tab Strip in Full Screen
+
+The system SHALL support a global option to keep the site tab strip visible in full screen while the app bar and URL bar stay hidden, giving more screen space without losing quick site switching. The option only applies when the tab strip is enabled.
+
+#### Scenario: Tab strip kept in full screen
+
+**Given** "Site Tab Strip" is enabled
+**And** "Keep Tab Strip in Full Screen" is enabled
+**When** the user enters full screen mode
+**Then** the app bar, URL bar, find toolbar, and system UI are hidden
+**And** the tab strip remains visible at the bottom
+
+#### Scenario: Tab strip hidden in full screen (default)
+
+**Given** "Keep Tab Strip in Full Screen" is disabled
+**When** the user enters full screen mode
+**Then** the tab strip is hidden along with the app bar and URL bar
+
+#### Scenario: Option gated on tab strip
+
+**Given** "Site Tab Strip" is disabled
+**Then** the "Keep Tab Strip in Full Screen" toggle is disabled (no tab strip to keep)
+
+---
+
 ### Requirement: FS-006 - Content Reachable Under Persistent System Bars
 
 The system SHALL keep the site's content reachable in full screen even when the platform fails to hide the system bars (e.g. Android 15 edge-to-edge, where `immersiveSticky` does not always hide the status/navigation bars).
@@ -154,11 +179,12 @@ The system SHALL keep the site's content reachable in full screen even when the 
 
 **_WebSpacePageState** (`lib/main.dart`):
 - `bool _isFullscreen = false` - Current fullscreen state (not persisted; runtime only)
+- `bool _tabStripInFullscreen = false` - Global pref mirror of the `tabStripInFullscreen` SharedPreferences key (registered in `kExportedAppPrefs`, round-trips through settings backup)
 
 ### UI Changes
 
 - **App bar**: Hidden when `_isFullscreen` is true (`appBar: _isFullscreen ? null : _buildAppBar()`)
-- **Tab strip**: `_buildTabStrip()` returns null when `_isFullscreen`
+- **Tab strip**: `_buildTabStrip()` returns null when `_isFullscreen` unless the global `tabStripInFullscreen` pref is set (then it stays in `bottomNavigationBar` and owns the bottom safe-area inset)
 - **Input bar**: `_buildInputBar()` returns null when `_isFullscreen`
 - **Body insets**: The fullscreen body keeps `SafeArea` active on both edges (`top: _isFullscreen`, `bottom: _isFullscreen || ...`). `immersiveSticky` does not reliably hide the system bars on Android 15 (edge-to-edge enforced); when a bar persists, the inset keeps the site's top/bottom controls clear of it. When the bars are truly hidden the inset is ~0 and the webview still fills the screen.
 - **Exit zone**: GestureDetector at top edge when fullscreen (`MediaQuery.padding.top + 20px`, measured inside the body `SafeArea`) with visible translucent handle just below the notch/status bar


### PR DESCRIPTION
Adds a new global preference `tabStripInFullscreen` that allows users to keep the site tab strip visible while in fullscreen mode, providing quick site switching without the app bar and URL bar.

Key changes:
- New requirement FS-007 in fullscreen spec with three scenarios: tab strip kept visible, hidden (default), and gated on tab strip being enabled
- Added `_tabStripInFullscreen` state variable to `WebSpacePageState` with persistence via SharedPreferences and settings backup
- Modified `_buildTabStrip()` to return the tab strip when fullscreen if the preference is enabled
- Updated safe area inset logic: tab strip now owns the bottom inset when kept in fullscreen, so body safe area bottom is only applied when no tab strip or input bar is present
- Added "Keep Tab Strip in Full Screen" toggle in app settings, disabled when tab strip itself is disabled
- Registered `tabStripInFullscreen` in `kExportedAppPrefs` for settings backup/restore

The tab strip remains in `bottomNavigationBar` and maintains its own safe area inset when visible in fullscreen, keeping the webview content clear of system bars.

https://claude.ai/code/session_01KJXYvaxZXALMre8ULXfspX