### PR TITLE
Restore back/forward history on Android cold start

### DIFF
--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -500,6 +500,17 @@ class WebViewConfig {
   /// the route at history start (NAV-008), which the native gesture would
   /// otherwise hijack. No effect on Android.
   final bool backForwardGestures;
+  /// Android only: build the webview with no initial load (neither
+  /// `initialUrlRequest` nor cached-HTML `initialData`) so the
+  /// controller-created handler can apply `restoreState` to a pristine
+  /// back/forward list. Android's `WebView.restoreState` is dropped when the
+  /// WebView has already navigated — its docs warn that calling it after the
+  /// view "had a chance to build state (load pages, create a back/forward
+  /// list, etc.) there may be undesirable side-effects". The handler reloads
+  /// the restored top entry afterward, since Android does not restore display
+  /// data. iOS/macOS replace state in place via `WKWebView.interactionState`,
+  /// so they keep the initial load and leave this false.
+  final bool deferInitialLoad;
   /// Language code for Accept-Language header (e.g., 'en', 'es', 'fr').
   /// If null, uses system default.
   final String? language;
@@ -666,6 +677,7 @@ class WebViewConfig {
     this.thirdPartyCookiesEnabled = false,
     this.incognito = false,
     this.backForwardGestures = false,
+    this.deferInitialLoad = false,
     this.language,
     this.zoomPercent = 100,
     this.clearUrlEnabled = true,
@@ -848,6 +860,26 @@ PerInstanceLifecycleCall perInstanceLifecycleCallFor({
   if (isIOS) return PerInstanceLifecycleCall.timers;
   return PerInstanceLifecycleCall.none;
 }
+
+/// Whether the root site webview must defer its initial load so the
+/// controller-created handler can apply `restoreState` to a pristine
+/// back/forward list. True only on Android: `WebView.restoreState` no-ops
+/// when the WebView has already navigated (an `initialUrlRequest` would build
+/// a 1-entry history first), so the back/forward stack restore is silently
+/// dropped. iOS/macOS `WKWebView.interactionState` replaces the stack in
+/// place even after a load started, so they keep the initial load.
+///
+/// Excludes file:// imports: their URL is a synthetic handle with no
+/// fetchable form, so the post-restore reload would surface
+/// ERR_FILE_NOT_FOUND — and back/forward history is meaningless for a static
+/// local page anyway, so they keep rendering their cached `initialData`.
+/// Only meaningful when nav-state bytes are actually pending for this build.
+bool deferInitialLoadForRestore({
+  required bool hasPendingRestoreState,
+  required bool isAndroid,
+  required bool isFileImport,
+}) =>
+    hasPendingRestoreState && isAndroid && !isFileImport;
 
 /// InAppWebView controller wrapper
 class _WebViewController implements WebViewController {
@@ -1495,8 +1527,14 @@ class WebViewFactory {
     // to load the synthetic file:// URL — there's no actual file on
     // disk, so the load would surface as ERR_INVALID_URL or
     // ERR_FILE_NOT_FOUND in the user's face.
-    final renderInitialData = config.initialHtml != null || isFileImport;
-    final usesCachedHtml = config.initialHtml != null;
+    // Android restore: suppress every initial-load form (URL + cached HTML)
+    // so `restoreState` can apply to a pristine history. With this set, the
+    // cached-HTML reload-to-live machinery below also stays off — the
+    // onControllerCreated restore handler owns the first navigation instead.
+    final suppressInitialLoad = config.deferInitialLoad;
+    final renderInitialData =
+        (config.initialHtml != null || isFileImport) && !suppressInitialLoad;
+    final usesCachedHtml = config.initialHtml != null && !suppressInitialLoad;
     // One-shot: when the cached HTML's first onLoadStop fires, do
     // exactly one controller.reload() to get a live page. Subsequent
     // onLoadStop events (post-reload, or for SPA navigations) leave
@@ -2394,7 +2432,7 @@ class WebViewFactory {
 
     final inapp.InAppWebView webViewWidget = inapp.InAppWebView(
       key: config.key,
-      initialUrlRequest: renderInitialData ? null : inapp.URLRequest(
+      initialUrlRequest: (renderInitialData || suppressInitialLoad) ? null : inapp.URLRequest(
         url: inapp.WebUri(config.initialUrl),
         headers: headers.isNotEmpty ? headers : null,
       ),

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -815,6 +815,16 @@ class WebViewModel {
         return uri != null &&
             LinkRoutingService.urlMatchesAnyClaim(uri, effectiveDomainClaims);
       }
+      // Android restore ordering: when nav-state bytes are queued for this
+      // build, the webview must apply restoreState to a pristine back/forward
+      // list. Suppress the initial load on Android and materialize the
+      // restored entry from onControllerCreated; iOS/macOS keep the
+      // initialUrlRequest load and replace state in place via interactionState.
+      final bool deferRestoreLoad = deferInitialLoadForRestore(
+        hasPendingRestoreState: _pendingRestoreState != null,
+        isAndroid: Platform.isAndroid,
+        isFileImport: currentUrl.startsWith('file://'),
+      );
       webview = WebViewFactory.createWebView(
         config: WebViewConfig(
           key: UniqueKey(), // Force new widget state when recreating
@@ -829,6 +839,7 @@ class WebViewModel {
           // there is no Flutter route-pop edge-swipe here, so opt into
           // WKWebView's native back/forward swipe. Nested screens don't (NAV-008).
           backForwardGestures: true,
+          deferInitialLoad: deferRestoreLoad,
           language: effectiveLanguage, // Use WebViewModel's language, not parameter
           zoomPercent: zoomPercent,
           // Umbrella `trackingProtectionEnabled`: when on, the four
@@ -1191,6 +1202,15 @@ class WebViewModel {
           final pending = _pendingRestoreState;
           if (pending != null) {
             _pendingRestoreState = null;
+            // On Android the webview was built with no initial load
+            // (deferRestoreLoad), so restoreState applies to a pristine
+            // back/forward list. Android does not restore display data, so
+            // the current entry must then be materialized with an explicit
+            // reload. iOS/macOS already kicked off the initialUrlRequest load
+            // and replace state in place via interactionState, so they skip
+            // this — the page is already on screen.
+            final materialize = deferRestoreLoad;
+            final restoreUrl = currentUrl;
             unawaited(() async {
               try {
                 final ok = await ctrl.restoreState(pending);
@@ -1199,10 +1219,26 @@ class WebViewModel {
                   'restoreState for "$name" (siteId: $siteId): $ok',
                   sensitivity: LogSensitivity.sensitive,
                 );
+                if (materialize) {
+                  // ok: reload the restored top entry (keeps the back stack).
+                  // !ok: nothing was restored, so just load the saved URL or
+                  // the suppressed-initial-load webview would stay blank.
+                  if (ok) {
+                    await ctrl.reload();
+                  } else {
+                    await ctrl.loadUrl(restoreUrl);
+                  }
+                }
               } catch (_) {
-                // Restore is best-effort; on failure the page is
-                // already loading from `currentUrl` — user just loses
-                // the back/forward stack and form data.
+                // Restore is best-effort. On Apple the page is already
+                // loading from `currentUrl`; on Android the initial load was
+                // suppressed, so fall back to loading it explicitly or the
+                // view would stay blank.
+                if (materialize) {
+                  try {
+                    await ctrl.loadUrl(restoreUrl);
+                  } catch (_) {}
+                }
               }
             }());
           }

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -174,7 +174,23 @@ The OS controls the curve: if pressure persists, the callback fires again and th
   - **Linux** (WebKitGTK / WPE) via `webkit_web_view_restore_session_state`
 **And** on iOS 15+ / macOS 12+ form-field values are restored too — Linux and Android only carry history + scroll
 
-The `initialUrlRequest` (set to `currentUrl` on the model) kicks off a navigation that lands at the most-recent saved URL; on Apple, assigning `interactionState` may trigger a brief redundant nav (acceptable for the much-better re-activation UX). Live JS heap and DOM are not preserved on any platform — re-execution starts fresh.
+The load ordering differs by platform because the restore APIs differ. On iOS/macOS the `initialUrlRequest` (set to `currentUrl` on the model) kicks off a navigation that lands at the most-recent saved URL, and assigning `interactionState` replaces the back/forward stack **in place** — a brief redundant nav, acceptable for the much-better re-activation UX. On Android `WebView.restoreState` is silently dropped if the WebView has already navigated (its docs warn of "undesirable side-effects" when called after the view has built state), so the root webview is instead built with **no** initial load — `WebViewConfig.deferInitialLoad`, gated by the pure `deferInitialLoadForRestore(hasPendingRestoreState, isAndroid)`. restoreState then applies to a pristine history and `onControllerCreated` reloads the restored top entry, since Android does not restore display data. Live JS heap and DOM are not preserved on any platform — re-execution starts fresh.
+
+#### Scenario: Android applies restoreState before any navigation
+
+**Given** site A on Android has an http(s) `currentUrl` and nav-state bytes queued via `schedulePendingRestoreState`
+**When** the webview is rebuilt
+**Then** it is constructed with no `initialUrlRequest` and no cached-HTML `initialData` (so the WebView has an empty back/forward list)
+**And** `onControllerCreated` calls `controller.restoreState(bytes)` first
+**And** on success it issues one `reload()` to materialize the restored current entry while preserving the back stack
+**And** if `restoreState` reports failure it falls back to loading `currentUrl` so the view is never left blank
+
+#### Scenario: Android file import is not deferred
+
+**Given** site A on Android is a `file://` import (synthetic, non-fetchable URL) with nav-state bytes queued
+**When** the webview is rebuilt
+**Then** the initial load is NOT suppressed — it keeps rendering its cached `initialData`
+**Because** the post-restore `reload()` would fail with ERR_FILE_NOT_FOUND and a static local page has no meaningful back/forward stack to restore
 
 #### Scenario: Active webspace tier is preserved over stale workspace
 

--- a/test/webview_pause_lifecycle_test.dart
+++ b/test/webview_pause_lifecycle_test.dart
@@ -147,6 +147,67 @@ void main() {
     });
   });
 
+  group('cold-start restore initial-load deferral', () {
+    test('Android with pending restore defers the initial load', () {
+      expect(
+        deferInitialLoadForRestore(
+            hasPendingRestoreState: true,
+            isAndroid: true,
+            isFileImport: false),
+        isTrue,
+        reason: 'WebView.restoreState is dropped if the WebView already '
+            'navigated, so the initial load must be suppressed.',
+      );
+    });
+
+    test('non-Android with pending restore keeps the initial load', () {
+      expect(
+        deferInitialLoadForRestore(
+            hasPendingRestoreState: true,
+            isAndroid: false,
+            isFileImport: false),
+        isFalse,
+        reason: 'iOS/macOS interactionState replaces the stack in place, so '
+            'the initialUrlRequest load stays.',
+      );
+    });
+
+    test('no deferral when nothing is pending (Android)', () {
+      expect(
+        deferInitialLoadForRestore(
+            hasPendingRestoreState: false,
+            isAndroid: true,
+            isFileImport: false),
+        isFalse,
+        reason: 'A normal build with no restore bytes loads currentUrl as '
+            'usual.',
+      );
+    });
+
+    test('no deferral when nothing is pending (non-Android)', () {
+      expect(
+        deferInitialLoadForRestore(
+            hasPendingRestoreState: false,
+            isAndroid: false,
+            isFileImport: false),
+        isFalse,
+      );
+    });
+
+    test('Android file import keeps its cached initialData (no deferral)', () {
+      expect(
+        deferInitialLoadForRestore(
+            hasPendingRestoreState: true,
+            isAndroid: true,
+            isFileImport: true),
+        isFalse,
+        reason: 'file:// has no fetchable form, so the post-restore reload '
+            'would ERR_FILE_NOT_FOUND; static local pages have no meaningful '
+            'back/forward to restore.',
+      );
+    });
+  });
+
   group('WebViewModel pause/resume null-safety', () {
     test('pauseWebView() with no controller is a no-op', () async {
       final m = _modelWith(null);


### PR DESCRIPTION
Android's WebView.restoreState() is silently dropped once the WebView has
navigated, so applying it after the initialUrlRequest load — fine on
iOS/macOS where interactionState replaces the stack in place — lost the
back/forward history on Android. The cross-restart restore (and in-session
savedForRestore re-activation) therefore never worked there.

On Android, defer the initial load when restore bytes are pending: build a
pristine webview, restoreState first, then reload the top entry (Android
doesn't restore display data). file:// imports stay on their cached
initialData since the synthetic URL has nothing to reload.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VrAmhy22D1vh1C7WVWdUXX