### PR TITLE
Always enable ABP engine timing, remove DevTools lifecycle toggle

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1533,7 +1533,7 @@
       }
     }
   },
-  "devToolsAbpEmptyNotConsulted": "Engine has not been consulted since DevTools opened.\n\nSub-resource checks fire from the JS-bridge `blockCheck` handler — they only run on cross-origin requests that hit the bloom prefilter.\n\nTry: reload an ad-heavy page with DevTools already open.",
+  "devToolsAbpEmptyNotConsulted": "Engine has not been consulted yet.\n\nSub-resource checks fire from the JS-bridge `blockCheck` handler; they only run on cross-origin requests that hit the bloom prefilter.\n\nTry: reload an ad-heavy page.",
   "@devToolsAbpEmptyNotConsulted": {
     "description": "Empty-state explanation shown in the ABP tab when the engine has not been consulted yet."
   },

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -234,13 +234,6 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
         : <BlockedCookie>{};
     LogService.instance.addListener(_onLogUpdate);
     DnsBlockService.instance.addDnsLogListener(_onDnsLogUpdate);
-    // ABP timing buffer is off in normal app runs (small but non-zero
-    // Stopwatch + ring-buffer cost on every sub-resource decision).
-    // Enable while DevTools is open so the ABP tab has fresh data;
-    // disable on close so production runs aren't paying the overhead.
-    if (ContentBlockerService.instance.usingRustEngine) {
-      ContentBlockerService.instance.engineTimingEnabled = true;
-    }
     if (_hasHost) {
       widget.host!.onConsoleLogChanged = _onConsoleUpdate;
     }
@@ -250,7 +243,6 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   void dispose() {
     LogService.instance.removeListener(_onLogUpdate);
     DnsBlockService.instance.removeDnsLogListener(_onDnsLogUpdate);
-    ContentBlockerService.instance.engineTimingEnabled = false;
     if (_hasHost) {
       widget.host!.onConsoleLogChanged = null;
     }

--- a/lib/services/content_blocker_service.dart
+++ b/lib/services/content_blocker_service.dart
@@ -140,7 +140,7 @@ class ContentBlockerService {
 
   static const int _engineDecisionBuffer = 200;
   final List<EngineDecisionSample> _recentEngineDecisions = [];
-  bool _engineTimingEnabled = false;
+  bool _engineTimingEnabled = true;
 
   int _engineConsultedSinceTimingOn = 0;
 


### PR DESCRIPTION
Remove the DevTools-scoped lifecycle management of ABP engine timing. The timing buffer is now always enabled to provide fresh data without requiring DevTools to be open.

Changes:
- Set `_engineTimingEnabled` default to `true` in ContentBlockerService, removing the need for explicit enable/disable
- Remove timing enable logic from DevToolsScreen `initState()`
- Remove timing disable logic from DevToolsScreen `dispose()`
- Update ABP empty-state message to remove references to "since DevTools opened" and simplify instructions

The overhead of maintaining the timing buffer is acceptable for production runs, and always-on timing ensures the ABP tab displays current data regardless of when DevTools is opened.

https://claude.ai/code/session_01D5jNVwuVVvhU3iavJQEWNU