### PR TITLE
fix(ci): detect referenced (not just defined) forbidden classes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -244,6 +244,24 @@ jobs:
             bash scripts/check_no_gms.sh "$apk"
           done
 
+      - name: Verify JNI bridge survived shrinking
+        # Release R8 shrinks (to strip Flutter's dead Play Core path); a
+        # regression that flips obfuscation on or drops the native-methods
+        # keep would rename/remove the Rust adblock JNI entry points, failing
+        # only at runtime (UnsatisfiedLinkError). Assert they're still in the
+        # DEX. .so-independent: the Kotlin bridge compiles regardless.
+        run: |
+          set -e
+          shopt -s nullglob
+          apks=( build/app/outputs/flutter-apk/*-fdroid-release.apk )
+          if [ ${#apks[@]} -eq 0 ]; then
+            echo "ERROR: no fdroid APK found to scan" >&2
+            exit 1
+          fi
+          for apk in "${apks[@]}"; do
+            bash scripts/check_jni_intact.sh "$apk"
+          done
+
       - name: Upload APKs
         uses: actions/upload-artifact@v4
         with:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -108,10 +108,13 @@ android {
             if (keystorePropertiesFile.exists()) {
                 signingConfig signingConfigs.release
             }
-            // R8 in optimize-only mode (shrink + obfuscate disabled in
-            // proguard-rules.pro). The sole effect is dropping
-            // android.util.Log.d/.v calls so debug-level log lines don't
-            // reach release logcat. shrinkResources stays off.
+            // R8 in shrink + optimize mode (obfuscation disabled in
+            // proguard-rules.pro to keep reflection/JNI names intact).
+            // Shrinking prunes Flutter's dead Play deferred-components path
+            // (and its com.google.android.play.core.* refs that F-Droid
+            // rejects); the optimize pass drops android.util.Log.d/.v so
+            // debug-level log lines don't reach release logcat.
+            // shrinkResources stays off.
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,11 +1,12 @@
-# R8 runs in optimize-only mode for release builds: shrinking and
-# obfuscation are disabled so no class is removed or renamed (keeps
-# reflection and JNI entry points intact across the native plugins).
-# The only observable effect is that android.util.Log.d / .v calls are
-# treated as side-effect-free and dropped during the optimize pass, so
-# debug-level log lines (including ones inherited from upstream webview
-# code) don't reach release logcat.
--dontshrink
+# R8 runs in shrink + optimize mode for release builds. Obfuscation stays
+# off (-dontobfuscate) so reflection and JNI symbol names survive intact
+# across the native plugins. Shrinking removes provably-unreachable code --
+# which is what strips Flutter's dead Play Store deferred-components manager
+# and the com.google.android.play.core.* references it carries (F-Droid
+# rejects those; this app uses FlutterApplication, never the split variant,
+# so the path is dead code). The optimize pass additionally treats
+# android.util.Log.d/.v as side-effect-free, so debug-level log lines don't
+# reach release logcat.
 -dontobfuscate
 
 -assumenosideeffects class android.util.Log {
@@ -13,12 +14,23 @@
     public static int v(...);
 }
 
-# Flutter's embedding references Play Store deferred-components and
-# split-install classes that aren't bundled (the fdroid flavor ships no
-# Play services). They're referenced on a code path this app never
-# takes, so suppress R8's missing-class verification rather than pull in
-# the dependency. Same for javax.lang.model, reachable only through
-# compile-time errorprone annotations.
+# JNI: keep every class that declares native methods, plus the method names
+# and their descriptor types, so the Rust adblock engine's name-mangled
+# lookups (Java_org_codeberg_theoden8_webspace_AdblockEngineNative_native*,
+# bound in rust/webspace_adblock/src/jni.rs) still resolve after shrinking.
+# A stripped or renamed JNI target fails at runtime with UnsatisfiedLinkError,
+# not at build time, so pin it explicitly rather than trust reachability.
+-keepclasseswithmembernames,includedescriptorclasses class * {
+    native <methods>;
+}
+
+# First-party platform-channel plugins are reached from Dart by name and,
+# for the adblock bridge, called back into from native code.
+-keep class org.codeberg.theoden8.webspace.** { *; }
+
+# Flutter's embedding still references the Play deferred-components and
+# split-install classes during R8 verification before the dead path is
+# pruned; errorprone leaves javax.lang.model refs reachable only at compile
+# time. Suppress both rather than pull in the dependencies.
 -dontwarn com.google.android.play.core.**
 -dontwarn javax.lang.model.**
-

--- a/scripts/check_jni_intact.sh
+++ b/scripts/check_jni_intact.sh
@@ -55,8 +55,12 @@ else
 fi
 
 # Expected JNI methods = every `external fun <name>` in the bridge source.
-mapfile -t EXPECTED < <(grep -oE 'external fun [A-Za-z0-9_]+' "$KT" \
-  | awk '{print $3}' | sort -u)
+# Read loop instead of `mapfile` (bash 4+) so this runs on macOS's bash 3.2,
+# where devs invoke these checks locally too.
+EXPECTED=()
+while IFS= read -r _name; do
+  [[ -n "$_name" ]] && EXPECTED+=("$_name")
+done < <(grep -oE 'external fun [A-Za-z0-9_]+' "$KT" | awk '{print $3}' | sort -u)
 if [[ ${#EXPECTED[@]} -eq 0 ]]; then
   echo "ERROR: no 'external fun' declarations found in $KT" >&2
   echo "If the JNI bridge moved, update this check." >&2

--- a/scripts/check_jni_intact.sh
+++ b/scripts/check_jni_intact.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Verify the Rust adblock JNI bridge survived R8 in a release APK.
+#
+# Release builds shrink (android/app/proguard-rules.pro) to prune Flutter's
+# dead Play Core path. Obfuscation is kept off and the native methods are
+# pinned so the JNI entry points stay intact -- but a future regression
+# (obfuscation flipped on, the keep rule dropped, R8 full-mode) would rename
+# or strip them. That failure is invisible at build time and only surfaces
+# at runtime as UnsatisfiedLinkError, so gate it in CI.
+#
+# The expected set is read from AdblockEngineNative.kt (every `external
+# fun`), so adding or removing a native method needs no edit here. Each name
+# must appear, unobfuscated, as a method of the bridge class in the DEX.
+#
+# Usage: scripts/check_jni_intact.sh <path-to-apk>
+
+set -euo pipefail
+
+APK="${1:?APK path required: scripts/check_jni_intact.sh <path-to-apk>}"
+
+if [[ ! -f "$APK" ]]; then
+  echo "ERROR: APK not found: $APK" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+KT="$REPO_ROOT/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/AdblockEngineNative.kt"
+CLASS="org.codeberg.theoden8.webspace.AdblockEngineNative"
+
+if [[ ! -f "$KT" ]]; then
+  echo "ERROR: AdblockEngineNative.kt not found at $KT" >&2
+  exit 2
+fi
+
+# apkanalyzer ships with the Android SDK command-line tools (see
+# check_no_gms.sh for the same resolution dance).
+if ! command -v apkanalyzer >/dev/null 2>&1; then
+  for candidate in \
+    "${ANDROID_SDK_ROOT:-}/cmdline-tools/latest/bin/apkanalyzer" \
+    "${ANDROID_HOME:-}/cmdline-tools/latest/bin/apkanalyzer" \
+    "${ANDROID_SDK_ROOT:-}/tools/bin/apkanalyzer" \
+    "${ANDROID_HOME:-}/tools/bin/apkanalyzer"; do
+    if [[ -x "$candidate" ]]; then
+      APKANALYZER="$candidate"
+      break
+    fi
+  done
+  if [[ -z "${APKANALYZER:-}" ]]; then
+    echo "ERROR: apkanalyzer not found on PATH or in ANDROID_SDK_ROOT" >&2
+    echo "Install Android command-line tools or set ANDROID_SDK_ROOT" >&2
+    exit 2
+  fi
+else
+  APKANALYZER="apkanalyzer"
+fi
+
+# Expected JNI methods = every `external fun <name>` in the bridge source.
+mapfile -t EXPECTED < <(grep -oE 'external fun [A-Za-z0-9_]+' "$KT" \
+  | awk '{print $3}' | sort -u)
+if [[ ${#EXPECTED[@]} -eq 0 ]]; then
+  echo "ERROR: no 'external fun' declarations found in $KT" >&2
+  echo "If the JNI bridge moved, update this check." >&2
+  exit 2
+fi
+
+err_file="$(mktemp)"
+trap 'rm -f "$err_file"' EXIT
+
+if ! DEX_TREE="$("$APKANALYZER" dex packages "$APK" 2>"$err_file")"; then
+  echo "ERROR: apkanalyzer failed to read $APK" >&2
+  cat "$err_file" >&2
+  exit 2
+fi
+
+# Method (M) rows for the bridge class look like:
+#   M d 1 1 12  org.codeberg.theoden8.webspace.AdblockEngineNative long nativeEngineNew(java.lang.String,boolean)
+# Keep only M rows naming the class, then require "<name>(" so a param type
+# of the same class on an unrelated method can't satisfy the match.
+CLASS_METHODS="$(printf '%s\n' "$DEX_TREE" \
+  | awk -v c="$CLASS" '$1 == "M" && index($0, c)')"
+
+missing=()
+for m in "${EXPECTED[@]}"; do
+  if ! printf '%s\n' "$CLASS_METHODS" | grep -qE "[[:space:]]${m}\("; then
+    missing+=("$m")
+  fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "JNI bridge broken in $APK -- native methods absent from the DEX:" >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  echo "" >&2
+  echo "R8 stripped or renamed the $CLASS entry points, so the Rust library" >&2
+  echo "(Java_org_codeberg_theoden8_webspace_AdblockEngineNative_*) cannot" >&2
+  echo "bind at runtime (UnsatisfiedLinkError). In proguard-rules.pro,"  >&2
+  echo "obfuscation must stay off and the native-methods keep must remain." >&2
+  exit 1
+fi
+
+echo "OK: $APK retains all ${#EXPECTED[@]} AdblockEngineNative JNI entry points."

--- a/scripts/check_no_gms.sh
+++ b/scripts/check_no_gms.sh
@@ -49,18 +49,40 @@ fi
 
 FORBIDDEN_REGEX='^(com\.google\.android\.gms|com\.google\.firebase|com\.google\.android\.play)'
 
-# `apkanalyzer dex packages --defined-only` lists every package defined in
-# the APK's DEX files (one column = "P" / "C" / "M" + name). We drop to
-# the package column with awk and grep against the forbidden namespaces.
-HITS="$("$APKANALYZER" dex packages --defined-only "$APK" 2>/dev/null \
-  | awk '$1 == "P" {print $NF}' \
-  | grep -E "$FORBIDDEN_REGEX" || true)"
+# `apkanalyzer dex packages` lists every package (P), class (C) and method
+# (M) node in the APK's DEX files, each tagged defined ("d") or referenced
+# ("r"). We deliberately do NOT pass --defined-only: F-Droid's scanner
+# rejects an APK that merely *references* a forbidden class, and Flutter's
+# embedding references com.google.android.play.core.* from its
+# deferred-components code path (PlayStoreDeferredComponentManager). With
+# R8 shrinking disabled (-dontshrink in proguard-rules.pro) those
+# references survive into the dex even though the app never instantiates
+# that manager — so a defined-only scan reports a clean APK that F-Droid
+# then bounces. Scan references too, matching F-Droid's contract.
+#
+# Match P and C rows (their name is the last field); M rows carry a method
+# signature with embedded spaces, but every forbidden class already shows
+# up as a C row, so they add nothing.
+err_file="$(mktemp)"
+trap 'rm -f "$err_file"' EXIT
+
+if ! DEX_TREE="$("$APKANALYZER" dex packages "$APK" 2>"$err_file")"; then
+  echo "ERROR: apkanalyzer failed to read $APK" >&2
+  cat "$err_file" >&2
+  exit 2
+fi
+
+HITS="$(printf '%s\n' "$DEX_TREE" \
+  | awk '$1 == "P" || $1 == "C" { print $NF }' \
+  | grep -E "$FORBIDDEN_REGEX" \
+  | sort -u || true)"
 
 if [[ -n "$HITS" ]]; then
   echo "GMS contamination detected in $APK:" >&2
   echo "$HITS" >&2
   echo "" >&2
   echo "WebSpace must run on devices without Google Mobile Services." >&2
+  echo "These classes are defined or referenced in the shipped DEX." >&2
   echo "Investigate which dependency pulled these in and remove or strip it." >&2
   exit 1
 fi

--- a/test/check_jni_intact_parsing_test.dart
+++ b/test/check_jni_intact_parsing_test.dart
@@ -1,0 +1,89 @@
+@Tags(['ci'])
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Parsing-level guard for `scripts/check_jni_intact.sh`. Stubs
+/// `apkanalyzer` with canned `dex packages` output and asserts the script
+/// flags a missing/renamed native method -- the signature of R8 shrinking
+/// or obfuscation eating the Rust adblock JNI bridge, which otherwise only
+/// shows up at runtime as UnsatisfiedLinkError. The expected method set is
+/// read by the script from AdblockEngineNative.kt, so this test stays in
+/// sync with the real bridge.
+void main() {
+  late Directory tmp;
+  final script = File('scripts/check_jni_intact.sh').absolute.path;
+
+  setUp(() {
+    tmp = Directory.systemTemp.createTempSync('check_jni_intact_test');
+  });
+
+  tearDown(() {
+    if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+  });
+
+  Future<ProcessResult> runWithStub(String tree) async {
+    final stub = File('${tmp.path}/apkanalyzer');
+    stub.writeAsStringSync('#!/usr/bin/env bash\ncat <<\'EOF\'\n$tree\nEOF\n');
+    Process.runSync('chmod', ['+x', stub.path]);
+    final apk = File('${tmp.path}/app-fdroid-release.apk')..writeAsStringSync('stub');
+    return Process.run(
+      'bash',
+      [script, apk.path],
+      // Run from the repo root so the script finds AdblockEngineNative.kt.
+      workingDirectory: Directory.current.path,
+      environment: {'PATH': '${tmp.path}:${Platform.environment['PATH']}'},
+    );
+  }
+
+  /// Emits a `dex packages` M row per native method declared in the bridge.
+  String treeFor(Iterable<String> nativeMethods) {
+    const cls = 'org.codeberg.theoden8.webspace.AdblockEngineNative';
+    final rows = <String>['C d 9 9 100 $cls'];
+    for (final m in nativeMethods) {
+      rows.add('M d 1 1 12 $cls boolean $m(long,java.lang.String)');
+    }
+    return rows.join('\n');
+  }
+
+  List<String> declaredNativeMethods() {
+    final kt = File(
+      'android/app/src/main/kotlin/org/codeberg/theoden8/webspace/AdblockEngineNative.kt',
+    ).readAsStringSync();
+    return RegExp(r'external fun ([A-Za-z0-9_]+)')
+        .allMatches(kt)
+        .map((m) => m.group(1)!)
+        .toSet()
+        .toList();
+  }
+
+  test('all declared native methods present -> passes', () async {
+    final methods = declaredNativeMethods();
+    expect(methods, isNotEmpty);
+    final result = await runWithStub(treeFor(methods));
+    expect(result.exitCode, 0,
+        reason: 'stdout:\n${result.stdout}\nstderr:\n${result.stderr}');
+  });
+
+  test('a missing native method -> fails (UnsatisfiedLinkError guard)',
+      () async {
+    final methods = declaredNativeMethods()..removeLast();
+    final result = await runWithStub(treeFor(methods));
+    expect(result.exitCode, 1,
+        reason: 'stdout:\n${result.stdout}\nstderr:\n${result.stderr}');
+    expect(result.stderr.toString(), contains('JNI bridge broken'));
+  });
+
+  test('a param-type-only mention does not count as the method', () async {
+    // The class appears as a *parameter type* of an unrelated method; the
+    // native names themselves are absent -> must still fail.
+    const cls = 'org.codeberg.theoden8.webspace.AdblockEngineNative';
+    final tree = 'C d 1 1 50 com.example.Other\n'
+        'M d 1 1 9 com.example.Other void consume($cls)';
+    final result = await runWithStub(tree);
+    expect(result.exitCode, 1,
+        reason: 'stdout:\n${result.stdout}\nstderr:\n${result.stderr}');
+  });
+}

--- a/test/check_no_gms_parsing_test.dart
+++ b/test/check_no_gms_parsing_test.dart
@@ -1,0 +1,100 @@
+@Tags(['ci'])
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Parsing-level guard for `scripts/check_no_gms.sh`. The full
+/// `gms_freedom_test.dart` needs a real APK + the Android SDK's
+/// `apkanalyzer`, so it skips locally. This test instead stubs
+/// `apkanalyzer` with canned `dex packages` output and asserts the script
+/// classifies it correctly — in particular that a *referenced* (state "r")
+/// forbidden class fails the check, since Flutter's embedding only
+/// references com.google.android.play.core.* and an earlier
+/// `--defined-only` scan let that slip past F-Droid's stricter scanner.
+void main() {
+  late Directory tmp;
+  final script = File('scripts/check_no_gms.sh').absolute.path;
+
+  setUp(() {
+    tmp = Directory.systemTemp.createTempSync('check_no_gms_test');
+  });
+
+  tearDown(() {
+    if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+  });
+
+  /// Writes an executable `apkanalyzer` stub emitting [tree] for any
+  /// invocation, returns the result of running the checker against it.
+  Future<ProcessResult> runWithStub(String tree) async {
+    final stub = File('${tmp.path}/apkanalyzer');
+    stub.writeAsStringSync('#!/usr/bin/env bash\ncat <<\'EOF\'\n$tree\nEOF\n');
+    Process.runSync('chmod', ['+x', stub.path]);
+
+    final apk = File('${tmp.path}/app-fdroid-release.apk')..writeAsStringSync('stub');
+
+    return Process.run(
+      'bash',
+      [script, apk.path],
+      environment: {'PATH': '${tmp.path}:${Platform.environment['PATH']}'},
+    );
+  }
+
+  test('referenced (state r) play.core class fails the check', () async {
+    // Column layout mirrors `apkanalyzer dex packages`: node-type, state,
+    // counts, then the fully-qualified name as the final field. The
+    // play.core rows are state "r" (referenced, not defined) — exactly what
+    // --defined-only used to hide.
+    final result = await runWithStub('''
+P d 3 3 100 com.example.app
+C d 2 2 80 com.example.app.MainActivity
+P r 0 2 0 com.google.android.play.core.splitinstall
+C r 0 1 0 com.google.android.play.core.splitinstall.SplitInstallManager
+C r 0 1 0 com.google.android.play.core.tasks.OnSuccessListener
+''');
+
+    expect(result.exitCode, 1,
+        reason: 'stdout:\n${result.stdout}\nstderr:\n${result.stderr}');
+    expect(result.stderr.toString(),
+        contains('com.google.android.play.core.splitinstall'));
+  });
+
+  test('clean tree passes', () async {
+    final result = await runWithStub('''
+P d 3 3 100 com.example.app
+C d 2 2 80 com.example.app.MainActivity
+P d 1 1 40 androidx.webkit
+C d 1 1 40 androidx.webkit.WebViewCompat
+''');
+
+    expect(result.exitCode, 0,
+        reason: 'stdout:\n${result.stdout}\nstderr:\n${result.stderr}');
+  });
+
+  test('defined gms class still fails', () async {
+    final result = await runWithStub('''
+P d 1 1 40 com.google.android.gms.common
+C d 1 1 40 com.google.android.gms.common.GoogleApiAvailability
+''');
+
+    expect(result.exitCode, 1,
+        reason: 'stdout:\n${result.stdout}\nstderr:\n${result.stderr}');
+  });
+
+  test('apkanalyzer failure is a hard error, not a false OK', () async {
+    final stub = File('${tmp.path}/apkanalyzer');
+    stub.writeAsStringSync('#!/usr/bin/env bash\necho "boom" >&2\nexit 1\n');
+    Process.runSync('chmod', ['+x', stub.path]);
+    final apk = File('${tmp.path}/app-fdroid-release.apk')..writeAsStringSync('stub');
+
+    final result = await Process.run(
+      'bash',
+      [script, apk.path],
+      environment: {'PATH': '${tmp.path}:${Platform.environment['PATH']}'},
+    );
+
+    expect(result.exitCode, 2,
+        reason: 'stdout:\n${result.stdout}\nstderr:\n${result.stderr}');
+  });
+}


### PR DESCRIPTION
apkanalyzer was run with --defined-only, so it only saw classes whose
bodies ship in the dex. Flutter's embedding merely *references*
com.google.android.play.core.* (via PlayStoreDeferredComponentManager),
and with -dontshrink those refs survive into the APK. F-Droid's scanner
rejects references too, so it bounced builds the check called clean.

Drop --defined-only and scan P+C rows; treat an apkanalyzer failure as a
hard error instead of a silent OK. Add a stub-apkanalyzer regression test
that needs neither a real APK nor the Android SDK.