### PR TITLE
Webview back/forward: native swipe gesture (iOS/macOS) + cold-start history restore

### DIFF
--- a/integration_test/safari_navigation_test.dart
+++ b/integration_test/safari_navigation_test.dart
@@ -1,0 +1,225 @@
+// Safari-style navigation restore integration test.
+//
+// Exercises the cross-restart back/forward restore wiring in
+// lib/main.dart + lib/web_view_model.dart: a webview's navigation state
+// is captured (`controller.saveState()`) on app background and re-applied
+// (`controller.restoreState()`) when the site is re-activated after a
+// cold start. Spec: openspec/specs/per-site-cookie-isolation has the
+// lifecycle; the restore path lives on branch "safari-history-restore".
+//
+// Flow:
+//   1. Boot, activate a site whose page auto-navigates once (so it builds
+//      a 2-entry back/forward history) to a URL carrying a per-load random
+//      nonce.
+//   2. Background the app -> capture the nav state to the (injected,
+//      in-memory) WebViewStateStorage.
+//   3. Restart (fresh WebSpaceApp tree, same process-global store) and
+//      re-activate the site -> restoreState re-applies the captured stack.
+//   4. Assert the restored top URL equals the *exact* nonce captured in
+//      step 1 (a fresh re-navigation would mint a different nonce, so this
+//      distinguishes a real restore from re-loading the page) and that
+//      back-navigation is available (the history survived).
+//
+// Platform-guarded: where `controller.saveState()` returns no bytes
+// (engine doesn't serialize nav state), the capture store stays empty and
+// the test skips the restore assertions rather than failing.
+//
+// Activating a site mounts a real WebView, so the wayland +
+// WEBKIT_DISABLE_SANDBOX harness is required (see
+// openspec/specs/integration-tests/spec.md). `pumpAndSettle` deadlocks on
+// a live WebView; the live-webview waits poll in fixed slices instead.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webspace/main.dart' as app;
+import 'package:webspace/demo_data.dart';
+import 'package:webspace/web_view_model.dart';
+import 'package:webspace/webspace_model.dart';
+import 'package:webspace/services/webview.dart';
+import 'package:webspace/services/webview_state_storage.dart';
+
+const String _siteId = 'safari-nav';
+const String _siteName = 'Safari Nav';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late HttpServer server;
+  late InMemoryWebViewStateStorage store;
+
+  setUpAll(() async {
+    isDemoMode = true;
+
+    // Process-global store: survives the simulated restart (a fresh
+    // WebSpaceApp tree re-reads it on cold start) and is directly
+    // inspectable, without needing a platform keychain backend.
+    store = InMemoryWebViewStateStorage();
+    app.debugWebViewStateStorageOverride = store;
+
+    server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    server.listen((req) {
+      final res = req.response..headers.contentType = ContentType.html;
+      if (req.uri.path == '/deep') {
+        res.write('<html><head><title>deep</title></head>'
+            '<body>deep</body></html>');
+      } else {
+        // /start auto-navigates once to a nonce'd /deep, building a
+        // 2-entry history. A long delay means that on restart restoreState
+        // (applied immediately on controller creation) wins over this
+        // reloaded page's timer, which is discarded with its document.
+        res.write('<html><head><title>start</title></head><body>start'
+            '<script>setTimeout(function(){'
+            'location.assign("/deep?n=" + Date.now() + "_" + '
+            'Math.floor(Math.random()*1e9));}, 1200);</script>'
+            '</body></html>');
+      }
+      res.close();
+    });
+
+    final site = WebViewModel(
+      siteId: _siteId,
+      initUrl: 'http://127.0.0.1:${server.port}/start',
+      name: _siteName,
+    );
+    SharedPreferences.setMockInitialValues({
+      'webViewModels': [jsonEncode(site.toJson())],
+    });
+  });
+
+  tearDownAll(() async {
+    app.debugWebViewStateStorageOverride = null;
+    await server.close(force: true);
+  });
+
+  testWidgets('back/forward history and current page survive a restart',
+      (tester) async {
+    WebViewModel? site() {
+      for (final m in app.debugWebViewModels ?? const <WebViewModel>[]) {
+        if (m.siteId == _siteId) return m;
+      }
+      return null;
+    }
+
+    WebViewController? controller() => site()?.controller;
+
+    Future<Uri?> currentUrl() async {
+      try {
+        return await controller()?.getUrl();
+      } catch (_) {
+        return null;
+      }
+    }
+
+    Future<bool> canGoBack() async {
+      try {
+        return await controller()?.canGoBack() ?? false;
+      } catch (_) {
+        return false;
+      }
+    }
+
+    Future<void> pumpUntil(
+      Future<bool> Function() predicate, {
+      required String description,
+      Duration timeout = const Duration(seconds: 45),
+      Duration step = const Duration(milliseconds: 250),
+    }) async {
+      final deadline = DateTime.now().add(timeout);
+      while (DateTime.now().isBefore(deadline)) {
+        await tester.pump(step);
+        if (await predicate()) return;
+      }
+      throw StateError('Timed out after ${timeout.inSeconds}s waiting for: '
+          '$description');
+    }
+
+    Future<void> openDrawer() async {
+      await tester.tap(find.byKey(const ValueKey(kAllWebspaceId)));
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+    }
+
+    Future<void> activateSite() async {
+      // Drawer is opened while no webview is live (lazy IndexedStack), so
+      // pumpAndSettle is safe up to the tap; the live-webview wait polls.
+      await openDrawer();
+      final tile = find.text(_siteName);
+      expect(tile, findsOneWidget,
+          reason: '$_siteName should appear in the drawer');
+      await tester.tap(tile);
+    }
+
+    Future<void> background() async {
+      await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+        'flutter/lifecycle',
+        const StringCodec()
+            .encodeMessage(AppLifecycleState.paused.toString()),
+        (_) {},
+      );
+    }
+
+    // --- Run 1: cold boot, build history, capture on background ---
+    app.main();
+    await tester.pumpAndSettle(const Duration(seconds: 30));
+
+    await activateSite();
+    try {
+      await pumpUntil(
+        () async => (await currentUrl())?.path == '/deep' && await canGoBack(),
+        description: 'site to navigate /start -> /deep with back history',
+      );
+    } on StateError {
+      // The webview never drove the loopback load + JS auto-navigation
+      // (no real nav on this harness). Nothing to restore; skip rather
+      // than fail for an environmental reason.
+      // ignore: avoid_print
+      print('[safari_navigation_test] SKIP: webview did not build nav '
+          'history on this platform.');
+      return;
+    }
+
+    final captured = (await currentUrl())!.toString();
+    expect(captured, contains('/deep?n='),
+        reason: 'history should be built before capture');
+
+    await background();
+    var captureSupported = false;
+    try {
+      await pumpUntil(
+        () async => (await store.loadState(_siteId))?.isNotEmpty ?? false,
+        description: 'nav state to be captured on background',
+        timeout: const Duration(seconds: 15),
+      );
+      captureSupported = true;
+    } on StateError {
+      captureSupported = false;
+    }
+
+    if (!captureSupported) {
+      // ignore: avoid_print
+      print('[safari_navigation_test] SKIP restore assertions: '
+          'controller.saveState() produced no bytes on this platform.');
+      return;
+    }
+
+    // --- Run 2: restart (fresh tree, same store), re-activate, restore ---
+    await tester.pumpWidget(app.WebSpaceApp());
+    await tester.pumpAndSettle(const Duration(seconds: 20));
+
+    await activateSite();
+    await pumpUntil(
+      () async => (await currentUrl())?.toString() == captured,
+      description: 'restored top URL to match the exact nonce from run 1',
+    );
+
+    expect((await currentUrl()).toString(), captured,
+        reason: 'current page (with run-1 nonce) restored after restart');
+    expect(await canGoBack(), isTrue,
+        reason: 'back/forward history restored after restart');
+  });
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -995,13 +995,6 @@ class _WebSpacePageState extends State<WebSpacePage>
   // it to the freshly-built controller.
   final WebViewStateStorage _stateStorage = SecureWebViewStateStorage();
 
-  // Per-site debounce for the navigation-state capture triggered by
-  // `WebViewModel.onNavStateDirty` on every committed navigation. Coalesces
-  // the saveState() IPC + encrypt + disk write to one per settle window so
-  // an SPA's pushState storm doesn't write on every pseudo-nav.
-  final Map<String, Timer> _navStateCaptureTimers = {};
-  static const Duration _kNavStateCaptureDebounce = Duration(seconds: 2);
-
   // Track which webview indices have been loaded (for lazy loading)
   // Only webviews in this set will be created - others remain as placeholders
   final Set<int> _loadedIndices = {};
@@ -1316,10 +1309,6 @@ class _WebSpacePageState extends State<WebSpacePage>
   void dispose() {
     _foregroundPollTimer?.cancel();
     _untrustSub?.cancel();
-    for (final t in _navStateCaptureTimers.values) {
-      t.cancel();
-    }
-    _navStateCaptureTimers.clear();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
@@ -3464,25 +3453,6 @@ class _WebSpacePageState extends State<WebSpacePage>
       sensitivity: LogSensitivity.sensitive,
     );
     return true;
-  }
-
-  /// Queue a debounced navigation-state capture for [model]. Fired from
-  /// `WebViewModel.onNavStateDirty` on every committed navigation; the
-  /// timer coalesces bursts (SPA pushState) into one capture per settle
-  /// window. Disposal-path captures stay synchronous (they must complete
-  /// before the webview is torn down) and bypass this. Archive-tier and
-  /// incognito sites never capture (ARCH-006 / ephemerality), so skip
-  /// scheduling for them.
-  void _scheduleNavStateCapture(WebViewModel model) {
-    if (!model.persistsNavState) return;
-    _navStateCaptureTimers[model.siteId]?.cancel();
-    _navStateCaptureTimers[model.siteId] = Timer(
-      _kNavStateCaptureDebounce,
-      () {
-        _navStateCaptureTimers.remove(model.siteId);
-        unawaited(_captureStateBytes(model));
-      },
-    );
   }
 
   /// Capture state and flip the lifecycle to [SiteLifecycleState.savedForRestore].
@@ -7015,14 +6985,6 @@ class _WebSpacePageState extends State<WebSpacePage>
                           isArchiveTier: webViewModel.isArchiveTier,
                           initUrl: webViewModel.initUrl,
                         );
-                        // Wire the debounced nav-state capture once per
-                        // loaded model. Only loaded models reach here (and
-                        // thus build a webview that can navigate), so this
-                        // covers exactly the set whose back/forward stack
-                        // is worth persisting.
-                        webViewModel.onNavStateDirty ??=
-                            () => _scheduleNavStateCapture(webViewModel);
-
                         return SizedBox.expand(
                           key: ValueKey(webViewModel.siteId),
                           child: Column(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3165,12 +3165,10 @@ class _WebSpacePageState extends State<WebSpacePage>
     // still sit on disk — that's the cross-restart back/forward restore.
     //
     // Skipped when the webview is already loaded (rebuild won't recreate
-    // the controller, so a queued restore would be stale), for incognito
-    // sites (capture never runs for them), and for archive-tier sites
-    // (ARCH-006: navigation state is never persisted for them).
-    if (!_loadedIndices.contains(index) &&
-        !target.incognito &&
-        !target.isArchiveTier) {
+    // the controller, so a queued restore would be stale) and for sites
+    // that never persist nav state — incognito (ephemeral) and
+    // archive-tier (ARCH-006: state lives only in the slot ciphertext).
+    if (!_loadedIndices.contains(index) && target.persistsNavState) {
       final bytes = await _stateStorage.loadState(target.siteId);
       if (version != _setCurrentIndexVersion) return;
       if (bytes != null) {
@@ -3455,12 +3453,8 @@ class _WebSpacePageState extends State<WebSpacePage>
   /// app-background) should leave the state at [SiteLifecycleState.resident]
   /// since the webview is still in memory.
   Future<bool> _captureStateBytes(WebViewModel model) async {
-    if (model.incognito) return false;
-    // ARCH-006: webview navigation state is disabled for archive-tier
-    // sites. The bytes would land in a per-`siteId` file whose existence
-    // correlates to a specific archive site on disk inspection; archive
-    // state lives only in the slot-pool ciphertext, never in files.
-    if (model.isArchiveTier) return false;
+    // Archive-tier (ARCH-006) and incognito sites never persist nav state.
+    if (!model.persistsNavState) return false;
     final bytes = await model.captureNavigationState();
     if (bytes == null) return false;
     await _stateStorage.saveState(model.siteId, bytes);
@@ -3480,7 +3474,7 @@ class _WebSpacePageState extends State<WebSpacePage>
   /// incognito sites never capture (ARCH-006 / ephemerality), so skip
   /// scheduling for them.
   void _scheduleNavStateCapture(WebViewModel model) {
-    if (model.incognito || model.isArchiveTier) return;
+    if (!model.persistsNavState) return;
     _navStateCaptureTimers[model.siteId]?.cancel();
     _navStateCaptureTimers[model.siteId] = Timer(
       _kNavStateCaptureDebounce,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -462,6 +462,19 @@ WebViewTheme _themeModeToWebViewTheme(ThemeMode mode) {
 // Cache for page titles
 final Map<String, String?> _pageTitleCache = {};
 
+/// Test seam: when set, the page state uses this store instead of
+/// constructing a [SecureWebViewStateStorage]. Lets integration tests
+/// inject an in-memory store that survives a simulated restart (re-run of
+/// [main]) without a platform keychain backend.
+@visibleForTesting
+WebViewStateStorage? debugWebViewStateStorageOverride;
+
+/// Test seam: live reference to the current run's loaded site models, so
+/// integration tests can reach a webview controller (URL, back/forward,
+/// restore state) the widget tree doesn't otherwise expose.
+@visibleForTesting
+List<WebViewModel>? debugWebViewModels;
+
 // Get page title by parsing HTML (fallback for platforms without native title support)
 Future<String?> getPageTitle(String url) async {
   // Check cache first
@@ -993,7 +1006,8 @@ class _WebSpacePageState extends State<WebSpacePage>
   // keyed by siteId; re-activation reads it and pre-populates the
   // model's `_pendingRestoreState` so onControllerCreated can apply
   // it to the freshly-built controller.
-  final WebViewStateStorage _stateStorage = SecureWebViewStateStorage();
+  final WebViewStateStorage _stateStorage =
+      debugWebViewStateStorageOverride ?? SecureWebViewStateStorage();
 
   // Track which webview indices have been loaded (for lazy loading)
   // Only webviews in this set will be created - others remain as placeholders
@@ -1054,6 +1068,7 @@ class _WebSpacePageState extends State<WebSpacePage>
   @override
   void initState() {
     super.initState();
+    debugWebViewModels = _webViewModels;
     WidgetsBinding.instance.addObserver(this);
     _restoreAppState();
     _refreshPinnedSiteIds();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -995,6 +995,13 @@ class _WebSpacePageState extends State<WebSpacePage>
   // it to the freshly-built controller.
   final WebViewStateStorage _stateStorage = SecureWebViewStateStorage();
 
+  // Per-site debounce for the navigation-state capture triggered by
+  // `WebViewModel.onNavStateDirty` on every committed navigation. Coalesces
+  // the saveState() IPC + encrypt + disk write to one per settle window so
+  // an SPA's pushState storm doesn't write on every pseudo-nav.
+  final Map<String, Timer> _navStateCaptureTimers = {};
+  static const Duration _kNavStateCaptureDebounce = Duration(seconds: 2);
+
   // Track which webview indices have been loaded (for lazy loading)
   // Only webviews in this set will be created - others remain as placeholders
   final Set<int> _loadedIndices = {};
@@ -1309,6 +1316,10 @@ class _WebSpacePageState extends State<WebSpacePage>
   void dispose() {
     _foregroundPollTimer?.cancel();
     _untrustSub?.cancel();
+    for (final t in _navStateCaptureTimers.values) {
+      t.cancel();
+    }
+    _navStateCaptureTimers.clear();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
@@ -3144,17 +3155,21 @@ class _WebSpacePageState extends State<WebSpacePage>
     _activationInFlightIndex = index;
     try {
 
-    // If the target was disposed under memory pressure (lifecycleState
-    // == savedForRestore), fetch its captured navigation state and
-    // hand it to the model so the soon-to-be-built controller's
-    // onControllerCreated handler can apply restoreState. Resets the
-    // tier to live regardless — the about-to-be-resumed webview
-    // is back at the lowest tier.
-    // ARCH-006: archive-tier sites never persist webview state to
-    // disk (`_captureStateBytes` early-returns for them), so there's
-    // nothing on disk to restore. Skip the load to avoid a per-site
-    // disk hit that would correlate to the archive siteId.
-    if (target.lifecycleState == SiteLifecycleState.savedForRestore &&
+    // Whenever the target is about to be built fresh (not already in
+    // `_loadedIndices`), fetch any saved navigation state and hand it to
+    // the model so the soon-to-be-built controller's onControllerCreated
+    // handler can apply restoreState. This covers both in-session
+    // re-activation of a `savedForRestore` site AND a cold start, where
+    // every site loads from JSON at the default `resident` tier yet the
+    // bytes persisted on the previous run (on navigation / backgrounding)
+    // still sit on disk — that's the cross-restart back/forward restore.
+    //
+    // Skipped when the webview is already loaded (rebuild won't recreate
+    // the controller, so a queued restore would be stale), for incognito
+    // sites (capture never runs for them), and for archive-tier sites
+    // (ARCH-006: navigation state is never persisted for them).
+    if (!_loadedIndices.contains(index) &&
+        !target.incognito &&
         !target.isArchiveTier) {
       final bytes = await _stateStorage.loadState(target.siteId);
       if (version != _setCurrentIndexVersion) return;
@@ -3167,11 +3182,11 @@ class _WebSpacePageState extends State<WebSpacePage>
           sensitivity: LogSensitivity.sensitive,
         );
       }
-      target.lifecycleState = SiteLifecycleState.resident;
-    } else if (target.lifecycleState != SiteLifecycleState.resident) {
-      // cacheCleared promoted back to live on activation — the user
-      // is interacting with it again, so any subsequent memory
-      // pressure starts the cascade fresh from the live tier.
+    }
+    // The about-to-be-resumed webview is back at the lowest tier; reset
+    // regardless of how it got here (savedForRestore dispose, cacheCleared
+    // promotion, or a fresh cold-start load).
+    if (target.lifecycleState != SiteLifecycleState.resident) {
       target.lifecycleState = SiteLifecycleState.resident;
     }
 
@@ -3441,10 +3456,10 @@ class _WebSpacePageState extends State<WebSpacePage>
   /// since the webview is still in memory.
   Future<bool> _captureStateBytes(WebViewModel model) async {
     if (model.incognito) return false;
-    // ARCH-006: per-site webview state is keyed by siteId on disk
-    // (encrypted, but the file's existence + path leaks archive site
-    // identity to forensic inspection, and the bytes encode the
-    // back/forward URL stack). Archive-tier sites never capture.
+    // ARCH-006: webview navigation state is disabled for archive-tier
+    // sites. The bytes would land in a per-`siteId` file whose existence
+    // correlates to a specific archive site on disk inspection; archive
+    // state lives only in the slot-pool ciphertext, never in files.
     if (model.isArchiveTier) return false;
     final bytes = await model.captureNavigationState();
     if (bytes == null) return false;
@@ -3455,6 +3470,25 @@ class _WebSpacePageState extends State<WebSpacePage>
       sensitivity: LogSensitivity.sensitive,
     );
     return true;
+  }
+
+  /// Queue a debounced navigation-state capture for [model]. Fired from
+  /// `WebViewModel.onNavStateDirty` on every committed navigation; the
+  /// timer coalesces bursts (SPA pushState) into one capture per settle
+  /// window. Disposal-path captures stay synchronous (they must complete
+  /// before the webview is torn down) and bypass this. Archive-tier and
+  /// incognito sites never capture (ARCH-006 / ephemerality), so skip
+  /// scheduling for them.
+  void _scheduleNavStateCapture(WebViewModel model) {
+    if (model.incognito || model.isArchiveTier) return;
+    _navStateCaptureTimers[model.siteId]?.cancel();
+    _navStateCaptureTimers[model.siteId] = Timer(
+      _kNavStateCaptureDebounce,
+      () {
+        _navStateCaptureTimers.remove(model.siteId);
+        unawaited(_captureStateBytes(model));
+      },
+    );
   }
 
   /// Capture state and flip the lifecycle to [SiteLifecycleState.savedForRestore].
@@ -6987,6 +7021,13 @@ class _WebSpacePageState extends State<WebSpacePage>
                           isArchiveTier: webViewModel.isArchiveTier,
                           initUrl: webViewModel.initUrl,
                         );
+                        // Wire the debounced nav-state capture once per
+                        // loaded model. Only loaded models reach here (and
+                        // thus build a webview that can navigate), so this
+                        // covers exactly the set whose back/forward stack
+                        // is worth persisting.
+                        webViewModel.onNavStateDirty ??=
+                            () => _scheduleNavStateCapture(webViewModel);
 
                         return SizedBox.expand(
                           key: ValueKey(webViewModel.siteId),

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -490,6 +490,16 @@ class WebViewConfig {
   final String? userAgent;
   final bool thirdPartyCookiesEnabled;
   final bool incognito;
+  /// iOS/macOS only: enable WKWebView's native back/forward swipe gesture
+  /// (`allowsBackForwardNavigationGestures`). Set only for the root site
+  /// webview, which lives at the `MaterialApp` root route where no Flutter
+  /// route-pop edge-swipe exists — so without this Apple has no reliable
+  /// back-swipe in the main view (the `PopScope` handler only fires for
+  /// pushable routes). Nested `InAppWebViewScreen`s leave this false: they
+  /// are pushed routes whose own PopScope navigates webview-back and pops
+  /// the route at history start (NAV-008), which the native gesture would
+  /// otherwise hijack. No effect on Android.
+  final bool backForwardGestures;
   /// Language code for Accept-Language header (e.g., 'en', 'es', 'fr').
   /// If null, uses system default.
   final String? language;
@@ -655,6 +665,7 @@ class WebViewConfig {
     this.userAgent,
     this.thirdPartyCookiesEnabled = false,
     this.incognito = false,
+    this.backForwardGestures = false,
     this.language,
     this.zoomPercent = 100,
     this.clearUrlEnabled = true,
@@ -2243,6 +2254,9 @@ class WebViewFactory {
       ..cacheMode = usesCachedHtml ? inapp.CacheMode.LOAD_CACHE_ELSE_NETWORK : null
       // iOS: play videos inline instead of auto-fullscreen
       ..allowsInlineMediaPlayback = true
+      // iOS/macOS: native Safari-style horizontal swipe for back/forward.
+      // Only the root site webview opts in (see WebViewConfig.backForwardGestures).
+      ..allowsBackForwardNavigationGestures = config.backForwardGestures
       // Required for onDownloadStartRequest to fire when the webview
       // navigates to a downloadable response (Content-Disposition:
       // attachment, or an unrecognized MIME type). Without this, the

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -989,6 +989,9 @@ class WebViewModel {
             }
             // State committed; sync currentUrl to the state's view of it.
             currentUrl = urlChangedState.currentUrl;
+            // The back/forward stack just advanced — let the host queue a
+            // debounced saveState() capture so a cold start can restore it.
+            onNavStateDirty?.call();
             // Trigger UI rebuild so URL bar updates
             if (stateSetterF != null) {
               stateSetterF!();
@@ -1432,6 +1435,15 @@ class WebViewModel {
   /// webview rebuild, so the IndexedStack repaint and the
   /// `restoreState` call land in the same render cycle.
   Uint8List? _pendingRestoreState;
+
+  /// Fired by [getWebView]'s `onUrlChanged` handler on every committed
+  /// navigation (initial load, link follow, back/forward, SPA pushState)
+  /// so the host can opportunistically persist `controller.saveState()`
+  /// to disk — the source of truth for cross-restart back/forward
+  /// restore. The host debounces; this only signals "the nav stack
+  /// advanced". Null in tests / engine contexts. Reads the field at call
+  /// time so the host can wire it after construction.
+  void Function()? onNavStateDirty;
 
   /// Opaque per-site container identifier for archive-tier sites
   /// (ARCH-007). Format mirrors [siteId] (radix-36-dash-radix-36) so a

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -793,6 +793,10 @@ class WebViewModel {
           userAgent: userAgent.isNotEmpty ? userAgent : null,
           thirdPartyCookiesEnabled: thirdPartyCookiesEnabled,
           incognito: incognito,
+          // Root site webview sits at the MaterialApp root route: on iOS/macOS
+          // there is no Flutter route-pop edge-swipe here, so opt into
+          // WKWebView's native back/forward swipe. Nested screens don't (NAV-008).
+          backForwardGestures: true,
           language: effectiveLanguage, // Use WebViewModel's language, not parameter
           zoomPercent: zoomPercent,
           // Umbrella `trackingProtectionEnabled`: when on, the four

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -466,6 +466,16 @@ class WebViewModel {
   bool get effectiveHtmlCachingEnabled =>
       isArchiveTier ? false : htmlCachingEnabled;
 
+  /// Whether this site may persist/restore webview navigation state
+  /// (`controller.saveState()` bytes) to the device-key on-disk store.
+  /// Single source of truth for the capture, debounce, and cold-start
+  /// restore gates. False for:
+  /// - **archive-tier** (ARCH-006): the bytes would land in a per-`siteId`
+  ///   file whose existence correlates to a specific archive site on disk;
+  ///   archive state lives only in the slot-pool ciphertext, never a file.
+  /// - **incognito**: navigation state is meant to be ephemeral.
+  bool get persistsNavState => !isArchiveTier && !incognito;
+
   /// Effective protected-content (Widevine/EME) decision. Archive-tier
   /// sites never grant DRM regardless of stored value: a grant provisions
   /// a per-container Widevine device identifier on disk and the prompt is

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -999,9 +999,6 @@ class WebViewModel {
             }
             // State committed; sync currentUrl to the state's view of it.
             currentUrl = urlChangedState.currentUrl;
-            // The back/forward stack just advanced — let the host queue a
-            // debounced saveState() capture so a cold start can restore it.
-            onNavStateDirty?.call();
             // Trigger UI rebuild so URL bar updates
             if (stateSetterF != null) {
               stateSetterF!();
@@ -1445,15 +1442,6 @@ class WebViewModel {
   /// webview rebuild, so the IndexedStack repaint and the
   /// `restoreState` call land in the same render cycle.
   Uint8List? _pendingRestoreState;
-
-  /// Fired by [getWebView]'s `onUrlChanged` handler on every committed
-  /// navigation (initial load, link follow, back/forward, SPA pushState)
-  /// so the host can opportunistically persist `controller.saveState()`
-  /// to disk — the source of truth for cross-restart back/forward
-  /// restore. The host debounces; this only signals "the nav stack
-  /// advanced". Null in tests / engine contexts. Reads the field at call
-  /// time so the host can wire it after construction.
-  void Function()? onNavStateDirty;
 
   /// Opaque per-site container identifier for archive-tier sites
   /// (ARCH-007). Format mirrors [siteId] (radix-36-dash-radix-36) so a

--- a/openspec/specs/navigation/spec.md
+++ b/openspec/specs/navigation/spec.md
@@ -26,7 +26,7 @@ WebSpace embeds webviews in a Scaffold with a drawer. Navigation gestures compet
 | iOS | `canGoBack()` returns `false` for `history.pushState()` entries (SPAs) | Back gesture can't trust it; mitigated by PopScope URL-comparison fallback (NAV-002) |
 | iOS | `onLoadStop` does not fire for BFCache page restorations during back/forward gestures | URL bar doesn't update without `onUpdateVisitedHistory` (fixed in PR #174) |
 | iOS | `target="_blank"` links may only trigger `onCreateWindow`, not `shouldOverrideUrlLoading` | Links load in current webview instead of nested browser without explicit delegation (fixed in PR #175) |
-| iOS | `allowsBackForwardNavigationGestures` is NOT set (defaults to `false`) | WKWebView has no native back swipe; only PopScope participates |
+| iOS/macOS | `allowsBackForwardNavigationGestures` is enabled for the **root site webview** only | The root webview lives at the `MaterialApp` root route, which has no Flutter route-pop edge-swipe — so without the native gesture the main view has no reliable back-swipe (PopScope only fires for pushable routes). Nested `InAppWebViewScreen`s leave it off so their route-pop-at-history-start (NAV-008) isn't hijacked. |
 | Android | `hasGesture` on `NavigationAction` is a reliable boolean | Used directly for gesture detection |
 | iOS/macOS | No `hasGesture`; must infer from `navigationType` (`LINK_ACTIVATED`, `FORM_SUBMITTED`) | Less reliable than Android's boolean flag |
 
@@ -36,7 +36,7 @@ WebSpace embeds webviews in a Scaffold with a drawer. Navigation gestures compet
 
 ### Requirement: NAV-001 - System Back Gesture
 
-The system back gesture (Android back button, iOS edge swipe via PopScope) SHALL navigate back in webview history when possible. It SHALL NOT open the drawer and SHALL NOT exit the app; when there is no back history it is a no-op.
+The system back gesture (Android back button, iOS/macOS left-edge swipe) SHALL navigate back in webview history when possible. On the root site webview, iOS/macOS use WKWebView's native back/forward swipe (`allowsBackForwardNavigationGestures`); Android, and all nested routes, use the PopScope handler. It SHALL NOT open the drawer and SHALL NOT exit the app; when there is no back history it is a no-op.
 
 **Rationale:** Users navigating content-heavy sites (especially SPA news sites) expect the back gesture to mean "go back in the page," not "open the menu" or "leave the app." Folding drawer-opening and app-exit into the back gesture made the gesture ambiguous and, combined with the iOS `canGoBack()` heuristic (NAV-002), occasionally misfired mid-navigation. The drawer is reached via the AppBar menu button; the app is left via the OS home/recents gesture.
 
@@ -45,6 +45,13 @@ The system back gesture (Android back button, iOS edge swipe via PopScope) SHALL
 **Given** a webview is visible and has navigation history
 **When** the user triggers the system back gesture
 **Then** the webview navigates back in history
+
+#### Scenario: Root site webview uses the native swipe on Apple
+
+**Given** the root site webview is visible on iOS or macOS
+**When** the user performs a left-edge back swipe
+**Then** WKWebView navigates back in its own history, including `history.pushState` entries
+**And** at the start of history the swipe is a no-op: the app does not exit and the drawer does not open
 
 #### Scenario: Webview has no back history
 

--- a/test/archive_neutrality_test.dart
+++ b/test/archive_neutrality_test.dart
@@ -76,6 +76,36 @@ void main() {
       expect(m.effectiveNotificationsEnabled, isTrue);
       expect(m.effectiveLocalCdnEnabled, isFalse);
     });
+
+    // persistsNavState is the single gate all three production call sites
+    // consult (capture, debounce, cold-start restore in main.dart). An
+    // archive-tier site returning true here is exactly the regression that
+    // would write `controller.saveState()` bytes to a per-`siteId` file —
+    // an ARCH-006 violation — so pin every combination.
+    test('persistsNavState is false for archive-tier sites', () {
+      final m = WebViewModel(initUrl: 'https://a.test', isArchiveTier: true);
+      expect(m.persistsNavState, isFalse);
+    });
+
+    test('persistsNavState is false for incognito sites', () {
+      final m = WebViewModel(initUrl: 'https://a.test', incognito: true);
+      expect(m.persistsNavState, isFalse);
+    });
+
+    test('persistsNavState is false for archive-tier even when not incognito',
+        () {
+      final m = WebViewModel(
+        initUrl: 'https://a.test',
+        isArchiveTier: true,
+        incognito: false,
+      );
+      expect(m.persistsNavState, isFalse);
+    });
+
+    test('persistsNavState is true for a plain app-tier site', () {
+      final m = WebViewModel(initUrl: 'https://a.test');
+      expect(m.persistsNavState, isTrue);
+    });
   });
 
   group('Archive does not touch SharedPreferences', () {

--- a/test/archive_neutrality_test.dart
+++ b/test/archive_neutrality_test.dart
@@ -1,10 +1,12 @@
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:webspace/services/archive.dart';
 import 'package:webspace/services/archive_storage.dart';
+import 'package:webspace/services/webview_state_secure_storage.dart';
 import 'package:webspace/web_view_model.dart';
 import 'package:webspace/webspace_model.dart';
 
@@ -100,6 +102,93 @@ void main() {
       // SharedPreferences must remain untouched throughout.
       final prefsAfter = await SharedPreferences.getInstance();
       expect(prefsAfter.getKeys(), isEmpty);
+    });
+  });
+
+  // ARCH-001 / ARCH-006 at the storage layer: archive persistence is
+  // confined to the fixed slot pool (the PDE framework) — it never writes
+  // a per-site keyed secure-storage entry, and never writes any file to
+  // the application documents directory. This is the coverage that was
+  // missing: the rest of the suite asserts the *serialization shape* of
+  // app-tier state is archive-neutral, but nothing inspected the real
+  // on-disk / secure-storage footprint. A regression that routes archive
+  // state through a docs-dir writer or a keyed secure-storage entry —
+  // even AES-encrypted, even blinded — fails here.
+  group('Archive persistence is confined to the slot pool', () {
+    Set<String> slotKeys() => {
+          for (var i = 0; i < kArchiveSlotCount; i++)
+            'archive_slot_${i.toString().padLeft(2, '0')}',
+        };
+
+    test('a full lifecycle touches only the 16 fixed slot keys', () async {
+      final mock = MockFlutterSecureStorage();
+      final archive = Archive(storage: ArchiveStorage(secureStorage: mock));
+      await archive.ensureInitialized();
+      expect(mock.storage.keys.toSet(), equals(slotKeys()),
+          reason: 'only the fixed pool exists after init');
+
+      final handle = await archive.createWithKey(_testKey(7));
+      handle.state.sites.add({'siteId': 'arch-site', 'initUrl': 'https://x.test'});
+      handle.state.cookies['arch-site'] = [
+        {'name': 'sid', 'value': 'super-secret-session'},
+      ];
+      await archive.save(handle);
+      await archive.close(handle);
+      final reopened = await archive.tryOpenWithKey(_testKey(7));
+      expect(reopened, isNotNull);
+      await archive.close(reopened!);
+
+      // The namespace is STILL exactly the slot pool — no per-site key
+      // (cookies, webview-state, proxy password) ever appeared.
+      expect(mock.storage.keys.toSet(), equals(slotKeys()),
+          reason: 'no per-site secure-storage key may be created');
+      // And nothing leaked the archive siteId / cookie value in cleartext;
+      // slot bodies are AEAD ciphertext (base64).
+      for (final value in mock.storage.values) {
+        expect(value.contains('arch-site'), isFalse);
+        expect(value.contains('super-secret-session'), isFalse);
+      }
+    });
+
+    test('a full lifecycle leaves the documents tree byte-identical', () async {
+      final docs =
+          await Directory.systemTemp.createTemp('archive_fs_neutrality');
+      try {
+        // Establish a legitimate app-tier on-disk footprint: an app-tier
+        // site persists webview navigation state to the real encrypted
+        // store rooted at our temp docs dir.
+        final stateStore = SecureWebViewStateStorage(
+          secureStorage: MockFlutterSecureStorage(),
+          overrideAppDir: docs,
+          versionProvider: () => 'test-v1',
+        );
+        await stateStore.saveState(
+            'app-site', Uint8List.fromList([1, 2, 3, 4, 5]));
+        final before = await _snapshotDir(docs);
+        expect(before, isNotEmpty,
+            reason: 'sanity: the app-tier write produced a file to diff against');
+
+        // A full archive lifecycle must write NOTHING under the documents
+        // directory — its state lives only in the secure-storage slots.
+        final archive =
+            Archive(storage: ArchiveStorage(secureStorage: MockFlutterSecureStorage()));
+        final handle = await archive.createWithKey(_testKey(8));
+        handle.state.sites.add({'siteId': 'arch-site', 'initUrl': 'https://y.test'});
+        handle.state.cookies['arch-site'] = [
+          {'name': 'sid', 'value': 'secret'},
+        ];
+        await archive.save(handle);
+        await archive.close(handle);
+        final reopened = await archive.tryOpenWithKey(_testKey(8));
+        await archive.close(reopened!);
+
+        final after = await _snapshotDir(docs);
+        expect(after, equals(before),
+            reason: 'archive operations must not write to the documents '
+                'directory (ARCH-001 / ARCH-006)');
+      } finally {
+        await docs.delete(recursive: true);
+      }
     });
   });
 
@@ -359,6 +448,21 @@ Uint8List _testKey(int seed) {
   return Uint8List.fromList(
     List<int>.generate(32, (i) => (seed * 17 + i * 31) & 0xff),
   );
+}
+
+/// Recursive `{relative-path: base64(bytes)}` snapshot of [dir], so two
+/// snapshots can be compared with `equals` to assert byte-identity of the
+/// whole tree (file set + every file's contents).
+Future<Map<String, String>> _snapshotDir(Directory dir) async {
+  final out = <String, String>{};
+  if (!await dir.exists()) return out;
+  await for (final entity in dir.list(recursive: true, followLinks: false)) {
+    if (entity is File) {
+      final rel = entity.path.substring(dir.path.length);
+      out[rel] = base64.encode(await entity.readAsBytes());
+    }
+  }
+  return out;
 }
 
 /// Mirror of `_WebSpacePageState._resolveWebspaceIndices`. The runtime


### PR DESCRIPTION
Two related back/forward navigation improvements.

## 1. Native back/forward swipe on the root site webview (iOS/macOS)

**Problem.** The root site webview lives at the `MaterialApp` root route, which on iOS/macOS has **no Flutter route-pop edge-swipe**. The webview's own native swipe (`allowsBackForwardNavigationGestures`) was off, so the only back path was a `PopScope` handler that doesn't reliably fire at the root. Result: swipe-back in the main view worked only intermittently — when a tap happened to open a pushed sub-screen, or when the racy fallback caught. On a Turbo site (GitHub: Pull requests → a PR), it usually did nothing.

**Fix.** Opt the root webview into WKWebView's `allowsBackForwardNavigationGestures` via a new per-config flag (`WebViewConfig.backForwardGestures`). WKWebView then owns the edge-swipe natively and walks its own back/forward list, including `history.pushState` entries — the Safari behavior, made consistent.

Nested `InAppWebViewScreen`s **keep it off**: they are pushed routes whose own `PopScope` navigates webview-back and pops the route at history start (NAV-008), which the native gesture would otherwise hijack. Navigation spec updated.

## 2. Restore back/forward history on cold start

**Problem.** `controller.saveState()` bytes were persisted but only reloaded when re-activating a site disposed *in the same session*. A freshly launched site loaded from JSON at the default tier, so the bytes were never read — history reset on every app restart.

**Fix.** On activation, load saved bytes whenever a site is built fresh (not already loaded) and apply `restoreState` in `onControllerCreated`. Rides the existing capture points (app backgrounding, memory-pressure / LRU unload); no new capture on the live navigation path. Capture/restore eligibility is consolidated into one predicate, `WebViewModel.persistsNavState`.

## Tests

- `persistsNavState` pinned across each flag combination.
- Storage-confinement regression tests: per-site state never escapes its intended store, and the application documents tree stays byte-identical across persistence cycles it must not touch.
- Existing navigation/model suites pass; `flutter analyze` clean on changed files.

https://claude.ai/code/session_01FcKWgUCAHWRA9yZZGQxDUd