### PR TITLE
Fix stuck zoom-out on load (WebKit): force initial-scale=1

### DIFF
--- a/docs/diagnostics/ios_viewport_probe.html
+++ b/docs/diagnostics/ios_viewport_probe.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<!--
+  iOS/WKWebView zoom-on-load probe.
+
+  Purpose: figure out why some sites load zoomed out (small) on iOS and
+  sometimes stay stuck. It records the viewport geometry that WKWebView
+  reports over the life of the load and shows whether the page is being
+  laid out wider than the visible area (which forces a zoom-out to fit).
+
+  Two variants of this file exist so you can A/B whether a declared
+  viewport matters: this one DECLARES width=device-width. The sibling
+  `ios_viewport_probe_noviewport.html` declares NONE.
+
+  What to look for:
+   - visualViewport.scale < 1  => the page is zoomed out. If it stays < 1
+     after load, that is the "stuck" bug.
+   - innerWidth  >> screen.width (in CSS px)  => WKWebView laid the page
+     out at a viewport WIDER than the device, so it zoomed out to fit.
+     This points at a wrong webview width at layout time (offstage /
+     IndexedStack / pre-constraint sizing), NOT a missing viewport meta.
+   - Compare the FIRST row (document-start) with the LAST row: if scale
+     starts <1 and never returns to 1, it never recovered.
+-->
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>iOS viewport probe (device-width)</title>
+<style>
+  html, body { margin: 0; padding: 0; font: 13px/1.4 -apple-system, system-ui, sans-serif; }
+  #panel {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 2147483647;
+    background: #111; color: #0f0; padding: 8px 10px;
+    font-family: ui-monospace, Menlo, monospace; white-space: pre;
+    box-shadow: 0 2px 6px rgba(0,0,0,.4);
+  }
+  #log { padding: 10px; margin-top: 220px; }
+  #log div { border-bottom: 1px solid #eee; padding: 2px 0; font-family: ui-monospace, Menlo, monospace; }
+  /* A full-viewport-width ruler. Each cell is 100 CSS px. If the page is
+     laid out wider than the screen, you will see more cells than fit and
+     the whole thing will look shrunk (zoomed out). */
+  #ruler { display: flex; width: 100%; margin-top: 6px; }
+  #ruler .tick { flex: 0 0 100px; height: 26px; border-right: 1px solid #c00;
+    background: #fee; color: #900; font: 10px/26px monospace; text-align: right;
+    padding-right: 2px; box-sizing: border-box; }
+  /* A block that is exactly the device width per the media query. If the
+     red ruler overflows past this green edge, layout width > device. */
+  #devwidth { height: 10px; background: #0a0; width: 100vw; }
+  button { font-size: 16px; padding: 8px 14px; margin: 8px; }
+</style>
+
+<div id="panel">measuring...</div>
+<div id="devwidth"></div>
+<div id="ruler"></div>
+<div id="log"></div>
+<button id="copy">Copy log to clipboard</button>
+<button id="mark">Add manual mark</button>
+
+<script>
+(function () {
+  var rows = [];
+  var vv = window.visualViewport || null;
+
+  function metrics() {
+    return {
+      innerW: window.innerWidth,
+      innerH: window.innerHeight,
+      outerW: window.outerWidth,
+      clientW: document.documentElement ? document.documentElement.clientWidth : -1,
+      bodyW: document.body ? document.body.clientWidth : -1,
+      screenW: screen.width,
+      availW: screen.availWidth,
+      dpr: window.devicePixelRatio,
+      vvW: vv ? Math.round(vv.width) : -1,
+      vvH: vv ? Math.round(vv.height) : -1,
+      vvScale: vv ? +vv.scale.toFixed(4) : -1,
+      vvOffL: vv ? Math.round(vv.offsetLeft) : -1,
+      viewportMeta: (function () {
+        var m = document.querySelector('meta[name="viewport" i]');
+        return m ? m.getAttribute('content') : '(none)';
+      })()
+    };
+  }
+
+  function t() { return Math.round(performance.now()); }
+
+  function record(evt) {
+    var m = metrics();
+    m.evt = evt;
+    m.t = t();
+    rows.push(m);
+    render(m);
+    updatePanel(m);
+  }
+
+  function fmt(m) {
+    return (m.t + 'ms').padEnd(8) + ' ' + m.evt.padEnd(16) +
+      ' scale=' + m.vvScale +
+      ' innerW=' + m.innerW +
+      ' vvW=' + m.vvW +
+      ' clientW=' + m.clientW +
+      ' screenW=' + m.screenW +
+      ' dpr=' + m.dpr +
+      ' vp=' + m.viewportMeta;
+  }
+
+  function render(m) {
+    var d = document.createElement('div');
+    var bad = (m.vvScale > 0 && m.vvScale < 0.99) || (m.innerW > m.screenW + 2);
+    d.style.color = bad ? '#b00' : '#060';
+    d.textContent = fmt(m);
+    var log = document.getElementById('log');
+    if (log) log.appendChild(d);
+  }
+
+  function updatePanel(m) {
+    var p = document.getElementById('panel');
+    if (!p) return;
+    var verdict =
+      (m.vvScale > 0 && m.vvScale < 0.99) ? 'ZOOMED OUT (scale ' + m.vvScale + ')' :
+      (m.innerW > m.screenW + 2) ? 'LAYOUT WIDER THAN SCREEN (innerW ' + m.innerW + ' > screenW ' + m.screenW + ')' :
+      'ok (scale ' + m.vvScale + ')';
+    p.textContent =
+      'VERDICT: ' + verdict + '\n' +
+      'visualViewport.scale = ' + m.vvScale + '   (<1 = zoomed out)\n' +
+      'innerWidth  = ' + m.innerW + ' CSS px   (layout viewport width)\n' +
+      'visualVP W  = ' + m.vvW + ' CSS px   (visible width)\n' +
+      'screen.width= ' + m.screenW + ' CSS px   devicePixelRatio=' + m.dpr + '\n' +
+      'viewport meta: ' + m.viewportMeta;
+  }
+
+  function buildRuler() {
+    var r = document.getElementById('ruler');
+    if (!r) return;
+    r.innerHTML = '';
+    var n = Math.ceil((window.innerWidth || 1200) / 100) + 2;
+    for (var i = 0; i < n; i++) {
+      var c = document.createElement('div');
+      c.className = 'tick';
+      c.textContent = (i * 100);
+      r.appendChild(c);
+    }
+  }
+
+  // Record across the whole load timeline.
+  record('document-start');
+  document.addEventListener('DOMContentLoaded', function () { buildRuler(); record('DOMContentLoaded'); });
+  window.addEventListener('load', function () { buildRuler(); record('load'); });
+  window.addEventListener('resize', function () { buildRuler(); record('resize'); });
+  window.addEventListener('orientationchange', function () { record('orientationchange'); });
+  if (vv) {
+    vv.addEventListener('resize', function () { record('vv-resize'); });
+    vv.addEventListener('scroll', function () { record('vv-scroll'); });
+  }
+  [250, 500, 1000, 2000, 4000].forEach(function (ms) {
+    setTimeout(function () { record('t+' + ms + 'ms'); }, ms);
+  });
+
+  document.addEventListener('click', function (e) {
+    if (e.target && e.target.id === 'mark') record('MANUAL-MARK');
+    if (e.target && e.target.id === 'copy') {
+      var text = rows.map(fmt).join('\n');
+      if (navigator.clipboard) navigator.clipboard.writeText(text);
+      var p = document.getElementById('panel');
+      if (p) p.textContent = 'Copied ' + rows.length + ' rows to clipboard.\n\n' + p.textContent;
+    }
+  });
+})();
+</script>

--- a/docs/diagnostics/ios_viewport_probe_noinitscale.html
+++ b/docs/diagnostics/ios_viewport_probe_noinitscale.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<!--
+  iOS/WKWebView zoom-on-load probe.
+
+  Purpose: figure out why some sites load zoomed out (small) on iOS and
+  sometimes stay stuck. It records the viewport geometry that WKWebView
+  reports over the life of the load and shows whether the page is being
+  laid out wider than the visible area (which forces a zoom-out to fit).
+
+  Two variants of this file exist so you can A/B whether a declared
+  viewport matters: this one DECLARES width=device-width. The sibling
+  `ios_viewport_probe_noviewport.html` declares NONE.
+
+  What to look for:
+   - visualViewport.scale < 1  => the page is zoomed out. If it stays < 1
+     after load, that is the "stuck" bug.
+   - innerWidth  >> screen.width (in CSS px)  => WKWebView laid the page
+     out at a viewport WIDER than the device, so it zoomed out to fit.
+     This points at a wrong webview width at layout time (offstage /
+     IndexedStack / pre-constraint sizing), NOT a missing viewport meta.
+   - Compare the FIRST row (document-start) with the LAST row: if scale
+     starts <1 and never returns to 1, it never recovered.
+-->
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+<title>iOS probe (width=device-width, NO initial-scale)</title>
+<style>
+  html, body { margin: 0; padding: 0; font: 13px/1.4 -apple-system, system-ui, sans-serif; }
+  #panel {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 2147483647;
+    background: #111; color: #0f0; padding: 8px 10px;
+    font-family: ui-monospace, Menlo, monospace; white-space: pre;
+    box-shadow: 0 2px 6px rgba(0,0,0,.4);
+  }
+  #log { padding: 10px; margin-top: 220px; }
+  #log div { border-bottom: 1px solid #eee; padding: 2px 0; font-family: ui-monospace, Menlo, monospace; }
+  /* A full-viewport-width ruler. Each cell is 100 CSS px. If the page is
+     laid out wider than the screen, you will see more cells than fit and
+     the whole thing will look shrunk (zoomed out). */
+  #ruler { display: flex; width: 100%; margin-top: 6px; }
+  #ruler .tick { flex: 0 0 100px; height: 26px; border-right: 1px solid #c00;
+    background: #fee; color: #900; font: 10px/26px monospace; text-align: right;
+    padding-right: 2px; box-sizing: border-box; }
+  /* A block that is exactly the device width per the media query. If the
+     red ruler overflows past this green edge, layout width > device. */
+  #devwidth { height: 10px; background: #0a0; width: 100vw; }
+  button { font-size: 16px; padding: 8px 14px; margin: 8px; }
+</style>
+
+<div id="panel">measuring...</div>
+<div id="devwidth"></div>
+<div id="ruler"></div>
+<div id="log"></div>
+<button id="copy">Copy log to clipboard</button>
+<button id="mark">Add manual mark</button>
+
+<script>
+(function () {
+  var rows = [];
+  var vv = window.visualViewport || null;
+
+  function metrics() {
+    return {
+      innerW: window.innerWidth,
+      innerH: window.innerHeight,
+      outerW: window.outerWidth,
+      clientW: document.documentElement ? document.documentElement.clientWidth : -1,
+      bodyW: document.body ? document.body.clientWidth : -1,
+      screenW: screen.width,
+      availW: screen.availWidth,
+      dpr: window.devicePixelRatio,
+      vvW: vv ? Math.round(vv.width) : -1,
+      vvH: vv ? Math.round(vv.height) : -1,
+      vvScale: vv ? +vv.scale.toFixed(4) : -1,
+      vvOffL: vv ? Math.round(vv.offsetLeft) : -1,
+      viewportMeta: (function () {
+        var m = document.querySelector('meta[name="viewport" i]');
+        return m ? m.getAttribute('content') : '(none)';
+      })()
+    };
+  }
+
+  function t() { return Math.round(performance.now()); }
+
+  function record(evt) {
+    var m = metrics();
+    m.evt = evt;
+    m.t = t();
+    rows.push(m);
+    render(m);
+    updatePanel(m);
+  }
+
+  function fmt(m) {
+    return (m.t + 'ms').padEnd(8) + ' ' + m.evt.padEnd(16) +
+      ' scale=' + m.vvScale +
+      ' innerW=' + m.innerW +
+      ' vvW=' + m.vvW +
+      ' clientW=' + m.clientW +
+      ' screenW=' + m.screenW +
+      ' dpr=' + m.dpr +
+      ' vp=' + m.viewportMeta;
+  }
+
+  function render(m) {
+    var d = document.createElement('div');
+    var bad = (m.vvScale > 0 && m.vvScale < 0.99) || (m.innerW > m.screenW + 2);
+    d.style.color = bad ? '#b00' : '#060';
+    d.textContent = fmt(m);
+    var log = document.getElementById('log');
+    if (log) log.appendChild(d);
+  }
+
+  function updatePanel(m) {
+    var p = document.getElementById('panel');
+    if (!p) return;
+    var verdict =
+      (m.vvScale > 0 && m.vvScale < 0.99) ? 'ZOOMED OUT (scale ' + m.vvScale + ')' :
+      (m.innerW > m.screenW + 2) ? 'LAYOUT WIDER THAN SCREEN (innerW ' + m.innerW + ' > screenW ' + m.screenW + ')' :
+      'ok (scale ' + m.vvScale + ')';
+    p.textContent =
+      'VERDICT: ' + verdict + '\n' +
+      'visualViewport.scale = ' + m.vvScale + '   (<1 = zoomed out)\n' +
+      'innerWidth  = ' + m.innerW + ' CSS px   (layout viewport width)\n' +
+      'visualVP W  = ' + m.vvW + ' CSS px   (visible width)\n' +
+      'screen.width= ' + m.screenW + ' CSS px   devicePixelRatio=' + m.dpr + '\n' +
+      'viewport meta: ' + m.viewportMeta;
+  }
+
+  function buildRuler() {
+    var r = document.getElementById('ruler');
+    if (!r) return;
+    r.innerHTML = '';
+    var n = Math.ceil((window.innerWidth || 1200) / 100) + 2;
+    for (var i = 0; i < n; i++) {
+      var c = document.createElement('div');
+      c.className = 'tick';
+      c.textContent = (i * 100);
+      r.appendChild(c);
+    }
+  }
+
+  // Record across the whole load timeline.
+  record('document-start');
+  document.addEventListener('DOMContentLoaded', function () { buildRuler(); record('DOMContentLoaded'); });
+  window.addEventListener('load', function () { buildRuler(); record('load'); });
+  window.addEventListener('resize', function () { buildRuler(); record('resize'); });
+  window.addEventListener('orientationchange', function () { record('orientationchange'); });
+  if (vv) {
+    vv.addEventListener('resize', function () { record('vv-resize'); });
+    vv.addEventListener('scroll', function () { record('vv-scroll'); });
+  }
+  [250, 500, 1000, 2000, 4000].forEach(function (ms) {
+    setTimeout(function () { record('t+' + ms + 'ms'); }, ms);
+  });
+
+  document.addEventListener('click', function (e) {
+    if (e.target && e.target.id === 'mark') record('MANUAL-MARK');
+    if (e.target && e.target.id === 'copy') {
+      var text = rows.map(fmt).join('\n');
+      if (navigator.clipboard) navigator.clipboard.writeText(text);
+      var p = document.getElementById('panel');
+      if (p) p.textContent = 'Copied ' + rows.length + ' rows to clipboard.\n\n' + p.textContent;
+    }
+  });
+})();
+</script>

--- a/docs/diagnostics/ios_viewport_probe_noviewport.html
+++ b/docs/diagnostics/ios_viewport_probe_noviewport.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<!--
+  iOS/WKWebView zoom-on-load probe.
+
+  Purpose: figure out why some sites load zoomed out (small) on iOS and
+  sometimes stay stuck. It records the viewport geometry that WKWebView
+  reports over the life of the load and shows whether the page is being
+  laid out wider than the visible area (which forces a zoom-out to fit).
+
+  Two variants of this file exist so you can A/B whether a declared
+  viewport matters: this one DECLARES width=device-width. The sibling
+  `ios_viewport_probe_noviewport.html` declares NONE.
+
+  What to look for:
+   - visualViewport.scale < 1  => the page is zoomed out. If it stays < 1
+     after load, that is the "stuck" bug.
+   - innerWidth  >> screen.width (in CSS px)  => WKWebView laid the page
+     out at a viewport WIDER than the device, so it zoomed out to fit.
+     This points at a wrong webview width at layout time (offstage /
+     IndexedStack / pre-constraint sizing), NOT a missing viewport meta.
+   - Compare the FIRST row (document-start) with the LAST row: if scale
+     starts <1 and never returns to 1, it never recovered.
+-->
+<meta charset="utf-8">
+<title>iOS viewport probe (NO viewport meta)</title>
+<style>
+  html, body { margin: 0; padding: 0; font: 13px/1.4 -apple-system, system-ui, sans-serif; }
+  #panel {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 2147483647;
+    background: #111; color: #0f0; padding: 8px 10px;
+    font-family: ui-monospace, Menlo, monospace; white-space: pre;
+    box-shadow: 0 2px 6px rgba(0,0,0,.4);
+  }
+  #log { padding: 10px; margin-top: 220px; }
+  #log div { border-bottom: 1px solid #eee; padding: 2px 0; font-family: ui-monospace, Menlo, monospace; }
+  /* A full-viewport-width ruler. Each cell is 100 CSS px. If the page is
+     laid out wider than the screen, you will see more cells than fit and
+     the whole thing will look shrunk (zoomed out). */
+  #ruler { display: flex; width: 100%; margin-top: 6px; }
+  #ruler .tick { flex: 0 0 100px; height: 26px; border-right: 1px solid #c00;
+    background: #fee; color: #900; font: 10px/26px monospace; text-align: right;
+    padding-right: 2px; box-sizing: border-box; }
+  /* A block that is exactly the device width per the media query. If the
+     red ruler overflows past this green edge, layout width > device. */
+  #devwidth { height: 10px; background: #0a0; width: 100vw; }
+  button { font-size: 16px; padding: 8px 14px; margin: 8px; }
+</style>
+
+<div id="panel">measuring...</div>
+<div id="devwidth"></div>
+<div id="ruler"></div>
+<div id="log"></div>
+<button id="copy">Copy log to clipboard</button>
+<button id="mark">Add manual mark</button>
+
+<script>
+(function () {
+  var rows = [];
+  var vv = window.visualViewport || null;
+
+  function metrics() {
+    return {
+      innerW: window.innerWidth,
+      innerH: window.innerHeight,
+      outerW: window.outerWidth,
+      clientW: document.documentElement ? document.documentElement.clientWidth : -1,
+      bodyW: document.body ? document.body.clientWidth : -1,
+      screenW: screen.width,
+      availW: screen.availWidth,
+      dpr: window.devicePixelRatio,
+      vvW: vv ? Math.round(vv.width) : -1,
+      vvH: vv ? Math.round(vv.height) : -1,
+      vvScale: vv ? +vv.scale.toFixed(4) : -1,
+      vvOffL: vv ? Math.round(vv.offsetLeft) : -1,
+      viewportMeta: (function () {
+        var m = document.querySelector('meta[name="viewport" i]');
+        return m ? m.getAttribute('content') : '(none)';
+      })()
+    };
+  }
+
+  function t() { return Math.round(performance.now()); }
+
+  function record(evt) {
+    var m = metrics();
+    m.evt = evt;
+    m.t = t();
+    rows.push(m);
+    render(m);
+    updatePanel(m);
+  }
+
+  function fmt(m) {
+    return (m.t + 'ms').padEnd(8) + ' ' + m.evt.padEnd(16) +
+      ' scale=' + m.vvScale +
+      ' innerW=' + m.innerW +
+      ' vvW=' + m.vvW +
+      ' clientW=' + m.clientW +
+      ' screenW=' + m.screenW +
+      ' dpr=' + m.dpr +
+      ' vp=' + m.viewportMeta;
+  }
+
+  function render(m) {
+    var d = document.createElement('div');
+    var bad = (m.vvScale > 0 && m.vvScale < 0.99) || (m.innerW > m.screenW + 2);
+    d.style.color = bad ? '#b00' : '#060';
+    d.textContent = fmt(m);
+    var log = document.getElementById('log');
+    if (log) log.appendChild(d);
+  }
+
+  function updatePanel(m) {
+    var p = document.getElementById('panel');
+    if (!p) return;
+    var verdict =
+      (m.vvScale > 0 && m.vvScale < 0.99) ? 'ZOOMED OUT (scale ' + m.vvScale + ')' :
+      (m.innerW > m.screenW + 2) ? 'LAYOUT WIDER THAN SCREEN (innerW ' + m.innerW + ' > screenW ' + m.screenW + ')' :
+      'ok (scale ' + m.vvScale + ')';
+    p.textContent =
+      'VERDICT: ' + verdict + '\n' +
+      'visualViewport.scale = ' + m.vvScale + '   (<1 = zoomed out)\n' +
+      'innerWidth  = ' + m.innerW + ' CSS px   (layout viewport width)\n' +
+      'visualVP W  = ' + m.vvW + ' CSS px   (visible width)\n' +
+      'screen.width= ' + m.screenW + ' CSS px   devicePixelRatio=' + m.dpr + '\n' +
+      'viewport meta: ' + m.viewportMeta;
+  }
+
+  function buildRuler() {
+    var r = document.getElementById('ruler');
+    if (!r) return;
+    r.innerHTML = '';
+    var n = Math.ceil((window.innerWidth || 1200) / 100) + 2;
+    for (var i = 0; i < n; i++) {
+      var c = document.createElement('div');
+      c.className = 'tick';
+      c.textContent = (i * 100);
+      r.appendChild(c);
+    }
+  }
+
+  // Record across the whole load timeline.
+  record('document-start');
+  document.addEventListener('DOMContentLoaded', function () { buildRuler(); record('DOMContentLoaded'); });
+  window.addEventListener('load', function () { buildRuler(); record('load'); });
+  window.addEventListener('resize', function () { buildRuler(); record('resize'); });
+  window.addEventListener('orientationchange', function () { record('orientationchange'); });
+  if (vv) {
+    vv.addEventListener('resize', function () { record('vv-resize'); });
+    vv.addEventListener('scroll', function () { record('vv-scroll'); });
+  }
+  [250, 500, 1000, 2000, 4000].forEach(function (ms) {
+    setTimeout(function () { record('t+' + ms + 'ms'); }, ms);
+  });
+
+  document.addEventListener('click', function (e) {
+    if (e.target && e.target.id === 'mark') record('MANUAL-MARK');
+    if (e.target && e.target.id === 'copy') {
+      var text = rows.map(fmt).join('\n');
+      if (navigator.clipboard) navigator.clipboard.writeText(text);
+      var p = document.getElementById('panel');
+      if (p) p.textContent = 'Copied ' + rows.length + ' rows to clipboard.\n\n' + p.textContent;
+    }
+  });
+})();
+</script>

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1384,28 +1384,73 @@ class WebViewFactory {
   else{document.addEventListener('DOMContentLoaded',apply);}
 })();''';
 
-  /// WebKit lays a page that ships no `<meta name="viewport">` out at its
-  /// ~980px default and zooms out to fit, so such sites load small and can
-  /// stay stuck there (Android handles this via useWideViewPort, which
-  /// WebKit ignores). Fill in a device-width viewport, but only when the
-  /// page declares none — checked at DOMContentLoaded so a page's own
-  /// (responsive) viewport, parsed after this DOCUMENT_START script runs,
-  /// is never clobbered. Adding the meta makes WebKit recompute the scale,
-  /// which also un-sticks a page that already loaded zoomed out.
+  /// Pin WebKit's initial scale to 1 on load.
+  ///
+  /// A page that reaches first layout without a `<meta name="viewport">`
+  /// (common on iOS: a `width=device-width` site whose meta has not parsed
+  /// yet on a re-navigation, e.g. Turbo/PJAX SPAs or the Universal-Link
+  /// cancel+reissue) is laid out at WebKit's ~980px default and zoomed out
+  /// to fit. WebKit then does not cleanly reset when the real meta arrives —
+  /// it latches a stuck fractional scale (observed 0.73 on github.com) that
+  /// never recovers. The trigger is a viewport that omits `initial-scale`,
+  /// which lets WebKit pick the scale itself.
+  ///
+  /// So: ensure every viewport meta carries `initial-scale=1`. Add a full
+  /// `width=device-width, initial-scale=1` when the page ships none; append
+  /// `initial-scale=1` to one that declares width but omits it. A page that
+  /// sets its own `initial-scale` is left untouched. Runs at DOCUMENT_START
+  /// and via a MutationObserver so the meta is corrected the instant it is
+  /// inserted — before WebKit locks in the 980-default scale. DOMContentLoaded
+  /// injection (the earlier approach) lands after that lock and does not undo
+  /// it. Android pins the scale natively via useWideViewPort, so this is
+  /// WebKit-only.
   static const String _defaultViewportScript = '''
 (function(){
-  function fill(){
-    if(document.querySelector('meta[name="viewport" i]'))return;
-    var m=document.createElement('meta');
-    m.setAttribute('name','viewport');
-    m.setAttribute('content','width=device-width, initial-scale=1');
-    (document.head||document.documentElement).appendChild(m);
+  function normalize(meta){
+    var c=(meta.getAttribute('content')||'').trim();
+    if(/initial-scale/i.test(c))return;
+    if(c===''){c='width=device-width, initial-scale=1';}
+    else{
+      c=c.replace(/\\s*,?\\s*\$/,'')+', initial-scale=1';
+      if(!/width\\s*=/i.test(c)){c='width=device-width, '+c;}
+    }
+    meta.setAttribute('content',c);
   }
-  if(document.readyState==='loading'){
-    document.addEventListener('DOMContentLoaded',fill,{once:true});
-  }else{
-    fill();
+  function ensure(){
+    var metas=document.querySelectorAll('meta[name="viewport" i]');
+    if(!metas.length){
+      var m=document.createElement('meta');
+      m.setAttribute('name','viewport');
+      m.setAttribute('content','width=device-width, initial-scale=1');
+      (document.head||document.documentElement).appendChild(m);
+      return;
+    }
+    for(var i=0;i<metas.length;i++){normalize(metas[i]);}
   }
+  ensure();
+  try{
+    var mo=new MutationObserver(function(muts){
+      for(var i=0;i<muts.length;i++){
+        var mu=muts[i], tgt=mu.target;
+        if(mu.type==='attributes'&&tgt&&tgt.tagName==='META'){
+          var n=tgt.getAttribute&&tgt.getAttribute('name');
+          if(n&&n.toLowerCase()==='viewport'){normalize(tgt);}
+        }
+        var add=mu.addedNodes;
+        if(add){for(var j=0;j<add.length;j++){
+          var el=add[j];
+          if(el&&el.nodeType===1&&el.tagName==='META'){
+            var n2=el.getAttribute&&el.getAttribute('name');
+            if(n2&&n2.toLowerCase()==='viewport'){normalize(el);}
+          }
+        }}
+      }
+    });
+    if(document.documentElement){
+      mo.observe(document.documentElement,{childList:true,subtree:true,attributes:true,attributeFilter:['content','name']});
+    }
+  }catch(e){}
+  if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',ensure,{once:true});}
 })();''';
 
   /// Determine if a navigation was triggered by a user gesture.
@@ -1694,9 +1739,10 @@ class WebViewFactory {
       ));
     }
 
-    // WebKit (iOS/macOS) renders viewport-less pages zoomed out to fit a
-    // wide default; supply a device-width viewport when the page ships
-    // none. Desktop mode owns the viewport via its own shim, so skip there.
+    // WebKit (iOS/macOS) zooms out and latches a stuck fractional scale
+    // when a page reaches first layout without an `initial-scale`; force
+    // one onto every viewport meta. Desktop mode owns the viewport via its
+    // own shim, so skip there.
     if ((Platform.isIOS || Platform.isMacOS) && !desktopMode) {
       userScripts.add(inapp.UserScript(
         groupName: 'default_viewport',


### PR DESCRIPTION
## Symptom

On iOS, some sites (e.g. github.com) load zoomed out and stay stuck — the page is laid out at the correct device width but the whole thing is displayed at a fractional scale that never recovers.

## Root cause (measured on device)

Captured with the diagnostic probe in this PR + a console logger on github.com:

```
scale: 0.73   innerW: 514   clientW: 375   vp: "width=device-width"
```

- The page is laid out correctly (`clientWidth 375` = real device width) but shown at `scale 0.73` (`375/514 ≈ 0.73`), stable across the whole load.
- Earlier in the load the viewport meta is briefly absent (`vp:(none)` → WebKit's ~980px default → `scale 0.383`), because GitHub's Turbo/PJAX re-navigations (and the iOS Universal-Link cancel+reissue) reach first layout before the meta parses.
- GitHub's viewport is `width=device-width` **with no `initial-scale`**, so WebKit is free to pick the scale. Once it starts from the 980 default it latches a stuck fractional scale and never resets when the real meta applies.

A clean probe that ships `width=device-width, initial-scale=1` renders at `scale 1`. Adding a document-start user script that forces `initial-scale=1` held GitHub at `scale 1` through load and SPA navigations — confirmed on device.

Note: PR #452 tried to fix a related case (fill a viewport when a page ships none) at `DOMContentLoaded`. That lands *after* WebKit locks the scale, so it does not undo the latch and did not help these sites.

## Fix

`lib/services/webview.dart`: replace #452's `DOMContentLoaded` fill with a **DOCUMENT_START** viewport normalizer (WebKit only; desktop mode owns its own viewport):

- Ensure every `<meta name="viewport">` carries `initial-scale=1`: add a full `width=device-width, initial-scale=1` when the page ships none; append `initial-scale=1` when it declares width but omits it.
- Re-apply via a `MutationObserver` so the meta is corrected the instant it is inserted — before WebKit locks in the 980-default scale.
- Pages that set their own `initial-scale` are left untouched.

## Diagnostics (also in this PR)

`docs/diagnostics/*.html` — self-contained probes that report `visualViewport.scale` / layout width over the load timeline (device-width, no-viewport, and width-only variants). Hand-authored, under `docs/`, not bundled. Can be dropped from the merge if unwanted.

## Testing

- Fix validated live on device via the equivalent document-start user script (GitHub held at `scale 1`).
- Could not run `flutter analyze`/tests in the web environment: installing the pinned Flutter SDK requires cloning `flutter/flutter`, which the egress policy blocks. The injected JS was syntax-checked with `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)