### PR TITLE
Move TLAPS proof verification into validate job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   validate:
-    name: Validate Fastlane + OpenSpec
+    name: Validate Fastlane + OpenSpec + proofs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -70,6 +70,20 @@ jobs:
           java-version: '21'
       - name: Verify formal kernel
         run: ./formal/check.sh
+      # tlapm (the TLA+ Proof Manager) machine-checks the unbounded proofs in
+      # formal/proofs/ -- formal verification of the same specs, so it sits in
+      # the validate tier next to OpenSpec validation and the TLC kernel. The
+      # installer is heavy (~145 MB, bundles Isabelle) but reuses the Java set
+      # up above, so a separate runner buys nothing.
+      - name: Install TLAPS
+        run: |
+          curl -fsSL -o /tmp/tlaps.bin \
+            https://github.com/tlaplus/tlapm/releases/download/202210041448/tlaps-1.5.0-x86_64-linux-gnu-inst.bin
+          chmod +x /tmp/tlaps.bin
+          /tmp/tlaps.bin -d "$HOME/tlaps"
+          echo "$HOME/tlaps/bin" >> "$GITHUB_PATH"
+      - name: Verify TLAPS proofs
+        run: ./formal/proofs/check_proofs.sh
       # Idempotent: if the cache restored a matching Chromium, this
       # step prints "already installed" and exits in <1s. Otherwise it
       # downloads ~280 MB into ~/.cache/puppeteer. Running it as a
@@ -97,24 +111,6 @@ jobs:
       # requireBrowser() in test/browser/helpers/launch.js.
       - name: Run browser tests (real-Chromium shim tier)
         run: npm run test:browser
-
-  verify-proofs:
-    name: Verify TLAPS proofs
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      # tlapm (the TLA+ Proof Manager) machine-checks the unbounded proofs in
-      # formal/proofs/. It is a heavy, self-contained install (~145 MB, bundles
-      # Isabelle), so it lives in its own job rather than the validate tier.
-      - name: Install TLAPS
-        run: |
-          curl -fsSL -o /tmp/tlaps.bin \
-            https://github.com/tlaplus/tlapm/releases/download/202210041448/tlaps-1.5.0-x86_64-linux-gnu-inst.bin
-          chmod +x /tmp/tlaps.bin
-          /tmp/tlaps.bin -d "$HOME/tlaps"
-          echo "$HOME/tlaps/bin" >> "$GITHUB_PATH"
-      - name: Check proofs
-        run: ./formal/proofs/check_proofs.sh
 
   build-android:
     name: Build Android

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ missing-transition classes, and cross-spec interference — bugs in the gaps *be
   observable projection (the model↔code bridge).
 - `formal/proofs/` holds **unbounded TLAPS proofs** (machine-checked by `tlapm`): every
   kernel safety invariant *and* the surface-repaint liveness `RepaintLiveness` for all N,
-  not just TLC's N = 3. Run via `proofs/check_proofs.sh` (CI job `verify-proofs`).
+  not just TLC's N = 3. Run via `proofs/check_proofs.sh` (in the `validate` CI job).
 - A bug's recurrence is also gated in **code**: structural Node tests under `test/js/`
   (`surface_repaint_funnel`, `renderer_gone_recovery`) fail CI if a new path skips the fix.
 - Don't commit `tla2tools.jar`, `states/`, `.tlacache/`, or generated `mc_*.tla` (derivatives).


### PR DESCRIPTION
Consolidate formal verification into the `validate` CI job by moving TLAPS proof checking from its own dedicated job into the existing validation tier alongside OpenSpec and TLC kernel verification.

- Merge `verify-proofs` job into `validate` job after the kernel check
- Install TLAPS and run proof verification as part of the same runner that handles other formal specs
- Remove the standalone `verify-proofs` job (no longer needed; TLAPS reuses the Java 21 environment already set up)
- Update CLAUDE.md to reflect that proof verification now runs in the `validate` job rather than a separate `verify-proofs` job

The TLAPS installer is heavy (~145 MB) but bundles Isabelle and reuses the Java environment already configured for the kernel check, so consolidating into a single runner eliminates unnecessary overhead.

https://claude.ai/code/session_01TnpBjtWetbFxDH3kFougz1