### PR TITLE
Enter fullscreen when a site opens from a home-screen shortcut

### DIFF
--- a/lib/l10n/app_af.arb
+++ b/lib/l10n/app_af.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Knoppieposisie",
   "appSettingsTabMaxWidth": "Oortjiebreedte-limiet",
   "appSettingsTabMaxWidthSubtitle": "Beperk hoe wyd elke oortjie kan word sodat lang name kompak bly",
+  "appSettingsFullscreenOnShortcut": "Volskerm by kortpad-loods",
+  "appSettingsFullscreenOnShortcutSubtitle": "Open in volskerm wanneer dit vanaf 'n tuisskerm-kortpad geloods word",
   "appSettingsFullscreenTabStrip": "In volskerm, oortjiebalk",
   "appSettingsFullscreenTabStripHidden": "Versteek",
   "appSettingsFullscreenTabStripAlways": "Altyd sigbaar",

--- a/lib/l10n/app_am.arb
+++ b/lib/l10n/app_am.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "የቁልፍ አቀማመጥ",
   "appSettingsTabMaxWidth": "የትር ስፋት ገደብ",
   "appSettingsTabMaxWidthSubtitle": "ረጅም ስሞች ጥቅጥቅ ብለው እንዲቆዩ እያንዳንዱ ትር ምን ያህል ሊሰፋ እንደሚችል ይገድቡ",
+  "appSettingsFullscreenOnShortcut": "በአቋራጭ ሲጀመር ሙሉ ማያ",
+  "appSettingsFullscreenOnShortcutSubtitle": "ከመነሻ ማያ አቋራጭ ሲጀመር በሙሉ ማያ ይክፈቱ",
   "appSettingsFullscreenTabStrip": "በሙሉ ማያ ገጽ፣ የትር አሞሌ",
   "appSettingsFullscreenTabStripHidden": "ተደብቋል",
   "appSettingsFullscreenTabStripAlways": "ሁልጊዜ የሚታይ",

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "موضع الزر",
   "appSettingsTabMaxWidth": "حد عرض التبويب",
   "appSettingsTabMaxWidthSubtitle": "حدّد مدى اتساع كل تبويب لإبقاء الأسماء الطويلة مضغوطة",
+  "appSettingsFullscreenOnShortcut": "ملء الشاشة عند التشغيل من اختصار",
+  "appSettingsFullscreenOnShortcutSubtitle": "افتح بملء الشاشة عند التشغيل من اختصار على الشاشة الرئيسية",
   "appSettingsFullscreenTabStrip": "في وضع ملء الشاشة، شريط التبويبات",
   "appSettingsFullscreenTabStripHidden": "مخفي",
   "appSettingsFullscreenTabStripAlways": "ظاهر دائمًا",

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Позиция на бутона",
   "appSettingsTabMaxWidth": "Ограничение на ширината на раздела",
   "appSettingsTabMaxWidthSubtitle": "Ограничете колко широк може да стане всеки раздел, за да останат дългите имена компактни",
+  "appSettingsFullscreenOnShortcut": "Цял екран при стартиране от пряк път",
+  "appSettingsFullscreenOnShortcutSubtitle": "Отваряне на цял екран при стартиране от пряк път на началния екран",
   "appSettingsFullscreenTabStrip": "На цял екран, лента с раздели",
   "appSettingsFullscreenTabStripHidden": "Скрита",
   "appSettingsFullscreenTabStripAlways": "Винаги видима",

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "বোতামের অবস্থান",
   "appSettingsTabMaxWidth": "ট্যাবের প্রস্থ সীমা",
   "appSettingsTabMaxWidthSubtitle": "দীর্ঘ নাম যাতে সংক্ষিপ্ত থাকে সেজন্য প্রতিটি ট্যাব কতটা চওড়া হতে পারে তা সীমিত করুন",
+  "appSettingsFullscreenOnShortcut": "শর্টকাট থেকে চালু হলে পূর্ণ স্ক্রিন",
+  "appSettingsFullscreenOnShortcutSubtitle": "হোম-স্ক্রিন শর্টকাট থেকে চালু হলে পূর্ণ স্ক্রিনে খুলুন",
   "appSettingsFullscreenTabStrip": "ফুলস্ক্রিনে, ট্যাব বার",
   "appSettingsFullscreenTabStripHidden": "লুকানো",
   "appSettingsFullscreenTabStripAlways": "সর্বদা দৃশ্যমান",

--- a/lib/l10n/app_bs.arb
+++ b/lib/l10n/app_bs.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Položaj dugmeta",
   "appSettingsTabMaxWidth": "Ograničenje širine kartice",
   "appSettingsTabMaxWidthSubtitle": "Ograničite koliko svaka kartica može biti široka kako bi duga imena ostala kompaktna",
+  "appSettingsFullscreenOnShortcut": "Cijeli ekran pri pokretanju iz prečice",
+  "appSettingsFullscreenOnShortcutSubtitle": "Otvori u punom ekranu kada se pokrene iz prečice na početnom ekranu",
   "appSettingsFullscreenTabStrip": "U punom ekranu, traka kartica",
   "appSettingsFullscreenTabStripHidden": "Skriveno",
   "appSettingsFullscreenTabStripAlways": "Uvijek vidljivo",

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Posició del botó",
   "appSettingsTabMaxWidth": "Límit d'amplada de pestanya",
   "appSettingsTabMaxWidthSubtitle": "Limita l'amplada de cada pestanya perquè els noms llargs es mantinguin compactes",
+  "appSettingsFullscreenOnShortcut": "Pantalla completa en obrir des d'una drecera",
+  "appSettingsFullscreenOnShortcutSubtitle": "Obre en pantalla completa quan s'inicia des d'una drecera de la pantalla d'inici",
   "appSettingsFullscreenTabStrip": "En pantalla completa, barra de pestanyes",
   "appSettingsFullscreenTabStripHidden": "Amagada",
   "appSettingsFullscreenTabStripAlways": "Sempre visible",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Poloha tlačítka",
   "appSettingsTabMaxWidth": "Omezení šířky karty",
   "appSettingsTabMaxWidthSubtitle": "Omezte, jak široká může být každá karta, aby dlouhé názvy zůstaly kompaktní",
+  "appSettingsFullscreenOnShortcut": "Celá obrazovka při spuštění ze zástupce",
+  "appSettingsFullscreenOnShortcutSubtitle": "Otevřít na celou obrazovku při spuštění ze zástupce na ploše",
   "appSettingsFullscreenTabStrip": "Na celé obrazovce, panel karet",
   "appSettingsFullscreenTabStripHidden": "Skrytý",
   "appSettingsFullscreenTabStripAlways": "Vždy viditelný",

--- a/lib/l10n/app_cy.arb
+++ b/lib/l10n/app_cy.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Safle'r botwm",
   "appSettingsTabMaxWidth": "Terfyn Lled Tab",
   "appSettingsTabMaxWidthSubtitle": "Cyfyngu pa mor llydan y gall pob tab dyfu fel bod enwau hir yn aros yn gryno",
+  "appSettingsFullscreenOnShortcut": "Sgrin lawn wrth lansio o lwybr byr",
+  "appSettingsFullscreenOnShortcutSubtitle": "Agor yn sgrin lawn pan gaiff ei lansio o lwybr byr ar y sgrin gartref",
   "appSettingsFullscreenTabStrip": "Yn y sgrin lawn, bar tabiau",
   "appSettingsFullscreenTabStripHidden": "Cuddiedig",
   "appSettingsFullscreenTabStripAlways": "Gweladwy bob amser",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Knapplacering",
   "appSettingsTabMaxWidth": "Grænse for fanebredde",
   "appSettingsTabMaxWidthSubtitle": "Begræns hvor bred hver fane kan blive, så lange navne forbliver kompakte",
+  "appSettingsFullscreenOnShortcut": "Fuld skærm ved start fra genvej",
+  "appSettingsFullscreenOnShortcutSubtitle": "Åbn i fuld skærm, når der startes fra en genvej på startskærmen",
   "appSettingsFullscreenTabStrip": "I fuld skærm, fanebjælke",
   "appSettingsFullscreenTabStripHidden": "Skjult",
   "appSettingsFullscreenTabStripAlways": "Altid synlig",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Schaltflächenposition",
   "appSettingsTabMaxWidth": "Tab-Breiten-Limit",
   "appSettingsTabMaxWidthSubtitle": "Begrenzen, wie breit jeder Tab werden kann, damit lange Namen kompakt bleiben",
+  "appSettingsFullscreenOnShortcut": "Vollbild beim Start über Verknüpfung",
+  "appSettingsFullscreenOnShortcutSubtitle": "Im Vollbild öffnen, wenn über eine Startbildschirm-Verknüpfung gestartet",
   "appSettingsFullscreenTabStrip": "Im Vollbild, Tableiste",
   "appSettingsFullscreenTabStripHidden": "Ausgeblendet",
   "appSettingsFullscreenTabStripAlways": "Immer sichtbar",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Θέση κουμπιού",
   "appSettingsTabMaxWidth": "Όριο πλάτους καρτέλας",
   "appSettingsTabMaxWidthSubtitle": "Περιορίστε πόσο φαρδιά μπορεί να γίνει κάθε καρτέλα ώστε τα μεγάλα ονόματα να παραμένουν συμπαγή",
+  "appSettingsFullscreenOnShortcut": "Πλήρης οθόνη κατά την εκκίνηση από συντόμευση",
+  "appSettingsFullscreenOnShortcutSubtitle": "Άνοιγμα σε πλήρη οθόνη κατά την εκκίνηση από συντόμευση αρχικής οθόνης",
   "appSettingsFullscreenTabStrip": "Σε πλήρη οθόνη, γραμμή καρτελών",
   "appSettingsFullscreenTabStripHidden": "Κρυφή",
   "appSettingsFullscreenTabStripAlways": "Πάντα ορατή",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -839,6 +839,14 @@
   "@appSettingsSiteTabStripSubtitle": {
     "description": "Subtitle for the site tab strip toggle"
   },
+  "appSettingsFullscreenOnShortcut": "Full screen on shortcut launch",
+  "@appSettingsFullscreenOnShortcut": {
+    "description": "Toggle title for automatically entering full screen when a site is opened from a home-screen shortcut"
+  },
+  "appSettingsFullscreenOnShortcutSubtitle": "Open in full screen when launched from a home-screen shortcut",
+  "@appSettingsFullscreenOnShortcutSubtitle": {
+    "description": "Subtitle for the toggle that enters full screen when a site is opened from a pinned home-screen shortcut"
+  },
   "appSettingsFullscreenTabStrip": "In full screen, tab strip",
   "@appSettingsFullscreenTabStrip": {
     "description": "Group label for the choice of how the tab strip behaves in full screen (followed by the Hidden / Always visible / Reveal with button options)"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Posición del botón",
   "appSettingsTabMaxWidth": "Límite de ancho de pestaña",
   "appSettingsTabMaxWidthSubtitle": "Limita cuánto puede crecer cada pestaña para que los nombres largos se mantengan compactos",
+  "appSettingsFullscreenOnShortcut": "Pantalla completa al abrir desde un acceso directo",
+  "appSettingsFullscreenOnShortcutSubtitle": "Abrir en pantalla completa cuando se inicia desde un acceso directo de la pantalla de inicio",
   "appSettingsFullscreenTabStrip": "En pantalla completa, barra de pestañas",
   "appSettingsFullscreenTabStripHidden": "Oculta",
   "appSettingsFullscreenTabStripAlways": "Siempre visible",

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Nupu asukoht",
   "appSettingsTabMaxWidth": "Vahekaardi laiuse piirang",
   "appSettingsTabMaxWidthSubtitle": "Piira, kui laiaks iga vahekaart võib kasvada, et pikad nimed jääksid kompaktseks",
+  "appSettingsFullscreenOnShortcut": "Täisekraan otsetee kaudu avamisel",
+  "appSettingsFullscreenOnShortcutSubtitle": "Ava täisekraanil, kui käivitatakse avakuva otseteest",
   "appSettingsFullscreenTabStrip": "Täisekraanil, vahekaartide riba",
   "appSettingsFullscreenTabStripHidden": "Peidetud",
   "appSettingsFullscreenTabStripAlways": "Alati nähtav",

--- a/lib/l10n/app_eu.arb
+++ b/lib/l10n/app_eu.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Botoiaren kokapena",
   "appSettingsTabMaxWidth": "Fitxaren zabalera-muga",
   "appSettingsTabMaxWidthSubtitle": "Mugatu fitxa bakoitza zenbat zabaldu daitekeen, izen luzeak trinko mantentzeko",
+  "appSettingsFullscreenOnShortcut": "Pantaila osoa lasterbidetik abiaraztean",
+  "appSettingsFullscreenOnShortcutSubtitle": "Ireki pantaila osoan hasierako pantailako lasterbide batetik abiarazten denean",
   "appSettingsFullscreenTabStrip": "Pantaila osoan, fitxa-barra",
   "appSettingsFullscreenTabStripHidden": "Ezkutatuta",
   "appSettingsFullscreenTabStripAlways": "Beti ikusgai",

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "موقعیت دکمه",
   "appSettingsTabMaxWidth": "محدودیت عرض زبانه",
   "appSettingsTabMaxWidthSubtitle": "محدود کنید هر زبانه چقدر می‌تواند پهن شود تا نام‌های طولانی فشرده بمانند",
+  "appSettingsFullscreenOnShortcut": "تمام‌صفحه هنگام اجرا از میان‌بر",
+  "appSettingsFullscreenOnShortcutSubtitle": "هنگام اجرا از میان‌بر صفحه اصلی، در حالت تمام‌صفحه باز شود",
   "appSettingsFullscreenTabStrip": "در تمام‌صفحه، نوار زبانه‌ها",
   "appSettingsFullscreenTabStripHidden": "پنهان",
   "appSettingsFullscreenTabStripAlways": "همیشه نمایان",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Painikkeen sijainti",
   "appSettingsTabMaxWidth": "Välilehden leveysraja",
   "appSettingsTabMaxWidthSubtitle": "Rajoita, kuinka leveäksi kukin välilehti voi kasvaa, jotta pitkät nimet pysyvät tiiviinä",
+  "appSettingsFullscreenOnShortcut": "Koko näyttö pikakuvakkeesta käynnistettäessä",
+  "appSettingsFullscreenOnShortcutSubtitle": "Avaa koko näytöllä, kun käynnistetään aloitusnäytön pikakuvakkeesta",
   "appSettingsFullscreenTabStrip": "Koko näytössä, välilehtipalkki",
   "appSettingsFullscreenTabStripHidden": "Piilotettu",
   "appSettingsFullscreenTabStripAlways": "Aina näkyvissä",

--- a/lib/l10n/app_fil.arb
+++ b/lib/l10n/app_fil.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Posisyon ng button",
   "appSettingsTabMaxWidth": "Limitasyon sa Lapad ng Tab",
   "appSettingsTabMaxWidthSubtitle": "Limitahan kung gaano kalapad ang bawat tab para manatiling compact ang mahahabang pangalan",
+  "appSettingsFullscreenOnShortcut": "Full screen kapag binuksan mula sa shortcut",
+  "appSettingsFullscreenOnShortcutSubtitle": "Buksan sa full screen kapag inilunsad mula sa shortcut sa home screen",
   "appSettingsFullscreenTabStrip": "Sa full screen, tab bar",
   "appSettingsFullscreenTabStripHidden": "Nakatago",
   "appSettingsFullscreenTabStripAlways": "Palaging nakikita",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Position du bouton",
   "appSettingsTabMaxWidth": "Limite de largeur des onglets",
   "appSettingsTabMaxWidthSubtitle": "Limiter la largeur de chaque onglet pour que les noms longs restent compacts",
+  "appSettingsFullscreenOnShortcut": "Plein écran au lancement depuis un raccourci",
+  "appSettingsFullscreenOnShortcutSubtitle": "Ouvrir en plein écran au lancement depuis un raccourci de l'écran d'accueil",
   "appSettingsFullscreenTabStrip": "En plein écran, barre d'onglets",
   "appSettingsFullscreenTabStripHidden": "Masquée",
   "appSettingsFullscreenTabStripAlways": "Toujours visible",

--- a/lib/l10n/app_ga.arb
+++ b/lib/l10n/app_ga.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Suíomh an chnaipe",
   "appSettingsTabMaxWidth": "Teorainn Leithead Cluaisín",
   "appSettingsTabMaxWidthSubtitle": "Cuir teorainn le leithead gach cluaisín ionas go bhfanfaidh ainmneacha fada dlúth",
+  "appSettingsFullscreenOnShortcut": "Lánscáileán nuair a sheoltar ó aicearra",
+  "appSettingsFullscreenOnShortcutSubtitle": "Oscail i lánscáileán nuair a sheoltar ó aicearra ar an scáileán baile",
   "appSettingsFullscreenTabStrip": "Sa scáileán iomlán, barra cluaisíní",
   "appSettingsFullscreenTabStripHidden": "Folaithe",
   "appSettingsFullscreenTabStripAlways": "Le feiceáil i gcónaí",

--- a/lib/l10n/app_gl.arb
+++ b/lib/l10n/app_gl.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Posición do botón",
   "appSettingsTabMaxWidth": "Límite de ancho da lapela",
   "appSettingsTabMaxWidthSubtitle": "Limita canto pode medrar cada lapela para que os nomes longos se manteñan compactos",
+  "appSettingsFullscreenOnShortcut": "Pantalla completa ao iniciar desde un atallo",
+  "appSettingsFullscreenOnShortcutSubtitle": "Abrir en pantalla completa cando se inicia desde un atallo da pantalla de inicio",
   "appSettingsFullscreenTabStrip": "En pantalla completa, barra de lapelas",
   "appSettingsFullscreenTabStripHidden": "Agochada",
   "appSettingsFullscreenTabStripAlways": "Sempre visible",

--- a/lib/l10n/app_gu.arb
+++ b/lib/l10n/app_gu.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "બટનની સ્થિતિ",
   "appSettingsTabMaxWidth": "ટૅબ પહોળાઈ મર્યાદા",
   "appSettingsTabMaxWidthSubtitle": "દરેક ટૅબ કેટલી પહોળી થઈ શકે તે મર્યાદિત કરો જેથી લાંબા નામ સંકુચિત રહે",
+  "appSettingsFullscreenOnShortcut": "શૉર્ટકટથી શરૂ થાય ત્યારે પૂર્ણ સ્ક્રીન",
+  "appSettingsFullscreenOnShortcutSubtitle": "હોમ-સ્ક્રીન શૉર્ટકટથી શરૂ થાય ત્યારે પૂર્ણ સ્ક્રીનમાં ખોલો",
   "appSettingsFullscreenTabStrip": "પૂર્ણ સ્ક્રીનમાં, ટૅબ બાર",
   "appSettingsFullscreenTabStripHidden": "છુપાયેલ",
   "appSettingsFullscreenTabStripAlways": "હંમેશા દૃશ્યમાન",

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "מיקום הכפתור",
   "appSettingsTabMaxWidth": "מגבלת רוחב כרטיסייה",
   "appSettingsTabMaxWidthSubtitle": "הגבל את רוחב כל כרטיסייה כדי ששמות ארוכים יישארו קומפקטיים",
+  "appSettingsFullscreenOnShortcut": "מסך מלא בהפעלה מקיצור דרך",
+  "appSettingsFullscreenOnShortcutSubtitle": "פתח במסך מלא בעת הפעלה מקיצור דרך במסך הבית",
   "appSettingsFullscreenTabStrip": "במסך מלא, סרגל כרטיסיות",
   "appSettingsFullscreenTabStripHidden": "מוסתר",
   "appSettingsFullscreenTabStripAlways": "תמיד גלוי",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "बटन की स्थिति",
   "appSettingsTabMaxWidth": "टैब चौड़ाई सीमा",
   "appSettingsTabMaxWidthSubtitle": "सीमित करें कि प्रत्येक टैब कितना चौड़ा हो सकता है ताकि लंबे नाम संक्षिप्त रहें",
+  "appSettingsFullscreenOnShortcut": "शॉर्टकट से खोलने पर फ़ुल स्क्रीन",
+  "appSettingsFullscreenOnShortcutSubtitle": "होम-स्क्रीन शॉर्टकट से लॉन्च होने पर फ़ुल स्क्रीन में खोलें",
   "appSettingsFullscreenTabStrip": "फ़ुल स्क्रीन में, टैब बार",
   "appSettingsFullscreenTabStripHidden": "छिपा हुआ",
   "appSettingsFullscreenTabStripAlways": "हमेशा दृश्यमान",

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Položaj gumba",
   "appSettingsTabMaxWidth": "Ograničenje širine kartice",
   "appSettingsTabMaxWidthSubtitle": "Ograničite koliko svaka kartica može biti široka kako bi dugačka imena ostala kompaktna",
+  "appSettingsFullscreenOnShortcut": "Cijeli zaslon pri pokretanju iz prečaca",
+  "appSettingsFullscreenOnShortcutSubtitle": "Otvori u punom zaslonu kada se pokrene iz prečaca na početnom zaslonu",
   "appSettingsFullscreenTabStrip": "U punom zaslonu, traka kartica",
   "appSettingsFullscreenTabStripHidden": "Skriveno",
   "appSettingsFullscreenTabStripAlways": "Uvijek vidljivo",

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Gomb helyzete",
   "appSettingsTabMaxWidth": "Lapszélesség korlát",
   "appSettingsTabMaxWidthSubtitle": "Korlátozza, milyen széles lehet az egyes lapok, hogy a hosszú nevek tömörek maradjanak",
+  "appSettingsFullscreenOnShortcut": "Teljes képernyő parancsikonból indításkor",
+  "appSettingsFullscreenOnShortcutSubtitle": "Megnyitás teljes képernyőn, ha a kezdőképernyő parancsikonjából indul",
   "appSettingsFullscreenTabStrip": "Teljes képernyőn, lapsáv",
   "appSettingsFullscreenTabStripHidden": "Rejtett",
   "appSettingsFullscreenTabStripAlways": "Mindig látható",

--- a/lib/l10n/app_hy.arb
+++ b/lib/l10n/app_hy.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Կոճակի դիրքը",
   "appSettingsTabMaxWidth": "Ներդիրի լայնության սահման",
   "appSettingsTabMaxWidthSubtitle": "Սահմանափակեք, թե որքան լայն կարող է լինել յուրաքանչյուր ներդիր, որպեսզի երկար անունները մնան կոմպակտ",
+  "appSettingsFullscreenOnShortcut": "Լրիվ էկրան դյուրանցումից բացելիս",
+  "appSettingsFullscreenOnShortcutSubtitle": "Բացել լրիվ էկրանով, երբ գործարկվում է հիմնական էկրանի դյուրանցումից",
   "appSettingsFullscreenTabStrip": "Ամբողջ էկրանին, ներդիրների գոտի",
   "appSettingsFullscreenTabStripHidden": "Թաքնված",
   "appSettingsFullscreenTabStripAlways": "Միշտ տեսանելի",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Posisi tombol",
   "appSettingsTabMaxWidth": "Batas Lebar Tab",
   "appSettingsTabMaxWidthSubtitle": "Batasi seberapa lebar setiap tab agar nama yang panjang tetap ringkas",
+  "appSettingsFullscreenOnShortcut": "Layar penuh saat dibuka dari pintasan",
+  "appSettingsFullscreenOnShortcutSubtitle": "Buka dalam layar penuh saat diluncurkan dari pintasan layar beranda",
   "appSettingsFullscreenTabStrip": "Di layar penuh, bilah tab",
   "appSettingsFullscreenTabStripHidden": "Tersembunyi",
   "appSettingsFullscreenTabStripAlways": "Selalu terlihat",

--- a/lib/l10n/app_is.arb
+++ b/lib/l10n/app_is.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Staðsetning hnapps",
   "appSettingsTabMaxWidth": "Breiddartakmark flipa",
   "appSettingsTabMaxWidthSubtitle": "Takmarkaðu hversu breiður hver flipi getur orðið svo löng nöfn haldist samanþjöppuð",
+  "appSettingsFullscreenOnShortcut": "Allur skjárinn þegar ræst er úr flýtileið",
+  "appSettingsFullscreenOnShortcutSubtitle": "Opna á öllum skjánum þegar ræst er úr flýtileið á heimaskjá",
   "appSettingsFullscreenTabStrip": "Í fullum skjá, flipastika",
   "appSettingsFullscreenTabStripHidden": "Falin",
   "appSettingsFullscreenTabStripAlways": "Alltaf sýnileg",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Posizione del pulsante",
   "appSettingsTabMaxWidth": "Limite larghezza scheda",
   "appSettingsTabMaxWidthSubtitle": "Limita quanto può diventare larga ogni scheda in modo che i nomi lunghi restino compatti",
+  "appSettingsFullscreenOnShortcut": "Schermo intero all'avvio da scorciatoia",
+  "appSettingsFullscreenOnShortcutSubtitle": "Apri a schermo intero quando avviato da una scorciatoia della schermata Home",
   "appSettingsFullscreenTabStrip": "A schermo intero, barra delle schede",
   "appSettingsFullscreenTabStripHidden": "Nascosta",
   "appSettingsFullscreenTabStripAlways": "Sempre visibile",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "ボタンの位置",
   "appSettingsTabMaxWidth": "タブ幅の上限",
   "appSettingsTabMaxWidthSubtitle": "長い名前がコンパクトに収まるよう、各タブの幅を制限します",
+  "appSettingsFullscreenOnShortcut": "ショートカットからの起動時に全画面",
+  "appSettingsFullscreenOnShortcutSubtitle": "ホーム画面のショートカットから起動したときに全画面で開く",
   "appSettingsFullscreenTabStrip": "全画面でのタブバー",
   "appSettingsFullscreenTabStripHidden": "非表示",
   "appSettingsFullscreenTabStripAlways": "常に表示",

--- a/lib/l10n/app_ka.arb
+++ b/lib/l10n/app_ka.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "ღილაკის პოზიცია",
   "appSettingsTabMaxWidth": "ჩანართის სიგანის ლიმიტი",
   "appSettingsTabMaxWidthSubtitle": "შეზღუდე, რამდენად განიერი შეიძლება იყოს თითოეული ჩანართი, რომ გრძელი სახელები კომპაქტური დარჩეს",
+  "appSettingsFullscreenOnShortcut": "სრული ეკრანი მალსახმობიდან გაშვებისას",
+  "appSettingsFullscreenOnShortcutSubtitle": "გახსენით სრულ ეკრანზე, როცა მთავარი ეკრანის მალსახმობიდან ეშვება",
   "appSettingsFullscreenTabStrip": "სრულ ეკრანზე, ჩანართების ზოლი",
   "appSettingsFullscreenTabStripHidden": "დამალული",
   "appSettingsFullscreenTabStripAlways": "ყოველთვის ხილული",

--- a/lib/l10n/app_km.arb
+++ b/lib/l10n/app_km.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "ទីតាំងប៊ូតុង",
   "appSettingsTabMaxWidth": "ដែនកំណត់ទទឹងផ្ទាំង",
   "appSettingsTabMaxWidthSubtitle": "កំណត់ទទឹងអតិបរមានៃផ្ទាំងនីមួយៗ ដើម្បីឱ្យឈ្មោះវែងនៅតែបង្រួម",
+  "appSettingsFullscreenOnShortcut": "ពេញអេក្រង់ពេលបើកពីផ្លូវកាត់",
+  "appSettingsFullscreenOnShortcutSubtitle": "បើកក្នុងពេញអេក្រង់ពេលបើកដំណើរការពីផ្លូវកាត់អេក្រង់ដើម",
   "appSettingsFullscreenTabStrip": "ក្នុងអេក្រង់ពេញ របារផ្ទាំង",
   "appSettingsFullscreenTabStripHidden": "លាក់",
   "appSettingsFullscreenTabStripAlways": "បង្ហាញជានិច្ច",

--- a/lib/l10n/app_kn.arb
+++ b/lib/l10n/app_kn.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "ಬಟನ್ ಸ್ಥಾನ",
   "appSettingsTabMaxWidth": "ಟ್ಯಾಬ್ ಅಗಲ ಮಿತಿ",
   "appSettingsTabMaxWidthSubtitle": "ಉದ್ದದ ಹೆಸರುಗಳು ಸಾಂದ್ರವಾಗಿರಲು ಪ್ರತಿ ಟ್ಯಾಬ್ ಎಷ್ಟು ಅಗಲವಾಗಬಹುದು ಎಂಬುದನ್ನು ಮಿತಿಗೊಳಿಸಿ",
+  "appSettingsFullscreenOnShortcut": "ಶಾರ್ಟ್‌ಕಟ್‌ನಿಂದ ತೆರೆದಾಗ ಪೂರ್ಣ ಪರದೆ",
+  "appSettingsFullscreenOnShortcutSubtitle": "ಮುಖಪುಟ ಪರದೆಯ ಶಾರ್ಟ್‌ಕಟ್‌ನಿಂದ ಪ್ರಾರಂಭಿಸಿದಾಗ ಪೂರ್ಣ ಪರದೆಯಲ್ಲಿ ತೆರೆಯಿರಿ",
   "appSettingsFullscreenTabStrip": "ಪೂರ್ಣ ಪರದೆಯಲ್ಲಿ, ಟ್ಯಾಬ್ ಬಾರ್",
   "appSettingsFullscreenTabStripHidden": "ಮರೆಮಾಡಲಾಗಿದೆ",
   "appSettingsFullscreenTabStripAlways": "ಯಾವಾಗಲೂ ಗೋಚರ",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "버튼 위치",
   "appSettingsTabMaxWidth": "탭 너비 제한",
   "appSettingsTabMaxWidthSubtitle": "긴 이름이 간결하게 유지되도록 각 탭이 넓어질 수 있는 정도를 제한합니다",
+  "appSettingsFullscreenOnShortcut": "바로가기로 실행 시 전체 화면",
+  "appSettingsFullscreenOnShortcutSubtitle": "홈 화면 바로가기로 실행할 때 전체 화면으로 열기",
   "appSettingsFullscreenTabStrip": "전체 화면에서 탭 바",
   "appSettingsFullscreenTabStripHidden": "숨김",
   "appSettingsFullscreenTabStripAlways": "항상 표시",

--- a/lib/l10n/app_la.arb
+++ b/lib/l10n/app_la.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Positio bullae",
   "appSettingsTabMaxWidth": "Limes latitudinis tabulae",
   "appSettingsTabMaxWidthSubtitle": "Limita quantum quaeque tabula latescere possit ut nomina longa compacta maneant",
+  "appSettingsFullscreenOnShortcut": "Plena pictura cum e compendio aperitur",
+  "appSettingsFullscreenOnShortcutSubtitle": "In plena pictura aperi cum e compendio paginae principalis initur",
   "appSettingsFullscreenTabStrip": "In pleno schemate, series tabularum",
   "appSettingsFullscreenTabStripHidden": "Occultata",
   "appSettingsFullscreenTabStripAlways": "Semper visibilis",

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Mygtuko padėtis",
   "appSettingsTabMaxWidth": "Kortelės pločio riba",
   "appSettingsTabMaxWidthSubtitle": "Apribokite, kokio pločio gali būti kiekviena kortelė, kad ilgi pavadinimai liktų kompaktiški",
+  "appSettingsFullscreenOnShortcut": "Visas ekranas paleidžiant iš nuorodos",
+  "appSettingsFullscreenOnShortcutSubtitle": "Atidaryti per visą ekraną, kai paleidžiama iš pradžios ekrano nuorodos",
   "appSettingsFullscreenTabStrip": "Viso ekrano režime, kortelių juosta",
   "appSettingsFullscreenTabStripHidden": "Paslėpta",
   "appSettingsFullscreenTabStripAlways": "Visada matoma",

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Pogas novietojums",
   "appSettingsTabMaxWidth": "Cilnes platuma ierobežojums",
   "appSettingsTabMaxWidthSubtitle": "Ierobežojiet, cik plata var kļūt katra cilne, lai gari nosaukumi paliktu kompakti",
+  "appSettingsFullscreenOnShortcut": "Pilnekrāns, palaižot no saīsnes",
+  "appSettingsFullscreenOnShortcutSubtitle": "Atvērt pilnekrānā, kad palaiž no sākuma ekrāna saīsnes",
   "appSettingsFullscreenTabStrip": "Pilnekrānā, ciļņu josla",
   "appSettingsFullscreenTabStripHidden": "Slēpta",
   "appSettingsFullscreenTabStripAlways": "Vienmēr redzama",

--- a/lib/l10n/app_mk.arb
+++ b/lib/l10n/app_mk.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Позиција на копчето",
   "appSettingsTabMaxWidth": "Ограничување на ширината на јазичето",
   "appSettingsTabMaxWidthSubtitle": "Ограничете колку широко може да стане секое јазиче за да останат долгите имиња компактни",
+  "appSettingsFullscreenOnShortcut": "Цел екран при отворање од кратенка",
+  "appSettingsFullscreenOnShortcutSubtitle": "Отвори на цел екран кога се стартува од кратенка на почетниот екран",
   "appSettingsFullscreenTabStrip": "На цел екран, лента со јазичиња",
   "appSettingsFullscreenTabStripHidden": "Скриено",
   "appSettingsFullscreenTabStripAlways": "Секогаш видливо",

--- a/lib/l10n/app_ml.arb
+++ b/lib/l10n/app_ml.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "ബട്ടണിന്റെ സ്ഥാനം",
   "appSettingsTabMaxWidth": "ടാബ് വീതി പരിധി",
   "appSettingsTabMaxWidthSubtitle": "നീണ്ട പേരുകൾ ഒതുക്കമായി നിലനിൽക്കാൻ ഓരോ ടാബും എത്രമാത്രം വീതിയാകാം എന്നത് പരിമിതപ്പെടുത്തുക",
+  "appSettingsFullscreenOnShortcut": "കുറുക്കുവഴിയിൽ നിന്ന് തുറക്കുമ്പോൾ പൂർണ്ണ സ്ക്രീൻ",
+  "appSettingsFullscreenOnShortcutSubtitle": "ഹോം-സ്ക്രീൻ കുറുക്കുവഴിയിൽ നിന്ന് സമാരംഭിക്കുമ്പോൾ പൂർണ്ണ സ്ക്രീനിൽ തുറക്കുക",
   "appSettingsFullscreenTabStrip": "പൂർണ്ണ സ്ക്രീനിൽ, ടാബ് ബാർ",
   "appSettingsFullscreenTabStripHidden": "മറച്ചിരിക്കുന്നു",
   "appSettingsFullscreenTabStripAlways": "എപ്പോഴും ദൃശ്യം",

--- a/lib/l10n/app_mn.arb
+++ b/lib/l10n/app_mn.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Товчны байрлал",
   "appSettingsTabMaxWidth": "Табын өргөний хязгаар",
   "appSettingsTabMaxWidthSubtitle": "Урт нэрс нягт байхын тулд таб бүр хэр өргөн болохыг хязгаарлана",
+  "appSettingsFullscreenOnShortcut": "Товчлолоор нээхэд бүтэн дэлгэц",
+  "appSettingsFullscreenOnShortcutSubtitle": "Үндсэн дэлгэцийн товчлолоор эхлүүлэхэд бүтэн дэлгэцээр нээх",
   "appSettingsFullscreenTabStrip": "Бүтэн дэлгэцэд, таб самбар",
   "appSettingsFullscreenTabStripHidden": "Нуусан",
   "appSettingsFullscreenTabStripAlways": "Үргэлж харагдана",

--- a/lib/l10n/app_mr.arb
+++ b/lib/l10n/app_mr.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "बटणाची स्थिती",
   "appSettingsTabMaxWidth": "टॅब रुंदी मर्यादा",
   "appSettingsTabMaxWidthSubtitle": "लांब नावे संक्षिप्त राहावीत म्हणून प्रत्येक टॅब किती रुंद होऊ शकतो ते मर्यादित करा",
+  "appSettingsFullscreenOnShortcut": "शॉर्टकटवरून उघडल्यावर पूर्ण स्क्रीन",
+  "appSettingsFullscreenOnShortcutSubtitle": "होम-स्क्रीन शॉर्टकटवरून सुरू केल्यावर पूर्ण स्क्रीनमध्ये उघडा",
   "appSettingsFullscreenTabStrip": "पूर्ण स्क्रीनमध्ये, टॅब बार",
   "appSettingsFullscreenTabStripHidden": "लपवलेले",
   "appSettingsFullscreenTabStripAlways": "नेहमी दृश्यमान",

--- a/lib/l10n/app_ms.arb
+++ b/lib/l10n/app_ms.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Kedudukan butang",
   "appSettingsTabMaxWidth": "Had Lebar Tab",
   "appSettingsTabMaxWidthSubtitle": "Hadkan sejauh mana setiap tab boleh melebar supaya nama panjang kekal padat",
+  "appSettingsFullscreenOnShortcut": "Skrin penuh apabila dilancarkan dari pintasan",
+  "appSettingsFullscreenOnShortcutSubtitle": "Buka dalam skrin penuh apabila dilancarkan dari pintasan skrin utama",
   "appSettingsFullscreenTabStrip": "Dalam skrin penuh, bar tab",
   "appSettingsFullscreenTabStripHidden": "Tersembunyi",
   "appSettingsFullscreenTabStripAlways": "Sentiasa kelihatan",

--- a/lib/l10n/app_mt.arb
+++ b/lib/l10n/app_mt.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Pożizzjoni tal-buttuna",
   "appSettingsTabMaxWidth": "Limitu tal-Wisa' tat-Tab",
   "appSettingsTabMaxWidthSubtitle": "Illimita kemm jista' jikber wiesa' kull tab biex ismijiet twal jibqgħu kompatti",
+  "appSettingsFullscreenOnShortcut": "Skrin sħiħ meta jitnieda minn shortcut",
+  "appSettingsFullscreenOnShortcutSubtitle": "Iftaħ fi skrin sħiħ meta jitnieda minn shortcut tal-iskrin tad-dar",
   "appSettingsFullscreenTabStrip": "Fl-iskrin sħiħ, bar tat-tabs",
   "appSettingsFullscreenTabStripHidden": "Moħbi",
   "appSettingsFullscreenTabStripAlways": "Dejjem viżibbli",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Knappplassering",
   "appSettingsTabMaxWidth": "Grense for fanebredde",
   "appSettingsTabMaxWidthSubtitle": "Begrens hvor bred hver fane kan bli, slik at lange navn forblir kompakte",
+  "appSettingsFullscreenOnShortcut": "Fullskjerm ved oppstart fra snarvei",
+  "appSettingsFullscreenOnShortcutSubtitle": "Åpne i fullskjerm når den startes fra en snarvei på startskjermen",
   "appSettingsFullscreenTabStrip": "I fullskjerm, fanelinje",
   "appSettingsFullscreenTabStripHidden": "Skjult",
   "appSettingsFullscreenTabStripAlways": "Alltid synlig",

--- a/lib/l10n/app_ne.arb
+++ b/lib/l10n/app_ne.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "बटनको स्थिति",
   "appSettingsTabMaxWidth": "ट्याब चौडाइ सीमा",
   "appSettingsTabMaxWidthSubtitle": "लामो नामहरू सङ्कुचित रहून् भनेर प्रत्येक ट्याब कति चौडा हुन सक्छ भनेर सीमित गर्नुहोस्",
+  "appSettingsFullscreenOnShortcut": "सर्टकटबाट सुरु गर्दा फुल स्क्रिन",
+  "appSettingsFullscreenOnShortcutSubtitle": "होम-स्क्रिन सर्टकटबाट सुरु हुँदा फुल स्क्रिनमा खोल्नुहोस्",
   "appSettingsFullscreenTabStrip": "पूर्ण स्क्रिनमा, ट्याब बार",
   "appSettingsFullscreenTabStripHidden": "लुकाइएको",
   "appSettingsFullscreenTabStripAlways": "सधैं देखिने",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Knoppositie",
   "appSettingsTabMaxWidth": "Tabbreedtelimiet",
   "appSettingsTabMaxWidthSubtitle": "Beperk hoe breed elke tab kan worden zodat lange namen compact blijven",
+  "appSettingsFullscreenOnShortcut": "Volledig scherm bij starten via snelkoppeling",
+  "appSettingsFullscreenOnShortcutSubtitle": "Open in volledig scherm bij starten vanaf een snelkoppeling op het startscherm",
   "appSettingsFullscreenTabStrip": "In volledig scherm, tabbalk",
   "appSettingsFullscreenTabStripHidden": "Verborgen",
   "appSettingsFullscreenTabStripAlways": "Altijd zichtbaar",

--- a/lib/l10n/app_pa.arb
+++ b/lib/l10n/app_pa.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "ਬਟਨ ਦੀ ਸਥਿਤੀ",
   "appSettingsTabMaxWidth": "ਟੈਬ ਚੌੜਾਈ ਸੀਮਾ",
   "appSettingsTabMaxWidthSubtitle": "ਸੀਮਤ ਕਰੋ ਕਿ ਹਰ ਟੈਬ ਕਿੰਨਾ ਚੌੜਾ ਹੋ ਸਕਦਾ ਹੈ ਤਾਂ ਜੋ ਲੰਬੇ ਨਾਮ ਸੰਖੇਪ ਰਹਿਣ",
+  "appSettingsFullscreenOnShortcut": "ਸ਼ਾਰਟਕੱਟ ਤੋਂ ਖੋਲ੍ਹਣ 'ਤੇ ਪੂਰੀ ਸਕਰੀਨ",
+  "appSettingsFullscreenOnShortcutSubtitle": "ਹੋਮ-ਸਕਰੀਨ ਸ਼ਾਰਟਕੱਟ ਤੋਂ ਲਾਂਚ ਹੋਣ 'ਤੇ ਪੂਰੀ ਸਕਰੀਨ ਵਿੱਚ ਖੋਲ੍ਹੋ",
   "appSettingsFullscreenTabStrip": "ਪੂਰੀ ਸਕ੍ਰੀਨ ਵਿੱਚ, ਟੈਬ ਬਾਰ",
   "appSettingsFullscreenTabStripHidden": "ਲੁਕਿਆ",
   "appSettingsFullscreenTabStripAlways": "ਹਮੇਸ਼ਾ ਦਿਖਾਈ ਦਿੰਦਾ",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Położenie przycisku",
   "appSettingsTabMaxWidth": "Limit szerokości karty",
   "appSettingsTabMaxWidthSubtitle": "Ogranicz szerokość każdej karty, aby długie nazwy pozostały zwarte",
+  "appSettingsFullscreenOnShortcut": "Pełny ekran przy uruchomieniu ze skrótu",
+  "appSettingsFullscreenOnShortcutSubtitle": "Otwieraj na pełnym ekranie po uruchomieniu ze skrótu na ekranie głównym",
   "appSettingsFullscreenTabStrip": "Na pełnym ekranie, pasek kart",
   "appSettingsFullscreenTabStripHidden": "Ukryty",
   "appSettingsFullscreenTabStripAlways": "Zawsze widoczny",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Posição do botão",
   "appSettingsTabMaxWidth": "Limite de largura do separador",
   "appSettingsTabMaxWidthSubtitle": "Limite a largura de cada separador para que os nomes longos se mantenham compactos",
+  "appSettingsFullscreenOnShortcut": "Ecrã inteiro ao abrir a partir de um atalho",
+  "appSettingsFullscreenOnShortcutSubtitle": "Abrir em ecrã inteiro quando iniciado a partir de um atalho do ecrã inicial",
   "appSettingsFullscreenTabStrip": "Em ecrã inteiro, barra de separadores",
   "appSettingsFullscreenTabStripHidden": "Oculta",
   "appSettingsFullscreenTabStripAlways": "Sempre visível",

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Posição do botão",
   "appSettingsTabMaxWidth": "Limite de largura da aba",
   "appSettingsTabMaxWidthSubtitle": "Limite a largura de cada aba para que os nomes longos fiquem compactos",
+  "appSettingsFullscreenOnShortcut": "Tela cheia ao abrir por atalho",
+  "appSettingsFullscreenOnShortcutSubtitle": "Abrir em tela cheia quando iniciado por um atalho da tela inicial",
   "appSettingsFullscreenTabStrip": "Em tela cheia, barra de abas",
   "appSettingsFullscreenTabStripHidden": "Oculta",
   "appSettingsFullscreenTabStripAlways": "Sempre visível",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Poziția butonului",
   "appSettingsTabMaxWidth": "Limită lățime filă",
   "appSettingsTabMaxWidthSubtitle": "Limitează cât de lată poate deveni fiecare filă, astfel încât numele lungi să rămână compacte",
+  "appSettingsFullscreenOnShortcut": "Ecran complet la lansarea din comandă rapidă",
+  "appSettingsFullscreenOnShortcutSubtitle": "Deschide pe ecran complet când este lansat dintr-o comandă rapidă de pe ecranul de pornire",
   "appSettingsFullscreenTabStrip": "Pe ecran complet, bara de file",
   "appSettingsFullscreenTabStripHidden": "Ascunsă",
   "appSettingsFullscreenTabStripAlways": "Întotdeauna vizibilă",

--- a/lib/l10n/app_si.arb
+++ b/lib/l10n/app_si.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "බොත්තමේ පිහිටීම",
   "appSettingsTabMaxWidth": "ටැබ් පළල සීමාව",
   "appSettingsTabMaxWidthSubtitle": "දිගු නම් සංයුක්තව තබා ගැනීමට එක් එක් ටැබය කොතරම් පළල් විය හැකිද යන්න සීමා කරන්න",
+  "appSettingsFullscreenOnShortcut": "කෙටිමඟකින් විවෘත කළ විට පූර්ණ තිරය",
+  "appSettingsFullscreenOnShortcutSubtitle": "මුල් තිර කෙටිමඟකින් දියත් කළ විට පූර්ණ තිරයේ විවෘත කරන්න",
   "appSettingsFullscreenTabStrip": "සම්පූර්ණ තිරයේ, ටැබ් තීරුව",
   "appSettingsFullscreenTabStripHidden": "සැඟවී ඇත",
   "appSettingsFullscreenTabStripAlways": "සැමවිටම දෘශ්‍යමාන",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Poloha tlačidla",
   "appSettingsTabMaxWidth": "Obmedzenie šírky karty",
   "appSettingsTabMaxWidthSubtitle": "Obmedzte, aká široká môže byť každá karta, aby dlhé názvy zostali kompaktné",
+  "appSettingsFullscreenOnShortcut": "Celá obrazovka pri spustení zo skratky",
+  "appSettingsFullscreenOnShortcutSubtitle": "Otvoriť na celej obrazovke pri spustení zo skratky na ploche",
   "appSettingsFullscreenTabStrip": "Na celej obrazovke, panel kariet",
   "appSettingsFullscreenTabStripHidden": "Skrytý",
   "appSettingsFullscreenTabStripAlways": "Vždy viditeľný",

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Položaj gumba",
   "appSettingsTabMaxWidth": "Omejitev širine zavihka",
   "appSettingsTabMaxWidthSubtitle": "Omejite, kako širok je lahko vsak zavihek, da dolga imena ostanejo zgoščena",
+  "appSettingsFullscreenOnShortcut": "Celozaslonski način pri zagonu iz bližnjice",
+  "appSettingsFullscreenOnShortcutSubtitle": "Odpri v celozaslonskem načinu, ko se zažene iz bližnjice na začetnem zaslonu",
   "appSettingsFullscreenTabStrip": "V celozaslonskem načinu, vrstica zavihkov",
   "appSettingsFullscreenTabStripHidden": "Skrito",
   "appSettingsFullscreenTabStripAlways": "Vedno vidno",

--- a/lib/l10n/app_sq.arb
+++ b/lib/l10n/app_sq.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Pozicioni i butonit",
   "appSettingsTabMaxWidth": "Kufiri i gjerësisë së skedës",
   "appSettingsTabMaxWidthSubtitle": "Kufizo sa e gjerë mund të bëhet çdo skedë që emrat e gjatë të mbeten kompaktë",
+  "appSettingsFullscreenOnShortcut": "Ekran i plotë kur nisitet nga shkurtorja",
+  "appSettingsFullscreenOnShortcutSubtitle": "Hape në ekran të plotë kur nisitet nga një shkurtore e ekranit bazë",
   "appSettingsFullscreenTabStrip": "Në ekran të plotë, shiriti i skedave",
   "appSettingsFullscreenTabStripHidden": "I fshehur",
   "appSettingsFullscreenTabStripAlways": "Gjithmonë i dukshëm",

--- a/lib/l10n/app_sr.arb
+++ b/lib/l10n/app_sr.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Положај дугмета",
   "appSettingsTabMaxWidth": "Ограничење ширине картице",
   "appSettingsTabMaxWidthSubtitle": "Ограничите колико свака картица може бити широка да би дугачка имена остала компактна",
+  "appSettingsFullscreenOnShortcut": "Цео екран при покретању из пречице",
+  "appSettingsFullscreenOnShortcutSubtitle": "Отвори преко целог екрана када се покрене из пречице на почетном екрану",
   "appSettingsFullscreenTabStrip": "На пуном екрану, трака картица",
   "appSettingsFullscreenTabStripHidden": "Скривено",
   "appSettingsFullscreenTabStripAlways": "Увек видљиво",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Knappens placering",
   "appSettingsTabMaxWidth": "Gräns för flikbredd",
   "appSettingsTabMaxWidthSubtitle": "Begränsa hur bred varje flik kan bli så att långa namn förblir kompakta",
+  "appSettingsFullscreenOnShortcut": "Helskärm vid start från genväg",
+  "appSettingsFullscreenOnShortcutSubtitle": "Öppna i helskärm när appen startas från en genväg på startskärmen",
   "appSettingsFullscreenTabStrip": "I helskärm, flikfält",
   "appSettingsFullscreenTabStripHidden": "Dold",
   "appSettingsFullscreenTabStripAlways": "Alltid synlig",

--- a/lib/l10n/app_sw.arb
+++ b/lib/l10n/app_sw.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Nafasi ya kitufe",
   "appSettingsTabMaxWidth": "Kikomo cha Upana wa Kichupo",
   "appSettingsTabMaxWidthSubtitle": "Punguza jinsi kila kichupo kinavyoweza kupanuka ili majina marefu yabaki yamebana",
+  "appSettingsFullscreenOnShortcut": "Skrini nzima inapozinduliwa kutoka njia ya mkato",
+  "appSettingsFullscreenOnShortcutSubtitle": "Fungua katika skrini nzima inapozinduliwa kutoka njia ya mkato ya skrini ya nyumbani",
   "appSettingsFullscreenTabStrip": "Katika skrini nzima, upau wa vichupo",
   "appSettingsFullscreenTabStripHidden": "Imefichwa",
   "appSettingsFullscreenTabStripAlways": "Inaonekana kila wakati",

--- a/lib/l10n/app_ta.arb
+++ b/lib/l10n/app_ta.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "பொத்தானின் இடம்",
   "appSettingsTabMaxWidth": "தாவல் அகல வரம்பு",
   "appSettingsTabMaxWidthSubtitle": "நீண்ட பெயர்கள் சுருக்கமாக இருக்க ஒவ்வொரு தாவலும் எவ்வளவு அகலமாக இருக்கலாம் என்பதை வரம்பிடவும்",
+  "appSettingsFullscreenOnShortcut": "குறுக்குவழியில் இருந்து திறக்கும்போது முழுத்திரை",
+  "appSettingsFullscreenOnShortcutSubtitle": "முகப்புத் திரை குறுக்குவழியில் இருந்து தொடங்கும்போது முழுத்திரையில் திறக்கவும்",
   "appSettingsFullscreenTabStrip": "முழுத்திரையில், தாவல் பட்டி",
   "appSettingsFullscreenTabStripHidden": "மறைக்கப்பட்டது",
   "appSettingsFullscreenTabStripAlways": "எப்போதும் தெரியும்",

--- a/lib/l10n/app_te.arb
+++ b/lib/l10n/app_te.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "బటన్ స్థానం",
   "appSettingsTabMaxWidth": "ట్యాబ్ వెడల్పు పరిమితి",
   "appSettingsTabMaxWidthSubtitle": "పొడవైన పేర్లు కుదించబడి ఉండేలా ప్రతి ట్యాబ్ ఎంత వెడల్పు కావచ్చో పరిమితం చేయండి",
+  "appSettingsFullscreenOnShortcut": "షార్ట్‌కట్ నుండి తెరిచినప్పుడు పూర్తి స్క్రీన్",
+  "appSettingsFullscreenOnShortcutSubtitle": "హోమ్-స్క్రీన్ షార్ట్‌కట్ నుండి ప్రారంభించినప్పుడు పూర్తి స్క్రీన్‌లో తెరవండి",
   "appSettingsFullscreenTabStrip": "పూర్తి స్క్రీన్‌లో, ట్యాబ్ బార్",
   "appSettingsFullscreenTabStripHidden": "దాచబడింది",
   "appSettingsFullscreenTabStripAlways": "ఎల్లప్పుడూ కనిపిస్తుంది",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "ตำแหน่งปุ่ม",
   "appSettingsTabMaxWidth": "ขีดจำกัดความกว้างของแท็บ",
   "appSettingsTabMaxWidthSubtitle": "จำกัดความกว้างของแต่ละแท็บเพื่อให้ชื่อยาว ๆ ยังคงกระชับ",
+  "appSettingsFullscreenOnShortcut": "เต็มหน้าจอเมื่อเปิดจากทางลัด",
+  "appSettingsFullscreenOnShortcutSubtitle": "เปิดแบบเต็มหน้าจอเมื่อเปิดใช้จากทางลัดบนหน้าจอหลัก",
   "appSettingsFullscreenTabStrip": "ในโหมดเต็มจอ แถบแท็บ",
   "appSettingsFullscreenTabStripHidden": "ซ่อน",
   "appSettingsFullscreenTabStripAlways": "แสดงตลอดเวลา",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Düğme konumu",
   "appSettingsTabMaxWidth": "Sekme Genişliği Sınırı",
   "appSettingsTabMaxWidthSubtitle": "Uzun adların derli toplu kalması için her sekmenin ne kadar genişleyebileceğini sınırlayın",
+  "appSettingsFullscreenOnShortcut": "Kısayoldan açılışta tam ekran",
+  "appSettingsFullscreenOnShortcutSubtitle": "Ana ekran kısayolundan başlatıldığında tam ekranda aç",
   "appSettingsFullscreenTabStrip": "Tam ekranda, sekme çubuğu",
   "appSettingsFullscreenTabStripHidden": "Gizli",
   "appSettingsFullscreenTabStripAlways": "Her zaman görünür",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "Положення кнопки",
   "appSettingsTabMaxWidth": "Обмеження ширини вкладки",
   "appSettingsTabMaxWidthSubtitle": "Обмежте, наскільки широкою може стати кожна вкладка, щоб довгі назви залишалися компактними",
+  "appSettingsFullscreenOnShortcut": "Повний екран під час запуску з ярлика",
+  "appSettingsFullscreenOnShortcutSubtitle": "Відкривати на весь екран під час запуску з ярлика головного екрана",
   "appSettingsFullscreenTabStrip": "На весь екран, панель вкладок",
   "appSettingsFullscreenTabStripHidden": "Прихована",
   "appSettingsFullscreenTabStripAlways": "Завжди видима",

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "بٹن کی پوزیشن",
   "appSettingsTabMaxWidth": "ٹیب چوڑائی کی حد",
   "appSettingsTabMaxWidthSubtitle": "محدود کریں کہ ہر ٹیب کتنا چوڑا ہو سکتا ہے تاکہ لمبے نام مختصر رہیں",
+  "appSettingsFullscreenOnShortcut": "شارٹ کٹ سے کھولنے پر فل اسکرین",
+  "appSettingsFullscreenOnShortcutSubtitle": "ہوم اسکرین شارٹ کٹ سے کھلنے پر فل اسکرین میں کھولیں",
   "appSettingsFullscreenTabStrip": "فل اسکرین میں، ٹیب بار",
   "appSettingsFullscreenTabStripHidden": "پوشیدہ",
   "appSettingsFullscreenTabStripAlways": "ہمیشہ نظر آنے والا",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "按钮位置",
   "appSettingsTabMaxWidth": "标签宽度上限",
   "appSettingsTabMaxWidthSubtitle": "限制每个标签的最大宽度，使较长的名称保持紧凑",
+  "appSettingsFullscreenOnShortcut": "通过快捷方式启动时全屏",
+  "appSettingsFullscreenOnShortcutSubtitle": "从主屏幕快捷方式启动时以全屏打开",
   "appSettingsFullscreenTabStrip": "全屏时，标签栏",
   "appSettingsFullscreenTabStripHidden": "隐藏",
   "appSettingsFullscreenTabStripAlways": "始终显示",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -632,6 +632,8 @@
   "appSettingsTabBarButtonCorner": "按鈕位置",
   "appSettingsTabMaxWidth": "分頁寬度上限",
   "appSettingsTabMaxWidthSubtitle": "限制每個分頁的最大寬度，讓較長的名稱保持精簡",
+  "appSettingsFullscreenOnShortcut": "透過捷徑啟動時全螢幕",
+  "appSettingsFullscreenOnShortcutSubtitle": "從主畫面捷徑啟動時以全螢幕開啟",
   "appSettingsFullscreenTabStrip": "全螢幕時，分頁列",
   "appSettingsFullscreenTabStripHidden": "隱藏",
   "appSettingsFullscreenTabStripAlways": "永遠顯示",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1693,9 +1693,15 @@ class _WebSpacePageState extends State<WebSpacePage>
       if (!mounted) return;
     }
     // A shortcut tap is the user's app-launcher entry point; enter fullscreen
-    // unless they've turned the global option off. Runs after _setCurrentIndex
-    // (which may have exited fullscreen for a non-fullscreen per-site target).
-    if (_fullscreenOnShortcut) _enterFullscreen();
+    // per the FS-008 policy. Runs after _setCurrentIndex (which already exited
+    // fullscreen for a non-fullscreen per-site target), so there's no else.
+    if (StartupRestoreEngine.shouldEnterFullscreen(
+      viaShortcut: true,
+      fullscreenOnShortcut: _fullscreenOnShortcut,
+      perSiteFullscreenMode: _webViewModels[index].fullscreenMode,
+    )) {
+      _enterFullscreen();
+    }
     setState(() {});
     await _saveWebViewModels();
   }
@@ -4089,10 +4095,14 @@ class _WebSpacePageState extends State<WebSpacePage>
     }
     if (!mounted) return;
     // indexToRestore is non-null only for a shortcut cold launch (see the
-    // "only restore index if launched via shortcut" comment above), so enter
-    // fullscreen here when the global option is on, regardless of the target's
-    // per-site fullscreenMode.
-    if (indexToRestore != null && _fullscreenOnShortcut) {
+    // "only restore index if launched via shortcut" comment above), so apply
+    // the FS-008 shortcut-launch fullscreen policy here.
+    if (indexToRestore != null &&
+        StartupRestoreEngine.shouldEnterFullscreen(
+          viaShortcut: true,
+          fullscreenOnShortcut: _fullscreenOnShortcut,
+          perSiteFullscreenMode: _webViewModels[indexToRestore].fullscreenMode,
+        )) {
       _enterFullscreen();
     }
     setState(() {}); // Trigger UI update after async operation

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -969,6 +969,10 @@ class _WebSpacePageState extends State<WebSpacePage>
   bool _tabStripInFullscreen = false;
   bool _tabBarButtonInFullscreen = false;
   bool _tabBarButtonOnRight = true;
+  // Enter fullscreen when a site is opened via a home-screen shortcut. Global
+  // pref mirror of the `fullscreenOnShortcut` SharedPreferences key. On by
+  // default. Independent of per-site `WebViewModel.fullscreenMode`.
+  bool _fullscreenOnShortcut = true;
   int _tabMaxWidth = 140;
   // Runtime-only: whether the fullscreen tab-bar button has revealed the
   // tab strip. Reset on exiting fullscreen; never persisted.
@@ -1688,6 +1692,10 @@ class _WebSpacePageState extends State<WebSpacePage>
       await _setCurrentIndex(index);
       if (!mounted) return;
     }
+    // A shortcut tap is the user's app-launcher entry point; enter fullscreen
+    // unless they've turned the global option off. Runs after _setCurrentIndex
+    // (which may have exited fullscreen for a non-fullscreen per-site target).
+    if (_fullscreenOnShortcut) _enterFullscreen();
     setState(() {});
     await _saveWebViewModels();
   }
@@ -2913,6 +2921,12 @@ class _WebSpacePageState extends State<WebSpacePage>
     await prefs.setBool('tabStripInFullscreen', _tabStripInFullscreen);
   }
 
+  Future<void> _saveFullscreenOnShortcut() async {
+    if (isDemoMode) return;
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('fullscreenOnShortcut', _fullscreenOnShortcut);
+  }
+
   Future<void> _saveTabBarButtonInFullscreen() async {
     if (isDemoMode) return;
     SharedPreferences prefs = await SharedPreferences.getInstance();
@@ -3861,6 +3875,7 @@ class _WebSpacePageState extends State<WebSpacePage>
       _tabStripInFullscreen = prefs.getBool('tabStripInFullscreen') ?? false;
       _tabBarButtonInFullscreen = prefs.getBool('tabBarButtonInFullscreen') ?? false;
       _tabBarButtonOnRight = prefs.getBool('tabBarButtonOnRight') ?? true;
+      _fullscreenOnShortcut = prefs.getBool('fullscreenOnShortcut') ?? true;
       _tabMaxWidth = prefs.getInt('tabMaxWidth') ?? 140;
       _showStatsBanner = prefs.getBool('showStatsBanner') ?? true;
       _linkHandlingEnabled = prefs.getBool(kLinkHandlingEnabledKey) ?? true;
@@ -4073,6 +4088,13 @@ class _WebSpacePageState extends State<WebSpacePage>
           'activate target site (_setCurrentIndex): ${swActivate.elapsedMilliseconds}ms');
     }
     if (!mounted) return;
+    // indexToRestore is non-null only for a shortcut cold launch (see the
+    // "only restore index if launched via shortcut" comment above), so enter
+    // fullscreen here when the global option is on, regardless of the target's
+    // per-site fullscreenMode.
+    if (indexToRestore != null && _fullscreenOnShortcut) {
+      _enterFullscreen();
+    }
     setState(() {}); // Trigger UI update after async operation
     if (swRestore != null) {
       LogService.instance.log('Startup',
@@ -5018,6 +5040,8 @@ class _WebSpacePageState extends State<WebSpacePage>
           backup.globalPrefs['tabBarButtonInFullscreen'] as bool? ?? _tabBarButtonInFullscreen;
       _tabBarButtonOnRight =
           backup.globalPrefs['tabBarButtonOnRight'] as bool? ?? _tabBarButtonOnRight;
+      _fullscreenOnShortcut =
+          backup.globalPrefs['fullscreenOnShortcut'] as bool? ?? _fullscreenOnShortcut;
       _tabMaxWidth =
           backup.globalPrefs['tabMaxWidth'] as int? ?? _tabMaxWidth;
       _showStatsBanner =
@@ -5466,6 +5490,13 @@ class _WebSpacePageState extends State<WebSpacePage>
                         _tabStripInFullscreen = value;
                       });
                       _saveTabStripInFullscreen();
+                    },
+                    fullscreenOnShortcut: _fullscreenOnShortcut,
+                    onFullscreenOnShortcutChanged: (value) {
+                      setState(() {
+                        _fullscreenOnShortcut = value;
+                      });
+                      _saveFullscreenOnShortcut();
                     },
                     tabBarButtonInFullscreen: _tabBarButtonInFullscreen,
                     onTabBarButtonInFullscreenChanged: (value) {

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -55,6 +55,8 @@ class AppSettingsScreen extends StatefulWidget {
   final ValueChanged<bool> onShowTabStripChanged;
   final bool tabStripInFullscreen;
   final ValueChanged<bool> onTabStripInFullscreenChanged;
+  final bool fullscreenOnShortcut;
+  final ValueChanged<bool> onFullscreenOnShortcutChanged;
   final bool tabBarButtonInFullscreen;
   final ValueChanged<bool> onTabBarButtonInFullscreenChanged;
   final bool tabBarButtonOnRight;
@@ -98,6 +100,8 @@ class AppSettingsScreen extends StatefulWidget {
     required this.onShowTabStripChanged,
     required this.tabStripInFullscreen,
     required this.onTabStripInFullscreenChanged,
+    required this.fullscreenOnShortcut,
+    required this.onFullscreenOnShortcutChanged,
     required this.tabBarButtonInFullscreen,
     required this.onTabBarButtonInFullscreenChanged,
     required this.tabBarButtonOnRight,
@@ -125,6 +129,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
   late AppThemeSettings _settings;
   late bool _showTabStrip;
   late bool _tabStripInFullscreen;
+  late bool _fullscreenOnShortcut;
   late bool _tabBarButtonInFullscreen;
   late bool _tabBarButtonOnRight;
   late double _tabMaxWidth;
@@ -182,6 +187,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
     _settings = widget.currentSettings;
     _showTabStrip = widget.showTabStrip;
     _tabStripInFullscreen = widget.tabStripInFullscreen;
+    _fullscreenOnShortcut = widget.fullscreenOnShortcut;
     _tabBarButtonInFullscreen = widget.tabBarButtonInFullscreen;
     _tabBarButtonOnRight = widget.tabBarButtonOnRight;
     _tabMaxWidth = widget.tabMaxWidth.toDouble();
@@ -827,6 +833,17 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
                 _showTabStrip = value;
               });
               widget.onShowTabStripChanged(value);
+            },
+          ),
+          SwitchListTile(
+            title: Text(loc.appSettingsFullscreenOnShortcut),
+            subtitle: Text(loc.appSettingsFullscreenOnShortcutSubtitle),
+            value: _fullscreenOnShortcut,
+            onChanged: (value) {
+              setState(() {
+                _fullscreenOnShortcut = value;
+              });
+              widget.onFullscreenOnShortcutChanged(value);
             },
           ),
           Padding(

--- a/lib/services/startup_restore_engine.dart
+++ b/lib/services/startup_restore_engine.dart
@@ -130,6 +130,23 @@ class StartupRestoreEngine {
 
     return LaunchOfferCreate(url: url, shortcutSiteId: shortcutSiteId);
   }
+
+  /// FS-008: whether activating a site should land in fullscreen.
+  ///
+  /// Combines the global "full screen on shortcut launch" option
+  /// ([fullscreenOnShortcut]) with the site's own per-site
+  /// [WebViewModel.fullscreenMode]. A shortcut launch ([viaShortcut] true)
+  /// forces fullscreen when the global option is on; every launch still
+  /// honors the per-site flag. A normal in-app switch ([viaShortcut] false)
+  /// depends on the per-site flag alone, so the global option never changes
+  /// the behavior of tab-strip / drawer navigation.
+  static bool shouldEnterFullscreen({
+    required bool viaShortcut,
+    required bool fullscreenOnShortcut,
+    required bool perSiteFullscreenMode,
+  }) {
+    return perSiteFullscreenMode || (viaShortcut && fullscreenOnShortcut);
+  }
 }
 
 /// Android-only `siteId -> url` ledger backing HS-011 routing. A pinned

--- a/lib/settings/app_prefs.dart
+++ b/lib/settings/app_prefs.dart
@@ -32,6 +32,12 @@ final Map<String, Object> kExportedAppPrefs = <String, Object>{
   'tabBarButtonInFullscreen': false,
   // Which bottom corner the fullscreen tab-bar button sits in (true = right).
   'tabBarButtonOnRight': true,
+  // Enter full screen automatically when a site is opened from a home-screen
+  // shortcut (Android pinned shortcut / iOS App Intents). On by default: a
+  // pinned shortcut is the user's "app launcher" entry point, so the immersive
+  // chrome-free view matches the expectation. Per-site `fullscreenMode` still
+  // applies independently on every activation.
+  'fullscreenOnShortcut': true,
   // Max width (logical px) of each tab in the bottom tab strip. Long site
   // names ellipsize at this width instead of stretching the tab.
   'tabMaxWidth': 140,

--- a/openspec/specs/fullscreen-mode/spec.md
+++ b/openspec/specs/fullscreen-mode/spec.md
@@ -165,6 +165,38 @@ The system SHALL support a global option to keep the site tab strip visible in f
 
 ---
 
+### Requirement: FS-008 - Full Screen on Shortcut Launch
+
+The system SHALL support a global option, enabled by default, to enter full screen automatically when a site is opened from a home-screen shortcut (Android pinned shortcut / iOS App Intents). The option is independent of the per-site `fullscreenMode` setting and applies to both cold and warm shortcut launches.
+
+#### Scenario: Cold launch from shortcut
+
+**Given** "Full screen on shortcut launch" is enabled
+**And** the app is not running
+**When** the user taps a pinned home-screen shortcut for a site
+**Then** the app launches that site directly in full screen mode
+
+#### Scenario: Warm launch from shortcut
+
+**Given** "Full screen on shortcut launch" is enabled
+**And** the app is already running in the background
+**When** the user taps a pinned home-screen shortcut for a site
+**Then** the app switches to that site and enters full screen mode
+
+#### Scenario: Option disabled
+
+**Given** "Full screen on shortcut launch" is disabled
+**When** the user opens a site from a home-screen shortcut
+**Then** full screen is governed only by the site's per-site `fullscreenMode` (not entered just because it was opened via a shortcut)
+
+#### Scenario: Normal site switch is unaffected
+
+**Given** "Full screen on shortcut launch" is enabled
+**When** the user switches sites from inside the app (tab strip, drawer) rather than via a shortcut
+**Then** full screen is governed only by the target site's `fullscreenMode`
+
+---
+
 ### Requirement: FS-006 - Content Reachable Under Persistent System Bars
 
 The system SHALL keep the site's content reachable in full screen even when the platform fails to hide the system bars (e.g. Android 15 edge-to-edge, where `immersiveSticky` does not always hide the status/navigation bars).
@@ -196,6 +228,7 @@ The system SHALL keep the site's content reachable in full screen even when the 
 **_WebSpacePageState** (`lib/main.dart`):
 - `bool _isFullscreen = false` - Current fullscreen state (not persisted; runtime only)
 - `bool _tabStripInFullscreen = false` - Global pref mirror of the `tabStripInFullscreen` SharedPreferences key (registered in `kExportedAppPrefs`, round-trips through settings backup)
+- `bool _fullscreenOnShortcut = true` - Global pref mirror of the `fullscreenOnShortcut` SharedPreferences key (registered in `kExportedAppPrefs`, on by default). When set, `_openShortcutIndex` (warm launch) and the cold-launch restore path (`indexToRestore != null`) call `_enterFullscreen()` after `_setCurrentIndex`, independent of the target's per-site `fullscreenMode`.
 
 ### UI Changes
 

--- a/openspec/specs/fullscreen-mode/spec.md
+++ b/openspec/specs/fullscreen-mode/spec.md
@@ -228,7 +228,7 @@ The system SHALL keep the site's content reachable in full screen even when the 
 **_WebSpacePageState** (`lib/main.dart`):
 - `bool _isFullscreen = false` - Current fullscreen state (not persisted; runtime only)
 - `bool _tabStripInFullscreen = false` - Global pref mirror of the `tabStripInFullscreen` SharedPreferences key (registered in `kExportedAppPrefs`, round-trips through settings backup)
-- `bool _fullscreenOnShortcut = true` - Global pref mirror of the `fullscreenOnShortcut` SharedPreferences key (registered in `kExportedAppPrefs`, on by default). When set, `_openShortcutIndex` (warm launch) and the cold-launch restore path (`indexToRestore != null`) call `_enterFullscreen()` after `_setCurrentIndex`, independent of the target's per-site `fullscreenMode`.
+- `bool _fullscreenOnShortcut = true` - Global pref mirror of the `fullscreenOnShortcut` SharedPreferences key (registered in `kExportedAppPrefs`, on by default). Both shortcut launch paths — `_openShortcutIndex` (warm) and the cold-launch restore path (`indexToRestore != null`) — route the decision through the pure `StartupRestoreEngine.shouldEnterFullscreen(viaShortcut, fullscreenOnShortcut, perSiteFullscreenMode)` policy and call `_enterFullscreen()` when it returns true. The policy returns `perSiteFullscreenMode || (viaShortcut && fullscreenOnShortcut)`, so a normal in-app switch (`viaShortcut: false`) is never pulled into fullscreen by the global option. Covered by `test/startup_restore_engine_test.dart`.
 
 ### UI Changes
 

--- a/test/startup_restore_engine_test.dart
+++ b/test/startup_restore_engine_test.dart
@@ -368,4 +368,63 @@ void main() {
       );
     });
   });
+
+  group('StartupRestoreEngine.shouldEnterFullscreen (FS-008)', () {
+    test('shortcut launch with global option on enters fullscreen', () {
+      expect(
+        StartupRestoreEngine.shouldEnterFullscreen(
+          viaShortcut: true,
+          fullscreenOnShortcut: true,
+          perSiteFullscreenMode: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('shortcut launch with global option off does not force fullscreen', () {
+      expect(
+        StartupRestoreEngine.shouldEnterFullscreen(
+          viaShortcut: true,
+          fullscreenOnShortcut: false,
+          perSiteFullscreenMode: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('per-site fullscreen still applies when global option is off', () {
+      expect(
+        StartupRestoreEngine.shouldEnterFullscreen(
+          viaShortcut: true,
+          fullscreenOnShortcut: false,
+          perSiteFullscreenMode: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('normal in-app switch is unaffected by the global option', () {
+      // viaShortcut=false models a tab-strip / drawer switch: the global
+      // shortcut option must not pull a non-fullscreen site into fullscreen.
+      expect(
+        StartupRestoreEngine.shouldEnterFullscreen(
+          viaShortcut: false,
+          fullscreenOnShortcut: true,
+          perSiteFullscreenMode: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('normal in-app switch still honors the per-site flag', () {
+      expect(
+        StartupRestoreEngine.shouldEnterFullscreen(
+          viaShortcut: false,
+          fullscreenOnShortcut: false,
+          perSiteFullscreenMode: true,
+        ),
+        isTrue,
+      );
+    });
+  });
 }


### PR DESCRIPTION
Global "Full screen on shortcut launch" option, on by default. A pinned
shortcut is an app-launcher entry point, so the immersive view matches
expectation. Independent of per-site fullscreenMode; normal in-app site
switches are unaffected.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XSXpa4qynwuTwBfHdtraNU