### PR TITLE
Make fullscreen menu item toggle instead of re-enter

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4798,9 +4798,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                   value: "fullscreen",
                   child: Row(
                     children: [
-                      Icon(Icons.fullscreen),
+                      Icon(_isFullscreen ? Icons.fullscreen_exit : Icons.fullscreen),
                       SizedBox(width: 8),
-                      Text("Full Screen"),
+                      Text(_isFullscreen ? "Exit Full Screen" : "Full Screen"),
                     ],
                   ),
                 ),
@@ -4843,7 +4843,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
                   _toggleFind();
                 break;
                 case 'fullscreen':
-                  _enterFullscreen();
+                  _toggleFullscreen();
                 break;
                 case 'settings':
                   await Navigator.push(
@@ -5188,9 +5188,9 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
             value: "fullscreen",
             child: Row(
               children: [
-                Icon(Icons.fullscreen),
+                Icon(_isFullscreen ? Icons.fullscreen_exit : Icons.fullscreen),
                 SizedBox(width: 8),
-                Text("Full Screen"),
+                Text(_isFullscreen ? "Exit Full Screen" : "Full Screen"),
               ],
             ),
           ),
@@ -5233,7 +5233,7 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
             _toggleFind();
           break;
           case 'fullscreen':
-            _enterFullscreen();
+            _toggleFullscreen();
           break;
           case 'settings':
             await Navigator.push(

--- a/openspec/specs/fullscreen-mode/spec.md
+++ b/openspec/specs/fullscreen-mode/spec.md
@@ -50,6 +50,15 @@ The system SHALL allow the user to exit full screen by tapping the top edge of t
 **When** the user taps the top edge of the screen (status bar / notch safe area + 20px)
 **Then** full screen mode is exited
 
+#### Scenario: Exit via tab strip menu
+
+**Given** "Keep Tab Strip in Full Screen" is enabled
+**And** the user is in full screen mode with the tab strip visible
+**When** the user opens the tab strip overflow menu and taps "Exit Full Screen"
+**Then** full screen mode is exited
+
+**Rationale:** With the tab strip kept in full screen, its overflow menu is the only chrome reachable while immersed. The "Full Screen" menu item reflects the current state ("Exit Full Screen" when already full screen) and toggles rather than re-entering.
+
 #### Scenario: Back gesture in full screen
 
 **Given** the user is in full screen mode


### PR DESCRIPTION
In fullscreen with the tab strip kept, its overflow menu was the only
reachable chrome but 'Full Screen' called _enterFullscreen() which
early-returns, leaving no menu path out. Toggle and reflect state.