### PR TITLE
WebView privacy/perf settings: attribution, media integrity, back/forward cache

### DIFF
--- a/integration_test/privacy_settings_test.dart
+++ b/integration_test/privacy_settings_test.dart
@@ -1,0 +1,195 @@
+// Privacy/perf WebView-settings integration test.
+//
+// Proves the androidx.webkit settings wired in
+// WebViewFactory.createWebView (lib/services/webview.dart) actually take
+// effect on a live engine, by loading a loopback fixture and observing the
+// request the WebView issues for itself:
+//
+//   * X-Requested-With suppression (requestedWithHeaderOriginAllowList = {}):
+//     a tracking-protection-on load must NOT carry the
+//     `X-Requested-With: <package>` header Android WebView otherwise sends.
+//   * Back/forward cache (backForwardCacheEnabled): with bfcache on, a
+//     back navigation is served from cache and does NOT re-hit the server.
+//
+// Both are androidx.webkit-only. The header test self-calibrates against an
+// ETP-off baseline and SKIPs on engines that never send X-Requested-With
+// (WKWebView/macOS, WPE/Linux) rather than asserting a vacuous truth. The
+// bfcache test is Android-gated: the flag maps to a feature WKWebView and WPE
+// don't have, and the repeated mount/replace it needs would wedge the headless
+// Linux runner's live platform view (see safari_navigation_test.dart). Run on
+// a real Android device/emulator for the meaningful assertions:
+//
+//   fvm flutter test integration_test/privacy_settings_test.dart -d emulator-5554
+//
+// Harness mirrors safari_navigation_test.dart: a live compositing WebView
+// wedges the Flutter UI thread, so waits run on real wall-clock inside
+// tester.runAsync() and frames are pumped only to mount widgets.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:webspace/services/webview.dart';
+
+class _Req {
+  _Req(this.path, this.xrw);
+  final String path;
+  final String? xrw;
+}
+
+class _Mounted {
+  _Mounted(this.request, this.controller);
+  final _Req? request;
+  final WebViewController? controller;
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late HttpServer server;
+  late int port;
+  final requests = <_Req>[];
+  final bool savedBfcache = WebViewFactory.backForwardCacheEnabled;
+
+  void log(String m) {
+    // ignore: avoid_print
+    print('[privacy] $m');
+  }
+
+  setUpAll(() async {
+    server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    port = server.port;
+    server.listen((req) {
+      requests.add(_Req(req.uri.path, req.headers.value('x-requested-with')));
+      final res = req.response..headers.contentType = ContentType.html;
+      res.write('<!doctype html><html><head><title>fixture</title></head>'
+          '<body>fixture ${req.uri.path}</body></html>');
+      res.close();
+    });
+  });
+
+  tearDownAll(() async {
+    WebViewFactory.backForwardCacheEnabled = savedBfcache;
+    await server.close(force: true);
+  });
+
+  setUp(requests.clear);
+
+  String url(String path) => 'http://127.0.0.1:$port$path';
+  int countFor(String path) => requests.where((r) => r.path == path).length;
+
+  Future<void> waitReal(WidgetTester tester, bool Function() done,
+      {Duration timeout = const Duration(seconds: 30)}) async {
+    await tester.runAsync(() async {
+      final deadline = DateTime.now().add(timeout);
+      while (DateTime.now().isBefore(deadline)) {
+        await Future<void>.delayed(const Duration(milliseconds: 300));
+        if (done()) return;
+      }
+    });
+  }
+
+  // Mount one webview through the real factory and wait (wall-clock) for its
+  // initial request to reach the loopback server. Frames are pumped only to
+  // mount the platform view; the load itself is awaited via runAsync.
+  Future<_Mounted> mount(
+    WidgetTester tester, {
+    required String path,
+    required bool trackingProtection,
+  }) async {
+    final ctrl = Completer<WebViewController>();
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: 320,
+            height: 480,
+            child: WebViewFactory.createWebView(
+              config: WebViewConfig(
+                initialUrl: url(path),
+                trackingProtectionEnabled: trackingProtection,
+              ),
+              onControllerCreated: (c) {
+                if (!ctrl.isCompleted) ctrl.complete(c);
+              },
+            ),
+          ),
+        ),
+      ),
+    ));
+    for (var i = 0; i < 20; i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+    await waitReal(tester, () => countFor(path) >= 1);
+    _Req? seen;
+    for (final r in requests) {
+      if (r.path == path) seen = r;
+    }
+    final controller = ctrl.isCompleted ? await ctrl.future : null;
+    return _Mounted(seen, controller);
+  }
+
+  testWidgets('tracking protection suppresses the X-Requested-With header',
+      (tester) async {
+    final off =
+        await mount(tester, path: '/xrw-off', trackingProtection: false);
+    expect(off.request, isNotNull, reason: 'ETP-off page should have loaded');
+    log('baseline X-Requested-With = ${off.request!.xrw}');
+    if (off.request!.xrw == null) {
+      log('SKIP: engine does not send X-Requested-With; the '
+          'requestedWithHeaderOriginAllowList setting is androidx.webkit-only. '
+          'Run on Android to assert suppression.');
+      return;
+    }
+    final on = await mount(tester, path: '/xrw-on', trackingProtection: true);
+    expect(on.request, isNotNull, reason: 'ETP-on page should have loaded');
+    expect(on.request!.xrw, isNull,
+        reason: 'requestedWithHeaderOriginAllowList={} must drop '
+            'X-Requested-With when tracking protection is on');
+  });
+
+  testWidgets('back/forward cache serves back-navigation from cache',
+      (tester) async {
+    if (!Platform.isAndroid) {
+      log('SKIP: backForwardCacheEnabled maps to the androidx.webkit '
+          'BACK_FORWARD_CACHE feature; WKWebView/WPE ignore it. Run on Android.');
+      return;
+    }
+
+    // Returns whether navigating back to A re-hits the network. With bfcache
+    // the back entry is restored from cache (no new request); without it the
+    // engine re-fetches A.
+    Future<bool> backRefetches(bool bfcache) async {
+      WebViewFactory.backForwardCacheEnabled = bfcache;
+      final tag = bfcache ? 'on' : 'off';
+      final aPath = '/bfa-$tag';
+      final bPath = '/bfb-$tag';
+      final m = await mount(tester, path: aPath, trackingProtection: false);
+      final c = m.controller;
+      if (c == null) return false;
+      await tester.runAsync(() => c.loadUrl(url(bPath)));
+      await waitReal(tester, () => countFor(bPath) >= 1);
+      final before = countFor(aPath);
+      await tester.runAsync(() => c.goBack());
+      await waitReal(tester, () => countFor(aPath) > before,
+          timeout: const Duration(seconds: 6));
+      return countFor(aPath) > before;
+    }
+
+    final offRefetch = await backRefetches(false);
+    log('bfcache off -> back refetched A: $offRefetch');
+    if (!offRefetch) {
+      log('SKIP: back-navigation served from an always-on engine cache here, '
+          'so the flag is not observable. Run on a WebView build where bfcache '
+          'is off by default.');
+      return;
+    }
+    final onRefetch = await backRefetches(true);
+    log('bfcache on -> back refetched A: $onRefetch');
+    expect(onRefetch, isFalse,
+        reason: 'with backForwardCacheEnabled, going back must restore from '
+            'the bfcache and not re-hit the network');
+  });
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3911,6 +3911,8 @@ class _WebSpacePageState extends State<WebSpacePage>
       _fullscreenOnShortcut = prefs.getBool('fullscreenOnShortcut') ?? true;
       _tabMaxWidth = prefs.getInt('tabMaxWidth') ?? 140;
       _showStatsBanner = prefs.getBool('showStatsBanner') ?? true;
+      WebViewFactory.backForwardCacheEnabled =
+          prefs.getBool(kBackForwardCacheEnabledKey) ?? true;
       _linkHandlingEnabled = prefs.getBool(kLinkHandlingEnabledKey) ?? true;
       _linkHandlingClaimDomains =
           prefs.getBool(kLinkHandlingClaimDomainsKey) ?? false;
@@ -5087,6 +5089,9 @@ class _WebSpacePageState extends State<WebSpacePage>
           backup.globalPrefs['tabMaxWidth'] as int? ?? _tabMaxWidth;
       _showStatsBanner =
           backup.globalPrefs['showStatsBanner'] as bool? ?? _showStatsBanner;
+      WebViewFactory.backForwardCacheEnabled =
+          backup.globalPrefs[kBackForwardCacheEnabledKey] as bool? ??
+              WebViewFactory.backForwardCacheEnabled;
 
       // Restore selection state
       if (backup.selectedWebspaceId != null &&

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1300,6 +1300,13 @@ class WebViewFactory {
   /// registering Attribution Reporting sources/triggers.
   static const int attributionBehaviorDisabled = 0;
 
+  /// androidx.webkit
+  /// `WebSettingsCompat.WEBVIEW_MEDIA_INTEGRITY_API_ENABLED_WITHOUT_APP_IDENTITY`.
+  /// Passed to the fork's `webViewMediaIntegrityApiStatus`: the integrity token
+  /// keeps working for site anti-fraud but no longer carries this app's
+  /// package/signing identity, closing the cross-site app-identity leak.
+  static const int mediaIntegrityEnabledWithoutAppIdentity = 1;
+
   /// System font scale → webview text zoom percent. Tracks the OS-level
   /// "font size" accessibility setting so web content matches the size
   /// users see in their system browser.
@@ -2334,11 +2341,18 @@ class WebViewFactory {
       // fork ignores both on iOS/macOS/Linux). When ETP is on: an empty
       // allow-list suppresses the `X-Requested-With: <package>` header for
       // every origin, and Attribution Reporting registration is disabled.
-      // When ETP is off, leave the native defaults untouched (null).
+      // When ETP is off, leave the native defaults untouched (null). For the
+      // Media Integrity API we keep it enabled-without-app-identity rather than
+      // fully disabling it: that preserves legitimate anti-fraud attestation
+      // while stripping the app package/signing identity that any origin
+      // (including non-DRM trackers) could otherwise read.
       ..requestedWithHeaderOriginAllowList =
           config.trackingProtectionEnabled ? const <String>{} : null
       ..attributionRegistrationBehavior = config.trackingProtectionEnabled
           ? WebViewFactory.attributionBehaviorDisabled
+          : null
+      ..webViewMediaIntegrityApiStatus = config.trackingProtectionEnabled
+          ? WebViewFactory.mediaIntegrityEnabledWithoutAppIdentity
           : null
       // Global perf pref; same value on every WebView, nested included.
       ..backForwardCacheEnabled = WebViewFactory.backForwardCacheEnabled

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1295,18 +1295,6 @@ class WebViewFactory {
   /// WebSettings; no-ops on platforms/providers without the feature.
   static bool backForwardCacheEnabled = true;
 
-  /// androidx.webkit `WebSettingsCompat.ATTRIBUTION_BEHAVIOR_DISABLED`. Passed
-  /// to the fork's `attributionRegistrationBehavior` to stop the WebView from
-  /// registering Attribution Reporting sources/triggers.
-  static const int attributionBehaviorDisabled = 0;
-
-  /// androidx.webkit
-  /// `WebSettingsCompat.WEBVIEW_MEDIA_INTEGRITY_API_ENABLED_WITHOUT_APP_IDENTITY`.
-  /// Passed to the fork's `webViewMediaIntegrityApiStatus`: the integrity token
-  /// keeps working for site anti-fraud but no longer carries this app's
-  /// package/signing identity, closing the cross-site app-identity leak.
-  static const int mediaIntegrityEnabledWithoutAppIdentity = 1;
-
   /// System font scale → webview text zoom percent. Tracks the OS-level
   /// "font size" accessibility setting so web content matches the size
   /// users see in their system browser.
@@ -2349,10 +2337,10 @@ class WebViewFactory {
       ..requestedWithHeaderOriginAllowList =
           config.trackingProtectionEnabled ? const <String>{} : null
       ..attributionRegistrationBehavior = config.trackingProtectionEnabled
-          ? WebViewFactory.attributionBehaviorDisabled
+          ? inapp.AttributionBehavior.DISABLED
           : null
       ..webViewMediaIntegrityApiStatus = config.trackingProtectionEnabled
-          ? WebViewFactory.mediaIntegrityEnabledWithoutAppIdentity
+          ? inapp.WebViewMediaIntegrityApiStatus.ENABLED_WITHOUT_APP_IDENTITY
           : null
       // Global perf pref; same value on every WebView, nested included.
       ..backForwardCacheEnabled = WebViewFactory.backForwardCacheEnabled

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1289,6 +1289,17 @@ persist, and the cache is cleared on app upgrade).</p>
 
 /// Factory for creating webviews
 class WebViewFactory {
+  /// Global back/forward-cache preference, mirrored from the
+  /// `backForwardCacheEnabled` app pref (kExportedAppPrefs) at startup and
+  /// after settings import. Applied verbatim to every WebView's native
+  /// WebSettings; no-ops on platforms/providers without the feature.
+  static bool backForwardCacheEnabled = true;
+
+  /// androidx.webkit `WebSettingsCompat.ATTRIBUTION_BEHAVIOR_DISABLED`. Passed
+  /// to the fork's `attributionRegistrationBehavior` to stop the WebView from
+  /// registering Attribution Reporting sources/triggers.
+  static const int attributionBehaviorDisabled = 0;
+
   /// System font scale → webview text zoom percent. Tracks the OS-level
   /// "font size" accessibility setting so web content matches the size
   /// users see in their system browser.
@@ -2319,6 +2330,18 @@ class WebViewFactory {
       // wire-level UA-CH headers contradict the spoofed UA. Silently
       // ignored on iOS/macOS/Linux (no equivalent native API).
       ..userAgentMetadata = buildUserAgentMetadata(config.userAgent)
+      // Folded under the Tracking Protection umbrella (Android only; the
+      // fork ignores both on iOS/macOS/Linux). When ETP is on: an empty
+      // allow-list suppresses the `X-Requested-With: <package>` header for
+      // every origin, and Attribution Reporting registration is disabled.
+      // When ETP is off, leave the native defaults untouched (null).
+      ..requestedWithHeaderOriginAllowList =
+          config.trackingProtectionEnabled ? const <String>{} : null
+      ..attributionRegistrationBehavior = config.trackingProtectionEnabled
+          ? WebViewFactory.attributionBehaviorDisabled
+          : null
+      // Global perf pref; same value on every WebView, nested included.
+      ..backForwardCacheEnabled = WebViewFactory.backForwardCacheEnabled
       ..thirdPartyCookiesEnabled = config.thirdPartyCookiesEnabled
       ..incognito = config.incognito
       ..textZoom = textZoom

--- a/lib/settings/app_prefs.dart
+++ b/lib/settings/app_prefs.dart
@@ -80,7 +80,14 @@ final Map<String, Object> kExportedAppPrefs = <String, Object>{
   // User-chosen UI language as a locale tag (e.g. 'de', 'pt_BR', 'zh_Hant').
   // Empty string means follow the system locale. Applied to MaterialApp.locale.
   'appLocaleOverride': '',
+  // Back/forward cache (Android, androidx.webkit BACK_FORWARD_CACHE). A
+  // per-WebView WebSettings flag, but the intent is global: instant restore
+  // on back/forward navigation. Mirrored into WebViewFactory and applied to
+  // every WebView; no-ops where the feature is unsupported.
+  kBackForwardCacheEnabledKey: true,
 };
+
+const String kBackForwardCacheEnabledKey = 'backForwardCacheEnabled';
 
 const String kLinkHandlingEnabledKey = 'linkHandlingEnabled';
 const String kLinkHandlingClaimDomainsKey = 'linkHandlingClaimDomains';

--- a/openspec/specs/tracking-protection/spec.md
+++ b/openspec/specs/tracking-protection/spec.md
@@ -695,6 +695,29 @@ the cache is empty)
 
 ---
 
+### Requirement: ETP-019 - Android native privacy settings under umbrella
+
+The umbrella SHALL apply the fork's Android-only privacy `InAppWebViewSettings` whenever `trackingProtectionEnabled` is true, and leave each at its native default (`null`) when false. These settings are serialized but ignored by the iOS/macOS/Linux plugins.
+
+- `requestedWithHeaderOriginAllowList` SHALL be the empty set (suppresses the `X-Requested-With: <package>` header for every origin).
+- `attributionRegistrationBehavior` SHALL be `WebSettingsCompat.ATTRIBUTION_BEHAVIOR_DISABLED` (no Attribution Reporting source/trigger registration).
+- `webViewMediaIntegrityApiStatus` SHALL be `WEBVIEW_MEDIA_INTEGRITY_API_ENABLED_WITHOUT_APP_IDENTITY`, not `DISABLED`: the integrity token stays available for legitimate site anti-fraud, but no longer carries this app's package/signing identity, closing the cross-site app-identity leak. This is independent of the protected-media (Widevine/EME) permission, which governs DRM playback rather than attestation.
+
+#### Scenario: Umbrella on sets native privacy settings
+
+**Given** a webview is constructed for a site with the umbrella on
+**Then** `requestedWithHeaderOriginAllowList` is the empty set
+**And** `attributionRegistrationBehavior` is the disabled constant
+**And** `webViewMediaIntegrityApiStatus` is the enabled-without-app-identity constant
+
+#### Scenario: Umbrella off leaves native defaults
+
+**Given** a webview is constructed for a site with the umbrella off
+**Then** `requestedWithHeaderOriginAllowList`, `attributionRegistrationBehavior`,
+and `webViewMediaIntegrityApiStatus` are each `null`
+
+---
+
 ## Implementation Details
 
 ### Shim seeding

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -327,8 +327,8 @@ packages:
     dependency: "direct main"
     description:
       path: flutter_inappwebview
-      ref: "claude/v6.2.0-beta.3-privacy-v5-candidate"
-      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
+      ref: "v6.2.0-beta.3-privacy-v5"
+      resolved-ref: 620a635884a4247e5faca36a065e07d4cb1f6768
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "6.2.0-beta.3"
@@ -336,8 +336,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_android
-      ref: "claude/v6.2.0-beta.3-privacy-v5-candidate"
-      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
+      ref: "v6.2.0-beta.3-privacy-v5"
+      resolved-ref: 620a635884a4247e5faca36a065e07d4cb1f6768
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.2.0-beta.3"
@@ -353,8 +353,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_ios
-      ref: "claude/v6.2.0-beta.3-privacy-v5-candidate"
-      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
+      ref: "v6.2.0-beta.3-privacy-v5"
+      resolved-ref: 620a635884a4247e5faca36a065e07d4cb1f6768
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.2.0-beta.3"
@@ -362,8 +362,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_linux
-      ref: "claude/v6.2.0-beta.3-privacy-v5-candidate"
-      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
+      ref: "v6.2.0-beta.3-privacy-v5"
+      resolved-ref: 620a635884a4247e5faca36a065e07d4cb1f6768
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "0.1.0-beta.2"
@@ -371,8 +371,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_macos
-      ref: "claude/v6.2.0-beta.3-privacy-v5-candidate"
-      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
+      ref: "v6.2.0-beta.3-privacy-v5"
+      resolved-ref: 620a635884a4247e5faca36a065e07d4cb1f6768
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.2.0-beta.3"
@@ -380,8 +380,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_platform_interface
-      ref: "claude/v6.2.0-beta.3-privacy-v5-candidate"
-      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
+      ref: "v6.2.0-beta.3-privacy-v5"
+      resolved-ref: 620a635884a4247e5faca36a065e07d4cb1f6768
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.4.0-beta.3"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -327,8 +327,8 @@ packages:
     dependency: "direct main"
     description:
       path: flutter_inappwebview
-      ref: "v6.2.0-beta.3-privacy-v4"
-      resolved-ref: "77022501c26d5d2d525fbac844766c88cb1c6f15"
+      ref: "claude/v6.2.0-beta.3-privacy-v5-candidate"
+      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "6.2.0-beta.3"
@@ -336,8 +336,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_android
-      ref: "v6.2.0-beta.3-privacy-v4"
-      resolved-ref: "77022501c26d5d2d525fbac844766c88cb1c6f15"
+      ref: "claude/v6.2.0-beta.3-privacy-v5-candidate"
+      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.2.0-beta.3"
@@ -353,8 +353,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_ios
-      ref: "v6.2.0-beta.3-privacy-v4"
-      resolved-ref: "77022501c26d5d2d525fbac844766c88cb1c6f15"
+      ref: "claude/v6.2.0-beta.3-privacy-v5-candidate"
+      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.2.0-beta.3"
@@ -362,8 +362,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_linux
-      ref: "v6.2.0-beta.3-privacy-v4"
-      resolved-ref: "77022501c26d5d2d525fbac844766c88cb1c6f15"
+      ref: "claude/v6.2.0-beta.3-privacy-v5-candidate"
+      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "0.1.0-beta.2"
@@ -371,8 +371,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_macos
-      ref: "v6.2.0-beta.3-privacy-v4"
-      resolved-ref: "77022501c26d5d2d525fbac844766c88cb1c6f15"
+      ref: "claude/v6.2.0-beta.3-privacy-v5-candidate"
+      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.2.0-beta.3"
@@ -380,8 +380,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_platform_interface
-      ref: "v6.2.0-beta.3-privacy-v4"
-      resolved-ref: "77022501c26d5d2d525fbac844766c88cb1c6f15"
+      ref: "claude/v6.2.0-beta.3-privacy-v5-candidate"
+      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.4.0-beta.3"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -328,7 +328,7 @@ packages:
     description:
       path: flutter_inappwebview
       ref: "v6.2.0-beta.3-privacy-v5"
-      resolved-ref: 620a635884a4247e5faca36a065e07d4cb1f6768
+      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "6.2.0-beta.3"
@@ -337,7 +337,7 @@ packages:
     description:
       path: flutter_inappwebview_android
       ref: "v6.2.0-beta.3-privacy-v5"
-      resolved-ref: 620a635884a4247e5faca36a065e07d4cb1f6768
+      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.2.0-beta.3"
@@ -354,7 +354,7 @@ packages:
     description:
       path: flutter_inappwebview_ios
       ref: "v6.2.0-beta.3-privacy-v5"
-      resolved-ref: 620a635884a4247e5faca36a065e07d4cb1f6768
+      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.2.0-beta.3"
@@ -363,7 +363,7 @@ packages:
     description:
       path: flutter_inappwebview_linux
       ref: "v6.2.0-beta.3-privacy-v5"
-      resolved-ref: 620a635884a4247e5faca36a065e07d4cb1f6768
+      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "0.1.0-beta.2"
@@ -372,7 +372,7 @@ packages:
     description:
       path: flutter_inappwebview_macos
       ref: "v6.2.0-beta.3-privacy-v5"
-      resolved-ref: 620a635884a4247e5faca36a065e07d4cb1f6768
+      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.2.0-beta.3"
@@ -381,7 +381,7 @@ packages:
     description:
       path: flutter_inappwebview_platform_interface
       ref: "v6.2.0-beta.3-privacy-v5"
-      resolved-ref: 620a635884a4247e5faca36a065e07d4cb1f6768
+      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.4.0-beta.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -96,32 +96,32 @@ dependency_overrides:
   flutter_inappwebview:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-privacy-v4
+      ref: claude/v6.2.0-beta.3-privacy-v5-candidate
       path: flutter_inappwebview
   flutter_inappwebview_android:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-privacy-v4
+      ref: claude/v6.2.0-beta.3-privacy-v5-candidate
       path: flutter_inappwebview_android
   flutter_inappwebview_ios:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-privacy-v4
+      ref: claude/v6.2.0-beta.3-privacy-v5-candidate
       path: flutter_inappwebview_ios
   flutter_inappwebview_macos:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-privacy-v4
+      ref: claude/v6.2.0-beta.3-privacy-v5-candidate
       path: flutter_inappwebview_macos
   flutter_inappwebview_linux:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-privacy-v4
+      ref: claude/v6.2.0-beta.3-privacy-v5-candidate
       path: flutter_inappwebview_linux
   flutter_inappwebview_platform_interface:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-privacy-v4
+      ref: claude/v6.2.0-beta.3-privacy-v5-candidate
       path: flutter_inappwebview_platform_interface
 
 flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,41 +87,39 @@ dev_dependencies:
 # binding + per-site iOS/macOS proxy). The overrides below pull the
 # fork's monorepo by git ref and point each plugin at its subdirectory.
 #
-# TODO: tag the fork with a stable version and pin `ref:` to that tag
-# instead of a branch (current branch is mutable; CI builds will drift
-# if the fork branch is force-pushed).
+# Pinned to an immutable fork tag so CI builds don't drift.
 #
 # Spec: openspec/specs/per-site-containers/spec.md
 dependency_overrides:
   flutter_inappwebview:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: claude/v6.2.0-beta.3-privacy-v5-candidate
+      ref: v6.2.0-beta.3-privacy-v5
       path: flutter_inappwebview
   flutter_inappwebview_android:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: claude/v6.2.0-beta.3-privacy-v5-candidate
+      ref: v6.2.0-beta.3-privacy-v5
       path: flutter_inappwebview_android
   flutter_inappwebview_ios:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: claude/v6.2.0-beta.3-privacy-v5-candidate
+      ref: v6.2.0-beta.3-privacy-v5
       path: flutter_inappwebview_ios
   flutter_inappwebview_macos:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: claude/v6.2.0-beta.3-privacy-v5-candidate
+      ref: v6.2.0-beta.3-privacy-v5
       path: flutter_inappwebview_macos
   flutter_inappwebview_linux:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: claude/v6.2.0-beta.3-privacy-v5-candidate
+      ref: v6.2.0-beta.3-privacy-v5
       path: flutter_inappwebview_linux
   flutter_inappwebview_platform_interface:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: claude/v6.2.0-beta.3-privacy-v5-candidate
+      ref: v6.2.0-beta.3-privacy-v5
       path: flutter_inappwebview_platform_interface
 
 flutter:


### PR DESCRIPTION
## Summary

Wires three androidx.webkit WebView settings (added in the `flutter_inappwebview` fork) into the app.

- **Tracking Protection umbrella (per-site, Android).** At the shared `WebViewFactory` assembly, when ETP is on: an empty `requestedWithHeaderOriginAllowList` suppresses the `X-Requested-With: <package>` header for every origin, and `attributionRegistrationBehavior` is set to `AttributionBehavior.DISABLED` so the WebView stops registering Attribution Reporting sources/triggers. When ETP is off, both stay at native defaults (`null`). Derived at the shared assembly, so nested webviews inherit them.
- **Media Integrity API under ETP.** With ETP on, `webViewMediaIntegrityApiStatus` is set to `WebViewMediaIntegrityApiStatus.ENABLED_WITHOUT_APP_IDENTITY` rather than fully disabled: the attestation token keeps working for legitimate site anti-fraud but no longer carries this app's package/signing identity, closing the cross-site app-identity leak. Independent of the Widevine/EME permission.
- **Global back/forward cache pref.** `backForwardCacheEnabled` (default `true`) added to `kExportedAppPrefs`, mirrored into `WebViewFactory` at startup and after settings import, and applied to every WebView (nested included).

All three are gated by `WebViewFeature` on the native side, so unsupported providers/platforms no-op; the fork ignores them on iOS/macOS/Linux.

## Dependency

Depends on the combined `flutter_inappwebview` fork ref `claude/v6.2.0-beta.3-privacy-v5-candidate` — the existing privacy/container fork patches with the three new settings rebased in (typed as the `AttributionBehavior` / `WebViewMediaIntegrityApiStatus` enums). `dependency_overrides` pins all six plugin packages to that ref (resolved-ref `fac0996`) as a temporary branch pin until it is tagged (e.g. `v6.2.0-beta.3-privacy-v5`). The three settings are also proposed upstream as standalone commits on `claude/webview-privacy-perf-settings-efvr9s`.

## Testing and review notes

- `flutter analyze` clean (0 errors).
- New `backForwardCacheEnabled` pref rides the export/import registry, so `test/settings_backup_test.dart` covers its round-trip automatically (no test edit needed for a `bool`).
- Per-site fields are applied at the shared `WebViewFactory` assembly point, satisfying the nested-webview propagation rule.
- Not exercised on a device in this change; behavior is gated natively so it is a no-op where the feature is unsupported.

## Commits

- `d3ce4a8` Wire androidx.webkit privacy/perf WebView settings
- `55f6db1` Point inappwebview override at privacy/perf fork branch
- `b98de2b` Fold Media Integrity API under ETP umbrella
- `2e56bf3` Adopt typed fork enums for attribution/media-integrity