### PR TITLE
Add version 21 changelog

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/21.txt
+++ b/fastlane/metadata/android/en-US/changelogs/21.txt
@@ -1,6 +1,5 @@
 🐛 Bug Fixes:
-• Swipe back/forward navigation
-• Tab history restored after restart
+• Swipe back/forward navigation and history restore
 • Faster launch from home shortcuts
 • Android rendering on site switch
 • Always-open-home no longer resets

--- a/fastlane/metadata/android/en-US/changelogs/21.txt
+++ b/fastlane/metadata/android/en-US/changelogs/21.txt
@@ -4,3 +4,4 @@
 • Faster launch from home shortcuts
 • Android rendering on site switch
 • Always-open-home no longer resets
+• Ad-blocking statistics

--- a/fastlane/metadata/android/en-US/changelogs/21.txt
+++ b/fastlane/metadata/android/en-US/changelogs/21.txt
@@ -1,0 +1,8 @@
+✨ New Features:
+• Swipe back/forward navigation
+• Tab history restored after restart
+
+🐛 Bug Fixes:
+• Faster launch from home shortcuts
+• Android rendering on site switch
+• Always-open-home no longer resets

--- a/fastlane/metadata/android/en-US/changelogs/21.txt
+++ b/fastlane/metadata/android/en-US/changelogs/21.txt
@@ -1,8 +1,6 @@
-✨ New Features:
+🐛 Bug Fixes:
 • Swipe back/forward navigation
 • Tab history restored after restart
-
-🐛 Bug Fixes:
 • Faster launch from home shortcuts
 • Android rendering on site switch
 • Always-open-home no longer resets

--- a/fastlane/metadata/android/en-US/changelogs/21.txt
+++ b/fastlane/metadata/android/en-US/changelogs/21.txt
@@ -1,6 +1,8 @@
+🔧 Improvements:
+• Faster launch from home shortcuts
+
 🐛 Bug Fixes:
 • Swipe back/forward navigation and history restore
-• Faster launch from home shortcuts
 • Android rendering on site switch
 • Always-open-home no longer resets
 • Ad-blocking statistics


### PR DESCRIPTION
Document release 21 changes in the Android metadata changelog.

Changes:
- New swipe back/forward navigation feature
- Tab history restoration after app restart
- Faster launch from home shortcuts
- Android rendering fix on site switch
- Fix for always-open-home resetting behavior

https://claude.ai/code/session_01FFpC2GXpFcaLEpFQVryL8j