### PR TITLE
Reset always-open-home sites on app close, not on site switch

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1302,7 +1302,18 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     if (state == AppLifecycleState.paused) {
       _foregroundPollTimer?.cancel();
       _foregroundPollTimer = null;
-      if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
+      // AOH-006: URL-ephemeral sites (alwaysOpenHome / incognito) revert to
+      // their initUrl when the app leaves the foreground, so reopening lands
+      // on home. This is the only warm-resume reset — fromJson handles cold
+      // start. In-app site switches never trigger it; only app close does.
+      final activeWentHome = _resetAlwaysOpenHomeForAppClose();
+      if (activeWentHome && mounted) {
+        // The active webview was disposed above. Mark dirty so the rebuild
+        // recreates it at initUrl once frames resume.
+        setState(() {});
+      }
+      if (!activeWentHome &&
+          _currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
         if (!_webViewModels[_currentIndex!].effectiveNotificationsEnabled) {
           _lifecyclePauseFuture = _webViewModels[_currentIndex!].pauseForAppLifecycle();
         }
@@ -4493,6 +4504,37 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       m.disposeWebView();
       _loadedIndices.remove(i);
     }
+  }
+
+  /// Reset every URL-ephemeral site (`alwaysOpenHome`, or incognito which
+  /// implies it per AOH-005) back to its initUrl when the app leaves the
+  /// foreground, disposing the live webview so the next foreground rebuild
+  /// loads home. Cookies, localStorage, and other persistent state are left
+  /// intact — that is the boundary between this toggle and incognito.
+  ///
+  /// Notification sites are skipped: their page must keep running in the
+  /// background to fire notifications, and resetting the URL would tear it
+  /// down. The active site stays in `_loadedIndices` (only its webview is
+  /// dropped) so the IndexedStack still has a child to rebuild at initUrl.
+  /// Returns true if the currently-active site was reset, so the caller can
+  /// skip the now-redundant pause/capture and schedule a rebuild instead.
+  bool _resetAlwaysOpenHomeForAppClose() {
+    bool activeReset = false;
+    for (int i = 0; i < _webViewModels.length; i++) {
+      final m = _webViewModels[i];
+      if (!(m.alwaysOpenHome || m.incognito)) continue;
+      if (m.effectiveNotificationsEnabled) continue;
+      if (m.currentUrl == m.initUrl && m.webview == null) continue;
+      _evictCacheIfOnline(m.siteId);
+      m.currentUrl = m.initUrl;
+      m.disposeWebView();
+      if (i == _currentIndex) {
+        activeReset = true;
+      } else {
+        _loadedIndices.remove(i);
+      }
+    }
+    return activeReset;
   }
 
   void _goHome() {

--- a/openspec/specs/always-open-home/spec.md
+++ b/openspec/specs/always-open-home/spec.md
@@ -5,9 +5,11 @@
 A per-site `alwaysOpenHome` toggle that makes the site's *navigation
 URL* ephemeral while keeping its persistent state (cookies,
 localStorage, IndexedDB, HTTP cache) intact. The site reverts to its
-`initUrl` on **app restart** and on **Android home-shortcut tap**, but
-the user's logged-in session, preferences, and other cookie-backed
-state survive both events.
+`initUrl` on **app restart**, on **app close** (the app leaving the
+foreground), and on **Android home-shortcut tap**, but the user's
+logged-in session, preferences, and other cookie-backed state survive
+all three events. Switching between sites *within* the app is not a
+reset trigger.
 
 Two motivating cases the user split out from
 [incognito-mode](../incognito-mode/spec.md) (which ALSO drops
@@ -161,6 +163,38 @@ regardless of the stored `alwaysOpenHome` value.
 
 ---
 
+### Requirement: AOH-006 - Reset On App Close, Not On Site Switch
+
+The system SHALL reset `currentUrl` to `initUrl` for every flagged site
+(`alwaysOpenHome = true` or `incognito = true`) when the app transitions
+to the backgrounded (`AppLifecycleState.paused`) lifecycle state, and SHALL
+dispose each such site's live webview so the next foregrounding rebuilds it
+at `initUrl`. Cookies and all other persistent per-site state SHALL be left
+untouched (AOH-003). Sites with notifications enabled SHALL be skipped so
+their background page keeps running. Switching the active site within the
+app SHALL NOT reset any flagged site.
+
+#### Scenario: Backgrounding the app sends the active flagged site home
+
+**Given** a site with `alwaysOpenHome = true` is active and navigated to a deep URL
+**When** the app is backgrounded (`AppLifecycleState.paused`) and later resumed
+**Then** the site's webview is rebuilt at `initUrl`
+**And** its persisted cookies are unchanged
+
+#### Scenario: Switching sites in-app does not reset
+
+**Given** site A (`alwaysOpenHome = true`) is active and navigated to a deep URL
+**And** the user switches to site B and back to A, with the app staying foregrounded
+**Then** A is still showing the deep URL (no reset)
+
+#### Scenario: Notification-enabled flagged site is not reset on background
+
+**Given** a site with `alwaysOpenHome = true` and notifications enabled
+**When** the app is backgrounded
+**Then** the site's `currentUrl` is unchanged and its webview is not disposed
+
+---
+
 ## Implementation
 
 ### Files
@@ -171,7 +205,8 @@ regardless of the stored `alwaysOpenHome` value.
   `toJson` URL-strip gate, `fromJson` URL-strip gate.
 - `lib/main.dart` — `_resetAlwaysOpenHomeOnShortcut(int)` helper
   invoked from `_restoreAppState` (cold) and `_handleShortcutIntent`
-  (warm).
+  (warm); `_resetAlwaysOpenHomeForAppClose()` invoked from
+  `didChangeAppLifecycleState` on `paused` (AOH-006).
 - `lib/services/webspace_selection_engine.dart` —
   `indicesToResetOnShortcutLaunch` pure helper computes the reset set
   from the launched index + the webspaces list + a flag predicate.


### PR DESCRIPTION
alwaysOpenHome/incognito sites only reverted to initUrl on cold start
and shortcut tap; backgrounding the app left the deep URL in place.
Reset flagged sites to home on AppLifecycleState.paused so reopening
lands on home, while in-app site switches stay untouched.