### PR TITLE
Move uBO redirect stubs hint to HintButton

### DIFF
--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -1476,12 +1476,19 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
           // and break (white page, infinite spinner), so default on.
           // Greyed out on platforms that don't ship the engine library.
           SwitchListTile(
-            title: Text(loc.appSettingsUboRedirectStubs),
-            subtitle: Text(
-              !ContentBlockerService.instance.rustEngineSupportedOnPlatform
-                  ? loc.appSettingsUboRedirectStubsUnavailable
-                  : loc.appSettingsUboRedirectStubsSubtitle,
+            title: Row(
+              children: [
+                Flexible(child: Text(loc.appSettingsUboRedirectStubs)),
+                HintButton(
+                  title: loc.appSettingsUboRedirectStubs,
+                  description: loc.appSettingsUboRedirectStubsSubtitle,
+                ),
+              ],
             ),
+            subtitle:
+                !ContentBlockerService.instance.rustEngineSupportedOnPlatform
+                    ? Text(loc.appSettingsUboRedirectStubsUnavailable)
+                    : null,
             value: ContentBlockerService.instance.useUboResources,
             onChanged: ContentBlockerService.instance
                     .rustEngineSupportedOnPlatform


### PR DESCRIPTION
Match the other app settings: show the explanation via the info-icon hint dialog instead of an inline subtitle. Keep the unavailable notice as the subtitle on unsupported platforms.