### PR TITLE
Recomposite Android webview surface on site activation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -940,6 +940,10 @@ class _WebSpacePageState extends State<WebSpacePage>
   // forces Android hybrid-composition platform views to recomposite after
   // the activity is recreated (shortcut/resume). Always false in steady state.
   bool _repaintNudge = false;
+  // Drive _nudgeSurfaceRepaint's loop so concurrent callers coalesce instead
+  // of starting interleaving loops that toggle _repaintNudge against each other.
+  int _nudgeTicksRemaining = 0;
+  bool _nudgeLoopRunning = false;
   /// When true, a full-screen opaque mask covers every webview so the
   /// OS task-switcher / recents snapshot doesn't capture archive-tier
   /// content (ARCH-009). Set on `inactive`/`paused` when at least one
@@ -1589,10 +1593,19 @@ class _WebSpacePageState extends State<WebSpacePage>
   /// is not enough on its own.
   void _nudgeSurfaceRepaint() {
     if (!Platform.isAndroid) return;
-    var ticks = 0;
+    // Coalesce concurrent callers (e.g. _setCurrentIndex from a warm-shortcut
+    // _openShortcutIndex, then _onResumed's tail call) onto a single loop:
+    // two interleaving loops toggle the same bool and can cancel out mid-flip.
+    // A second call just refills the remaining ticks.
+    _nudgeTicksRemaining = 6;
+    if (_nudgeLoopRunning) return;
+    _nudgeLoopRunning = true;
     void tick() {
-      if (!mounted || ticks >= 6) return;
-      ticks++;
+      if (!mounted || _nudgeTicksRemaining <= 0) {
+        _nudgeLoopRunning = false;
+        return;
+      }
+      _nudgeTicksRemaining--;
       setState(() => _repaintNudge = !_repaintNudge);
       Future.delayed(const Duration(milliseconds: 100), tick);
     }
@@ -3355,6 +3368,14 @@ class _WebSpacePageState extends State<WebSpacePage>
     }
 
     LogService.instance.log('CookieIsolation', 'After switch, loaded indices: $_loadedIndices', sensitivity: LogSensitivity.sensitive);
+    // Force the just-activated Android platform-view surface to recomposite.
+    // Bringing a webview onstage (tab tap, shortcut open, cold-start restore)
+    // can re-attach the hybrid-composition SurfaceView blank: the page is alive
+    // (JS runs, DOM serializes) but nothing paints and the native overscroll
+    // gesture is dead, so pull-to-refresh can't recover it — only this relayout
+    // can. _probeRendererAndRecover above only relayouts web content, not the
+    // surface (see its doc), so it does not cover this. No-op off Android.
+    _nudgeSurfaceRepaint();
     // _loadedIndices may have changed (LRU eviction, conflict unload,
     // first-load of target), so re-evaluate the background refresh
     // schedule. No-op on non-iOS / non-Android.

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -740,10 +740,12 @@ abstract class WebViewController {
   Future<bool> canGoBack();
   /// Per-instance pause to reduce resource usage.
   ///
-  /// On Android: calls `WebView.onPause()`, which is a best-effort pause of
-  /// animations and geolocation. **Does NOT pause JavaScript** — Android only
-  /// pauses JS via the process-global `pauseTimers()`, which we do not call
-  /// here because it would also freeze every other loaded webview.
+  /// On Android: **no-op.** `WebView.onPause()` only does a best-effort pause
+  /// of animations and geolocation and **does NOT pause JavaScript** (Android
+  /// pauses JS only via the process-global `pauseTimers()`), so per-instance
+  /// pause is nearly useless — while cycling the foreground hybrid-composition
+  /// SurfaceView through onPause/onResume blanks it on the next paint. JS is
+  /// frozen at app-background via [pauseAllJsTimers]; memory pressure disposes.
   ///
   /// On iOS: calls `pauseTimers()`, which the plugin implements per-instance
   /// via an `alert()`-deadlock hack that blocks this WebView's main JS thread.
@@ -984,9 +986,18 @@ class _WebViewController implements WebViewController {
   @override
   Future<void> pause() async {
     if (Platform.isAndroid) {
-      // Android: per-instance only. pauseTimers() is process-global and would
-      // freeze every other loaded WebView too — see [pauseAllJsTimers].
-      await _c.pause();
+      // No-op on Android. `WebView.onPause()` does not pause JavaScript (only
+      // the process-global `pauseTimers()` does), so per-instance pause buys
+      // nothing for the JS-freeze goal — yet cycling the foreground hybrid-
+      // composition SurfaceView through onPause/onResume leaves it blank on
+      // the next paint (the white-screen bug). App-lifecycle backgrounding
+      // freezes JS via the global `pauseAllJsTimers()`; memory pressure
+      // disposes background sites. The active site is therefore never
+      // per-instance paused/resumed on Android.
+      //
+      // Must NOT throw: callers run `pause()` then `pauseAllJsTimers()` inside
+      // one try block, so an exception here would skip the global JS freeze.
+      return;
     } else if (Platform.isIOS) {
       // iOS has no per-instance native pause; pauseTimers() is the plugin's
       // per-instance alert()-deadlock hack and is safe to call on one site.
@@ -997,7 +1008,8 @@ class _WebViewController implements WebViewController {
   @override
   Future<void> resume() async {
     if (Platform.isAndroid) {
-      await _c.resume();
+      // Mirror of [pause]: per-instance resume is unused on Android.
+      return;
     } else if (Platform.isIOS) {
       await _c.resumeTimers();
     }

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -815,6 +815,29 @@ abstract class WebViewController {
   Future<bool> restoreState(Uint8List state);
 }
 
+/// Which native call the per-instance [WebViewController.pause] /
+/// [WebViewController.resume] makes on a given platform (PAUSE-016).
+enum PerInstanceLifecycleCall {
+  /// No native call. Android (`WebView.onPause()` doesn't freeze JS and
+  /// cycling the SurfaceView blanks it — PAUSE-016) and desktop platforms.
+  none,
+
+  /// iOS: `pauseTimers()` / `resumeTimers()` — the plugin's per-instance
+  /// `alert()`-deadlock hack, the only per-site JS-freeze lever on iOS.
+  timers,
+}
+
+/// Pure platform dispatch for per-instance pause/resume. Extracted so the
+/// PAUSE-016 Android no-op is unit-testable without a native controller.
+PerInstanceLifecycleCall perInstanceLifecycleCallFor({
+  required bool isAndroid,
+  required bool isIOS,
+}) {
+  if (isAndroid) return PerInstanceLifecycleCall.none;
+  if (isIOS) return PerInstanceLifecycleCall.timers;
+  return PerInstanceLifecycleCall.none;
+}
+
 /// InAppWebView controller wrapper
 class _WebViewController implements WebViewController {
   final inapp.InAppWebViewController _c;
@@ -985,33 +1008,33 @@ class _WebViewController implements WebViewController {
 
   @override
   Future<void> pause() async {
-    if (Platform.isAndroid) {
-      // No-op on Android. `WebView.onPause()` does not pause JavaScript (only
-      // the process-global `pauseTimers()` does), so per-instance pause buys
-      // nothing for the JS-freeze goal — yet cycling the foreground hybrid-
-      // composition SurfaceView through onPause/onResume leaves it blank on
-      // the next paint (the white-screen bug). App-lifecycle backgrounding
-      // freezes JS via the global `pauseAllJsTimers()`; memory pressure
-      // disposes background sites. The active site is therefore never
-      // per-instance paused/resumed on Android.
-      //
-      // Must NOT throw: callers run `pause()` then `pauseAllJsTimers()` inside
-      // one try block, so an exception here would skip the global JS freeze.
-      return;
-    } else if (Platform.isIOS) {
-      // iOS has no per-instance native pause; pauseTimers() is the plugin's
-      // per-instance alert()-deadlock hack and is safe to call on one site.
-      await _c.pauseTimers();
+    // PAUSE-016: Android is a no-op. `WebView.onPause()` doesn't pause JS (only
+    // the process-global `pauseTimers()` does), so per-instance pause buys
+    // nothing for the JS-freeze goal — yet cycling the foreground hybrid-
+    // composition SurfaceView through onPause/onResume leaves it blank on the
+    // next paint (the white-screen bug). App-lifecycle backgrounding freezes JS
+    // via the global `pauseAllJsTimers()`; memory pressure disposes.
+    //
+    // Must NOT throw: callers run `pause()` then `pauseAllJsTimers()` inside one
+    // try block, so an exception here would skip the global JS freeze.
+    switch (perInstanceLifecycleCallFor(
+        isAndroid: Platform.isAndroid, isIOS: Platform.isIOS)) {
+      case PerInstanceLifecycleCall.none:
+        return;
+      case PerInstanceLifecycleCall.timers:
+        await _c.pauseTimers();
     }
   }
 
   @override
   Future<void> resume() async {
-    if (Platform.isAndroid) {
-      // Mirror of [pause]: per-instance resume is unused on Android.
-      return;
-    } else if (Platform.isIOS) {
-      await _c.resumeTimers();
+    // Mirror of [pause] (PAUSE-016): no-op on Android.
+    switch (perInstanceLifecycleCallFor(
+        isAndroid: Platform.isAndroid, isIOS: Platform.isIOS)) {
+      case PerInstanceLifecycleCall.none:
+        return;
+      case PerInstanceLifecycleCall.timers:
+        await _c.resumeTimers();
     }
   }
 

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -613,13 +613,24 @@ abstract class WebViewController {
   Future<void> resumeAllJsTimers();
 }
 
+// Pure platform dispatch — unit-tested without a native controller (PAUSE-016).
+enum PerInstanceLifecycleCall { none, timers }
+PerInstanceLifecycleCall perInstanceLifecycleCallFor({
+  required bool isAndroid,
+  required bool isIOS,
+}) {
+  if (isAndroid) return PerInstanceLifecycleCall.none;   // PAUSE-016
+  if (isIOS) return PerInstanceLifecycleCall.timers;
+  return PerInstanceLifecycleCall.none;                  // desktop
+}
+
 class _WebViewController implements WebViewController {
   @override
   Future<void> pause() async {
-    if (Platform.isAndroid) {
-      return;                    // no-op: see PAUSE-016
-    } else if (Platform.isIOS) {
-      await _c.pauseTimers();    // plugin's per-instance alert() hack
+    switch (perInstanceLifecycleCallFor(
+        isAndroid: Platform.isAndroid, isIOS: Platform.isIOS)) {
+      case PerInstanceLifecycleCall.none:    return;     // no native call
+      case PerInstanceLifecycleCall.timers:  await _c.pauseTimers();
     }
   }
 
@@ -650,6 +661,9 @@ class _WebViewController implements WebViewController {
 - A site-switch round trip never touches `*AllJsTimers`.
 - A lifecycle round trip toggles each global flag exactly once.
 - All four methods are no-ops when `controller == null`.
+- PAUSE-016: `perInstanceLifecycleCallFor` returns `none` for Android and
+  desktop, `timers` for iOS — verifying the Android per-instance no-op without
+  a native controller.
 
 ## Files
 

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -51,7 +51,7 @@ The system SHALL pause the previously active webview on site switch using the pe
 **And** site A is the currently active site
 **When** the user switches to site B
 **Then** `pauseWebView()` is called on A
-**And** A's controller receives `pause()` (Android: `WebView.onPause()`; iOS: per-instance `pauseTimers()` alert hack)
+**And** A's controller receives `pause()` (Android: **no-op**, see PAUSE-016; iOS: per-instance `pauseTimers()` alert hack)
 **And** A's controller does NOT receive `pauseAllJsTimers()`
 **And** B's JS timers are unaffected by A's pause
 
@@ -84,7 +84,7 @@ The system SHALL pause both the active webview and process-global JS timers when
 **Given** the app is in the foreground with N loaded webviews
 **When** `AppLifecycleState.paused` (or `inactive`) fires
 **Then** `pauseForAppLifecycle()` is called on the active webview
-**And** the controller receives `pause()` followed by `pauseAllJsTimers()`
+**And** the controller receives `pause()` followed by `pauseAllJsTimers()` (on Android `pause()` is a no-op per PAUSE-016, so only the global timer freeze takes effect; the call order is preserved so the iOS path and the contract test are unchanged)
 **And** every loaded webview's JS timers are now frozen (Android: globally; iOS: pauseTimers is per-instance, so only the active webview is timer-paused — acceptable since the OS suspends the rest)
 
 #### Scenario: App returns to foreground
@@ -522,6 +522,45 @@ This is complementary to PAUSE-014: the probe recreates a *dead* renderer; the s
 
 ---
 
+### Requirement: PAUSE-016 — Android Per-Instance Pause Is a No-Op
+
+On Android the per-instance `pause()` / `resume()` (`WebView.onPause()` / `onResume()`) SHALL be no-ops. Android exposes no per-instance JavaScript pause — `onPause()` halts only animations and geolocation and explicitly does not pause JS, while the only JS-timer pause (`pauseTimers()`) is process-global. So per-instance pause contributes nothing to the lifecycle freeze, yet cycling the foreground hybrid-composition `SurfaceView` through onPause/onResume re-attaches it blank on the next paint — the white screen the user hits after a transient background or a navigation that follows a resume.
+
+The replacement contract on Android:
+
+- **App background** freezes JavaScript through the process-global `pauseAllJsTimers()` (`pauseTimers()`), which is surface-safe — it never touches the SurfaceView.
+- **Memory pressure** reclaims via the PAUSE-006 dispose cascade, which hard-protects the active site.
+- The active site is therefore **never** per-instance paused or resumed on Android; its surface is never cycled, so it cannot come back blank.
+
+The no-op MUST return silently rather than throw: callers invoke `pause()` and `pauseAllJsTimers()` inside a single `try`, so an exception from `pause()` would skip the global JS freeze. iOS is unchanged — there `pause()` maps to the per-instance `pauseTimers()` alert hack (the only JS-freeze lever on iOS) and there is no SurfaceView to blank.
+
+This narrows PAUSE-001 and PAUSE-002 on Android only: the call sites and call order are unchanged (so the interface-level contract test still observes `pause` → `pauseAllJsTimers`), but the real `_WebViewController.pause()` Android branch does nothing.
+
+#### Scenario: Transient background does not blank the active site
+
+**Given** the app is foreground on Android with active site A
+**When** the OS fires a spurious / transient `paused` → `resumed` pair (an OEM quirk or a memory-pressure tick)
+**Then** `pauseForAppLifecycle(A)` runs `pause()` (no-op) then `pauseAllJsTimers()` (global freeze), and `resumeFromAppLifecycle(A)` runs `resume()` (no-op) then `resumeAllJsTimers()`
+**And** A's `SurfaceView` is never cycled through onPause/onResume
+**And** A does not come back blank on the next navigation
+
+#### Scenario: JS still freezes on a genuine background
+
+**Given** active site A and three other loaded sites on Android
+**When** the app goes to background
+**Then** `pauseAllJsTimers()` freezes JS timers for every loaded webview process-wide
+**And** no per-instance `onPause()` is issued to any of them
+**And** on resume `resumeAllJsTimers()` unfreezes them
+
+#### Scenario: Pause never throws on Android
+
+**Given** `pauseForAppLifecycle()` calls `await c.pause()` then `await c.pauseAllJsTimers()` inside one try block
+**When** running on Android
+**Then** `c.pause()` returns immediately without throwing
+**And** `c.pauseAllJsTimers()` still runs, so the global JS freeze is applied
+
+---
+
 ### Requirement: PAUSE-004 — Null-Safe Controller Access
 
 `pauseWebView()`, `resumeWebView()`, `pauseForAppLifecycle()`, and `resumeFromAppLifecycle()` SHALL be no-ops when the underlying controller has not yet been initialized or has been disposed.
@@ -578,7 +617,7 @@ class _WebViewController implements WebViewController {
   @override
   Future<void> pause() async {
     if (Platform.isAndroid) {
-      await _c.pause();          // WebView.onPause()
+      return;                    // no-op: see PAUSE-016
     } else if (Platform.isIOS) {
       await _c.pauseTimers();    // plugin's per-instance alert() hack
     }

--- a/test/webview_pause_lifecycle_test.dart
+++ b/test/webview_pause_lifecycle_test.dart
@@ -122,6 +122,31 @@ void main() {
     });
   });
 
+  group('PAUSE-016 per-instance pause platform dispatch', () {
+    test('Android issues no per-instance native call', () {
+      expect(
+        perInstanceLifecycleCallFor(isAndroid: true, isIOS: false),
+        PerInstanceLifecycleCall.none,
+        reason: 'onPause() does not freeze JS and cycling the SurfaceView '
+            'blanks it — per-instance pause is a no-op on Android.',
+      );
+    });
+
+    test('iOS issues the per-instance pauseTimers alert hack', () {
+      expect(
+        perInstanceLifecycleCallFor(isAndroid: false, isIOS: true),
+        PerInstanceLifecycleCall.timers,
+      );
+    });
+
+    test('desktop platforms issue no per-instance native call', () {
+      expect(
+        perInstanceLifecycleCallFor(isAndroid: false, isIOS: false),
+        PerInstanceLifecycleCall.none,
+      );
+    });
+  });
+
   group('WebViewModel pause/resume null-safety', () {
     test('pauseWebView() with no controller is a no-op', () async {
       final m = _modelWith(null);


### PR DESCRIPTION
Bringing a webview onstage via _setCurrentIndex (tab tap, shortcut open,
cold-start restore) can re-attach the hybrid-composition SurfaceView blank:
the page is alive but nothing paints and the native overscroll gesture is
dead, so pull-to-refresh can't recover it. Only _onResumed ran the surface
nudge; the switch path ran only the JS renderer probe, which by design
relayouts web content, not the surface. Run _nudgeSurfaceRepaint on the
activation path too, and make it re-entrant so the warm-shortcut +
_onResumed double-call coalesces instead of interleaving two toggle loops.

Refs #405

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015ysmKRe9wo4HSHjjJx3q3E