### PR TITLE
Instrument notification wake-up chain and widen polyfill coverage

### DIFF
--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/BackgroundTaskAndroidPlugin.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/BackgroundTaskAndroidPlugin.kt
@@ -3,6 +3,7 @@ package org.codeberg.theoden8.webspace
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
@@ -79,15 +80,18 @@ class BackgroundTaskAndroidPlugin(
             ExistingPeriodicWorkPolicy.UPDATE,
             request,
         )
+        Log.i(TAG, "scheduled periodic refresh ($UNIQUE_NAME, 15min)")
     }
 
     private fun cancel() {
         WorkManager.getInstance(context).cancelUniqueWork(UNIQUE_NAME)
+        Log.i(TAG, "cancelled periodic refresh ($UNIQUE_NAME)")
     }
 
     companion object {
         const val CHANNEL = "org.codeberg.theoden8.webspace/background_task"
         const val UNIQUE_NAME = "webspace-notification-refresh"
+        private const val TAG = "WebspaceBgRefresh"
     }
 }
 
@@ -123,11 +127,15 @@ internal object NotificationRefreshDispatcher {
      * and return `Result.success()` so WorkManager doesn't retry-storm.
      */
     fun dispatch(onComplete: (Boolean) -> Unit): Boolean {
-        val c = channel ?: return false
+        val c = channel ?: run {
+            Log.w("WebspaceBgRefresh", "dispatch: no bound channel (engine gone)")
+            return false
+        }
         // Resolve any older pending refresh as failed before taking over.
         pendingCompletion?.invoke(false)
         pendingCompletion = onComplete
         mainHandler.post {
+            Log.i("WebspaceBgRefresh", "dispatch: invoking onBackgroundRefresh in Dart")
             c.invokeMethod("onBackgroundRefresh", null)
         }
         return true

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/NotificationRefreshWorker.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/NotificationRefreshWorker.kt
@@ -1,6 +1,7 @@
 package org.codeberg.theoden8.webspace
 
 import android.content.Context
+import android.util.Log
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import kotlinx.coroutines.CompletableDeferred
@@ -22,15 +23,24 @@ class NotificationRefreshWorker(
 ) : CoroutineWorker(appContext, params) {
 
     override suspend fun doWork(): Result = withContext(Dispatchers.Main) {
+        Log.i(TAG, "NotificationRefreshWorker fired")
         val deferred = CompletableDeferred<Boolean>()
         val dispatched = NotificationRefreshDispatcher.dispatch { success ->
             if (!deferred.isCompleted) deferred.complete(success)
         }
-        if (!dispatched) return@withContext Result.success()
+        if (!dispatched) {
+            Log.w(TAG, "Flutter engine unreachable — refresh is a no-op this slot")
+            return@withContext Result.success()
+        }
         // 60s ceiling — Dart's reload-all-notif-sites flow finishes in
         // a few seconds in practice; the cap stops a stuck channel from
         // pinning the worker until WorkManager's own ~10min ANR timeout.
-        withTimeoutOrNull(REFRESH_TIMEOUT_MS) { deferred.await() }
+        val result = withTimeoutOrNull(REFRESH_TIMEOUT_MS) { deferred.await() }
+        if (result == null) {
+            Log.w(TAG, "Dart did not report completion within ${REFRESH_TIMEOUT_MS}ms")
+        } else {
+            Log.i(TAG, "Dart reported refresh complete (success=$result)")
+        }
         // Either branch returns success — retrying a stale wakeup adds
         // no value, the next periodic slot does the same job fresh.
         Result.success()
@@ -38,5 +48,6 @@ class NotificationRefreshWorker(
 
     companion object {
         private const val REFRESH_TIMEOUT_MS = 60_000L
+        private const val TAG = "WebspaceBgRefresh"
     }
 }

--- a/ios/Runner/BackgroundTaskPlugin.swift
+++ b/ios/Runner/BackgroundTaskPlugin.swift
@@ -67,11 +67,13 @@ class BackgroundTaskPlugin: NSObject {
   /// Called by AppDelegate when iOS hands us a refresh task. Forwards to
   /// Dart and re-schedules the next refresh.
   func handleRefreshTask(_ task: BGAppRefreshTask) {
+    NSLog("BackgroundTaskPlugin: BGAppRefreshTask received — forwarding to Dart")
     pendingRefreshTask?.setTaskCompleted(success: false)
     pendingRefreshTask = task
 
     task.expirationHandler = { [weak self] in
       guard let self = self, let pending = self.pendingRefreshTask else { return }
+      NSLog("BackgroundTaskPlugin: refresh task expired before Dart completed")
       self.pendingRefreshTask = nil
       pending.setTaskCompleted(success: false)
     }
@@ -95,6 +97,7 @@ class BackgroundTaskPlugin: NSObject {
       timeIntervalSinceNow: BackgroundTaskPlugin.refreshMinDelaySeconds)
     do {
       try BGTaskScheduler.shared.submit(request)
+      NSLog("BackgroundTaskPlugin: scheduled next refresh in >= \(Int(BackgroundTaskPlugin.refreshMinDelaySeconds))s")
     } catch {
       NSLog("BackgroundTaskPlugin: failed to schedule refresh: \(error)")
     }
@@ -112,6 +115,7 @@ class BackgroundTaskPlugin: NSObject {
       scheduleNextRefresh()
       result(nil)
     case "cancelScheduledRefreshes":
+      NSLog("BackgroundTaskPlugin: cancelling scheduled refreshes")
       BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: BackgroundTaskPlugin.refreshIdentifier)
       result(nil)
     case "bgRefreshDidComplete":
@@ -121,6 +125,7 @@ class BackgroundTaskPlugin: NSObject {
       } else {
         success = true
       }
+      NSLog("BackgroundTaskPlugin: Dart reported refresh complete (success: \(success))")
       pendingRefreshTask?.setTaskCompleted(success: success)
       pendingRefreshTask = nil
       result(nil)

--- a/ios/Runner/BackgroundTaskPlugin.swift
+++ b/ios/Runner/BackgroundTaskPlugin.swift
@@ -76,8 +76,10 @@ class BackgroundTaskPlugin: NSObject {
   /// every access to the pending slot is funnelled onto the main queue and
   /// completion is made idempotent per task via [completeTask].
   func handleRefreshTask(_ task: BGAppRefreshTask) {
+    NSLog("BackgroundTaskPlugin: BGAppRefreshTask received — forwarding to Dart")
     task.expirationHandler = { [weak self, weak task] in
       guard let self = self, let task = task else { return }
+      NSLog("BackgroundTaskPlugin: refresh task expired before Dart completed")
       DispatchQueue.main.async { self.completeTask(task, success: false) }
     }
 
@@ -114,6 +116,7 @@ class BackgroundTaskPlugin: NSObject {
       timeIntervalSinceNow: BackgroundTaskPlugin.refreshMinDelaySeconds)
     do {
       try BGTaskScheduler.shared.submit(request)
+      NSLog("BackgroundTaskPlugin: scheduled next refresh in >= \(Int(BackgroundTaskPlugin.refreshMinDelaySeconds))s")
     } catch {
       NSLog("BackgroundTaskPlugin: failed to schedule refresh: \(error)")
     }
@@ -131,6 +134,7 @@ class BackgroundTaskPlugin: NSObject {
       scheduleNextRefresh()
       result(nil)
     case "cancelScheduledRefreshes":
+      NSLog("BackgroundTaskPlugin: cancelling scheduled refreshes")
       BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: BackgroundTaskPlugin.refreshIdentifier)
       result(nil)
     case "bgRefreshDidComplete":
@@ -140,6 +144,7 @@ class BackgroundTaskPlugin: NSObject {
       } else {
         success = true
       }
+      NSLog("BackgroundTaskPlugin: Dart reported refresh complete (success: \(success))")
       // Runs on the Flutter platform (main) thread, the same queue the
       // pending slot is confined to. Complete via the funnel so a racing
       // expiration handler can't also complete the task.

--- a/lib/l10n/app_af.arb
+++ b/lib/l10n/app_af.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "In volskerm, oortjiebalk",
   "appSettingsFullscreenTabStripHidden": "Versteek",
   "appSettingsFullscreenTabStripAlways": "Altyd sigbaar",
-  "appSettingsFullscreenTabStripButton": "Wys met knoppie"
+  "appSettingsFullscreenTabStripButton": "Wys met knoppie",
+  "devToolsSimulateRefresh": "Simuleer agtergrondverfrissing",
+  "devToolsSimulateRefreshDone": "Kennisgewingswebwerwe herlaai (sien logboeke)",
+  "devToolsTestNotification": "Stuur toetskennisgewing",
+  "devToolsTestNotificationSent": "Toetskennisgewing gestuur (sien logboeke)",
+  "devToolsTestNotificationTitle": "WebSpace-toetskennisgewing",
+  "devToolsTestNotificationBody": "As jy dit kan sien, werk die bedryfstelsel se kennisgewingaflewering."
 }

--- a/lib/l10n/app_af.arb
+++ b/lib/l10n/app_af.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "In volskerm, oortjiebalk",
   "appSettingsFullscreenTabStripHidden": "Versteek",
   "appSettingsFullscreenTabStripAlways": "Altyd sigbaar",
-  "appSettingsFullscreenTabStripButton": "Wys met knoppie"
+  "appSettingsFullscreenTabStripButton": "Wys met knoppie",
+  "devToolsSimulateRefresh": "Simuleer agtergrondverfrissing",
+  "devToolsSimulateRefreshDone": "Kennisgewingswebwerwe herlaai (sien logboeke)",
+  "devToolsTestNotification": "Stuur toetskennisgewing",
+  "devToolsTestNotificationSent": "Toetskennisgewing gestuur (sien logboeke)",
+  "devToolsTestNotificationTitle": "WebSpace-toetskennisgewing",
+  "devToolsTestNotificationBody": "As jy dit kan sien, werk die bedryfstelsel se kennisgewingaflewering."
 }

--- a/lib/l10n/app_am.arb
+++ b/lib/l10n/app_am.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "በሙሉ ማያ ገጽ፣ የትር አሞሌ",
   "appSettingsFullscreenTabStripHidden": "ተደብቋል",
   "appSettingsFullscreenTabStripAlways": "ሁልጊዜ የሚታይ",
-  "appSettingsFullscreenTabStripButton": "በቁልፍ አሳይ"
+  "appSettingsFullscreenTabStripButton": "በቁልፍ አሳይ",
+  "devToolsSimulateRefresh": "የጀርባ ማደስን አስመስል",
+  "devToolsSimulateRefreshDone": "የማስታወቂያ ጣቢያዎች እንደገና ተጫኑ (ምዝግቦችን ይመልከቱ)",
+  "devToolsTestNotification": "የሙከራ ማስታወቂያ ላክ",
+  "devToolsTestNotificationSent": "የሙከራ ማስታወቂያ ተልኳል (ምዝግቦችን ይመልከቱ)",
+  "devToolsTestNotificationTitle": "የWebSpace የሙከራ ማስታወቂያ",
+  "devToolsTestNotificationBody": "ይህን ማየት ከቻሉ የስርዓተ ክወና ማስታወቂያ ማድረስ ይሰራል።"
 }

--- a/lib/l10n/app_am.arb
+++ b/lib/l10n/app_am.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "በሙሉ ማያ ገጽ፣ የትር አሞሌ",
   "appSettingsFullscreenTabStripHidden": "ተደብቋል",
   "appSettingsFullscreenTabStripAlways": "ሁልጊዜ የሚታይ",
-  "appSettingsFullscreenTabStripButton": "በቁልፍ አሳይ"
+  "appSettingsFullscreenTabStripButton": "በቁልፍ አሳይ",
+  "devToolsSimulateRefresh": "የጀርባ ማደስን አስመስል",
+  "devToolsSimulateRefreshDone": "የማስታወቂያ ጣቢያዎች እንደገና ተጫኑ (ምዝግቦችን ይመልከቱ)",
+  "devToolsTestNotification": "የሙከራ ማስታወቂያ ላክ",
+  "devToolsTestNotificationSent": "የሙከራ ማስታወቂያ ተልኳል (ምዝግቦችን ይመልከቱ)",
+  "devToolsTestNotificationTitle": "የWebSpace የሙከራ ማስታወቂያ",
+  "devToolsTestNotificationBody": "ይህን ማየት ከቻሉ የስርዓተ ክወና ማስታወቂያ ማድረስ ይሰራል።"
 }

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "في وضع ملء الشاشة، شريط التبويبات",
   "appSettingsFullscreenTabStripHidden": "مخفي",
   "appSettingsFullscreenTabStripAlways": "ظاهر دائمًا",
-  "appSettingsFullscreenTabStripButton": "إظهار بزر"
+  "appSettingsFullscreenTabStripButton": "إظهار بزر",
+  "devToolsSimulateRefresh": "محاكاة تحديث الخلفية",
+  "devToolsSimulateRefreshDone": "تمت إعادة تحميل مواقع الإشعارات (راجع السجلات)",
+  "devToolsTestNotification": "إرسال إشعار اختباري",
+  "devToolsTestNotificationSent": "تم إرسال الإشعار الاختباري (راجع السجلات)",
+  "devToolsTestNotificationTitle": "إشعار اختباري من WebSpace",
+  "devToolsTestNotificationBody": "إذا كنت ترى هذا، فإن تسليم إشعارات نظام التشغيل يعمل."
 }

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "في وضع ملء الشاشة، شريط التبويبات",
   "appSettingsFullscreenTabStripHidden": "مخفي",
   "appSettingsFullscreenTabStripAlways": "ظاهر دائمًا",
-  "appSettingsFullscreenTabStripButton": "إظهار بزر"
+  "appSettingsFullscreenTabStripButton": "إظهار بزر",
+  "devToolsSimulateRefresh": "محاكاة تحديث الخلفية",
+  "devToolsSimulateRefreshDone": "تمت إعادة تحميل مواقع الإشعارات (راجع السجلات)",
+  "devToolsTestNotification": "إرسال إشعار اختباري",
+  "devToolsTestNotificationSent": "تم إرسال الإشعار الاختباري (راجع السجلات)",
+  "devToolsTestNotificationTitle": "إشعار اختباري من WebSpace",
+  "devToolsTestNotificationBody": "إذا كنت ترى هذا، فإن تسليم إشعارات نظام التشغيل يعمل."
 }

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "На цял екран, лента с раздели",
   "appSettingsFullscreenTabStripHidden": "Скрита",
   "appSettingsFullscreenTabStripAlways": "Винаги видима",
-  "appSettingsFullscreenTabStripButton": "Показване с бутон"
+  "appSettingsFullscreenTabStripButton": "Показване с бутон",
+  "devToolsSimulateRefresh": "Симулиране на фоново обновяване",
+  "devToolsSimulateRefreshDone": "Сайтовете за известия са презаредени (вижте дневниците)",
+  "devToolsTestNotification": "Изпращане на тестово известие",
+  "devToolsTestNotificationSent": "Тестовото известие е изпратено (вижте дневниците)",
+  "devToolsTestNotificationTitle": "Тестово известие на WebSpace",
+  "devToolsTestNotificationBody": "Ако виждате това, доставянето на известия от операционната система работи."
 }

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "На цял екран, лента с раздели",
   "appSettingsFullscreenTabStripHidden": "Скрита",
   "appSettingsFullscreenTabStripAlways": "Винаги видима",
-  "appSettingsFullscreenTabStripButton": "Показване с бутон"
+  "appSettingsFullscreenTabStripButton": "Показване с бутон",
+  "devToolsSimulateRefresh": "Симулиране на фоново обновяване",
+  "devToolsSimulateRefreshDone": "Сайтовете за известия са презаредени (вижте дневниците)",
+  "devToolsTestNotification": "Изпращане на тестово известие",
+  "devToolsTestNotificationSent": "Тестовото известие е изпратено (вижте дневниците)",
+  "devToolsTestNotificationTitle": "Тестово известие на WebSpace",
+  "devToolsTestNotificationBody": "Ако виждате това, доставянето на известия от операционната система работи."
 }

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "ফুলস্ক্রিনে, ট্যাব বার",
   "appSettingsFullscreenTabStripHidden": "লুকানো",
   "appSettingsFullscreenTabStripAlways": "সর্বদা দৃশ্যমান",
-  "appSettingsFullscreenTabStripButton": "বোতাম দিয়ে দেখান"
+  "appSettingsFullscreenTabStripButton": "বোতাম দিয়ে দেখান",
+  "devToolsSimulateRefresh": "ব্যাকগ্রাউন্ড রিফ্রেশ সিমুলেট করুন",
+  "devToolsSimulateRefreshDone": "বিজ্ঞপ্তি সাইটগুলি পুনরায় লোড করা হয়েছে (লগ দেখুন)",
+  "devToolsTestNotification": "পরীক্ষামূলক বিজ্ঞপ্তি পাঠান",
+  "devToolsTestNotificationSent": "পরীক্ষামূলক বিজ্ঞপ্তি পাঠানো হয়েছে (লগ দেখুন)",
+  "devToolsTestNotificationTitle": "WebSpace পরীক্ষামূলক বিজ্ঞপ্তি",
+  "devToolsTestNotificationBody": "আপনি যদি এটি দেখতে পান, তাহলে অপারেটিং সিস্টেমের বিজ্ঞপ্তি প্রদান কাজ করছে।"
 }

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "ফুলস্ক্রিনে, ট্যাব বার",
   "appSettingsFullscreenTabStripHidden": "লুকানো",
   "appSettingsFullscreenTabStripAlways": "সর্বদা দৃশ্যমান",
-  "appSettingsFullscreenTabStripButton": "বোতাম দিয়ে দেখান"
+  "appSettingsFullscreenTabStripButton": "বোতাম দিয়ে দেখান",
+  "devToolsSimulateRefresh": "ব্যাকগ্রাউন্ড রিফ্রেশ সিমুলেট করুন",
+  "devToolsSimulateRefreshDone": "বিজ্ঞপ্তি সাইটগুলি পুনরায় লোড করা হয়েছে (লগ দেখুন)",
+  "devToolsTestNotification": "পরীক্ষামূলক বিজ্ঞপ্তি পাঠান",
+  "devToolsTestNotificationSent": "পরীক্ষামূলক বিজ্ঞপ্তি পাঠানো হয়েছে (লগ দেখুন)",
+  "devToolsTestNotificationTitle": "WebSpace পরীক্ষামূলক বিজ্ঞপ্তি",
+  "devToolsTestNotificationBody": "আপনি যদি এটি দেখতে পান, তাহলে অপারেটিং সিস্টেমের বিজ্ঞপ্তি প্রদান কাজ করছে।"
 }

--- a/lib/l10n/app_bs.arb
+++ b/lib/l10n/app_bs.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "U punom ekranu, traka kartica",
   "appSettingsFullscreenTabStripHidden": "Skriveno",
   "appSettingsFullscreenTabStripAlways": "Uvijek vidljivo",
-  "appSettingsFullscreenTabStripButton": "Prikaži dugmetom"
+  "appSettingsFullscreenTabStripButton": "Prikaži dugmetom",
+  "devToolsSimulateRefresh": "Simuliraj osvježavanje u pozadini",
+  "devToolsSimulateRefreshDone": "Stranice s obavijestima su ponovo učitane (pogledajte zapise)",
+  "devToolsTestNotification": "Pošalji probnu obavijest",
+  "devToolsTestNotificationSent": "Probna obavijest je poslana (pogledajte zapise)",
+  "devToolsTestNotificationTitle": "WebSpace probna obavijest",
+  "devToolsTestNotificationBody": "Ako vidite ovo, isporuka obavijesti operativnog sistema radi."
 }

--- a/lib/l10n/app_bs.arb
+++ b/lib/l10n/app_bs.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "U punom ekranu, traka kartica",
   "appSettingsFullscreenTabStripHidden": "Skriveno",
   "appSettingsFullscreenTabStripAlways": "Uvijek vidljivo",
-  "appSettingsFullscreenTabStripButton": "Prikaži dugmetom"
+  "appSettingsFullscreenTabStripButton": "Prikaži dugmetom",
+  "devToolsSimulateRefresh": "Simuliraj osvježavanje u pozadini",
+  "devToolsSimulateRefreshDone": "Stranice s obavijestima su ponovo učitane (pogledajte zapise)",
+  "devToolsTestNotification": "Pošalji probnu obavijest",
+  "devToolsTestNotificationSent": "Probna obavijest je poslana (pogledajte zapise)",
+  "devToolsTestNotificationTitle": "WebSpace probna obavijest",
+  "devToolsTestNotificationBody": "Ako vidite ovo, isporuka obavijesti operativnog sistema radi."
 }

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "En pantalla completa, barra de pestanyes",
   "appSettingsFullscreenTabStripHidden": "Amagada",
   "appSettingsFullscreenTabStripAlways": "Sempre visible",
-  "appSettingsFullscreenTabStripButton": "Mostra amb un botó"
+  "appSettingsFullscreenTabStripButton": "Mostra amb un botó",
+  "devToolsSimulateRefresh": "Simula l'actualització en segon pla",
+  "devToolsSimulateRefreshDone": "Llocs de notificació recarregats (vegeu els registres)",
+  "devToolsTestNotification": "Envia una notificació de prova",
+  "devToolsTestNotificationSent": "Notificació de prova enviada (vegeu els registres)",
+  "devToolsTestNotificationTitle": "Notificació de prova de WebSpace",
+  "devToolsTestNotificationBody": "Si pots veure això, el lliurament de notificacions del sistema operatiu funciona."
 }

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "En pantalla completa, barra de pestanyes",
   "appSettingsFullscreenTabStripHidden": "Amagada",
   "appSettingsFullscreenTabStripAlways": "Sempre visible",
-  "appSettingsFullscreenTabStripButton": "Mostra amb un botó"
+  "appSettingsFullscreenTabStripButton": "Mostra amb un botó",
+  "devToolsSimulateRefresh": "Simula l'actualització en segon pla",
+  "devToolsSimulateRefreshDone": "Llocs de notificació recarregats (vegeu els registres)",
+  "devToolsTestNotification": "Envia una notificació de prova",
+  "devToolsTestNotificationSent": "Notificació de prova enviada (vegeu els registres)",
+  "devToolsTestNotificationTitle": "Notificació de prova de WebSpace",
+  "devToolsTestNotificationBody": "Si pots veure això, el lliurament de notificacions del sistema operatiu funciona."
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Na celé obrazovce, panel karet",
   "appSettingsFullscreenTabStripHidden": "Skrytý",
   "appSettingsFullscreenTabStripAlways": "Vždy viditelný",
-  "appSettingsFullscreenTabStripButton": "Zobrazit tlačítkem"
+  "appSettingsFullscreenTabStripButton": "Zobrazit tlačítkem",
+  "devToolsSimulateRefresh": "Simulovat obnovení na pozadí",
+  "devToolsSimulateRefreshDone": "Weby s oznámeními byly znovu načteny (viz protokoly)",
+  "devToolsTestNotification": "Odeslat testovací oznámení",
+  "devToolsTestNotificationSent": "Testovací oznámení odesláno (viz protokoly)",
+  "devToolsTestNotificationTitle": "Testovací oznámení WebSpace",
+  "devToolsTestNotificationBody": "Pokud toto vidíte, doručování oznámení operačního systému funguje."
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Na celé obrazovce, panel karet",
   "appSettingsFullscreenTabStripHidden": "Skrytý",
   "appSettingsFullscreenTabStripAlways": "Vždy viditelný",
-  "appSettingsFullscreenTabStripButton": "Zobrazit tlačítkem"
+  "appSettingsFullscreenTabStripButton": "Zobrazit tlačítkem",
+  "devToolsSimulateRefresh": "Simulovat obnovení na pozadí",
+  "devToolsSimulateRefreshDone": "Weby s oznámeními byly znovu načteny (viz protokoly)",
+  "devToolsTestNotification": "Odeslat testovací oznámení",
+  "devToolsTestNotificationSent": "Testovací oznámení odesláno (viz protokoly)",
+  "devToolsTestNotificationTitle": "Testovací oznámení WebSpace",
+  "devToolsTestNotificationBody": "Pokud toto vidíte, doručování oznámení operačního systému funguje."
 }

--- a/lib/l10n/app_cy.arb
+++ b/lib/l10n/app_cy.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Yn y sgrin lawn, bar tabiau",
   "appSettingsFullscreenTabStripHidden": "Cuddiedig",
   "appSettingsFullscreenTabStripAlways": "Gweladwy bob amser",
-  "appSettingsFullscreenTabStripButton": "Datgelu â botwm"
+  "appSettingsFullscreenTabStripButton": "Datgelu â botwm",
+  "devToolsSimulateRefresh": "Efelychu adnewyddu cefndir",
+  "devToolsSimulateRefreshDone": "Ail-lwythwyd safleoedd hysbysu (gweler y cofnodion)",
+  "devToolsTestNotification": "Anfon hysbysiad prawf",
+  "devToolsTestNotificationSent": "Anfonwyd hysbysiad prawf (gweler y cofnodion)",
+  "devToolsTestNotificationTitle": "Hysbysiad prawf WebSpace",
+  "devToolsTestNotificationBody": "Os gallwch weld hyn, mae danfon hysbysiadau'r system weithredu yn gweithio."
 }

--- a/lib/l10n/app_cy.arb
+++ b/lib/l10n/app_cy.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Yn y sgrin lawn, bar tabiau",
   "appSettingsFullscreenTabStripHidden": "Cuddiedig",
   "appSettingsFullscreenTabStripAlways": "Gweladwy bob amser",
-  "appSettingsFullscreenTabStripButton": "Datgelu â botwm"
+  "appSettingsFullscreenTabStripButton": "Datgelu â botwm",
+  "devToolsSimulateRefresh": "Efelychu adnewyddu cefndir",
+  "devToolsSimulateRefreshDone": "Ail-lwythwyd safleoedd hysbysu (gweler y cofnodion)",
+  "devToolsTestNotification": "Anfon hysbysiad prawf",
+  "devToolsTestNotificationSent": "Anfonwyd hysbysiad prawf (gweler y cofnodion)",
+  "devToolsTestNotificationTitle": "Hysbysiad prawf WebSpace",
+  "devToolsTestNotificationBody": "Os gallwch weld hyn, mae danfon hysbysiadau'r system weithredu yn gweithio."
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "I fuld skærm, fanebjælke",
   "appSettingsFullscreenTabStripHidden": "Skjult",
   "appSettingsFullscreenTabStripAlways": "Altid synlig",
-  "appSettingsFullscreenTabStripButton": "Vis med knap"
+  "appSettingsFullscreenTabStripButton": "Vis med knap",
+  "devToolsSimulateRefresh": "Simuler baggrundsopdatering",
+  "devToolsSimulateRefreshDone": "Notifikationssider genindlæst (se logfiler)",
+  "devToolsTestNotification": "Send testnotifikation",
+  "devToolsTestNotificationSent": "Testnotifikation sendt (se logfiler)",
+  "devToolsTestNotificationTitle": "WebSpace-testnotifikation",
+  "devToolsTestNotificationBody": "Hvis du kan se dette, fungerer operativsystemets notifikationslevering."
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "I fuld skærm, fanebjælke",
   "appSettingsFullscreenTabStripHidden": "Skjult",
   "appSettingsFullscreenTabStripAlways": "Altid synlig",
-  "appSettingsFullscreenTabStripButton": "Vis med knap"
+  "appSettingsFullscreenTabStripButton": "Vis med knap",
+  "devToolsSimulateRefresh": "Simuler baggrundsopdatering",
+  "devToolsSimulateRefreshDone": "Notifikationssider genindlæst (se logfiler)",
+  "devToolsTestNotification": "Send testnotifikation",
+  "devToolsTestNotificationSent": "Testnotifikation sendt (se logfiler)",
+  "devToolsTestNotificationTitle": "WebSpace-testnotifikation",
+  "devToolsTestNotificationBody": "Hvis du kan se dette, fungerer operativsystemets notifikationslevering."
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Im Vollbild, Tableiste",
   "appSettingsFullscreenTabStripHidden": "Ausgeblendet",
   "appSettingsFullscreenTabStripAlways": "Immer sichtbar",
-  "appSettingsFullscreenTabStripButton": "Mit Schaltfläche einblenden"
+  "appSettingsFullscreenTabStripButton": "Mit Schaltfläche einblenden",
+  "devToolsSimulateRefresh": "Hintergrundaktualisierung simulieren",
+  "devToolsSimulateRefreshDone": "Benachrichtigungsseiten neu geladen (siehe Protokolle)",
+  "devToolsTestNotification": "Testbenachrichtigung senden",
+  "devToolsTestNotificationSent": "Testbenachrichtigung gesendet (siehe Protokolle)",
+  "devToolsTestNotificationTitle": "WebSpace-Testbenachrichtigung",
+  "devToolsTestNotificationBody": "Wenn Sie dies sehen können, funktioniert die Benachrichtigungszustellung des Betriebssystems."
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Im Vollbild, Tableiste",
   "appSettingsFullscreenTabStripHidden": "Ausgeblendet",
   "appSettingsFullscreenTabStripAlways": "Immer sichtbar",
-  "appSettingsFullscreenTabStripButton": "Mit Schaltfläche einblenden"
+  "appSettingsFullscreenTabStripButton": "Mit Schaltfläche einblenden",
+  "devToolsSimulateRefresh": "Hintergrundaktualisierung simulieren",
+  "devToolsSimulateRefreshDone": "Benachrichtigungsseiten neu geladen (siehe Protokolle)",
+  "devToolsTestNotification": "Testbenachrichtigung senden",
+  "devToolsTestNotificationSent": "Testbenachrichtigung gesendet (siehe Protokolle)",
+  "devToolsTestNotificationTitle": "WebSpace-Testbenachrichtigung",
+  "devToolsTestNotificationBody": "Wenn Sie dies sehen können, funktioniert die Benachrichtigungszustellung des Betriebssystems."
 }

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Σε πλήρη οθόνη, γραμμή καρτελών",
   "appSettingsFullscreenTabStripHidden": "Κρυφή",
   "appSettingsFullscreenTabStripAlways": "Πάντα ορατή",
-  "appSettingsFullscreenTabStripButton": "Εμφάνιση με κουμπί"
+  "appSettingsFullscreenTabStripButton": "Εμφάνιση με κουμπί",
+  "devToolsSimulateRefresh": "Προσομοίωση ανανέωσης παρασκηνίου",
+  "devToolsSimulateRefreshDone": "Οι ιστότοποι ειδοποιήσεων επαναφορτώθηκαν (δείτε τα αρχεία καταγραφής)",
+  "devToolsTestNotification": "Αποστολή δοκιμαστικής ειδοποίησης",
+  "devToolsTestNotificationSent": "Η δοκιμαστική ειδοποίηση στάλθηκε (δείτε τα αρχεία καταγραφής)",
+  "devToolsTestNotificationTitle": "Δοκιμαστική ειδοποίηση WebSpace",
+  "devToolsTestNotificationBody": "Αν μπορείτε να το δείτε αυτό, η παράδοση ειδοποιήσεων του λειτουργικού συστήματος λειτουργεί."
 }

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Σε πλήρη οθόνη, γραμμή καρτελών",
   "appSettingsFullscreenTabStripHidden": "Κρυφή",
   "appSettingsFullscreenTabStripAlways": "Πάντα ορατή",
-  "appSettingsFullscreenTabStripButton": "Εμφάνιση με κουμπί"
+  "appSettingsFullscreenTabStripButton": "Εμφάνιση με κουμπί",
+  "devToolsSimulateRefresh": "Προσομοίωση ανανέωσης παρασκηνίου",
+  "devToolsSimulateRefreshDone": "Οι ιστότοποι ειδοποιήσεων επαναφορτώθηκαν (δείτε τα αρχεία καταγραφής)",
+  "devToolsTestNotification": "Αποστολή δοκιμαστικής ειδοποίησης",
+  "devToolsTestNotificationSent": "Η δοκιμαστική ειδοποίηση στάλθηκε (δείτε τα αρχεία καταγραφής)",
+  "devToolsTestNotificationTitle": "Δοκιμαστική ειδοποίηση WebSpace",
+  "devToolsTestNotificationBody": "Αν μπορείτε να το δείτε αυτό, η παράδοση ειδοποιήσεων του λειτουργικού συστήματος λειτουργεί."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2437,6 +2437,30 @@
   "@devToolsCopy": {
     "description": "Button label that copies the current tab's entries to the clipboard."
   },
+  "devToolsSimulateRefresh": "Simulate background refresh",
+  "@devToolsSimulateRefresh": {
+    "description": "Developer-tools button. Runs the same notification-site reload that the OS background task would run, so the user can test web push wake-up in the foreground without waiting for the OS scheduler."
+  },
+  "devToolsSimulateRefreshDone": "Reloaded notification sites (see logs)",
+  "@devToolsSimulateRefreshDone": {
+    "description": "Confirmation shown after the simulate-background-refresh developer-tools button runs; points the user to the App Logs tab for the result."
+  },
+  "devToolsTestNotification": "Send test notification",
+  "@devToolsTestNotification": {
+    "description": "Developer-tools button that posts a local test notification for the current site to verify OS notification permission and delivery work."
+  },
+  "devToolsTestNotificationSent": "Test notification sent (see logs)",
+  "@devToolsTestNotificationSent": {
+    "description": "Confirmation shown after the send-test-notification developer-tools button runs; points the user to the App Logs tab for the result."
+  },
+  "devToolsTestNotificationTitle": "WebSpace test notification",
+  "@devToolsTestNotificationTitle": {
+    "description": "Title of the local test notification posted by the send-test-notification developer-tools button."
+  },
+  "devToolsTestNotificationBody": "If you can see this, OS notification delivery works.",
+  "@devToolsTestNotificationBody": {
+    "description": "Body text of the local test notification posted by the send-test-notification developer-tools button."
+  },
   "devToolsEvalHint": "Evaluate JavaScript...",
   "@devToolsEvalHint": {
     "description": "Hint text in the console JavaScript evaluation input."

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2520,6 +2520,30 @@
   "@devToolsCopy": {
     "description": "Button label that copies the current tab's entries to the clipboard."
   },
+  "devToolsSimulateRefresh": "Simulate background refresh",
+  "@devToolsSimulateRefresh": {
+    "description": "Developer-tools button. Runs the same notification-site reload that the OS background task would run, so the user can test web push wake-up in the foreground without waiting for the OS scheduler."
+  },
+  "devToolsSimulateRefreshDone": "Reloaded notification sites (see logs)",
+  "@devToolsSimulateRefreshDone": {
+    "description": "Confirmation shown after the simulate-background-refresh developer-tools button runs; points the user to the App Logs tab for the result."
+  },
+  "devToolsTestNotification": "Send test notification",
+  "@devToolsTestNotification": {
+    "description": "Developer-tools button that posts a local test notification for the current site to verify OS notification permission and delivery work."
+  },
+  "devToolsTestNotificationSent": "Test notification sent (see logs)",
+  "@devToolsTestNotificationSent": {
+    "description": "Confirmation shown after the send-test-notification developer-tools button runs; points the user to the App Logs tab for the result."
+  },
+  "devToolsTestNotificationTitle": "WebSpace test notification",
+  "@devToolsTestNotificationTitle": {
+    "description": "Title of the local test notification posted by the send-test-notification developer-tools button."
+  },
+  "devToolsTestNotificationBody": "If you can see this, OS notification delivery works.",
+  "@devToolsTestNotificationBody": {
+    "description": "Body text of the local test notification posted by the send-test-notification developer-tools button."
+  },
   "devToolsEvalHint": "Evaluate JavaScript...",
   "@devToolsEvalHint": {
     "description": "Hint text in the console JavaScript evaluation input."

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "En pantalla completa, barra de pestañas",
   "appSettingsFullscreenTabStripHidden": "Oculta",
   "appSettingsFullscreenTabStripAlways": "Siempre visible",
-  "appSettingsFullscreenTabStripButton": "Mostrar con un botón"
+  "appSettingsFullscreenTabStripButton": "Mostrar con un botón",
+  "devToolsSimulateRefresh": "Simular actualización en segundo plano",
+  "devToolsSimulateRefreshDone": "Sitios de notificación recargados (consulta los registros)",
+  "devToolsTestNotification": "Enviar notificación de prueba",
+  "devToolsTestNotificationSent": "Notificación de prueba enviada (consulta los registros)",
+  "devToolsTestNotificationTitle": "Notificación de prueba de WebSpace",
+  "devToolsTestNotificationBody": "Si puedes ver esto, la entrega de notificaciones del sistema operativo funciona."
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "En pantalla completa, barra de pestañas",
   "appSettingsFullscreenTabStripHidden": "Oculta",
   "appSettingsFullscreenTabStripAlways": "Siempre visible",
-  "appSettingsFullscreenTabStripButton": "Mostrar con un botón"
+  "appSettingsFullscreenTabStripButton": "Mostrar con un botón",
+  "devToolsSimulateRefresh": "Simular actualización en segundo plano",
+  "devToolsSimulateRefreshDone": "Sitios de notificación recargados (consulta los registros)",
+  "devToolsTestNotification": "Enviar notificación de prueba",
+  "devToolsTestNotificationSent": "Notificación de prueba enviada (consulta los registros)",
+  "devToolsTestNotificationTitle": "Notificación de prueba de WebSpace",
+  "devToolsTestNotificationBody": "Si puedes ver esto, la entrega de notificaciones del sistema operativo funciona."
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Täisekraanil, vahekaartide riba",
   "appSettingsFullscreenTabStripHidden": "Peidetud",
   "appSettingsFullscreenTabStripAlways": "Alati nähtav",
-  "appSettingsFullscreenTabStripButton": "Kuva nupuga"
+  "appSettingsFullscreenTabStripButton": "Kuva nupuga",
+  "devToolsSimulateRefresh": "Simuleeri taustal värskendamist",
+  "devToolsSimulateRefreshDone": "Teavitussaidid laaditi uuesti (vaata logisid)",
+  "devToolsTestNotification": "Saada testteavitus",
+  "devToolsTestNotificationSent": "Testteavitus saadetud (vaata logisid)",
+  "devToolsTestNotificationTitle": "WebSpace'i testteavitus",
+  "devToolsTestNotificationBody": "Kui näete seda, siis operatsioonisüsteemi teavituste edastamine töötab."
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Täisekraanil, vahekaartide riba",
   "appSettingsFullscreenTabStripHidden": "Peidetud",
   "appSettingsFullscreenTabStripAlways": "Alati nähtav",
-  "appSettingsFullscreenTabStripButton": "Kuva nupuga"
+  "appSettingsFullscreenTabStripButton": "Kuva nupuga",
+  "devToolsSimulateRefresh": "Simuleeri taustal värskendamist",
+  "devToolsSimulateRefreshDone": "Teavitussaidid laaditi uuesti (vaata logisid)",
+  "devToolsTestNotification": "Saada testteavitus",
+  "devToolsTestNotificationSent": "Testteavitus saadetud (vaata logisid)",
+  "devToolsTestNotificationTitle": "WebSpace'i testteavitus",
+  "devToolsTestNotificationBody": "Kui näete seda, siis operatsioonisüsteemi teavituste edastamine töötab."
 }

--- a/lib/l10n/app_eu.arb
+++ b/lib/l10n/app_eu.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Pantaila osoan, fitxa-barra",
   "appSettingsFullscreenTabStripHidden": "Ezkutatuta",
   "appSettingsFullscreenTabStripAlways": "Beti ikusgai",
-  "appSettingsFullscreenTabStripButton": "Erakutsi botoiarekin"
+  "appSettingsFullscreenTabStripButton": "Erakutsi botoiarekin",
+  "devToolsSimulateRefresh": "Simulatu atzeko planoko freskatzea",
+  "devToolsSimulateRefreshDone": "Jakinarazpen-guneak birkargatu dira (ikus erregistroak)",
+  "devToolsTestNotification": "Bidali probako jakinarazpena",
+  "devToolsTestNotificationSent": "Probako jakinarazpena bidali da (ikus erregistroak)",
+  "devToolsTestNotificationTitle": "WebSpace probako jakinarazpena",
+  "devToolsTestNotificationBody": "Hau ikus badezakezu, sistema eragilearen jakinarazpenen entrega ondo dabil."
 }

--- a/lib/l10n/app_eu.arb
+++ b/lib/l10n/app_eu.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Pantaila osoan, fitxa-barra",
   "appSettingsFullscreenTabStripHidden": "Ezkutatuta",
   "appSettingsFullscreenTabStripAlways": "Beti ikusgai",
-  "appSettingsFullscreenTabStripButton": "Erakutsi botoiarekin"
+  "appSettingsFullscreenTabStripButton": "Erakutsi botoiarekin",
+  "devToolsSimulateRefresh": "Simulatu atzeko planoko freskatzea",
+  "devToolsSimulateRefreshDone": "Jakinarazpen-guneak birkargatu dira (ikus erregistroak)",
+  "devToolsTestNotification": "Bidali probako jakinarazpena",
+  "devToolsTestNotificationSent": "Probako jakinarazpena bidali da (ikus erregistroak)",
+  "devToolsTestNotificationTitle": "WebSpace probako jakinarazpena",
+  "devToolsTestNotificationBody": "Hau ikus badezakezu, sistema eragilearen jakinarazpenen entrega ondo dabil."
 }

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "در تمام‌صفحه، نوار زبانه‌ها",
   "appSettingsFullscreenTabStripHidden": "پنهان",
   "appSettingsFullscreenTabStripAlways": "همیشه نمایان",
-  "appSettingsFullscreenTabStripButton": "نمایش با دکمه"
+  "appSettingsFullscreenTabStripButton": "نمایش با دکمه",
+  "devToolsSimulateRefresh": "شبیه‌سازی به‌روزرسانی پس‌زمینه",
+  "devToolsSimulateRefreshDone": "سایت‌های اعلان دوباره بارگذاری شدند (گزارش‌ها را ببینید)",
+  "devToolsTestNotification": "ارسال اعلان آزمایشی",
+  "devToolsTestNotificationSent": "اعلان آزمایشی ارسال شد (گزارش‌ها را ببینید)",
+  "devToolsTestNotificationTitle": "اعلان آزمایشی WebSpace",
+  "devToolsTestNotificationBody": "اگر این را می‌بینید، تحویل اعلان‌های سیستم‌عامل کار می‌کند."
 }

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "در تمام‌صفحه، نوار زبانه‌ها",
   "appSettingsFullscreenTabStripHidden": "پنهان",
   "appSettingsFullscreenTabStripAlways": "همیشه نمایان",
-  "appSettingsFullscreenTabStripButton": "نمایش با دکمه"
+  "appSettingsFullscreenTabStripButton": "نمایش با دکمه",
+  "devToolsSimulateRefresh": "شبیه‌سازی به‌روزرسانی پس‌زمینه",
+  "devToolsSimulateRefreshDone": "سایت‌های اعلان دوباره بارگذاری شدند (گزارش‌ها را ببینید)",
+  "devToolsTestNotification": "ارسال اعلان آزمایشی",
+  "devToolsTestNotificationSent": "اعلان آزمایشی ارسال شد (گزارش‌ها را ببینید)",
+  "devToolsTestNotificationTitle": "اعلان آزمایشی WebSpace",
+  "devToolsTestNotificationBody": "اگر این را می‌بینید، تحویل اعلان‌های سیستم‌عامل کار می‌کند."
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Koko näytössä, välilehtipalkki",
   "appSettingsFullscreenTabStripHidden": "Piilotettu",
   "appSettingsFullscreenTabStripAlways": "Aina näkyvissä",
-  "appSettingsFullscreenTabStripButton": "Näytä painikkeella"
+  "appSettingsFullscreenTabStripButton": "Näytä painikkeella",
+  "devToolsSimulateRefresh": "Simuloi taustapäivitystä",
+  "devToolsSimulateRefreshDone": "Ilmoitussivustot ladattu uudelleen (katso lokit)",
+  "devToolsTestNotification": "Lähetä testi-ilmoitus",
+  "devToolsTestNotificationSent": "Testi-ilmoitus lähetetty (katso lokit)",
+  "devToolsTestNotificationTitle": "WebSpace-testi-ilmoitus",
+  "devToolsTestNotificationBody": "Jos näet tämän, käyttöjärjestelmän ilmoitusten toimitus toimii."
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Koko näytössä, välilehtipalkki",
   "appSettingsFullscreenTabStripHidden": "Piilotettu",
   "appSettingsFullscreenTabStripAlways": "Aina näkyvissä",
-  "appSettingsFullscreenTabStripButton": "Näytä painikkeella"
+  "appSettingsFullscreenTabStripButton": "Näytä painikkeella",
+  "devToolsSimulateRefresh": "Simuloi taustapäivitystä",
+  "devToolsSimulateRefreshDone": "Ilmoitussivustot ladattu uudelleen (katso lokit)",
+  "devToolsTestNotification": "Lähetä testi-ilmoitus",
+  "devToolsTestNotificationSent": "Testi-ilmoitus lähetetty (katso lokit)",
+  "devToolsTestNotificationTitle": "WebSpace-testi-ilmoitus",
+  "devToolsTestNotificationBody": "Jos näet tämän, käyttöjärjestelmän ilmoitusten toimitus toimii."
 }

--- a/lib/l10n/app_fil.arb
+++ b/lib/l10n/app_fil.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Sa full screen, tab bar",
   "appSettingsFullscreenTabStripHidden": "Nakatago",
   "appSettingsFullscreenTabStripAlways": "Palaging nakikita",
-  "appSettingsFullscreenTabStripButton": "Ipakita gamit ang button"
+  "appSettingsFullscreenTabStripButton": "Ipakita gamit ang button",
+  "devToolsSimulateRefresh": "I-simulate ang pag-refresh sa background",
+  "devToolsSimulateRefreshDone": "Na-reload ang mga site ng notification (tingnan ang mga log)",
+  "devToolsTestNotification": "Magpadala ng test notification",
+  "devToolsTestNotificationSent": "Naipadala ang test notification (tingnan ang mga log)",
+  "devToolsTestNotificationTitle": "Test notification ng WebSpace",
+  "devToolsTestNotificationBody": "Kung makikita mo ito, gumagana ang paghahatid ng notification ng operating system."
 }

--- a/lib/l10n/app_fil.arb
+++ b/lib/l10n/app_fil.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Sa full screen, tab bar",
   "appSettingsFullscreenTabStripHidden": "Nakatago",
   "appSettingsFullscreenTabStripAlways": "Palaging nakikita",
-  "appSettingsFullscreenTabStripButton": "Ipakita gamit ang button"
+  "appSettingsFullscreenTabStripButton": "Ipakita gamit ang button",
+  "devToolsSimulateRefresh": "I-simulate ang pag-refresh sa background",
+  "devToolsSimulateRefreshDone": "Na-reload ang mga site ng notification (tingnan ang mga log)",
+  "devToolsTestNotification": "Magpadala ng test notification",
+  "devToolsTestNotificationSent": "Naipadala ang test notification (tingnan ang mga log)",
+  "devToolsTestNotificationTitle": "Test notification ng WebSpace",
+  "devToolsTestNotificationBody": "Kung makikita mo ito, gumagana ang paghahatid ng notification ng operating system."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "En plein écran, barre d'onglets",
   "appSettingsFullscreenTabStripHidden": "Masquée",
   "appSettingsFullscreenTabStripAlways": "Toujours visible",
-  "appSettingsFullscreenTabStripButton": "Afficher avec un bouton"
+  "appSettingsFullscreenTabStripButton": "Afficher avec un bouton",
+  "devToolsSimulateRefresh": "Simuler l'actualisation en arrière-plan",
+  "devToolsSimulateRefreshDone": "Sites de notification rechargés (voir les journaux)",
+  "devToolsTestNotification": "Envoyer une notification de test",
+  "devToolsTestNotificationSent": "Notification de test envoyée (voir les journaux)",
+  "devToolsTestNotificationTitle": "Notification de test WebSpace",
+  "devToolsTestNotificationBody": "Si vous voyez ceci, la diffusion des notifications du système d'exploitation fonctionne."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "En plein écran, barre d'onglets",
   "appSettingsFullscreenTabStripHidden": "Masquée",
   "appSettingsFullscreenTabStripAlways": "Toujours visible",
-  "appSettingsFullscreenTabStripButton": "Afficher avec un bouton"
+  "appSettingsFullscreenTabStripButton": "Afficher avec un bouton",
+  "devToolsSimulateRefresh": "Simuler l'actualisation en arrière-plan",
+  "devToolsSimulateRefreshDone": "Sites de notification rechargés (voir les journaux)",
+  "devToolsTestNotification": "Envoyer une notification de test",
+  "devToolsTestNotificationSent": "Notification de test envoyée (voir les journaux)",
+  "devToolsTestNotificationTitle": "Notification de test WebSpace",
+  "devToolsTestNotificationBody": "Si vous voyez ceci, la diffusion des notifications du système d'exploitation fonctionne."
 }

--- a/lib/l10n/app_ga.arb
+++ b/lib/l10n/app_ga.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Sa scáileán iomlán, barra cluaisíní",
   "appSettingsFullscreenTabStripHidden": "Folaithe",
   "appSettingsFullscreenTabStripAlways": "Le feiceáil i gcónaí",
-  "appSettingsFullscreenTabStripButton": "Taispeáin le cnaipe"
+  "appSettingsFullscreenTabStripButton": "Taispeáin le cnaipe",
+  "devToolsSimulateRefresh": "Insamhail athnuachan sa chúlra",
+  "devToolsSimulateRefreshDone": "Athluchtaíodh suíomhanna fógraí (féach na logaí)",
+  "devToolsTestNotification": "Seol fógra tástála",
+  "devToolsTestNotificationSent": "Seoladh fógra tástála (féach na logaí)",
+  "devToolsTestNotificationTitle": "Fógra tástála WebSpace",
+  "devToolsTestNotificationBody": "Más féidir leat é seo a fheiceáil, tá seachadadh fógraí an chórais oibriúcháin ag obair."
 }

--- a/lib/l10n/app_ga.arb
+++ b/lib/l10n/app_ga.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Sa scáileán iomlán, barra cluaisíní",
   "appSettingsFullscreenTabStripHidden": "Folaithe",
   "appSettingsFullscreenTabStripAlways": "Le feiceáil i gcónaí",
-  "appSettingsFullscreenTabStripButton": "Taispeáin le cnaipe"
+  "appSettingsFullscreenTabStripButton": "Taispeáin le cnaipe",
+  "devToolsSimulateRefresh": "Insamhail athnuachan sa chúlra",
+  "devToolsSimulateRefreshDone": "Athluchtaíodh suíomhanna fógraí (féach na logaí)",
+  "devToolsTestNotification": "Seol fógra tástála",
+  "devToolsTestNotificationSent": "Seoladh fógra tástála (féach na logaí)",
+  "devToolsTestNotificationTitle": "Fógra tástála WebSpace",
+  "devToolsTestNotificationBody": "Más féidir leat é seo a fheiceáil, tá seachadadh fógraí an chórais oibriúcháin ag obair."
 }

--- a/lib/l10n/app_gl.arb
+++ b/lib/l10n/app_gl.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "En pantalla completa, barra de lapelas",
   "appSettingsFullscreenTabStripHidden": "Agochada",
   "appSettingsFullscreenTabStripAlways": "Sempre visible",
-  "appSettingsFullscreenTabStripButton": "Mostrar cun botón"
+  "appSettingsFullscreenTabStripButton": "Mostrar cun botón",
+  "devToolsSimulateRefresh": "Simular actualización en segundo plano",
+  "devToolsSimulateRefreshDone": "Sitios de notificación recargados (consulta os rexistros)",
+  "devToolsTestNotification": "Enviar notificación de proba",
+  "devToolsTestNotificationSent": "Notificación de proba enviada (consulta os rexistros)",
+  "devToolsTestNotificationTitle": "Notificación de proba de WebSpace",
+  "devToolsTestNotificationBody": "Se podes ver isto, a entrega de notificacións do sistema operativo funciona."
 }

--- a/lib/l10n/app_gl.arb
+++ b/lib/l10n/app_gl.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "En pantalla completa, barra de lapelas",
   "appSettingsFullscreenTabStripHidden": "Agochada",
   "appSettingsFullscreenTabStripAlways": "Sempre visible",
-  "appSettingsFullscreenTabStripButton": "Mostrar cun botón"
+  "appSettingsFullscreenTabStripButton": "Mostrar cun botón",
+  "devToolsSimulateRefresh": "Simular actualización en segundo plano",
+  "devToolsSimulateRefreshDone": "Sitios de notificación recargados (consulta os rexistros)",
+  "devToolsTestNotification": "Enviar notificación de proba",
+  "devToolsTestNotificationSent": "Notificación de proba enviada (consulta os rexistros)",
+  "devToolsTestNotificationTitle": "Notificación de proba de WebSpace",
+  "devToolsTestNotificationBody": "Se podes ver isto, a entrega de notificacións do sistema operativo funciona."
 }

--- a/lib/l10n/app_gu.arb
+++ b/lib/l10n/app_gu.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "પૂર્ણ સ્ક્રીનમાં, ટૅબ બાર",
   "appSettingsFullscreenTabStripHidden": "છુપાયેલ",
   "appSettingsFullscreenTabStripAlways": "હંમેશા દૃશ્યમાન",
-  "appSettingsFullscreenTabStripButton": "બટન વડે બતાવો"
+  "appSettingsFullscreenTabStripButton": "બટન વડે બતાવો",
+  "devToolsSimulateRefresh": "બેકગ્રાઉન્ડ રિફ્રેશનું અનુકરણ કરો",
+  "devToolsSimulateRefreshDone": "સૂચના સાઇટ્સ ફરી લોડ થઈ (લોગ જુઓ)",
+  "devToolsTestNotification": "પરીક્ષણ સૂચના મોકલો",
+  "devToolsTestNotificationSent": "પરીક્ષણ સૂચના મોકલાઈ (લોગ જુઓ)",
+  "devToolsTestNotificationTitle": "WebSpace પરીક્ષણ સૂચના",
+  "devToolsTestNotificationBody": "જો તમે આ જોઈ શકતા હો, તો ઓપરેટિંગ સિસ્ટમની સૂચના વિતરણ કાર્ય કરે છે."
 }

--- a/lib/l10n/app_gu.arb
+++ b/lib/l10n/app_gu.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "પૂર્ણ સ્ક્રીનમાં, ટૅબ બાર",
   "appSettingsFullscreenTabStripHidden": "છુપાયેલ",
   "appSettingsFullscreenTabStripAlways": "હંમેશા દૃશ્યમાન",
-  "appSettingsFullscreenTabStripButton": "બટન વડે બતાવો"
+  "appSettingsFullscreenTabStripButton": "બટન વડે બતાવો",
+  "devToolsSimulateRefresh": "બેકગ્રાઉન્ડ રિફ્રેશનું અનુકરણ કરો",
+  "devToolsSimulateRefreshDone": "સૂચના સાઇટ્સ ફરી લોડ થઈ (લોગ જુઓ)",
+  "devToolsTestNotification": "પરીક્ષણ સૂચના મોકલો",
+  "devToolsTestNotificationSent": "પરીક્ષણ સૂચના મોકલાઈ (લોગ જુઓ)",
+  "devToolsTestNotificationTitle": "WebSpace પરીક્ષણ સૂચના",
+  "devToolsTestNotificationBody": "જો તમે આ જોઈ શકતા હો, તો ઓપરેટિંગ સિસ્ટમની સૂચના વિતરણ કાર્ય કરે છે."
 }

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "במסך מלא, סרגל כרטיסיות",
   "appSettingsFullscreenTabStripHidden": "מוסתר",
   "appSettingsFullscreenTabStripAlways": "תמיד גלוי",
-  "appSettingsFullscreenTabStripButton": "הצג בעזרת כפתור"
+  "appSettingsFullscreenTabStripButton": "הצג בעזרת כפתור",
+  "devToolsSimulateRefresh": "הדמיית רענון ברקע",
+  "devToolsSimulateRefreshDone": "אתרי ההתראות נטענו מחדש (ראה יומנים)",
+  "devToolsTestNotification": "שלח התראת בדיקה",
+  "devToolsTestNotificationSent": "התראת הבדיקה נשלחה (ראה יומנים)",
+  "devToolsTestNotificationTitle": "התראת בדיקה של WebSpace",
+  "devToolsTestNotificationBody": "אם אתה רואה זאת, מסירת ההתראות של מערכת ההפעלה פועלת."
 }

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "במסך מלא, סרגל כרטיסיות",
   "appSettingsFullscreenTabStripHidden": "מוסתר",
   "appSettingsFullscreenTabStripAlways": "תמיד גלוי",
-  "appSettingsFullscreenTabStripButton": "הצג בעזרת כפתור"
+  "appSettingsFullscreenTabStripButton": "הצג בעזרת כפתור",
+  "devToolsSimulateRefresh": "הדמיית רענון ברקע",
+  "devToolsSimulateRefreshDone": "אתרי ההתראות נטענו מחדש (ראה יומנים)",
+  "devToolsTestNotification": "שלח התראת בדיקה",
+  "devToolsTestNotificationSent": "התראת הבדיקה נשלחה (ראה יומנים)",
+  "devToolsTestNotificationTitle": "התראת בדיקה של WebSpace",
+  "devToolsTestNotificationBody": "אם אתה רואה זאת, מסירת ההתראות של מערכת ההפעלה פועלת."
 }

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "फ़ुल स्क्रीन में, टैब बार",
   "appSettingsFullscreenTabStripHidden": "छिपा हुआ",
   "appSettingsFullscreenTabStripAlways": "हमेशा दृश्यमान",
-  "appSettingsFullscreenTabStripButton": "बटन से दिखाएँ"
+  "appSettingsFullscreenTabStripButton": "बटन से दिखाएँ",
+  "devToolsSimulateRefresh": "पृष्ठभूमि रिफ्रेश का अनुकरण करें",
+  "devToolsSimulateRefreshDone": "सूचना साइटें पुनः लोड हुईं (लॉग देखें)",
+  "devToolsTestNotification": "परीक्षण सूचना भेजें",
+  "devToolsTestNotificationSent": "परीक्षण सूचना भेजी गई (लॉग देखें)",
+  "devToolsTestNotificationTitle": "WebSpace परीक्षण सूचना",
+  "devToolsTestNotificationBody": "यदि आप इसे देख सकते हैं, तो ऑपरेटिंग सिस्टम की सूचना वितरण कार्य कर रहा है।"
 }

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "फ़ुल स्क्रीन में, टैब बार",
   "appSettingsFullscreenTabStripHidden": "छिपा हुआ",
   "appSettingsFullscreenTabStripAlways": "हमेशा दृश्यमान",
-  "appSettingsFullscreenTabStripButton": "बटन से दिखाएँ"
+  "appSettingsFullscreenTabStripButton": "बटन से दिखाएँ",
+  "devToolsSimulateRefresh": "पृष्ठभूमि रिफ्रेश का अनुकरण करें",
+  "devToolsSimulateRefreshDone": "सूचना साइटें पुनः लोड हुईं (लॉग देखें)",
+  "devToolsTestNotification": "परीक्षण सूचना भेजें",
+  "devToolsTestNotificationSent": "परीक्षण सूचना भेजी गई (लॉग देखें)",
+  "devToolsTestNotificationTitle": "WebSpace परीक्षण सूचना",
+  "devToolsTestNotificationBody": "यदि आप इसे देख सकते हैं, तो ऑपरेटिंग सिस्टम की सूचना वितरण कार्य कर रहा है।"
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "U punom zaslonu, traka kartica",
   "appSettingsFullscreenTabStripHidden": "Skriveno",
   "appSettingsFullscreenTabStripAlways": "Uvijek vidljivo",
-  "appSettingsFullscreenTabStripButton": "Prikaži gumbom"
+  "appSettingsFullscreenTabStripButton": "Prikaži gumbom",
+  "devToolsSimulateRefresh": "Simuliraj osvježavanje u pozadini",
+  "devToolsSimulateRefreshDone": "Stranice s obavijestima ponovno su učitane (pogledajte zapisnike)",
+  "devToolsTestNotification": "Pošalji probnu obavijest",
+  "devToolsTestNotificationSent": "Probna obavijest poslana (pogledajte zapisnike)",
+  "devToolsTestNotificationTitle": "WebSpace probna obavijest",
+  "devToolsTestNotificationBody": "Ako ovo vidite, isporuka obavijesti operativnog sustava radi."
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "U punom zaslonu, traka kartica",
   "appSettingsFullscreenTabStripHidden": "Skriveno",
   "appSettingsFullscreenTabStripAlways": "Uvijek vidljivo",
-  "appSettingsFullscreenTabStripButton": "Prikaži gumbom"
+  "appSettingsFullscreenTabStripButton": "Prikaži gumbom",
+  "devToolsSimulateRefresh": "Simuliraj osvježavanje u pozadini",
+  "devToolsSimulateRefreshDone": "Stranice s obavijestima ponovno su učitane (pogledajte zapisnike)",
+  "devToolsTestNotification": "Pošalji probnu obavijest",
+  "devToolsTestNotificationSent": "Probna obavijest poslana (pogledajte zapisnike)",
+  "devToolsTestNotificationTitle": "WebSpace probna obavijest",
+  "devToolsTestNotificationBody": "Ako ovo vidite, isporuka obavijesti operativnog sustava radi."
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Teljes képernyőn, lapsáv",
   "appSettingsFullscreenTabStripHidden": "Rejtett",
   "appSettingsFullscreenTabStripAlways": "Mindig látható",
-  "appSettingsFullscreenTabStripButton": "Megjelenítés gombbal"
+  "appSettingsFullscreenTabStripButton": "Megjelenítés gombbal",
+  "devToolsSimulateRefresh": "Háttérfrissítés szimulálása",
+  "devToolsSimulateRefreshDone": "Értesítési oldalak újratöltve (lásd a naplókat)",
+  "devToolsTestNotification": "Tesztértesítés küldése",
+  "devToolsTestNotificationSent": "Tesztértesítés elküldve (lásd a naplókat)",
+  "devToolsTestNotificationTitle": "WebSpace tesztértesítés",
+  "devToolsTestNotificationBody": "Ha ezt látja, az operációs rendszer értesítéskézbesítése működik."
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Teljes képernyőn, lapsáv",
   "appSettingsFullscreenTabStripHidden": "Rejtett",
   "appSettingsFullscreenTabStripAlways": "Mindig látható",
-  "appSettingsFullscreenTabStripButton": "Megjelenítés gombbal"
+  "appSettingsFullscreenTabStripButton": "Megjelenítés gombbal",
+  "devToolsSimulateRefresh": "Háttérfrissítés szimulálása",
+  "devToolsSimulateRefreshDone": "Értesítési oldalak újratöltve (lásd a naplókat)",
+  "devToolsTestNotification": "Tesztértesítés küldése",
+  "devToolsTestNotificationSent": "Tesztértesítés elküldve (lásd a naplókat)",
+  "devToolsTestNotificationTitle": "WebSpace tesztértesítés",
+  "devToolsTestNotificationBody": "Ha ezt látja, az operációs rendszer értesítéskézbesítése működik."
 }

--- a/lib/l10n/app_hy.arb
+++ b/lib/l10n/app_hy.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Ամբողջ էկրանին, ներդիրների գոտի",
   "appSettingsFullscreenTabStripHidden": "Թաքնված",
   "appSettingsFullscreenTabStripAlways": "Միշտ տեսանելի",
-  "appSettingsFullscreenTabStripButton": "Ցուցադրել կոճակով"
+  "appSettingsFullscreenTabStripButton": "Ցուցադրել կոճակով",
+  "devToolsSimulateRefresh": "Նմանակել ֆոնային թարմացումը",
+  "devToolsSimulateRefreshDone": "Ծանուցումների կայքերը վերաբեռնվել են (տես մատյանները)",
+  "devToolsTestNotification": "Ուղարկել փորձնական ծանուցում",
+  "devToolsTestNotificationSent": "Փորձնական ծանուցումն ուղարկվել է (տես մատյանները)",
+  "devToolsTestNotificationTitle": "WebSpace փորձնական ծանուցում",
+  "devToolsTestNotificationBody": "Եթե տեսնում եք սա, օպերացիոն համակարգի ծանուցումների առաքումն աշխատում է:"
 }

--- a/lib/l10n/app_hy.arb
+++ b/lib/l10n/app_hy.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Ամբողջ էկրանին, ներդիրների գոտի",
   "appSettingsFullscreenTabStripHidden": "Թաքնված",
   "appSettingsFullscreenTabStripAlways": "Միշտ տեսանելի",
-  "appSettingsFullscreenTabStripButton": "Ցուցադրել կոճակով"
+  "appSettingsFullscreenTabStripButton": "Ցուցադրել կոճակով",
+  "devToolsSimulateRefresh": "Նմանակել ֆոնային թարմացումը",
+  "devToolsSimulateRefreshDone": "Ծանուցումների կայքերը վերաբեռնվել են (տես մատյանները)",
+  "devToolsTestNotification": "Ուղարկել փորձնական ծանուցում",
+  "devToolsTestNotificationSent": "Փորձնական ծանուցումն ուղարկվել է (տես մատյանները)",
+  "devToolsTestNotificationTitle": "WebSpace փորձնական ծանուցում",
+  "devToolsTestNotificationBody": "Եթե տեսնում եք սա, օպերացիոն համակարգի ծանուցումների առաքումն աշխատում է:"
 }

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Di layar penuh, bilah tab",
   "appSettingsFullscreenTabStripHidden": "Tersembunyi",
   "appSettingsFullscreenTabStripAlways": "Selalu terlihat",
-  "appSettingsFullscreenTabStripButton": "Tampilkan dengan tombol"
+  "appSettingsFullscreenTabStripButton": "Tampilkan dengan tombol",
+  "devToolsSimulateRefresh": "Simulasikan penyegaran latar belakang",
+  "devToolsSimulateRefreshDone": "Situs notifikasi dimuat ulang (lihat log)",
+  "devToolsTestNotification": "Kirim notifikasi uji",
+  "devToolsTestNotificationSent": "Notifikasi uji terkirim (lihat log)",
+  "devToolsTestNotificationTitle": "Notifikasi uji WebSpace",
+  "devToolsTestNotificationBody": "Jika Anda dapat melihat ini, pengiriman notifikasi sistem operasi berfungsi."
 }

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Di layar penuh, bilah tab",
   "appSettingsFullscreenTabStripHidden": "Tersembunyi",
   "appSettingsFullscreenTabStripAlways": "Selalu terlihat",
-  "appSettingsFullscreenTabStripButton": "Tampilkan dengan tombol"
+  "appSettingsFullscreenTabStripButton": "Tampilkan dengan tombol",
+  "devToolsSimulateRefresh": "Simulasikan penyegaran latar belakang",
+  "devToolsSimulateRefreshDone": "Situs notifikasi dimuat ulang (lihat log)",
+  "devToolsTestNotification": "Kirim notifikasi uji",
+  "devToolsTestNotificationSent": "Notifikasi uji terkirim (lihat log)",
+  "devToolsTestNotificationTitle": "Notifikasi uji WebSpace",
+  "devToolsTestNotificationBody": "Jika Anda dapat melihat ini, pengiriman notifikasi sistem operasi berfungsi."
 }

--- a/lib/l10n/app_is.arb
+++ b/lib/l10n/app_is.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Í fullum skjá, flipastika",
   "appSettingsFullscreenTabStripHidden": "Falin",
   "appSettingsFullscreenTabStripAlways": "Alltaf sýnileg",
-  "appSettingsFullscreenTabStripButton": "Birta með hnappi"
+  "appSettingsFullscreenTabStripButton": "Birta með hnappi",
+  "devToolsSimulateRefresh": "Líkja eftir bakgrunnsendurnýjun",
+  "devToolsSimulateRefreshDone": "Tilkynningasíður endurhlaðnar (sjá annála)",
+  "devToolsTestNotification": "Senda prufutilkynningu",
+  "devToolsTestNotificationSent": "Prufutilkynning send (sjá annála)",
+  "devToolsTestNotificationTitle": "WebSpace prufutilkynning",
+  "devToolsTestNotificationBody": "Ef þú sérð þetta virkar afhending tilkynninga stýrikerfisins."
 }

--- a/lib/l10n/app_is.arb
+++ b/lib/l10n/app_is.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Í fullum skjá, flipastika",
   "appSettingsFullscreenTabStripHidden": "Falin",
   "appSettingsFullscreenTabStripAlways": "Alltaf sýnileg",
-  "appSettingsFullscreenTabStripButton": "Birta með hnappi"
+  "appSettingsFullscreenTabStripButton": "Birta með hnappi",
+  "devToolsSimulateRefresh": "Líkja eftir bakgrunnsendurnýjun",
+  "devToolsSimulateRefreshDone": "Tilkynningasíður endurhlaðnar (sjá annála)",
+  "devToolsTestNotification": "Senda prufutilkynningu",
+  "devToolsTestNotificationSent": "Prufutilkynning send (sjá annála)",
+  "devToolsTestNotificationTitle": "WebSpace prufutilkynning",
+  "devToolsTestNotificationBody": "Ef þú sérð þetta virkar afhending tilkynninga stýrikerfisins."
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "A schermo intero, barra delle schede",
   "appSettingsFullscreenTabStripHidden": "Nascosta",
   "appSettingsFullscreenTabStripAlways": "Sempre visibile",
-  "appSettingsFullscreenTabStripButton": "Mostra con un pulsante"
+  "appSettingsFullscreenTabStripButton": "Mostra con un pulsante",
+  "devToolsSimulateRefresh": "Simula aggiornamento in background",
+  "devToolsSimulateRefreshDone": "Siti di notifica ricaricati (vedi i registri)",
+  "devToolsTestNotification": "Invia notifica di prova",
+  "devToolsTestNotificationSent": "Notifica di prova inviata (vedi i registri)",
+  "devToolsTestNotificationTitle": "Notifica di prova WebSpace",
+  "devToolsTestNotificationBody": "Se riesci a vedere questo, la consegna delle notifiche del sistema operativo funziona."
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "A schermo intero, barra delle schede",
   "appSettingsFullscreenTabStripHidden": "Nascosta",
   "appSettingsFullscreenTabStripAlways": "Sempre visibile",
-  "appSettingsFullscreenTabStripButton": "Mostra con un pulsante"
+  "appSettingsFullscreenTabStripButton": "Mostra con un pulsante",
+  "devToolsSimulateRefresh": "Simula aggiornamento in background",
+  "devToolsSimulateRefreshDone": "Siti di notifica ricaricati (vedi i registri)",
+  "devToolsTestNotification": "Invia notifica di prova",
+  "devToolsTestNotificationSent": "Notifica di prova inviata (vedi i registri)",
+  "devToolsTestNotificationTitle": "Notifica di prova WebSpace",
+  "devToolsTestNotificationBody": "Se riesci a vedere questo, la consegna delle notifiche del sistema operativo funziona."
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "全画面でのタブバー",
   "appSettingsFullscreenTabStripHidden": "非表示",
   "appSettingsFullscreenTabStripAlways": "常に表示",
-  "appSettingsFullscreenTabStripButton": "ボタンで表示"
+  "appSettingsFullscreenTabStripButton": "ボタンで表示",
+  "devToolsSimulateRefresh": "バックグラウンド更新をシミュレート",
+  "devToolsSimulateRefreshDone": "通知サイトを再読み込みしました（ログを参照）",
+  "devToolsTestNotification": "テスト通知を送信",
+  "devToolsTestNotificationSent": "テスト通知を送信しました（ログを参照）",
+  "devToolsTestNotificationTitle": "WebSpace テスト通知",
+  "devToolsTestNotificationBody": "これが表示されている場合、OSの通知配信は正常に機能しています。"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "全画面でのタブバー",
   "appSettingsFullscreenTabStripHidden": "非表示",
   "appSettingsFullscreenTabStripAlways": "常に表示",
-  "appSettingsFullscreenTabStripButton": "ボタンで表示"
+  "appSettingsFullscreenTabStripButton": "ボタンで表示",
+  "devToolsSimulateRefresh": "バックグラウンド更新をシミュレート",
+  "devToolsSimulateRefreshDone": "通知サイトを再読み込みしました（ログを参照）",
+  "devToolsTestNotification": "テスト通知を送信",
+  "devToolsTestNotificationSent": "テスト通知を送信しました（ログを参照）",
+  "devToolsTestNotificationTitle": "WebSpace テスト通知",
+  "devToolsTestNotificationBody": "これが表示されている場合、OSの通知配信は正常に機能しています。"
 }

--- a/lib/l10n/app_ka.arb
+++ b/lib/l10n/app_ka.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "სრულ ეკრანზე, ჩანართების ზოლი",
   "appSettingsFullscreenTabStripHidden": "დამალული",
   "appSettingsFullscreenTabStripAlways": "ყოველთვის ხილული",
-  "appSettingsFullscreenTabStripButton": "ღილაკით გამოჩენა"
+  "appSettingsFullscreenTabStripButton": "ღილაკით გამოჩენა",
+  "devToolsSimulateRefresh": "ფონური განახლების სიმულაცია",
+  "devToolsSimulateRefreshDone": "შეტყობინების საიტები ხელახლა ჩაიტვირთა (იხილეთ ჟურნალები)",
+  "devToolsTestNotification": "სატესტო შეტყობინების გაგზავნა",
+  "devToolsTestNotificationSent": "სატესტო შეტყობინება გაიგზავნა (იხილეთ ჟურნალები)",
+  "devToolsTestNotificationTitle": "WebSpace-ის სატესტო შეტყობინება",
+  "devToolsTestNotificationBody": "თუ ამას ხედავთ, ოპერაციული სისტემის შეტყობინებების მიწოდება მუშაობს."
 }

--- a/lib/l10n/app_ka.arb
+++ b/lib/l10n/app_ka.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "სრულ ეკრანზე, ჩანართების ზოლი",
   "appSettingsFullscreenTabStripHidden": "დამალული",
   "appSettingsFullscreenTabStripAlways": "ყოველთვის ხილული",
-  "appSettingsFullscreenTabStripButton": "ღილაკით გამოჩენა"
+  "appSettingsFullscreenTabStripButton": "ღილაკით გამოჩენა",
+  "devToolsSimulateRefresh": "ფონური განახლების სიმულაცია",
+  "devToolsSimulateRefreshDone": "შეტყობინების საიტები ხელახლა ჩაიტვირთა (იხილეთ ჟურნალები)",
+  "devToolsTestNotification": "სატესტო შეტყობინების გაგზავნა",
+  "devToolsTestNotificationSent": "სატესტო შეტყობინება გაიგზავნა (იხილეთ ჟურნალები)",
+  "devToolsTestNotificationTitle": "WebSpace-ის სატესტო შეტყობინება",
+  "devToolsTestNotificationBody": "თუ ამას ხედავთ, ოპერაციული სისტემის შეტყობინებების მიწოდება მუშაობს."
 }

--- a/lib/l10n/app_km.arb
+++ b/lib/l10n/app_km.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "ក្នុងអេក្រង់ពេញ របារផ្ទាំង",
   "appSettingsFullscreenTabStripHidden": "លាក់",
   "appSettingsFullscreenTabStripAlways": "បង្ហាញជានិច្ច",
-  "appSettingsFullscreenTabStripButton": "បង្ហាញដោយប៊ូតុង"
+  "appSettingsFullscreenTabStripButton": "បង្ហាញដោយប៊ូតុង",
+  "devToolsSimulateRefresh": "ក្លែងធ្វើការផ្ទុកឡើងវិញនៅផ្ទៃខាងក្រោយ",
+  "devToolsSimulateRefreshDone": "បានផ្ទុកគេហទំព័រជូនដំណឹងឡើងវិញ (មើលកំណត់ហេតុ)",
+  "devToolsTestNotification": "ផ្ញើការជូនដំណឹងសាកល្បង",
+  "devToolsTestNotificationSent": "បានផ្ញើការជូនដំណឹងសាកល្បង (មើលកំណត់ហេតុ)",
+  "devToolsTestNotificationTitle": "ការជូនដំណឹងសាកល្បង WebSpace",
+  "devToolsTestNotificationBody": "ប្រសិនបើអ្នកអាចមើលឃើញវា ការផ្ញើការជូនដំណឹងរបស់ប្រព័ន្ធប្រតិបត្តិការដំណើរការ។"
 }

--- a/lib/l10n/app_km.arb
+++ b/lib/l10n/app_km.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "ក្នុងអេក្រង់ពេញ របារផ្ទាំង",
   "appSettingsFullscreenTabStripHidden": "លាក់",
   "appSettingsFullscreenTabStripAlways": "បង្ហាញជានិច្ច",
-  "appSettingsFullscreenTabStripButton": "បង្ហាញដោយប៊ូតុង"
+  "appSettingsFullscreenTabStripButton": "បង្ហាញដោយប៊ូតុង",
+  "devToolsSimulateRefresh": "ក្លែងធ្វើការផ្ទុកឡើងវិញនៅផ្ទៃខាងក្រោយ",
+  "devToolsSimulateRefreshDone": "បានផ្ទុកគេហទំព័រជូនដំណឹងឡើងវិញ (មើលកំណត់ហេតុ)",
+  "devToolsTestNotification": "ផ្ញើការជូនដំណឹងសាកល្បង",
+  "devToolsTestNotificationSent": "បានផ្ញើការជូនដំណឹងសាកល្បង (មើលកំណត់ហេតុ)",
+  "devToolsTestNotificationTitle": "ការជូនដំណឹងសាកល្បង WebSpace",
+  "devToolsTestNotificationBody": "ប្រសិនបើអ្នកអាចមើលឃើញវា ការផ្ញើការជូនដំណឹងរបស់ប្រព័ន្ធប្រតិបត្តិការដំណើរការ។"
 }

--- a/lib/l10n/app_kn.arb
+++ b/lib/l10n/app_kn.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "ಪೂರ್ಣ ಪರದೆಯಲ್ಲಿ, ಟ್ಯಾಬ್ ಬಾರ್",
   "appSettingsFullscreenTabStripHidden": "ಮರೆಮಾಡಲಾಗಿದೆ",
   "appSettingsFullscreenTabStripAlways": "ಯಾವಾಗಲೂ ಗೋಚರ",
-  "appSettingsFullscreenTabStripButton": "ಬಟನ್‌ನಿಂದ ತೋರಿಸಿ"
+  "appSettingsFullscreenTabStripButton": "ಬಟನ್‌ನಿಂದ ತೋರಿಸಿ",
+  "devToolsSimulateRefresh": "ಹಿನ್ನೆಲೆ ರಿಫ್ರೆಶ್ ಅನ್ನು ಅನುಕರಿಸಿ",
+  "devToolsSimulateRefreshDone": "ಅಧಿಸೂಚನೆ ಸೈಟ್‌ಗಳನ್ನು ಮರುಲೋಡ್ ಮಾಡಲಾಗಿದೆ (ಲಾಗ್‌ಗಳನ್ನು ನೋಡಿ)",
+  "devToolsTestNotification": "ಪರೀಕ್ಷಾ ಅಧಿಸೂಚನೆ ಕಳುಹಿಸಿ",
+  "devToolsTestNotificationSent": "ಪರೀಕ್ಷಾ ಅಧಿಸೂಚನೆ ಕಳುಹಿಸಲಾಗಿದೆ (ಲಾಗ್‌ಗಳನ್ನು ನೋಡಿ)",
+  "devToolsTestNotificationTitle": "WebSpace ಪರೀಕ್ಷಾ ಅಧಿಸೂಚನೆ",
+  "devToolsTestNotificationBody": "ಇದು ನಿಮಗೆ ಕಾಣಿಸಿದರೆ, ಆಪರೇಟಿಂಗ್ ಸಿಸ್ಟಂನ ಅಧಿಸೂಚನೆ ವಿತರಣೆ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತಿದೆ."
 }

--- a/lib/l10n/app_kn.arb
+++ b/lib/l10n/app_kn.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "ಪೂರ್ಣ ಪರದೆಯಲ್ಲಿ, ಟ್ಯಾಬ್ ಬಾರ್",
   "appSettingsFullscreenTabStripHidden": "ಮರೆಮಾಡಲಾಗಿದೆ",
   "appSettingsFullscreenTabStripAlways": "ಯಾವಾಗಲೂ ಗೋಚರ",
-  "appSettingsFullscreenTabStripButton": "ಬಟನ್‌ನಿಂದ ತೋರಿಸಿ"
+  "appSettingsFullscreenTabStripButton": "ಬಟನ್‌ನಿಂದ ತೋರಿಸಿ",
+  "devToolsSimulateRefresh": "ಹಿನ್ನೆಲೆ ರಿಫ್ರೆಶ್ ಅನ್ನು ಅನುಕರಿಸಿ",
+  "devToolsSimulateRefreshDone": "ಅಧಿಸೂಚನೆ ಸೈಟ್‌ಗಳನ್ನು ಮರುಲೋಡ್ ಮಾಡಲಾಗಿದೆ (ಲಾಗ್‌ಗಳನ್ನು ನೋಡಿ)",
+  "devToolsTestNotification": "ಪರೀಕ್ಷಾ ಅಧಿಸೂಚನೆ ಕಳುಹಿಸಿ",
+  "devToolsTestNotificationSent": "ಪರೀಕ್ಷಾ ಅಧಿಸೂಚನೆ ಕಳುಹಿಸಲಾಗಿದೆ (ಲಾಗ್‌ಗಳನ್ನು ನೋಡಿ)",
+  "devToolsTestNotificationTitle": "WebSpace ಪರೀಕ್ಷಾ ಅಧಿಸೂಚನೆ",
+  "devToolsTestNotificationBody": "ಇದು ನಿಮಗೆ ಕಾಣಿಸಿದರೆ, ಆಪರೇಟಿಂಗ್ ಸಿಸ್ಟಂನ ಅಧಿಸೂಚನೆ ವಿತರಣೆ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತಿದೆ."
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "전체 화면에서 탭 바",
   "appSettingsFullscreenTabStripHidden": "숨김",
   "appSettingsFullscreenTabStripAlways": "항상 표시",
-  "appSettingsFullscreenTabStripButton": "버튼으로 표시"
+  "appSettingsFullscreenTabStripButton": "버튼으로 표시",
+  "devToolsSimulateRefresh": "백그라운드 새로 고침 시뮬레이션",
+  "devToolsSimulateRefreshDone": "알림 사이트를 다시 로드했습니다 (로그 참조)",
+  "devToolsTestNotification": "테스트 알림 보내기",
+  "devToolsTestNotificationSent": "테스트 알림을 보냈습니다 (로그 참조)",
+  "devToolsTestNotificationTitle": "WebSpace 테스트 알림",
+  "devToolsTestNotificationBody": "이것이 보이면 운영 체제의 알림 전송이 작동합니다."
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "전체 화면에서 탭 바",
   "appSettingsFullscreenTabStripHidden": "숨김",
   "appSettingsFullscreenTabStripAlways": "항상 표시",
-  "appSettingsFullscreenTabStripButton": "버튼으로 표시"
+  "appSettingsFullscreenTabStripButton": "버튼으로 표시",
+  "devToolsSimulateRefresh": "백그라운드 새로 고침 시뮬레이션",
+  "devToolsSimulateRefreshDone": "알림 사이트를 다시 로드했습니다 (로그 참조)",
+  "devToolsTestNotification": "테스트 알림 보내기",
+  "devToolsTestNotificationSent": "테스트 알림을 보냈습니다 (로그 참조)",
+  "devToolsTestNotificationTitle": "WebSpace 테스트 알림",
+  "devToolsTestNotificationBody": "이것이 보이면 운영 체제의 알림 전송이 작동합니다."
 }

--- a/lib/l10n/app_la.arb
+++ b/lib/l10n/app_la.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "In pleno schemate, series tabularum",
   "appSettingsFullscreenTabStripHidden": "Occultata",
   "appSettingsFullscreenTabStripAlways": "Semper visibilis",
-  "appSettingsFullscreenTabStripButton": "Bulla ostendere"
+  "appSettingsFullscreenTabStripButton": "Bulla ostendere",
+  "devToolsSimulateRefresh": "Renovationem in fundo simulare",
+  "devToolsSimulateRefreshDone": "Loci nuntiationis iterum onerati sunt (vide acta)",
+  "devToolsTestNotification": "Nuntiationem probatoriam mittere",
+  "devToolsTestNotificationSent": "Nuntiatio probatoria missa est (vide acta)",
+  "devToolsTestNotificationTitle": "Nuntiatio probatoria WebSpace",
+  "devToolsTestNotificationBody": "Si hoc videre potes, traditio nuntiationum systematis operandi operatur."
 }

--- a/lib/l10n/app_la.arb
+++ b/lib/l10n/app_la.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "In pleno schemate, series tabularum",
   "appSettingsFullscreenTabStripHidden": "Occultata",
   "appSettingsFullscreenTabStripAlways": "Semper visibilis",
-  "appSettingsFullscreenTabStripButton": "Bulla ostendere"
+  "appSettingsFullscreenTabStripButton": "Bulla ostendere",
+  "devToolsSimulateRefresh": "Renovationem in fundo simulare",
+  "devToolsSimulateRefreshDone": "Loci nuntiationis iterum onerati sunt (vide acta)",
+  "devToolsTestNotification": "Nuntiationem probatoriam mittere",
+  "devToolsTestNotificationSent": "Nuntiatio probatoria missa est (vide acta)",
+  "devToolsTestNotificationTitle": "Nuntiatio probatoria WebSpace",
+  "devToolsTestNotificationBody": "Si hoc videre potes, traditio nuntiationum systematis operandi operatur."
 }

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Viso ekrano režime, kortelių juosta",
   "appSettingsFullscreenTabStripHidden": "Paslėpta",
   "appSettingsFullscreenTabStripAlways": "Visada matoma",
-  "appSettingsFullscreenTabStripButton": "Rodyti mygtuku"
+  "appSettingsFullscreenTabStripButton": "Rodyti mygtuku",
+  "devToolsSimulateRefresh": "Imituoti foninį atnaujinimą",
+  "devToolsSimulateRefreshDone": "Pranešimų svetainės įkeltos iš naujo (žr. žurnalus)",
+  "devToolsTestNotification": "Siųsti bandomąjį pranešimą",
+  "devToolsTestNotificationSent": "Bandomasis pranešimas išsiųstas (žr. žurnalus)",
+  "devToolsTestNotificationTitle": "WebSpace bandomasis pranešimas",
+  "devToolsTestNotificationBody": "Jei tai matote, operacinės sistemos pranešimų pristatymas veikia."
 }

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Viso ekrano režime, kortelių juosta",
   "appSettingsFullscreenTabStripHidden": "Paslėpta",
   "appSettingsFullscreenTabStripAlways": "Visada matoma",
-  "appSettingsFullscreenTabStripButton": "Rodyti mygtuku"
+  "appSettingsFullscreenTabStripButton": "Rodyti mygtuku",
+  "devToolsSimulateRefresh": "Imituoti foninį atnaujinimą",
+  "devToolsSimulateRefreshDone": "Pranešimų svetainės įkeltos iš naujo (žr. žurnalus)",
+  "devToolsTestNotification": "Siųsti bandomąjį pranešimą",
+  "devToolsTestNotificationSent": "Bandomasis pranešimas išsiųstas (žr. žurnalus)",
+  "devToolsTestNotificationTitle": "WebSpace bandomasis pranešimas",
+  "devToolsTestNotificationBody": "Jei tai matote, operacinės sistemos pranešimų pristatymas veikia."
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Pilnekrānā, ciļņu josla",
   "appSettingsFullscreenTabStripHidden": "Slēpta",
   "appSettingsFullscreenTabStripAlways": "Vienmēr redzama",
-  "appSettingsFullscreenTabStripButton": "Rādīt ar pogu"
+  "appSettingsFullscreenTabStripButton": "Rādīt ar pogu",
+  "devToolsSimulateRefresh": "Simulēt fona atsvaidzināšanu",
+  "devToolsSimulateRefreshDone": "Paziņojumu vietnes pārlādētas (skatiet žurnālus)",
+  "devToolsTestNotification": "Sūtīt testa paziņojumu",
+  "devToolsTestNotificationSent": "Testa paziņojums nosūtīts (skatiet žurnālus)",
+  "devToolsTestNotificationTitle": "WebSpace testa paziņojums",
+  "devToolsTestNotificationBody": "Ja redzat šo, operētājsistēmas paziņojumu piegāde darbojas."
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Pilnekrānā, ciļņu josla",
   "appSettingsFullscreenTabStripHidden": "Slēpta",
   "appSettingsFullscreenTabStripAlways": "Vienmēr redzama",
-  "appSettingsFullscreenTabStripButton": "Rādīt ar pogu"
+  "appSettingsFullscreenTabStripButton": "Rādīt ar pogu",
+  "devToolsSimulateRefresh": "Simulēt fona atsvaidzināšanu",
+  "devToolsSimulateRefreshDone": "Paziņojumu vietnes pārlādētas (skatiet žurnālus)",
+  "devToolsTestNotification": "Sūtīt testa paziņojumu",
+  "devToolsTestNotificationSent": "Testa paziņojums nosūtīts (skatiet žurnālus)",
+  "devToolsTestNotificationTitle": "WebSpace testa paziņojums",
+  "devToolsTestNotificationBody": "Ja redzat šo, operētājsistēmas paziņojumu piegāde darbojas."
 }

--- a/lib/l10n/app_mk.arb
+++ b/lib/l10n/app_mk.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "На цел екран, лента со јазичиња",
   "appSettingsFullscreenTabStripHidden": "Скриено",
   "appSettingsFullscreenTabStripAlways": "Секогаш видливо",
-  "appSettingsFullscreenTabStripButton": "Прикажи со копче"
+  "appSettingsFullscreenTabStripButton": "Прикажи со копче",
+  "devToolsSimulateRefresh": "Симулирај освежување во заднина",
+  "devToolsSimulateRefreshDone": "Сајтовите за известувања се повторно вчитани (видете ги дневниците)",
+  "devToolsTestNotification": "Испрати тестно известување",
+  "devToolsTestNotificationSent": "Тестното известување е испратено (видете ги дневниците)",
+  "devToolsTestNotificationTitle": "WebSpace тестно известување",
+  "devToolsTestNotificationBody": "Ако го гледате ова, испораката на известувања на оперативниот систем работи."
 }

--- a/lib/l10n/app_mk.arb
+++ b/lib/l10n/app_mk.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "На цел екран, лента со јазичиња",
   "appSettingsFullscreenTabStripHidden": "Скриено",
   "appSettingsFullscreenTabStripAlways": "Секогаш видливо",
-  "appSettingsFullscreenTabStripButton": "Прикажи со копче"
+  "appSettingsFullscreenTabStripButton": "Прикажи со копче",
+  "devToolsSimulateRefresh": "Симулирај освежување во заднина",
+  "devToolsSimulateRefreshDone": "Сајтовите за известувања се повторно вчитани (видете ги дневниците)",
+  "devToolsTestNotification": "Испрати тестно известување",
+  "devToolsTestNotificationSent": "Тестното известување е испратено (видете ги дневниците)",
+  "devToolsTestNotificationTitle": "WebSpace тестно известување",
+  "devToolsTestNotificationBody": "Ако го гледате ова, испораката на известувања на оперативниот систем работи."
 }

--- a/lib/l10n/app_ml.arb
+++ b/lib/l10n/app_ml.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "പൂർണ്ണ സ്ക്രീനിൽ, ടാബ് ബാർ",
   "appSettingsFullscreenTabStripHidden": "മറച്ചിരിക്കുന്നു",
   "appSettingsFullscreenTabStripAlways": "എപ്പോഴും ദൃശ്യം",
-  "appSettingsFullscreenTabStripButton": "ബട്ടൺ ഉപയോഗിച്ച് കാണിക്കുക"
+  "appSettingsFullscreenTabStripButton": "ബട്ടൺ ഉപയോഗിച്ച് കാണിക്കുക",
+  "devToolsSimulateRefresh": "പശ്ചാത്തല പുതുക്കൽ അനുകരിക്കുക",
+  "devToolsSimulateRefreshDone": "അറിയിപ്പ് സൈറ്റുകൾ വീണ്ടും ലോഡ് ചെയ്തു (ലോഗുകൾ കാണുക)",
+  "devToolsTestNotification": "ടെസ്റ്റ് അറിയിപ്പ് അയയ്ക്കുക",
+  "devToolsTestNotificationSent": "ടെസ്റ്റ് അറിയിപ്പ് അയച്ചു (ലോഗുകൾ കാണുക)",
+  "devToolsTestNotificationTitle": "WebSpace ടെസ്റ്റ് അറിയിപ്പ്",
+  "devToolsTestNotificationBody": "ഇത് നിങ്ങൾക്ക് കാണാൻ കഴിയുമെങ്കിൽ, ഓപ്പറേറ്റിംഗ് സിസ്റ്റത്തിന്റെ അറിയിപ്പ് വിതരണം പ്രവർത്തിക്കുന്നു."
 }

--- a/lib/l10n/app_ml.arb
+++ b/lib/l10n/app_ml.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "പൂർണ്ണ സ്ക്രീനിൽ, ടാബ് ബാർ",
   "appSettingsFullscreenTabStripHidden": "മറച്ചിരിക്കുന്നു",
   "appSettingsFullscreenTabStripAlways": "എപ്പോഴും ദൃശ്യം",
-  "appSettingsFullscreenTabStripButton": "ബട്ടൺ ഉപയോഗിച്ച് കാണിക്കുക"
+  "appSettingsFullscreenTabStripButton": "ബട്ടൺ ഉപയോഗിച്ച് കാണിക്കുക",
+  "devToolsSimulateRefresh": "പശ്ചാത്തല പുതുക്കൽ അനുകരിക്കുക",
+  "devToolsSimulateRefreshDone": "അറിയിപ്പ് സൈറ്റുകൾ വീണ്ടും ലോഡ് ചെയ്തു (ലോഗുകൾ കാണുക)",
+  "devToolsTestNotification": "ടെസ്റ്റ് അറിയിപ്പ് അയയ്ക്കുക",
+  "devToolsTestNotificationSent": "ടെസ്റ്റ് അറിയിപ്പ് അയച്ചു (ലോഗുകൾ കാണുക)",
+  "devToolsTestNotificationTitle": "WebSpace ടെസ്റ്റ് അറിയിപ്പ്",
+  "devToolsTestNotificationBody": "ഇത് നിങ്ങൾക്ക് കാണാൻ കഴിയുമെങ്കിൽ, ഓപ്പറേറ്റിംഗ് സിസ്റ്റത്തിന്റെ അറിയിപ്പ് വിതരണം പ്രവർത്തിക്കുന്നു."
 }

--- a/lib/l10n/app_mn.arb
+++ b/lib/l10n/app_mn.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Бүтэн дэлгэцэд, таб самбар",
   "appSettingsFullscreenTabStripHidden": "Нуусан",
   "appSettingsFullscreenTabStripAlways": "Үргэлж харагдана",
-  "appSettingsFullscreenTabStripButton": "Товчоор харуулах"
+  "appSettingsFullscreenTabStripButton": "Товчоор харуулах",
+  "devToolsSimulateRefresh": "Дэвсгэр шинэчлэлтийг загварчлах",
+  "devToolsSimulateRefreshDone": "Мэдэгдлийн сайтуудыг дахин ачааллаа (бүртгэлийг харна уу)",
+  "devToolsTestNotification": "Туршилтын мэдэгдэл илгээх",
+  "devToolsTestNotificationSent": "Туршилтын мэдэгдэл илгээгдсэн (бүртгэлийг харна уу)",
+  "devToolsTestNotificationTitle": "WebSpace туршилтын мэдэгдэл",
+  "devToolsTestNotificationBody": "Хэрэв та үүнийг харж байгаа бол үйлдлийн системийн мэдэгдэл хүргэлт ажиллаж байна."
 }

--- a/lib/l10n/app_mn.arb
+++ b/lib/l10n/app_mn.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Бүтэн дэлгэцэд, таб самбар",
   "appSettingsFullscreenTabStripHidden": "Нуусан",
   "appSettingsFullscreenTabStripAlways": "Үргэлж харагдана",
-  "appSettingsFullscreenTabStripButton": "Товчоор харуулах"
+  "appSettingsFullscreenTabStripButton": "Товчоор харуулах",
+  "devToolsSimulateRefresh": "Дэвсгэр шинэчлэлтийг загварчлах",
+  "devToolsSimulateRefreshDone": "Мэдэгдлийн сайтуудыг дахин ачааллаа (бүртгэлийг харна уу)",
+  "devToolsTestNotification": "Туршилтын мэдэгдэл илгээх",
+  "devToolsTestNotificationSent": "Туршилтын мэдэгдэл илгээгдсэн (бүртгэлийг харна уу)",
+  "devToolsTestNotificationTitle": "WebSpace туршилтын мэдэгдэл",
+  "devToolsTestNotificationBody": "Хэрэв та үүнийг харж байгаа бол үйлдлийн системийн мэдэгдэл хүргэлт ажиллаж байна."
 }

--- a/lib/l10n/app_mr.arb
+++ b/lib/l10n/app_mr.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "पूर्ण स्क्रीनमध्ये, टॅब बार",
   "appSettingsFullscreenTabStripHidden": "लपवलेले",
   "appSettingsFullscreenTabStripAlways": "नेहमी दृश्यमान",
-  "appSettingsFullscreenTabStripButton": "बटणाने दाखवा"
+  "appSettingsFullscreenTabStripButton": "बटणाने दाखवा",
+  "devToolsSimulateRefresh": "पार्श्वभूमी रिफ्रेशचे अनुकरण करा",
+  "devToolsSimulateRefreshDone": "सूचना साइट्स पुन्हा लोड केल्या (लॉग पाहा)",
+  "devToolsTestNotification": "चाचणी सूचना पाठवा",
+  "devToolsTestNotificationSent": "चाचणी सूचना पाठवली (लॉग पाहा)",
+  "devToolsTestNotificationTitle": "WebSpace चाचणी सूचना",
+  "devToolsTestNotificationBody": "तुम्हाला हे दिसत असल्यास, ऑपरेटिंग सिस्टमचे सूचना वितरण कार्य करत आहे."
 }

--- a/lib/l10n/app_mr.arb
+++ b/lib/l10n/app_mr.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "पूर्ण स्क्रीनमध्ये, टॅब बार",
   "appSettingsFullscreenTabStripHidden": "लपवलेले",
   "appSettingsFullscreenTabStripAlways": "नेहमी दृश्यमान",
-  "appSettingsFullscreenTabStripButton": "बटणाने दाखवा"
+  "appSettingsFullscreenTabStripButton": "बटणाने दाखवा",
+  "devToolsSimulateRefresh": "पार्श्वभूमी रिफ्रेशचे अनुकरण करा",
+  "devToolsSimulateRefreshDone": "सूचना साइट्स पुन्हा लोड केल्या (लॉग पाहा)",
+  "devToolsTestNotification": "चाचणी सूचना पाठवा",
+  "devToolsTestNotificationSent": "चाचणी सूचना पाठवली (लॉग पाहा)",
+  "devToolsTestNotificationTitle": "WebSpace चाचणी सूचना",
+  "devToolsTestNotificationBody": "तुम्हाला हे दिसत असल्यास, ऑपरेटिंग सिस्टमचे सूचना वितरण कार्य करत आहे."
 }

--- a/lib/l10n/app_ms.arb
+++ b/lib/l10n/app_ms.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Dalam skrin penuh, bar tab",
   "appSettingsFullscreenTabStripHidden": "Tersembunyi",
   "appSettingsFullscreenTabStripAlways": "Sentiasa kelihatan",
-  "appSettingsFullscreenTabStripButton": "Tunjukkan dengan butang"
+  "appSettingsFullscreenTabStripButton": "Tunjukkan dengan butang",
+  "devToolsSimulateRefresh": "Simulasikan penyegaran latar belakang",
+  "devToolsSimulateRefreshDone": "Tapak pemberitahuan dimuat semula (lihat log)",
+  "devToolsTestNotification": "Hantar pemberitahuan ujian",
+  "devToolsTestNotificationSent": "Pemberitahuan ujian dihantar (lihat log)",
+  "devToolsTestNotificationTitle": "Pemberitahuan ujian WebSpace",
+  "devToolsTestNotificationBody": "Jika anda dapat melihat ini, penghantaran pemberitahuan sistem pengendalian berfungsi."
 }

--- a/lib/l10n/app_ms.arb
+++ b/lib/l10n/app_ms.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Dalam skrin penuh, bar tab",
   "appSettingsFullscreenTabStripHidden": "Tersembunyi",
   "appSettingsFullscreenTabStripAlways": "Sentiasa kelihatan",
-  "appSettingsFullscreenTabStripButton": "Tunjukkan dengan butang"
+  "appSettingsFullscreenTabStripButton": "Tunjukkan dengan butang",
+  "devToolsSimulateRefresh": "Simulasikan penyegaran latar belakang",
+  "devToolsSimulateRefreshDone": "Tapak pemberitahuan dimuat semula (lihat log)",
+  "devToolsTestNotification": "Hantar pemberitahuan ujian",
+  "devToolsTestNotificationSent": "Pemberitahuan ujian dihantar (lihat log)",
+  "devToolsTestNotificationTitle": "Pemberitahuan ujian WebSpace",
+  "devToolsTestNotificationBody": "Jika anda dapat melihat ini, penghantaran pemberitahuan sistem pengendalian berfungsi."
 }

--- a/lib/l10n/app_mt.arb
+++ b/lib/l10n/app_mt.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Fl-iskrin sħiħ, bar tat-tabs",
   "appSettingsFullscreenTabStripHidden": "Moħbi",
   "appSettingsFullscreenTabStripAlways": "Dejjem viżibbli",
-  "appSettingsFullscreenTabStripButton": "Uri b'buttuna"
+  "appSettingsFullscreenTabStripButton": "Uri b'buttuna",
+  "devToolsSimulateRefresh": "Simula t-tiġdid fl-isfond",
+  "devToolsSimulateRefreshDone": "Is-siti tan-notifiki reġgħu ġew mgħobbija (ara r-reġistri)",
+  "devToolsTestNotification": "Ibgħat notifika ta' prova",
+  "devToolsTestNotificationSent": "In-notifika ta' prova ntbagħtet (ara r-reġistri)",
+  "devToolsTestNotificationTitle": "Notifika ta' prova WebSpace",
+  "devToolsTestNotificationBody": "Jekk tista' tara dan, il-konsenja tan-notifiki tas-sistema operattiva taħdem."
 }

--- a/lib/l10n/app_mt.arb
+++ b/lib/l10n/app_mt.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Fl-iskrin sħiħ, bar tat-tabs",
   "appSettingsFullscreenTabStripHidden": "Moħbi",
   "appSettingsFullscreenTabStripAlways": "Dejjem viżibbli",
-  "appSettingsFullscreenTabStripButton": "Uri b'buttuna"
+  "appSettingsFullscreenTabStripButton": "Uri b'buttuna",
+  "devToolsSimulateRefresh": "Simula t-tiġdid fl-isfond",
+  "devToolsSimulateRefreshDone": "Is-siti tan-notifiki reġgħu ġew mgħobbija (ara r-reġistri)",
+  "devToolsTestNotification": "Ibgħat notifika ta' prova",
+  "devToolsTestNotificationSent": "In-notifika ta' prova ntbagħtet (ara r-reġistri)",
+  "devToolsTestNotificationTitle": "Notifika ta' prova WebSpace",
+  "devToolsTestNotificationBody": "Jekk tista' tara dan, il-konsenja tan-notifiki tas-sistema operattiva taħdem."
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "I fullskjerm, fanelinje",
   "appSettingsFullscreenTabStripHidden": "Skjult",
   "appSettingsFullscreenTabStripAlways": "Alltid synlig",
-  "appSettingsFullscreenTabStripButton": "Vis med knapp"
+  "appSettingsFullscreenTabStripButton": "Vis med knapp",
+  "devToolsSimulateRefresh": "Simuler bakgrunnsoppdatering",
+  "devToolsSimulateRefreshDone": "Varselnettsteder lastet inn på nytt (se loggene)",
+  "devToolsTestNotification": "Send testvarsel",
+  "devToolsTestNotificationSent": "Testvarsel sendt (se loggene)",
+  "devToolsTestNotificationTitle": "WebSpace-testvarsel",
+  "devToolsTestNotificationBody": "Hvis du kan se dette, fungerer operativsystemets varsellevering."
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "I fullskjerm, fanelinje",
   "appSettingsFullscreenTabStripHidden": "Skjult",
   "appSettingsFullscreenTabStripAlways": "Alltid synlig",
-  "appSettingsFullscreenTabStripButton": "Vis med knapp"
+  "appSettingsFullscreenTabStripButton": "Vis med knapp",
+  "devToolsSimulateRefresh": "Simuler bakgrunnsoppdatering",
+  "devToolsSimulateRefreshDone": "Varselnettsteder lastet inn på nytt (se loggene)",
+  "devToolsTestNotification": "Send testvarsel",
+  "devToolsTestNotificationSent": "Testvarsel sendt (se loggene)",
+  "devToolsTestNotificationTitle": "WebSpace-testvarsel",
+  "devToolsTestNotificationBody": "Hvis du kan se dette, fungerer operativsystemets varsellevering."
 }

--- a/lib/l10n/app_ne.arb
+++ b/lib/l10n/app_ne.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "पूर्ण स्क्रिनमा, ट्याब बार",
   "appSettingsFullscreenTabStripHidden": "लुकाइएको",
   "appSettingsFullscreenTabStripAlways": "सधैं देखिने",
-  "appSettingsFullscreenTabStripButton": "बटनले देखाउनुहोस्"
+  "appSettingsFullscreenTabStripButton": "बटनले देखाउनुहोस्",
+  "devToolsSimulateRefresh": "पृष्ठभूमि रिफ्रेस सिमुलेट गर्नुहोस्",
+  "devToolsSimulateRefreshDone": "सूचना साइटहरू पुनः लोड भए (लगहरू हेर्नुहोस्)",
+  "devToolsTestNotification": "परीक्षण सूचना पठाउनुहोस्",
+  "devToolsTestNotificationSent": "परीक्षण सूचना पठाइयो (लगहरू हेर्नुहोस्)",
+  "devToolsTestNotificationTitle": "WebSpace परीक्षण सूचना",
+  "devToolsTestNotificationBody": "यदि तपाईं यो देख्न सक्नुहुन्छ भने, अपरेटिङ सिस्टमको सूचना वितरण काम गरिरहेको छ।"
 }

--- a/lib/l10n/app_ne.arb
+++ b/lib/l10n/app_ne.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "पूर्ण स्क्रिनमा, ट्याब बार",
   "appSettingsFullscreenTabStripHidden": "लुकाइएको",
   "appSettingsFullscreenTabStripAlways": "सधैं देखिने",
-  "appSettingsFullscreenTabStripButton": "बटनले देखाउनुहोस्"
+  "appSettingsFullscreenTabStripButton": "बटनले देखाउनुहोस्",
+  "devToolsSimulateRefresh": "पृष्ठभूमि रिफ्रेस सिमुलेट गर्नुहोस्",
+  "devToolsSimulateRefreshDone": "सूचना साइटहरू पुनः लोड भए (लगहरू हेर्नुहोस्)",
+  "devToolsTestNotification": "परीक्षण सूचना पठाउनुहोस्",
+  "devToolsTestNotificationSent": "परीक्षण सूचना पठाइयो (लगहरू हेर्नुहोस्)",
+  "devToolsTestNotificationTitle": "WebSpace परीक्षण सूचना",
+  "devToolsTestNotificationBody": "यदि तपाईं यो देख्न सक्नुहुन्छ भने, अपरेटिङ सिस्टमको सूचना वितरण काम गरिरहेको छ।"
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "In volledig scherm, tabbalk",
   "appSettingsFullscreenTabStripHidden": "Verborgen",
   "appSettingsFullscreenTabStripAlways": "Altijd zichtbaar",
-  "appSettingsFullscreenTabStripButton": "Tonen met knop"
+  "appSettingsFullscreenTabStripButton": "Tonen met knop",
+  "devToolsSimulateRefresh": "Achtergrondvernieuwing simuleren",
+  "devToolsSimulateRefreshDone": "Meldingssites opnieuw geladen (zie logboeken)",
+  "devToolsTestNotification": "Testmelding verzenden",
+  "devToolsTestNotificationSent": "Testmelding verzonden (zie logboeken)",
+  "devToolsTestNotificationTitle": "WebSpace-testmelding",
+  "devToolsTestNotificationBody": "Als je dit kunt zien, werkt de meldingslevering van het besturingssysteem."
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "In volledig scherm, tabbalk",
   "appSettingsFullscreenTabStripHidden": "Verborgen",
   "appSettingsFullscreenTabStripAlways": "Altijd zichtbaar",
-  "appSettingsFullscreenTabStripButton": "Tonen met knop"
+  "appSettingsFullscreenTabStripButton": "Tonen met knop",
+  "devToolsSimulateRefresh": "Achtergrondvernieuwing simuleren",
+  "devToolsSimulateRefreshDone": "Meldingssites opnieuw geladen (zie logboeken)",
+  "devToolsTestNotification": "Testmelding verzenden",
+  "devToolsTestNotificationSent": "Testmelding verzonden (zie logboeken)",
+  "devToolsTestNotificationTitle": "WebSpace-testmelding",
+  "devToolsTestNotificationBody": "Als je dit kunt zien, werkt de meldingslevering van het besturingssysteem."
 }

--- a/lib/l10n/app_pa.arb
+++ b/lib/l10n/app_pa.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "ਪੂਰੀ ਸਕ੍ਰੀਨ ਵਿੱਚ, ਟੈਬ ਬਾਰ",
   "appSettingsFullscreenTabStripHidden": "ਲੁਕਿਆ",
   "appSettingsFullscreenTabStripAlways": "ਹਮੇਸ਼ਾ ਦਿਖਾਈ ਦਿੰਦਾ",
-  "appSettingsFullscreenTabStripButton": "ਬਟਨ ਨਾਲ ਦਿਖਾਓ"
+  "appSettingsFullscreenTabStripButton": "ਬਟਨ ਨਾਲ ਦਿਖਾਓ",
+  "devToolsSimulateRefresh": "ਬੈਕਗ੍ਰਾਊਂਡ ਰਿਫਰੈਸ਼ ਦੀ ਨਕਲ ਕਰੋ",
+  "devToolsSimulateRefreshDone": "ਸੂਚਨਾ ਸਾਈਟਾਂ ਮੁੜ ਲੋਡ ਹੋਈਆਂ (ਲੌਗ ਵੇਖੋ)",
+  "devToolsTestNotification": "ਟੈਸਟ ਸੂਚਨਾ ਭੇਜੋ",
+  "devToolsTestNotificationSent": "ਟੈਸਟ ਸੂਚਨਾ ਭੇਜੀ ਗਈ (ਲੌਗ ਵੇਖੋ)",
+  "devToolsTestNotificationTitle": "WebSpace ਟੈਸਟ ਸੂਚਨਾ",
+  "devToolsTestNotificationBody": "ਜੇ ਤੁਸੀਂ ਇਹ ਵੇਖ ਸਕਦੇ ਹੋ, ਤਾਂ ਓਪਰੇਟਿੰਗ ਸਿਸਟਮ ਦੀ ਸੂਚਨਾ ਡਿਲਿਵਰੀ ਕੰਮ ਕਰ ਰਹੀ ਹੈ।"
 }

--- a/lib/l10n/app_pa.arb
+++ b/lib/l10n/app_pa.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "ਪੂਰੀ ਸਕ੍ਰੀਨ ਵਿੱਚ, ਟੈਬ ਬਾਰ",
   "appSettingsFullscreenTabStripHidden": "ਲੁਕਿਆ",
   "appSettingsFullscreenTabStripAlways": "ਹਮੇਸ਼ਾ ਦਿਖਾਈ ਦਿੰਦਾ",
-  "appSettingsFullscreenTabStripButton": "ਬਟਨ ਨਾਲ ਦਿਖਾਓ"
+  "appSettingsFullscreenTabStripButton": "ਬਟਨ ਨਾਲ ਦਿਖਾਓ",
+  "devToolsSimulateRefresh": "ਬੈਕਗ੍ਰਾਊਂਡ ਰਿਫਰੈਸ਼ ਦੀ ਨਕਲ ਕਰੋ",
+  "devToolsSimulateRefreshDone": "ਸੂਚਨਾ ਸਾਈਟਾਂ ਮੁੜ ਲੋਡ ਹੋਈਆਂ (ਲੌਗ ਵੇਖੋ)",
+  "devToolsTestNotification": "ਟੈਸਟ ਸੂਚਨਾ ਭੇਜੋ",
+  "devToolsTestNotificationSent": "ਟੈਸਟ ਸੂਚਨਾ ਭੇਜੀ ਗਈ (ਲੌਗ ਵੇਖੋ)",
+  "devToolsTestNotificationTitle": "WebSpace ਟੈਸਟ ਸੂਚਨਾ",
+  "devToolsTestNotificationBody": "ਜੇ ਤੁਸੀਂ ਇਹ ਵੇਖ ਸਕਦੇ ਹੋ, ਤਾਂ ਓਪਰੇਟਿੰਗ ਸਿਸਟਮ ਦੀ ਸੂਚਨਾ ਡਿਲਿਵਰੀ ਕੰਮ ਕਰ ਰਹੀ ਹੈ।"
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Na pełnym ekranie, pasek kart",
   "appSettingsFullscreenTabStripHidden": "Ukryty",
   "appSettingsFullscreenTabStripAlways": "Zawsze widoczny",
-  "appSettingsFullscreenTabStripButton": "Pokaż przyciskiem"
+  "appSettingsFullscreenTabStripButton": "Pokaż przyciskiem",
+  "devToolsSimulateRefresh": "Symuluj odświeżanie w tle",
+  "devToolsSimulateRefreshDone": "Witryny powiadomień ponownie załadowane (zobacz logi)",
+  "devToolsTestNotification": "Wyślij powiadomienie testowe",
+  "devToolsTestNotificationSent": "Wysłano powiadomienie testowe (zobacz logi)",
+  "devToolsTestNotificationTitle": "Powiadomienie testowe WebSpace",
+  "devToolsTestNotificationBody": "Jeśli to widzisz, dostarczanie powiadomień systemu operacyjnego działa."
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Na pełnym ekranie, pasek kart",
   "appSettingsFullscreenTabStripHidden": "Ukryty",
   "appSettingsFullscreenTabStripAlways": "Zawsze widoczny",
-  "appSettingsFullscreenTabStripButton": "Pokaż przyciskiem"
+  "appSettingsFullscreenTabStripButton": "Pokaż przyciskiem",
+  "devToolsSimulateRefresh": "Symuluj odświeżanie w tle",
+  "devToolsSimulateRefreshDone": "Witryny powiadomień ponownie załadowane (zobacz logi)",
+  "devToolsTestNotification": "Wyślij powiadomienie testowe",
+  "devToolsTestNotificationSent": "Wysłano powiadomienie testowe (zobacz logi)",
+  "devToolsTestNotificationTitle": "Powiadomienie testowe WebSpace",
+  "devToolsTestNotificationBody": "Jeśli to widzisz, dostarczanie powiadomień systemu operacyjnego działa."
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Em ecrã inteiro, barra de separadores",
   "appSettingsFullscreenTabStripHidden": "Oculta",
   "appSettingsFullscreenTabStripAlways": "Sempre visível",
-  "appSettingsFullscreenTabStripButton": "Mostrar com um botão"
+  "appSettingsFullscreenTabStripButton": "Mostrar com um botão",
+  "devToolsSimulateRefresh": "Simular atualização em segundo plano",
+  "devToolsSimulateRefreshDone": "Sites de notificação recarregados (consulte os registos)",
+  "devToolsTestNotification": "Enviar notificação de teste",
+  "devToolsTestNotificationSent": "Notificação de teste enviada (consulte os registos)",
+  "devToolsTestNotificationTitle": "Notificação de teste WebSpace",
+  "devToolsTestNotificationBody": "Se conseguir ver isto, a entrega de notificações do sistema operativo funciona."
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Em ecrã inteiro, barra de separadores",
   "appSettingsFullscreenTabStripHidden": "Oculta",
   "appSettingsFullscreenTabStripAlways": "Sempre visível",
-  "appSettingsFullscreenTabStripButton": "Mostrar com um botão"
+  "appSettingsFullscreenTabStripButton": "Mostrar com um botão",
+  "devToolsSimulateRefresh": "Simular atualização em segundo plano",
+  "devToolsSimulateRefreshDone": "Sites de notificação recarregados (consulte os registos)",
+  "devToolsTestNotification": "Enviar notificação de teste",
+  "devToolsTestNotificationSent": "Notificação de teste enviada (consulte os registos)",
+  "devToolsTestNotificationTitle": "Notificação de teste WebSpace",
+  "devToolsTestNotificationBody": "Se conseguir ver isto, a entrega de notificações do sistema operativo funciona."
 }

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Em tela cheia, barra de abas",
   "appSettingsFullscreenTabStripHidden": "Oculta",
   "appSettingsFullscreenTabStripAlways": "Sempre visível",
-  "appSettingsFullscreenTabStripButton": "Mostrar com um botão"
+  "appSettingsFullscreenTabStripButton": "Mostrar com um botão",
+  "devToolsSimulateRefresh": "Simular atualização em segundo plano",
+  "devToolsSimulateRefreshDone": "Sites de notificação recarregados (consulte os logs)",
+  "devToolsTestNotification": "Enviar notificação de teste",
+  "devToolsTestNotificationSent": "Notificação de teste enviada (consulte os logs)",
+  "devToolsTestNotificationTitle": "Notificação de teste do WebSpace",
+  "devToolsTestNotificationBody": "Se você consegue ver isto, a entrega de notificações do sistema operacional funciona."
 }

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Em tela cheia, barra de abas",
   "appSettingsFullscreenTabStripHidden": "Oculta",
   "appSettingsFullscreenTabStripAlways": "Sempre visível",
-  "appSettingsFullscreenTabStripButton": "Mostrar com um botão"
+  "appSettingsFullscreenTabStripButton": "Mostrar com um botão",
+  "devToolsSimulateRefresh": "Simular atualização em segundo plano",
+  "devToolsSimulateRefreshDone": "Sites de notificação recarregados (consulte os logs)",
+  "devToolsTestNotification": "Enviar notificação de teste",
+  "devToolsTestNotificationSent": "Notificação de teste enviada (consulte os logs)",
+  "devToolsTestNotificationTitle": "Notificação de teste do WebSpace",
+  "devToolsTestNotificationBody": "Se você consegue ver isto, a entrega de notificações do sistema operacional funciona."
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Pe ecran complet, bara de file",
   "appSettingsFullscreenTabStripHidden": "Ascunsă",
   "appSettingsFullscreenTabStripAlways": "Întotdeauna vizibilă",
-  "appSettingsFullscreenTabStripButton": "Afișează cu un buton"
+  "appSettingsFullscreenTabStripButton": "Afișează cu un buton",
+  "devToolsSimulateRefresh": "Simulează reîmprospătarea în fundal",
+  "devToolsSimulateRefreshDone": "Site-urile de notificări reîncărcate (vezi jurnalele)",
+  "devToolsTestNotification": "Trimite o notificare de test",
+  "devToolsTestNotificationSent": "Notificarea de test a fost trimisă (vezi jurnalele)",
+  "devToolsTestNotificationTitle": "Notificare de test WebSpace",
+  "devToolsTestNotificationBody": "Dacă vezi acest mesaj, livrarea notificărilor sistemului de operare funcționează."
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Pe ecran complet, bara de file",
   "appSettingsFullscreenTabStripHidden": "Ascunsă",
   "appSettingsFullscreenTabStripAlways": "Întotdeauna vizibilă",
-  "appSettingsFullscreenTabStripButton": "Afișează cu un buton"
+  "appSettingsFullscreenTabStripButton": "Afișează cu un buton",
+  "devToolsSimulateRefresh": "Simulează reîmprospătarea în fundal",
+  "devToolsSimulateRefreshDone": "Site-urile de notificări reîncărcate (vezi jurnalele)",
+  "devToolsTestNotification": "Trimite o notificare de test",
+  "devToolsTestNotificationSent": "Notificarea de test a fost trimisă (vezi jurnalele)",
+  "devToolsTestNotificationTitle": "Notificare de test WebSpace",
+  "devToolsTestNotificationBody": "Dacă vezi acest mesaj, livrarea notificărilor sistemului de operare funcționează."
 }

--- a/lib/l10n/app_si.arb
+++ b/lib/l10n/app_si.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "සම්පූර්ණ තිරයේ, ටැබ් තීරුව",
   "appSettingsFullscreenTabStripHidden": "සැඟවී ඇත",
   "appSettingsFullscreenTabStripAlways": "සැමවිටම දෘශ්‍යමාන",
-  "appSettingsFullscreenTabStripButton": "බොත්තමෙන් පෙන්වන්න"
+  "appSettingsFullscreenTabStripButton": "බොත්තමෙන් පෙන්වන්න",
+  "devToolsSimulateRefresh": "පසුබිම් නැවුම් කිරීම අනුකරණය කරන්න",
+  "devToolsSimulateRefreshDone": "දැනුම්දීම් අඩවි නැවත පූරණය කරන ලදී (ලඝු-සටහන් බලන්න)",
+  "devToolsTestNotification": "පරීක්ෂණ දැනුම්දීමක් යවන්න",
+  "devToolsTestNotificationSent": "පරීක්ෂණ දැනුම්දීම යවන ලදී (ලඝු-සටහන් බලන්න)",
+  "devToolsTestNotificationTitle": "WebSpace පරීක්ෂණ දැනුම්දීම",
+  "devToolsTestNotificationBody": "ඔබට මෙය දැකිය හැකි නම්, මෙහෙයුම් පද්ධතියේ දැනුම්දීම් බෙදා හැරීම ක්‍රියා කරයි."
 }

--- a/lib/l10n/app_si.arb
+++ b/lib/l10n/app_si.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "සම්පූර්ණ තිරයේ, ටැබ් තීරුව",
   "appSettingsFullscreenTabStripHidden": "සැඟවී ඇත",
   "appSettingsFullscreenTabStripAlways": "සැමවිටම දෘශ්‍යමාන",
-  "appSettingsFullscreenTabStripButton": "බොත්තමෙන් පෙන්වන්න"
+  "appSettingsFullscreenTabStripButton": "බොත්තමෙන් පෙන්වන්න",
+  "devToolsSimulateRefresh": "පසුබිම් නැවුම් කිරීම අනුකරණය කරන්න",
+  "devToolsSimulateRefreshDone": "දැනුම්දීම් අඩවි නැවත පූරණය කරන ලදී (ලඝු-සටහන් බලන්න)",
+  "devToolsTestNotification": "පරීක්ෂණ දැනුම්දීමක් යවන්න",
+  "devToolsTestNotificationSent": "පරීක්ෂණ දැනුම්දීම යවන ලදී (ලඝු-සටහන් බලන්න)",
+  "devToolsTestNotificationTitle": "WebSpace පරීක්ෂණ දැනුම්දීම",
+  "devToolsTestNotificationBody": "ඔබට මෙය දැකිය හැකි නම්, මෙහෙයුම් පද්ධතියේ දැනුම්දීම් බෙදා හැරීම ක්‍රියා කරයි."
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Na celej obrazovke, panel kariet",
   "appSettingsFullscreenTabStripHidden": "Skrytý",
   "appSettingsFullscreenTabStripAlways": "Vždy viditeľný",
-  "appSettingsFullscreenTabStripButton": "Zobraziť tlačidlom"
+  "appSettingsFullscreenTabStripButton": "Zobraziť tlačidlom",
+  "devToolsSimulateRefresh": "Simulovať obnovenie na pozadí",
+  "devToolsSimulateRefreshDone": "Stránky upozornení boli znova načítané (pozri protokoly)",
+  "devToolsTestNotification": "Odoslať testovacie upozornenie",
+  "devToolsTestNotificationSent": "Testovacie upozornenie odoslané (pozri protokoly)",
+  "devToolsTestNotificationTitle": "Testovacie upozornenie WebSpace",
+  "devToolsTestNotificationBody": "Ak toto vidíte, doručovanie upozornení operačného systému funguje."
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Na celej obrazovke, panel kariet",
   "appSettingsFullscreenTabStripHidden": "Skrytý",
   "appSettingsFullscreenTabStripAlways": "Vždy viditeľný",
-  "appSettingsFullscreenTabStripButton": "Zobraziť tlačidlom"
+  "appSettingsFullscreenTabStripButton": "Zobraziť tlačidlom",
+  "devToolsSimulateRefresh": "Simulovať obnovenie na pozadí",
+  "devToolsSimulateRefreshDone": "Stránky upozornení boli znova načítané (pozri protokoly)",
+  "devToolsTestNotification": "Odoslať testovacie upozornenie",
+  "devToolsTestNotificationSent": "Testovacie upozornenie odoslané (pozri protokoly)",
+  "devToolsTestNotificationTitle": "Testovacie upozornenie WebSpace",
+  "devToolsTestNotificationBody": "Ak toto vidíte, doručovanie upozornení operačného systému funguje."
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "V celozaslonskem načinu, vrstica zavihkov",
   "appSettingsFullscreenTabStripHidden": "Skrito",
   "appSettingsFullscreenTabStripAlways": "Vedno vidno",
-  "appSettingsFullscreenTabStripButton": "Pokaži z gumbom"
+  "appSettingsFullscreenTabStripButton": "Pokaži z gumbom",
+  "devToolsSimulateRefresh": "Simuliraj osvežitev v ozadju",
+  "devToolsSimulateRefreshDone": "Spletna mesta z obvestili znova naložena (glejte dnevnike)",
+  "devToolsTestNotification": "Pošlji preizkusno obvestilo",
+  "devToolsTestNotificationSent": "Preizkusno obvestilo poslano (glejte dnevnike)",
+  "devToolsTestNotificationTitle": "Preizkusno obvestilo WebSpace",
+  "devToolsTestNotificationBody": "Če to vidite, dostava obvestil operacijskega sistema deluje."
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "V celozaslonskem načinu, vrstica zavihkov",
   "appSettingsFullscreenTabStripHidden": "Skrito",
   "appSettingsFullscreenTabStripAlways": "Vedno vidno",
-  "appSettingsFullscreenTabStripButton": "Pokaži z gumbom"
+  "appSettingsFullscreenTabStripButton": "Pokaži z gumbom",
+  "devToolsSimulateRefresh": "Simuliraj osvežitev v ozadju",
+  "devToolsSimulateRefreshDone": "Spletna mesta z obvestili znova naložena (glejte dnevnike)",
+  "devToolsTestNotification": "Pošlji preizkusno obvestilo",
+  "devToolsTestNotificationSent": "Preizkusno obvestilo poslano (glejte dnevnike)",
+  "devToolsTestNotificationTitle": "Preizkusno obvestilo WebSpace",
+  "devToolsTestNotificationBody": "Če to vidite, dostava obvestil operacijskega sistema deluje."
 }

--- a/lib/l10n/app_sq.arb
+++ b/lib/l10n/app_sq.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Në ekran të plotë, shiriti i skedave",
   "appSettingsFullscreenTabStripHidden": "I fshehur",
   "appSettingsFullscreenTabStripAlways": "Gjithmonë i dukshëm",
-  "appSettingsFullscreenTabStripButton": "Shfaq me buton"
+  "appSettingsFullscreenTabStripButton": "Shfaq me buton",
+  "devToolsSimulateRefresh": "Simulo rifreskimin në sfond",
+  "devToolsSimulateRefreshDone": "Sajtet e njoftimeve u ringarkuan (shih regjistrat)",
+  "devToolsTestNotification": "Dërgo njoftim provë",
+  "devToolsTestNotificationSent": "Njoftimi provë u dërgua (shih regjistrat)",
+  "devToolsTestNotificationTitle": "Njoftim provë i WebSpace",
+  "devToolsTestNotificationBody": "Nëse mund ta shihni këtë, dorëzimi i njoftimeve të sistemit operativ funksionon."
 }

--- a/lib/l10n/app_sq.arb
+++ b/lib/l10n/app_sq.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Në ekran të plotë, shiriti i skedave",
   "appSettingsFullscreenTabStripHidden": "I fshehur",
   "appSettingsFullscreenTabStripAlways": "Gjithmonë i dukshëm",
-  "appSettingsFullscreenTabStripButton": "Shfaq me buton"
+  "appSettingsFullscreenTabStripButton": "Shfaq me buton",
+  "devToolsSimulateRefresh": "Simulo rifreskimin në sfond",
+  "devToolsSimulateRefreshDone": "Sajtet e njoftimeve u ringarkuan (shih regjistrat)",
+  "devToolsTestNotification": "Dërgo njoftim provë",
+  "devToolsTestNotificationSent": "Njoftimi provë u dërgua (shih regjistrat)",
+  "devToolsTestNotificationTitle": "Njoftim provë i WebSpace",
+  "devToolsTestNotificationBody": "Nëse mund ta shihni këtë, dorëzimi i njoftimeve të sistemit operativ funksionon."
 }

--- a/lib/l10n/app_sr.arb
+++ b/lib/l10n/app_sr.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "На пуном екрану, трака картица",
   "appSettingsFullscreenTabStripHidden": "Скривено",
   "appSettingsFullscreenTabStripAlways": "Увек видљиво",
-  "appSettingsFullscreenTabStripButton": "Прикажи дугметом"
+  "appSettingsFullscreenTabStripButton": "Прикажи дугметом",
+  "devToolsSimulateRefresh": "Симулирај освежавање у позадини",
+  "devToolsSimulateRefreshDone": "Сајтови за обавештења поново учитани (погледајте записе)",
+  "devToolsTestNotification": "Пошаљи пробно обавештење",
+  "devToolsTestNotificationSent": "Пробно обавештење послато (погледајте записе)",
+  "devToolsTestNotificationTitle": "WebSpace пробно обавештење",
+  "devToolsTestNotificationBody": "Ако ово видите, испорука обавештења оперативног система ради."
 }

--- a/lib/l10n/app_sr.arb
+++ b/lib/l10n/app_sr.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "На пуном екрану, трака картица",
   "appSettingsFullscreenTabStripHidden": "Скривено",
   "appSettingsFullscreenTabStripAlways": "Увек видљиво",
-  "appSettingsFullscreenTabStripButton": "Прикажи дугметом"
+  "appSettingsFullscreenTabStripButton": "Прикажи дугметом",
+  "devToolsSimulateRefresh": "Симулирај освежавање у позадини",
+  "devToolsSimulateRefreshDone": "Сајтови за обавештења поново учитани (погледајте записе)",
+  "devToolsTestNotification": "Пошаљи пробно обавештење",
+  "devToolsTestNotificationSent": "Пробно обавештење послато (погледајте записе)",
+  "devToolsTestNotificationTitle": "WebSpace пробно обавештење",
+  "devToolsTestNotificationBody": "Ако ово видите, испорука обавештења оперативног система ради."
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "I helskärm, flikfält",
   "appSettingsFullscreenTabStripHidden": "Dold",
   "appSettingsFullscreenTabStripAlways": "Alltid synlig",
-  "appSettingsFullscreenTabStripButton": "Visa med knapp"
+  "appSettingsFullscreenTabStripButton": "Visa med knapp",
+  "devToolsSimulateRefresh": "Simulera bakgrundsuppdatering",
+  "devToolsSimulateRefreshDone": "Aviseringswebbplatser har laddats om (se loggarna)",
+  "devToolsTestNotification": "Skicka testavisering",
+  "devToolsTestNotificationSent": "Testavisering skickad (se loggarna)",
+  "devToolsTestNotificationTitle": "WebSpace-testavisering",
+  "devToolsTestNotificationBody": "Om du kan se detta fungerar operativsystemets aviseringsleverans."
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "I helskärm, flikfält",
   "appSettingsFullscreenTabStripHidden": "Dold",
   "appSettingsFullscreenTabStripAlways": "Alltid synlig",
-  "appSettingsFullscreenTabStripButton": "Visa med knapp"
+  "appSettingsFullscreenTabStripButton": "Visa med knapp",
+  "devToolsSimulateRefresh": "Simulera bakgrundsuppdatering",
+  "devToolsSimulateRefreshDone": "Aviseringswebbplatser har laddats om (se loggarna)",
+  "devToolsTestNotification": "Skicka testavisering",
+  "devToolsTestNotificationSent": "Testavisering skickad (se loggarna)",
+  "devToolsTestNotificationTitle": "WebSpace-testavisering",
+  "devToolsTestNotificationBody": "Om du kan se detta fungerar operativsystemets aviseringsleverans."
 }

--- a/lib/l10n/app_sw.arb
+++ b/lib/l10n/app_sw.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Katika skrini nzima, upau wa vichupo",
   "appSettingsFullscreenTabStripHidden": "Imefichwa",
   "appSettingsFullscreenTabStripAlways": "Inaonekana kila wakati",
-  "appSettingsFullscreenTabStripButton": "Onyesha kwa kitufe"
+  "appSettingsFullscreenTabStripButton": "Onyesha kwa kitufe",
+  "devToolsSimulateRefresh": "Iga uonyeshaji upya wa chinichini",
+  "devToolsSimulateRefreshDone": "Tovuti za arifa zimepakiwa upya (angalia kumbukumbu)",
+  "devToolsTestNotification": "Tuma arifa ya majaribio",
+  "devToolsTestNotificationSent": "Arifa ya majaribio imetumwa (angalia kumbukumbu)",
+  "devToolsTestNotificationTitle": "Arifa ya majaribio ya WebSpace",
+  "devToolsTestNotificationBody": "Ikiwa unaweza kuona hili, uwasilishaji wa arifa za mfumo wa uendeshaji unafanya kazi."
 }

--- a/lib/l10n/app_sw.arb
+++ b/lib/l10n/app_sw.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Katika skrini nzima, upau wa vichupo",
   "appSettingsFullscreenTabStripHidden": "Imefichwa",
   "appSettingsFullscreenTabStripAlways": "Inaonekana kila wakati",
-  "appSettingsFullscreenTabStripButton": "Onyesha kwa kitufe"
+  "appSettingsFullscreenTabStripButton": "Onyesha kwa kitufe",
+  "devToolsSimulateRefresh": "Iga uonyeshaji upya wa chinichini",
+  "devToolsSimulateRefreshDone": "Tovuti za arifa zimepakiwa upya (angalia kumbukumbu)",
+  "devToolsTestNotification": "Tuma arifa ya majaribio",
+  "devToolsTestNotificationSent": "Arifa ya majaribio imetumwa (angalia kumbukumbu)",
+  "devToolsTestNotificationTitle": "Arifa ya majaribio ya WebSpace",
+  "devToolsTestNotificationBody": "Ikiwa unaweza kuona hili, uwasilishaji wa arifa za mfumo wa uendeshaji unafanya kazi."
 }

--- a/lib/l10n/app_ta.arb
+++ b/lib/l10n/app_ta.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "முழுத்திரையில், தாவல் பட்டி",
   "appSettingsFullscreenTabStripHidden": "மறைக்கப்பட்டது",
   "appSettingsFullscreenTabStripAlways": "எப்போதும் தெரியும்",
-  "appSettingsFullscreenTabStripButton": "பொத்தானால் காட்டு"
+  "appSettingsFullscreenTabStripButton": "பொத்தானால் காட்டு",
+  "devToolsSimulateRefresh": "பின்னணி புதுப்பிப்பை உருவகப்படுத்து",
+  "devToolsSimulateRefreshDone": "அறிவிப்பு தளங்கள் மீண்டும் ஏற்றப்பட்டன (பதிவுகளைப் பார்க்கவும்)",
+  "devToolsTestNotification": "சோதனை அறிவிப்பை அனுப்பு",
+  "devToolsTestNotificationSent": "சோதனை அறிவிப்பு அனுப்பப்பட்டது (பதிவுகளைப் பார்க்கவும்)",
+  "devToolsTestNotificationTitle": "WebSpace சோதனை அறிவிப்பு",
+  "devToolsTestNotificationBody": "இதை நீங்கள் பார்க்க முடிந்தால், இயக்க முறைமையின் அறிவிப்பு வழங்கல் வேலை செய்கிறது."
 }

--- a/lib/l10n/app_ta.arb
+++ b/lib/l10n/app_ta.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "முழுத்திரையில், தாவல் பட்டி",
   "appSettingsFullscreenTabStripHidden": "மறைக்கப்பட்டது",
   "appSettingsFullscreenTabStripAlways": "எப்போதும் தெரியும்",
-  "appSettingsFullscreenTabStripButton": "பொத்தானால் காட்டு"
+  "appSettingsFullscreenTabStripButton": "பொத்தானால் காட்டு",
+  "devToolsSimulateRefresh": "பின்னணி புதுப்பிப்பை உருவகப்படுத்து",
+  "devToolsSimulateRefreshDone": "அறிவிப்பு தளங்கள் மீண்டும் ஏற்றப்பட்டன (பதிவுகளைப் பார்க்கவும்)",
+  "devToolsTestNotification": "சோதனை அறிவிப்பை அனுப்பு",
+  "devToolsTestNotificationSent": "சோதனை அறிவிப்பு அனுப்பப்பட்டது (பதிவுகளைப் பார்க்கவும்)",
+  "devToolsTestNotificationTitle": "WebSpace சோதனை அறிவிப்பு",
+  "devToolsTestNotificationBody": "இதை நீங்கள் பார்க்க முடிந்தால், இயக்க முறைமையின் அறிவிப்பு வழங்கல் வேலை செய்கிறது."
 }

--- a/lib/l10n/app_te.arb
+++ b/lib/l10n/app_te.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "పూర్తి స్క్రీన్‌లో, ట్యాబ్ బార్",
   "appSettingsFullscreenTabStripHidden": "దాచబడింది",
   "appSettingsFullscreenTabStripAlways": "ఎల్లప్పుడూ కనిపిస్తుంది",
-  "appSettingsFullscreenTabStripButton": "బటన్‌తో చూపించు"
+  "appSettingsFullscreenTabStripButton": "బటన్‌తో చూపించు",
+  "devToolsSimulateRefresh": "నేపథ్య రిఫ్రెష్‌ను అనుకరించండి",
+  "devToolsSimulateRefreshDone": "నోటిఫికేషన్ సైట్‌లు మళ్లీ లోడ్ అయ్యాయి (లాగ్‌లను చూడండి)",
+  "devToolsTestNotification": "పరీక్ష నోటిఫికేషన్ పంపండి",
+  "devToolsTestNotificationSent": "పరీక్ష నోటిఫికేషన్ పంపబడింది (లాగ్‌లను చూడండి)",
+  "devToolsTestNotificationTitle": "WebSpace పరీక్ష నోటిఫికేషన్",
+  "devToolsTestNotificationBody": "ఇది మీకు కనిపిస్తే, ఆపరేటింగ్ సిస్టమ్ నోటిఫికేషన్ డెలివరీ పని చేస్తోంది."
 }

--- a/lib/l10n/app_te.arb
+++ b/lib/l10n/app_te.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "పూర్తి స్క్రీన్‌లో, ట్యాబ్ బార్",
   "appSettingsFullscreenTabStripHidden": "దాచబడింది",
   "appSettingsFullscreenTabStripAlways": "ఎల్లప్పుడూ కనిపిస్తుంది",
-  "appSettingsFullscreenTabStripButton": "బటన్‌తో చూపించు"
+  "appSettingsFullscreenTabStripButton": "బటన్‌తో చూపించు",
+  "devToolsSimulateRefresh": "నేపథ్య రిఫ్రెష్‌ను అనుకరించండి",
+  "devToolsSimulateRefreshDone": "నోటిఫికేషన్ సైట్‌లు మళ్లీ లోడ్ అయ్యాయి (లాగ్‌లను చూడండి)",
+  "devToolsTestNotification": "పరీక్ష నోటిఫికేషన్ పంపండి",
+  "devToolsTestNotificationSent": "పరీక్ష నోటిఫికేషన్ పంపబడింది (లాగ్‌లను చూడండి)",
+  "devToolsTestNotificationTitle": "WebSpace పరీక్ష నోటిఫికేషన్",
+  "devToolsTestNotificationBody": "ఇది మీకు కనిపిస్తే, ఆపరేటింగ్ సిస్టమ్ నోటిఫికేషన్ డెలివరీ పని చేస్తోంది."
 }

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "ในโหมดเต็มจอ แถบแท็บ",
   "appSettingsFullscreenTabStripHidden": "ซ่อน",
   "appSettingsFullscreenTabStripAlways": "แสดงตลอดเวลา",
-  "appSettingsFullscreenTabStripButton": "แสดงด้วยปุ่ม"
+  "appSettingsFullscreenTabStripButton": "แสดงด้วยปุ่ม",
+  "devToolsSimulateRefresh": "จำลองการรีเฟรชเบื้องหลัง",
+  "devToolsSimulateRefreshDone": "โหลดไซต์การแจ้งเตือนใหม่แล้ว (ดูบันทึก)",
+  "devToolsTestNotification": "ส่งการแจ้งเตือนทดสอบ",
+  "devToolsTestNotificationSent": "ส่งการแจ้งเตือนทดสอบแล้ว (ดูบันทึก)",
+  "devToolsTestNotificationTitle": "การแจ้งเตือนทดสอบ WebSpace",
+  "devToolsTestNotificationBody": "หากคุณเห็นข้อความนี้ แสดงว่าการส่งการแจ้งเตือนของระบบปฏิบัติการทำงานได้"
 }

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "ในโหมดเต็มจอ แถบแท็บ",
   "appSettingsFullscreenTabStripHidden": "ซ่อน",
   "appSettingsFullscreenTabStripAlways": "แสดงตลอดเวลา",
-  "appSettingsFullscreenTabStripButton": "แสดงด้วยปุ่ม"
+  "appSettingsFullscreenTabStripButton": "แสดงด้วยปุ่ม",
+  "devToolsSimulateRefresh": "จำลองการรีเฟรชเบื้องหลัง",
+  "devToolsSimulateRefreshDone": "โหลดไซต์การแจ้งเตือนใหม่แล้ว (ดูบันทึก)",
+  "devToolsTestNotification": "ส่งการแจ้งเตือนทดสอบ",
+  "devToolsTestNotificationSent": "ส่งการแจ้งเตือนทดสอบแล้ว (ดูบันทึก)",
+  "devToolsTestNotificationTitle": "การแจ้งเตือนทดสอบ WebSpace",
+  "devToolsTestNotificationBody": "หากคุณเห็นข้อความนี้ แสดงว่าการส่งการแจ้งเตือนของระบบปฏิบัติการทำงานได้"
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "Tam ekranda, sekme çubuğu",
   "appSettingsFullscreenTabStripHidden": "Gizli",
   "appSettingsFullscreenTabStripAlways": "Her zaman görünür",
-  "appSettingsFullscreenTabStripButton": "Düğmeyle göster"
+  "appSettingsFullscreenTabStripButton": "Düğmeyle göster",
+  "devToolsSimulateRefresh": "Arka plan yenilemesini simüle et",
+  "devToolsSimulateRefreshDone": "Bildirim siteleri yeniden yüklendi (günlüklere bakın)",
+  "devToolsTestNotification": "Test bildirimi gönder",
+  "devToolsTestNotificationSent": "Test bildirimi gönderildi (günlüklere bakın)",
+  "devToolsTestNotificationTitle": "WebSpace test bildirimi",
+  "devToolsTestNotificationBody": "Bunu görebiliyorsanız, işletim sisteminin bildirim teslimatı çalışıyor."
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "Tam ekranda, sekme çubuğu",
   "appSettingsFullscreenTabStripHidden": "Gizli",
   "appSettingsFullscreenTabStripAlways": "Her zaman görünür",
-  "appSettingsFullscreenTabStripButton": "Düğmeyle göster"
+  "appSettingsFullscreenTabStripButton": "Düğmeyle göster",
+  "devToolsSimulateRefresh": "Arka plan yenilemesini simüle et",
+  "devToolsSimulateRefreshDone": "Bildirim siteleri yeniden yüklendi (günlüklere bakın)",
+  "devToolsTestNotification": "Test bildirimi gönder",
+  "devToolsTestNotificationSent": "Test bildirimi gönderildi (günlüklere bakın)",
+  "devToolsTestNotificationTitle": "WebSpace test bildirimi",
+  "devToolsTestNotificationBody": "Bunu görebiliyorsanız, işletim sisteminin bildirim teslimatı çalışıyor."
 }

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "На весь екран, панель вкладок",
   "appSettingsFullscreenTabStripHidden": "Прихована",
   "appSettingsFullscreenTabStripAlways": "Завжди видима",
-  "appSettingsFullscreenTabStripButton": "Показувати кнопкою"
+  "appSettingsFullscreenTabStripButton": "Показувати кнопкою",
+  "devToolsSimulateRefresh": "Імітувати фонове оновлення",
+  "devToolsSimulateRefreshDone": "Сайти сповіщень перезавантажено (див. журнали)",
+  "devToolsTestNotification": "Надіслати тестове сповіщення",
+  "devToolsTestNotificationSent": "Тестове сповіщення надіслано (див. журнали)",
+  "devToolsTestNotificationTitle": "Тестове сповіщення WebSpace",
+  "devToolsTestNotificationBody": "Якщо ви це бачите, доставлення сповіщень операційної системи працює."
 }

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "На весь екран, панель вкладок",
   "appSettingsFullscreenTabStripHidden": "Прихована",
   "appSettingsFullscreenTabStripAlways": "Завжди видима",
-  "appSettingsFullscreenTabStripButton": "Показувати кнопкою"
+  "appSettingsFullscreenTabStripButton": "Показувати кнопкою",
+  "devToolsSimulateRefresh": "Імітувати фонове оновлення",
+  "devToolsSimulateRefreshDone": "Сайти сповіщень перезавантажено (див. журнали)",
+  "devToolsTestNotification": "Надіслати тестове сповіщення",
+  "devToolsTestNotificationSent": "Тестове сповіщення надіслано (див. журнали)",
+  "devToolsTestNotificationTitle": "Тестове сповіщення WebSpace",
+  "devToolsTestNotificationBody": "Якщо ви це бачите, доставлення сповіщень операційної системи працює."
 }

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "فل اسکرین میں، ٹیب بار",
   "appSettingsFullscreenTabStripHidden": "پوشیدہ",
   "appSettingsFullscreenTabStripAlways": "ہمیشہ نظر آنے والا",
-  "appSettingsFullscreenTabStripButton": "بٹن سے دکھائیں"
+  "appSettingsFullscreenTabStripButton": "بٹن سے دکھائیں",
+  "devToolsSimulateRefresh": "پس منظر ریفریش کی نقل کریں",
+  "devToolsSimulateRefreshDone": "اطلاعاتی سائٹس دوبارہ لوڈ ہو گئیں (لاگز دیکھیں)",
+  "devToolsTestNotification": "ٹیسٹ اطلاع بھیجیں",
+  "devToolsTestNotificationSent": "ٹیسٹ اطلاع بھیج دی گئی (لاگز دیکھیں)",
+  "devToolsTestNotificationTitle": "WebSpace ٹیسٹ اطلاع",
+  "devToolsTestNotificationBody": "اگر آپ یہ دیکھ سکتے ہیں، تو آپریٹنگ سسٹم کی اطلاع کی ترسیل کام کر رہی ہے۔"
 }

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "فل اسکرین میں، ٹیب بار",
   "appSettingsFullscreenTabStripHidden": "پوشیدہ",
   "appSettingsFullscreenTabStripAlways": "ہمیشہ نظر آنے والا",
-  "appSettingsFullscreenTabStripButton": "بٹن سے دکھائیں"
+  "appSettingsFullscreenTabStripButton": "بٹن سے دکھائیں",
+  "devToolsSimulateRefresh": "پس منظر ریفریش کی نقل کریں",
+  "devToolsSimulateRefreshDone": "اطلاعاتی سائٹس دوبارہ لوڈ ہو گئیں (لاگز دیکھیں)",
+  "devToolsTestNotification": "ٹیسٹ اطلاع بھیجیں",
+  "devToolsTestNotificationSent": "ٹیسٹ اطلاع بھیج دی گئی (لاگز دیکھیں)",
+  "devToolsTestNotificationTitle": "WebSpace ٹیسٹ اطلاع",
+  "devToolsTestNotificationBody": "اگر آپ یہ دیکھ سکتے ہیں، تو آپریٹنگ سسٹم کی اطلاع کی ترسیل کام کر رہی ہے۔"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "全屏时，标签栏",
   "appSettingsFullscreenTabStripHidden": "隐藏",
   "appSettingsFullscreenTabStripAlways": "始终显示",
-  "appSettingsFullscreenTabStripButton": "用按钮显示"
+  "appSettingsFullscreenTabStripButton": "用按钮显示",
+  "devToolsSimulateRefresh": "模拟后台刷新",
+  "devToolsSimulateRefreshDone": "已重新加载通知站点（查看日志）",
+  "devToolsTestNotification": "发送测试通知",
+  "devToolsTestNotificationSent": "已发送测试通知（查看日志）",
+  "devToolsTestNotificationTitle": "WebSpace 测试通知",
+  "devToolsTestNotificationBody": "如果您能看到这条消息，说明操作系统的通知投递功能正常。"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "全屏时，标签栏",
   "appSettingsFullscreenTabStripHidden": "隐藏",
   "appSettingsFullscreenTabStripAlways": "始终显示",
-  "appSettingsFullscreenTabStripButton": "用按钮显示"
+  "appSettingsFullscreenTabStripButton": "用按钮显示",
+  "devToolsSimulateRefresh": "模拟后台刷新",
+  "devToolsSimulateRefreshDone": "已重新加载通知站点（查看日志）",
+  "devToolsTestNotification": "发送测试通知",
+  "devToolsTestNotificationSent": "已发送测试通知（查看日志）",
+  "devToolsTestNotificationTitle": "WebSpace 测试通知",
+  "devToolsTestNotificationBody": "如果您能看到这条消息，说明操作系统的通知投递功能正常。"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -652,5 +652,11 @@
   "appSettingsFullscreenTabStrip": "全螢幕時，分頁列",
   "appSettingsFullscreenTabStripHidden": "隱藏",
   "appSettingsFullscreenTabStripAlways": "永遠顯示",
-  "appSettingsFullscreenTabStripButton": "用按鈕顯示"
+  "appSettingsFullscreenTabStripButton": "用按鈕顯示",
+  "devToolsSimulateRefresh": "模擬背景重新整理",
+  "devToolsSimulateRefreshDone": "已重新載入通知網站（查看記錄）",
+  "devToolsTestNotification": "傳送測試通知",
+  "devToolsTestNotificationSent": "已傳送測試通知（查看記錄）",
+  "devToolsTestNotificationTitle": "WebSpace 測試通知",
+  "devToolsTestNotificationBody": "如果您能看到這則訊息，表示作業系統的通知傳遞功能正常。"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -673,5 +673,11 @@
   "appSettingsFullscreenTabStrip": "全螢幕時，分頁列",
   "appSettingsFullscreenTabStripHidden": "隱藏",
   "appSettingsFullscreenTabStripAlways": "永遠顯示",
-  "appSettingsFullscreenTabStripButton": "用按鈕顯示"
+  "appSettingsFullscreenTabStripButton": "用按鈕顯示",
+  "devToolsSimulateRefresh": "模擬背景重新整理",
+  "devToolsSimulateRefreshDone": "已重新載入通知網站（查看記錄）",
+  "devToolsTestNotification": "傳送測試通知",
+  "devToolsTestNotificationSent": "已傳送測試通知（查看記錄）",
+  "devToolsTestNotificationTitle": "WebSpace 測試通知",
+  "devToolsTestNotificationBody": "如果您能看到這則訊息，表示作業系統的通知傳遞功能正常。"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4415,14 +4415,20 @@ class _WebSpacePageState extends State<WebSpacePage>
   /// pending request for the same identifier / unique-work name.
   Future<void> _updateBackgroundRefreshSchedule() async {
     if (!Platform.isIOS && !Platform.isAndroid) return;
-    bool any = false;
+    int enabled = 0;
+    int loaded = 0;
     for (int i = 0; i < _webViewModels.length; i++) {
       final m = _webViewModels[i];
       if (!m.effectiveNotificationsEnabled) continue;
-      if (!_loadedIndices.contains(i)) continue;
-      any = true;
-      break;
+      enabled++;
+      if (_loadedIndices.contains(i)) loaded++;
     }
+    final any = loaded > 0;
+    LogService.instance.log(
+      'BackgroundTask',
+      '${any ? "schedule" : "cancel"} refresh — '
+          'notif sites: $enabled enabled, $loaded loaded',
+    );
     if (any) {
       await BackgroundTaskService.instance.scheduleNextRefresh();
     } else {
@@ -4437,17 +4443,34 @@ class _WebSpacePageState extends State<WebSpacePage>
   ///   2. The iOS BGAppRefreshTask handler (no active-site exclusion since
   ///      the app is suspended at that point).
   Future<void> _refreshNotificationSites({bool excludeActive = false}) async {
+    int reloaded = 0;
+    int skippedUnloaded = 0;
+    int skippedNoController = 0;
     for (int i = 0; i < _webViewModels.length; i++) {
       final m = _webViewModels[i];
       if (!m.effectiveNotificationsEnabled) continue;
       if (excludeActive && i == _currentIndex) continue;
-      if (!_loadedIndices.contains(i)) continue;
+      if (!_loadedIndices.contains(i)) {
+        skippedUnloaded++;
+        continue;
+      }
+      if (m.controller == null) {
+        skippedNoController++;
+        continue;
+      }
       try {
         await m.controller?.reload();
+        reloaded++;
       } catch (_) {
         // Controller may have been disposed mid-iteration.
       }
     }
+    LogService.instance.log(
+      'BackgroundTask',
+      'refresh notif sites (excludeActive=$excludeActive): '
+          'reloaded=$reloaded, skipped(unloaded)=$skippedUnloaded, '
+          'skipped(no controller)=$skippedNoController',
+    );
   }
 
   void _onNotificationTapped(String siteId) {
@@ -5780,6 +5803,7 @@ class _WebSpacePageState extends State<WebSpacePage>
                           containerCookieManager: _containerCookieManager,
                           onSave: _saveWebViewModels,
                           globalUserScripts: _globalUserScripts,
+                          onSimulateBackgroundRefresh: _refreshNotificationSites,
                         ),
                       ),
                     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4696,14 +4696,20 @@ class _WebSpacePageState extends State<WebSpacePage>
   /// pending request for the same identifier / unique-work name.
   Future<void> _updateBackgroundRefreshSchedule() async {
     if (!Platform.isIOS && !Platform.isAndroid) return;
-    bool any = false;
+    int enabled = 0;
+    int loaded = 0;
     for (int i = 0; i < _webViewModels.length; i++) {
       final m = _webViewModels[i];
       if (!m.effectiveNotificationsEnabled) continue;
-      if (!_loadedIndices.contains(i)) continue;
-      any = true;
-      break;
+      enabled++;
+      if (_loadedIndices.contains(i)) loaded++;
     }
+    final any = loaded > 0;
+    LogService.instance.log(
+      'BackgroundTask',
+      '${any ? "schedule" : "cancel"} refresh — '
+          'notif sites: $enabled enabled, $loaded loaded',
+    );
     if (any) {
       await BackgroundTaskService.instance.scheduleNextRefresh();
     } else {
@@ -4718,16 +4724,37 @@ class _WebSpacePageState extends State<WebSpacePage>
   ///   2. The iOS BGAppRefreshTask handler (no active-site exclusion since
   ///      the app is suspended at that point).
   Future<void> _refreshNotificationSites({bool excludeActive = false}) async {
+    int reloaded = 0;
+    int skippedUnloaded = 0;
+    int skippedNoController = 0;
     for (int i = 0; i < _webViewModels.length; i++) {
       final m = _webViewModels[i];
       if (!m.effectiveNotificationsEnabled) continue;
       if (excludeActive && i == _currentIndex) continue;
-      if (!_loadedIndices.contains(i)) continue;
-      // Funnelled: the BGAppRefreshTask path does not exclude the active
-      // site, so this can reload the visible webview and blank its surface
-      // exactly like a user refresh (PAUSE-021).
-      await m.reloadAndRepaint();
+      if (!_loadedIndices.contains(i)) {
+        skippedUnloaded++;
+        continue;
+      }
+      if (m.controller == null) {
+        skippedNoController++;
+        continue;
+      }
+      try {
+        // Funnelled: the BGAppRefreshTask path does not exclude the active
+        // site, so this can reload the visible webview and blank its surface
+        // exactly like a user refresh (PAUSE-021).
+        await m.reloadAndRepaint();
+        reloaded++;
+      } catch (_) {
+        // Controller may have been disposed mid-iteration.
+      }
     }
+    LogService.instance.log(
+      'BackgroundTask',
+      'refresh notif sites (excludeActive=$excludeActive): '
+          'reloaded=$reloaded, skipped(unloaded)=$skippedUnloaded, '
+          'skipped(no controller)=$skippedNoController',
+    );
   }
 
   void _onNotificationTapped(String siteId) {
@@ -6136,6 +6163,7 @@ class _WebSpacePageState extends State<WebSpacePage>
                           containerCookieManager: _containerCookieManager,
                           onSave: _saveWebViewModels,
                           globalUserScripts: _globalUserScripts,
+                          onSimulateBackgroundRefresh: _refreshNotificationSites,
                         ),
                       ),
                     );

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -15,6 +15,7 @@ import 'package:webspace/services/container_cookie_manager.dart';
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/services/icon_png_export.dart';
 import 'package:webspace/services/log_service.dart';
+import 'package:webspace/services/notification_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/settings/proxy.dart';
@@ -163,6 +164,14 @@ class DevToolsScreen extends StatefulWidget {
   final VoidAsyncCallback? onSave;
   final List<UserScriptConfig> globalUserScripts;
 
+  /// When non-null, the App Logs tab shows a diagnostics row that triggers
+  /// the same notification-site reload the OS background task would run.
+  /// Lets the wake-up chain (reload -> page JS -> webNotification handler ->
+  /// NotificationService.show) be exercised in the foreground without
+  /// waiting on iOS BGAppRefreshTask / Android WorkManager. Wired only from
+  /// the top-level (per-site) launch; null for nested webviews.
+  final VoidAsyncCallback? onSimulateBackgroundRefresh;
+
   const DevToolsScreen({
     super.key,
     this.host,
@@ -170,6 +179,7 @@ class DevToolsScreen extends StatefulWidget {
     this.containerCookieManager,
     this.onSave,
     this.globalUserScripts = const [],
+    this.onSimulateBackgroundRefresh,
   });
 
   @override
@@ -1629,6 +1639,8 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
         _buildLogActions(filtered),
         _buildLogFilters(),
         _buildSensitiveToggle(),
+        if (widget.onSimulateBackgroundRefresh != null)
+          _buildNotificationDiagnostics(),
         Expanded(
           child: filtered.isEmpty
               ? Center(child: Text(_searchQuery.isEmpty ? loc.devToolsLogsEmpty : loc.devToolsNoMatches))
@@ -1642,6 +1654,57 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
                 ),
         ),
       ],
+    );
+  }
+
+  Future<void> _simulateBackgroundRefresh() async {
+    final loc = AppLocalizations.of(context);
+    final cb = widget.onSimulateBackgroundRefresh;
+    if (cb == null) return;
+    await cb();
+    if (!mounted) return;
+    setState(() {});
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(loc.devToolsSimulateRefreshDone)),
+    );
+  }
+
+  Future<void> _sendTestNotification() async {
+    final loc = AppLocalizations.of(context);
+    final siteId = widget.host?.siteId;
+    if (siteId == null) return;
+    await NotificationService.instance.show(
+      siteId: siteId,
+      title: loc.devToolsTestNotificationTitle,
+      body: loc.devToolsTestNotificationBody,
+    );
+    if (!mounted) return;
+    setState(() {});
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(loc.devToolsTestNotificationSent)),
+    );
+  }
+
+  Widget _buildNotificationDiagnostics() {
+    final loc = AppLocalizations.of(context);
+    final hasSite = widget.host?.siteId != null;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+      child: Wrap(
+        spacing: 4,
+        children: [
+          TextButton.icon(
+            onPressed: _simulateBackgroundRefresh,
+            icon: const Icon(Icons.refresh, size: 18),
+            label: Text(loc.devToolsSimulateRefresh),
+          ),
+          TextButton.icon(
+            onPressed: hasSite ? _sendTestNotification : null,
+            icon: const Icon(Icons.notifications_active, size: 18),
+            label: Text(loc.devToolsTestNotification),
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -15,6 +15,7 @@ import 'package:webspace/services/container_cookie_manager.dart';
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/services/icon_png_export.dart';
 import 'package:webspace/services/log_service.dart';
+import 'package:webspace/services/notification_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/settings/proxy.dart';
@@ -163,6 +164,14 @@ class DevToolsScreen extends StatefulWidget {
   final VoidAsyncCallback? onSave;
   final List<UserScriptConfig> globalUserScripts;
 
+  /// When non-null, the App Logs tab shows a diagnostics row that triggers
+  /// the same notification-site reload the OS background task would run.
+  /// Lets the wake-up chain (reload -> page JS -> webNotification handler ->
+  /// NotificationService.show) be exercised in the foreground without
+  /// waiting on iOS BGAppRefreshTask / Android WorkManager. Wired only from
+  /// the top-level (per-site) launch; null for nested webviews.
+  final VoidAsyncCallback? onSimulateBackgroundRefresh;
+
   const DevToolsScreen({
     super.key,
     this.host,
@@ -170,6 +179,7 @@ class DevToolsScreen extends StatefulWidget {
     this.containerCookieManager,
     this.onSave,
     this.globalUserScripts = const [],
+    this.onSimulateBackgroundRefresh,
   });
 
   @override
@@ -1632,6 +1642,8 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
         _buildLogActions(filtered),
         _buildLogFilters(),
         _buildSensitiveToggle(),
+        if (widget.onSimulateBackgroundRefresh != null)
+          _buildNotificationDiagnostics(),
         Expanded(
           child: filtered.isEmpty
               ? Center(child: Text(_searchQuery.isEmpty ? loc.devToolsLogsEmpty : loc.devToolsNoMatches))
@@ -1645,6 +1657,57 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
                 ),
         ),
       ],
+    );
+  }
+
+  Future<void> _simulateBackgroundRefresh() async {
+    final loc = AppLocalizations.of(context);
+    final cb = widget.onSimulateBackgroundRefresh;
+    if (cb == null) return;
+    await cb();
+    if (!mounted) return;
+    setState(() {});
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(loc.devToolsSimulateRefreshDone)),
+    );
+  }
+
+  Future<void> _sendTestNotification() async {
+    final loc = AppLocalizations.of(context);
+    final siteId = widget.host?.siteId;
+    if (siteId == null) return;
+    await NotificationService.instance.show(
+      siteId: siteId,
+      title: loc.devToolsTestNotificationTitle,
+      body: loc.devToolsTestNotificationBody,
+    );
+    if (!mounted) return;
+    setState(() {});
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(loc.devToolsTestNotificationSent)),
+    );
+  }
+
+  Widget _buildNotificationDiagnostics() {
+    final loc = AppLocalizations.of(context);
+    final hasSite = widget.host?.siteId != null;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+      child: Wrap(
+        spacing: 4,
+        children: [
+          TextButton.icon(
+            onPressed: _simulateBackgroundRefresh,
+            icon: const Icon(Icons.refresh, size: 18),
+            label: Text(loc.devToolsSimulateRefresh),
+          ),
+          TextButton.icon(
+            onPressed: hasSite ? _sendTestNotification : null,
+            icon: const Icon(Icons.notifications_active, size: 18),
+            label: Text(loc.devToolsTestNotification),
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1142,26 +1142,48 @@ String _notificationPolyfillScript({
   final permission = notificationsEnabled ? 'granted' : 'denied';
   return '''
 (function() {
+  var SITE_ID = '$siteId';
   var permission = '$permission';
-  function Notification(title, options) {
+  function deliver(title, options) {
     options = options || {};
-    if (permission !== 'granted') return;
     window.flutter_inappwebview.callHandler('webNotification', {
       title: String(title),
       body: String(options.body || ''),
       icon: String(options.icon || ''),
       tag: String(options.tag || ''),
-      siteId: '$siteId'
+      siteId: SITE_ID
     });
+  }
+  function blocked(api, title) {
+    try { console.warn('[WebSpace] ' + api + '("' + title + '") suppressed: permission ' + permission); } catch (e) {}
+  }
+  function Notification(title, options) {
+    if (permission !== 'granted') { blocked('Notification', title); return; }
+    deliver(title, options);
   }
   Notification.permission = permission;
   Notification.requestPermission = function(cb) {
-    var p = window.flutter_inappwebview.callHandler('webNotificationRequestPermission', {siteId: '$siteId'})
+    var p = window.flutter_inappwebview.callHandler('webNotificationRequestPermission', {siteId: SITE_ID})
       .then(function(result) { permission = result; Notification.permission = result; return result; });
     if (typeof cb === 'function') p.then(cb);
     return p;
   };
   Object.defineProperty(window, 'Notification', { value: Notification, writable: false, configurable: false });
+  // Page-context ServiceWorkerRegistration.showNotification(). Catches sites
+  // that post notifications from the page after `navigator.serviceWorker.ready`.
+  // Notifications raised from INSIDE the worker's own `push`/`message` handler
+  // run in the worker global scope, which a page-injected script cannot reach —
+  // those (true server-driven web push) remain unsupported by design.
+  try {
+    if (window.ServiceWorkerRegistration && ServiceWorkerRegistration.prototype) {
+      ServiceWorkerRegistration.prototype.showNotification = function(title, options) {
+        if (permission !== 'granted') { blocked('showNotification', title); return Promise.resolve(); }
+        deliver(title, options);
+        return Promise.resolve();
+      };
+      ServiceWorkerRegistration.prototype.getNotifications = function() { return Promise.resolve([]); };
+    }
+  } catch (e) {}
 })();
 ;null;''';
 }

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1190,26 +1190,48 @@ String _notificationPolyfillScript({
   final permission = notificationsEnabled ? 'granted' : 'denied';
   return '''
 (function() {
+  var SITE_ID = ${jsonEncode(siteId)};
   var permission = '$permission';
-  function Notification(title, options) {
+  function deliver(title, options) {
     options = options || {};
-    if (permission !== 'granted') return;
     window.flutter_inappwebview.callHandler('webNotification', {
       title: String(title),
       body: String(options.body || ''),
       icon: String(options.icon || ''),
       tag: String(options.tag || ''),
-      siteId: ${jsonEncode(siteId)}
+      siteId: SITE_ID
     });
+  }
+  function blocked(api, title) {
+    try { console.warn('[WebSpace] ' + api + '("' + title + '") suppressed: permission ' + permission); } catch (e) {}
+  }
+  function Notification(title, options) {
+    if (permission !== 'granted') { blocked('Notification', title); return; }
+    deliver(title, options);
   }
   Notification.permission = permission;
   Notification.requestPermission = function(cb) {
-    var p = window.flutter_inappwebview.callHandler('webNotificationRequestPermission', {siteId: ${jsonEncode(siteId)}})
+    var p = window.flutter_inappwebview.callHandler('webNotificationRequestPermission', {siteId: SITE_ID})
       .then(function(result) { permission = result; Notification.permission = result; return result; });
     if (typeof cb === 'function') p.then(cb);
     return p;
   };
   Object.defineProperty(window, 'Notification', { value: Notification, writable: false, configurable: false });
+  // Page-context ServiceWorkerRegistration.showNotification(). Catches sites
+  // that post notifications from the page after `navigator.serviceWorker.ready`.
+  // Notifications raised from INSIDE the worker's own `push`/`message` handler
+  // run in the worker global scope, which a page-injected script cannot reach —
+  // those (true server-driven web push) remain unsupported by design.
+  try {
+    if (window.ServiceWorkerRegistration && ServiceWorkerRegistration.prototype) {
+      ServiceWorkerRegistration.prototype.showNotification = function(title, options) {
+        if (permission !== 'granted') { blocked('showNotification', title); return Promise.resolve(); }
+        deliver(title, options);
+        return Promise.resolve();
+      };
+      ServiceWorkerRegistration.prototype.getNotifications = function() { return Promise.resolve([]); };
+    }
+  } catch (e) {}
 })();
 ;null;''';
 }

--- a/openspec/changes/web-push-notifications/specs/web-push-notifications/spec.md
+++ b/openspec/changes/web-push-notifications/specs/web-push-notifications/spec.md
@@ -53,6 +53,22 @@ The system SHALL inject a JavaScript polyfill at `DOCUMENT_START` (with `forMain
 **When** the site calls `new Notification(...)`
 **Then** the polyfill returns without invoking the JS bridge
 **And** no native notification is shown
+**And** the polyfill emits a `console.warn` breadcrumb (`[WebSpace] Notification(...) suppressed: permission denied`) so the suppression is visible in the dev-tools Console
+
+#### Scenario: Page-context Service Worker notification is bridged
+
+**Given** a site has notification permission granted
+**And** the site calls `registration.showNotification("title", {...})` from page context (e.g. after `navigator.serviceWorker.ready`)
+**When** the override runs
+**Then** the polyfill calls `flutter_inappwebview.callHandler('webNotification', ...)` with the same payload shape as the `Notification` constructor
+**And** a native notification is shown tagged with the originating `siteId`
+
+#### Scenario: True server-driven web push is out of reach by design
+
+**Given** a site delivers notifications from inside its Service Worker's `push` or `message` event handler (the standard Web Push pattern)
+**When** the push event fires
+**Then** WebSpace does NOT deliver the notification, because the handler runs in the worker global scope which a page-injected script cannot patch, and the app has no Web Push subscription endpoint
+**And** this is a known architectural limit: WebSpace approximates notifications by reloading the page so its page-context JS can fire `Notification` / page-context `showNotification`, not by receiving true server push
 
 ### Requirement: NOTIF-003 - Notification Tap Navigation
 
@@ -265,6 +281,31 @@ The system SHALL request OS-level notification permission before displaying the 
 **When** a site attempts to show a notification
 **Then** the system requests the `POST_NOTIFICATIONS` runtime permission
 **And** notifications are displayed only if the permission is granted
+
+### Requirement: NOTIF-008 - Wake-up Diagnostics
+
+Because the wake-up chain (OS scheduler -> webview reload -> page JS -> `webNotification` handler -> `NotificationService.show` -> OS delivery) spans three layers that each fail silently, the system SHALL make the chain observable and foreground-triggerable so a regression can be localized without waiting on the OS background scheduler.
+
+#### Scenario: Every hop logs a trace line
+
+**Given** a background refresh runs (real OS task or simulated)
+**Then** the schedule/cancel decision logs the enabled and loaded notification-site counts
+**And** the reload pass logs how many sites were reloaded versus skipped (unloaded / no controller)
+**And** the native bridge logs task receipt, dispatch reachability, completion, expiration, and timeout (iOS `NSLog`, Android `Log` under tag `WebspaceBgRefresh`)
+
+#### Scenario: Developer can simulate a background refresh in the foreground
+
+**Given** the developer-tools App Logs tab is open for a site
+**When** the developer taps "Simulate background refresh"
+**Then** the same reload pass the OS background task would run executes immediately
+**And** the resulting trace is visible in the App Logs tab
+
+#### Scenario: Developer can verify OS notification delivery directly
+
+**Given** the developer-tools App Logs tab is open for a site
+**When** the developer taps "Send test notification"
+**Then** `NotificationService.show` posts a local notification for that `siteId`
+**And** the OS permission gate and delivery are exercised independently of any page JS
 
 ## Manual Test Procedure
 

--- a/test/fixtures/notification_test.html
+++ b/test/fixtures/notification_test.html
@@ -56,6 +56,12 @@
   </div>
 
   <div class="section">
+    <h3>Service Worker (page-context)</h3>
+    <button onclick="testServiceWorkerNotification()">Send via registration.showNotification()</button>
+    <p class="info">Tests NOTIF-002 page-context Service Worker coverage. Notifications raised from inside the worker's own push handler (true server push) are unsupported by design.</p>
+  </div>
+
+  <div class="section">
     <h3>Edge Cases</h3>
     <button onclick="testRapidNotifications()">Send 5 Rapid Notifications</button>
     <button onclick="testEmptyNotification()">Send Empty Notification (no body)</button>
@@ -121,6 +127,24 @@
         log('Periodic #' + periodicCount + ' sent', 'pass');
       } catch (e) {
         log('Periodic #' + periodicCount + ' failed: ' + e.message, 'fail');
+      }
+    }
+
+    function testServiceWorkerNotification() {
+      if (typeof ServiceWorkerRegistration === 'undefined' ||
+          !ServiceWorkerRegistration.prototype.showNotification) {
+        log('ServiceWorkerRegistration.showNotification not available', 'fail');
+        return;
+      }
+      try {
+        var reg = Object.create(ServiceWorkerRegistration.prototype);
+        var ret = reg.showNotification('SW Notification', {
+          body: 'Posted via registration.showNotification()',
+          tag: 'sw-test'
+        });
+        log('showNotification() called (returns ' + (ret && ret.then ? 'Promise' : typeof ret) + ')', 'pass');
+      } catch (e) {
+        log('showNotification() failed: ' + e.message, 'fail');
       }
     }
 

--- a/test/notification_polyfill_test.dart
+++ b/test/notification_polyfill_test.dart
@@ -18,26 +18,43 @@ void main() {
       final permission = notificationsEnabled ? 'granted' : 'denied';
       return '''
 (function() {
+  var SITE_ID = '$siteId';
   var permission = '$permission';
-  function Notification(title, options) {
+  function deliver(title, options) {
     options = options || {};
-    if (permission !== 'granted') return;
     window.flutter_inappwebview.callHandler('webNotification', {
       title: String(title),
       body: String(options.body || ''),
       icon: String(options.icon || ''),
       tag: String(options.tag || ''),
-      siteId: '$siteId'
+      siteId: SITE_ID
     });
+  }
+  function blocked(api, title) {
+    try { console.warn('[WebSpace] ' + api + '("' + title + '") suppressed: permission ' + permission); } catch (e) {}
+  }
+  function Notification(title, options) {
+    if (permission !== 'granted') { blocked('Notification', title); return; }
+    deliver(title, options);
   }
   Notification.permission = permission;
   Notification.requestPermission = function(cb) {
-    var p = window.flutter_inappwebview.callHandler('webNotificationRequestPermission', {siteId: '$siteId'})
+    var p = window.flutter_inappwebview.callHandler('webNotificationRequestPermission', {siteId: SITE_ID})
       .then(function(result) { permission = result; Notification.permission = result; return result; });
     if (typeof cb === 'function') p.then(cb);
     return p;
   };
   Object.defineProperty(window, 'Notification', { value: Notification, writable: false, configurable: false });
+  try {
+    if (window.ServiceWorkerRegistration && ServiceWorkerRegistration.prototype) {
+      ServiceWorkerRegistration.prototype.showNotification = function(title, options) {
+        if (permission !== 'granted') { blocked('showNotification', title); return Promise.resolve(); }
+        deliver(title, options);
+        return Promise.resolve();
+      };
+      ServiceWorkerRegistration.prototype.getNotifications = function() { return Promise.resolve([]); };
+    }
+  } catch (e) {}
 })();
 ;null;''';
     }
@@ -48,9 +65,29 @@ void main() {
         notificationsEnabled: true,
       );
       expect(script, contains("permission = 'granted'"));
-      expect(script, contains("siteId: 'abc123'"));
+      expect(script, contains("SITE_ID = 'abc123'"));
       expect(script, isNot(contains('__PER_SITE_PERMISSION__')));
       expect(script, isNot(contains('__SITE_ID__')));
+    });
+
+    test('covers page-context ServiceWorkerRegistration.showNotification', () {
+      final script = buildPolyfill(
+        siteId: 'sw1',
+        notificationsEnabled: true,
+      );
+      expect(script,
+          contains('ServiceWorkerRegistration.prototype.showNotification'));
+      expect(script, contains("callHandler('webNotification'"));
+    });
+
+    test('emits a console breadcrumb when a notification is suppressed', () {
+      final script = buildPolyfill(
+        siteId: 'sw2',
+        notificationsEnabled: false,
+      );
+      expect(script, contains('suppressed: permission'));
+      expect(script, contains("blocked('Notification'"));
+      expect(script, contains("blocked('showNotification'"));
     });
 
     test('denied permission when notificationsEnabled is false', () {
@@ -59,7 +96,7 @@ void main() {
         notificationsEnabled: false,
       );
       expect(script, contains("permission = 'denied'"));
-      expect(script, contains("siteId: 'xyz789'"));
+      expect(script, contains("SITE_ID = 'xyz789'"));
     });
 
     test('siteId with special characters is embedded literally', () {
@@ -67,7 +104,7 @@ void main() {
         siteId: 'lqv2x3k-abc123',
         notificationsEnabled: true,
       );
-      expect(script, contains("siteId: 'lqv2x3k-abc123'"));
+      expect(script, contains("SITE_ID = 'lqv2x3k-abc123'"));
     });
 
     test('script defines window.Notification', () {

--- a/test/notification_polyfill_test.dart
+++ b/test/notification_polyfill_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 
 // Import the function directly since it's in the webview.dart library.
@@ -18,26 +20,43 @@ void main() {
       final permission = notificationsEnabled ? 'granted' : 'denied';
       return '''
 (function() {
+  var SITE_ID = ${jsonEncode(siteId)};
   var permission = '$permission';
-  function Notification(title, options) {
+  function deliver(title, options) {
     options = options || {};
-    if (permission !== 'granted') return;
     window.flutter_inappwebview.callHandler('webNotification', {
       title: String(title),
       body: String(options.body || ''),
       icon: String(options.icon || ''),
       tag: String(options.tag || ''),
-      siteId: '$siteId'
+      siteId: SITE_ID
     });
+  }
+  function blocked(api, title) {
+    try { console.warn('[WebSpace] ' + api + '("' + title + '") suppressed: permission ' + permission); } catch (e) {}
+  }
+  function Notification(title, options) {
+    if (permission !== 'granted') { blocked('Notification', title); return; }
+    deliver(title, options);
   }
   Notification.permission = permission;
   Notification.requestPermission = function(cb) {
-    var p = window.flutter_inappwebview.callHandler('webNotificationRequestPermission', {siteId: '$siteId'})
+    var p = window.flutter_inappwebview.callHandler('webNotificationRequestPermission', {siteId: SITE_ID})
       .then(function(result) { permission = result; Notification.permission = result; return result; });
     if (typeof cb === 'function') p.then(cb);
     return p;
   };
   Object.defineProperty(window, 'Notification', { value: Notification, writable: false, configurable: false });
+  try {
+    if (window.ServiceWorkerRegistration && ServiceWorkerRegistration.prototype) {
+      ServiceWorkerRegistration.prototype.showNotification = function(title, options) {
+        if (permission !== 'granted') { blocked('showNotification', title); return Promise.resolve(); }
+        deliver(title, options);
+        return Promise.resolve();
+      };
+      ServiceWorkerRegistration.prototype.getNotifications = function() { return Promise.resolve([]); };
+    }
+  } catch (e) {}
 })();
 ;null;''';
     }
@@ -48,9 +67,29 @@ void main() {
         notificationsEnabled: true,
       );
       expect(script, contains("permission = 'granted'"));
-      expect(script, contains("siteId: 'abc123'"));
+      expect(script, contains('SITE_ID = "abc123"'));
       expect(script, isNot(contains('__PER_SITE_PERMISSION__')));
       expect(script, isNot(contains('__SITE_ID__')));
+    });
+
+    test('covers page-context ServiceWorkerRegistration.showNotification', () {
+      final script = buildPolyfill(
+        siteId: 'sw1',
+        notificationsEnabled: true,
+      );
+      expect(script,
+          contains('ServiceWorkerRegistration.prototype.showNotification'));
+      expect(script, contains("callHandler('webNotification'"));
+    });
+
+    test('emits a console breadcrumb when a notification is suppressed', () {
+      final script = buildPolyfill(
+        siteId: 'sw2',
+        notificationsEnabled: false,
+      );
+      expect(script, contains('suppressed: permission'));
+      expect(script, contains("blocked('Notification'"));
+      expect(script, contains("blocked('showNotification'"));
     });
 
     test('denied permission when notificationsEnabled is false', () {
@@ -59,7 +98,7 @@ void main() {
         notificationsEnabled: false,
       );
       expect(script, contains("permission = 'denied'"));
-      expect(script, contains("siteId: 'xyz789'"));
+      expect(script, contains('SITE_ID = "xyz789"'));
     });
 
     test('siteId with special characters is embedded literally', () {
@@ -67,7 +106,7 @@ void main() {
         siteId: 'lqv2x3k-abc123',
         notificationsEnabled: true,
       );
-      expect(script, contains("siteId: 'lqv2x3k-abc123'"));
+      expect(script, contains('SITE_ID = "lqv2x3k-abc123"'));
     });
 
     test('script defines window.Notification', () {


### PR DESCRIPTION
The OS-scheduler -> reload -> page JS -> webNotification -> show chain
failed silently at every hop, forcing slow manual testing. Add trace
logging across the Dart orchestration and the iOS/Android native bridges
(aggregate counts and lifecycle only, no per-site metadata), plus
dev-tools "Simulate background refresh" and "Send test notification"
buttons so the chain can be exercised in the foreground without waiting
on BGAppRefreshTask / WorkManager.

Also cover page-context ServiceWorkerRegistration.showNotification (a
common pattern the constructor-only polyfill missed) and emit console
breadcrumbs when a notification is suppressed. True server-driven web
push via the worker push handler stays out of reach by design; document
that in the spec.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01296hFrdpF98B9MiqG83zMr