### PR TITLE
Recomposite Android surface when a fresh webview controller attaches

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7147,6 +7147,16 @@ class _WebSpacePageState extends State<WebSpacePage>
                           return const SizedBox.shrink();
                         }
 
+                        // When a fresh native controller attaches for the
+                        // visible site (cold start, _goHome recreate,
+                        // renderer-gone rebuild), recomposite the Android
+                        // surface — a newly-mounted hybrid-composition
+                        // SurfaceView can come back blank-white. Reads
+                        // _currentIndex live at fire time; no-op off Android.
+                        webViewModel.onControllerReady = () {
+                          if (index == _currentIndex) _nudgeSurfaceRepaint();
+                        };
+
                         // Single source of truth for which HTML store backs
                         // this site — shared with `_ensureSiteHtml`'s preload so
                         // read and preload can't target different stores.

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -495,6 +495,14 @@ class WebViewModel {
   /// dialogs. Cleared once [protectedContentAllowed] is recorded.
   Future<bool>? _protectedMediaDecisionInFlight;
   Function? stateSetterF;
+  /// Host hook fired once each time a fresh native controller attaches for
+  /// this model (cold start, `_goHome` recreate, renderer-gone recovery,
+  /// savedForRestore re-creation). The host uses it to recomposite the
+  /// Android hybrid-composition surface, which can re-attach blank-white
+  /// when a new platform view mounts. Re-activation of an already-loaded
+  /// webview does NOT recreate the controller, so it does not fire here —
+  /// that path is nudged explicitly by `_setCurrentIndex`.
+  Function? onControllerReady;
   FindMatchesResult findMatches = FindMatchesResult();
   WebViewTheme _currentTheme = WebViewTheme.light;
 
@@ -1152,6 +1160,13 @@ class WebViewModel {
               }
             }());
           }
+          // A brand-new platform-view surface just attached; let the host
+          // recomposite it if this is the visible site (Android blank-white
+          // surface recovery). Fires for every fresh controller, so it
+          // covers _goHome, renderer-gone rebuild, and savedForRestore
+          // re-creation in one place — paths _setCurrentIndex's own nudge
+          // does not reach because they don't go through it.
+          onControllerReady?.call();
         },
       );
     }

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -520,6 +520,25 @@ This is complementary to PAUSE-014: the probe recreates a *dead* renderer; the s
 **Then** it is a no-op on non-Android platforms
 **And** `_repaintNudge` remains false so the body inset stays 0 — no visible jitter during normal use
 
+### Requirement: PAUSE-017 — Surface Repaint On Fresh Controller Attach
+
+On Android, the system SHALL recomposite the surface whenever a **fresh** native controller attaches for the visible site, not only on the resume/re-activation paths of PAUSE-015. Re-activating an already-loaded webview reuses its controller and is covered by `_setCurrentIndex`'s explicit nudge; but a webview that is **recreated from scratch** mounts a brand-new hybrid-composition `SurfaceView` that can likewise attach blank — rendering **white** (the fresh surface's default fill) rather than black. These recreation paths do not run through `_setCurrentIndex` and so were uncovered: `_goHome` (disposes and rebuilds at `initUrl`), renderer-gone recovery (`handleRendererGone` rebuilds at `currentUrl`), and `savedForRestore` re-creation.
+
+The host SHALL set `WebViewModel.onControllerReady` for each loaded model in the build, and `getWebView`'s `onControllerCreated` SHALL invoke it after the controller is wired. The callback fires `_nudgeSurfaceRepaint` only when the model's index equals the live `_currentIndex`, so a background site's (re)creation never nudges. Because it keys off controller creation — the single chokepoint every recreation passes through — it covers current and future recreation paths in one place rather than per call site.
+
+#### Scenario: Home button recreates the active webview
+
+**Given** a site is visible on Android
+**When** the user taps Home, which disposes the webview and rebuilds it at `initUrl`
+**Then** the rebuilt webview's `onControllerCreated` fires `onControllerReady`
+**And** because its index equals `_currentIndex`, `_nudgeSurfaceRepaint` runs and the fresh surface paints instead of staying blank-white
+
+#### Scenario: Background site re-creation does not nudge
+
+**Given** a notification site is rebuilt off-screen while another site is visible
+**When** its `onControllerReady` fires
+**Then** its index does not equal `_currentIndex`, so no nudge runs and the visible site does not jitter
+
 ---
 
 ### Requirement: PAUSE-016 — Android Per-Instance Pause Is a No-Op


### PR DESCRIPTION
The PAUSE-015 surface nudge only fired on the resume/re-activation paths.
Webviews recreated from scratch (_goHome, renderer-gone recovery,
savedForRestore) mount a brand-new hybrid-composition SurfaceView that can
attach blank — rendering white — and none of those paths run through
_setCurrentIndex, so they were uncovered. Fire the nudge from
onControllerCreated for the visible site, the one chokepoint every
recreation passes through