### PR TITLE
Tighten letterbox margins on phone-sized viewports

### DIFF
--- a/lib/services/letterbox.dart
+++ b/lib/services/letterbox.dart
@@ -1,12 +1,40 @@
 import 'dart:math' as math;
 
 /// Upper bound on the letterbox margin per axis, as a fraction of the
-/// available extent. A coarse fixed grid (200x100) trims almost half of a
-/// phone-width viewport (e.g. 390 -> 200), so the margin is capped here and
-/// the grid is refined until the trimmed strip fits the budget. Tuned so a
-/// maximised desktop window still snaps to the 200x100 grid (1366 -> 1200 is
-/// 12.15%).
+/// available extent. Reached on large (desktop) viewports, where the coarse
+/// 200x100 grid's ~12% trim is accepted to keep size buckets few. A coarse
+/// fixed grid trims almost half of a phone-width viewport (e.g. 390 -> 200),
+/// so the margin is capped and the grid is refined until the trimmed strip
+/// fits the budget. Tuned so a maximised desktop window still snaps to the
+/// 200x100 grid (1366 -> 1200 is 12.15%).
 const double kLetterboxMaxMarginFraction = 1 / 8;
+
+/// Smallest margin budget, applied on narrow/short (phone) viewports so the
+/// bars stay thin instead of eating the desktop-sized 12.5%.
+const double kLetterboxMinMarginFraction = 1 / 16;
+
+/// Smallest extent that is treated as a full desktop window and gets the loose
+/// [kLetterboxMaxMarginFraction] budget (so 1366 still snaps to the 200 grid).
+const double _kLetterboxDesktopExtent = 1366.0;
+
+/// Largest extent that is treated as a phone/small viewport and gets the tight
+/// [kLetterboxMinMarginFraction] budget. Between this and
+/// [_kLetterboxDesktopExtent] the budget ramps linearly.
+const double _kLetterboxSmallExtent = 960.0;
+
+/// Margin budget for an axis of length [extent]. Flat at the tight phone budget
+/// up to [_kLetterboxSmallExtent], then ramps to the loose desktop budget by
+/// [_kLetterboxDesktopExtent]. Phones thus refine to a finer grid and keep thin
+/// bars (e.g. 390 -> 375, 873 -> 850) at the cost of a few more buckets, while a
+/// maximised desktop window still snaps to the coarse 200-wide grid (1366 ->
+/// 1200) for low fingerprint entropy.
+double _maxMarginFraction(double extent) {
+  final t = ((extent - _kLetterboxSmallExtent) /
+          (_kLetterboxDesktopExtent - _kLetterboxSmallExtent))
+      .clamp(0.0, 1.0);
+  return kLetterboxMinMarginFraction +
+      t * (kLetterboxMaxMarginFraction - kLetterboxMinMarginFraction);
+}
 
 /// Target size (logical pixels) for the letterboxed web-content box. When
 /// [width]/[height] equal the available area, no margin is drawn.
@@ -29,16 +57,19 @@ class LetterboxTarget {
 }
 
 /// Snap [available] DOWN to the coarsest grid (starting at [grid], halving)
-/// whose trimmed margin stays within [kLetterboxMaxMarginFraction]. Coarse
-/// steps bucket many real sizes onto one value (lower fingerprint entropy);
-/// refining only when the coarse step would eat too much keeps the margin a
-/// thin strip on small screens instead of half the viewport.
+/// whose trimmed margin stays within [_maxMarginFraction] for this extent.
+/// Coarse steps bucket many real sizes onto one value (lower fingerprint
+/// entropy); refining only when the coarse step would eat too much keeps the
+/// margin a thin strip on small screens instead of half the viewport. The
+/// budget shrinks with the extent, so phones refine further than desktops and
+/// end up with thinner bars.
 double _snapAxis(double available, double grid) {
   if (available <= 0 || !available.isFinite) return math.max(0.0, available);
+  final budget = _maxMarginFraction(available) * available;
   for (var step = grid; step >= 1; step /= 2) {
     if (available < step) continue;
     final snapped = (available / step).floorToDouble() * step;
-    if (available - snapped <= kLetterboxMaxMarginFraction * available) {
+    if (available - snapped <= budget) {
       return snapped;
     }
   }

--- a/test/letterbox_test.dart
+++ b/test/letterbox_test.dart
@@ -3,12 +3,14 @@ import 'package:webspace/services/letterbox.dart';
 
 void main() {
   group('computeLetterboxTarget', () {
-    test('snaps a desktop window down to the 200x100 grid', () {
+    test('snaps a maximised desktop width down to the 200 grid', () {
       final t = computeLetterboxTarget(
           availableWidth: 1366, availableHeight: 768);
-      // 1366 -> 1200 (6*200), 768 -> 700 (7*100); both within the margin cap.
+      // 1366 -> 1200 (6*200) keeps the coarse width bucket. The 768 height is
+      // small enough to fall in the tight phone budget and refines to the 50
+      // grid: 768 -> 750.
       expect(t.width, 1200);
-      expect(t.height, 700);
+      expect(t.height, 750);
     });
 
     test('exact multiples are unchanged', () {
@@ -25,6 +27,26 @@ void main() {
           availableWidth: 390, availableHeight: 844);
       expect(t.width, greaterThanOrEqualTo(390 * (1 - kLetterboxMaxMarginFraction)));
       expect(t.width, lessThanOrEqualTo(390));
+    });
+
+    test('phone margins are tighter than the desktop budget', () {
+      // Phones get a smaller budget than the 12.5% desktop cap, so the bars
+      // are thin. 390 -> 375 (15px), 780 -> 750 (30px).
+      final w = computeLetterboxTarget(availableWidth: 390, availableHeight: 780);
+      expect(w.width, 375);
+      expect(w.height, 750);
+      for (final s in const <List<double>>[
+        [360, 780], [390, 844], [393, 873], [412, 915], [428, 926],
+      ]) {
+        final t = computeLetterboxTarget(
+            availableWidth: s[0], availableHeight: s[1]);
+        expect((s[0] - t.width) / s[0],
+            lessThanOrEqualTo(kLetterboxMinMarginFraction),
+            reason: 'w margin for $s');
+        expect((s[1] - t.height) / s[1],
+            lessThanOrEqualTo(kLetterboxMinMarginFraction),
+            reason: 'h margin for $s');
+      }
     });
 
     test('two nearby phone widths still collapse onto the same bucket', () {
@@ -91,7 +113,7 @@ void main() {
         fixedWidth: 1024,
       );
       expect(t.width, 1200);
-      expect(t.height, 700);
+      expect(t.height, 750);
     });
 
     test('infinite or non-positive constraints degrade gracefully', () {


### PR DESCRIPTION
The flat 1/8 margin budget let phones letterbox at the full desktop 12.5%
(wide side/top/bottom bars). Make the budget extent-dependent: tight (1/16)
on small viewports, ramping to 1/8 by desktop width so the 1366 -> 1200
width bucket is preserved. Phones now refine to a finer grid and keep thin
bars (390 -> 375, 873 -> 850).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F3utCMCfiZQdrCaQd6odWL