### PR TITLE
TLS-010: Silent cancellation of loopback sinkhole certs

### DIFF
--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -3401,6 +3401,27 @@ class WebViewFactory {
       return inapp.ServerTrustAuthResponse(
           action: inapp.ServerTrustAuthResponseAction.PROCEED);
     }
+    // Loopback sinkhole: a device-level DNS/ad blocker (VPN-based
+    // blocker, hosts-file sinkhole, Private DNS, etc.) may resolve a
+    // tracker host to 127.0.0.1 where a local responder answers with a
+    // self-signed `CN=localhost` cert. The OS rejects it (hostname
+    // mismatch + untrusted self-signed) and the trust callback fires
+    // per sub-resource, which used to stack a separate "Untrusted
+    // certificate" prompt for every blocked ad domain on the page. No
+    // user would trust `localhost` for a remote host, so cancel
+    // silently — never prompt, never pin. The genuine local-dev case
+    // (browsing to `https://localhost`) is preserved because the
+    // requested host then matches the cert identity.
+    if (_isLoopbackSinkholeCert(host, cert)) {
+      LogService.instance.log(
+        'TLS',
+        'localhost sinkhole cert for $host:$port — cancelling silently '
+            '(no prompt; likely a device-level DNS/ad blocker)',
+        sensitivity: LogSensitivity.sensitive,
+      );
+      return inapp.ServerTrustAuthResponse(
+          action: inapp.ServerTrustAuthResponseAction.CANCEL);
+    }
     // Post-failure platforms (Android, Linux): the OS already rejected
     // the chain. Prompt the user now.
     if (prompt == null) {
@@ -3458,6 +3479,40 @@ class WebViewFactory {
 
   static String _certCacheKey(String host, int port) =>
       '${host.toLowerCase()}:$port';
+
+  static bool _isLoopbackHost(String host) {
+    final h = host.toLowerCase();
+    return h == 'localhost' || h == '127.0.0.1' || h == '::1' || h == '[::1]';
+  }
+
+  /// True when [cert] is a self-signed `CN=localhost` certificate served
+  /// for a non-loopback [host] — the signature of a device-level DNS/ad
+  /// sinkhole answering a blocked tracker on `127.0.0.1`. Such a cert is
+  /// never something the user means to trust for a remote host, so the
+  /// caller cancels the load without prompting. A real `https://localhost`
+  /// dev server is excluded because [host] then matches the cert identity.
+  static bool _isLoopbackSinkholeCert(String host, inapp.SslCertificate? cert) {
+    if (cert == null) return false;
+    return isLoopbackSinkholeCert(
+      host: host,
+      issuedToCName: cert.issuedTo?.CName,
+      issuedByCName: cert.issuedBy?.CName,
+    );
+  }
+
+  /// Pure classification behind [_isLoopbackSinkholeCert], split out so it
+  /// can be unit-tested without constructing a plugin `SslCertificate`.
+  @visibleForTesting
+  static bool isLoopbackSinkholeCert({
+    required String host,
+    String? issuedToCName,
+    String? issuedByCName,
+  }) {
+    if (_isLoopbackHost(host)) return false;
+    final issuedTo = issuedToCName?.trim().toLowerCase();
+    final issuedBy = issuedByCName?.trim().toLowerCase();
+    return issuedTo == 'localhost' || issuedBy == 'localhost';
+  }
 
   /// Whether [error] indicates the OS rejected the server certificate.
   /// Used by the iOS/macOS post-failure branch in `onReceivedError`.

--- a/openspec/specs/tls-trust-prompt/spec.md
+++ b/openspec/specs/tls-trust-prompt/spec.md
@@ -311,6 +311,39 @@ probes and downloads.
 
 ---
 
+### Requirement: TLS-010 - Loopback sinkhole certs are cancelled without a prompt
+
+The app SHALL NOT prompt the user for a self-signed `CN=localhost`
+certificate served for a non-loopback host. A device-level DNS/ad
+blocker (VPN-based blocker, hosts-file sinkhole, Private DNS) may
+resolve a blocked tracker host to `127.0.0.1`, where a local responder
+answers with a self-signed `localhost` cert. Because every such host
+shares the same loopback cert, the post-failure trust callback would
+otherwise stack one "Untrusted certificate" dialog per blocked
+sub-resource on the page. The app SHALL `CANCEL` these loads silently
+and SHALL NOT pin them. A genuine `https://localhost` dev server is
+unaffected because the requested host then matches the cert identity.
+
+#### Scenario: Tracker sinkholed to a localhost responder
+
+**Given** a device DNS/ad blocker resolves `htlb.casalemedia.com` to a local responder presenting a self-signed cert whose `issuedTo.CName` / `issuedBy.CName` is `localhost`
+**And** no pin exists for `htlb.casalemedia.com:443`
+**When** the page loads it as a sub-resource and the OS rejects the cert
+**Then** `_handleServerTrust` detects the loopback sinkhole cert
+**And** returns `ServerTrustAuthResponseAction.CANCEL`
+**And** no dialog is shown
+**And** no pin is persisted
+**And** a `[TLS] localhost sinkhole cert for ... — cancelling silently` log line is emitted
+
+#### Scenario: Real local dev server still prompts
+
+**Given** the user navigates to `https://localhost:8443` which presents a self-signed `CN=localhost` cert
+**When** the OS rejects the chain and fires the trust callback
+**Then** the requested host matches the loopback identity, so the sinkhole guard does not apply
+**And** the normal Android/Linux prompt is shown (TLS-002)
+
+---
+
 ## Implementation Notes
 
 ### Why `null` and not `ServerTrustAuthResponse()` for the defer path

--- a/test/tls_loopback_sinkhole_test.dart
+++ b/test/tls_loopback_sinkhole_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/webview.dart';
+
+void main() {
+  group('TLS-010 loopback sinkhole cert classification', () {
+    test('localhost cert for a remote host is a sinkhole', () {
+      expect(
+        WebViewFactory.isLoopbackSinkholeCert(
+          host: 'htlb.casalemedia.com',
+          issuedToCName: 'localhost',
+          issuedByCName: 'localhost',
+        ),
+        isTrue,
+      );
+    });
+
+    test('only issuer is localhost still counts', () {
+      expect(
+        WebViewFactory.isLoopbackSinkholeCert(
+          host: 'fastlane.rubiconproject.com',
+          issuedToCName: 'ads.example.com',
+          issuedByCName: 'localhost',
+        ),
+        isTrue,
+      );
+    });
+
+    test('case and whitespace are normalized', () {
+      expect(
+        WebViewFactory.isLoopbackSinkholeCert(
+          host: 'tracker.example.com',
+          issuedToCName: '  LocalHost ',
+          issuedByCName: null,
+        ),
+        isTrue,
+      );
+    });
+
+    test('genuine https://localhost dev server is not suppressed', () {
+      expect(
+        WebViewFactory.isLoopbackSinkholeCert(
+          host: 'localhost',
+          issuedToCName: 'localhost',
+          issuedByCName: 'localhost',
+        ),
+        isFalse,
+      );
+      expect(
+        WebViewFactory.isLoopbackSinkholeCert(
+          host: '127.0.0.1',
+          issuedToCName: 'localhost',
+          issuedByCName: 'localhost',
+        ),
+        isFalse,
+      );
+    });
+
+    test('ordinary self-signed cert with a real CN still prompts', () {
+      expect(
+        WebViewFactory.isLoopbackSinkholeCert(
+          host: 'self-signed.example.com',
+          issuedToCName: 'self-signed.example.com',
+          issuedByCName: 'My Homelab CA',
+        ),
+        isFalse,
+      );
+    });
+
+    test('missing CNames are not a sinkhole', () {
+      expect(
+        WebViewFactory.isLoopbackSinkholeCert(
+          host: 'example.com',
+          issuedToCName: null,
+          issuedByCName: null,
+        ),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Detect and silently cancel self-signed `CN=localhost` certificates served for non-loopback hosts, which are the signature of device-level DNS/ad blockers (VPN-based blockers, hosts-file sinkholes, Private DNS) resolving tracker domains to `127.0.0.1`. Without this, the post-failure trust callback would stack one "Untrusted certificate" dialog per blocked sub-resource on the page.

Key changes:
- Add `isLoopbackSinkholeCert()` classification logic that returns true when a cert has `CN=localhost` in either the issuer or subject and the requested host is not a loopback address (localhost, 127.0.0.1, ::1, [::1]).
- Integrate detection into `_handleServerTrust()` to return `CANCEL` without prompting or pinning when a sinkhole cert is detected.
- Log sinkhole cancellations at `[TLS]` level with sensitivity=sensitive.
- Preserve genuine `https://localhost` dev servers by excluding loopback hosts from the sinkhole classification.
- Add comprehensive unit tests covering tracker sinkholes, case/whitespace normalization, legitimate dev servers, self-signed certs with real CNs, and missing certificate names.
- Document requirement TLS-010 in the spec with scenarios for both sinkhole and dev-server cases.

https://claude.ai/code/session_012BLTZigtyTGUVWp3XMeKBd