### PR TITLE
Improve HTML file detection in Android share intent handler

### DIFF
--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -240,22 +240,32 @@ class MainActivity: FlutterActivity() {
         }
         if (intent.action != Intent.ACTION_SEND) return
         val mime = intent.type?.lowercase() ?: ""
-        // Prefer HTML when the sharer signals it via mime type OR ships
-        // a text/html stream extra. Sharers that pass HTML as a tiny
-        // EXTRA_TEXT (e.g. a copy-pasted snippet) still hit the URL path
-        // first; only when EXTRA_STREAM is present do we treat the
-        // payload as a file import.
+        // Prefer HTML when EXTRA_STREAM is present. The sharer's declared mime
+        // can't be trusted: file managers hand .html files as text/plain or
+        // application/octet-stream, and content:// URIs don't carry the file
+        // name in their path, so neither the intent mime nor streamUri.path is
+        // enough on its own. Resolve the provider's own type + display name and,
+        // failing that, sniff the bytes. Only EXTRA_STREAM shares are file
+        // imports; a copy-pasted URL rides EXTRA_TEXT and hits the URL path.
         val streamUri: Uri? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
         } else {
             @Suppress("DEPRECATION")
             intent.getParcelableExtra(Intent.EXTRA_STREAM)
         }
-        val isHtmlMime = mime == "text/html" || mime == "application/xhtml+xml"
-        if (streamUri != null && (isHtmlMime || streamUri.path?.lowercase()?.endsWith(".html") == true || streamUri.path?.lowercase()?.endsWith(".htm") == true)) {
+        if (streamUri != null) {
+            val displayName = queryDisplayName(streamUri)
+            val resolvedType = try {
+                contentResolver.getType(streamUri)?.lowercase()
+            } catch (e: Exception) {
+                null
+            }
+            val htmlByMeta = mime == "text/html" || mime == "application/xhtml+xml" ||
+                resolvedType == "text/html" || resolvedType == "application/xhtml+xml" ||
+                isHtmlName(displayName) || isHtmlName(streamUri.path)
             val html = readStreamAsString(streamUri)
-            if (html != null && html.isNotEmpty()) {
-                val title = guessTitleFrom(streamUri, html)
+            if (html != null && html.isNotEmpty() && (htmlByMeta || looksLikeHtml(html))) {
+                val title = guessTitleFrom(displayName ?: streamUri.lastPathSegment, html)
                 pendingShareHtml = HtmlPayload(content = html, title = title, sourceUri = streamUri.toString())
                 pendingShareUrl = null
                 return
@@ -264,6 +274,35 @@ class MainActivity: FlutterActivity() {
         val url = extractShareUrl(intent)
         if (url != null) {
             pendingShareUrl = url
+        }
+    }
+
+    private fun isHtmlName(name: String?): Boolean {
+        val n = name?.lowercase() ?: return false
+        return n.endsWith(".html") || n.endsWith(".htm") || n.endsWith(".xhtml")
+    }
+
+    private fun looksLikeHtml(s: String): Boolean {
+        val head = s.take(1024).lowercase()
+        return head.contains("<!doctype html") || head.contains("<html") ||
+            head.contains("<head") || head.contains("<body")
+    }
+
+    private fun queryDisplayName(uri: Uri): String? {
+        if (uri.scheme?.lowercase() != "content") return uri.lastPathSegment
+        return try {
+            contentResolver.query(
+                uri, arrayOf(android.provider.OpenableColumns.DISPLAY_NAME), null, null, null
+            )?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val idx = cursor.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
+                    if (idx >= 0) cursor.getString(idx) else null
+                } else {
+                    null
+                }
+            }
+        } catch (e: Exception) {
+            null
         }
     }
 
@@ -277,13 +316,13 @@ class MainActivity: FlutterActivity() {
         }
     }
 
-    private fun guessTitleFrom(uri: Uri, html: String): String? {
+    private fun guessTitleFrom(name: String?, html: String): String? {
         // Honour an explicit <title>; fall back to the file name (without
         // extension), which is what the desktop file-import flow does.
         val titleMatch = Regex("(?is)<title[^>]*>(.*?)</title>").find(html)
         val fromTitle = titleMatch?.groupValues?.getOrNull(1)?.trim().orEmpty()
         if (fromTitle.isNotEmpty()) return fromTitle
-        val name = uri.lastPathSegment ?: return null
+        if (name == null) return null
         val dot = name.lastIndexOf('.')
         return if (dot > 0) name.substring(0, dot) else name
     }

--- a/openspec/changes/default-app-for-links/specs/link-intent-routing/spec.md
+++ b/openspec/changes/default-app-for-links/specs/link-intent-routing/spec.md
@@ -249,7 +249,7 @@ The engine SHALL also expose follow-up entry points for the LIR-010 picker: `ope
 
 ### Requirement: LIR-012 - HTML File Share Goes Only To Create-New-Site
 
-When the OS hands the app an HTML file via share (Android `ACTION_SEND` with `mimeType="text/html"` or `application/xhtml+xml` carrying `EXTRA_STREAM`; iOS / macOS Share Extension future-equivalent), the dispatcher SHALL skip the LIR-010 picker entirely and emit `DispatchCreateSiteFromHtml(html, suggestedTitle)`. The executor SHALL persist the HTML via `HtmlImportStorage` (same store used by the in-app file-import flow), create a `WebViewModel` with a synthesised `file:///webspace_import_<microseconds>.html` `initUrl`, register the new site, activate it, and apply the current theme. The picker's "open in existing site" and "bind to site" options SHALL NOT be offered for HTML payloads, because an existing site cannot meaningfully claim opaque file content (no host, no domain) — only the create path is sensible.
+When the OS hands the app an HTML file via share (Android `ACTION_SEND` carrying `EXTRA_STREAM`; iOS / macOS Share Extension future-equivalent), the dispatcher SHALL skip the LIR-010 picker entirely and emit `DispatchCreateSiteFromHtml(html, suggestedTitle)`. The Android intent handler SHALL NOT rely solely on the intent's declared MIME type or the stream URI's path to recognise HTML, because file managers frequently share `.html` files as `text/plain` or `application/octet-stream` and `content://` URIs carry no filename in their path. It SHALL treat an `EXTRA_STREAM` payload as HTML when any of the following hold: the intent MIME is `text/html`/`application/xhtml+xml`; the `ContentResolver`-resolved type is `text/html`/`application/xhtml+xml`; the resolver-provided display name (or, absent that, the URI path) ends in `.html`/`.htm`/`.xhtml`; or the leading bytes sniff as HTML (`<!doctype html`, `<html`, `<head`, or `<body`). The suggested title SHALL derive from the document `<title>` first and the resolver-provided display name second. The executor SHALL persist the HTML via `HtmlImportStorage` (same store used by the in-app file-import flow), create a `WebViewModel` with a synthesised `file:///webspace_import_<microseconds>.html` `initUrl`, register the new site, activate it, and apply the current theme. The picker's "open in existing site" and "bind to site" options SHALL NOT be offered for HTML payloads, because an existing site cannot meaningfully claim opaque file content (no host, no domain) — only the create path is sensible.
 
 #### Scenario: HTML payload short-circuits picker
 
@@ -270,6 +270,13 @@ When the OS hands the app an HTML file via share (Android `ACTION_SEND` with `mi
 - **GIVEN** a shared HTML file with no `<title>` and filename `notes.html`
 - **WHEN** the share is dispatched
 - **THEN** the new site's `name` is `notes`
+
+#### Scenario: HTML shared as text/plain via content URI is still imported
+
+- **GIVEN** a file manager shares an `.html` file to WebSpace as `text/plain` via a `content://` URI whose path is an opaque document id
+- **WHEN** the Android intent handler processes the `EXTRA_STREAM`
+- **THEN** the handler resolves the provider type / display name (or sniffs the bytes) and recognises the payload as HTML
+- **AND** the dispatcher emits `DispatchCreateSiteFromHtml` rather than silently dropping the share
 
 #### Scenario: Empty HTML payload is unsupported
 


### PR DESCRIPTION
The Android share intent handler now robustly detects HTML files even when file managers declare them as `text/plain` or `application/octet-stream`, or when shared via opaque `content://` URIs that carry no filename in their path.

Changes:
- Query the ContentResolver for the provider's own MIME type and display name, since the intent's declared type cannot be trusted
- Add `isHtmlName()` to check file extensions (`.html`, `.htm`, `.xhtml`)
- Add `looksLikeHtml()` to sniff the first 1024 bytes for HTML markers (`<!doctype html`, `<html`, `<head`, `<body`)
- Add `queryDisplayName()` to extract the display name from `content://` URIs via `OpenableColumns.DISPLAY_NAME`
- Treat a payload as HTML when any of: intent MIME is HTML, resolved type is HTML, display name or path ends in `.html`/`.htm`/`.xhtml`, or bytes sniff as HTML
- Pass the resolved display name (or URI path segment) to `guessTitleFrom()` instead of the URI object, since the title should derive from the filename first

Updates the LIR-012 spec to document the detection logic and adds a scenario covering HTML shared as `text/plain` via opaque `content://` URI.

https://claude.ai/code/session_01WksWMBkrhVFAPpXkxPMVRu