### PR TITLE
Rebind orphaned home shortcuts by domain (HS-011)

### DIFF
--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -79,20 +79,26 @@ class MainActivity: FlutterActivity() {
                     val siteId = call.argument<String>("siteId")
                     val label = call.argument<String>("label")
                     val iconUrl = call.argument<String>("iconUrl")
+                    val iconBytes = call.argument<ByteArray>("iconBytes")
 
                     if (siteId == null || label == null) {
                         result.error("INVALID_ARGS", "siteId and label are required", null)
                         return@setMethodCallHandler
                     }
 
-                    pinShortcut(siteId, label, iconUrl, result)
+                    pinShortcut(siteId, label, iconBytes, iconUrl, result)
                 }
                 "removeShortcut" -> {
                     val siteId = call.argument<String>("siteId")
                     if (siteId != null) {
+                        // Remove any dynamic copy, but DO NOT disable the pinned
+                        // shortcut: HS-011 keeps the launcher tile alive so a tap
+                        // after the site is deleted still launches the app and
+                        // re-routes via the siteId->url ledger (offer to open a
+                        // domain match or create a new site). Disabling it makes
+                        // the launcher refuse the tap with "shortcut isn't
+                        // available", which defeats that recovery.
                         ShortcutManagerCompat.removeDynamicShortcuts(this, listOf("site_$siteId"))
-                        // Also disable the pinned shortcut so it shows as unavailable
-                        ShortcutManagerCompat.disableShortcuts(this, listOf("site_$siteId"), "Site has been removed")
                     }
                     result.success(true)
                 }
@@ -125,7 +131,7 @@ class MainActivity: FlutterActivity() {
         }
     }
 
-    private fun pinShortcut(siteId: String, label: String, iconUrl: String?, result: MethodChannel.Result) {
+    private fun pinShortcut(siteId: String, label: String, iconBytes: ByteArray?, iconUrl: String?, result: MethodChannel.Result) {
         if (!ShortcutManagerCompat.isRequestPinShortcutSupported(this)) {
             result.error("NOT_SUPPORTED", "Pinned shortcuts not supported on this device", null)
             return
@@ -139,17 +145,26 @@ class MainActivity: FlutterActivity() {
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 }
 
-                val icon = if (iconUrl != null) {
-                    try {
-                        val stream = URL(iconUrl).openStream()
-                        val bitmap = BitmapFactory.decodeStream(stream)
-                        stream.close()
-                        if (bitmap != null) IconCompat.createWithBitmap(bitmap) else IconCompat.createWithResource(this, R.mipmap.ic_launcher)
-                    } catch (e: Exception) {
-                        IconCompat.createWithResource(this, R.mipmap.ic_launcher)
+                val appIcon = IconCompat.createWithResource(this, R.mipmap.ic_launcher)
+                // Prefer Dart-rasterized PNG bytes (handles SVG/ICO favicons that
+                // BitmapFactory.decodeStream can't). Fall back to downloading the
+                // raw iconUrl, then to the app icon.
+                val icon = when {
+                    iconBytes != null -> {
+                        val bmp = BitmapFactory.decodeByteArray(iconBytes, 0, iconBytes.size)
+                        if (bmp != null) IconCompat.createWithBitmap(bmp) else appIcon
                     }
-                } else {
-                    IconCompat.createWithResource(this, R.mipmap.ic_launcher)
+                    iconUrl != null -> {
+                        try {
+                            val stream = URL(iconUrl).openStream()
+                            val bitmap = BitmapFactory.decodeStream(stream)
+                            stream.close()
+                            if (bitmap != null) IconCompat.createWithBitmap(bitmap) else appIcon
+                        } catch (e: Exception) {
+                            appIcon
+                        }
+                    }
+                    else -> appIcon
                 }
 
                 val shortcut = ShortcutInfoCompat.Builder(this, "site_$siteId")

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -79,13 +79,14 @@ class MainActivity: FlutterActivity() {
                     val siteId = call.argument<String>("siteId")
                     val label = call.argument<String>("label")
                     val iconUrl = call.argument<String>("iconUrl")
+                    val siteUrl = call.argument<String>("siteUrl")
 
                     if (siteId == null || label == null) {
                         result.error("INVALID_ARGS", "siteId and label are required", null)
                         return@setMethodCallHandler
                     }
 
-                    pinShortcut(siteId, label, iconUrl, result)
+                    pinShortcut(siteId, label, iconUrl, siteUrl, result)
                 }
                 "removeShortcut" -> {
                     val siteId = call.argument<String>("siteId")
@@ -98,13 +99,21 @@ class MainActivity: FlutterActivity() {
                 }
                 "getLaunchSiteId" -> {
                     val siteId = intent?.getStringExtra("siteId")
-                    // Drain the extra after reading so it fires once per tap.
+                    val siteUrl = intent?.getStringExtra("siteUrl")
+                    // Drain the extras after reading so it fires once per tap.
                     // didChangeAppLifecycleState(resumed) re-polls this on every
                     // foreground; without clearing, a plain background/return
                     // would re-navigate to the pinned site (issue: shortcut
                     // re-opens on resume).
                     intent?.removeExtra("siteId")
-                    result.success(siteId)
+                    intent?.removeExtra("siteUrl")
+                    if (siteId == null) {
+                        result.success(null)
+                    } else {
+                        // url lets the Dart side fall back to a domain match when
+                        // the pinned siteId no longer maps to a site (HS-011).
+                        result.success(mapOf("siteId" to siteId, "url" to siteUrl))
+                    }
                 }
                 "getPinnedSiteIds" -> {
                     try {
@@ -125,7 +134,7 @@ class MainActivity: FlutterActivity() {
         }
     }
 
-    private fun pinShortcut(siteId: String, label: String, iconUrl: String?, result: MethodChannel.Result) {
+    private fun pinShortcut(siteId: String, label: String, iconUrl: String?, siteUrl: String?, result: MethodChannel.Result) {
         if (!ShortcutManagerCompat.isRequestPinShortcutSupported(this)) {
             result.error("NOT_SUPPORTED", "Pinned shortcuts not supported on this device", null)
             return
@@ -136,6 +145,7 @@ class MainActivity: FlutterActivity() {
                 val intent = Intent(this, MainActivity::class.java).apply {
                     action = Intent.ACTION_VIEW
                     putExtra("siteId", siteId)
+                    if (siteUrl != null) putExtra("siteUrl", siteUrl)
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 }
 

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -102,6 +102,21 @@ class MainActivity: FlutterActivity() {
                     }
                     result.success(true)
                 }
+                "disableShortcut" -> {
+                    // Explicit user opt-in (HS-011): the app can't remove a
+                    // pinned tile, but it can disable it — greyed out, launcher
+                    // shows "shortcut isn't available" on tap until the user
+                    // drags it off the home screen.
+                    val siteId = call.argument<String>("siteId")
+                    if (siteId != null) {
+                        ShortcutManagerCompat.disableShortcuts(
+                            this,
+                            listOf("site_$siteId"),
+                            "Site has been removed"
+                        )
+                    }
+                    result.success(true)
+                }
                 "getLaunchSiteId" -> {
                     val siteId = intent?.getStringExtra("siteId")
                     // Drain the extra after reading so it fires once per tap.

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -79,14 +79,13 @@ class MainActivity: FlutterActivity() {
                     val siteId = call.argument<String>("siteId")
                     val label = call.argument<String>("label")
                     val iconUrl = call.argument<String>("iconUrl")
-                    val siteUrl = call.argument<String>("siteUrl")
 
                     if (siteId == null || label == null) {
                         result.error("INVALID_ARGS", "siteId and label are required", null)
                         return@setMethodCallHandler
                     }
 
-                    pinShortcut(siteId, label, iconUrl, siteUrl, result)
+                    pinShortcut(siteId, label, iconUrl, result)
                 }
                 "removeShortcut" -> {
                     val siteId = call.argument<String>("siteId")
@@ -99,21 +98,13 @@ class MainActivity: FlutterActivity() {
                 }
                 "getLaunchSiteId" -> {
                     val siteId = intent?.getStringExtra("siteId")
-                    val siteUrl = intent?.getStringExtra("siteUrl")
-                    // Drain the extras after reading so it fires once per tap.
+                    // Drain the extra after reading so it fires once per tap.
                     // didChangeAppLifecycleState(resumed) re-polls this on every
                     // foreground; without clearing, a plain background/return
                     // would re-navigate to the pinned site (issue: shortcut
                     // re-opens on resume).
                     intent?.removeExtra("siteId")
-                    intent?.removeExtra("siteUrl")
-                    if (siteId == null) {
-                        result.success(null)
-                    } else {
-                        // url lets the Dart side fall back to a domain match when
-                        // the pinned siteId no longer maps to a site (HS-011).
-                        result.success(mapOf("siteId" to siteId, "url" to siteUrl))
-                    }
+                    result.success(siteId)
                 }
                 "getPinnedSiteIds" -> {
                     try {
@@ -134,7 +125,7 @@ class MainActivity: FlutterActivity() {
         }
     }
 
-    private fun pinShortcut(siteId: String, label: String, iconUrl: String?, siteUrl: String?, result: MethodChannel.Result) {
+    private fun pinShortcut(siteId: String, label: String, iconUrl: String?, result: MethodChannel.Result) {
         if (!ShortcutManagerCompat.isRequestPinShortcutSupported(this)) {
             result.error("NOT_SUPPORTED", "Pinned shortcuts not supported on this device", null)
             return
@@ -145,7 +136,6 @@ class MainActivity: FlutterActivity() {
                 val intent = Intent(this, MainActivity::class.java).apply {
                     action = Intent.ACTION_VIEW
                     putExtra("siteId", siteId)
-                    if (siteUrl != null) putExtra("siteUrl", siteUrl)
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 }
 

--- a/ios/Runner/ShortcutsPlugin.swift
+++ b/ios/Runner/ShortcutsPlugin.swift
@@ -24,7 +24,9 @@ class ShortcutsPlugin: NSObject {
   private static let channelName = "org.codeberg.theoden8.webspace/shortcuts"
   private static let appGroupId = "group.org.codeberg.theoden8.webspace"
   private static let sitesKey = "shortcut_sites"
+  private static let tombstonesKey = "shortcut_tombstones"
   private static let pendingKey = "pending_shortcut_site_id"
+  private static let pendingUrlKey = "pending_shortcut_url"
 
   init(messenger: FlutterBinaryMessenger) {
     self.channel = FlutterMethodChannel(
@@ -48,10 +50,11 @@ class ShortcutsPlugin: NSObject {
     case "syncSites":
       let args = call.arguments as? [String: Any]
       let sites = args?["sites"] as? [[String: Any]] ?? []
-      syncSites(sites)
+      let tombstones = args?["tombstones"] as? [[String: Any]] ?? []
+      syncSites(sites, tombstones: tombstones)
       result(true)
     case "getLaunchSiteId":
-      result(drainPendingSiteId())
+      result(drainPendingLaunch())
     case "pinShortcut":
       openShortcutsApp(result: result)
     case "removeShortcut":
@@ -65,20 +68,16 @@ class ShortcutsPlugin: NSObject {
     }
   }
 
-  private func syncSites(_ rawSites: [[String: Any]]) {
-    let entries: [[String: String]] = rawSites.compactMap { dict in
-      guard let id = dict["siteId"] as? String,
-            let name = dict["label"] as? String,
-            !id.isEmpty
-      else { return nil }
-      return ["id": id, "name": name]
-    }
+  private func syncSites(_ rawSites: [[String: Any]], tombstones rawTombstones: [[String: Any]]) {
     guard let defaults = UserDefaults(suiteName: Self.appGroupId) else {
       NSLog("[WebSpace] ShortcutsPlugin: App Group \(Self.appGroupId) unavailable")
       return
     }
-    if let json = try? JSONSerialization.data(withJSONObject: entries) {
+    if let json = try? JSONSerialization.data(withJSONObject: Self.normalize(rawSites)) {
       defaults.set(json, forKey: Self.sitesKey)
+    }
+    if let json = try? JSONSerialization.data(withJSONObject: Self.normalize(rawTombstones)) {
+      defaults.set(json, forKey: Self.tombstonesKey)
     }
     #if canImport(AppIntents)
     if #available(iOS 16, *) {
@@ -87,13 +86,31 @@ class ShortcutsPlugin: NSObject {
     #endif
   }
 
-  private func drainPendingSiteId() -> String? {
+  private static func normalize(_ raw: [[String: Any]]) -> [[String: String]] {
+    raw.compactMap { dict in
+      guard let id = dict["siteId"] as? String,
+            let name = dict["label"] as? String,
+            !id.isEmpty
+      else { return nil }
+      var entry = ["id": id, "name": name]
+      if let url = dict["url"] as? String, !url.isEmpty {
+        entry["url"] = url
+      }
+      return entry
+    }
+  }
+
+  private func drainPendingLaunch() -> [String: String]? {
     guard let defaults = UserDefaults(suiteName: Self.appGroupId),
           let siteId = defaults.string(forKey: Self.pendingKey),
           !siteId.isEmpty
     else { return nil }
+    let url = defaults.string(forKey: Self.pendingUrlKey)
     defaults.removeObject(forKey: Self.pendingKey)
-    return siteId
+    defaults.removeObject(forKey: Self.pendingUrlKey)
+    var payload = ["siteId": siteId]
+    if let url = url, !url.isEmpty { payload["url"] = url }
+    return payload
   }
 
   private func openShortcutsApp(result: @escaping FlutterResult) {

--- a/ios/Runner/ShortcutsPlugin.swift
+++ b/ios/Runner/ShortcutsPlugin.swift
@@ -25,6 +25,7 @@ class ShortcutsPlugin: NSObject {
   private static let appGroupId = "group.org.codeberg.theoden8.webspace"
   private static let sitesKey = "shortcut_sites"
   private static let pendingKey = "pending_shortcut_site_id"
+  private static let pendingUrlKey = "pending_shortcut_url"
 
   init(messenger: FlutterBinaryMessenger) {
     self.channel = FlutterMethodChannel(
@@ -51,7 +52,7 @@ class ShortcutsPlugin: NSObject {
       syncSites(sites)
       result(true)
     case "getLaunchSiteId":
-      result(drainPendingSiteId())
+      result(drainPendingLaunch())
     case "pinShortcut":
       openShortcutsApp(result: result)
     case "removeShortcut":
@@ -71,7 +72,11 @@ class ShortcutsPlugin: NSObject {
             let name = dict["label"] as? String,
             !id.isEmpty
       else { return nil }
-      return ["id": id, "name": name]
+      var entry = ["id": id, "name": name]
+      if let url = dict["url"] as? String, !url.isEmpty {
+        entry["url"] = url
+      }
+      return entry
     }
     guard let defaults = UserDefaults(suiteName: Self.appGroupId) else {
       NSLog("[WebSpace] ShortcutsPlugin: App Group \(Self.appGroupId) unavailable")
@@ -87,13 +92,19 @@ class ShortcutsPlugin: NSObject {
     #endif
   }
 
-  private func drainPendingSiteId() -> String? {
+  private func drainPendingLaunch() -> [String: String]? {
     guard let defaults = UserDefaults(suiteName: Self.appGroupId),
           let siteId = defaults.string(forKey: Self.pendingKey),
           !siteId.isEmpty
     else { return nil }
+    let url = defaults.string(forKey: Self.pendingUrlKey)
     defaults.removeObject(forKey: Self.pendingKey)
-    return siteId
+    defaults.removeObject(forKey: Self.pendingUrlKey)
+    var payload = ["siteId": siteId]
+    if let url = url, !url.isEmpty {
+      payload["url"] = url
+    }
+    return payload
   }
 
   private func openShortcutsApp(result: @escaping FlutterResult) {

--- a/ios/Runner/ShortcutsPlugin.swift
+++ b/ios/Runner/ShortcutsPlugin.swift
@@ -25,7 +25,6 @@ class ShortcutsPlugin: NSObject {
   private static let appGroupId = "group.org.codeberg.theoden8.webspace"
   private static let sitesKey = "shortcut_sites"
   private static let pendingKey = "pending_shortcut_site_id"
-  private static let pendingUrlKey = "pending_shortcut_url"
 
   init(messenger: FlutterBinaryMessenger) {
     self.channel = FlutterMethodChannel(
@@ -52,7 +51,7 @@ class ShortcutsPlugin: NSObject {
       syncSites(sites)
       result(true)
     case "getLaunchSiteId":
-      result(drainPendingLaunch())
+      result(drainPendingSiteId())
     case "pinShortcut":
       openShortcutsApp(result: result)
     case "removeShortcut":
@@ -72,11 +71,7 @@ class ShortcutsPlugin: NSObject {
             let name = dict["label"] as? String,
             !id.isEmpty
       else { return nil }
-      var entry = ["id": id, "name": name]
-      if let url = dict["url"] as? String, !url.isEmpty {
-        entry["url"] = url
-      }
-      return entry
+      return ["id": id, "name": name]
     }
     guard let defaults = UserDefaults(suiteName: Self.appGroupId) else {
       NSLog("[WebSpace] ShortcutsPlugin: App Group \(Self.appGroupId) unavailable")
@@ -92,19 +87,13 @@ class ShortcutsPlugin: NSObject {
     #endif
   }
 
-  private func drainPendingLaunch() -> [String: String]? {
+  private func drainPendingSiteId() -> String? {
     guard let defaults = UserDefaults(suiteName: Self.appGroupId),
           let siteId = defaults.string(forKey: Self.pendingKey),
           !siteId.isEmpty
     else { return nil }
-    let url = defaults.string(forKey: Self.pendingUrlKey)
     defaults.removeObject(forKey: Self.pendingKey)
-    defaults.removeObject(forKey: Self.pendingUrlKey)
-    var payload = ["siteId": siteId]
-    if let url = url, !url.isEmpty {
-      payload["url"] = url
-    }
-    return payload
+    return siteId
   }
 
   private func openShortcutsApp(result: @escaping FlutterResult) {

--- a/ios/Runner/ShortcutsPlugin.swift
+++ b/ios/Runner/ShortcutsPlugin.swift
@@ -73,10 +73,13 @@ class ShortcutsPlugin: NSObject {
       NSLog("[WebSpace] ShortcutsPlugin: App Group \(Self.appGroupId) unavailable")
       return
     }
-    if let json = try? JSONSerialization.data(withJSONObject: Self.normalize(rawSites)) {
+    let sites = Self.normalize(rawSites)
+    let tombs = Self.normalize(rawTombstones)
+    NSLog("[WebSpace] ShortcutsPlugin.syncSites sites=\(sites.count) tombstones=\(tombs.count)")
+    if let json = try? JSONSerialization.data(withJSONObject: sites) {
       defaults.set(json, forKey: Self.sitesKey)
     }
-    if let json = try? JSONSerialization.data(withJSONObject: Self.normalize(rawTombstones)) {
+    if let json = try? JSONSerialization.data(withJSONObject: tombs) {
       defaults.set(json, forKey: Self.tombstonesKey)
     }
     #if canImport(AppIntents)
@@ -110,6 +113,7 @@ class ShortcutsPlugin: NSObject {
     defaults.removeObject(forKey: Self.pendingUrlKey)
     var payload = ["siteId": siteId]
     if let url = url, !url.isEmpty { payload["url"] = url }
+    NSLog("[WebSpace] drainPendingLaunch siteId=\(siteId) url=\(url ?? "nil")")
     return payload
   }
 

--- a/ios/Runner/WebSpaceAppIntents.swift
+++ b/ios/Runner/WebSpaceAppIntents.swift
@@ -3,25 +3,36 @@ import Foundation
 #if canImport(AppIntents)
 import AppIntents
 
-/// Key for the JSON-encoded `[{id, name}]` site list in the shared App Group
-/// UserDefaults. Written by Dart via `ShortcutsPlugin.syncSites`; read by
-/// `SiteEntityQuery` when Shortcuts.app asks for available entities.
+/// Key for the JSON-encoded `[{id, name, url}]` live site list in the shared
+/// App Group UserDefaults. Written by Dart via `ShortcutsPlugin.syncSites`;
+/// read by `SiteEntityQuery` for the Shortcuts.app picker.
 let kShortcutSitesKey = "shortcut_sites"
+
+/// Key for the JSON-encoded `[{id, name, url}]` tombstone list — recently
+/// deleted sites. NOT shown in the picker (`suggestedEntities`), but resolved
+/// by `entities(for:)` so a Shortcut tile bound to a deleted site still runs
+/// and routes by domain on the Dart side (HS-011).
+let kShortcutTombstonesKey = "shortcut_tombstones"
 
 /// Key for the pending siteId that an `OpenSiteIntent` has just resolved.
 /// Drained by `ShortcutsPlugin.getLaunchSiteId` (and ultimately by the
 /// Dart-side `_handleShortcutIntent` / `_restoreAppState` paths).
 let kPendingShortcutSiteIdKey = "pending_shortcut_site_id"
 
+/// Key for the pending site url an `OpenSiteIntent` carries alongside the id,
+/// so a deleted-site tap can route by domain (HS-011). Drained with the id.
+let kPendingShortcutUrlKey = "pending_shortcut_url"
+
 let kShortcutAppGroupId = "group.org.codeberg.theoden8.webspace"
 
 /// One synced WebSpace site as it appears to App Intents. Decoded from the
-/// JSON the Dart side writes; only the fields the picker / OpenIntent need
-/// live here (`id`, `name`) so the on-disk shape stays small.
+/// JSON the Dart side writes. `url` lets a deleted-site Shortcut (resolved via
+/// the tombstone list) carry its address so the Dart side can route by domain.
 @available(iOS 16, *)
 struct SiteEntity: AppEntity {
   let id: String
   let name: String
+  let url: String?
 
   static var typeDisplayRepresentation: TypeDisplayRepresentation {
     TypeDisplayRepresentation(name: "Site")
@@ -55,19 +66,34 @@ struct SiteEntity: AppEntity {
 /// missing or no sites have been synced yet.
 @available(iOS 16, *)
 struct SiteEntityQuery: EntityQuery {
+  // Resolve a bound parameter from live sites AND tombstones, so a Shortcut
+  // tile pointing at a since-deleted site still resolves (its run then routes
+  // by domain on the Dart side) instead of failing with "no longer available".
   func entities(for identifiers: [SiteEntity.ID]) async throws -> [SiteEntity] {
-    let all = Self.loadAll()
+    let all = Self.loadSites() + Self.loadTombstones()
     let wanted = Set(identifiers)
-    return all.filter { wanted.contains($0.id) }
+    // De-dupe by id (a tombstone should never shadow a live site).
+    var seen = Set<String>()
+    return all.filter { wanted.contains($0.id) && seen.insert($0.id).inserted }
   }
 
+  // The picker only offers live sites — deleted sites must not reappear here
+  // (HS-009).
   func suggestedEntities() async throws -> [SiteEntity] {
-    Self.loadAll()
+    Self.loadSites()
   }
 
-  static func loadAll() -> [SiteEntity] {
+  static func loadSites() -> [SiteEntity] {
+    load(key: kShortcutSitesKey)
+  }
+
+  static func loadTombstones() -> [SiteEntity] {
+    load(key: kShortcutTombstonesKey)
+  }
+
+  static func load(key: String) -> [SiteEntity] {
     guard let defaults = UserDefaults(suiteName: kShortcutAppGroupId),
-          let data = defaults.data(forKey: kShortcutSitesKey) ?? defaults.string(forKey: kShortcutSitesKey)?.data(using: .utf8)
+          let data = defaults.data(forKey: key) ?? defaults.string(forKey: key)?.data(using: .utf8)
     else {
       return []
     }
@@ -78,7 +104,7 @@ struct SiteEntityQuery: EntityQuery {
       guard let id = dict["id"] as? String, let name = dict["name"] as? String else {
         return nil
       }
-      return SiteEntity(id: id, name: name)
+      return SiteEntity(id: id, name: name, url: dict["url"] as? String)
     }
   }
 }
@@ -105,6 +131,11 @@ struct OpenSiteIntent: AppIntent, OpenIntent {
   func perform() async throws -> some IntentResult {
     if let defaults = UserDefaults(suiteName: kShortcutAppGroupId) {
       defaults.set(target.id, forKey: kPendingShortcutSiteIdKey)
+      if let url = target.url, !url.isEmpty {
+        defaults.set(url, forKey: kPendingShortcutUrlKey)
+      } else {
+        defaults.removeObject(forKey: kPendingShortcutUrlKey)
+      }
     } else {
       NSLog("[WebSpace] OpenSiteIntent: App Group \(kShortcutAppGroupId) unavailable")
     }

--- a/ios/Runner/WebSpaceAppIntents.swift
+++ b/ios/Runner/WebSpaceAppIntents.swift
@@ -13,11 +13,6 @@ let kShortcutSitesKey = "shortcut_sites"
 /// Dart-side `_handleShortcutIntent` / `_restoreAppState` paths).
 let kPendingShortcutSiteIdKey = "pending_shortcut_site_id"
 
-/// Key for the pending site url that an `OpenSiteIntent` carries alongside the
-/// siteId, so the Dart side can fall back to a domain match when the siteId no
-/// longer maps to a site (HS-011). Drained together with the siteId.
-let kPendingShortcutUrlKey = "pending_shortcut_url"
-
 let kShortcutAppGroupId = "group.org.codeberg.theoden8.webspace"
 
 /// One synced WebSpace site as it appears to App Intents. Decoded from the
@@ -27,7 +22,6 @@ let kShortcutAppGroupId = "group.org.codeberg.theoden8.webspace"
 struct SiteEntity: AppEntity {
   let id: String
   let name: String
-  let url: String?
 
   static var typeDisplayRepresentation: TypeDisplayRepresentation {
     TypeDisplayRepresentation(name: "Site")
@@ -84,7 +78,7 @@ struct SiteEntityQuery: EntityQuery {
       guard let id = dict["id"] as? String, let name = dict["name"] as? String else {
         return nil
       }
-      return SiteEntity(id: id, name: name, url: dict["url"] as? String)
+      return SiteEntity(id: id, name: name)
     }
   }
 }
@@ -111,11 +105,6 @@ struct OpenSiteIntent: AppIntent, OpenIntent {
   func perform() async throws -> some IntentResult {
     if let defaults = UserDefaults(suiteName: kShortcutAppGroupId) {
       defaults.set(target.id, forKey: kPendingShortcutSiteIdKey)
-      if let url = target.url, !url.isEmpty {
-        defaults.set(url, forKey: kPendingShortcutUrlKey)
-      } else {
-        defaults.removeObject(forKey: kPendingShortcutUrlKey)
-      }
     } else {
       NSLog("[WebSpace] OpenSiteIntent: App Group \(kShortcutAppGroupId) unavailable")
     }

--- a/ios/Runner/WebSpaceAppIntents.swift
+++ b/ios/Runner/WebSpaceAppIntents.swift
@@ -70,11 +70,15 @@ struct SiteEntityQuery: EntityQuery {
   // tile pointing at a since-deleted site still resolves (its run then routes
   // by domain on the Dart side) instead of failing with "no longer available".
   func entities(for identifiers: [SiteEntity.ID]) async throws -> [SiteEntity] {
-    let all = Self.loadSites() + Self.loadTombstones()
+    let live = Self.loadSites()
+    let tombs = Self.loadTombstones()
+    let all = live + tombs
     let wanted = Set(identifiers)
     // De-dupe by id (a tombstone should never shadow a live site).
     var seen = Set<String>()
-    return all.filter { wanted.contains($0.id) && seen.insert($0.id).inserted }
+    let resolved = all.filter { wanted.contains($0.id) && seen.insert($0.id).inserted }
+    NSLog("[WebSpace] SiteEntityQuery.entities(for: \(identifiers)) live=\(live.count) tombstones=\(tombs.count) resolved=\(resolved.count)")
+    return resolved
   }
 
   // The picker only offers live sites — deleted sites must not reappear here
@@ -129,6 +133,7 @@ struct OpenSiteIntent: AppIntent, OpenIntent {
   }
 
   func perform() async throws -> some IntentResult {
+    NSLog("[WebSpace] OpenSiteIntent.perform id=\(target.id) url=\(target.url ?? "nil")")
     if let defaults = UserDefaults(suiteName: kShortcutAppGroupId) {
       defaults.set(target.id, forKey: kPendingShortcutSiteIdKey)
       if let url = target.url, !url.isEmpty {

--- a/ios/Runner/WebSpaceAppIntents.swift
+++ b/ios/Runner/WebSpaceAppIntents.swift
@@ -66,17 +66,22 @@ struct SiteEntity: AppEntity {
 /// missing or no sites have been synced yet.
 @available(iOS 16, *)
 struct SiteEntityQuery: EntityQuery {
-  // Resolve a bound parameter from live sites AND tombstones, so a Shortcut
-  // tile pointing at a since-deleted site still resolves (its run then routes
-  // by domain on the Dart side) instead of failing with "no longer available".
+  // Resolve EVERY requested id: a live site, then a tombstone, else a
+  // placeholder. Returning a placeholder for an unknown id (a Shortcut bound to
+  // a site deleted before tombstones existed) keeps the tile from reading "no
+  // longer available" — a tap opens WebSpace and offers to reroute the handle
+  // to an existing site on the Dart side (HS-014). De-dupe by id; preserve the
+  // requested order.
   func entities(for identifiers: [SiteEntity.ID]) async throws -> [SiteEntity] {
     let live = Self.loadSites()
     let tombs = Self.loadTombstones()
-    let all = live + tombs
-    let wanted = Set(identifiers)
-    // De-dupe by id (a tombstone should never shadow a live site).
+    var byId: [String: SiteEntity] = [:]
+    for e in (live + tombs) where byId[e.id] == nil { byId[e.id] = e }
     var seen = Set<String>()
-    let resolved = all.filter { wanted.contains($0.id) && seen.insert($0.id).inserted }
+    var resolved: [SiteEntity] = []
+    for id in identifiers where seen.insert(id).inserted {
+      resolved.append(byId[id] ?? SiteEntity(id: id, name: "Removed WebSpace site", url: nil))
+    }
     NSLog("[WebSpace] SiteEntityQuery.entities(for: \(identifiers)) live=\(live.count) tombstones=\(tombs.count) resolved=\(resolved.count)")
     return resolved
   }

--- a/ios/Runner/WebSpaceAppIntents.swift
+++ b/ios/Runner/WebSpaceAppIntents.swift
@@ -81,17 +81,17 @@ struct SiteEntityQuery: EntityQuery {
     return resolved
   }
 
-  // iOS validates a Shortcut's bound parameter against the suggested set (not
-  // just entities(for:)), so to keep a deleted-site Shortcut runnable (HS-011)
-  // tombstones must be surfaced here too. Tradeoff: recently-deleted sites stay
-  // visible in the Shortcuts.app picker until evicted from the capped list.
+  // The picker (and the materialized Siri/Spotlight App Shortcuts) offer only
+  // live sites — deleted sites are NOT surfaced here (HS-009). A Shortcut
+  // already bound to a since-deleted site is resolved at run time via
+  // entities(for:), which also reads tombstones, so it keeps working without
+  // cluttering the picker. If iOS turns out to validate a bound parameter
+  // against this suggested set, an outdated tile would stop running — that is
+  // the behaviour this split is meant to verify.
   func suggestedEntities() async throws -> [SiteEntity] {
     let live = Self.loadSites()
-    let tombs = Self.loadTombstones()
-    var seen = Set<String>()
-    let merged = (live + tombs).filter { seen.insert($0.id).inserted }
-    NSLog("[WebSpace] SiteEntityQuery.suggestedEntities live=\(live.count) tombstones=\(tombs.count)")
-    return merged
+    NSLog("[WebSpace] SiteEntityQuery.suggestedEntities live=\(live.count)")
+    return live
   }
 
   static func loadSites() -> [SiteEntity] {

--- a/ios/Runner/WebSpaceAppIntents.swift
+++ b/ios/Runner/WebSpaceAppIntents.swift
@@ -81,10 +81,17 @@ struct SiteEntityQuery: EntityQuery {
     return resolved
   }
 
-  // The picker only offers live sites — deleted sites must not reappear here
-  // (HS-009).
+  // iOS validates a Shortcut's bound parameter against the suggested set (not
+  // just entities(for:)), so to keep a deleted-site Shortcut runnable (HS-011)
+  // tombstones must be surfaced here too. Tradeoff: recently-deleted sites stay
+  // visible in the Shortcuts.app picker until evicted from the capped list.
   func suggestedEntities() async throws -> [SiteEntity] {
-    Self.loadSites()
+    let live = Self.loadSites()
+    let tombs = Self.loadTombstones()
+    var seen = Set<String>()
+    let merged = (live + tombs).filter { seen.insert($0.id).inserted }
+    NSLog("[WebSpace] SiteEntityQuery.suggestedEntities live=\(live.count) tombstones=\(tombs.count)")
+    return merged
   }
 
   static func loadSites() -> [SiteEntity] {

--- a/ios/Runner/WebSpaceAppIntents.swift
+++ b/ios/Runner/WebSpaceAppIntents.swift
@@ -13,6 +13,11 @@ let kShortcutSitesKey = "shortcut_sites"
 /// Dart-side `_handleShortcutIntent` / `_restoreAppState` paths).
 let kPendingShortcutSiteIdKey = "pending_shortcut_site_id"
 
+/// Key for the pending site url that an `OpenSiteIntent` carries alongside the
+/// siteId, so the Dart side can fall back to a domain match when the siteId no
+/// longer maps to a site (HS-011). Drained together with the siteId.
+let kPendingShortcutUrlKey = "pending_shortcut_url"
+
 let kShortcutAppGroupId = "group.org.codeberg.theoden8.webspace"
 
 /// One synced WebSpace site as it appears to App Intents. Decoded from the
@@ -22,6 +27,7 @@ let kShortcutAppGroupId = "group.org.codeberg.theoden8.webspace"
 struct SiteEntity: AppEntity {
   let id: String
   let name: String
+  let url: String?
 
   static var typeDisplayRepresentation: TypeDisplayRepresentation {
     TypeDisplayRepresentation(name: "Site")
@@ -78,7 +84,7 @@ struct SiteEntityQuery: EntityQuery {
       guard let id = dict["id"] as? String, let name = dict["name"] as? String else {
         return nil
       }
-      return SiteEntity(id: id, name: name)
+      return SiteEntity(id: id, name: name, url: dict["url"] as? String)
     }
   }
 }
@@ -105,6 +111,11 @@ struct OpenSiteIntent: AppIntent, OpenIntent {
   func perform() async throws -> some IntentResult {
     if let defaults = UserDefaults(suiteName: kShortcutAppGroupId) {
       defaults.set(target.id, forKey: kPendingShortcutSiteIdKey)
+      if let url = target.url, !url.isEmpty {
+        defaults.set(url, forKey: kPendingShortcutUrlKey)
+      } else {
+        defaults.removeObject(forKey: kPendingShortcutUrlKey)
+      }
     } else {
       NSLog("[WebSpace] OpenSiteIntent: App Group \(kShortcutAppGroupId) unavailable")
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -955,11 +955,18 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   // every overflow-menu open.
   bool _iosAppIntentsSupported = false;
 
-  // HS-011: a tapped shortcut whose siteId is gone (settings restore on a new
-  // device, delete+recreate) is rebound — on confirm — to a domain-matching or
-  // freshly created site. The user's choice is remembered here (stale siteId ->
-  // live siteId) and persisted so later taps resolve silently. Machine state
-  // derived from shortcut activity, not a user setting: excluded from backups.
+  // HS-011 (Android only): a pinned shortcut's intent carries only the random
+  // siteId. Once the owning site is deleted (delete+recreate) that id is opaque,
+  // so we keep a `siteId -> url` ledger — recorded for pinned sites, pruned to
+  // the pinned/current set — to drive the domain fallback. iOS needs none of
+  // this: a deleted SiteEntity resolves to nil, so a stale id never launches.
+  static const _kShortcutUrlLedgerKey = 'shortcutUrlLedger';
+  Map<String, String> _shortcutUrlLedger = {};
+
+  // When the user confirms a rebind, the choice is remembered here (stale
+  // siteId -> live siteId) and persisted so later taps of the same shortcut
+  // resolve silently. Machine state derived from shortcut activity, not a user
+  // setting: excluded from settings backups.
   static const _kShortcutRemapKey = 'shortcutSiteRemap';
   Map<String, String> _shortcutSiteRemap = {};
 
@@ -1149,9 +1156,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       await ShortcutService.pinShortcut(
         siteId: model.siteId,
         label: model.name,
-        url: model.initUrl,
         iconUrl: isSvg ? null : faviconUrl,
       );
+      // HS-011: remember this id's url now so a later delete+recreate can be
+      // routed by domain. _refreshPinnedSiteIds also reconciles on resume.
+      await _recordShortcutLedger(model.siteId, model.initUrl);
       return;
     }
     if (Platform.isIOS && _iosAppIntentsSupported) {
@@ -1187,6 +1196,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
   Future<void> _refreshPinnedSiteIds() async {
     final ids = await ShortcutService.getPinnedSiteIds();
+    if (!mounted) return;
+    // HS-011: keep the url ledger in step with the launcher — record urls for
+    // pinned sites that still exist, drop entries no longer reachable. Runs on
+    // initState and every resume, so it catches in-app pins and out-of-app
+    // removals. Android-only (iOS getPinnedSiteIds is always empty).
+    await _reconcileShortcutLedger(ids);
     if (!mounted) return;
     if (ids.length == _pinnedSiteIds.length &&
         ids.containsAll(_pinnedSiteIds)) {
@@ -1483,11 +1498,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   }
 
   Future<void> _handleShortcutIntent() async {
-    final launch = await ShortcutService.getLaunch();
-    if (!mounted || launch == null) return;
+    final siteId = await ShortcutService.getLaunchSiteId();
+    if (!mounted || siteId == null) return;
     final resolution = StartupRestoreEngine.resolveLaunch(
-      shortcutSiteId: launch.siteId,
-      shortcutUrl: launch.url,
+      shortcutSiteId: siteId,
+      shortcutUrl: _shortcutUrlLedger[siteId],
       models: _webViewModels,
       rememberedRemap: _shortcutSiteRemap,
     );
@@ -1608,19 +1623,49 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   }
 
   void _loadShortcutRemap(SharedPreferences prefs) {
-    final raw = prefs.getString(_kShortcutRemapKey);
-    if (raw == null) return;
+    _shortcutSiteRemap = _decodeStringMap(prefs.getString(_kShortcutRemapKey));
+    _shortcutUrlLedger = _decodeStringMap(prefs.getString(_kShortcutUrlLedgerKey));
+  }
+
+  Map<String, String> _decodeStringMap(String? raw) {
+    if (raw == null) return {};
     try {
       final decoded = jsonDecode(raw);
       if (decoded is Map) {
-        _shortcutSiteRemap = {
-          for (final e in decoded.entries)
-            e.key.toString(): e.value.toString(),
+        return {
+          for (final e in decoded.entries) e.key.toString(): e.value.toString(),
         };
       }
     } catch (_) {
-      // Corrupt entry — start fresh; it'll be rewritten on the next rebind.
+      // Corrupt entry — start fresh; it'll be rewritten on the next update.
     }
+    return {};
+  }
+
+  /// Record one `siteId -> url` ledger entry (HS-011) and persist if it changed.
+  Future<void> _recordShortcutLedger(String siteId, String url) async {
+    if (url.isEmpty || _shortcutUrlLedger[siteId] == url) return;
+    _shortcutUrlLedger[siteId] = url;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_kShortcutUrlLedgerKey, jsonEncode(_shortcutUrlLedger));
+  }
+
+  /// Reconcile the ledger against the launcher's [pinnedSiteIds] (HS-011):
+  /// record urls for pinned sites that still exist, prune unreachable entries.
+  Future<void> _reconcileShortcutLedger(Set<String> pinnedSiteIds) async {
+    final currentSiteUrls = {
+      for (final m in _webViewModels)
+        if (!m.isArchiveTier) m.siteId: m.initUrl,
+    };
+    final next = ShortcutUrlLedger.reconcile(
+      ledger: _shortcutUrlLedger,
+      currentSiteUrls: currentSiteUrls,
+      pinnedSiteIds: pinnedSiteIds,
+    );
+    if (mapEquals(next, _shortcutUrlLedger)) return;
+    _shortcutUrlLedger = next;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_kShortcutUrlLedgerKey, jsonEncode(_shortcutUrlLedger));
   }
 
   bool _handlingShareIntent = false;
@@ -2580,7 +2625,6 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           ShortcutSite(
             siteId: m.siteId,
             label: m.name,
-            url: m.initUrl,
             iconUrl: FaviconUrlCache.get(m.initUrl),
           ),
     ];
@@ -3600,10 +3644,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     }
 
     // Always start at home screen on launch - only restore index if launched via shortcut
-    final launch = await ShortcutService.getLaunch();
+    final shortcutSiteId = await ShortcutService.getLaunchSiteId();
     final resolution = StartupRestoreEngine.resolveLaunch(
-      shortcutSiteId: launch?.siteId,
-      shortcutUrl: launch?.url,
+      shortcutSiteId: shortcutSiteId,
+      shortcutUrl:
+          shortcutSiteId == null ? null : _shortcutUrlLedger[shortcutSiteId],
       models: _webViewModels,
       rememberedRemap: _shortcutSiteRemap,
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5844,6 +5844,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
     final wasCurrentIndex = _currentIndex == index;
     final deletedModel = _webViewModels[index];
+    // Capture before mutation: HS-011 delete-time shortcut prompt (Android).
+    final hadPinnedShortcut =
+        Platform.isAndroid && _pinnedSiteIds.contains(deletedModel.siteId);
     deletedModel.disposeWebView();
     _loadedIndices.remove(index);
 
@@ -5920,8 +5923,91 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     // platforms.
     unawaited(_updateBackgroundRefreshSchedule());
 
+    if (hadPinnedShortcut) {
+      await _handleDeletedSiteShortcut(deletedSiteId);
+    }
+
     if (!mounted) return;
     Navigator.pop(context);
+  }
+
+  /// HS-011: the deleted site had a pinned home shortcut. Ask what to do with
+  /// the now-orphaned launcher tile (Android can't remove it for the user):
+  /// keep it (a tap re-routes via the ledger — open a domain match or offer to
+  /// create), point it at another site, or disable it.
+  Future<void> _handleDeletedSiteShortcut(String deletedSiteId) async {
+    if (!mounted) return;
+    final choice = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Home screen shortcut'),
+        content: const Text(
+          'This site had a home screen shortcut. By default, tapping it lets '
+          'you reopen a matching site or create a new one.\n\n'
+          'You can instead point it at another site, or disable it. (Android '
+          "can't delete a pinned shortcut for you — disabling greys it out "
+          'until you remove it from the home screen.)',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, 'keep'),
+            child: const Text('Keep'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, 'reassign'),
+            child: const Text('Reassign'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, 'disable'),
+            child: const Text('Disable'),
+          ),
+        ],
+      ),
+    );
+    if (!mounted || choice == null || choice == 'keep') return;
+
+    if (choice == 'disable') {
+      await ShortcutService.disableShortcut(deletedSiteId);
+      _shortcutSiteRemap.remove(deletedSiteId);
+      _shortcutUrlLedger.remove(deletedSiteId);
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_kShortcutRemapKey, jsonEncode(_shortcutSiteRemap));
+      await prefs.setString(
+          _kShortcutUrlLedgerKey, jsonEncode(_shortcutUrlLedger));
+      if (!mounted) return;
+      setState(() {
+        _pinnedSiteIds = {..._pinnedSiteIds}..remove(deletedSiteId);
+      });
+      return;
+    }
+
+    // 'reassign': point the tile at an existing site via the rebind map.
+    final targetSiteId = await _pickSiteForShortcut();
+    if (targetSiteId == null || !mounted) return;
+    await _rememberShortcutRemap(deletedSiteId, targetSiteId);
+  }
+
+  /// Pick an existing (non-archive) site to reassign an orphaned shortcut to.
+  /// Returns the chosen siteId, or null if dismissed / nothing to pick.
+  Future<String?> _pickSiteForShortcut() async {
+    final candidates = [
+      for (final m in _webViewModels)
+        if (!m.isArchiveTier) m,
+    ];
+    if (candidates.isEmpty || !mounted) return null;
+    return showDialog<String>(
+      context: context,
+      builder: (ctx) => SimpleDialog(
+        title: const Text('Point shortcut at'),
+        children: [
+          for (final m in candidates)
+            SimpleDialogOption(
+              onPressed: () => Navigator.pop(ctx, m.siteId),
+              child: Text(m.getDisplayName()),
+            ),
+        ],
+      ),
+    );
   }
 
   Widget _buildSiteGridTile(BuildContext context, int index, int listIndex) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6126,14 +6126,46 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     if (candidates.isEmpty || !mounted) return null;
     return showDialog<String>(
       context: context,
-      builder: (ctx) => SimpleDialog(
+      builder: (ctx) => AlertDialog(
         title: const Text('Point shortcut at'),
-        children: [
-          for (final m in candidates)
-            SimpleDialogOption(
-              onPressed: () => Navigator.pop(ctx, m.siteId),
-              child: Text(m.getDisplayName()),
-            ),
+        contentPadding: const EdgeInsets.symmetric(vertical: 8),
+        content: SizedBox(
+          width: double.maxFinite,
+          child: ListView.builder(
+            shrinkWrap: true,
+            itemCount: candidates.length,
+            itemBuilder: (context, i) {
+              final m = candidates[i];
+              return ListTile(
+                leading: SizedBox(
+                  width: 32,
+                  height: 32,
+                  child: UnifiedFaviconImage(
+                    url: m.initUrl,
+                    size: 32,
+                    proxy: m.proxySettings,
+                  ),
+                ),
+                title: Text(
+                  m.getDisplayName(),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                subtitle: Text(
+                  m.initUrl,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                onTap: () => Navigator.of(ctx).pop(m.siteId),
+              );
+            },
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Cancel'),
+          ),
         ],
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5935,9 +5935,22 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
     final wasCurrentIndex = _currentIndex == index;
     final deletedModel = _webViewModels[index];
-    // Capture before mutation: HS-011 delete-time shortcut prompt (Android).
-    final hadPinnedShortcut =
-        Platform.isAndroid && _pinnedSiteIds.contains(deletedModel.siteId);
+    // Capture before mutation: HS-013 delete-time shortcut prompt (Android).
+    // Query the launcher fresh rather than trusting the cached _pinnedSiteIds,
+    // which only refreshes on init/resume — a shortcut pinned and deleted in
+    // the same session wouldn't be in the cache yet, so the prompt would be
+    // silently skipped.
+    final hadPinnedShortcut = Platform.isAndroid &&
+        (await ShortcutService.getPinnedSiteIds())
+            .contains(deletedModel.siteId);
+    if (!mounted) return;
+    if (Platform.isAndroid) {
+      LogService.instance.log(
+        'Shortcut',
+        'delete siteId=${deletedModel.siteId} hadPinnedShortcut=$hadPinnedShortcut',
+        sensitivity: LogSensitivity.sensitive,
+      );
+    }
     deletedModel.disposeWebView();
     _loadedIndices.remove(index);
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ import 'package:webspace/screens/add_site.dart' show AddSiteScreen, UnifiedFavic
 import 'package:webspace/screens/settings.dart';
 import 'package:webspace/screens/app_settings.dart';
 import 'package:webspace/services/icon_service.dart';
+import 'package:webspace/services/icon_png_export.dart';
 import 'package:webspace/screens/inappbrowser.dart';
 import 'package:webspace/screens/webspaces_list.dart';
 import 'package:webspace/screens/webspace_detail.dart';
@@ -1152,11 +1153,21 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   Future<void> _handleAddToHome(WebViewModel model) async {
     if (Platform.isAndroid) {
       final faviconUrl = FaviconUrlCache.get(model.initUrl);
-      final isSvg = faviconUrl != null && faviconUrl.toLowerCase().endsWith('.svg');
+      // Rasterize the favicon to PNG here (HS-003): Android's BitmapFactory
+      // can't decode SVG, so an SVG favicon would otherwise fall back to the
+      // WebSpace app icon. exportIconAsPng also normalizes ICO/PNG and applies
+      // the site's proxy. iconUrl stays as a native-side fallback if it fails.
+      final iconBytes = await exportIconAsPng(
+        model.initUrl,
+        resolvedIconUrl: faviconUrl,
+        proxy: model.proxySettings,
+      );
+      if (!mounted) return;
       await ShortcutService.pinShortcut(
         siteId: model.siteId,
         label: model.name,
-        iconUrl: isSvg ? null : faviconUrl,
+        iconBytes: iconBytes,
+        iconUrl: iconBytes == null ? faviconUrl : null,
       );
       // HS-011: remember this id's url now so a later delete+recreate can be
       // routed by domain. _refreshPinnedSiteIds also reconciles on resume.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5943,20 +5943,27 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     final deletedModel = _webViewModels[index];
     // Capture before mutation: HS-013 delete-time shortcut prompt (Android).
     // Query the launcher fresh rather than trusting the cached _pinnedSiteIds,
-    // which only refreshes on init/resume — a shortcut pinned and deleted in
-    // the same session wouldn't be in the cache yet, so the prompt would be
-    // silently skipped.
-    final hadPinnedShortcut = Platform.isAndroid &&
-        (await ShortcutService.getPinnedSiteIds())
-            .contains(deletedModel.siteId);
-    if (!mounted) return;
+    // which only refreshes on init/resume. Find every pinned tile that REACHES
+    // this site — directly (tile id == siteId) or via an HS-011 rebind
+    // (remap[tile] == siteId) — so deleting a site an orphaned tile was
+    // rebound to still prompts about that tile.
+    Set<String> reachingTiles = const {};
     if (Platform.isAndroid) {
+      final pinnedNow = await ShortcutService.getPinnedSiteIds();
+      if (!mounted) return;
+      reachingTiles = ShortcutPinState.tilesReaching(
+        siteId: deletedModel.siteId,
+        pinnedSiteIds: pinnedNow,
+        rememberedRemap: _shortcutSiteRemap,
+      );
       LogService.instance.log(
         'Shortcut',
-        'delete siteId=${deletedModel.siteId} hadPinnedShortcut=$hadPinnedShortcut',
+        'delete siteId=${deletedModel.siteId} pinned=$pinnedNow '
+            'reachingTiles=$reachingTiles',
         sensitivity: LogSensitivity.sensitive,
       );
     }
+    final hadPinnedShortcut = reachingTiles.isNotEmpty;
     deletedModel.disposeWebView();
     _loadedIndices.remove(index);
 
@@ -6034,7 +6041,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     unawaited(_updateBackgroundRefreshSchedule());
 
     if (hadPinnedShortcut) {
-      await _handleDeletedSiteShortcut(deletedSiteId);
+      await _handleDeletedSiteShortcut(reachingTiles);
     }
     // iOS can't tell whether a Shortcut tile exists, so tombstone every
     // (non-archive) deletion: if a tile was pointing here it now resolves and
@@ -6048,12 +6055,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     Navigator.pop(context);
   }
 
-  /// HS-011: the deleted site had a pinned home shortcut. Ask what to do with
-  /// the now-orphaned launcher tile (Android can't remove it for the user):
-  /// keep it (a tap re-routes via the ledger — open a domain match or offer to
-  /// create), point it at another site, or disable it.
-  Future<void> _handleDeletedSiteShortcut(String deletedSiteId) async {
-    if (!mounted) return;
+  /// HS-013: the deleted site was reachable by one or more pinned tiles
+  /// ([tileIds] — directly or via an HS-011 rebind). Ask what to do with those
+  /// now-orphaned launcher tiles (Android can't remove them for the user):
+  /// keep them (a tap re-routes — open a domain match or offer to create),
+  /// point them at another site, or disable them.
+  Future<void> _handleDeletedSiteShortcut(Set<String> tileIds) async {
+    if (!mounted || tileIds.isEmpty) return;
     final choice = await showDialog<String>(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -6084,24 +6092,28 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     if (!mounted || choice == null || choice == 'keep') return;
 
     if (choice == 'disable') {
-      await ShortcutService.disableShortcut(deletedSiteId);
-      _shortcutSiteRemap.remove(deletedSiteId);
-      _shortcutUrlLedger.remove(deletedSiteId);
+      for (final tile in tileIds) {
+        await ShortcutService.disableShortcut(tile);
+        _shortcutSiteRemap.remove(tile);
+        _shortcutUrlLedger.remove(tile);
+      }
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(_kShortcutRemapKey, jsonEncode(_shortcutSiteRemap));
       await prefs.setString(
           _kShortcutUrlLedgerKey, jsonEncode(_shortcutUrlLedger));
       if (!mounted) return;
       setState(() {
-        _pinnedSiteIds = {..._pinnedSiteIds}..remove(deletedSiteId);
+        _pinnedSiteIds = {..._pinnedSiteIds}..removeAll(tileIds);
       });
       return;
     }
 
-    // 'reassign': point the tile at an existing site via the rebind map.
+    // 'reassign': point every reaching tile at an existing site via the remap.
     final targetSiteId = await _pickSiteForShortcut();
     if (targetSiteId == null || !mounted) return;
-    await _rememberShortcutRemap(deletedSiteId, targetSiteId);
+    for (final tile in tileIds) {
+      await _rememberShortcutRemap(tile, targetSiteId);
+    }
   }
 
   /// Pick an existing (non-archive) site to reassign an orphaned shortcut to.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1638,6 +1638,14 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         await _registerNewSite(model);
         if (!mounted) return;
         await _rememberShortcutRemap(resolution.shortcutSiteId, model.siteId);
+      } else if (resolution is LaunchOfferReroute) {
+        // Handle resolved to a placeholder (site removed, no url known). Let the
+        // user point it at an existing site; remembered so the next tap is direct.
+        final targetSiteId = await _pickSiteForShortcut();
+        if (targetSiteId == null || !mounted) return;
+        await _rememberShortcutRemap(resolution.shortcutSiteId, targetSiteId);
+        final i = _webViewModels.indexWhere((m) => m.siteId == targetSiteId);
+        if (i >= 0) await _openShortcutIndex(i);
       }
     } finally {
       _handlingShortcutPrompt = false;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3707,6 +3707,17 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
             _kShortcutRemapKey, jsonEncode(_shortcutSiteRemap));
       }
     }
+    // HS-014: drop tombstones whose siteId is live again (defensive — ids are
+    // unique per create, so this only fires if a backup reintroduced one).
+    if (_shortcutTombstones.isNotEmpty) {
+      final before = _shortcutTombstones.length;
+      _shortcutTombstones =
+          ShortcutTombstones.pruneLive(_shortcutTombstones, activeSiteIdsAtStartup);
+      if (_shortcutTombstones.length != before) {
+        await prefs.setString(
+            _kShortcutTombstonesKey, jsonEncode(_shortcutTombstones));
+      }
+    }
     // Incognito sites are treated as orphans for any session-scoped GC
     // (cookies, html cache, navigation state, container) so on-disk
     // remnants don't outlive the process — see issue #298. Their config

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1147,7 +1147,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     // shortcuts (visible in the launcher / Shortcuts.app indefinitely).
     if (_webViewModels[index].isArchiveTier) return false;
     if (Platform.isAndroid) {
-      return !_pinnedSiteIds.contains(_webViewModels[index].siteId);
+      // Treat a site an orphaned tile was rebound to (HS-011) as already
+      // pinned — it's reachable via that tile, so don't offer a second one.
+      final effective = ShortcutPinState.effectivePinnedSiteIds(
+        pinnedSiteIds: _pinnedSiteIds,
+        rememberedRemap: _shortcutSiteRemap,
+      );
+      return !effective.contains(_webViewModels[index].siteId);
     }
     if (Platform.isIOS) {
       return _iosAppIntentsSupported;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1603,14 +1603,20 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
         }
         await _openShortcutIndex(resolution.index);
       } else if (resolution is LaunchOfferCreate) {
-        final ok = await _showShortcutConfirm(
-          title: 'Create site?',
-          message:
-              'This shortcut points to a site that no longer exists. Create a '
-              'new site for ${resolution.url}?',
-          confirmLabel: 'Create',
-        );
-        if (ok != true || !mounted) return;
+        // No live site and no domain match: let the user reroute this handle to
+        // any existing site or create a fresh one. Either choice is remembered
+        // as a remap so the next tap resolves directly (HS-011/HS-014).
+        final choice = await _showShortcutMissingChoice(resolution.url);
+        if (choice == null || !mounted) return;
+        if (choice == 'reroute') {
+          final targetSiteId = await _pickSiteForShortcut();
+          if (targetSiteId == null || !mounted) return;
+          await _rememberShortcutRemap(resolution.shortcutSiteId, targetSiteId);
+          final i =
+              _webViewModels.indexWhere((m) => m.siteId == targetSiteId);
+          if (i >= 0) await _openShortcutIndex(i);
+          return;
+        }
         final model = WebViewModel(
           initUrl: resolution.url,
           stateSetterF: () {
@@ -1651,6 +1657,35 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(true),
             child: Text(confirmLabel),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Tap-time chooser for a handle whose site is gone and that has no domain
+  /// match (HS-011 step 3). Returns 'reroute' | 'create' | null (dismissed).
+  Future<String?> _showShortcutMissingChoice(String url) {
+    return showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Shortcut site missing'),
+        content: Text(
+          'This shortcut points to a site that no longer exists. Open another '
+          'site instead, or create a new one for $url?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(null),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop('reroute'),
+            child: const Text('Open another'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop('create'),
+            child: const Text('Create'),
           ),
         ],
       ),
@@ -6054,11 +6089,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     if (hadPinnedShortcut) {
       await _handleDeletedSiteShortcut(reachingTiles);
     }
-    // iOS: can't detect whether a Shortcut tile exists, so prompt on every
-    // (non-archive) deletion (HS-013/HS-014) — keep/reassign records a
-    // tombstone so a tile stays resolvable, disable records nothing.
+    // iOS can't detect whether a Shortcut tile exists, so prompting on delete
+    // would fire blindly on every deletion. Instead, tombstone silently: if a
+    // tile was bound here it stays resolvable and routes (or offers to reroute)
+    // when actually tapped (HS-011/HS-014). The list is capped (HS-014).
     if (Platform.isIOS && !deletedModel.isArchiveTier) {
-      await _handleDeletedSiteShortcutIos(
+      await _recordShortcutTombstone(
           deletedSiteId, deletedModel.name, deletedModel.initUrl);
     }
 
@@ -6131,45 +6167,6 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     for (final tile in tileIds) {
       await _rememberShortcutRemap(tile, targetSiteId);
     }
-  }
-
-  /// HS-013/HS-014 (iOS): iOS can't tell whether a home-screen tile exists, so
-  /// the prompt fires on every (non-archive) deletion. Keep records a tombstone
-  /// so a tile bound to this site still resolves and routes; Reassign also
-  /// remaps it to a chosen site; Disable records nothing and drops any remap,
-  /// so the handle no longer resolves and the tile stops running.
-  Future<void> _handleDeletedSiteShortcutIos(
-    String siteId,
-    String label,
-    String url,
-  ) async {
-    if (!mounted) return;
-    final choice = await _showShortcutFateChoice(
-      'If you made a home screen shortcut for this site, choose what it does '
-      'now.\n\n'
-      'Keep: tapping it reopens a matching site or offers to create one. '
-      'Reassign: point it at another site. Disable: it stops opening anything.',
-    );
-    if (!mounted) return;
-
-    if (choice == 'disable') {
-      _shortcutSiteRemap.remove(siteId);
-      _shortcutTombstones =
-          ShortcutTombstones.pruneLive(_shortcutTombstones, {siteId});
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setString(_kShortcutRemapKey, jsonEncode(_shortcutSiteRemap));
-      await prefs.setString(
-          _kShortcutTombstonesKey, jsonEncode(_shortcutTombstones));
-      _syncShortcutSites();
-      return;
-    }
-
-    // 'keep' / dismissed / 'reassign' all keep the tile resolvable.
-    await _recordShortcutTombstone(siteId, label, url);
-    if (choice != 'reassign' || !mounted) return;
-    final targetSiteId = await _pickSiteForShortcut();
-    if (targetSiteId == null || !mounted) return;
-    await _rememberShortcutRemap(siteId, targetSiteId);
   }
 
   /// Pick an existing (non-archive) site to reassign an orphaned shortcut to.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -956,13 +956,20 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   // every overflow-menu open.
   bool _iosAppIntentsSupported = false;
 
-  // HS-011 (Android only): a pinned shortcut's intent carries only the random
+  // HS-011 (Android): a pinned shortcut's intent carries only the random
   // siteId. Once the owning site is deleted (delete+recreate) that id is opaque,
   // so we keep a `siteId -> url` ledger — recorded for pinned sites, pruned to
-  // the pinned/current set — to drive the domain fallback. iOS needs none of
-  // this: a deleted SiteEntity resolves to nil, so a stale id never launches.
+  // the pinned/current set — to drive the domain fallback.
   static const _kShortcutUrlLedgerKey = 'shortcutUrlLedger';
   Map<String, String> _shortcutUrlLedger = {};
+
+  // HS-011 (iOS): iOS can't enumerate home-screen tiles, so the Android ledger
+  // approach can't GC. Instead we keep a bounded tombstone list of deleted
+  // `{siteId, label, url}` and sync it to the App Group: `entities(for:)`
+  // resolves a deleted-site Shortcut from live ∪ tombstones (so it still
+  // launches and routes by domain), while the picker stays live-only (HS-009).
+  static const _kShortcutTombstonesKey = 'shortcutTombstones';
+  List<Map<String, String>> _shortcutTombstones = [];
 
   // When the user confirms a rebind, the choice is remembered here (stale
   // siteId -> live siteId) and persisted so later taps of the same shortcut
@@ -1509,11 +1516,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   }
 
   Future<void> _handleShortcutIntent() async {
-    final siteId = await ShortcutService.getLaunchSiteId();
-    if (!mounted || siteId == null) return;
+    final launch = await ShortcutService.getLaunch();
+    if (!mounted || launch == null) return;
     final resolution = StartupRestoreEngine.resolveLaunch(
-      shortcutSiteId: siteId,
-      shortcutUrl: _shortcutUrlLedger[siteId],
+      shortcutSiteId: launch.siteId,
+      // iOS carries the url in the launch payload; Android pairs the id with
+      // its url ledger.
+      shortcutUrl: launch.url ?? _shortcutUrlLedger[launch.siteId],
       models: _webViewModels,
       rememberedRemap: _shortcutSiteRemap,
     );
@@ -1636,6 +1645,43 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   void _loadShortcutRemap(SharedPreferences prefs) {
     _shortcutSiteRemap = _decodeStringMap(prefs.getString(_kShortcutRemapKey));
     _shortcutUrlLedger = _decodeStringMap(prefs.getString(_kShortcutUrlLedgerKey));
+    _shortcutTombstones = _decodeTombstones(prefs.getString(_kShortcutTombstonesKey));
+  }
+
+  List<Map<String, String>> _decodeTombstones(String? raw) {
+    if (raw == null) return [];
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is List) {
+        return [
+          for (final e in decoded)
+            if (e is Map)
+              {
+                for (final kv in e.entries) kv.key.toString(): kv.value.toString(),
+              },
+        ];
+      }
+    } catch (_) {
+      // Corrupt entry — start fresh.
+    }
+    return [];
+  }
+
+  /// HS-011 (iOS): tombstone a deleted site so a Shortcut tile bound to it
+  /// still resolves and routes by domain. Persists and re-syncs the App Group.
+  Future<void> _recordShortcutTombstone(
+    String siteId,
+    String label,
+    String url,
+  ) async {
+    _shortcutTombstones = ShortcutTombstones.add(
+      tombstones: _shortcutTombstones,
+      entry: {'siteId': siteId, 'label': label, 'url': url},
+    );
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+        _kShortcutTombstonesKey, jsonEncode(_shortcutTombstones));
+    _syncShortcutSites();
   }
 
   Map<String, String> _decodeStringMap(String? raw) {
@@ -2636,10 +2682,21 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           ShortcutSite(
             siteId: m.siteId,
             label: m.name,
+            url: m.initUrl,
             iconUrl: FaviconUrlCache.get(m.initUrl),
           ),
     ];
-    unawaited(ShortcutService.syncSites(sites));
+    // HS-011: a deleted-site Shortcut still resolves via these tombstones, so
+    // it launches and routes by domain instead of failing "no longer available".
+    final tombstones = [
+      for (final t in _shortcutTombstones)
+        ShortcutSite(
+          siteId: t['siteId'] ?? '',
+          label: t['label'] ?? '',
+          url: t['url'],
+        ),
+    ];
+    unawaited(ShortcutService.syncSites(sites, tombstones: tombstones));
   }
 
   Future<void> _saveCurrentIndex() async {
@@ -3655,11 +3712,14 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     }
 
     // Always start at home screen on launch - only restore index if launched via shortcut
-    final shortcutSiteId = await ShortcutService.getLaunchSiteId();
+    final launch = await ShortcutService.getLaunch();
     final resolution = StartupRestoreEngine.resolveLaunch(
-      shortcutSiteId: shortcutSiteId,
-      shortcutUrl:
-          shortcutSiteId == null ? null : _shortcutUrlLedger[shortcutSiteId],
+      shortcutSiteId: launch?.siteId,
+      // iOS carries the url in the launch payload; Android pairs the id with
+      // its url ledger.
+      shortcutUrl: launch == null
+          ? null
+          : (launch.url ?? _shortcutUrlLedger[launch.siteId]),
       models: _webViewModels,
       rememberedRemap: _shortcutSiteRemap,
     );
@@ -5925,6 +5985,13 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
     if (hadPinnedShortcut) {
       await _handleDeletedSiteShortcut(deletedSiteId);
+    }
+    // iOS can't tell whether a Shortcut tile exists, so tombstone every
+    // (non-archive) deletion: if a tile was pointing here it now resolves and
+    // routes by domain; the list is capped so this stays bounded (HS-011).
+    if (Platform.isIOS && !deletedModel.isArchiveTier) {
+      await _recordShortcutTombstone(
+          deletedSiteId, deletedModel.name, deletedModel.initUrl);
     }
 
     if (!mounted) return;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6054,11 +6054,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     if (hadPinnedShortcut) {
       await _handleDeletedSiteShortcut(reachingTiles);
     }
-    // iOS can't tell whether a Shortcut tile exists, so tombstone every
-    // (non-archive) deletion: if a tile was pointing here it now resolves and
-    // routes by domain; the list is capped so this stays bounded (HS-011).
+    // iOS: can't detect whether a Shortcut tile exists, so prompt on every
+    // (non-archive) deletion (HS-013/HS-014) — keep/reassign records a
+    // tombstone so a tile stays resolvable, disable records nothing.
     if (Platform.isIOS && !deletedModel.isArchiveTier) {
-      await _recordShortcutTombstone(
+      await _handleDeletedSiteShortcutIos(
           deletedSiteId, deletedModel.name, deletedModel.initUrl);
     }
 
@@ -6066,24 +6066,14 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     Navigator.pop(context);
   }
 
-  /// HS-013: the deleted site was reachable by one or more pinned tiles
-  /// ([tileIds] — directly or via an HS-011 rebind). Ask what to do with those
-  /// now-orphaned launcher tiles (Android can't remove them for the user):
-  /// keep them (a tap re-routes — open a domain match or offer to create),
-  /// point them at another site, or disable them.
-  Future<void> _handleDeletedSiteShortcut(Set<String> tileIds) async {
-    if (!mounted || tileIds.isEmpty) return;
-    final choice = await showDialog<String>(
+  /// Shared Keep/Reassign/Disable chooser for the delete-time shortcut prompt
+  /// (HS-013). Returns 'keep' | 'reassign' | 'disable' | null (dismissed).
+  Future<String?> _showShortcutFateChoice(String message) {
+    return showDialog<String>(
       context: context,
       builder: (ctx) => AlertDialog(
         title: const Text('Home screen shortcut'),
-        content: const Text(
-          'This site had a home screen shortcut. By default, tapping it lets '
-          'you reopen a matching site or create a new one.\n\n'
-          'You can instead point it at another site, or disable it. (Android '
-          "can't delete a pinned shortcut for you — disabling greys it out "
-          'until you remove it from the home screen.)',
-        ),
+        content: Text(message),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(ctx, 'keep'),
@@ -6099,6 +6089,22 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           ),
         ],
       ),
+    );
+  }
+
+  /// HS-013: the deleted site was reachable by one or more pinned tiles
+  /// ([tileIds] — directly or via an HS-011 rebind). Ask what to do with those
+  /// now-orphaned launcher tiles (Android can't remove them for the user):
+  /// keep them (a tap re-routes — open a domain match or offer to create),
+  /// point them at another site, or disable them.
+  Future<void> _handleDeletedSiteShortcut(Set<String> tileIds) async {
+    if (!mounted || tileIds.isEmpty) return;
+    final choice = await _showShortcutFateChoice(
+      'This site had a home screen shortcut. By default, tapping it lets '
+      'you reopen a matching site or create a new one.\n\n'
+      'You can instead point it at another site, or disable it. (Android '
+      "can't delete a pinned shortcut for you — disabling greys it out "
+      'until you remove it from the home screen.)',
     );
     if (!mounted || choice == null || choice == 'keep') return;
 
@@ -6125,6 +6131,45 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     for (final tile in tileIds) {
       await _rememberShortcutRemap(tile, targetSiteId);
     }
+  }
+
+  /// HS-013/HS-014 (iOS): iOS can't tell whether a home-screen tile exists, so
+  /// the prompt fires on every (non-archive) deletion. Keep records a tombstone
+  /// so a tile bound to this site still resolves and routes; Reassign also
+  /// remaps it to a chosen site; Disable records nothing and drops any remap,
+  /// so the handle no longer resolves and the tile stops running.
+  Future<void> _handleDeletedSiteShortcutIos(
+    String siteId,
+    String label,
+    String url,
+  ) async {
+    if (!mounted) return;
+    final choice = await _showShortcutFateChoice(
+      'If you made a home screen shortcut for this site, choose what it does '
+      'now.\n\n'
+      'Keep: tapping it reopens a matching site or offers to create one. '
+      'Reassign: point it at another site. Disable: it stops opening anything.',
+    );
+    if (!mounted) return;
+
+    if (choice == 'disable') {
+      _shortcutSiteRemap.remove(siteId);
+      _shortcutTombstones =
+          ShortcutTombstones.pruneLive(_shortcutTombstones, {siteId});
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_kShortcutRemapKey, jsonEncode(_shortcutSiteRemap));
+      await prefs.setString(
+          _kShortcutTombstonesKey, jsonEncode(_shortcutTombstones));
+      _syncShortcutSites();
+      return;
+    }
+
+    // 'keep' / dismissed / 'reassign' all keep the tile resolvable.
+    await _recordShortcutTombstone(siteId, label, url);
+    if (choice != 'reassign' || !mounted) return;
+    final targetSiteId = await _pickSiteForShortcut();
+    if (targetSiteId == null || !mounted) return;
+    await _rememberShortcutRemap(siteId, targetSiteId);
   }
 
   /// Pick an existing (non-archive) site to reassign an orphaned shortcut to.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -955,6 +955,20 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   // every overflow-menu open.
   bool _iosAppIntentsSupported = false;
 
+  // HS-011: a tapped shortcut whose siteId is gone (settings restore on a new
+  // device, delete+recreate) is rebound — on confirm — to a domain-matching or
+  // freshly created site. The user's choice is remembered here (stale siteId ->
+  // live siteId) and persisted so later taps resolve silently. Machine state
+  // derived from shortcut activity, not a user setting: excluded from backups.
+  static const _kShortcutRemapKey = 'shortcutSiteRemap';
+  Map<String, String> _shortcutSiteRemap = {};
+
+  // A cold-launch shortcut that needs a confirm/create prompt can't show a
+  // dialog mid-restore (no UI yet); it's parked here and handled on the first
+  // post-frame. Guards re-entry while a prompt is on screen.
+  LaunchResolution? _pendingShortcutResolution;
+  bool _handlingShortcutPrompt = false;
+
   StreamSubscription<TrustedHostEntry>? _untrustSub;
 
   @override
@@ -1135,6 +1149,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       await ShortcutService.pinShortcut(
         siteId: model.siteId,
         label: model.name,
+        url: model.initUrl,
         iconUrl: isSvg ? null : faviconUrl,
       );
       return;
@@ -1468,19 +1483,143 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   }
 
   Future<void> _handleShortcutIntent() async {
-    final siteId = await ShortcutService.getLaunchSiteId();
-    if (!mounted) return;
-    if (siteId != null) {
-      final index = _webViewModels.indexWhere((m) => m.siteId == siteId);
-      if (index >= 0) {
-        _resetAlwaysOpenHomeOnShortcut(index);
-        if (index != _currentIndex) {
-          await _setCurrentIndex(index);
-          if (!mounted) return;
+    final launch = await ShortcutService.getLaunch();
+    if (!mounted || launch == null) return;
+    final resolution = StartupRestoreEngine.resolveLaunch(
+      shortcutSiteId: launch.siteId,
+      shortcutUrl: launch.url,
+      models: _webViewModels,
+      rememberedRemap: _shortcutSiteRemap,
+    );
+    if (resolution is LaunchOpenSite) {
+      await _openShortcutIndex(resolution.index);
+    } else if (resolution is! LaunchNone) {
+      await _applyInteractiveShortcut(resolution, coldLaunch: false);
+    }
+  }
+
+  /// Warm-tap switch to a resolved site: reset flagged siblings to home
+  /// (HS-007), switch if not already active, persist. Does NOT reset the
+  /// launched site's own currentUrl — a warm tap preserves the live session
+  /// (HS-006); cold launch handles the initUrl reset separately.
+  Future<void> _openShortcutIndex(int index) async {
+    if (index < 0 || index >= _webViewModels.length) return;
+    _resetAlwaysOpenHomeOnShortcut(index);
+    if (index != _currentIndex) {
+      await _setCurrentIndex(index);
+      if (!mounted) return;
+    }
+    setState(() {});
+    await _saveWebViewModels();
+  }
+
+  /// HS-011: drive the confirm/create prompt for a shortcut whose siteId no
+  /// longer maps to a site. On confirm, remembers the rebind so future taps
+  /// resolve directly via [_shortcutSiteRemap].
+  Future<void> _applyInteractiveShortcut(
+    LaunchResolution resolution, {
+    required bool coldLaunch,
+  }) async {
+    if (_handlingShortcutPrompt) return;
+    _handlingShortcutPrompt = true;
+    try {
+      if (resolution is LaunchConfirmExisting) {
+        if (resolution.index < 0 ||
+            resolution.index >= _webViewModels.length) {
+          return;
         }
-        setState(() {});
-        await _saveWebViewModels();
+        final model = _webViewModels[resolution.index];
+        final ok = await _showShortcutConfirm(
+          title: 'Open site?',
+          message:
+              'This shortcut points to a site that no longer exists. Open '
+              '"${model.getDisplayName()}" instead? It matches the same address.',
+          confirmLabel: 'Open',
+        );
+        if (ok != true || !mounted) return;
+        await _rememberShortcutRemap(resolution.shortcutSiteId, model.siteId);
+        if (coldLaunch && model.currentUrl != model.initUrl) {
+          model.currentUrl = model.initUrl;
+        }
+        await _openShortcutIndex(resolution.index);
+      } else if (resolution is LaunchOfferCreate) {
+        final ok = await _showShortcutConfirm(
+          title: 'Create site?',
+          message:
+              'This shortcut points to a site that no longer exists. Create a '
+              'new site for ${resolution.url}?',
+          confirmLabel: 'Create',
+        );
+        if (ok != true || !mounted) return;
+        final model = WebViewModel(
+          initUrl: resolution.url,
+          stateSetterF: () {
+            if (mounted) setState(() {});
+          },
+        );
+        final title = await getPageTitle(resolution.url);
+        if (!mounted) return;
+        if (title != null && title.isNotEmpty) {
+          model.name = title;
+          model.pageTitle = title;
+        }
+        // _registerNewSite adds, activates, applies theme, and persists.
+        await _registerNewSite(model);
+        if (!mounted) return;
+        await _rememberShortcutRemap(resolution.shortcutSiteId, model.siteId);
       }
+    } finally {
+      _handlingShortcutPrompt = false;
+    }
+  }
+
+  Future<bool?> _showShortcutConfirm({
+    required String title,
+    required String message,
+    required String confirmLabel,
+  }) {
+    return showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(title),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(confirmLabel),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _rememberShortcutRemap(
+    String shortcutSiteId,
+    String resolvedSiteId,
+  ) async {
+    if (_shortcutSiteRemap[shortcutSiteId] == resolvedSiteId) return;
+    _shortcutSiteRemap[shortcutSiteId] = resolvedSiteId;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_kShortcutRemapKey, jsonEncode(_shortcutSiteRemap));
+  }
+
+  void _loadShortcutRemap(SharedPreferences prefs) {
+    final raw = prefs.getString(_kShortcutRemapKey);
+    if (raw == null) return;
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map) {
+        _shortcutSiteRemap = {
+          for (final e in decoded.entries)
+            e.key.toString(): e.value.toString(),
+        };
+      }
+    } catch (_) {
+      // Corrupt entry — start fresh; it'll be rewritten on the next rebind.
     }
   }
 
@@ -2441,6 +2580,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
           ShortcutSite(
             siteId: m.siteId,
             label: m.name,
+            url: m.initUrl,
             iconUrl: FaviconUrlCache.get(m.initUrl),
           ),
     ];
@@ -3383,6 +3523,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       _tabStripInFullscreen = prefs.getBool('tabStripInFullscreen') ?? false;
       _showStatsBanner = prefs.getBool('showStatsBanner') ?? true;
       _linkHandlingEnabled = prefs.getBool(kLinkHandlingEnabledKey) ?? true;
+      _loadShortcutRemap(prefs);
       widget.onThemeSettingsChanged(_themeSettings);
     });
     await _loadWebspaces();
@@ -3417,6 +3558,18 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     // activated site. `_restoreCookiesForSite` re-nukes on every switch; this
     // extra pass covers launch before any site is activated.
     final activeSiteIdsAtStartup = _webViewModels.map((m) => m.siteId).toSet();
+    // HS-011: drop remap entries whose resolved target was since deleted —
+    // they'd never resolve, and a fresh tap re-prompts (and re-remembers).
+    if (_shortcutSiteRemap.isNotEmpty) {
+      final before = _shortcutSiteRemap.length;
+      _shortcutSiteRemap.removeWhere(
+        (_, resolved) => !activeSiteIdsAtStartup.contains(resolved),
+      );
+      if (_shortcutSiteRemap.length != before) {
+        await prefs.setString(
+            _kShortcutRemapKey, jsonEncode(_shortcutSiteRemap));
+      }
+    }
     // Incognito sites are treated as orphans for any session-scoped GC
     // (cookies, html cache, navigation state, container) so on-disk
     // remnants don't outlive the process — see issue #298. Their config
@@ -3447,11 +3600,21 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     }
 
     // Always start at home screen on launch - only restore index if launched via shortcut
-    final shortcutSiteId = await ShortcutService.getLaunchSiteId();
-    final indexToRestore = StartupRestoreEngine.resolveLaunchTarget(
-      shortcutSiteId: shortcutSiteId,
+    final launch = await ShortcutService.getLaunch();
+    final resolution = StartupRestoreEngine.resolveLaunch(
+      shortcutSiteId: launch?.siteId,
+      shortcutUrl: launch?.url,
       models: _webViewModels,
+      rememberedRemap: _shortcutSiteRemap,
     );
+    // A direct hit activates inline below; a confirm/create outcome can't show
+    // a dialog mid-restore (no UI yet), so park it and prompt post-frame.
+    int? indexToRestore;
+    if (resolution is LaunchOpenSite) {
+      indexToRestore = resolution.index;
+    } else if (resolution is! LaunchNone) {
+      _pendingShortcutResolution = resolution;
+    }
     // A Home Shortcut represents the user's stated entry point for that
     // site — they pinned it expecting "open google maps", not "resume
     // wherever I last drifted to". Reset the launched site's currentUrl
@@ -3494,6 +3657,19 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     await _setCurrentIndex(indexToRestore);
     if (!mounted) return;
     setState(() {}); // Trigger UI update after async operation
+
+    // HS-011: a shortcut whose siteId is gone but that carried a url needs a
+    // confirm/create prompt. The UI is up now, so fire it on the next frame.
+    if (_pendingShortcutResolution != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        final pending = _pendingShortcutResolution;
+        _pendingShortcutResolution = null;
+        if (pending != null) {
+          unawaited(_applyInteractiveShortcut(pending, coldLaunch: true));
+        }
+      });
+    }
 
     // Refresh the iOS App Intents picker on every launch, not just on save.
     // iOS queries `suggestedEntities()` (and may re-materialize the per-site

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1518,11 +1518,21 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   Future<void> _handleShortcutIntent() async {
     final launch = await ShortcutService.getLaunch();
     if (!mounted || launch == null) return;
+    final url = launch.url ??
+        _shortcutUrlLedger[launch.siteId] ??
+        _tombstoneUrlFor(launch.siteId);
+    LogService.instance.log(
+      'Shortcut',
+      'warm launch siteId=${launch.siteId} payloadUrl=${launch.url} '
+          'resolvedUrl=$url',
+      sensitivity: LogSensitivity.sensitive,
+    );
     final resolution = StartupRestoreEngine.resolveLaunch(
       shortcutSiteId: launch.siteId,
       // iOS carries the url in the launch payload; Android pairs the id with
-      // its url ledger.
-      shortcutUrl: launch.url ?? _shortcutUrlLedger[launch.siteId],
+      // its url ledger. Fall back to the iOS tombstone url in case iOS handed
+      // back a stale cached entity without a url.
+      shortcutUrl: url,
       models: _webViewModels,
       rememberedRemap: _shortcutSiteRemap,
     );
@@ -1531,6 +1541,15 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     } else if (resolution is! LaunchNone) {
       await _applyInteractiveShortcut(resolution, coldLaunch: false);
     }
+  }
+
+  /// Look up a deleted site's url from the iOS tombstone list (HS-014), so a
+  /// stale launch payload without a url can still route by domain.
+  String? _tombstoneUrlFor(String siteId) {
+    for (final t in _shortcutTombstones) {
+      if (t['siteId'] == siteId) return t['url'];
+    }
+    return null;
   }
 
   /// Warm-tap switch to a resolved site: reset flagged siblings to home
@@ -3713,13 +3732,25 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
 
     // Always start at home screen on launch - only restore index if launched via shortcut
     final launch = await ShortcutService.getLaunch();
+    final launchUrl = launch == null
+        ? null
+        : (launch.url ??
+            _shortcutUrlLedger[launch.siteId] ??
+            _tombstoneUrlFor(launch.siteId));
+    if (launch != null) {
+      LogService.instance.log(
+        'Shortcut',
+        'cold launch siteId=${launch.siteId} payloadUrl=${launch.url} '
+            'resolvedUrl=$launchUrl',
+        sensitivity: LogSensitivity.sensitive,
+      );
+    }
     final resolution = StartupRestoreEngine.resolveLaunch(
       shortcutSiteId: launch?.siteId,
       // iOS carries the url in the launch payload; Android pairs the id with
-      // its url ledger.
-      shortcutUrl: launch == null
-          ? null
-          : (launch.url ?? _shortcutUrlLedger[launch.siteId]),
+      // its url ledger; the iOS tombstone url is the last fallback if iOS
+      // handed back a stale cached entity without a url.
+      shortcutUrl: launchUrl,
       models: _webViewModels,
       rememberedRemap: _shortcutSiteRemap,
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -951,10 +951,10 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   // "Home Shortcut" menu item can hide for sites that are already pinned.
   Set<String> _pinnedSiteIds = const <String>{};
 
-  // HS-006/007: iOS 16+ exposes home shortcuts via App Intents. Probed once
-  // at startup so the menu can render synchronously without a future on
-  // every overflow-menu open.
-  bool _iosAppIntentsSupported = false;
+  // HS-006/007: iOS 16+ / macOS 13+ expose home shortcuts via App Intents.
+  // Probed once at startup so the menu can render synchronously without a
+  // future on every overflow-menu open.
+  bool _appIntentsSupported = false;
 
   // HS-011 (Android): a pinned shortcut's intent carries only the random
   // siteId. Once the owning site is deleted (delete+recreate) that id is opaque,
@@ -992,7 +992,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     WidgetsBinding.instance.addObserver(this);
     _restoreAppState();
     _refreshPinnedSiteIds();
-    _probeIosAppIntents();
+    _probeAppIntents();
     // When a pin is revoked while the site is still rendered, the
     // existing webview keeps showing the cached DOM and the live
     // reload may serve from WebView HTTP cache without doing a fresh
@@ -1129,18 +1129,18 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     if (changed && mounted) setState(() {});
   }
 
-  Future<void> _probeIosAppIntents() async {
+  Future<void> _probeAppIntents() async {
     final supported = await ShortcutService.isAppIntentsSupported();
-    if (!mounted || supported == _iosAppIntentsSupported) return;
+    if (!mounted || supported == _appIntentsSupported) return;
     setState(() {
-      _iosAppIntentsSupported = supported;
+      _appIntentsSupported = supported;
     });
   }
 
   /// HS-004 / HS-005: gate the "Home Shortcut" menu item. On Android, hide
-  /// once the site already has a pinned shortcut (HS-005). On iOS 16+ the
-  /// item is always visible (iOS has no API to detect home-screen pinning).
-  /// Other platforms hide it.
+  /// once the site already has a pinned shortcut (HS-005). On iOS 16+ /
+  /// macOS 13+ the item is always visible (no API to detect home-screen /
+  /// Shortcuts.app pinning). Other platforms hide it.
   bool _isHomeShortcutMenuVisible(int index) {
     if (index >= _webViewModels.length) return false;
     // ARCH-006: archive-tier sites must not get OS-level pinned
@@ -1155,8 +1155,8 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       );
       return !effective.contains(_webViewModels[index].siteId);
     }
-    if (Platform.isIOS) {
-      return _iosAppIntentsSupported;
+    if (Platform.isIOS || Platform.isMacOS) {
+      return _appIntentsSupported;
     }
     return false;
   }
@@ -1187,15 +1187,20 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       await _recordShortcutLedger(model.siteId, model.initUrl);
       return;
     }
-    if (Platform.isIOS && _iosAppIntentsSupported) {
+    if ((Platform.isIOS || Platform.isMacOS) && _appIntentsSupported) {
+      final addStep = Platform.isMacOS
+          ? 'then add it to the Dock or run it from the menu bar.'
+          : 'then tap "Add to Home Screen" from the share menu.';
       final confirmed = await showDialog<bool>(
         context: context,
         builder: (ctx) => AlertDialog(
-          title: const Text('Add to Home Screen'),
+          title: Text(
+              Platform.isMacOS ? 'Add a Shortcut' : 'Add to Home Screen'),
           content: Text(
-            'iOS adds WebSpace sites through the Shortcuts app.\n\n'
+            '${Platform.isMacOS ? "macOS" : "iOS"} adds WebSpace sites through '
+            'the Shortcuts app.\n\n'
             'In Shortcuts, find the "Open Site" action under WebSpace, pick '
-            '"${model.name}", then tap "Add to Home Screen" from the share menu.',
+            '"${model.name}", $addStep',
           ),
           actions: [
             TextButton(
@@ -2735,7 +2740,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
   /// renames / additions / deletions show up in Shortcuts.app the next time
   /// the user touches it. No-op on non-iOS platforms.
   void _syncShortcutSites() {
-    if (!Platform.isIOS) return;
+    if (!Platform.isIOS && !Platform.isMacOS) return;
     final sites = [
       for (final m in _webViewModels)
         if (!m.isArchiveTier)
@@ -6089,11 +6094,11 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     if (hadPinnedShortcut) {
       await _handleDeletedSiteShortcut(reachingTiles);
     }
-    // iOS can't detect whether a Shortcut tile exists, so prompting on delete
-    // would fire blindly on every deletion. Instead, tombstone silently: if a
-    // tile was bound here it stays resolvable and routes (or offers to reroute)
-    // when actually tapped (HS-011/HS-014). The list is capped (HS-014).
-    if (Platform.isIOS && !deletedModel.isArchiveTier) {
+    // iOS/macOS can't detect whether a Shortcut tile exists, so prompting on
+    // delete would fire blindly on every deletion. Instead, tombstone silently:
+    // if a tile was bound here it stays resolvable and routes (or offers to
+    // reroute) when actually tapped (HS-011/HS-014). The list is capped.
+    if ((Platform.isIOS || Platform.isMacOS) && !deletedModel.isArchiveTier) {
       await _recordShortcutTombstone(
           deletedSiteId, deletedModel.name, deletedModel.initUrl);
     }

--- a/lib/services/shortcut_service.dart
+++ b/lib/services/shortcut_service.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:flutter/services.dart';
 
 /// One site as it crosses the platform-channel boundary into the iOS App
@@ -32,9 +33,16 @@ class ShortcutService {
   /// Shortcuts app — the caller is responsible for showing the
   /// instructional dialog (HS-008) before invoking. Returns false on
   /// platforms without either path.
+  ///
+  /// [iconBytes] is a ready-to-use raster PNG (the caller rasterizes the
+  /// favicon, including SVG, before invoking — Android's BitmapFactory can't
+  /// decode SVG). When present the native side uses it directly; [iconUrl] is
+  /// only a fallback the native side downloads if no bytes were supplied. With
+  /// neither, the shortcut uses the WebSpace app icon.
   static Future<bool> pinShortcut({
     required String siteId,
     required String label,
+    Uint8List? iconBytes,
     String? iconUrl,
   }) async {
     if (!Platform.isAndroid && !Platform.isIOS) return false;
@@ -42,6 +50,7 @@ class ShortcutService {
       final result = await _channel.invokeMethod('pinShortcut', {
         'siteId': siteId,
         'label': label,
+        'iconBytes': iconBytes,
         'iconUrl': iconUrl,
       });
       return result == true;
@@ -50,9 +59,12 @@ class ShortcutService {
     }
   }
 
-  /// Remove a pinned shortcut when a site is deleted (Android only).
-  /// On iOS the App Intents site list is rebuilt from the user's actual
-  /// sites by `syncSites` so a deletion drops out implicitly.
+  /// Drop any dynamic shortcut copy for a deleted site (Android only). The
+  /// pinned launcher tile is deliberately left ENABLED: HS-011 routes a tap on
+  /// an orphaned shortcut through the url ledger (open a domain match / offer
+  /// to create), which only works if the launcher still launches the app.
+  /// On iOS the App Intents site list is rebuilt from the user's actual sites
+  /// by `syncSites`, so a deletion drops out of the picker implicitly.
   static Future<void> removeShortcut(String siteId) async {
     if (!Platform.isAndroid) return;
     try {

--- a/lib/services/shortcut_service.dart
+++ b/lib/services/shortcut_service.dart
@@ -61,7 +61,9 @@ class ShortcutService {
     Uint8List? iconBytes,
     String? iconUrl,
   }) async {
-    if (!Platform.isAndroid && !Platform.isIOS) return false;
+    if (!Platform.isAndroid && !Platform.isIOS && !Platform.isMacOS) {
+      return false;
+    }
     try {
       final result = await _channel.invokeMethod('pinShortcut', {
         'siteId': siteId,
@@ -96,10 +98,12 @@ class ShortcutService {
   /// every resume don't re-navigate on a plain background/return.
   ///
   /// Android returns a bare siteId string (`url` null — the caller pairs it
-  /// with the url ledger); iOS returns a `{siteId, url}` map. Both shapes are
-  /// tolerated so the two platforms can share one call site.
+  /// with the url ledger); iOS/macOS return a `{siteId, url}` map. Both shapes
+  /// are tolerated so the platforms can share one call site.
   static Future<ShortcutLaunch?> getLaunch() async {
-    if (!Platform.isAndroid && !Platform.isIOS) return null;
+    if (!Platform.isAndroid && !Platform.isIOS && !Platform.isMacOS) {
+      return null;
+    }
     try {
       final res = await _channel.invokeMethod('getLaunchSiteId');
       if (res is String) {
@@ -157,12 +161,12 @@ class ShortcutService {
   /// `tombstones` (recently-deleted sites — NOT shown in the picker, but kept
   /// resolvable so a Shortcut tile bound to a deleted site still launches and
   /// routes via HS-011) into the shared App Group UserDefaults. No-op on
-  /// non-iOS platforms.
+  /// platforms without App Intents (everything but iOS/macOS).
   static Future<void> syncSites(
     List<ShortcutSite> sites, {
     List<ShortcutSite> tombstones = const [],
   }) async {
-    if (!Platform.isIOS) return;
+    if (!Platform.isIOS && !Platform.isMacOS) return;
     try {
       await _channel.invokeMethod('syncSites', {
         'sites': sites.map((s) => s.toMap()).toList(),
@@ -173,11 +177,11 @@ class ShortcutService {
     }
   }
 
-  /// True iff the iOS App Intents-based path is available (iOS 16+). False
-  /// on Android (Android uses its own pin path, not gated by this), on
-  /// older iOS, and on every other platform.
+  /// True iff the App Intents-based path is available (iOS 16+ / macOS 13+).
+  /// False on Android (Android uses its own pin path, not gated by this), on
+  /// older iOS/macOS, and on every other platform.
   static Future<bool> isAppIntentsSupported() async {
-    if (!Platform.isIOS) return false;
+    if (!Platform.isIOS && !Platform.isMacOS) return false;
     try {
       final result = await _channel.invokeMethod('isAppIntentsSupported');
       return result == true;

--- a/lib/services/shortcut_service.dart
+++ b/lib/services/shortcut_service.dart
@@ -3,23 +3,39 @@ import 'package:flutter/services.dart';
 
 /// One site as it crosses the platform-channel boundary into the iOS App
 /// Intents picker (HS-007). `iconUrl` is reserved for future favicon syncing
-/// and is currently unused on the Swift side.
+/// and is currently unused on the Swift side. `url` rides along so a launched
+/// shortcut whose `siteId` no longer maps to a site can fall back to a
+/// domain match (HS-011).
 class ShortcutSite {
   final String siteId;
   final String label;
+  final String? url;
   final String? iconUrl;
 
   const ShortcutSite({
     required this.siteId,
     required this.label,
+    this.url,
     this.iconUrl,
   });
 
   Map<String, dynamic> toMap() => {
         'siteId': siteId,
         'label': label,
+        if (url != null) 'url': url,
         if (iconUrl != null) 'iconUrl': iconUrl,
       };
+}
+
+/// What a tapped home shortcut hands back: the pinned `siteId` plus the site's
+/// `url` (when the shortcut was created after HS-011). Older shortcuts predate
+/// the `url` extra, so `url` is null for them and resolution degrades to
+/// siteId-only matching.
+class ShortcutLaunch {
+  final String siteId;
+  final String? url;
+
+  const ShortcutLaunch({required this.siteId, this.url});
 }
 
 class ShortcutService {
@@ -35,6 +51,7 @@ class ShortcutService {
   static Future<bool> pinShortcut({
     required String siteId,
     required String label,
+    String? url,
     String? iconUrl,
   }) async {
     if (!Platform.isAndroid && !Platform.isIOS) return false;
@@ -42,6 +59,7 @@ class ShortcutService {
       final result = await _channel.invokeMethod('pinShortcut', {
         'siteId': siteId,
         'label': label,
+        'siteUrl': url,
         'iconUrl': iconUrl,
       });
       return result == true;
@@ -62,12 +80,31 @@ class ShortcutService {
     }
   }
 
-  /// Get the siteId from the launch intent if the app was opened via a
-  /// pinned shortcut (Android) or a Shortcuts.app `OpenSiteIntent` (iOS 16+).
-  static Future<String?> getLaunchSiteId() async {
+  /// Get the launch target (siteId + url) if the app was opened via a pinned
+  /// shortcut (Android) or a Shortcuts.app `OpenSiteIntent` (iOS 16+). Drains
+  /// the underlying pending state on read (consume-once), so callers polling on
+  /// every resume don't re-navigate on a plain background/return.
+  ///
+  /// The native side returns a `{siteId, url}` map for shortcuts pinned after
+  /// HS-011; a bare string is tolerated for backward compatibility (url null).
+  static Future<ShortcutLaunch?> getLaunch() async {
     if (!Platform.isAndroid && !Platform.isIOS) return null;
     try {
-      return await _channel.invokeMethod('getLaunchSiteId');
+      final res = await _channel.invokeMethod('getLaunchSiteId');
+      if (res is String) {
+        return res.isEmpty ? null : ShortcutLaunch(siteId: res);
+      }
+      if (res is Map) {
+        final id = res['siteId'];
+        if (id is String && id.isNotEmpty) {
+          final url = res['url'];
+          return ShortcutLaunch(
+            siteId: id,
+            url: url is String && url.isNotEmpty ? url : null,
+          );
+        }
+      }
+      return null;
     } on PlatformException {
       return null;
     }

--- a/lib/services/shortcut_service.dart
+++ b/lib/services/shortcut_service.dart
@@ -103,6 +103,21 @@ class ShortcutService {
     }
   }
 
+  /// Disable a pinned shortcut for a deleted site (Android only). Android has
+  /// no API to remove a pinned tile, so this greys it out and makes the
+  /// launcher show "shortcut isn't available" on tap until the user drags it
+  /// off the home screen. Used only when the user explicitly opts to kill a
+  /// deleted site's shortcut (HS-011); the default leaves the tile tappable so
+  /// it can re-route via the url ledger.
+  static Future<void> disableShortcut(String siteId) async {
+    if (!Platform.isAndroid) return;
+    try {
+      await _channel.invokeMethod('disableShortcut', {'siteId': siteId});
+    } on PlatformException {
+      // Ignore — shortcut may not exist.
+    }
+  }
+
   /// Push the user's current site list to the iOS App Intents picker
   /// (HS-007). Writes `[{id, name}]` into the shared App Group UserDefaults
   /// so `SiteEntityQuery` returns real sites. No-op on non-iOS platforms.

--- a/lib/services/shortcut_service.dart
+++ b/lib/services/shortcut_service.dart
@@ -4,23 +4,39 @@ import 'package:flutter/services.dart';
 
 /// One site as it crosses the platform-channel boundary into the iOS App
 /// Intents picker (HS-007). `iconUrl` is reserved for future favicon syncing
-/// and is currently unused on the Swift side.
+/// and is currently unused on the Swift side. `url` lets the iOS `SiteEntity`
+/// carry the site address so an orphaned Shortcut (a tile bound to a deleted
+/// site, resolved via the tombstone list) can route by domain (HS-011).
 class ShortcutSite {
   final String siteId;
   final String label;
+  final String? url;
   final String? iconUrl;
 
   const ShortcutSite({
     required this.siteId,
     required this.label,
+    this.url,
     this.iconUrl,
   });
 
   Map<String, dynamic> toMap() => {
         'siteId': siteId,
         'label': label,
+        if (url != null) 'url': url,
         if (iconUrl != null) 'iconUrl': iconUrl,
       };
+}
+
+/// What a tapped home shortcut hands back: the `siteId` plus, on iOS, the
+/// site's `url` carried through the App Group (`OpenSiteIntent` writes it). On
+/// Android the launch intent is siteId-only and `url` is null — the caller
+/// supplies it from the Android-side url ledger instead.
+class ShortcutLaunch {
+  final String siteId;
+  final String? url;
+
+  const ShortcutLaunch({required this.siteId, this.url});
 }
 
 class ShortcutService {
@@ -74,14 +90,32 @@ class ShortcutService {
     }
   }
 
-  /// Get the siteId from the launch intent if the app was opened via a
-  /// pinned shortcut (Android) or a Shortcuts.app `OpenSiteIntent` (iOS 16+).
-  /// Drains the underlying pending state on read (consume-once), so callers
-  /// polling on every resume don't re-navigate on a plain background/return.
-  static Future<String?> getLaunchSiteId() async {
+  /// Get the launch target if the app was opened via a pinned shortcut
+  /// (Android) or a Shortcuts.app `OpenSiteIntent` (iOS 16+). Drains the
+  /// underlying pending state on read (consume-once), so callers polling on
+  /// every resume don't re-navigate on a plain background/return.
+  ///
+  /// Android returns a bare siteId string (`url` null — the caller pairs it
+  /// with the url ledger); iOS returns a `{siteId, url}` map. Both shapes are
+  /// tolerated so the two platforms can share one call site.
+  static Future<ShortcutLaunch?> getLaunch() async {
     if (!Platform.isAndroid && !Platform.isIOS) return null;
     try {
-      return await _channel.invokeMethod('getLaunchSiteId');
+      final res = await _channel.invokeMethod('getLaunchSiteId');
+      if (res is String) {
+        return res.isEmpty ? null : ShortcutLaunch(siteId: res);
+      }
+      if (res is Map) {
+        final id = res['siteId'];
+        if (id is String && id.isNotEmpty) {
+          final url = res['url'];
+          return ShortcutLaunch(
+            siteId: id,
+            url: url is String && url.isNotEmpty ? url : null,
+          );
+        }
+      }
+      return null;
     } on PlatformException {
       return null;
     }
@@ -118,14 +152,21 @@ class ShortcutService {
     }
   }
 
-  /// Push the user's current site list to the iOS App Intents picker
-  /// (HS-007). Writes `[{id, name}]` into the shared App Group UserDefaults
-  /// so `SiteEntityQuery` returns real sites. No-op on non-iOS platforms.
-  static Future<void> syncSites(List<ShortcutSite> sites) async {
+  /// Push the user's current site list to the iOS App Intents picker (HS-007).
+  /// Writes the live `sites` (shown in the Shortcuts.app picker) and the
+  /// `tombstones` (recently-deleted sites — NOT shown in the picker, but kept
+  /// resolvable so a Shortcut tile bound to a deleted site still launches and
+  /// routes via HS-011) into the shared App Group UserDefaults. No-op on
+  /// non-iOS platforms.
+  static Future<void> syncSites(
+    List<ShortcutSite> sites, {
+    List<ShortcutSite> tombstones = const [],
+  }) async {
     if (!Platform.isIOS) return;
     try {
       await _channel.invokeMethod('syncSites', {
         'sites': sites.map((s) => s.toMap()).toList(),
+        'tombstones': tombstones.map((s) => s.toMap()).toList(),
       });
     } on PlatformException {
       // best-effort; the picker just shows stale data until next call.

--- a/lib/services/shortcut_service.dart
+++ b/lib/services/shortcut_service.dart
@@ -3,39 +3,23 @@ import 'package:flutter/services.dart';
 
 /// One site as it crosses the platform-channel boundary into the iOS App
 /// Intents picker (HS-007). `iconUrl` is reserved for future favicon syncing
-/// and is currently unused on the Swift side. `url` rides along so a launched
-/// shortcut whose `siteId` no longer maps to a site can fall back to a
-/// domain match (HS-011).
+/// and is currently unused on the Swift side.
 class ShortcutSite {
   final String siteId;
   final String label;
-  final String? url;
   final String? iconUrl;
 
   const ShortcutSite({
     required this.siteId,
     required this.label,
-    this.url,
     this.iconUrl,
   });
 
   Map<String, dynamic> toMap() => {
         'siteId': siteId,
         'label': label,
-        if (url != null) 'url': url,
         if (iconUrl != null) 'iconUrl': iconUrl,
       };
-}
-
-/// What a tapped home shortcut hands back: the pinned `siteId` plus the site's
-/// `url` (when the shortcut was created after HS-011). Older shortcuts predate
-/// the `url` extra, so `url` is null for them and resolution degrades to
-/// siteId-only matching.
-class ShortcutLaunch {
-  final String siteId;
-  final String? url;
-
-  const ShortcutLaunch({required this.siteId, this.url});
 }
 
 class ShortcutService {
@@ -51,7 +35,6 @@ class ShortcutService {
   static Future<bool> pinShortcut({
     required String siteId,
     required String label,
-    String? url,
     String? iconUrl,
   }) async {
     if (!Platform.isAndroid && !Platform.isIOS) return false;
@@ -59,7 +42,6 @@ class ShortcutService {
       final result = await _channel.invokeMethod('pinShortcut', {
         'siteId': siteId,
         'label': label,
-        'siteUrl': url,
         'iconUrl': iconUrl,
       });
       return result == true;
@@ -80,31 +62,14 @@ class ShortcutService {
     }
   }
 
-  /// Get the launch target (siteId + url) if the app was opened via a pinned
-  /// shortcut (Android) or a Shortcuts.app `OpenSiteIntent` (iOS 16+). Drains
-  /// the underlying pending state on read (consume-once), so callers polling on
-  /// every resume don't re-navigate on a plain background/return.
-  ///
-  /// The native side returns a `{siteId, url}` map for shortcuts pinned after
-  /// HS-011; a bare string is tolerated for backward compatibility (url null).
-  static Future<ShortcutLaunch?> getLaunch() async {
+  /// Get the siteId from the launch intent if the app was opened via a
+  /// pinned shortcut (Android) or a Shortcuts.app `OpenSiteIntent` (iOS 16+).
+  /// Drains the underlying pending state on read (consume-once), so callers
+  /// polling on every resume don't re-navigate on a plain background/return.
+  static Future<String?> getLaunchSiteId() async {
     if (!Platform.isAndroid && !Platform.isIOS) return null;
     try {
-      final res = await _channel.invokeMethod('getLaunchSiteId');
-      if (res is String) {
-        return res.isEmpty ? null : ShortcutLaunch(siteId: res);
-      }
-      if (res is Map) {
-        final id = res['siteId'];
-        if (id is String && id.isNotEmpty) {
-          final url = res['url'];
-          return ShortcutLaunch(
-            siteId: id,
-            url: url is String && url.isNotEmpty ? url : null,
-          );
-        }
-      }
-      return null;
+      return await _channel.invokeMethod('getLaunchSiteId');
     } on PlatformException {
       return null;
     }

--- a/lib/services/startup_restore_engine.dart
+++ b/lib/services/startup_restore_engine.dart
@@ -147,6 +147,26 @@ class ShortcutUrlLedger {
   }
 }
 
+/// Helpers for "is this site already reachable by a home shortcut?", used to
+/// gate the "Home Shortcut" menu item (HS-005).
+class ShortcutPinState {
+  /// The set of siteIds that already have a reachable shortcut: the pinned
+  /// tiles themselves, plus any site a pinned tile has been rebound to via the
+  /// HS-011 remap. Without folding in remap targets, a site an orphaned tile
+  /// now routes to would still offer to create a second, redundant tile.
+  static Set<String> effectivePinnedSiteIds({
+    required Set<String> pinnedSiteIds,
+    required Map<String, String> rememberedRemap,
+  }) {
+    final result = Set<String>.from(pinnedSiteIds);
+    for (final pinned in pinnedSiteIds) {
+      final target = rememberedRemap[pinned];
+      if (target != null) result.add(target);
+    }
+    return result;
+  }
+}
+
 /// iOS-only tombstone list backing HS-011 parity. iOS can't enumerate
 /// home-screen Shortcut tiles, so when a site is deleted we keep a small
 /// `{siteId, label, url}` record. `SiteEntityQuery.entities(for:)` resolves

--- a/lib/services/startup_restore_engine.dart
+++ b/lib/services/startup_restore_engine.dart
@@ -146,3 +146,44 @@ class ShortcutUrlLedger {
     return next;
   }
 }
+
+/// iOS-only tombstone list backing HS-011 parity. iOS can't enumerate
+/// home-screen Shortcut tiles, so when a site is deleted we keep a small
+/// `{siteId, label, url}` record. `SiteEntityQuery.entities(for:)` resolves
+/// from live sites ∪ tombstones (so a tile bound to the deleted site still
+/// launches and routes by domain), while `suggestedEntities()` stays
+/// live-only (HS-009 — the picker doesn't show dead sites). Because a tile may
+/// outlive any number of deletes and iOS gives no pin introspection to GC
+/// against, the list is bounded by a cap (oldest evicted).
+class ShortcutTombstones {
+  /// Append [entry] (`{siteId, label, url}`), de-duped by siteId and moved to
+  /// the most-recent end, capping the list at [cap] (oldest dropped). Returns
+  /// the new list; the caller persists it.
+  static List<Map<String, String>> add({
+    required List<Map<String, String>> tombstones,
+    required Map<String, String> entry,
+    int cap = 64,
+  }) {
+    final id = entry['siteId'];
+    if (id == null || id.isEmpty) return tombstones;
+    final next = <Map<String, String>>[
+      for (final t in tombstones)
+        if (t['siteId'] != id) t,
+      entry,
+    ];
+    if (next.length > cap) return next.sublist(next.length - cap);
+    return next;
+  }
+
+  /// Drop tombstones whose siteId is now a live site (defensive: ids are
+  /// unique per create, so this only fires if a backup reintroduces one).
+  static List<Map<String, String>> pruneLive(
+    List<Map<String, String>> tombstones,
+    Set<String> liveSiteIds,
+  ) {
+    return [
+      for (final t in tombstones)
+        if (!liveSiteIds.contains(t['siteId'])) t,
+    ];
+  }
+}

--- a/lib/services/startup_restore_engine.dart
+++ b/lib/services/startup_restore_engine.dart
@@ -1,5 +1,50 @@
 import 'package:webspace/web_view_model.dart';
 
+/// Outcome of resolving a tapped home shortcut against the current site list.
+/// The engine only decides *what* should happen; the caller owns the dialogs,
+/// `setCurrentIndex`, site creation, and remap persistence.
+sealed class LaunchResolution {
+  const LaunchResolution();
+}
+
+/// No shortcut intent, or nothing actionable (e.g. a legacy shortcut whose
+/// siteId is gone and that carried no url to fall back on). Caller lands on
+/// the home screen without activating a site.
+class LaunchNone extends LaunchResolution {
+  const LaunchNone();
+}
+
+/// The shortcut resolved directly to a known site (by siteId or a remembered
+/// remap). Caller switches to [index] with no prompt.
+class LaunchOpenSite extends LaunchResolution {
+  final int index;
+  const LaunchOpenSite(this.index);
+}
+
+/// The shortcut's siteId is gone, but a current site at [index] matches the
+/// shortcut url's base domain. Caller prompts the user to open it; on confirm,
+/// remembers `shortcutSiteId -> that site` so the next tap resolves directly.
+class LaunchConfirmExisting extends LaunchResolution {
+  final int index;
+  final String shortcutSiteId;
+  const LaunchConfirmExisting({
+    required this.index,
+    required this.shortcutSiteId,
+  });
+}
+
+/// The shortcut's siteId is gone and no current site matches its domain.
+/// Caller offers to create a new site for [url]; on confirm, creates it and
+/// remembers `shortcutSiteId -> new site`.
+class LaunchOfferCreate extends LaunchResolution {
+  final String url;
+  final String shortcutSiteId;
+  const LaunchOfferCreate({
+    required this.url,
+    required this.shortcutSiteId,
+  });
+}
+
 /// Pure helpers for `_WebSpacePageState._restoreAppState`. Only the
 /// straight-line decisions live here; SharedPreferences I/O, native
 /// cookie-jar nuking, and `_setCurrentIndex` chaining stay at the
@@ -14,6 +59,9 @@ class StartupRestoreEngine {
   /// Matches by `WebViewModel.siteId`; the first hit wins (siteIds are
   /// generated to be unique, so collisions only occur if a backup was
   /// hand-edited).
+  ///
+  /// Kept as the siteId-only view used where the richer [resolveLaunch]
+  /// outcome (domain fallback, offer-to-create) isn't needed.
   static int? resolveLaunchTarget({
     required String? shortcutSiteId,
     required List<WebViewModel> models,
@@ -21,5 +69,47 @@ class StartupRestoreEngine {
     if (shortcutSiteId == null) return null;
     final i = models.indexWhere((m) => m.siteId == shortcutSiteId);
     return i >= 0 ? i : null;
+  }
+
+  /// Full shortcut resolution (HS-011). Tries, in order:
+  ///
+  /// 1. direct `siteId` match — [LaunchOpenSite];
+  /// 2. a remembered remap (`shortcutSiteId -> siteId` from a prior
+  ///    user choice) that still resolves — [LaunchOpenSite];
+  /// 3. a current site whose base domain matches the shortcut url —
+  ///    [LaunchConfirmExisting] (caller prompts before binding);
+  /// 4. otherwise, with a usable url — [LaunchOfferCreate].
+  ///
+  /// Falls back to [LaunchNone] when there's no intent, or the siteId is
+  /// gone and no url is available to match on (legacy shortcuts).
+  static LaunchResolution resolveLaunch({
+    required String? shortcutSiteId,
+    required String? shortcutUrl,
+    required List<WebViewModel> models,
+    required Map<String, String> rememberedRemap,
+  }) {
+    if (shortcutSiteId == null) return const LaunchNone();
+
+    final direct = models.indexWhere((m) => m.siteId == shortcutSiteId);
+    if (direct >= 0) return LaunchOpenSite(direct);
+
+    final remembered = rememberedRemap[shortcutSiteId];
+    if (remembered != null) {
+      final i = models.indexWhere((m) => m.siteId == remembered);
+      if (i >= 0) return LaunchOpenSite(i);
+    }
+
+    final url = shortcutUrl?.trim() ?? '';
+    if (url.isEmpty) return const LaunchNone();
+
+    final base = getBaseDomain(url);
+    if (base.isNotEmpty) {
+      final i = models.indexWhere((m) => getBaseDomain(m.initUrl) == base);
+      if (i >= 0) {
+        return LaunchConfirmExisting(index: i, shortcutSiteId: shortcutSiteId);
+      }
+    }
+
+    return LaunchOfferCreate(url: url, shortcutSiteId: shortcutSiteId);
   }
 }

--- a/lib/services/startup_restore_engine.dart
+++ b/lib/services/startup_restore_engine.dart
@@ -113,3 +113,36 @@ class StartupRestoreEngine {
     return LaunchOfferCreate(url: url, shortcutSiteId: shortcutSiteId);
   }
 }
+
+/// Android-only `siteId -> url` ledger backing HS-011 routing. A pinned
+/// shortcut's launch intent carries only the random `siteId`; once the owning
+/// site is deleted that id is opaque, so we keep a trail of the url it pointed
+/// at to drive [StartupRestoreEngine.resolveLaunch]'s domain fallback.
+///
+/// iOS needs none of this: a Shortcuts.app tile binds to a `SiteEntity` whose
+/// query resolves a deleted site to nil, so a stale id never reaches the app.
+class ShortcutUrlLedger {
+  /// Returns the ledger after recording urls for currently-pinned sites and
+  /// dropping entries that are no longer reachable. An entry survives only if
+  /// its site still exists ([currentSiteUrls]) or a pinned shortcut still
+  /// references it ([pinnedSiteIds]) — the latter is the orphan trail we route
+  /// on; the former lets a still-present pinned site's url be recorded so a
+  /// later delete leaves something to match. Everything else is unreachable
+  /// (the site is gone and no launcher tile points at it) and is pruned.
+  ///
+  /// Caller compares against the input and persists only when it changed.
+  static Map<String, String> reconcile({
+    required Map<String, String> ledger,
+    required Map<String, String> currentSiteUrls,
+    required Set<String> pinnedSiteIds,
+  }) {
+    final next = Map<String, String>.from(ledger);
+    for (final id in pinnedSiteIds) {
+      final url = currentSiteUrls[id];
+      if (url != null && url.isNotEmpty) next[id] = url;
+    }
+    next.removeWhere((id, _) =>
+        !currentSiteUrls.containsKey(id) && !pinnedSiteIds.contains(id));
+    return next;
+  }
+}

--- a/lib/services/startup_restore_engine.dart
+++ b/lib/services/startup_restore_engine.dart
@@ -165,6 +165,22 @@ class ShortcutPinState {
     }
     return result;
   }
+
+  /// The pinned tile ids that currently reach [siteId] — either directly (the
+  /// tile's id IS the siteId) or through an HS-011 rebind (`remap[tile] ==
+  /// siteId`). Used by the delete-time prompt (HS-013) so deleting a site an
+  /// orphaned tile was rebound to still prompts about that tile, not just the
+  /// site that was originally pinned.
+  static Set<String> tilesReaching({
+    required String siteId,
+    required Set<String> pinnedSiteIds,
+    required Map<String, String> rememberedRemap,
+  }) {
+    return {
+      for (final tile in pinnedSiteIds)
+        if (tile == siteId || rememberedRemap[tile] == siteId) tile,
+    };
+  }
 }
 
 /// iOS-only tombstone list backing HS-011 parity. iOS can't enumerate

--- a/lib/services/startup_restore_engine.dart
+++ b/lib/services/startup_restore_engine.dart
@@ -45,6 +45,16 @@ class LaunchOfferCreate extends LaunchResolution {
   });
 }
 
+/// The shortcut's siteId is gone and no url is known to match or create on —
+/// e.g. a handle bound to a site deleted before tombstones existed, which iOS
+/// resolves to a placeholder entity so the tile stays tappable instead of
+/// reading "no longer available". Caller offers to reroute the handle to an
+/// existing site; on confirm, remembers `shortcutSiteId -> chosen site`.
+class LaunchOfferReroute extends LaunchResolution {
+  final String shortcutSiteId;
+  const LaunchOfferReroute({required this.shortcutSiteId});
+}
+
 /// Pure helpers for `_WebSpacePageState._restoreAppState`. Only the
 /// straight-line decisions live here; SharedPreferences I/O, native
 /// cookie-jar nuking, and `_setCurrentIndex` chaining stay at the
@@ -78,10 +88,11 @@ class StartupRestoreEngine {
   ///    user choice) that still resolves — [LaunchOpenSite];
   /// 3. a current site whose base domain matches the shortcut url —
   ///    [LaunchConfirmExisting] (caller prompts before binding);
-  /// 4. otherwise, with a usable url — [LaunchOfferCreate].
+  /// 4. with a usable url but no domain match — [LaunchOfferCreate];
+  /// 5. siteId gone and no url, but sites exist — [LaunchOfferReroute].
   ///
   /// Falls back to [LaunchNone] when there's no intent, or the siteId is
-  /// gone and no url is available to match on (legacy shortcuts).
+  /// gone with no url and no sites to reroute to.
   static LaunchResolution resolveLaunch({
     required String? shortcutSiteId,
     required String? shortcutUrl,
@@ -100,7 +111,14 @@ class StartupRestoreEngine {
     }
 
     final url = shortcutUrl?.trim() ?? '';
-    if (url.isEmpty) return const LaunchNone();
+    if (url.isEmpty) {
+      // No url to match a domain or seed a create — but the handle still
+      // resolved (placeholder), so offer to reroute it to an existing site if
+      // there is one; otherwise land on the home screen.
+      return models.isEmpty
+          ? const LaunchNone()
+          : LaunchOfferReroute(shortcutSiteId: shortcutSiteId);
+    }
 
     final base = getBaseDomain(url);
     if (base.isNotEmpty) {

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		7AC2A0000000000000000002 /* ShortcutsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC2A0000000000000000001 /* ShortcutsPlugin.swift */; };
+		7AC2A0000000000000000004 /* WebSpaceAppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC2A0000000000000000003 /* WebSpaceAppIntents.swift */; };
 		BAD4A6ABA9F68FDD7BBA2F60 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0266C30107C75BF1C1D6CA07 /* Pods_RunnerTests.framework */; };
 		D250C5AD4C555C05347D37AA /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FCD7097E9429D61CF36E47F0 /* Pods_Runner.framework */; };
 		7B0F0000000000000000001E /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0F0000000000000000000A /* ShareViewController.swift */; };
@@ -94,6 +96,8 @@
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		33CC10F72044A3C60003C045 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Runner/Info.plist; sourceTree = "<group>"; };
 		33CC11122044BFA00003C045 /* MainFlutterWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainFlutterWindow.swift; sourceTree = "<group>"; };
+		7AC2A0000000000000000001 /* ShortcutsPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShortcutsPlugin.swift; sourceTree = "<group>"; };
+		7AC2A0000000000000000003 /* WebSpaceAppIntents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebSpaceAppIntents.swift; sourceTree = "<group>"; };
 		33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Flutter-Debug.xcconfig"; sourceTree = "<group>"; };
 		33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Flutter-Release.xcconfig"; sourceTree = "<group>"; };
 		33CEB47722A0578A004F2AC0 /* Flutter-Generated.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Flutter-Generated.xcconfig"; path = "ephemeral/Flutter-Generated.xcconfig"; sourceTree = "<group>"; };
@@ -220,6 +224,8 @@
 			children = (
 				33CC10F02044A3C60003C045 /* AppDelegate.swift */,
 				33CC11122044BFA00003C045 /* MainFlutterWindow.swift */,
+				7AC2A0000000000000000001 /* ShortcutsPlugin.swift */,
+				7AC2A0000000000000000003 /* WebSpaceAppIntents.swift */,
 				33E51913231747F40026EE4D /* DebugProfile.entitlements */,
 				33E51914231749380026EE4D /* Release.entitlements */,
 				33CC11242044D66E0003C045 /* Resources */,
@@ -513,6 +519,8 @@
 			files = (
 				33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */,
 				33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */,
+				7AC2A0000000000000000002 /* ShortcutsPlugin.swift in Sources */,
+				7AC2A0000000000000000004 /* WebSpaceAppIntents.swift in Sources */,
 				335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -5,6 +5,7 @@ import UserNotifications
 @main
 class AppDelegate: FlutterAppDelegate {
   private var pendingShareUrl: String?
+  private var shortcutsPlugin: ShortcutsPlugin?
   private let shareChannelName = "org.codeberg.theoden8.webspace/share_intent"
 
   /// Mirrors `macos/ShareExtension/ShareViewController.swift`. macOS
@@ -54,6 +55,7 @@ class AppDelegate: FlutterAppDelegate {
       let window = NSApplication.shared.windows.first,
       let controller = window.contentViewController as? FlutterViewController
     else { return }
+    shortcutsPlugin = ShortcutsPlugin(messenger: controller.engine.binaryMessenger)
     let channel = FlutterMethodChannel(
       name: shareChannelName,
       binaryMessenger: controller.engine.binaryMessenger

--- a/macos/Runner/ShortcutsPlugin.swift
+++ b/macos/Runner/ShortcutsPlugin.swift
@@ -1,0 +1,124 @@
+import Cocoa
+import FlutterMacOS
+import Foundation
+
+#if canImport(AppIntents)
+import AppIntents
+#endif
+
+/// macOS bridge for [`ShortcutService`](../../lib/services/shortcut_service.dart),
+/// mirroring ios/Runner/ShortcutsPlugin.swift. macOS has no programmatic pin
+/// API either, so the menu defers to Shortcuts.app: this plugin keeps an App
+/// Group-backed site list in sync so `WebSpaceShortcuts` / `SiteEntityQuery`
+/// (macOS 13+) surface the user's real sites, and opens `shortcuts://` when the
+/// user asks to add one. A run `OpenSiteIntent` stashes the chosen siteId in
+/// App Group UserDefaults; `getLaunchSiteId` drains it on the next Flutter ask.
+class ShortcutsPlugin: NSObject {
+  private let channel: FlutterMethodChannel
+  private static let channelName = "org.codeberg.theoden8.webspace/shortcuts"
+  // Team-prefixed App Group id, required for sandboxed macOS UserDefaults.
+  // Must match AppDelegate.appGroupId and WebSpaceAppIntents.kShortcutAppGroupId.
+  private static let appGroupId = "7NGC2P87LM.group.org.codeberg.theoden8.webspace"
+  private static let sitesKey = "shortcut_sites"
+  private static let tombstonesKey = "shortcut_tombstones"
+  private static let pendingKey = "pending_shortcut_site_id"
+  private static let pendingUrlKey = "pending_shortcut_url"
+
+  init(messenger: FlutterBinaryMessenger) {
+    self.channel = FlutterMethodChannel(
+      name: Self.channelName,
+      binaryMessenger: messenger
+    )
+    super.init()
+    self.channel.setMethodCallHandler { [weak self] call, result in
+      self?.handle(call: call, result: result)
+    }
+  }
+
+  private func handle(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "isAppIntentsSupported":
+      if #available(macOS 13, *) {
+        result(true)
+      } else {
+        result(false)
+      }
+    case "syncSites":
+      let args = call.arguments as? [String: Any]
+      let sites = args?["sites"] as? [[String: Any]] ?? []
+      let tombstones = args?["tombstones"] as? [[String: Any]] ?? []
+      syncSites(sites, tombstones: tombstones)
+      result(true)
+    case "getLaunchSiteId":
+      result(drainPendingLaunch())
+    case "pinShortcut":
+      openShortcutsApp(result: result)
+    case "removeShortcut":
+      // No-op on macOS: we don't pin, we don't track.
+      result(nil)
+    case "getPinnedSiteIds":
+      // macOS has no public API to enumerate Shortcuts.app tiles.
+      result([])
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func syncSites(_ rawSites: [[String: Any]], tombstones rawTombstones: [[String: Any]]) {
+    guard let defaults = UserDefaults(suiteName: Self.appGroupId) else {
+      NSLog("[WebSpace.macOS] ShortcutsPlugin: App Group \(Self.appGroupId) unavailable")
+      return
+    }
+    let sites = Self.normalize(rawSites)
+    let tombs = Self.normalize(rawTombstones)
+    NSLog("[WebSpace.macOS] ShortcutsPlugin.syncSites sites=\(sites.count) tombstones=\(tombs.count)")
+    if let json = try? JSONSerialization.data(withJSONObject: sites) {
+      defaults.set(json, forKey: Self.sitesKey)
+    }
+    if let json = try? JSONSerialization.data(withJSONObject: tombs) {
+      defaults.set(json, forKey: Self.tombstonesKey)
+    }
+    #if canImport(AppIntents)
+    if #available(macOS 13, *) {
+      WebSpaceShortcuts.updateAppShortcutParameters()
+    }
+    #endif
+  }
+
+  private static func normalize(_ raw: [[String: Any]]) -> [[String: String]] {
+    raw.compactMap { dict in
+      guard let id = dict["siteId"] as? String,
+            let name = dict["label"] as? String,
+            !id.isEmpty
+      else { return nil }
+      var entry = ["id": id, "name": name]
+      if let url = dict["url"] as? String, !url.isEmpty {
+        entry["url"] = url
+      }
+      return entry
+    }
+  }
+
+  private func drainPendingLaunch() -> [String: String]? {
+    guard let defaults = UserDefaults(suiteName: Self.appGroupId),
+          let siteId = defaults.string(forKey: Self.pendingKey),
+          !siteId.isEmpty
+    else { return nil }
+    let url = defaults.string(forKey: Self.pendingUrlKey)
+    defaults.removeObject(forKey: Self.pendingKey)
+    defaults.removeObject(forKey: Self.pendingUrlKey)
+    var payload = ["siteId": siteId]
+    if let url = url, !url.isEmpty { payload["url"] = url }
+    NSLog("[WebSpace.macOS] drainPendingLaunch siteId=\(siteId) url=\(url ?? "nil")")
+    return payload
+  }
+
+  private func openShortcutsApp(result: @escaping FlutterResult) {
+    guard let url = URL(string: "shortcuts://") else {
+      result(false)
+      return
+    }
+    NSWorkspace.shared.open(url)
+    result(true)
+  }
+}

--- a/macos/Runner/WebSpaceAppIntents.swift
+++ b/macos/Runner/WebSpaceAppIntents.swift
@@ -59,16 +59,19 @@ struct SiteEntity: AppEntity {
 /// App Group UserDefaults so the Shortcuts.app picker shows real sites.
 @available(macOS 13, *)
 struct SiteEntityQuery: EntityQuery {
-  // Resolve a bound parameter from live sites AND tombstones, so a Shortcut
-  // pointing at a since-deleted site still resolves (its run then routes by
-  // domain on the Dart side) instead of failing "no longer available".
+  // Resolve EVERY requested id: a live site, then a tombstone, else a
+  // placeholder, so a Shortcut bound to a since-removed site stays tappable
+  // instead of reading "no longer available" (HS-014). De-dupe; preserve order.
   func entities(for identifiers: [SiteEntity.ID]) async throws -> [SiteEntity] {
     let live = Self.loadSites()
     let tombs = Self.loadTombstones()
-    let all = live + tombs
-    let wanted = Set(identifiers)
+    var byId: [String: SiteEntity] = [:]
+    for e in (live + tombs) where byId[e.id] == nil { byId[e.id] = e }
     var seen = Set<String>()
-    let resolved = all.filter { wanted.contains($0.id) && seen.insert($0.id).inserted }
+    var resolved: [SiteEntity] = []
+    for id in identifiers where seen.insert(id).inserted {
+      resolved.append(byId[id] ?? SiteEntity(id: id, name: "Removed WebSpace site", url: nil))
+    }
     NSLog("[WebSpace.macOS] SiteEntityQuery.entities(for: \(identifiers)) live=\(live.count) tombstones=\(tombs.count) resolved=\(resolved.count)")
     return resolved
   }

--- a/macos/Runner/WebSpaceAppIntents.swift
+++ b/macos/Runner/WebSpaceAppIntents.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+#if canImport(AppIntents)
+import AppIntents
+
+// macOS counterpart of ios/Runner/WebSpaceAppIntents.swift. Kept as a separate
+// per-target file (the iOS/macOS Runner targets already keep separate
+// AppDelegate.swift etc.) because the App Group id differs: a sandboxed macOS
+// app must address its group UserDefaults with the team-prefixed form, while
+// iOS uses the bare id. Behavior is otherwise identical (HS-007/HS-011/HS-014).
+
+/// Key for the JSON-encoded `[{id, name, url}]` live site list in the shared
+/// App Group UserDefaults. Written by Dart via `ShortcutsPlugin.syncSites`;
+/// read by `SiteEntityQuery` for the Shortcuts.app picker.
+let kShortcutSitesKey = "shortcut_sites"
+
+/// Key for the JSON-encoded `[{id, name, url}]` tombstone list — recently
+/// deleted sites. NOT shown in the picker (`suggestedEntities`), but resolved
+/// by `entities(for:)` so a Shortcut bound to a deleted site still runs and
+/// routes by domain on the Dart side (HS-011).
+let kShortcutTombstonesKey = "shortcut_tombstones"
+
+/// Key for the pending siteId that an `OpenSiteIntent` has just resolved.
+let kPendingShortcutSiteIdKey = "pending_shortcut_site_id"
+
+/// Key for the pending site url an `OpenSiteIntent` carries alongside the id,
+/// so a deleted-site tap can route by domain (HS-011). Drained with the id.
+let kPendingShortcutUrlKey = "pending_shortcut_url"
+
+/// Sandboxed macOS requires the team-prefixed App Group id for
+/// `UserDefaults(suiteName:)`; this must match `AppDelegate.appGroupId`. If you
+/// change DEVELOPMENT_TEAM, update both.
+let kShortcutAppGroupId = "7NGC2P87LM.group.org.codeberg.theoden8.webspace"
+
+/// One synced WebSpace site as it appears to App Intents.
+@available(macOS 13, *)
+struct SiteEntity: AppEntity {
+  let id: String
+  let name: String
+  let url: String?
+
+  static var typeDisplayRepresentation: TypeDisplayRepresentation {
+    TypeDisplayRepresentation(name: "Site")
+  }
+
+  // See ios/Runner/WebSpaceAppIntents.swift for why this is a static "%@" key
+  // (compile-time extractable) plus a runtime defaultValue: any other form
+  // collapses every site to a single mis-titled tile.
+  var displayRepresentation: DisplayRepresentation {
+    DisplayRepresentation(
+      title: LocalizedStringResource("%@", defaultValue: String.LocalizationValue(name))
+    )
+  }
+
+  static var defaultQuery = SiteEntityQuery()
+}
+
+/// Backing query for `OpenSiteIntent.target`. Reads the synced site list from
+/// App Group UserDefaults so the Shortcuts.app picker shows real sites.
+@available(macOS 13, *)
+struct SiteEntityQuery: EntityQuery {
+  // Resolve a bound parameter from live sites AND tombstones, so a Shortcut
+  // pointing at a since-deleted site still resolves (its run then routes by
+  // domain on the Dart side) instead of failing "no longer available".
+  func entities(for identifiers: [SiteEntity.ID]) async throws -> [SiteEntity] {
+    let live = Self.loadSites()
+    let tombs = Self.loadTombstones()
+    let all = live + tombs
+    let wanted = Set(identifiers)
+    var seen = Set<String>()
+    let resolved = all.filter { wanted.contains($0.id) && seen.insert($0.id).inserted }
+    NSLog("[WebSpace.macOS] SiteEntityQuery.entities(for: \(identifiers)) live=\(live.count) tombstones=\(tombs.count) resolved=\(resolved.count)")
+    return resolved
+  }
+
+  // The picker offers only live sites — deleted sites are NOT surfaced (HS-009).
+  func suggestedEntities() async throws -> [SiteEntity] {
+    let live = Self.loadSites()
+    NSLog("[WebSpace.macOS] SiteEntityQuery.suggestedEntities live=\(live.count)")
+    return live
+  }
+
+  static func loadSites() -> [SiteEntity] {
+    load(key: kShortcutSitesKey)
+  }
+
+  static func loadTombstones() -> [SiteEntity] {
+    load(key: kShortcutTombstonesKey)
+  }
+
+  static func load(key: String) -> [SiteEntity] {
+    guard let defaults = UserDefaults(suiteName: kShortcutAppGroupId),
+          let data = defaults.data(forKey: key) ?? defaults.string(forKey: key)?.data(using: .utf8)
+    else {
+      return []
+    }
+    guard let raw = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+      return []
+    }
+    return raw.compactMap { dict in
+      guard let id = dict["id"] as? String, let name = dict["name"] as? String else {
+        return nil
+      }
+      return SiteEntity(id: id, name: name, url: dict["url"] as? String)
+    }
+  }
+}
+
+/// App Intent the user invokes from Shortcuts.app / Spotlight to open a
+/// specific WebSpace site. `perform()` stashes the chosen siteId in the App
+/// Group so the Flutter resume / cold-launch path can route it.
+@available(macOS 13, *)
+struct OpenSiteIntent: AppIntent, OpenIntent {
+  static var title: LocalizedStringResource = "Open Site"
+  static var description = IntentDescription("Open a WebSpace site by name.")
+  static var openAppWhenRun: Bool = true
+
+  @Parameter(title: "Site")
+  var target: SiteEntity
+
+  init() {}
+
+  init(target: SiteEntity) {
+    self.target = target
+  }
+
+  func perform() async throws -> some IntentResult {
+    NSLog("[WebSpace.macOS] OpenSiteIntent.perform id=\(target.id) url=\(target.url ?? "nil")")
+    if let defaults = UserDefaults(suiteName: kShortcutAppGroupId) {
+      defaults.set(target.id, forKey: kPendingShortcutSiteIdKey)
+      if let url = target.url, !url.isEmpty {
+        defaults.set(url, forKey: kPendingShortcutUrlKey)
+      } else {
+        defaults.removeObject(forKey: kPendingShortcutUrlKey)
+      }
+    } else {
+      NSLog("[WebSpace.macOS] OpenSiteIntent: App Group \(kShortcutAppGroupId) unavailable")
+    }
+    return .result()
+  }
+}
+
+/// Declares the discoverable App Shortcut iOS/macOS surface in Shortcuts.app.
+@available(macOS 13, *)
+struct WebSpaceShortcuts: AppShortcutsProvider {
+  static var appShortcuts: [AppShortcut] {
+    AppShortcut(
+      intent: OpenSiteIntent(),
+      phrases: [
+        "Open \(\.$target) in \(.applicationName)",
+        "Open \(\.$target) site in \(.applicationName)",
+      ],
+      shortTitle: "Open Site",
+      systemImageName: "globe"
+    )
+  }
+}
+
+#endif

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -345,6 +345,44 @@ The reconcile logic is a pure function exercised in [test/startup_restore_engine
 
 ---
 
+### Requirement: HS-013 - Delete-Time Shortcut Prompt (Android)
+
+When the user deletes a site that currently has a pinned home shortcut (`siteId` in the cached pinned set), the system SHALL prompt for the fate of the now-orphaned launcher tile, since Android cannot remove a pinned tile programmatically. The prompt offers three choices:
+
+- **Keep** — leave the tile enabled; a tap re-routes via HS-011 (open a domain match or offer to create). This is also the outcome if the prompt is dismissed.
+- **Reassign** — pick another existing site; the system records a rebind (`deletedSiteId -> chosen siteId`) so a tap opens the chosen site directly (HS-011 step 2).
+- **Disable** — disable the pinned shortcut (it greys out and the launcher rejects the tap until the user removes it from the home screen) and drop the deleted id's ledger and rebind entries.
+
+The prompt SHALL only appear on Android and only when the deleted site actually had a pinned shortcut; deleting a site with no shortcut is unaffected.
+
+#### Scenario: Deleting a shortcutted site offers keep / reassign / disable
+
+**Given** the user deletes a site that has a pinned home shortcut
+**When** the deletion completes
+**Then** the system prompts with Keep, Reassign, and Disable
+
+#### Scenario: Reassign points the tile at another site
+
+**Given** the delete-time prompt is shown
+**When** the user chooses Reassign and picks another site
+**Then** a rebind from the deleted siteId to the chosen site is remembered
+**And** a later tap of the tile opens the chosen site with no prompt
+
+#### Scenario: Disable greys out the tile
+
+**Given** the delete-time prompt is shown
+**When** the user chooses Disable
+**Then** the pinned shortcut is disabled
+**And** the deleted id's ledger and rebind entries are dropped
+
+#### Scenario: Deleting a site with no shortcut shows no prompt
+
+**Given** the user deletes a site that has no pinned shortcut
+**When** the deletion completes
+**Then** no shortcut prompt is shown
+
+---
+
 ### Requirement: HS-006 - Shortcut Launch Resets To Home URL
 
 A pinned shortcut SHALL launch the targeted site at its `initUrl`, not at the last persisted `currentUrl`. The shortcut represents the user's stated entry point for that site (the URL they pinned), not the URL the previous session happened to drift to. Without this, location/tracking/state parameters that accumulate during a session resurface every time the shortcut is tapped — particularly visible on map and search sites that encode coordinates or query state in the URL (issue #298).

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -364,7 +364,14 @@ When the user deletes a site that is reachable by one or more pinned tiles, the 
 - **Reassign** — pick another existing site; the system records a rebind (`tile -> chosen siteId`) for each reaching tile so a tap opens the chosen site directly (HS-011 step 2).
 - **Disable** — disable each reaching tile (it greys out and the launcher rejects the tap until the user removes it from the home screen) and drop its ledger and rebind entries.
 
-The prompt SHALL only appear on Android and only when at least one pinned tile reaches the deleted site; deleting a site no tile reaches is unaffected.
+On **Android** the prompt appears only when at least one pinned tile reaches the deleted site (detectable via `getPinnedSiteIds`); deleting a site no tile reaches is unaffected. On **iOS** there is no tile-introspection API, so the prompt appears on every non-archive deletion, and the actions map to the tombstone (HS-014): Keep/Reassign record a tombstone so a tile bound to the site stays resolvable (Reassign also remaps it to the chosen site); Disable records no tombstone and drops any remap, so the handle no longer resolves and the tile stops running.
+
+#### Scenario: iOS prompts on delete and Disable kills the handle
+
+**Given** the user deletes a non-archive site on iOS
+**When** the prompt appears and the user chooses Disable
+**Then** no tombstone is kept for that site
+**And** a Shortcut bound to it no longer resolves or runs
 
 #### Scenario: Deleting a site a tile was rebound to still prompts
 

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -364,14 +364,21 @@ When the user deletes a site that is reachable by one or more pinned tiles, the 
 - **Reassign** — pick another existing site; the system records a rebind (`tile -> chosen siteId`) for each reaching tile so a tap opens the chosen site directly (HS-011 step 2).
 - **Disable** — disable each reaching tile (it greys out and the launcher rejects the tap until the user removes it from the home screen) and drop its ledger and rebind entries.
 
-On **Android** the prompt appears only when at least one pinned tile reaches the deleted site (detectable via `getPinnedSiteIds`); deleting a site no tile reaches is unaffected. On **iOS** there is no tile-introspection API, so the prompt appears on every non-archive deletion, and the actions map to the tombstone (HS-014): Keep/Reassign record a tombstone so a tile bound to the site stays resolvable (Reassign also remaps it to the chosen site); Disable records no tombstone and drops any remap, so the handle no longer resolves and the tile stops running.
+The prompt appears only on **Android**, and only when at least one pinned tile reaches the deleted site (detectable via `getPinnedSiteIds`); deleting a site no tile reaches is unaffected. The prompt is Android-only because only Android can enumerate tiles (to know one exists) and disable them (so the choice has a system-UI effect). On platforms with no tile-introspection or disable API (**iOS**; macOS and Linux if/when they gain a shortcut path), a delete-time prompt would fire blindly on every deletion, so the site is tombstoned silently (HS-014) and the choice is deferred to the only moment a handle reveals itself — when it is tapped (HS-011 step 3): a tap with no live/remap/domain match offers to reroute the handle to an existing site or create a new one, and the choice is remembered as a remap.
 
-#### Scenario: iOS prompts on delete and Disable kills the handle
+#### Scenario: iOS records a tombstone silently on delete
 
 **Given** the user deletes a non-archive site on iOS
-**When** the prompt appears and the user chooses Disable
-**Then** no tombstone is kept for that site
-**And** a Shortcut bound to it no longer resolves or runs
+**When** the deletion completes
+**Then** no prompt is shown
+**And** a tombstone is recorded so a Shortcut bound to the site stays resolvable and routes when tapped
+
+#### Scenario: Tapping a handle with no match offers reroute or create
+
+**Given** a tapped Shortcut handle resolves to no live site, remap, or domain match
+**When** the launch is handled
+**Then** the user is offered to reroute the handle to an existing site or create a new one
+**And** the choice is remembered as a remap so the next tap resolves directly
 
 #### Scenario: Deleting a site a tile was rebound to still prompts
 

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -208,8 +208,8 @@ The system SHALL keep the iOS App Intents site picker in sync with the user's ac
 
 **Given** a site is referenced by an existing user-created Shortcut
 **When** the user deletes the site in WebSpace
-**Then** the deleted site no longer appears in the App Intents picker (`suggestedEntities` is live-only)
-**And** invoking the orphaned Shortcut still launches WebSpace and routes the id by domain via the tombstone list (HS-011 / HS-014), rather than failing to resolve
+**Then** invoking the orphaned Shortcut still launches WebSpace and routes the id by domain via the tombstone list (HS-011 / HS-014), rather than failing to resolve
+**And** the deleted site stays visible in the App Intents picker until its tombstone is evicted (HS-014 — iOS validates a bound parameter against `suggestedEntities`, so a deleted entity must remain surfaced there to stay runnable)
 
 #### Scenario: App Group unavailable
 
@@ -391,7 +391,7 @@ The prompt SHALL only appear on Android and only when the deleted site actually 
 iOS cannot enumerate or disable home-screen Shortcut tiles, so to give HS-011 parity the system SHALL keep a bounded tombstone list of deleted sites and sync it to the App Group alongside the live site list. The system SHALL:
 
 - on deletion of any non-archive site, append `{siteId, label, url}` to the tombstone list (deduped by siteId, capped — oldest evicted) and re-sync;
-- write tombstones under a key (`shortcut_tombstones`) distinct from the live list, so `SiteEntityQuery.entities(for:)` resolves a bound parameter from **live ∪ tombstones** while `suggestedEntities()` (the Shortcuts.app picker) returns **live only** (HS-009);
+- write tombstones under a key (`shortcut_tombstones`) distinct from the live list; BOTH `SiteEntityQuery.entities(for:)` and `suggestedEntities()` resolve from **live ∪ tombstones**. iOS validates a Shortcut's bound parameter against the *suggested* set, not just `entities(for:)`, so a deleted entity must remain surfaced in `suggestedEntities()` to stay runnable — the accepted cost is that recently-deleted sites stay visible in the Shortcuts.app picker (and Siri/Spotlight) until evicted from the capped tombstone list;
 - have `OpenSiteIntent.perform()` write the resolved entity's url to the App Group (`pending_shortcut_url`) so the Dart side can route by domain.
 
 Because iOS gives no way to know whether a tile actually exists, the system tombstones every qualifying deletion rather than only shortcutted ones; the cap bounds growth. Archive-tier sites are never tombstoned (ARCH-006).
@@ -403,11 +403,11 @@ Because iOS gives no way to know whether a tile actually exists, the system tomb
 **Then** the bound `SiteEntity` resolves from the tombstone list (it is NOT in the picker)
 **And** WebSpace launches and routes the orphaned id by domain per HS-011 (open a match or offer to create)
 
-#### Scenario: Tombstoned site stays out of the picker
+#### Scenario: Tombstoned site stays runnable from the picker
 
 **Given** a site has been deleted and tombstoned
 **When** the user opens the "Open Site" action in Shortcuts.app
-**Then** the deleted site does NOT appear in the site picker (HS-009)
+**Then** the deleted site is still listed (so an existing Shortcut bound to it stays valid and runnable), until its tombstone is evicted from the capped list
 
 #### Scenario: Tombstone list is bounded
 
@@ -471,7 +471,7 @@ Methods:
 `ios/Runner/WebSpaceAppIntents.swift` defines (all `@available(iOS 16, *)`):
 
 - `SiteEntity: AppEntity` — one synced site with `id: String` (siteId), `name: String`, and `url: String?` (so a tombstone-resolved deleted site can route by domain, HS-011/HS-014). `displayRepresentation` MUST use `DisplayRepresentation(title: LocalizedStringResource("%@", defaultValue: String.LocalizationValue(name)))`. The static `"%@"` key is stable for the compile-time App Intents metadata extractor while the runtime `defaultValue` still resolves to each site's name. Two earlier forms both collapse the materialized parameterized App Shortcuts (one per entity) down to a single visible entry in Shortcuts.app: `DisplayRepresentation(title: "\(name)")` (interpolation renders the literal `%@`), and `DisplayRepresentation(stringLiteral: name)` (resolves in the live picker but not in the materialized tiles, since a runtime string can't be a compile-time title key — the surviving tile also keeps a stale bound target).
-- `SiteEntityQuery: EntityQuery` — `suggestedEntities()` reads `shortcut_sites` (live only) so the picker shows real WebSpace sites; `entities(for:)` resolves from `shortcut_sites` ∪ `shortcut_tombstones` so a tile bound to a deleted site still resolves and launches (HS-014).
+- `SiteEntityQuery: EntityQuery` — both `suggestedEntities()` and `entities(for:)` resolve from `shortcut_sites` ∪ `shortcut_tombstones`, so a tile bound to a deleted site stays valid and runnable (HS-014). Deleted sites therefore remain in the picker until their tombstone is evicted.
 - `OpenSiteIntent: AppIntent, OpenIntent` — parameterized on `SiteEntity`. `openAppWhenRun = true` foregrounds WebSpace; `perform()` writes the chosen siteId to `pending_shortcut_site_id` and its url to `pending_shortcut_url` in App Group UserDefaults.
 - `WebSpaceShortcuts: AppShortcutsProvider` — declares the discoverable "Open Site" App Shortcut with phrase template `"Open \(\.$target) in WebSpace"`.
 

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -262,24 +262,26 @@ in any webspace containing the launched site.
 
 ---
 
-### Requirement: HS-011 - Domain Fallback For Orphaned Shortcuts
+### Requirement: HS-011 - Domain Fallback For Orphaned Shortcuts (Android)
 
-A pinned shortcut carries the site's `url` alongside its `siteId`. The system SHALL use that url to recover when a tapped shortcut's `siteId` no longer maps to any site — which happens after a settings restore on a new device (siteIds are random per install) or a delete+recreate. Recovery resolution runs in order:
+An Android pinned shortcut's launch intent carries only the random `siteId`. When that `siteId` no longer maps to any site — the user deleted the site and created a new one for the same address — the tap would otherwise fall back to the home screen. The system SHALL recover by routing the orphaned id through a persisted `siteId -> url` ledger and matching by base domain. Resolution runs in order:
 
 1. **Direct match** — the `siteId` maps to a current site. Open it (HS-002), no prompt.
 2. **Remembered rebind** — a prior user choice mapped this `siteId` to a live site. Open it, no prompt.
-3. **Domain match** — a current site shares the shortcut url's base domain. The system SHALL prompt the user to open that site; on confirm it SHALL remember the rebind so later taps resolve via step 2.
-4. **Offer to create** — no current site matches. The system SHALL prompt the user to create a new site for the shortcut url; on confirm it SHALL create the site, open it, and remember the rebind.
+3. **Domain match** — the ledger has a url for this `siteId` and a current site shares its base domain. The system SHALL prompt the user to open that site; on confirm it SHALL remember the rebind so later taps resolve via step 2.
+4. **Offer to create** — the ledger has a url but no current site matches. The system SHALL prompt the user to create a new site for that url; on confirm it SHALL create the site, open it, and remember the rebind.
 
-A shortcut pinned before this feature carries no url; if its `siteId` is gone the system falls back to the home screen (legacy HS-002 behavior). The remembered rebind map is machine state derived from shortcut activity: it is persisted in `SharedPreferences` under `shortcutSiteRemap`, is NOT part of settings export/import, and entries whose resolved target is later deleted are pruned at startup.
+With no ledger url for the id (e.g. a shortcut pinned before this feature whose site was deleted before any reconcile recorded its url), the system falls back to the home screen (legacy HS-002 behavior).
 
-On Android the url rides the launch intent as the `siteUrl` extra (drained with `siteId`). On iOS the synced site list and `OpenSiteIntent` carry the url through the App Group (`pending_shortcut_url`).
+The ledger is **Android-only**. iOS needs no recovery: a Shortcuts.app tile binds to a `SiteEntity` whose query resolves a deleted site to nil, so `OpenSiteIntent.perform()` never runs and a stale id never reaches the app.
 
-#### Scenario: Restored backup, same site exists under a new siteId
+The ledger and the remembered-rebind map are machine state derived from shortcut activity: both are persisted in `SharedPreferences` (`shortcutUrlLedger`, `shortcutSiteRemap`), are NOT part of settings export/import, and are pruned to reachable entries (see HS-012). A rebind whose resolved target is later deleted is dropped at startup.
 
-**Given** the user restored a settings backup on a new device, so a site for `https://www.example.com` exists but under a different `siteId` than the one baked into a previously pinned shortcut
-**When** the user taps that shortcut
-**Then** the app prompts "Open <matching site>?" because the shortcut url's base domain matches the restored site
+#### Scenario: Pinned site deleted and recreated under a new id
+
+**Given** the user pinned a shortcut for a site at `https://www.example.com`, then deleted that site and created a new one for the same address (a new random `siteId`)
+**When** the user taps the original shortcut
+**Then** the app prompts "Open <matching site>?" because the ledger url's base domain matches the recreated site
 **And** on confirm the matching site is selected
 **And** a subsequent tap of the same shortcut opens it directly with no prompt
 
@@ -287,8 +289,8 @@ On Android the url rides the launch intent as the `siteUrl` extra (drained with 
 
 **Given** the user deleted the site a shortcut pointed to and has no other site on that domain
 **When** the user taps the shortcut
-**Then** the app prompts "Create a new site for <url>?"
-**And** on confirm a new site rooted at the shortcut url is created, selected, and remembered for that shortcut
+**Then** the app prompts "Create a new site for <url>?" using the ledger url
+**And** on confirm a new site rooted at that url is created, selected, and remembered for that shortcut
 
 #### Scenario: User declines the prompt
 
@@ -297,11 +299,34 @@ On Android the url rides the launch intent as the `siteUrl` extra (drained with 
 **Then** no site is opened or created and no rebind is remembered
 **And** a later tap shows the prompt again
 
-#### Scenario: Legacy shortcut without a url
+#### Scenario: Orphaned id with no ledger url
 
-**Given** a shortcut pinned before HS-011 (no url extra) whose `siteId` no longer maps to a site
-**When** the user taps it
-**Then** the app launches on the home screen with no site activated (HS-002)
+**Given** a tapped shortcut whose `siteId` maps to no site and for which the ledger holds no url
+**When** the app resolves the launch
+**Then** it launches on the home screen with no site activated (HS-002)
+
+---
+
+### Requirement: HS-012 - Shortcut URL Ledger Maintenance (Android)
+
+The system SHALL maintain the HS-011 `siteId -> url` ledger against the launcher's actual pinned set, so it carries exactly the entries needed to route orphaned shortcuts and no stale cruft. On pin, and on every `initState` / `AppLifecycleState.resumed` (the same cadence as the HS-005 pinned-set refresh), the system SHALL:
+
+- record `siteId -> initUrl` for every pinned shortcut whose site still exists, so a later deletion leaves a routable trail; and
+- drop any ledger entry whose `siteId` is neither a current site nor in the pinned set (unreachable: the site is gone and no launcher tile points at it).
+
+The reconcile logic is a pure function exercised in [test/startup_restore_engine_test.dart](../../../test/startup_restore_engine_test.dart).
+
+#### Scenario: Pinning records the url
+
+**Given** the user pins a shortcut for a site at `https://www.example.com`
+**When** the pin completes
+**Then** the ledger holds that site's `siteId -> https://www.example.com`
+
+#### Scenario: Removing the launcher tile prunes the entry
+
+**Given** a ledger entry exists for a site that has since been deleted and whose launcher tile the user has now removed
+**When** the app next reconciles on resume
+**Then** the entry is dropped (neither current nor pinned)
 
 ---
 
@@ -346,9 +371,9 @@ This requirement applies only to **process-startup** launches (cold or post-kill
 Both Android and iOS share the channel `MethodChannel('org.codeberg.theoden8.webspace/shortcuts')`.
 
 Methods:
-- `pinShortcut({siteId, label, siteUrl, iconUrl})` — **Android**: requests a pinned shortcut via `ShortcutManagerCompat.requestPinShortcut()`, baking `siteUrl` into the launch intent for HS-011 domain fallback. **iOS 16+**: opens `shortcuts://` (the Dart UI shows the HS-010 instructional dialog first).
+- `pinShortcut({siteId, label, iconUrl})` — **Android**: requests a pinned shortcut via `ShortcutManagerCompat.requestPinShortcut()`. **iOS 16+**: opens `shortcuts://` (the Dart UI shows the HS-010 instructional dialog first).
 - `removeShortcut(siteId)` — Android: disables and removes the dynamic+pinned shortcut for a deleted site. iOS: no-op (the App Intents site list is recomputed from `_webViewModels` on every save via HS-009).
-- `getLaunchSiteId()` — **Android**: returns a `{siteId, url}` map from the launch intent extras, then drains both (`intent.removeExtra(...)`) so it fires once per tap. **iOS**: drains the `pending_shortcut_site_id` + `pending_shortcut_url` keys from App Group UserDefaults (written by `OpenSiteIntent.perform()`) into the same map. Both platforms MUST consume-on-read: `_handleShortcutIntent` re-polls on every `AppLifecycleState.resumed`, so a non-draining read would re-navigate to the pinned site on a plain background/return with no new tap. The Dart `ShortcutService.getLaunch()` wraps the map as a `ShortcutLaunch`; a bare-string return is tolerated for shortcuts pinned before HS-011 (url null).
+- `getLaunchSiteId()` — **Android**: returns the `siteId` from the launch intent extra, then drains it (`intent.removeExtra("siteId")`) so it fires once per tap. **iOS**: drains the `pending_shortcut_site_id` key from App Group UserDefaults (written by `OpenSiteIntent.perform()`). Both platforms MUST consume-on-read: `_handleShortcutIntent` re-polls on every `AppLifecycleState.resumed`, so a non-draining read would re-navigate to the pinned site on a plain background/return with no new tap. For HS-011 the Android caller pairs the returned `siteId` with its `shortcutUrlLedger` url before resolving.
 - `getPinnedSiteIds()` — Android: returns the set of `siteId`s currently pinned, derived from `ShortcutManagerCompat.getShortcuts(FLAG_MATCH_PINNED)` by stripping the `site_` prefix. iOS: always returns an empty list (no public API for pin-state introspection).
 - `syncSites({sites: [{siteId, label, iconUrl?}]})` — **iOS only**: writes `[{id, name}]` to App Group UserDefaults under `shortcut_sites` and calls `WebSpaceShortcuts.updateAppShortcutParameters()` to refresh the Shortcuts.app picker. No-op on Android.
 - `isAppIntentsSupported()` — **iOS**: true if `#available(iOS 16, *)`. Other platforms: false.
@@ -374,7 +399,8 @@ The shortcut launches `MainActivity` with:
 ### Launch Handling
 
 On app start and on `onNewIntent` (app already running), read the launch
-target via `ShortcutService.getLaunch()` and resolve it through
+`siteId` via `ShortcutService.getLaunchSiteId()`, pair it with its
+`shortcutUrlLedger` url (HS-011/HS-012), and resolve through
 [`StartupRestoreEngine.resolveLaunch`](../../../lib/services/startup_restore_engine.dart):
 
 1. `resolveLaunch(shortcutSiteId, shortcutUrl, models, rememberedRemap)`
@@ -387,13 +413,15 @@ target via `ShortcutService.getLaunch()` and resolve it through
    - `LaunchOfferCreate(url, shortcutSiteId)` — siteId gone, no domain
      match; caller prompts to create a site for `url`, remembering the
      rebind on confirm.
-   - `LaunchNone` — no intent, or a legacy url-less shortcut whose siteId
-     is gone (home screen).
+   - `LaunchNone` — no intent, or an orphaned siteId with no ledger url
+     (home screen).
 2. On cold launch the confirm/create prompts are deferred to the first
    post-frame (no UI exists mid-`_restoreAppState`); direct hits activate
    inline. The warm path (`_handleShortcutIntent`) prompts immediately.
-3. The remembered rebind map is persisted in `SharedPreferences` under
-   `shortcutSiteRemap` (HS-011) and pruned of dangling targets at startup.
+3. The remembered rebind map (`shortcutSiteRemap`) and the url ledger
+   (`shortcutUrlLedger`) are persisted in `SharedPreferences` (HS-011 /
+   HS-012); dangling rebind targets are pruned at startup and the ledger
+   is reconciled to the pinned set.
 
 `resolveLaunchTarget` is retained as the siteId-only view (direct hit or
 null). Both rules are exercised headlessly in

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -216,8 +216,8 @@ The system SHALL keep the iOS App Intents site picker in sync with the user's ac
 
 **Given** a site is referenced by an existing user-created Shortcut
 **When** the user deletes the site in WebSpace
-**Then** invoking the orphaned Shortcut still launches WebSpace and routes the id by domain via the tombstone list (HS-011 / HS-014), rather than failing to resolve
-**And** the deleted site stays visible in the App Intents picker until its tombstone is evicted (HS-014 — iOS validates a bound parameter against `suggestedEntities`, so a deleted entity must remain surfaced there to stay runnable)
+**Then** the deleted site no longer appears in the App Intents picker (`suggestedEntities` is live-only)
+**And** invoking the orphaned Shortcut still launches WebSpace and routes the id by domain, because `entities(for:)` resolves it from the tombstone list (HS-011 / HS-014)
 
 #### Scenario: App Group unavailable
 
@@ -406,8 +406,9 @@ The prompt SHALL only appear on Android and only when at least one pinned tile r
 iOS cannot enumerate or disable home-screen Shortcut tiles, so to give HS-011 parity the system SHALL keep a bounded tombstone list of deleted sites and sync it to the App Group alongside the live site list. The system SHALL:
 
 - on deletion of any non-archive site, append `{siteId, label, url}` to the tombstone list (deduped by siteId, capped — oldest evicted) and re-sync;
-- write tombstones under a key (`shortcut_tombstones`) distinct from the live list; BOTH `SiteEntityQuery.entities(for:)` and `suggestedEntities()` resolve from **live ∪ tombstones**. iOS validates a Shortcut's bound parameter against the *suggested* set, not just `entities(for:)`, so a deleted entity must remain surfaced in `suggestedEntities()` to stay runnable — the accepted cost is that recently-deleted sites stay visible in the Shortcuts.app picker (and Siri/Spotlight) until evicted from the capped tombstone list;
-- have `OpenSiteIntent.perform()` write the resolved entity's url to the App Group (`pending_shortcut_url`) so the Dart side can route by domain.
+- write tombstones under a key (`shortcut_tombstones`) distinct from the live list; `SiteEntityQuery.entities(for:)` resolves a bound parameter from **live ∪ tombstones** (so a deleted-site tile still resolves and runs) while `suggestedEntities()` returns **live only** (so the picker and the materialized Siri/Spotlight App Shortcuts stay clean — HS-009). This split assumes iOS resolves a stored binding via `entities(for:)`; if a build shows outdated tiles failing to run, that assumption is wrong and tombstones must also be surfaced from `suggestedEntities()` (at the cost of picker clutter);
+- have `OpenSiteIntent.perform()` write the resolved entity's url to the App Group (`pending_shortcut_url`) so the Dart side can route by domain;
+- treat "disable" (the HS-013 action) on iOS as dropping the site's tombstone: with no tombstone, `entities(for:)` no longer resolves the id, so the orphaned tile stops running — the iOS analogue of Android greying out a pinned tile.
 
 Because iOS gives no way to know whether a tile actually exists, the system tombstones every qualifying deletion rather than only shortcutted ones; the cap bounds growth. Archive-tier sites are never tombstoned (ARCH-006).
 
@@ -418,11 +419,18 @@ Because iOS gives no way to know whether a tile actually exists, the system tomb
 **Then** the bound `SiteEntity` resolves from the tombstone list (it is NOT in the picker)
 **And** WebSpace launches and routes the orphaned id by domain per HS-011 (open a match or offer to create)
 
-#### Scenario: Tombstoned site stays runnable from the picker
+#### Scenario: Tombstoned site stays out of the picker but still runs
 
 **Given** a site has been deleted and tombstoned
 **When** the user opens the "Open Site" action in Shortcuts.app
-**Then** the deleted site is still listed (so an existing Shortcut bound to it stays valid and runnable), until its tombstone is evicted from the capped list
+**Then** the deleted site does NOT appear in the picker (`suggestedEntities` is live-only)
+**And** an existing Shortcut already bound to it still runs (resolved via `entities(for:)`)
+
+#### Scenario: Disabling an orphaned iOS tile drops its tombstone
+
+**Given** an orphaned iOS tile resolves via a tombstone
+**When** the user disables it (HS-013)
+**Then** the tombstone is removed and the tile no longer resolves or runs
 
 #### Scenario: Tombstone list is bounded
 
@@ -486,7 +494,7 @@ Methods:
 `ios/Runner/WebSpaceAppIntents.swift` defines (all `@available(iOS 16, *)`):
 
 - `SiteEntity: AppEntity` — one synced site with `id: String` (siteId), `name: String`, and `url: String?` (so a tombstone-resolved deleted site can route by domain, HS-011/HS-014). `displayRepresentation` MUST use `DisplayRepresentation(title: LocalizedStringResource("%@", defaultValue: String.LocalizationValue(name)))`. The static `"%@"` key is stable for the compile-time App Intents metadata extractor while the runtime `defaultValue` still resolves to each site's name. Two earlier forms both collapse the materialized parameterized App Shortcuts (one per entity) down to a single visible entry in Shortcuts.app: `DisplayRepresentation(title: "\(name)")` (interpolation renders the literal `%@`), and `DisplayRepresentation(stringLiteral: name)` (resolves in the live picker but not in the materialized tiles, since a runtime string can't be a compile-time title key — the surviving tile also keeps a stale bound target).
-- `SiteEntityQuery: EntityQuery` — both `suggestedEntities()` and `entities(for:)` resolve from `shortcut_sites` ∪ `shortcut_tombstones`, so a tile bound to a deleted site stays valid and runnable (HS-014). Deleted sites therefore remain in the picker until their tombstone is evicted.
+- `SiteEntityQuery: EntityQuery` — `suggestedEntities()` returns `shortcut_sites` (live only) so the picker / materialized App Shortcuts stay clean; `entities(for:)` resolves from `shortcut_sites` ∪ `shortcut_tombstones` so a tile bound to a deleted site still resolves and runs (HS-014).
 - `OpenSiteIntent: AppIntent, OpenIntent` — parameterized on `SiteEntity`. `openAppWhenRun = true` foregrounds WebSpace; `perform()` writes the chosen siteId to `pending_shortcut_site_id` and its url to `pending_shortcut_url` in App Group UserDefaults.
 - `WebSpaceShortcuts: AppShortcutsProvider` — declares the discoverable "Open Site" App Shortcut with phrase template `"Open \(\.$target) in WebSpace"`.
 

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Allow users to add a site shortcut to the home screen. Tapping the shortcut launches WebSpace and navigates to that site. On Android the system pins the shortcut directly via `ShortcutManagerCompat.requestPinShortcut`. On iOS 16+ the system exposes WebSpace sites as App Intents (`OpenSiteIntent`) that the user adds through the Shortcuts app and pins to the home screen from there.
+Allow users to add a site shortcut to the home screen. Tapping the shortcut launches WebSpace and navigates to that site. On Android the system pins the shortcut directly via `ShortcutManagerCompat.requestPinShortcut`. On iOS 16+ and macOS 13+ the system exposes WebSpace sites as App Intents (`OpenSiteIntent`) that the user adds through the Shortcuts app (and pins to the home screen / Dock from there). The iOS and macOS Runner targets keep separate copies of the App Intents + plugin Swift because the App Group id differs (sandboxed macOS requires the team-prefixed form).
 
 ## Status
 
@@ -89,7 +89,7 @@ The system SHALL use the site's favicon as the shortcut icon when available, fal
 
 ### Requirement: HS-004 - Platform Availability
 
-The "Home Shortcut" menu item SHALL be shown on Android and on iOS 16+. On macOS, Linux, web, and iOS 13/14/15 the menu item SHALL be hidden.
+The "Home Shortcut" menu item SHALL be shown on Android, on iOS 16+, and on macOS 13+ (the App Intents path is shared between iOS and macOS). On Linux, web, iOS 13/14/15, and macOS 12 or earlier the menu item SHALL be hidden.
 
 #### Scenario: Menu item shown on Android
 
@@ -97,21 +97,21 @@ The "Home Shortcut" menu item SHALL be shown on Android and on iOS 16+. On macOS
 **When** the user opens the overflow menu for a site that is not already pinned
 **Then** the "Home Shortcut" option is shown
 
-#### Scenario: Menu item shown on iOS 16 or later
+#### Scenario: Menu item shown on iOS 16+ or macOS 13+
 
-**Given** the app is running on iOS 16.0 or later
+**Given** the app is running on iOS 16.0+ or macOS 13.0+
 **When** the user opens the overflow menu for any site
 **Then** the "Home Shortcut" option is shown
 
-#### Scenario: Menu item hidden on iOS 15 or earlier
+#### Scenario: Menu item hidden on older iOS/macOS
 
-**Given** the app is running on iOS 13, 14, or 15
+**Given** the app is running on iOS 13/14/15 or macOS 12 or earlier
 **When** the user opens the overflow menu
 **Then** the "Home Shortcut" option is not shown
 
-#### Scenario: Menu item hidden on macOS and Linux
+#### Scenario: Menu item hidden on Linux
 
-**Given** the app is running on macOS or Linux
+**Given** the app is running on Linux
 **When** the user opens the overflow menu
 **Then** the "Home Shortcut" option is not shown
 
@@ -153,9 +153,9 @@ For the menu-visibility check the pinned set is widened to its **effective** for
 
 ### Requirement: HS-008 - iOS App Intent for Site Launching
 
-The system SHALL expose an iOS App Intent named "Open Site" that opens WebSpace and navigates to a chosen site. The intent SHALL conform to `OpenIntent` so iOS brings WebSpace to the foreground when the intent runs. The intent's site parameter SHALL be backed by a dynamic `AppEntity` query that returns the user's actual WebSpace sites.
+The system SHALL expose an App Intent named "Open Site" (on iOS 16+ and macOS 13+) that opens WebSpace and navigates to a chosen site. The intent SHALL conform to `OpenIntent` so the system brings WebSpace to the foreground when the intent runs. The intent's site parameter SHALL be backed by a dynamic `AppEntity` query that returns the user's actual WebSpace sites.
 
-Only available on iOS 16+. On older iOS the intent type is compiled but never registered; the menu item is hidden per HS-004.
+Available on iOS 16+ / macOS 13+. On older OS versions the intent type is compiled (guarded by `@available`) but never registered; the menu item is hidden per HS-004.
 
 #### Scenario: User adds the Open Site shortcut in Shortcuts.app
 
@@ -198,7 +198,7 @@ Only available on iOS 16+. On older iOS the intent type is compiled but never re
 
 ### Requirement: HS-009 - Site List Synced to App Group
 
-The system SHALL keep the iOS App Intents site picker in sync with the user's actual WebSpace sites. Whenever the persisted site list changes (`_saveWebViewModels`) and once per launch after `_restoreAppState` finishes loading models, the system SHALL write the current `[{id, name}]` list to `UserDefaults(suiteName: "group.org.codeberg.theoden8.webspace")` under key `shortcut_sites`, and SHALL invalidate the App Shortcuts parameter cache via `AppShortcutsProvider.updateAppShortcutParameters()` so the Shortcuts app re-queries the entity provider. The per-launch sync guards against iOS materializing the per-site App Shortcuts against an empty/stale App Group (e.g. on first launch after install, before any save has run), which can otherwise surface a single stale entry whose bound target no longer matches its displayed title.
+The system SHALL keep the App Intents site picker in sync with the user's actual WebSpace sites. Whenever the persisted site list changes (`_saveWebViewModels`) and once per launch after `_restoreAppState` finishes loading models, the system SHALL write the current `[{id, name}]` list to the shared App Group `UserDefaults` (suite `group.org.codeberg.theoden8.webspace` on iOS; the team-prefixed `<TEAMID>.group.org.codeberg.theoden8.webspace` on sandboxed macOS) under key `shortcut_sites`, and SHALL invalidate the App Shortcuts parameter cache via `AppShortcutsProvider.updateAppShortcutParameters()` so the Shortcuts app re-queries the entity provider. The per-launch sync guards against iOS materializing the per-site App Shortcuts against an empty/stale App Group (e.g. on first launch after install, before any save has run), which can otherwise surface a single stale entry whose bound target no longer matches its displayed title.
 
 #### Scenario: Site added
 
@@ -228,27 +228,27 @@ The system SHALL keep the iOS App Intents site picker in sync with the user's ac
 
 ---
 
-### Requirement: HS-010 - iOS "Add to Home Screen" Dialog
+### Requirement: HS-010 - "Add to Home Screen" Dialog (iOS/macOS)
 
-On iOS, tapping the "Home Shortcut" menu item SHALL show an instructional dialog explaining that iOS surfaces WebSpace sites through the Shortcuts app, with a primary button that deep-links to Shortcuts.app. The system SHALL NOT attempt to pin a shortcut programmatically (iOS has no such public API).
+On iOS and macOS, tapping the "Home Shortcut" menu item SHALL show an instructional dialog explaining that the OS surfaces WebSpace sites through the Shortcuts app, with a primary button that deep-links to Shortcuts.app. The dialog copy SHALL match the platform (iOS: "Add to Home Screen" from the share menu; macOS: add to the Dock / run from the menu bar). The system SHALL NOT attempt to pin a shortcut programmatically (neither OS has such a public API).
 
 #### Scenario: Dialog content
 
-**Given** the user is on iOS 16+
+**Given** the user is on iOS 16+ or macOS 13+
 **When** the user taps "Home Shortcut" in the overflow menu
-**Then** an `AlertDialog` is shown explaining the iOS flow ("find the Open Site action under WebSpace, pick this site, then tap Add to Home Screen")
+**Then** an `AlertDialog` is shown explaining the flow ("find the Open Site action under WebSpace, pick this site, then add it")
 **And** the dialog has an "Open Shortcuts" primary button and a "Cancel" button
 
 #### Scenario: User confirms
 
-**Given** the iOS instructional dialog is shown
+**Given** the instructional dialog is shown
 **When** the user taps "Open Shortcuts"
-**Then** the system opens the URL `shortcuts://` via `UIApplication.shared.open`
+**Then** the system opens the URL `shortcuts://` (`UIApplication.shared.open` on iOS, `NSWorkspace.shared.open` on macOS)
 **And** the Shortcuts.app launches
 
 #### Scenario: User cancels
 
-**Given** the iOS instructional dialog is shown
+**Given** the instructional dialog is shown
 **When** the user taps "Cancel"
 **Then** the dialog dismisses
 **And** Shortcuts.app is not opened
@@ -277,7 +277,7 @@ in any webspace containing the launched site.
 
 ---
 
-### Requirement: HS-011 - Domain Fallback For Orphaned Shortcuts (Android + iOS)
+### Requirement: HS-011 - Domain Fallback For Orphaned Shortcuts (Android + iOS/macOS)
 
 A home shortcut identifies its site by the random `siteId`. When that `siteId` no longer maps to any site — the user deleted the site and created a new one for the same address — the tap would otherwise fail (Android falls back to the home screen; iOS shows "no longer available"). The system SHALL recover by resolving the launch against the current site list with a base-domain fallback, in order:
 
@@ -291,7 +291,7 @@ With no url known for the id, the system falls back to the home screen (legacy H
 The resolution engine (`StartupRestoreEngine.resolveLaunch`) is platform-agnostic; the two platforms differ only in **where the url comes from**:
 
 - **Android** — the launch intent is siteId-only, so a persisted `siteId -> url` ledger supplies the url (recorded for pinned sites, pruned to the pinned/current set; see HS-012).
-- **iOS** — the launch can't be intercepted for a deleted entity unless the entity still resolves, so a deleted site is kept in a bounded **tombstone** list that `SiteEntityQuery.entities(for:)` resolves (while the picker stays live-only, HS-009). The resolved `SiteEntity` carries the url, which `OpenSiteIntent.perform()` writes into the launch payload (see HS-014).
+- **iOS / macOS** — the launch can't be intercepted for a deleted entity unless the entity still resolves, so a deleted site is kept in a bounded **tombstone** list that `SiteEntityQuery.entities(for:)` resolves (while the picker stays live-only, HS-009). The resolved `SiteEntity` carries the url, which `OpenSiteIntent.perform()` writes into the launch payload (see HS-014). The choice for a no-match tap (reroute to an existing site or create one) is made when the handle is tapped, not at delete time, since neither OS can enumerate or disable home-screen tiles.
 
 The ledger, tombstone list, and remembered-rebind map are machine state derived from shortcut activity: all are persisted in `SharedPreferences` (`shortcutUrlLedger`, `shortcutTombstones`, `shortcutSiteRemap`), are NOT part of settings export/import, and are bounded/pruned (HS-012, HS-014). A rebind whose resolved target is later deleted is dropped at startup.
 

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -415,23 +415,30 @@ The prompt appears only on **Android**, and only when at least one pinned tile r
 
 ---
 
-### Requirement: HS-014 - Shortcut Tombstones (iOS)
+### Requirement: HS-014 - Shortcut Resolution and Tombstones (iOS/macOS)
 
-iOS cannot enumerate or disable home-screen Shortcut tiles, so to give HS-011 parity the system SHALL keep a bounded tombstone list of deleted sites and sync it to the App Group alongside the live site list. The system SHALL:
+iOS/macOS cannot enumerate or remove home-screen Shortcut tiles, and they mark a tile "no longer available" whenever `SiteEntityQuery.entities(for:)` returns nothing for its bound id. To keep every WebSpace shortcut tappable, `entities(for:)` SHALL resolve **every** requested id: from the live list, then the tombstone list, and otherwise to a **placeholder** `SiteEntity(id:, name: "Removed WebSpace site", url: nil)`. `suggestedEntities()` SHALL stay **live only** (the picker and materialized App Shortcuts stay clean — HS-009). The system SHALL also:
 
-- on deletion of any non-archive site, append `{siteId, label, url}` to the tombstone list (deduped by siteId, capped — oldest evicted) and re-sync;
-- write tombstones under a key (`shortcut_tombstones`) distinct from the live list; `SiteEntityQuery.entities(for:)` resolves a bound parameter from **live ∪ tombstones** (so a deleted-site tile still resolves and runs) while `suggestedEntities()` returns **live only** (so the picker and the materialized Siri/Spotlight App Shortcuts stay clean — HS-009). This split assumes iOS resolves a stored binding via `entities(for:)`; if a build shows outdated tiles failing to run, that assumption is wrong and tombstones must also be surfaced from `suggestedEntities()` (at the cost of picker clutter);
-- have `OpenSiteIntent.perform()` write the resolved entity's url to the App Group (`pending_shortcut_url`) so the Dart side can route by domain;
-- treat "disable" (the HS-013 action) on iOS as dropping the site's tombstone: with no tombstone, `entities(for:)` no longer resolves the id, so the orphaned tile stops running — the iOS analogue of Android greying out a pinned tile.
+- on deletion of any non-archive site, append `{siteId, label, url}` to a bounded tombstone list (deduped by siteId, capped — oldest evicted), persist it (`shortcutTombstones`), and re-sync the App Group (live list under `shortcut_sites`, tombstones under `shortcut_tombstones`);
+- have `OpenSiteIntent.perform()` write the resolved entity's url to the App Group (`pending_shortcut_url`) so the Dart side can route by domain when a url is known.
 
-Because iOS gives no way to know whether a tile actually exists, the system tombstones every qualifying deletion rather than only shortcutted ones; the cap bounds growth. Archive-tier sites are never tombstoned (ARCH-006).
+A tap is then resolved on the Dart side (HS-011): a tombstone-resolved tile carries its url and routes by domain (open a match / offer reroute or create); a placeholder-resolved tile (no url — typically a shortcut bound to a site deleted before tombstones existed) opens WebSpace and offers to reroute the handle to an existing site. The placeholder is the only mechanism that covers shortcuts for sites deleted before tombstoning existed, since their siteIds were never recorded and iOS/macOS expose no API to enumerate or delete the tiles.
 
-#### Scenario: Deleted-site Shortcut still launches and routes
+Because the OS gives no way to know whether a tile exists, the system tombstones every qualifying deletion rather than only shortcutted ones; the cap bounds growth. Archive-tier sites are never tombstoned (ARCH-006).
 
-**Given** the user added an iOS home Shortcut for a site, then deleted that site
+#### Scenario: Deleted-site Shortcut (tombstoned) still launches and routes
+
+**Given** the user added a home Shortcut for a site, then deleted that site
 **When** the user taps the Shortcut
 **Then** the bound `SiteEntity` resolves from the tombstone list (it is NOT in the picker)
-**And** WebSpace launches and routes the orphaned id by domain per HS-011 (open a match or offer to create)
+**And** WebSpace launches and routes the orphaned id by domain per HS-011 (open a match or offer to reroute/create)
+
+#### Scenario: Shortcut for a pre-tombstone deletion stays tappable
+
+**Given** a Shortcut bound to a site that was deleted before any tombstone was recorded for it
+**When** the user views or taps the Shortcut
+**Then** it does NOT read "no longer available" (the id resolves to a placeholder)
+**And** tapping it opens WebSpace and offers to reroute the handle to an existing site
 
 #### Scenario: Tombstoned site stays out of the picker but still runs
 
@@ -439,12 +446,6 @@ Because iOS gives no way to know whether a tile actually exists, the system tomb
 **When** the user opens the "Open Site" action in Shortcuts.app
 **Then** the deleted site does NOT appear in the picker (`suggestedEntities` is live-only)
 **And** an existing Shortcut already bound to it still runs (resolved via `entities(for:)`)
-
-#### Scenario: Disabling an orphaned iOS tile drops its tombstone
-
-**Given** an orphaned iOS tile resolves via a tombstone
-**When** the user disables it (HS-013)
-**Then** the tombstone is removed and the tile no longer resolves or runs
 
 #### Scenario: Tombstone list is bounded
 
@@ -508,7 +509,7 @@ Methods:
 `ios/Runner/WebSpaceAppIntents.swift` defines (all `@available(iOS 16, *)`):
 
 - `SiteEntity: AppEntity` — one synced site with `id: String` (siteId), `name: String`, and `url: String?` (so a tombstone-resolved deleted site can route by domain, HS-011/HS-014). `displayRepresentation` MUST use `DisplayRepresentation(title: LocalizedStringResource("%@", defaultValue: String.LocalizationValue(name)))`. The static `"%@"` key is stable for the compile-time App Intents metadata extractor while the runtime `defaultValue` still resolves to each site's name. Two earlier forms both collapse the materialized parameterized App Shortcuts (one per entity) down to a single visible entry in Shortcuts.app: `DisplayRepresentation(title: "\(name)")` (interpolation renders the literal `%@`), and `DisplayRepresentation(stringLiteral: name)` (resolves in the live picker but not in the materialized tiles, since a runtime string can't be a compile-time title key — the surviving tile also keeps a stale bound target).
-- `SiteEntityQuery: EntityQuery` — `suggestedEntities()` returns `shortcut_sites` (live only) so the picker / materialized App Shortcuts stay clean; `entities(for:)` resolves from `shortcut_sites` ∪ `shortcut_tombstones` so a tile bound to a deleted site still resolves and runs (HS-014).
+- `SiteEntityQuery: EntityQuery` — `suggestedEntities()` returns `shortcut_sites` (live only) so the picker / materialized App Shortcuts stay clean; `entities(for:)` resolves **every** requested id from `shortcut_sites` ∪ `shortcut_tombstones`, falling back to a placeholder `SiteEntity` for any unknown id so a tile never reads "no longer available" (HS-014).
 - `OpenSiteIntent: AppIntent, OpenIntent` — parameterized on `SiteEntity`. `openAppWhenRun = true` foregrounds WebSpace; `perform()` writes the chosen siteId to `pending_shortcut_site_id` and its url to `pending_shortcut_url` in App Group UserDefaults.
 - `WebSpaceShortcuts: AppShortcutsProvider` — declares the discoverable "Open Site" App Shortcut with phrase template `"Open \(\.$target) in WebSpace"`.
 

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -262,6 +262,49 @@ in any webspace containing the launched site.
 
 ---
 
+### Requirement: HS-011 - Domain Fallback For Orphaned Shortcuts
+
+A pinned shortcut carries the site's `url` alongside its `siteId`. The system SHALL use that url to recover when a tapped shortcut's `siteId` no longer maps to any site — which happens after a settings restore on a new device (siteIds are random per install) or a delete+recreate. Recovery resolution runs in order:
+
+1. **Direct match** — the `siteId` maps to a current site. Open it (HS-002), no prompt.
+2. **Remembered rebind** — a prior user choice mapped this `siteId` to a live site. Open it, no prompt.
+3. **Domain match** — a current site shares the shortcut url's base domain. The system SHALL prompt the user to open that site; on confirm it SHALL remember the rebind so later taps resolve via step 2.
+4. **Offer to create** — no current site matches. The system SHALL prompt the user to create a new site for the shortcut url; on confirm it SHALL create the site, open it, and remember the rebind.
+
+A shortcut pinned before this feature carries no url; if its `siteId` is gone the system falls back to the home screen (legacy HS-002 behavior). The remembered rebind map is machine state derived from shortcut activity: it is persisted in `SharedPreferences` under `shortcutSiteRemap`, is NOT part of settings export/import, and entries whose resolved target is later deleted are pruned at startup.
+
+On Android the url rides the launch intent as the `siteUrl` extra (drained with `siteId`). On iOS the synced site list and `OpenSiteIntent` carry the url through the App Group (`pending_shortcut_url`).
+
+#### Scenario: Restored backup, same site exists under a new siteId
+
+**Given** the user restored a settings backup on a new device, so a site for `https://www.example.com` exists but under a different `siteId` than the one baked into a previously pinned shortcut
+**When** the user taps that shortcut
+**Then** the app prompts "Open <matching site>?" because the shortcut url's base domain matches the restored site
+**And** on confirm the matching site is selected
+**And** a subsequent tap of the same shortcut opens it directly with no prompt
+
+#### Scenario: Pinned site was deleted, no replacement
+
+**Given** the user deleted the site a shortcut pointed to and has no other site on that domain
+**When** the user taps the shortcut
+**Then** the app prompts "Create a new site for <url>?"
+**And** on confirm a new site rooted at the shortcut url is created, selected, and remembered for that shortcut
+
+#### Scenario: User declines the prompt
+
+**Given** an orphaned shortcut's confirm/create prompt is shown
+**When** the user taps Cancel
+**Then** no site is opened or created and no rebind is remembered
+**And** a later tap shows the prompt again
+
+#### Scenario: Legacy shortcut without a url
+
+**Given** a shortcut pinned before HS-011 (no url extra) whose `siteId` no longer maps to a site
+**When** the user taps it
+**Then** the app launches on the home screen with no site activated (HS-002)
+
+---
+
 ### Requirement: HS-006 - Shortcut Launch Resets To Home URL
 
 A pinned shortcut SHALL launch the targeted site at its `initUrl`, not at the last persisted `currentUrl`. The shortcut represents the user's stated entry point for that site (the URL they pinned), not the URL the previous session happened to drift to. Without this, location/tracking/state parameters that accumulate during a session resurface every time the shortcut is tapped — particularly visible on map and search sites that encode coordinates or query state in the URL (issue #298).
@@ -303,9 +346,9 @@ This requirement applies only to **process-startup** launches (cold or post-kill
 Both Android and iOS share the channel `MethodChannel('org.codeberg.theoden8.webspace/shortcuts')`.
 
 Methods:
-- `pinShortcut({siteId, label, iconUrl})` — **Android**: requests a pinned shortcut via `ShortcutManagerCompat.requestPinShortcut()`. **iOS 16+**: opens `shortcuts://` (the Dart UI shows the HS-010 instructional dialog first).
+- `pinShortcut({siteId, label, siteUrl, iconUrl})` — **Android**: requests a pinned shortcut via `ShortcutManagerCompat.requestPinShortcut()`, baking `siteUrl` into the launch intent for HS-011 domain fallback. **iOS 16+**: opens `shortcuts://` (the Dart UI shows the HS-010 instructional dialog first).
 - `removeShortcut(siteId)` — Android: disables and removes the dynamic+pinned shortcut for a deleted site. iOS: no-op (the App Intents site list is recomputed from `_webViewModels` on every save via HS-009).
-- `getLaunchSiteId()` — **Android**: returns the `siteId` from the launch intent extra, then drains it (`intent.removeExtra("siteId")`) so it fires once per tap. **iOS**: drains the `pending_shortcut_site_id` key from App Group UserDefaults (written by `OpenSiteIntent.perform()`). Both platforms MUST consume-on-read: `_handleShortcutIntent` re-polls on every `AppLifecycleState.resumed`, so a non-draining read would re-navigate to the pinned site on a plain background/return with no new tap.
+- `getLaunchSiteId()` — **Android**: returns a `{siteId, url}` map from the launch intent extras, then drains both (`intent.removeExtra(...)`) so it fires once per tap. **iOS**: drains the `pending_shortcut_site_id` + `pending_shortcut_url` keys from App Group UserDefaults (written by `OpenSiteIntent.perform()`) into the same map. Both platforms MUST consume-on-read: `_handleShortcutIntent` re-polls on every `AppLifecycleState.resumed`, so a non-draining read would re-navigate to the pinned site on a plain background/return with no new tap. The Dart `ShortcutService.getLaunch()` wraps the map as a `ShortcutLaunch`; a bare-string return is tolerated for shortcuts pinned before HS-011 (url null).
 - `getPinnedSiteIds()` — Android: returns the set of `siteId`s currently pinned, derived from `ShortcutManagerCompat.getShortcuts(FLAG_MATCH_PINNED)` by stripping the `site_` prefix. iOS: always returns an empty list (no public API for pin-state introspection).
 - `syncSites({sites: [{siteId, label, iconUrl?}]})` — **iOS only**: writes `[{id, name}]` to App Group UserDefaults under `shortcut_sites` and calls `WebSpaceShortcuts.updateAppShortcutParameters()` to refresh the Shortcuts.app picker. No-op on Android.
 - `isAppIntentsSupported()` — **iOS**: true if `#available(iOS 16, *)`. Other platforms: false.
@@ -330,15 +373,30 @@ The shortcut launches `MainActivity` with:
 
 ### Launch Handling
 
-On app start and on `onNewIntent` (app already running), check for `siteId` in the intent:
-1. Call [`StartupRestoreEngine.resolveLaunchTarget`](../../../lib/services/startup_restore_engine.dart)
-   with the shortcut siteId and the current models list — it returns
-   the matching index (or `null` when there is no intent, or the
-   siteId no longer maps to any site because the user deleted it after
-   pinning)
-2. Call `_setCurrentIndex(index)` to switch to that site
+On app start and on `onNewIntent` (app already running), read the launch
+target via `ShortcutService.getLaunch()` and resolve it through
+[`StartupRestoreEngine.resolveLaunch`](../../../lib/services/startup_restore_engine.dart):
 
-The resolution rule is exercised headlessly in
+1. `resolveLaunch(shortcutSiteId, shortcutUrl, models, rememberedRemap)`
+   returns a sealed `LaunchResolution`:
+   - `LaunchOpenSite(index)` — direct siteId hit or a remembered rebind;
+     caller switches to `index` with no prompt.
+   - `LaunchConfirmExisting(index, shortcutSiteId)` — siteId gone, a
+     current site matches the url's base domain; caller prompts, and on
+     confirm remembers `shortcutSiteId -> that site`.
+   - `LaunchOfferCreate(url, shortcutSiteId)` — siteId gone, no domain
+     match; caller prompts to create a site for `url`, remembering the
+     rebind on confirm.
+   - `LaunchNone` — no intent, or a legacy url-less shortcut whose siteId
+     is gone (home screen).
+2. On cold launch the confirm/create prompts are deferred to the first
+   post-frame (no UI exists mid-`_restoreAppState`); direct hits activate
+   inline. The warm path (`_handleShortcutIntent`) prompts immediately.
+3. The remembered rebind map is persisted in `SharedPreferences` under
+   `shortcutSiteRemap` (HS-011) and pruned of dangling targets at startup.
+
+`resolveLaunchTarget` is retained as the siteId-only view (direct hit or
+null). Both rules are exercised headlessly in
 [test/startup_restore_engine_test.dart](../../../test/startup_restore_engine_test.dart);
 no widget tree required.
 

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -358,13 +358,20 @@ The reconcile logic is a pure function exercised in [test/startup_restore_engine
 
 ### Requirement: HS-013 - Delete-Time Shortcut Prompt (Android)
 
-When the user deletes a site that currently has a pinned home shortcut (`siteId` in the cached pinned set), the system SHALL prompt for the fate of the now-orphaned launcher tile, since Android cannot remove a pinned tile programmatically. The prompt offers three choices:
+When the user deletes a site that is reachable by one or more pinned tiles, the system SHALL prompt for the fate of those now-orphaned tiles, since Android cannot remove a pinned tile programmatically. A tile "reaches" the deleted site if its id IS the deleted `siteId` OR a prior HS-011 rebind points it there (`remap[tile] == siteId`) — computed via `ShortcutPinState.tilesReaching` against a **fresh** `getPinnedSiteIds()` query (not the cached set, which lags pins made this session). The prompt offers three choices, applied to every reaching tile:
 
-- **Keep** — leave the tile enabled; a tap re-routes via HS-011 (open a domain match or offer to create). This is also the outcome if the prompt is dismissed.
-- **Reassign** — pick another existing site; the system records a rebind (`deletedSiteId -> chosen siteId`) so a tap opens the chosen site directly (HS-011 step 2).
-- **Disable** — disable the pinned shortcut (it greys out and the launcher rejects the tap until the user removes it from the home screen) and drop the deleted id's ledger and rebind entries.
+- **Keep** — leave the tile(s) enabled; a tap re-routes via HS-011 (open a domain match or offer to create). This is also the outcome if the prompt is dismissed.
+- **Reassign** — pick another existing site; the system records a rebind (`tile -> chosen siteId`) for each reaching tile so a tap opens the chosen site directly (HS-011 step 2).
+- **Disable** — disable each reaching tile (it greys out and the launcher rejects the tap until the user removes it from the home screen) and drop its ledger and rebind entries.
 
-The prompt SHALL only appear on Android and only when the deleted site actually had a pinned shortcut; deleting a site with no shortcut is unaffected.
+The prompt SHALL only appear on Android and only when at least one pinned tile reaches the deleted site; deleting a site no tile reaches is unaffected.
+
+#### Scenario: Deleting a site a tile was rebound to still prompts
+
+**Given** an orphaned tile was rebound (HS-011) to site B, and B has no shortcut of its own
+**When** the user deletes B
+**Then** the prompt still appears (the rebound tile reaches B)
+**And** the chosen action applies to that tile, not to B's own (absent) shortcut
 
 #### Scenario: Deleting a shortcutted site offers keep / reassign / disable
 

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -64,17 +64,24 @@ The system SHALL navigate to the correct site when launched via a home screen sh
 
 ### Requirement: HS-003 - Shortcut Icon
 
-The system SHALL use the site's favicon as the shortcut icon when available, falling back to the app icon.
+The system SHALL use the site's favicon as the shortcut icon when available, falling back to the app icon. The favicon is rasterized to a PNG on the Dart side (`exportIconAsPng`) before it crosses to native, because Android's `BitmapFactory` cannot decode SVG; this covers PNG, ICO, and SVG favicons uniformly.
 
-#### Scenario: Site has favicon
+#### Scenario: Site has a raster favicon
 
-**Given** the site has a cached favicon URL (non-SVG)
+**Given** the site has a cached PNG or ICO favicon URL
 **When** a shortcut is created
-**Then** the shortcut icon is the site's favicon
+**Then** the favicon is decoded and re-encoded to PNG and used as the shortcut icon
 
-#### Scenario: Site has no favicon or SVG favicon
+#### Scenario: Site has an SVG favicon
 
-**Given** the site has no cached favicon, or the favicon is SVG (not supported by Android shortcuts)
+**Given** the site's favicon is an SVG (e.g. claude.ai)
+**When** a shortcut is created
+**Then** the SVG is rasterized to a PNG and used as the shortcut icon
+**And** the shortcut does NOT fall back to the WebSpace app icon
+
+#### Scenario: Favicon cannot be fetched or rasterized
+
+**Given** the site has no resolvable favicon, or fetch/rasterize fails (e.g. proxy fail-closed)
 **When** a shortcut is created
 **Then** the shortcut icon is the WebSpace app icon
 
@@ -292,6 +299,14 @@ The ledger and the remembered-rebind map are machine state derived from shortcut
 **Then** the app prompts "Create a new site for <url>?" using the ledger url
 **And** on confirm a new site rooted at that url is created, selected, and remembered for that shortcut
 
+#### Scenario: Deleting a site leaves its shortcut tappable
+
+**Given** the user pinned a shortcut for a site and then deleted that site
+**When** the user taps the pinned shortcut
+**Then** the launcher launches WebSpace (it MUST NOT show "shortcut isn't available")
+**And** the app routes the orphaned id through the ledger per this requirement
+(`removeShortcut` removes only any dynamic copy and never disables the pinned tile)
+
 #### Scenario: User declines the prompt
 
 **Given** an orphaned shortcut's confirm/create prompt is shown
@@ -372,7 +387,7 @@ Both Android and iOS share the channel `MethodChannel('org.codeberg.theoden8.web
 
 Methods:
 - `pinShortcut({siteId, label, iconUrl})` — **Android**: requests a pinned shortcut via `ShortcutManagerCompat.requestPinShortcut()`. **iOS 16+**: opens `shortcuts://` (the Dart UI shows the HS-010 instructional dialog first).
-- `removeShortcut(siteId)` — Android: disables and removes the dynamic+pinned shortcut for a deleted site. iOS: no-op (the App Intents site list is recomputed from `_webViewModels` on every save via HS-009).
+- `removeShortcut(siteId)` — Android: removes any dynamic shortcut copy but leaves the pinned launcher tile ENABLED, so an HS-011 tap on the now-orphaned shortcut still launches the app and re-routes via the ledger. (It MUST NOT call `disableShortcuts`, which makes the launcher reject the tap with "shortcut isn't available".) iOS: no-op (the App Intents site list is recomputed from `_webViewModels` on every save via HS-009).
 - `getLaunchSiteId()` — **Android**: returns the `siteId` from the launch intent extra, then drains it (`intent.removeExtra("siteId")`) so it fires once per tap. **iOS**: drains the `pending_shortcut_site_id` key from App Group UserDefaults (written by `OpenSiteIntent.perform()`). Both platforms MUST consume-on-read: `_handleShortcutIntent` re-polls on every `AppLifecycleState.resumed`, so a non-draining read would re-navigate to the pinned site on a plain background/return with no new tap. For HS-011 the Android caller pairs the returned `siteId` with its `shortcutUrlLedger` url before resolving.
 - `getPinnedSiteIds()` — Android: returns the set of `siteId`s currently pinned, derived from `ShortcutManagerCompat.getShortcuts(FLAG_MATCH_PINNED)` by stripping the `site_` prefix. iOS: always returns an empty list (no public API for pin-state introspection).
 - `syncSites({sites: [{siteId, label, iconUrl?}]})` — **iOS only**: writes `[{id, name}]` to App Group UserDefaults under `shortcut_sites` and calls `WebSpaceShortcuts.updateAppShortcutParameters()` to refresh the Shortcuts.app picker. No-op on Android.

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -208,8 +208,8 @@ The system SHALL keep the iOS App Intents site picker in sync with the user's ac
 
 **Given** a site is referenced by an existing user-created Shortcut
 **When** the user deletes the site in WebSpace
-**Then** the deleted site no longer appears in the App Intents picker
-**And** invoking the orphaned Shortcut performs no navigation (the entity resolves to nil)
+**Then** the deleted site no longer appears in the App Intents picker (`suggestedEntities` is live-only)
+**And** invoking the orphaned Shortcut still launches WebSpace and routes the id by domain via the tombstone list (HS-011 / HS-014), rather than failing to resolve
 
 #### Scenario: App Group unavailable
 
@@ -269,20 +269,23 @@ in any webspace containing the launched site.
 
 ---
 
-### Requirement: HS-011 - Domain Fallback For Orphaned Shortcuts (Android)
+### Requirement: HS-011 - Domain Fallback For Orphaned Shortcuts (Android + iOS)
 
-An Android pinned shortcut's launch intent carries only the random `siteId`. When that `siteId` no longer maps to any site — the user deleted the site and created a new one for the same address — the tap would otherwise fall back to the home screen. The system SHALL recover by routing the orphaned id through a persisted `siteId -> url` ledger and matching by base domain. Resolution runs in order:
+A home shortcut identifies its site by the random `siteId`. When that `siteId` no longer maps to any site — the user deleted the site and created a new one for the same address — the tap would otherwise fail (Android falls back to the home screen; iOS shows "no longer available"). The system SHALL recover by resolving the launch against the current site list with a base-domain fallback, in order:
 
 1. **Direct match** — the `siteId` maps to a current site. Open it (HS-002), no prompt.
 2. **Remembered rebind** — a prior user choice mapped this `siteId` to a live site. Open it, no prompt.
-3. **Domain match** — the ledger has a url for this `siteId` and a current site shares its base domain. The system SHALL prompt the user to open that site; on confirm it SHALL remember the rebind so later taps resolve via step 2.
-4. **Offer to create** — the ledger has a url but no current site matches. The system SHALL prompt the user to create a new site for that url; on confirm it SHALL create the site, open it, and remember the rebind.
+3. **Domain match** — a url is known for this `siteId` and a current site shares its base domain. The system SHALL prompt the user to open that site; on confirm it SHALL remember the rebind so later taps resolve via step 2.
+4. **Offer to create** — a url is known but no current site matches. The system SHALL prompt the user to create a new site for that url; on confirm it SHALL create the site, open it, and remember the rebind.
 
-With no ledger url for the id (e.g. a shortcut pinned before this feature whose site was deleted before any reconcile recorded its url), the system falls back to the home screen (legacy HS-002 behavior).
+With no url known for the id, the system falls back to the home screen (legacy HS-002 behavior).
 
-The ledger is **Android-only**. iOS needs no recovery: a Shortcuts.app tile binds to a `SiteEntity` whose query resolves a deleted site to nil, so `OpenSiteIntent.perform()` never runs and a stale id never reaches the app.
+The resolution engine (`StartupRestoreEngine.resolveLaunch`) is platform-agnostic; the two platforms differ only in **where the url comes from**:
 
-The ledger and the remembered-rebind map are machine state derived from shortcut activity: both are persisted in `SharedPreferences` (`shortcutUrlLedger`, `shortcutSiteRemap`), are NOT part of settings export/import, and are pruned to reachable entries (see HS-012). A rebind whose resolved target is later deleted is dropped at startup.
+- **Android** — the launch intent is siteId-only, so a persisted `siteId -> url` ledger supplies the url (recorded for pinned sites, pruned to the pinned/current set; see HS-012).
+- **iOS** — the launch can't be intercepted for a deleted entity unless the entity still resolves, so a deleted site is kept in a bounded **tombstone** list that `SiteEntityQuery.entities(for:)` resolves (while the picker stays live-only, HS-009). The resolved `SiteEntity` carries the url, which `OpenSiteIntent.perform()` writes into the launch payload (see HS-014).
+
+The ledger, tombstone list, and remembered-rebind map are machine state derived from shortcut activity: all are persisted in `SharedPreferences` (`shortcutUrlLedger`, `shortcutTombstones`, `shortcutSiteRemap`), are NOT part of settings export/import, and are bounded/pruned (HS-012, HS-014). A rebind whose resolved target is later deleted is dropped at startup.
 
 #### Scenario: Pinned site deleted and recreated under a new id
 
@@ -383,6 +386,37 @@ The prompt SHALL only appear on Android and only when the deleted site actually 
 
 ---
 
+### Requirement: HS-014 - Shortcut Tombstones (iOS)
+
+iOS cannot enumerate or disable home-screen Shortcut tiles, so to give HS-011 parity the system SHALL keep a bounded tombstone list of deleted sites and sync it to the App Group alongside the live site list. The system SHALL:
+
+- on deletion of any non-archive site, append `{siteId, label, url}` to the tombstone list (deduped by siteId, capped — oldest evicted) and re-sync;
+- write tombstones under a key (`shortcut_tombstones`) distinct from the live list, so `SiteEntityQuery.entities(for:)` resolves a bound parameter from **live ∪ tombstones** while `suggestedEntities()` (the Shortcuts.app picker) returns **live only** (HS-009);
+- have `OpenSiteIntent.perform()` write the resolved entity's url to the App Group (`pending_shortcut_url`) so the Dart side can route by domain.
+
+Because iOS gives no way to know whether a tile actually exists, the system tombstones every qualifying deletion rather than only shortcutted ones; the cap bounds growth. Archive-tier sites are never tombstoned (ARCH-006).
+
+#### Scenario: Deleted-site Shortcut still launches and routes
+
+**Given** the user added an iOS home Shortcut for a site, then deleted that site
+**When** the user taps the Shortcut
+**Then** the bound `SiteEntity` resolves from the tombstone list (it is NOT in the picker)
+**And** WebSpace launches and routes the orphaned id by domain per HS-011 (open a match or offer to create)
+
+#### Scenario: Tombstoned site stays out of the picker
+
+**Given** a site has been deleted and tombstoned
+**When** the user opens the "Open Site" action in Shortcuts.app
+**Then** the deleted site does NOT appear in the site picker (HS-009)
+
+#### Scenario: Tombstone list is bounded
+
+**Given** the user deletes more sites than the tombstone cap
+**When** each deletion is recorded
+**Then** the oldest tombstones are evicted so the list never exceeds the cap
+
+---
+
 ### Requirement: HS-006 - Shortcut Launch Resets To Home URL
 
 A pinned shortcut SHALL launch the targeted site at its `initUrl`, not at the last persisted `currentUrl`. The shortcut represents the user's stated entry point for that site (the URL they pinned), not the URL the previous session happened to drift to. Without this, location/tracking/state parameters that accumulate during a session resurface every time the shortcut is tapped — particularly visible on map and search sites that encode coordinates or query state in the URL (issue #298).
@@ -426,18 +460,19 @@ Both Android and iOS share the channel `MethodChannel('org.codeberg.theoden8.web
 Methods:
 - `pinShortcut({siteId, label, iconUrl})` — **Android**: requests a pinned shortcut via `ShortcutManagerCompat.requestPinShortcut()`. **iOS 16+**: opens `shortcuts://` (the Dart UI shows the HS-010 instructional dialog first).
 - `removeShortcut(siteId)` — Android: removes any dynamic shortcut copy but leaves the pinned launcher tile ENABLED, so an HS-011 tap on the now-orphaned shortcut still launches the app and re-routes via the ledger. (It MUST NOT call `disableShortcuts`, which makes the launcher reject the tap with "shortcut isn't available".) iOS: no-op (the App Intents site list is recomputed from `_webViewModels` on every save via HS-009).
-- `getLaunchSiteId()` — **Android**: returns the `siteId` from the launch intent extra, then drains it (`intent.removeExtra("siteId")`) so it fires once per tap. **iOS**: drains the `pending_shortcut_site_id` key from App Group UserDefaults (written by `OpenSiteIntent.perform()`). Both platforms MUST consume-on-read: `_handleShortcutIntent` re-polls on every `AppLifecycleState.resumed`, so a non-draining read would re-navigate to the pinned site on a plain background/return with no new tap. For HS-011 the Android caller pairs the returned `siteId` with its `shortcutUrlLedger` url before resolving.
+- `getLaunchSiteId()` — **Android**: returns the bare `siteId` string from the launch intent extra, then drains it (`intent.removeExtra("siteId")`) so it fires once per tap. **iOS**: drains `pending_shortcut_site_id` + `pending_shortcut_url` from App Group UserDefaults (written by `OpenSiteIntent.perform()`) and returns a `{siteId, url}` map. Both platforms MUST consume-on-read: `_handleShortcutIntent` re-polls on every `AppLifecycleState.resumed`, so a non-draining read would re-navigate to the pinned site on a plain background/return with no new tap. The Dart `ShortcutService.getLaunch()` tolerates both shapes (`ShortcutLaunch`); for HS-011 the caller uses `launch.url ?? shortcutUrlLedger[siteId]` (iOS carries the url, Android supplies it from the ledger).
 - `getPinnedSiteIds()` — Android: returns the set of `siteId`s currently pinned, derived from `ShortcutManagerCompat.getShortcuts(FLAG_MATCH_PINNED)` by stripping the `site_` prefix. iOS: always returns an empty list (no public API for pin-state introspection).
-- `syncSites({sites: [{siteId, label, iconUrl?}]})` — **iOS only**: writes `[{id, name}]` to App Group UserDefaults under `shortcut_sites` and calls `WebSpaceShortcuts.updateAppShortcutParameters()` to refresh the Shortcuts.app picker. No-op on Android.
+- `disableShortcut(siteId)` — **Android only** (HS-013): `ShortcutManagerCompat.disableShortcuts` greys out a pinned tile when the user opts to kill a deleted site's shortcut. No-op elsewhere.
+- `syncSites({sites: [{siteId, label, url?, iconUrl?}], tombstones: [{siteId, label, url?}]})` — **iOS only**: writes the live `sites` to `shortcut_sites` and the deleted-site `tombstones` to `shortcut_tombstones` in App Group UserDefaults (HS-014), then calls `WebSpaceShortcuts.updateAppShortcutParameters()` to refresh the picker. No-op on Android.
 - `isAppIntentsSupported()` — **iOS**: true if `#available(iOS 16, *)`. Other platforms: false.
 
 ### iOS App Intents
 
 `ios/Runner/WebSpaceAppIntents.swift` defines (all `@available(iOS 16, *)`):
 
-- `SiteEntity: AppEntity` — one synced site with `id: String` (siteId) and `name: String`. `displayRepresentation` MUST use `DisplayRepresentation(title: LocalizedStringResource("%@", defaultValue: String.LocalizationValue(name)))`. The static `"%@"` key is stable for the compile-time App Intents metadata extractor while the runtime `defaultValue` still resolves to each site's name. Two earlier forms both collapse the materialized parameterized App Shortcuts (one per entity) down to a single visible entry in Shortcuts.app: `DisplayRepresentation(title: "\(name)")` (interpolation renders the literal `%@`), and `DisplayRepresentation(stringLiteral: name)` (resolves in the live picker but not in the materialized tiles, since a runtime string can't be a compile-time title key — the surviving tile also keeps a stale bound target).
-- `SiteEntityQuery: EntityQuery` — reads the synced site list from App Group UserDefaults under `shortcut_sites` so Shortcuts.app's parameter picker shows real WebSpace sites.
-- `OpenSiteIntent: AppIntent, OpenIntent` — parameterized on `SiteEntity`. `openAppWhenRun = true` foregrounds WebSpace; `perform()` writes the chosen siteId to App Group UserDefaults under `pending_shortcut_site_id`.
+- `SiteEntity: AppEntity` — one synced site with `id: String` (siteId), `name: String`, and `url: String?` (so a tombstone-resolved deleted site can route by domain, HS-011/HS-014). `displayRepresentation` MUST use `DisplayRepresentation(title: LocalizedStringResource("%@", defaultValue: String.LocalizationValue(name)))`. The static `"%@"` key is stable for the compile-time App Intents metadata extractor while the runtime `defaultValue` still resolves to each site's name. Two earlier forms both collapse the materialized parameterized App Shortcuts (one per entity) down to a single visible entry in Shortcuts.app: `DisplayRepresentation(title: "\(name)")` (interpolation renders the literal `%@`), and `DisplayRepresentation(stringLiteral: name)` (resolves in the live picker but not in the materialized tiles, since a runtime string can't be a compile-time title key — the surviving tile also keeps a stale bound target).
+- `SiteEntityQuery: EntityQuery` — `suggestedEntities()` reads `shortcut_sites` (live only) so the picker shows real WebSpace sites; `entities(for:)` resolves from `shortcut_sites` ∪ `shortcut_tombstones` so a tile bound to a deleted site still resolves and launches (HS-014).
+- `OpenSiteIntent: AppIntent, OpenIntent` — parameterized on `SiteEntity`. `openAppWhenRun = true` foregrounds WebSpace; `perform()` writes the chosen siteId to `pending_shortcut_site_id` and its url to `pending_shortcut_url` in App Group UserDefaults.
 - `WebSpaceShortcuts: AppShortcutsProvider` — declares the discoverable "Open Site" App Shortcut with phrase template `"Open \(\.$target) in WebSpace"`.
 
 The Swift method-channel handler lives in `ios/Runner/ShortcutsPlugin.swift` and is registered alongside the other plugins in `AppDelegate.application(_:didFinishLaunchingWithOptions:)`.

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -141,6 +141,14 @@ Sites in WebSpace are stable, so a home shortcut is a one-time setup per site. O
 
 The Android pinned-shortcut set is queried via `ShortcutManagerCompat.getShortcuts(FLAG_MATCH_PINNED)` exposed through the platform channel as `getPinnedSiteIds`. The cached set is refreshed on `initState` and on `AppLifecycleState.resumed`, which covers both the in-app pin flow (the launcher's pin dialog backgrounds the app) and out-of-app removal. On iOS the same channel method returns an empty list.
 
+For the menu-visibility check the pinned set is widened to its **effective** form (`ShortcutPinState.effectivePinnedSiteIds`): the pinned ids plus any site a pinned tile has been rebound to via the HS-011 remap. A site an orphaned tile now routes to is already reachable, so the "Home Shortcut" item is hidden for it too — otherwise the user could pin a second, redundant tile to the same site.
+
+#### Scenario: Android — rebound site hides the menu
+
+**Given** an orphaned pinned tile was rebound to (or created) a site via HS-011
+**When** the user opens the overflow menu for that site
+**Then** the "Home Shortcut" option is not shown (the existing tile already reaches it)
+
 ---
 
 ### Requirement: HS-008 - iOS App Intent for Site Launching

--- a/test/shortcut_service_test.dart
+++ b/test/shortcut_service_test.dart
@@ -154,25 +154,31 @@ void main() {
   // interpolation renders the literal "%@". Guard the Swift source so a
   // future refactor can't silently revert to either broken form.
   group('WebSpaceAppIntents.swift — SiteEntity displayRepresentation', () {
-    test('uses a static %@ key with a runtime defaultValue', () {
-      final source =
-          File('ios/Runner/WebSpaceAppIntents.swift').readAsStringSync();
-      expect(
-          source,
-          contains(
-              'LocalizedStringResource("%@", defaultValue: String.LocalizationValue(name))'),
-          reason: 'SiteEntity.displayRepresentation must use a static "%@" '
-              'key plus a runtime defaultValue so each site materializes as '
-              'its own App Shortcut entry. See HS-008 / openspec spec.');
-      expect(source, isNot(contains(r'DisplayRepresentation(title: "\(name)")')),
-          reason: 'String interpolation inside DisplayRepresentation(title:) '
-              'is parsed as a LocalizedStringResource template, which '
-              'collapses every materialized App Shortcut to a single %@ '
-              'placeholder row in Shortcuts.app.');
-      expect(source, isNot(contains('DisplayRepresentation(stringLiteral: name)')),
-          reason: 'A bare stringLiteral resolves in the live picker but not '
-              'in the materialized App Shortcut tiles, because the App Intents '
-              'metadata extractor cannot bake a runtime string as the key.');
-    });
+    // The iOS and macOS Runner targets keep separate copies (the App Group id
+    // differs), so guard both against the same %@-key regression (HS-008).
+    for (final path in const [
+      'ios/Runner/WebSpaceAppIntents.swift',
+      'macos/Runner/WebSpaceAppIntents.swift',
+    ]) {
+      test('$path uses a static %@ key with a runtime defaultValue', () {
+        final source = File(path).readAsStringSync();
+        expect(
+            source,
+            contains(
+                'LocalizedStringResource("%@", defaultValue: String.LocalizationValue(name))'),
+            reason: 'SiteEntity.displayRepresentation must use a static "%@" '
+                'key plus a runtime defaultValue so each site materializes as '
+                'its own App Shortcut entry. See HS-008 / openspec spec.');
+        expect(source, isNot(contains(r'DisplayRepresentation(title: "\(name)")')),
+            reason: 'String interpolation inside DisplayRepresentation(title:) '
+                'is parsed as a LocalizedStringResource template, which '
+                'collapses every materialized App Shortcut to a single %@ '
+                'placeholder row in Shortcuts.app.');
+        expect(source, isNot(contains('DisplayRepresentation(stringLiteral: name)')),
+            reason: 'A bare stringLiteral resolves in the live picker but not '
+                'in the materialized App Shortcut tiles, because the App Intents '
+                'metadata extractor cannot bake a runtime string as the key.');
+      });
+    }
   });
 }

--- a/test/shortcut_service_test.dart
+++ b/test/shortcut_service_test.dart
@@ -47,19 +47,6 @@ void main() {
         'iconUrl': 'https://example.com/favicon.png',
       });
     });
-
-    test('toMap includes url when present', () {
-      final m = const ShortcutSite(
-        siteId: 'abc',
-        label: 'Site A',
-        url: 'https://example.com/',
-      ).toMap();
-      expect(m, {
-        'siteId': 'abc',
-        'label': 'Site A',
-        'url': 'https://example.com/',
-      });
-    });
   });
 
   group('ShortcutService — non-mobile host', () {
@@ -96,10 +83,10 @@ void main() {
       }
     });
 
-    test('getLaunch is null on non-mobile host', () async {
-      final launch = await ShortcutService.getLaunch();
+    test('getLaunchSiteId is null on non-mobile host', () async {
+      final id = await ShortcutService.getLaunchSiteId();
       if (!isMobileHost) {
-        expect(launch, isNull);
+        expect(id, isNull);
         expect(calls, isEmpty);
       }
     });
@@ -130,7 +117,7 @@ void main() {
       // channel; this case really exercises mobile hosts. Still: the calls
       // must never throw a PlatformException out of the service.
       expect(await ShortcutService.pinShortcut(siteId: 'a', label: 'A'), isFalse);
-      expect(await ShortcutService.getLaunch(), isNull);
+      expect(await ShortcutService.getLaunchSiteId(), isNull);
       expect(await ShortcutService.getPinnedSiteIds(), isEmpty);
       expect(await ShortcutService.isAppIntentsSupported(), isFalse);
       await ShortcutService.syncSites(const []);

--- a/test/shortcut_service_test.dart
+++ b/test/shortcut_service_test.dart
@@ -62,43 +62,46 @@ void main() {
     });
   });
 
-  group('ShortcutService — non-mobile host', () {
+  group('ShortcutService — host gating', () {
     // Test host is the OS running `flutter test` (Linux on CI, macOS for local
-    // dev). All methods that gate on Platform.isAndroid / Platform.isIOS must
-    // short-circuit without touching the channel.
-    final isMobileHost = Platform.isAndroid || Platform.isIOS;
+    // dev and some CI lanes). Methods gate on the platform: pin/getLaunch run
+    // on Android + iOS + macOS; syncSites/isAppIntentsSupported run on the App
+    // Intents hosts (iOS + macOS); the rest short-circuit without the channel.
+    final isShortcutHost =
+        Platform.isAndroid || Platform.isIOS || Platform.isMacOS;
+    final isAppIntentsHost = Platform.isIOS || Platform.isMacOS;
 
-    test('syncSites is a no-op off iOS', () async {
+    test('syncSites is a no-op off iOS/macOS', () async {
       await ShortcutService.syncSites(const [
         ShortcutSite(siteId: 'a', label: 'A'),
       ]);
-      if (!Platform.isIOS) {
+      if (!isAppIntentsHost) {
         expect(calls, isEmpty);
       }
     });
 
-    test('isAppIntentsSupported is false off iOS', () async {
+    test('isAppIntentsSupported is false off iOS/macOS', () async {
       final supported = await ShortcutService.isAppIntentsSupported();
-      if (!Platform.isIOS) {
+      if (!isAppIntentsHost) {
         expect(supported, isFalse);
         expect(calls, isEmpty);
       }
     });
 
-    test('pinShortcut is false on non-mobile host', () async {
+    test('pinShortcut is false off a shortcut host', () async {
       final ok = await ShortcutService.pinShortcut(
         siteId: 'a',
         label: 'A',
       );
-      if (!isMobileHost) {
+      if (!isShortcutHost) {
         expect(ok, isFalse);
         expect(calls, isEmpty);
       }
     });
 
-    test('getLaunch is null on non-mobile host', () async {
+    test('getLaunch is null off a shortcut host', () async {
       final launch = await ShortcutService.getLaunch();
-      if (!isMobileHost) {
+      if (!isShortcutHost) {
         expect(launch, isNull);
         expect(calls, isEmpty);
       }

--- a/test/shortcut_service_test.dart
+++ b/test/shortcut_service_test.dart
@@ -105,6 +105,13 @@ void main() {
         expect(calls, isEmpty);
       }
     });
+
+    test('disableShortcut is a no-op off Android', () async {
+      await ShortcutService.disableShortcut('a');
+      if (!Platform.isAndroid) {
+        expect(calls, isEmpty);
+      }
+    });
   });
 
   group('ShortcutService — channel error handling', () {

--- a/test/shortcut_service_test.dart
+++ b/test/shortcut_service_test.dart
@@ -47,6 +47,19 @@ void main() {
         'iconUrl': 'https://example.com/favicon.png',
       });
     });
+
+    test('toMap includes url when present', () {
+      final m = const ShortcutSite(
+        siteId: 'abc',
+        label: 'Site A',
+        url: 'https://example.com/',
+      ).toMap();
+      expect(m, {
+        'siteId': 'abc',
+        'label': 'Site A',
+        'url': 'https://example.com/',
+      });
+    });
   });
 
   group('ShortcutService — non-mobile host', () {
@@ -83,10 +96,10 @@ void main() {
       }
     });
 
-    test('getLaunchSiteId is null on non-mobile host', () async {
-      final id = await ShortcutService.getLaunchSiteId();
+    test('getLaunch is null on non-mobile host', () async {
+      final launch = await ShortcutService.getLaunch();
       if (!isMobileHost) {
-        expect(id, isNull);
+        expect(launch, isNull);
         expect(calls, isEmpty);
       }
     });
@@ -117,7 +130,7 @@ void main() {
       // channel; this case really exercises mobile hosts. Still: the calls
       // must never throw a PlatformException out of the service.
       expect(await ShortcutService.pinShortcut(siteId: 'a', label: 'A'), isFalse);
-      expect(await ShortcutService.getLaunchSiteId(), isNull);
+      expect(await ShortcutService.getLaunch(), isNull);
       expect(await ShortcutService.getPinnedSiteIds(), isEmpty);
       expect(await ShortcutService.isAppIntentsSupported(), isFalse);
       await ShortcutService.syncSites(const []);

--- a/test/shortcut_service_test.dart
+++ b/test/shortcut_service_test.dart
@@ -47,6 +47,19 @@ void main() {
         'iconUrl': 'https://example.com/favicon.png',
       });
     });
+
+    test('toMap includes url when present', () {
+      final m = const ShortcutSite(
+        siteId: 'abc',
+        label: 'Site A',
+        url: 'https://example.com/',
+      ).toMap();
+      expect(m, {
+        'siteId': 'abc',
+        'label': 'Site A',
+        'url': 'https://example.com/',
+      });
+    });
   });
 
   group('ShortcutService — non-mobile host', () {
@@ -83,10 +96,10 @@ void main() {
       }
     });
 
-    test('getLaunchSiteId is null on non-mobile host', () async {
-      final id = await ShortcutService.getLaunchSiteId();
+    test('getLaunch is null on non-mobile host', () async {
+      final launch = await ShortcutService.getLaunch();
       if (!isMobileHost) {
-        expect(id, isNull);
+        expect(launch, isNull);
         expect(calls, isEmpty);
       }
     });
@@ -124,7 +137,7 @@ void main() {
       // channel; this case really exercises mobile hosts. Still: the calls
       // must never throw a PlatformException out of the service.
       expect(await ShortcutService.pinShortcut(siteId: 'a', label: 'A'), isFalse);
-      expect(await ShortcutService.getLaunchSiteId(), isNull);
+      expect(await ShortcutService.getLaunch(), isNull);
       expect(await ShortcutService.getPinnedSiteIds(), isEmpty);
       expect(await ShortcutService.isAppIntentsSupported(), isFalse);
       await ShortcutService.syncSites(const []);

--- a/test/startup_restore_engine_test.dart
+++ b/test/startup_restore_engine_test.dart
@@ -216,16 +216,60 @@ void main() {
       expect(next, {'s1': 'https://a.com'});
     });
 
-    test('an orphan with no pinned tile is pruned (iOS getPinnedSiteIds=[])', () {
-      // On iOS getPinnedSiteIds is always empty, so a deleted site's entry is
-      // pruned. That is fine: iOS resolves a stale SiteEntity to nil, so a gone
-      // id never reaches the app and never needs the ledger.
+    test('an orphan with no pinned tile is pruned (Android getPinnedSiteIds)', () {
       final next = ShortcutUrlLedger.reconcile(
         ledger: const {'gone': 'https://gone.com'},
         currentSiteUrls: const {},
         pinnedSiteIds: const {},
       );
       expect(next, isEmpty);
+    });
+  });
+
+  group('ShortcutTombstones.add (iOS HS-011)', () {
+    Map<String, String> tomb(String id, String url) =>
+        {'siteId': id, 'label': id, 'url': url};
+
+    test('appends a new tombstone', () {
+      final next = ShortcutTombstones.add(
+        tombstones: const [],
+        entry: tomb('s1', 'https://a.com'),
+      );
+      expect(next, [tomb('s1', 'https://a.com')]);
+    });
+
+    test('de-dupes by siteId and moves the entry to the most-recent end', () {
+      final next = ShortcutTombstones.add(
+        tombstones: [tomb('s1', 'https://old.com'), tomb('s2', 'https://b.com')],
+        entry: tomb('s1', 'https://new.com'),
+      );
+      expect(next, [tomb('s2', 'https://b.com'), tomb('s1', 'https://new.com')]);
+    });
+
+    test('caps the list, evicting the oldest', () {
+      final start = [for (var i = 0; i < 3; i++) tomb('s$i', 'https://$i.com')];
+      final next = ShortcutTombstones.add(
+        tombstones: start,
+        entry: tomb('s3', 'https://3.com'),
+        cap: 3,
+      );
+      expect(next.map((t) => t['siteId']), ['s1', 's2', 's3']);
+    });
+
+    test('ignores an entry with an empty siteId', () {
+      final next = ShortcutTombstones.add(
+        tombstones: [tomb('s1', 'https://a.com')],
+        entry: tomb('', 'https://x.com'),
+      );
+      expect(next, [tomb('s1', 'https://a.com')]);
+    });
+
+    test('pruneLive drops tombstones whose id is now live', () {
+      final next = ShortcutTombstones.pruneLive(
+        [tomb('s1', 'https://a.com'), tomb('s2', 'https://b.com')],
+        {'s1'},
+      );
+      expect(next, [tomb('s2', 'https://b.com')]);
     });
   });
 }

--- a/test/startup_restore_engine_test.dart
+++ b/test/startup_restore_engine_test.dart
@@ -307,4 +307,52 @@ void main() {
       );
     });
   });
+
+  group('ShortcutPinState.tilesReaching', () {
+    test('finds the directly-pinned tile', () {
+      expect(
+        ShortcutPinState.tilesReaching(
+          siteId: 'a',
+          pinnedSiteIds: {'a', 'b'},
+          rememberedRemap: const {},
+        ),
+        {'a'},
+      );
+    });
+
+    test('finds a tile rebound to the site (delete a rebind target)', () {
+      // Tile "old" (pinned) was rebound to "new"; deleting "new" must still
+      // surface "old" so the prompt can manage that tile.
+      expect(
+        ShortcutPinState.tilesReaching(
+          siteId: 'new',
+          pinnedSiteIds: {'old'},
+          rememberedRemap: const {'old': 'new'},
+        ),
+        {'old'},
+      );
+    });
+
+    test('finds both a direct tile and rebound tiles', () {
+      expect(
+        ShortcutPinState.tilesReaching(
+          siteId: 's',
+          pinnedSiteIds: {'s', 'x', 'y'},
+          rememberedRemap: const {'x': 's', 'y': 'other'},
+        ),
+        {'s', 'x'},
+      );
+    });
+
+    test('returns empty when nothing reaches the site', () {
+      expect(
+        ShortcutPinState.tilesReaching(
+          siteId: 'z',
+          pinnedSiteIds: {'a'},
+          rememberedRemap: const {'a': 'b'},
+        ),
+        isEmpty,
+      );
+    });
+  });
 }

--- a/test/startup_restore_engine_test.dart
+++ b/test/startup_restore_engine_test.dart
@@ -165,4 +165,67 @@ void main() {
       expect(r, isA<LaunchNone>());
     });
   });
+
+  group('ShortcutUrlLedger.reconcile', () {
+    test('records url for a pinned site that still exists', () {
+      final next = ShortcutUrlLedger.reconcile(
+        ledger: const {},
+        currentSiteUrls: const {'s1': 'https://a.com'},
+        pinnedSiteIds: const {'s1'},
+      );
+      expect(next, {'s1': 'https://a.com'});
+    });
+
+    test('keeps an orphan trail: site deleted but shortcut still pinned', () {
+      // s1 was pinned and its url recorded; the site is since gone but the
+      // launcher tile remains, so we must keep the url to route the next tap.
+      final next = ShortcutUrlLedger.reconcile(
+        ledger: const {'s1': 'https://a.com'},
+        currentSiteUrls: const {},
+        pinnedSiteIds: const {'s1'},
+      );
+      expect(next, {'s1': 'https://a.com'});
+    });
+
+    test('prunes entries that are neither current nor pinned', () {
+      final next = ShortcutUrlLedger.reconcile(
+        ledger: const {'gone': 'https://gone.com', 's1': 'https://a.com'},
+        currentSiteUrls: const {'s1': 'https://a.com'},
+        pinnedSiteIds: const {'s1'},
+      );
+      expect(next, {'s1': 'https://a.com'});
+    });
+
+    test('does not record pinned ids that have no current url', () {
+      // An id pinned but not in the model list and not already in the ledger
+      // can't be recorded (no url to record) — and is pruned as unreachable.
+      final next = ShortcutUrlLedger.reconcile(
+        ledger: const {},
+        currentSiteUrls: const {},
+        pinnedSiteIds: const {'s1'},
+      );
+      expect(next, isEmpty);
+    });
+
+    test('current sites are kept even when not pinned', () {
+      final next = ShortcutUrlLedger.reconcile(
+        ledger: const {'s1': 'https://a.com'},
+        currentSiteUrls: const {'s1': 'https://a.com'},
+        pinnedSiteIds: const {},
+      );
+      expect(next, {'s1': 'https://a.com'});
+    });
+
+    test('an orphan with no pinned tile is pruned (iOS getPinnedSiteIds=[])', () {
+      // On iOS getPinnedSiteIds is always empty, so a deleted site's entry is
+      // pruned. That is fine: iOS resolves a stale SiteEntity to nil, so a gone
+      // id never reaches the app and never needs the ledger.
+      final next = ShortcutUrlLedger.reconcile(
+        ledger: const {'gone': 'https://gone.com'},
+        currentSiteUrls: const {},
+        pinnedSiteIds: const {},
+      );
+      expect(next, isEmpty);
+    });
+  });
 }

--- a/test/startup_restore_engine_test.dart
+++ b/test/startup_restore_engine_test.dart
@@ -154,12 +154,25 @@ void main() {
       expect(r.shortcutSiteId, 'stale-id');
     });
 
-    test('legacy shortcut (siteId gone, no url) -> LaunchNone', () {
+    test('placeholder handle (siteId gone, no url) with sites -> LaunchOfferReroute',
+        () {
       final a = _site('https://a.com');
       final r = StartupRestoreEngine.resolveLaunch(
         shortcutSiteId: 'stale-id',
         shortcutUrl: null,
         models: [a],
+        rememberedRemap: const {},
+      );
+      expect(r, isA<LaunchOfferReroute>());
+      expect((r as LaunchOfferReroute).shortcutSiteId, 'stale-id');
+    });
+
+    test('placeholder handle (siteId gone, no url) with no sites -> LaunchNone',
+        () {
+      final r = StartupRestoreEngine.resolveLaunch(
+        shortcutSiteId: 'stale-id',
+        shortcutUrl: null,
+        models: const [],
         rememberedRemap: const {},
       );
       expect(r, isA<LaunchNone>());

--- a/test/startup_restore_engine_test.dart
+++ b/test/startup_restore_engine_test.dart
@@ -272,4 +272,39 @@ void main() {
       expect(next, [tomb('s2', 'https://b.com')]);
     });
   });
+
+  group('ShortcutPinState.effectivePinnedSiteIds', () {
+    test('returns the pinned set when there is no remap', () {
+      expect(
+        ShortcutPinState.effectivePinnedSiteIds(
+          pinnedSiteIds: {'a', 'b'},
+          rememberedRemap: const {},
+        ),
+        {'a', 'b'},
+      );
+    });
+
+    test('folds in a pinned tile\'s rebind target', () {
+      // Tile "old" (pinned) was rebound to "new"; "new" is now reachable.
+      expect(
+        ShortcutPinState.effectivePinnedSiteIds(
+          pinnedSiteIds: {'old'},
+          rememberedRemap: const {'old': 'new'},
+        ),
+        {'old', 'new'},
+      );
+    });
+
+    test('ignores remap entries whose source tile is not pinned', () {
+      // A stale remap from a tile the user has since removed should not mark
+      // its target as pinned.
+      expect(
+        ShortcutPinState.effectivePinnedSiteIds(
+          pinnedSiteIds: {'a'},
+          rememberedRemap: const {'removed': 'target'},
+        ),
+        {'a'},
+      );
+    });
+  });
 }

--- a/test/startup_restore_engine_test.dart
+++ b/test/startup_restore_engine_test.dart
@@ -64,4 +64,105 @@ void main() {
       );
     });
   });
+
+  group('StartupRestoreEngine.resolveLaunch', () {
+    test('no intent -> LaunchNone', () {
+      final r = StartupRestoreEngine.resolveLaunch(
+        shortcutSiteId: null,
+        shortcutUrl: null,
+        models: [_site('https://a.com')],
+        rememberedRemap: const {},
+      );
+      expect(r, isA<LaunchNone>());
+    });
+
+    test('direct siteId hit -> LaunchOpenSite at its index', () {
+      final a = _site('https://a.com');
+      final b = _site('https://b.com');
+      final r = StartupRestoreEngine.resolveLaunch(
+        shortcutSiteId: b.siteId,
+        shortcutUrl: 'https://b.com',
+        models: [a, b],
+        rememberedRemap: const {},
+      );
+      expect(r, isA<LaunchOpenSite>());
+      expect((r as LaunchOpenSite).index, 1);
+    });
+
+    test('siteId gone but remembered remap resolves -> LaunchOpenSite', () {
+      final a = _site('https://a.com');
+      final b = _site('https://b.com');
+      final r = StartupRestoreEngine.resolveLaunch(
+        shortcutSiteId: 'stale-id',
+        shortcutUrl: 'https://b.com',
+        models: [a, b],
+        rememberedRemap: {'stale-id': b.siteId},
+      );
+      expect(r, isA<LaunchOpenSite>());
+      expect((r as LaunchOpenSite).index, 1);
+    });
+
+    test('remembered remap takes priority over a domain match', () {
+      final a = _site('https://a.com');
+      final b = _site('https://b.com');
+      // url points at a.com, but the user previously rebound to b.
+      final r = StartupRestoreEngine.resolveLaunch(
+        shortcutSiteId: 'stale-id',
+        shortcutUrl: 'https://a.com',
+        models: [a, b],
+        rememberedRemap: {'stale-id': b.siteId},
+      );
+      expect((r as LaunchOpenSite).index, 1);
+    });
+
+    test('stale remap (target deleted) falls through to domain match', () {
+      final a = _site('https://mail.example.com/inbox');
+      final r = StartupRestoreEngine.resolveLaunch(
+        shortcutSiteId: 'stale-id',
+        shortcutUrl: 'https://www.example.com/',
+        models: [a],
+        rememberedRemap: const {'stale-id': 'also-gone'},
+      );
+      expect(r, isA<LaunchConfirmExisting>());
+      expect((r as LaunchConfirmExisting).index, 0);
+      expect(r.shortcutSiteId, 'stale-id');
+    });
+
+    test('siteId gone, base-domain match -> LaunchConfirmExisting', () {
+      final a = _site('https://a.com');
+      final b = _site('https://mail.example.com/inbox');
+      final r = StartupRestoreEngine.resolveLaunch(
+        shortcutSiteId: 'stale-id',
+        shortcutUrl: 'https://calendar.example.com/day',
+        models: [a, b],
+        rememberedRemap: const {},
+      );
+      expect(r, isA<LaunchConfirmExisting>());
+      expect((r as LaunchConfirmExisting).index, 1);
+    });
+
+    test('siteId gone, no domain match -> LaunchOfferCreate', () {
+      final a = _site('https://a.com');
+      final r = StartupRestoreEngine.resolveLaunch(
+        shortcutSiteId: 'stale-id',
+        shortcutUrl: 'https://newsite.example/',
+        models: [a],
+        rememberedRemap: const {},
+      );
+      expect(r, isA<LaunchOfferCreate>());
+      expect((r as LaunchOfferCreate).url, 'https://newsite.example/');
+      expect(r.shortcutSiteId, 'stale-id');
+    });
+
+    test('legacy shortcut (siteId gone, no url) -> LaunchNone', () {
+      final a = _site('https://a.com');
+      final r = StartupRestoreEngine.resolveLaunch(
+        shortcutSiteId: 'stale-id',
+        shortcutUrl: null,
+        models: [a],
+        rememberedRemap: const {},
+      );
+      expect(r, isA<LaunchNone>());
+    });
+  });
 }


### PR DESCRIPTION
A pinned shortcut carried only its siteId, so after a settings restore on
a new device (siteIds are random per install) or a delete+recreate the tap
silently fell back to the home screen. Carry the site url too and, when the
siteId no longer maps to a site, fall back to a base-domain match: prompt to
open the matching site, or offer to create one if none matches. The user's
choice is remembered in SharedPreferences so later taps resolve silently.