### PR TITLE
Fix target=_blank links silently dropped on cross-domain taps

### DIFF
--- a/lib/services/target_blank_rewrite.dart
+++ b/lib/services/target_blank_rewrite.dart
@@ -1,0 +1,65 @@
+/// Capture-phase click shim that rewrites new-window anchor targets
+/// (`target="_blank"` / `_new`) to `_self` for http(s) links.
+///
+/// Why this exists: the app enables `supportMultipleWindows` (Cloudflare
+/// Turnstile and other challenges need it). A side effect is that on
+/// Android a `target="_blank"` link tap is routed to
+/// `WebChromeClient.onCreateWindow` instead of `shouldOverrideUrlLoading`.
+/// In that path the user-gesture flag (`createWindowAction.hasGesture`) is
+/// unreliable — Android frequently reports `false` for a genuine tap — and
+/// the request URL is sometimes empty. The nested-url-blocking engine then
+/// reads "no gesture" and silently cancels the navigation (NESTED-004), so
+/// the link does nothing (issue #405). iOS has the same divergence:
+/// `target="_blank"` taps often only fire `onCreateWindow`.
+///
+/// Rewriting the target to `_self` at capture phase (before the browser's
+/// default action and before site click handlers) routes the tap through
+/// the normal top-level navigation path, where the per-request gesture
+/// signal IS reliable. The decision engine then sees a real gesture and
+/// opens the cross-domain destination in a nested webview as intended.
+///
+/// Scope and safety:
+///   * Only http(s) anchors are touched. `blob:`/`data:`/external-scheme
+///     and download links (handled by `blobDownloadClickInterceptScript`)
+///     are left alone.
+///   * Same-domain `target="_blank"` links already loaded in the current
+///     webview via the `onCreateWindow` allow path, so rewriting them to
+///     `_self` keeps the identical in-place behavior — no regression.
+///   * Script-driven `window.open()` (captcha popups, analytics) is not an
+///     anchor target and is untouched; it still flows through
+///     `onCreateWindow` and its existing gesture/captcha filtering.
+const String targetBlankRewriteScript = r'''
+(function() {
+  if (window.__webspaceTargetBlankHooked) return;
+  window.__webspaceTargetBlankHooked = true;
+  try {
+    function opensNewWindow(t) {
+      if (!t) return false;
+      t = ('' + t).toLowerCase();
+      return t === '_blank' || t === '_new';
+    }
+    function isHttpAnchor(el) {
+      if (!el || el.tagName !== 'A') return false;
+      var href = '';
+      try { href = el.href || el.getAttribute('href') || ''; } catch (_) {}
+      if (typeof href !== 'string') return false;
+      return href.indexOf('http://') === 0 || href.indexOf('https://') === 0;
+    }
+    var listener = function(e) {
+      var el = e.target;
+      // Walk up so a click on a child of the anchor (icon, span) still
+      // resolves to the <a>.
+      while (el && el !== document && el.tagName !== 'A') {
+        el = el.parentNode;
+      }
+      if (!el || el === document || el.tagName !== 'A') return;
+      try {
+        if (!opensNewWindow(el.getAttribute('target'))) return;
+        if (!isHttpAnchor(el)) return;
+        el.setAttribute('target', '_self');
+      } catch (_) {}
+    };
+    document.addEventListener('click', listener, true);
+  } catch (_) {}
+})();
+''';

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -13,6 +13,7 @@ import 'package:webspace/services/do_not_track_shim.dart';
 import 'package:webspace/services/language_shim.dart';
 import 'package:webspace/services/launch_nonce.dart';
 import 'package:webspace/services/proxy_relay.dart';
+import 'package:webspace/services/target_blank_rewrite.dart';
 import 'package:webspace/services/theme_color_scheme_shim.dart';
 import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
@@ -1471,6 +1472,18 @@ class WebViewFactory {
     userScripts.add(inapp.UserScript(
       groupName: 'do_not_track',
       source: '${buildDoNotTrackShim()}\n;null;',
+      injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
+      forMainFrameOnly: false,
+    ));
+
+    // Always-on: rewrite `target="_blank"` anchors to `_self` so cross-domain
+    // link taps route through shouldOverrideUrlLoading (reliable gesture)
+    // instead of onCreateWindow (unreliable gesture / empty URL on Android),
+    // where the nested-url-blocking engine would otherwise silently drop the
+    // navigation. See target_blank_rewrite.dart and issue #405.
+    userScripts.add(inapp.UserScript(
+      groupName: 'target_blank_rewrite',
+      source: '$targetBlankRewriteScript\n;null;',
       injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
       forMainFrameOnly: false,
     ));

--- a/openspec/specs/nested-url-blocking/spec.md
+++ b/openspec/specs/nested-url-blocking/spec.md
@@ -133,6 +133,52 @@ The system SHALL provide a per-site setting to disable auto-redirect blocking.
 
 ---
 
+### Requirement: NESTED-008 - Route target="_blank" Through the Main-Frame Gesture Path
+
+The system SHALL rewrite new-window anchor targets (`target="_blank"` /
+`target="_new"`) on http(s) links to `_self` at capture phase, so a tapped
+link is dispatched as a top-level navigation through
+`shouldOverrideUrlLoading` instead of `onCreateWindow`.
+
+**Rationale:** `supportMultipleWindows` is enabled for captcha popups
+(see captcha-support). A side effect is that on Android a `target="_blank"`
+tap is routed to `onCreateWindow`, where the user-gesture flag is
+unreliable (frequently `false` for a genuine tap) and the request URL is
+sometimes empty. The gesture-based cross-domain block (NESTED-004) then
+silently cancels the navigation, so the link does nothing (issue #405).
+iOS has the same divergence: `target="_blank"` taps often only fire
+`onCreateWindow`. The top-level navigation path carries a reliable
+per-request gesture signal on every platform.
+
+**Scope:** only http(s) anchors are rewritten. `blob:` / `data:` /
+external-scheme and `download` links are untouched (the blob-download
+intercept and external-scheme handling own those). Script-driven
+`window.open()` is not an anchor target and is unaffected — it still flows
+through `onCreateWindow` with its existing captcha/gesture filtering.
+Same-domain `target="_blank"` links already loaded in-place via the
+`onCreateWindow` allow path, so the rewrite preserves their behavior.
+
+Implementation: `lib/services/target_blank_rewrite.dart`
+(`targetBlankRewriteScript`), injected always-on at `AT_DOCUMENT_START`,
+`forMainFrameOnly: false`.
+
+#### Scenario: Cross-domain target="_blank" link opens a nested webview
+
+**Given** the user is on a page with an `<a target="_blank" href="https://other.example">` link
+**When** the user taps the link
+**Then** the anchor's target is rewritten to `_self` before the default action
+**And** the navigation is dispatched through `shouldOverrideUrlLoading` with a user gesture
+**And** the cross-domain destination opens in a nested webview (NESTED-004 "Direct link click allowed")
+
+#### Scenario: Captcha popup still uses onCreateWindow
+
+**Given** a site invokes `window.open()` for a Cloudflare/hCaptcha challenge
+**When** the popup is requested
+**Then** the rewrite does not apply (no anchor target involved)
+**And** the challenge is handled by the existing `onCreateWindow` captcha path
+
+---
+
 ### Requirement: NESTED-007 - Preserve Same-Domain Navigation
 
 The system SHALL allow normal website navigation within the same domain regardless of gesture.
@@ -220,6 +266,14 @@ CLAUDE.md now forbids. Direct engine tests live in
 - `isCaptchaChallenge()` — detects captcha domains and paths; passed to `decideOnUrlChanged` as a callback
 - `shouldOverrideUrlLoading` callback passes `hasGesture` from `NavigationAction`
 - `onCreateWindow` — dismisses all `window.open()` except captcha challenges
+- Registers `targetBlankRewriteScript` always-on at `AT_DOCUMENT_START`
+
+#### `lib/services/target_blank_rewrite.dart`
+- `targetBlankRewriteScript` — capture-phase click shim that rewrites
+  http(s) `target="_blank"` / `_new` anchors to `_self`, routing taps
+  through the reliable main-frame gesture path (NESTED-008). Behaviour
+  proven in `test/js/target_blank_rewrite.test.js`; string shape +
+  registration guarded by `test/target_blank_rewrite_test.dart`.
 
 #### `lib/web_view_model.dart`
 - `blockAutoRedirects` field (default: `true`)

--- a/test/js/target_blank_rewrite.test.js
+++ b/test/js/target_blank_rewrite.test.js
@@ -1,0 +1,117 @@
+// Behavioural tests for the target="_blank" rewrite shim
+// (lib/services/target_blank_rewrite.dart#targetBlankRewriteScript).
+//
+// Goal: prove a new-window http(s) anchor is rewritten to _self at
+// capture phase (so the tap routes through the reliable top-level
+// navigation path), while leaving everything else untouched:
+//   - <a target="_blank" href="https://..."> becomes target="_self" on click.
+//   - target="_new" is treated the same.
+//   - Same-domain target="_blank" is rewritten too (harmless: the app
+//     already loaded those in-place).
+//   - blob:/data:/non-http and external-scheme targets are left alone.
+//   - Anchors without a new-window target are left alone.
+//   - A click on a child element still resolves to the ancestor anchor.
+//   - Re-evaluating the shim is idempotent.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { makeDom, readFixture, runInDom } = require('./helpers/load_shim');
+
+function bootDom() {
+  const dom = makeDom();
+  // The default action of a (now _self) link triggers jsdom's
+  // "Not implemented: navigation" emit; swallow it.
+  if (dom.window._virtualConsole &&
+      typeof dom.window._virtualConsole.on === 'function') {
+    dom.window._virtualConsole.removeAllListeners('jsdomError');
+    dom.window._virtualConsole.on('jsdomError', () => {});
+  }
+  runInDom(dom, readFixture('target_blank_rewrite/shim.js'));
+  return dom;
+}
+
+function clickAnchor(dom, el) {
+  const ev = new dom.window.MouseEvent('click', {
+    bubbles: true,
+    cancelable: true,
+  });
+  el.dispatchEvent(ev);
+  return ev;
+}
+
+test('target="_blank" http anchor is rewritten to _self on click', () => {
+  const dom = bootDom();
+  const a = dom.window.document.createElement('a');
+  a.href = 'https://github.com/theoden8/webspace_app';
+  a.setAttribute('target', '_blank');
+  dom.window.document.body.appendChild(a);
+  clickAnchor(dom, a);
+  assert.equal(a.getAttribute('target'), '_self');
+});
+
+test('target="_new" is rewritten the same way', () => {
+  const dom = bootDom();
+  const a = dom.window.document.createElement('a');
+  a.href = 'http://example.com/page';
+  a.setAttribute('target', '_new');
+  dom.window.document.body.appendChild(a);
+  clickAnchor(dom, a);
+  assert.equal(a.getAttribute('target'), '_self');
+});
+
+test('click on a child element still rewrites the ancestor anchor', () => {
+  const dom = bootDom();
+  const a = dom.window.document.createElement('a');
+  a.href = 'https://github.com/x';
+  a.setAttribute('target', '_blank');
+  const inner = dom.window.document.createElement('span');
+  inner.textContent = 'GitHub';
+  a.appendChild(inner);
+  dom.window.document.body.appendChild(a);
+  clickAnchor(dom, inner);
+  assert.equal(a.getAttribute('target'), '_self');
+});
+
+test('blob: target="_blank" anchor is left untouched (download path owns it)', () => {
+  const dom = bootDom();
+  const a = dom.window.document.createElement('a');
+  a.href = 'blob:https://example.com/abc';
+  a.setAttribute('target', '_blank');
+  a.setAttribute('download', 'x.bin');
+  dom.window.document.body.appendChild(a);
+  clickAnchor(dom, a);
+  assert.equal(a.getAttribute('target'), '_blank');
+});
+
+test('external-scheme target="_blank" anchor is left untouched', () => {
+  const dom = bootDom();
+  const a = dom.window.document.createElement('a');
+  a.setAttribute('href', 'mailto:hi@example.com');
+  a.setAttribute('target', '_blank');
+  dom.window.document.body.appendChild(a);
+  clickAnchor(dom, a);
+  assert.equal(a.getAttribute('target'), '_blank');
+});
+
+test('anchor without a new-window target is left untouched', () => {
+  const dom = bootDom();
+  const a = dom.window.document.createElement('a');
+  a.href = 'https://example.com/';
+  dom.window.document.body.appendChild(a);
+  clickAnchor(dom, a);
+  assert.equal(a.hasAttribute('target'), false);
+});
+
+test('re-evaluating the shim is idempotent', () => {
+  const dom = bootDom();
+  // Re-run in the same realm; the reentrance guard must skip re-adding
+  // the listener so a single click still results in exactly one rewrite
+  // (observable here as the target ending at _self without error).
+  runInDom(dom, readFixture('target_blank_rewrite/shim.js'));
+  const a = dom.window.document.createElement('a');
+  a.href = 'https://example.com/q';
+  a.setAttribute('target', '_blank');
+  dom.window.document.body.appendChild(a);
+  clickAnchor(dom, a);
+  assert.equal(a.getAttribute('target'), '_self');
+});

--- a/test/js_fixtures/target_blank_rewrite/shim.js
+++ b/test/js_fixtures/target_blank_rewrite/shim.js
@@ -1,0 +1,33 @@
+(function() {
+  if (window.__webspaceTargetBlankHooked) return;
+  window.__webspaceTargetBlankHooked = true;
+  try {
+    function opensNewWindow(t) {
+      if (!t) return false;
+      t = ('' + t).toLowerCase();
+      return t === '_blank' || t === '_new';
+    }
+    function isHttpAnchor(el) {
+      if (!el || el.tagName !== 'A') return false;
+      var href = '';
+      try { href = el.href || el.getAttribute('href') || ''; } catch (_) {}
+      if (typeof href !== 'string') return false;
+      return href.indexOf('http://') === 0 || href.indexOf('https://') === 0;
+    }
+    var listener = function(e) {
+      var el = e.target;
+      // Walk up so a click on a child of the anchor (icon, span) still
+      // resolves to the <a>.
+      while (el && el !== document && el.tagName !== 'A') {
+        el = el.parentNode;
+      }
+      if (!el || el === document || el.tagName !== 'A') return;
+      try {
+        if (!opensNewWindow(el.getAttribute('target'))) return;
+        if (!isHttpAnchor(el)) return;
+        el.setAttribute('target', '_self');
+      } catch (_) {}
+    };
+    document.addEventListener('click', listener, true);
+  } catch (_) {}
+})();

--- a/test/target_blank_rewrite_test.dart
+++ b/test/target_blank_rewrite_test.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/target_blank_rewrite.dart';
+
+void main() {
+  group('targetBlankRewriteScript', () {
+    test('guards against double-installation', () {
+      expect(targetBlankRewriteScript,
+          contains('if (window.__webspaceTargetBlankHooked) return'));
+      expect(targetBlankRewriteScript,
+          contains('window.__webspaceTargetBlankHooked = true'));
+    });
+
+    test('rewrites only _blank / _new targets', () {
+      expect(targetBlankRewriteScript, contains("t === '_blank'"));
+      expect(targetBlankRewriteScript, contains("t === '_new'"));
+      expect(targetBlankRewriteScript, contains("setAttribute('target', '_self')"));
+    });
+
+    test('only touches http(s) anchors', () {
+      expect(targetBlankRewriteScript, contains("href.indexOf('http://') === 0"));
+      expect(targetBlankRewriteScript, contains("href.indexOf('https://') === 0"));
+    });
+
+    test('listens in capture phase and walks up to the anchor', () {
+      expect(targetBlankRewriteScript,
+          contains("document.addEventListener('click', listener, true)"));
+      expect(targetBlankRewriteScript, contains("el.tagName !== 'A'"));
+      expect(targetBlankRewriteScript, contains('el = el.parentNode'));
+    });
+
+    test('is wired into WebViewFactory at AT_DOCUMENT_START', () {
+      // Regression guard for the user-script registration in webview.dart.
+      // If the registration is dropped (or moved past DOCUMENT_END), the
+      // rewrite never runs before the page wires its own click handlers and
+      // target="_blank" cross-domain taps go silent again (issue #405).
+      final webviewSrc = File('lib/services/webview.dart').readAsStringSync();
+      expect(webviewSrc, contains("groupName: 'target_blank_rewrite'"));
+      final blockStart = webviewSrc.indexOf("groupName: 'target_blank_rewrite'");
+      expect(blockStart, greaterThan(0));
+      final blockEnd = webviewSrc.indexOf('));', blockStart);
+      expect(blockEnd, greaterThan(blockStart));
+      final block = webviewSrc.substring(blockStart, blockEnd);
+      expect(block, contains('AT_DOCUMENT_START'));
+      expect(block, contains(r'$targetBlankRewriteScript'));
+      // Must reach iframes too — outbound links live inside embedded frames.
+      expect(block, contains('forMainFrameOnly: false'));
+    });
+  });
+}

--- a/tool/dump_shim_js.dart
+++ b/tool/dump_shim_js.dart
@@ -26,6 +26,7 @@ import 'package:webspace/services/generic_cosmetic_shim.dart';
 import 'package:webspace/services/desktop_mode_shim.dart';
 import 'package:webspace/services/do_not_track_shim.dart';
 import 'package:webspace/services/language_shim.dart';
+import 'package:webspace/services/target_blank_rewrite.dart';
 import 'package:webspace/services/location_spoof_service.dart';
 import 'package:webspace/services/theme_color_scheme_shim.dart';
 import 'package:webspace/services/user_agent_classifier.dart';
@@ -131,6 +132,8 @@ Map<String, String> buildAllFixtures() {
   )!;
 
   fixtures['do_not_track/shim.js'] = buildDoNotTrackShim();
+
+  fixtures['target_blank_rewrite/shim.js'] = targetBlankRewriteScript;
 
   // Two pinned seeds — one stable string for shape/behaviour tests, one
   // variant to confirm the seed actually flows through (different seeds


### PR DESCRIPTION
supportMultipleWindows (needed for captcha popups) routes target="_blank"
taps to onCreateWindow, where Android's user-gesture flag is unreliable and
the request URL can be empty. The nested-url-blocking engine reads "no
gesture" and silently cancels, so outbound links do nothing (issue #405).

Inject a capture-phase shim that rewrites http(s) _blank/_new anchor
targets to _self before the default action, routing taps through the
top-level navigation path where the per-request gesture signal is reliable.
Same-domain _blank already loaded in-place, so no behavior change there;
window.open() captcha popups are untouched.