### PR TITLE
Don't reset always-open-home URL on transient background

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,6 +47,7 @@ import 'package:webspace/services/container_native.dart';
 import 'package:webspace/services/container_cookie_manager.dart';
 import 'package:webspace/services/site_settings_qr_codec.dart';
 import 'package:webspace/services/site_activation_engine.dart';
+import 'package:webspace/services/app_lifecycle_engine.dart';
 import 'package:webspace/services/site_data_clear_engine.dart';
 import 'package:webspace/services/site_lifecycle_engine.dart';
 import 'package:webspace/services/site_lifecycle_promotion_engine.dart';
@@ -1390,12 +1391,20 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       // cold start, AOH-002) and on home-shortcut tap (AOH-004) — never on a
       // transient background. Leaving the app to fetch an emailed 2FA code and
       // returning must land on the in-progress page, not home (issue #333).
-      if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
-        if (!_webViewModels[_currentIndex!].effectiveNotificationsEnabled) {
-          _lifecyclePauseFuture = _webViewModels[_currentIndex!].pauseForAppLifecycle();
-        }
-        final activeIdx = _currentIndex!;
-        unawaited(_captureStateBytes(_webViewModels[activeIdx]));
+      // The plan therefore has no reset; it just pauses/captures the active
+      // site like any other.
+      final pausePlan = AppLifecycleEngine.backgroundPlan(
+        currentIndex: _currentIndex,
+        siteCount: _webViewModels.length,
+        loadedIndices: _loadedIndices,
+        notificationsEnabled: (i) => _webViewModels[i].effectiveNotificationsEnabled,
+      );
+      if (pausePlan.jsPauseIndex != null) {
+        _lifecyclePauseFuture =
+            _webViewModels[pausePlan.jsPauseIndex!].pauseForAppLifecycle();
+      }
+      if (pausePlan.captureStateIndex != null) {
+        unawaited(_captureStateBytes(_webViewModels[pausePlan.captureStateIndex!]));
       }
       // iOS: open a ~30s background-task window so notification webviews
       // can flush in-flight setTimeouts before iOS suspends the process.
@@ -1466,11 +1475,22 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       await _lifecyclePauseFuture;
       _lifecyclePauseFuture = null;
     }
-    if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
-      if (!_webViewModels[_currentIndex!].effectiveNotificationsEnabled) {
-        await _webViewModels[_currentIndex!].resumeFromAppLifecycle();
-      }
-      unawaited(_probeRendererAndRecover(_webViewModels[_currentIndex!]));
+    final resumeIdx = AppLifecycleEngine.resumeJsIndex(
+      currentIndex: _currentIndex,
+      siteCount: _webViewModels.length,
+      loadedIndices: _loadedIndices,
+      notificationsEnabled: (i) => _webViewModels[i].effectiveNotificationsEnabled,
+    );
+    if (resumeIdx != null) {
+      await _webViewModels[resumeIdx].resumeFromAppLifecycle();
+    }
+    final probeIdx = AppLifecycleEngine.activeLoadedIndex(
+      currentIndex: _currentIndex,
+      siteCount: _webViewModels.length,
+      loadedIndices: _loadedIndices,
+    );
+    if (probeIdx != null) {
+      unawaited(_probeRendererAndRecover(_webViewModels[probeIdx]));
     }
     // Re-apply fullscreen system UI mode after resume
     if (_isFullscreen) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1385,18 +1385,12 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
     if (state == AppLifecycleState.paused) {
       _foregroundPollTimer?.cancel();
       _foregroundPollTimer = null;
-      // AOH-006: URL-ephemeral sites (alwaysOpenHome / incognito) revert to
-      // their initUrl when the app leaves the foreground, so reopening lands
-      // on home. This is the only warm-resume reset — fromJson handles cold
-      // start. In-app site switches never trigger it; only app close does.
-      final activeWentHome = _resetAlwaysOpenHomeForAppClose();
-      if (activeWentHome && mounted) {
-        // The active webview was disposed above. Mark dirty so the rebuild
-        // recreates it at initUrl once frames resume.
-        setState(() {});
-      }
-      if (!activeWentHome &&
-          _currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
+      // URL-ephemeral sites (alwaysOpenHome / incognito) revert to their
+      // initUrl only on a genuine app restart (fromJson strips currentUrl on
+      // cold start, AOH-002) and on home-shortcut tap (AOH-004) — never on a
+      // transient background. Leaving the app to fetch an emailed 2FA code and
+      // returning must land on the in-progress page, not home (issue #333).
+      if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
         if (!_webViewModels[_currentIndex!].effectiveNotificationsEnabled) {
           _lifecyclePauseFuture = _webViewModels[_currentIndex!].pauseForAppLifecycle();
         }
@@ -4922,37 +4916,6 @@ class _WebSpacePageState extends State<WebSpacePage> with WidgetsBindingObserver
       m.disposeWebView();
       _loadedIndices.remove(i);
     }
-  }
-
-  /// Reset every URL-ephemeral site (`alwaysOpenHome`, or incognito which
-  /// implies it per AOH-005) back to its initUrl when the app leaves the
-  /// foreground, disposing the live webview so the next foreground rebuild
-  /// loads home. Cookies, localStorage, and other persistent state are left
-  /// intact — that is the boundary between this toggle and incognito.
-  ///
-  /// Notification sites are skipped: their page must keep running in the
-  /// background to fire notifications, and resetting the URL would tear it
-  /// down. The active site stays in `_loadedIndices` (only its webview is
-  /// dropped) so the IndexedStack still has a child to rebuild at initUrl.
-  /// Returns true if the currently-active site was reset, so the caller can
-  /// skip the now-redundant pause/capture and schedule a rebuild instead.
-  bool _resetAlwaysOpenHomeForAppClose() {
-    bool activeReset = false;
-    for (int i = 0; i < _webViewModels.length; i++) {
-      final m = _webViewModels[i];
-      if (!(m.alwaysOpenHome || m.incognito)) continue;
-      if (m.effectiveNotificationsEnabled) continue;
-      if (m.currentUrl == m.initUrl && m.webview == null) continue;
-      _evictCacheIfOnline(m.siteId);
-      m.currentUrl = m.initUrl;
-      m.disposeWebView();
-      if (i == _currentIndex) {
-        activeReset = true;
-      } else {
-        _loadedIndices.remove(i);
-      }
-    }
-    return activeReset;
   }
 
   void _goHome() {

--- a/lib/services/app_lifecycle_engine.dart
+++ b/lib/services/app_lifecycle_engine.dart
@@ -1,0 +1,89 @@
+/// Pure decisions for app background/foreground (`AppLifecycleState`)
+/// transitions: which active site to pause + capture on background, and which
+/// to resume on foreground. Kept Flutter-free so it unit-tests without a
+/// widget; the caller maps the result to controller calls and `setState`.
+///
+/// Deliberately offers NO URL-reset output. Per AOH-006 a transient background
+/// preserves the in-progress page (issue #333): leaving the app to fetch an
+/// emailed 2FA code and returning must not send a URL-ephemeral
+/// (`alwaysOpenHome` / `incognito`) site back to its `initUrl`. The only
+/// URL-reset triggers are a cold start (fromJson strips `currentUrl`, AOH-002)
+/// and a home-shortcut tap (`WebspaceSelectionEngine
+/// .indicesToResetOnShortcutLaunch`, AOH-004) — neither is a lifecycle event.
+/// A flagged site is therefore handled here exactly like any other site.
+class LifecycleBackgroundPlan {
+  /// Active site whose JS timers should pause for the background, or null when
+  /// there is no eligible active site (or it is a notification site, which
+  /// must keep ticking to fire notifications).
+  final int? jsPauseIndex;
+
+  /// Active site whose restore-state bytes should be captured, or null. Capture
+  /// is not gated on notifications — any loaded active site is captured.
+  final int? captureStateIndex;
+
+  const LifecycleBackgroundPlan({
+    required this.jsPauseIndex,
+    required this.captureStateIndex,
+  });
+}
+
+class AppLifecycleEngine {
+  /// The active, in-bounds, loaded site index eligible for lifecycle
+  /// pause/resume, or null. Mirrors the call-site guard
+  /// `currentIndex != null && currentIndex < siteCount && loaded`.
+  static int? activeLoadedIndex({
+    required int? currentIndex,
+    required int siteCount,
+    required Set<int> loadedIndices,
+  }) {
+    if (currentIndex == null) return null;
+    if (currentIndex < 0 || currentIndex >= siteCount) return null;
+    if (!loadedIndices.contains(currentIndex)) return null;
+    return currentIndex;
+  }
+
+  /// Plan for `AppLifecycleState.paused`. The active site's JS timers pause
+  /// only when it is loaded and NOT a notification site; restore-state is
+  /// captured for any loaded active site.
+  static LifecycleBackgroundPlan backgroundPlan({
+    required int? currentIndex,
+    required int siteCount,
+    required Set<int> loadedIndices,
+    required bool Function(int index) notificationsEnabled,
+  }) {
+    final active = activeLoadedIndex(
+      currentIndex: currentIndex,
+      siteCount: siteCount,
+      loadedIndices: loadedIndices,
+    );
+    if (active == null) {
+      return const LifecycleBackgroundPlan(
+        jsPauseIndex: null,
+        captureStateIndex: null,
+      );
+    }
+    return LifecycleBackgroundPlan(
+      jsPauseIndex: notificationsEnabled(active) ? null : active,
+      captureStateIndex: active,
+    );
+  }
+
+  /// Active site whose JS timers should resume on `AppLifecycleState.resumed`:
+  /// the loaded active site unless it is a notification site (never paused, so
+  /// nothing to resume). The renderer probe runs against
+  /// [activeLoadedIndex] regardless — notification sites included.
+  static int? resumeJsIndex({
+    required int? currentIndex,
+    required int siteCount,
+    required Set<int> loadedIndices,
+    required bool Function(int index) notificationsEnabled,
+  }) {
+    final active = activeLoadedIndex(
+      currentIndex: currentIndex,
+      siteCount: siteCount,
+      loadedIndices: loadedIndices,
+    );
+    if (active == null || notificationsEnabled(active)) return null;
+    return active;
+  }
+}

--- a/openspec/specs/always-open-home/spec.md
+++ b/openspec/specs/always-open-home/spec.md
@@ -5,11 +5,12 @@
 A per-site `alwaysOpenHome` toggle that makes the site's *navigation
 URL* ephemeral while keeping its persistent state (cookies,
 localStorage, IndexedDB, HTTP cache) intact. The site reverts to its
-`initUrl` on **app restart**, on **app close** (the app leaving the
-foreground), and on **Android home-shortcut tap**, but the user's
-logged-in session, preferences, and other cookie-backed state survive
-all three events. Switching between sites *within* the app is not a
-reset trigger.
+`initUrl` on **app restart** (cold start) and on **Android
+home-shortcut tap**, but the user's logged-in session, preferences,
+and other cookie-backed state survive both events. Switching between
+sites *within* the app is not a reset trigger, and neither is a
+transient background — leaving the app to fetch an emailed 2FA code
+and returning preserves the in-progress page (issue #333).
 
 Two motivating cases the user split out from
 [incognito-mode](../incognito-mode/spec.md) (which ALSO drops
@@ -163,22 +164,23 @@ regardless of the stored `alwaysOpenHome` value.
 
 ---
 
-### Requirement: AOH-006 - Reset On App Close, Not On Site Switch
+### Requirement: AOH-006 - Transient Background Does Not Reset
 
-The system SHALL reset `currentUrl` to `initUrl` for every flagged site
-(`alwaysOpenHome = true` or `incognito = true`) when the app transitions
-to the backgrounded (`AppLifecycleState.paused`) lifecycle state, and SHALL
-dispose each such site's live webview so the next foregrounding rebuilds it
-at `initUrl`. Cookies and all other persistent per-site state SHALL be left
-untouched (AOH-003). Sites with notifications enabled SHALL be skipped so
-their background page keeps running. Switching the active site within the
-app SHALL NOT reset any flagged site.
+The system SHALL NOT reset `currentUrl` for a flagged site
+(`alwaysOpenHome = true` or `incognito = true`) when the app is merely
+backgrounded and later foregrounded with its process intact
+(`AppLifecycleState.paused` → `resumed`). The URL reverts to `initUrl`
+only on a genuine app restart (cold start, where `fromJson` strips
+`currentUrl` per AOH-002) and on home-shortcut tap (AOH-004). Switching
+the active site within the app SHALL NOT reset any flagged site either.
+This keeps a multi-step flow that requires briefly leaving the app —
+e.g. fetching an emailed 2FA code — intact on return (issue #333).
 
-#### Scenario: Backgrounding the app sends the active flagged site home
+#### Scenario: Leaving the app for a 2FA code preserves the deep URL
 
-**Given** a site with `alwaysOpenHome = true` is active and navigated to a deep URL
-**When** the app is backgrounded (`AppLifecycleState.paused`) and later resumed
-**Then** the site's webview is rebuilt at `initUrl`
+**Given** a site with `alwaysOpenHome = true` (or `incognito = true`) is active and navigated to a deep login-step URL
+**When** the user switches to an email app to read a 2FA code and returns to the foregrounded app (process intact)
+**Then** the site is still showing the deep login-step URL (no reset)
 **And** its persisted cookies are unchanged
 
 #### Scenario: Switching sites in-app does not reset
@@ -187,11 +189,13 @@ app SHALL NOT reset any flagged site.
 **And** the user switches to site B and back to A, with the app staying foregrounded
 **Then** A is still showing the deep URL (no reset)
 
-#### Scenario: Notification-enabled flagged site is not reset on background
+#### Scenario: Cold restart still lands on home
 
-**Given** a site with `alwaysOpenHome = true` and notifications enabled
-**When** the app is backgrounded
-**Then** the site's `currentUrl` is unchanged and its webview is not disposed
+**Given** a site with `alwaysOpenHome = true` was navigated to a deep URL before the OS killed the process
+**When** the app is cold-launched again
+**Then** `fromJson` rehydrates the site with `currentUrl == initUrl` (AOH-002)
+**And** the site's webview loads at `initUrl`
+**And** its persisted cookies are restored unchanged
 
 ---
 
@@ -205,8 +209,8 @@ app SHALL NOT reset any flagged site.
   `toJson` URL-strip gate, `fromJson` URL-strip gate.
 - `lib/main.dart` — `_resetAlwaysOpenHomeOnShortcut(int)` helper
   invoked from `_restoreAppState` (cold) and `_handleShortcutIntent`
-  (warm); `_resetAlwaysOpenHomeForAppClose()` invoked from
-  `didChangeAppLifecycleState` on `paused` (AOH-006).
+  (warm). `didChangeAppLifecycleState` on `paused` does NOT reset
+  flagged sites (AOH-006); a transient background preserves the URL.
 - `lib/services/webspace_selection_engine.dart` —
   `indicesToResetOnShortcutLaunch` pure helper computes the reset set
   from the launched index + the webspaces list + a flag predicate.

--- a/test/app_lifecycle_engine_test.dart
+++ b/test/app_lifecycle_engine_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/app_lifecycle_engine.dart';
+
+void main() {
+  group('AppLifecycleEngine.activeLoadedIndex', () {
+    test('null currentIndex yields null', () {
+      expect(
+        AppLifecycleEngine.activeLoadedIndex(
+          currentIndex: null,
+          siteCount: 3,
+          loadedIndices: {0, 1, 2},
+        ),
+        isNull,
+      );
+    });
+
+    test('out-of-bounds currentIndex yields null', () {
+      expect(
+        AppLifecycleEngine.activeLoadedIndex(
+          currentIndex: 5,
+          siteCount: 3,
+          loadedIndices: {0, 1, 2, 5},
+        ),
+        isNull,
+      );
+      expect(
+        AppLifecycleEngine.activeLoadedIndex(
+          currentIndex: -1,
+          siteCount: 3,
+          loadedIndices: {0},
+        ),
+        isNull,
+      );
+    });
+
+    test('active but not loaded yields null', () {
+      expect(
+        AppLifecycleEngine.activeLoadedIndex(
+          currentIndex: 1,
+          siteCount: 3,
+          loadedIndices: {0, 2},
+        ),
+        isNull,
+      );
+    });
+
+    test('active, in-bounds and loaded yields the index', () {
+      expect(
+        AppLifecycleEngine.activeLoadedIndex(
+          currentIndex: 1,
+          siteCount: 3,
+          loadedIndices: {0, 1},
+        ),
+        1,
+      );
+    });
+  });
+
+  group('AppLifecycleEngine.backgroundPlan', () {
+    test('no eligible active site: nothing to pause or capture', () {
+      final plan = AppLifecycleEngine.backgroundPlan(
+        currentIndex: null,
+        siteCount: 2,
+        loadedIndices: {0, 1},
+        notificationsEnabled: (_) => false,
+      );
+      expect(plan.jsPauseIndex, isNull);
+      expect(plan.captureStateIndex, isNull);
+    });
+
+    test('active not loaded: nothing to pause or capture', () {
+      final plan = AppLifecycleEngine.backgroundPlan(
+        currentIndex: 2,
+        siteCount: 3,
+        loadedIndices: {0, 1},
+        notificationsEnabled: (_) => false,
+      );
+      expect(plan.jsPauseIndex, isNull);
+      expect(plan.captureStateIndex, isNull);
+    });
+
+    test('loaded non-notification active site: pause and capture it', () {
+      final plan = AppLifecycleEngine.backgroundPlan(
+        currentIndex: 1,
+        siteCount: 3,
+        loadedIndices: {0, 1},
+        notificationsEnabled: (_) => false,
+      );
+      expect(plan.jsPauseIndex, 1);
+      expect(plan.captureStateIndex, 1);
+    });
+
+    test('notification active site: capture but do NOT pause', () {
+      final plan = AppLifecycleEngine.backgroundPlan(
+        currentIndex: 1,
+        siteCount: 3,
+        loadedIndices: {0, 1},
+        notificationsEnabled: (i) => i == 1,
+      );
+      expect(plan.jsPauseIndex, isNull);
+      expect(plan.captureStateIndex, 1);
+    });
+
+    // Regression guard for issue #333 / AOH-006: a URL-ephemeral
+    // (alwaysOpenHome / incognito) site that is active when the app is
+    // backgrounded must be paused + captured like any other site, NOT reset
+    // to its initUrl or disposed. The engine offers no reset output, so a
+    // flagged site is indistinguishable from a plain one here.
+    test('URL-ephemeral active site is paused+captured, never reset', () {
+      const flaggedIndex = 1;
+      // Model: site 1 is alwaysOpenHome/incognito (urlEphemeral) but NOT a
+      // notification site. The plan must treat it like a normal site.
+      bool urlEphemeral(int i) => i == flaggedIndex;
+      final plan = AppLifecycleEngine.backgroundPlan(
+        currentIndex: flaggedIndex,
+        siteCount: 3,
+        loadedIndices: {0, 1, 2},
+        notificationsEnabled: (_) => false,
+      );
+      expect(plan.jsPauseIndex, flaggedIndex);
+      expect(plan.captureStateIndex, flaggedIndex);
+      // The engine exposes no field that could carry a reset for the flagged
+      // site; the only signals are pause + capture, identical to a plain site.
+      expect(urlEphemeral(flaggedIndex), isTrue,
+          reason: 'sanity: the index under test is the flagged one');
+    });
+  });
+
+  group('AppLifecycleEngine.resumeJsIndex', () {
+    test('no eligible active site yields null', () {
+      expect(
+        AppLifecycleEngine.resumeJsIndex(
+          currentIndex: null,
+          siteCount: 2,
+          loadedIndices: {0, 1},
+          notificationsEnabled: (_) => false,
+        ),
+        isNull,
+      );
+    });
+
+    test('loaded non-notification active site resumes', () {
+      expect(
+        AppLifecycleEngine.resumeJsIndex(
+          currentIndex: 0,
+          siteCount: 2,
+          loadedIndices: {0, 1},
+          notificationsEnabled: (_) => false,
+        ),
+        0,
+      );
+    });
+
+    test('notification active site is not resumed (never paused)', () {
+      expect(
+        AppLifecycleEngine.resumeJsIndex(
+          currentIndex: 0,
+          siteCount: 2,
+          loadedIndices: {0, 1},
+          notificationsEnabled: (i) => i == 0,
+        ),
+        isNull,
+      );
+    });
+
+    test('probe target (activeLoadedIndex) covers notification sites too', () {
+      // resumeJsIndex skips notif sites, but the renderer probe should still
+      // run against them: activeLoadedIndex returns the notif site.
+      expect(
+        AppLifecycleEngine.resumeJsIndex(
+          currentIndex: 0,
+          siteCount: 2,
+          loadedIndices: {0},
+          notificationsEnabled: (_) => true,
+        ),
+        isNull,
+      );
+      expect(
+        AppLifecycleEngine.activeLoadedIndex(
+          currentIndex: 0,
+          siteCount: 2,
+          loadedIndices: {0},
+        ),
+        0,
+      );
+    });
+  });
+}


### PR DESCRIPTION
AOH-006 reset currentUrl to initUrl on every AppLifecycleState.paused,
so switching to an email app to fetch a 2FA code and returning landed
on home and broke the login flow (#333). Reset now happens only on a
genuine app restart (fromJson strips currentUrl, AOH-002) and on
home-shortcut tap (AOH-004), matching the toggle's own subtitle.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VMyC7MzCTq2wMZnTMV2fHe