### PR TITLE
Wire iOS Share Extension HTML file import

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -13,6 +13,9 @@ import UserNotifications
   private let shareChannelName = "org.codeberg.theoden8.webspace/share_intent"
   private let appGroupId = "group.org.codeberg.theoden8.webspace"
   private let pendingUrlKey = "pending_share_url"
+  private let pendingHtmlFileName = "pending_share.html"
+  private let pendingHtmlTitleKey = "pending_share_html_title"
+  private let pendingHtmlSourceKey = "pending_share_html_source"
 
   override func application(
     _ application: UIApplication,
@@ -70,11 +73,14 @@ import UserNotifications
         #endif
         result(url)
       case "consumeLaunchHtml":
-        // LIR-012: iOS Share Extension HTML delivery isn't wired yet
-        // (depends on the Share Extension target work in tasks 5.1 / 5.5).
-        // Return null so the Dart side falls through to the URL channel
-        // without raising MissingPluginException.
-        result(nil)
+        // LIR-012: the Share Extension writes an HTML document into the
+        // app-group container and wakes us with `webspace://openhtml`. Drain
+        // it here (one read, then delete) and hand the payload to Dart.
+        let payload = self.drainAppGroupPendingHtml()
+        #if DEBUG
+        NSLog("[WebSpace] consumeLaunchHtml returning: \(payload == nil ? "nil" : "payload")")
+        #endif
+        result(payload)
       default:
         result(FlutterMethodNotImplemented)
       }
@@ -115,6 +121,13 @@ import UserNotifications
       #if DEBUG
       NSLog("[WebSpace] captured share inner URL: \(inner)")
       #endif
+    } else if host == "openhtml" {
+      // The HTML document rides the app-group container, not the URL. This
+      // trigger only foregrounds the app; the Dart share poll then calls
+      // consumeLaunchHtml to drain the container.
+      #if DEBUG
+      NSLog("[WebSpace] received openhtml trigger")
+      #endif
     } else if host == "qr" {
       // Pass the original webspace:// URL through; Dart routes it to the
       // QR-apply path by scheme.
@@ -127,6 +140,36 @@ import UserNotifications
       NSLog("[WebSpace] unrecognized webspace host: \(host ?? "nil")")
       #endif
     }
+  }
+
+  private func drainAppGroupPendingHtml() -> [String: Any]? {
+    let fm = FileManager.default
+    guard let container = fm.containerURL(forSecurityApplicationGroupIdentifier: appGroupId) else {
+      NSLog("[WebSpace] app group \(appGroupId) unavailable; cannot drain pending HTML")
+      return nil
+    }
+    let fileURL = container.appendingPathComponent(pendingHtmlFileName)
+    guard let data = try? Data(contentsOf: fileURL),
+          let content = String(data: data, encoding: .utf8),
+          !content.isEmpty else {
+      return nil
+    }
+    var payload: [String: Any] = ["content": content]
+    if let defaults = UserDefaults(suiteName: appGroupId) {
+      if let title = defaults.string(forKey: pendingHtmlTitleKey), !title.isEmpty {
+        payload["title"] = title
+      }
+      if let source = defaults.string(forKey: pendingHtmlSourceKey), !source.isEmpty {
+        payload["sourceUri"] = source
+      }
+      defaults.removeObject(forKey: pendingHtmlTitleKey)
+      defaults.removeObject(forKey: pendingHtmlSourceKey)
+    }
+    try? fm.removeItem(at: fileURL)
+    #if DEBUG
+    NSLog("[WebSpace] drained pending HTML from app group (\(content.count) chars)")
+    #endif
+    return payload
   }
 
   private func drainAppGroupPendingUrl() {

--- a/ios/ShareExtension/Info.plist
+++ b/ios/ShareExtension/Info.plist
@@ -30,6 +30,8 @@
 				<integer>1</integer>
 				<key>NSExtensionActivationSupportsText</key>
 				<true/>
+				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
+				<integer>1</integer>
 			</dict>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ios/ShareExtension/ShareViewController.swift
+++ b/ios/ShareExtension/ShareViewController.swift
@@ -8,55 +8,126 @@ final class ShareViewController: UIViewController {
 
     private static let appGroupId = "group.org.codeberg.theoden8.webspace"
     private static let pendingUrlKey = "pending_share_url"
+    private static let pendingHtmlFileName = "pending_share.html"
+    private static let pendingHtmlTitleKey = "pending_share_html_title"
+    private static let pendingHtmlSourceKey = "pending_share_html_source"
     private static let hostScheme = "webspace"
-    private static let hostHost = "share"
+    private static let hostShareHost = "share"
+    private static let hostHtmlHost = "openhtml"
 
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .clear
         NSLog("[WebSpace.ShareExt] viewDidLoad")
-        extractURL { url in
+        extractPayload { payload in
             DispatchQueue.main.async {
-                guard let url = url, !url.isEmpty else {
-                    NSLog("[WebSpace.ShareExt] no URL extracted; dismissing")
+                if let html = payload?.html, !html.isEmpty {
+                    NSLog("[WebSpace.ShareExt] extracted HTML (\(html.count) chars)")
+                    self.handOffHtml(html, title: payload?.htmlTitle, source: payload?.htmlSource) {
+                        self.finish()
+                    }
+                    return
+                }
+                guard let url = payload?.url, !url.isEmpty else {
+                    NSLog("[WebSpace.ShareExt] nothing extracted; dismissing")
                     self.finish(); return
                 }
                 NSLog("[WebSpace.ShareExt] extracted URL: \(url)")
-                self.handOff(url) {
+                self.handOffUrl(url) {
                     self.finish()
                 }
             }
         }
     }
 
-    private func extractURL(_ done: @escaping (String?) -> Void) {
-        guard let item = (extensionContext?.inputItems as? [NSExtensionItem])?.first,
-              let providers = item.attachments, !providers.isEmpty else {
+    private struct SharePayload {
+        var url: String?
+        var html: String?
+        var htmlTitle: String?
+        var htmlSource: String?
+    }
+
+    /// Pulls the first usable payload off the share's attachments. HTML files
+    /// win over URLs (Dart dispatches HTML first), so a page shared *as a file*
+    /// becomes a new site rather than being mistaken for a link.
+    private func extractPayload(_ done: @escaping (SharePayload?) -> Void) {
+        guard let items = extensionContext?.inputItems as? [NSExtensionItem] else {
             done(nil); return
         }
+        let providers = items.compactMap { $0.attachments }.flatMap { $0 }
+        guard !providers.isEmpty else { done(nil); return }
 
+        let htmlType = UTType.html.identifier
         let urlType = UTType.url.identifier
+        let fileUrlType = UTType.fileURL.identifier
         let textType = UTType.plainText.identifier
+
         let group = DispatchGroup()
         let lock = NSLock()
-        var found: String?
+        var payload = SharePayload()
 
-        let publish: (String?) -> Void = { value in
+        let setHtml: (String, String?) -> Void = { content, filename in
+            guard !content.isEmpty else { return }
+            lock.lock(); defer { lock.unlock() }
+            if payload.html == nil {
+                payload.html = content
+                payload.htmlTitle = ShareViewController.guessTitle(html: content, filename: filename)
+                payload.htmlSource = filename
+            }
+        }
+        let setUrl: (String?) -> Void = { value in
             guard let value = value, !value.isEmpty else { return }
             lock.lock(); defer { lock.unlock() }
-            if found == nil { found = value }
+            if payload.url == nil { payload.url = value }
         }
 
         for provider in providers {
-            if provider.hasItemConformingToTypeIdentifier(urlType) {
+            if provider.hasItemConformingToTypeIdentifier(htmlType) {
+                group.enter()
+                provider.loadItem(forTypeIdentifier: htmlType, options: nil) { value, _ in
+                    if let parsed = ShareViewController.htmlString(from: value) {
+                        setHtml(parsed.content, parsed.filename)
+                    }
+                    group.leave()
+                }
+            } else if provider.hasItemConformingToTypeIdentifier(fileUrlType) {
+                group.enter()
+                provider.loadItem(forTypeIdentifier: fileUrlType, options: nil) { value, _ in
+                    if let url = value as? URL,
+                       ShareViewController.isHtmlName(url.lastPathComponent),
+                       let data = try? Data(contentsOf: url),
+                       let s = String(data: data, encoding: .utf8) {
+                        setHtml(s, url.lastPathComponent)
+                    }
+                    group.leave()
+                }
+            } else if provider.hasItemConformingToTypeIdentifier(UTType.data.identifier),
+                      ShareViewController.isHtmlName(provider.suggestedName) {
+                // Some apps expose an .html attachment only as generic data;
+                // the suggested name is the only HTML signal.
+                let suggested = provider.suggestedName
+                group.enter()
+                provider.loadItem(forTypeIdentifier: UTType.data.identifier, options: nil) { value, _ in
+                    if let parsed = ShareViewController.htmlString(from: value) {
+                        setHtml(parsed.content, parsed.filename ?? suggested)
+                    }
+                    group.leave()
+                }
+            } else if provider.hasItemConformingToTypeIdentifier(urlType) {
                 group.enter()
                 provider.loadItem(forTypeIdentifier: urlType, options: nil) { value, _ in
-                    if let url = value as? URL,
-                       let scheme = url.scheme?.lowercased(),
-                       scheme == "http" || scheme == "https" {
-                        publish(url.absoluteString)
+                    if let url = value as? URL {
+                        let scheme = url.scheme?.lowercased()
+                        if scheme == "http" || scheme == "https" {
+                            setUrl(url.absoluteString)
+                        } else if url.isFileURL,
+                                  ShareViewController.isHtmlName(url.lastPathComponent),
+                                  let data = try? Data(contentsOf: url),
+                                  let s = String(data: data, encoding: .utf8) {
+                            setHtml(s, url.lastPathComponent)
+                        }
                     } else if let s = value as? String {
-                        publish(ShareViewController.firstHttpUrl(in: s))
+                        setUrl(ShareViewController.firstHttpUrl(in: s))
                     }
                     group.leave()
                 }
@@ -64,16 +135,53 @@ final class ShareViewController: UIViewController {
                 group.enter()
                 provider.loadItem(forTypeIdentifier: textType, options: nil) { value, _ in
                     if let s = value as? String {
-                        publish(ShareViewController.firstHttpUrl(in: s))
+                        setUrl(ShareViewController.firstHttpUrl(in: s))
                     }
                     group.leave()
                 }
             }
         }
 
-        group.notify(queue: .global()) {
-            done(found)
+        group.notify(queue: .global()) { done(payload) }
+    }
+
+    private static func htmlString(from value: Any?) -> (content: String, filename: String?)? {
+        if let url = value as? URL {
+            guard let data = try? Data(contentsOf: url),
+                  let s = String(data: data, encoding: .utf8) else { return nil }
+            return (s, url.lastPathComponent)
         }
+        if let data = value as? Data {
+            guard let s = String(data: data, encoding: .utf8) else { return nil }
+            return (s, nil)
+        }
+        if let s = value as? String { return (s, nil) }
+        return nil
+    }
+
+    private static func isHtmlName(_ name: String?) -> Bool {
+        guard let n = name?.lowercased() else { return false }
+        return n.hasSuffix(".html") || n.hasSuffix(".htm") || n.hasSuffix(".xhtml")
+    }
+
+    /// Mirrors the Android `guessTitleFrom`: honour an explicit `<title>`,
+    /// else the file name without its extension.
+    private static func guessTitle(html: String, filename: String?) -> String? {
+        let pattern = "<title[^>]*>([\\s\\S]*?)</title>"
+        if let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) {
+            let range = NSRange(html.startIndex..., in: html)
+            if let match = regex.firstMatch(in: html, options: [], range: range),
+               match.numberOfRanges > 1,
+               let r = Range(match.range(at: 1), in: html) {
+                let title = html[r].trimmingCharacters(in: .whitespacesAndNewlines)
+                if !title.isEmpty { return title }
+            }
+        }
+        guard let name = filename else { return nil }
+        if let dot = name.lastIndex(of: "."), dot != name.startIndex {
+            return String(name[name.startIndex..<dot])
+        }
+        return name
     }
 
     private static func firstHttpUrl(in text: String) -> String? {
@@ -93,7 +201,7 @@ final class ShareViewController: UIViewController {
         return String(trimmed[r])
     }
 
-    private func handOff(_ url: String, completion: @escaping () -> Void) {
+    private func handOffUrl(_ url: String, completion: @escaping () -> Void) {
         if let defaults = UserDefaults(suiteName: ShareViewController.appGroupId) {
             defaults.set(url, forKey: ShareViewController.pendingUrlKey)
             NSLog("[WebSpace.ShareExt] wrote URL to app group")
@@ -102,8 +210,47 @@ final class ShareViewController: UIViewController {
         }
         var components = URLComponents()
         components.scheme = ShareViewController.hostScheme
-        components.host = ShareViewController.hostHost
+        components.host = ShareViewController.hostShareHost
         components.queryItems = [URLQueryItem(name: "url", value: url)]
+        guard let openUrl = components.url else {
+            completion()
+            return
+        }
+        NSLog("[WebSpace.ShareExt] opening host app via \(openUrl.absoluteString)")
+        openHostApp(openUrl, completion: completion)
+    }
+
+    /// HTML can't ride a URL scheme, so the document is written to the shared
+    /// app-group container and the app is woken with a bare `webspace://openhtml`
+    /// trigger; the app drains the container on its next share poll.
+    private func handOffHtml(_ content: String, title: String?, source: String?, completion: @escaping () -> Void) {
+        let fm = FileManager.default
+        if let container = fm.containerURL(forSecurityApplicationGroupIdentifier: ShareViewController.appGroupId) {
+            let fileURL = container.appendingPathComponent(ShareViewController.pendingHtmlFileName)
+            do {
+                try content.data(using: .utf8)?.write(to: fileURL, options: .atomic)
+                NSLog("[WebSpace.ShareExt] wrote HTML to app group container")
+            } catch {
+                NSLog("[WebSpace.ShareExt] failed to write HTML: \(error.localizedDescription)")
+            }
+        } else {
+            NSLog("[WebSpace.ShareExt] app group unavailable; HTML not persisted")
+        }
+        if let defaults = UserDefaults(suiteName: ShareViewController.appGroupId) {
+            if let title = title {
+                defaults.set(title, forKey: ShareViewController.pendingHtmlTitleKey)
+            } else {
+                defaults.removeObject(forKey: ShareViewController.pendingHtmlTitleKey)
+            }
+            if let source = source {
+                defaults.set(source, forKey: ShareViewController.pendingHtmlSourceKey)
+            } else {
+                defaults.removeObject(forKey: ShareViewController.pendingHtmlSourceKey)
+            }
+        }
+        var components = URLComponents()
+        components.scheme = ShareViewController.hostScheme
+        components.host = ShareViewController.hostHtmlHost
         guard let openUrl = components.url else {
             completion()
             return

--- a/openspec/changes/default-app-for-links/specs/link-intent-routing/spec.md
+++ b/openspec/changes/default-app-for-links/specs/link-intent-routing/spec.md
@@ -142,7 +142,7 @@ The Android app SHALL declare an `ACTION_SEND` intent-filter with `mimeType="tex
 
 ### Requirement: LIR-006 - iOS Share Extension
 
-The iOS app SHALL ship a Share Extension target that accepts Web URLs (`NSExtensionActivationSupportsWebURLWithMaxCount = 1`). The extension SHALL hand the URL to the main app via `extensionContext.open(URL(string: "webspace://open?url=<encoded>")!)` and then call `completeRequest(returningItems: nil)`. The main app SHALL handle the resulting `webspace://open` URL via LIR-004.
+The iOS app SHALL ship a Share Extension target that accepts Web URLs (`NSExtensionActivationSupportsWebURLWithMaxCount = 1`) and HTML files (`NSExtensionActivationSupportsFileWithMaxCount`, handled per LIR-012). The extension SHALL hand the URL to the main app via `extensionContext.open(URL(string: "webspace://open?url=<encoded>")!)` and then call `completeRequest(returningItems: nil)`. The main app SHALL handle the resulting `webspace://open` URL via LIR-004.
 
 #### Scenario: Share from Safari
 
@@ -249,7 +249,7 @@ The engine SHALL also expose follow-up entry points for the LIR-010 picker: `ope
 
 ### Requirement: LIR-012 - HTML File Share Goes Only To Create-New-Site
 
-When the OS hands the app an HTML file via share (Android `ACTION_SEND` carrying `EXTRA_STREAM`; iOS / macOS Share Extension future-equivalent), the dispatcher SHALL skip the LIR-010 picker entirely and emit `DispatchCreateSiteFromHtml(html, suggestedTitle)`. The Android intent handler SHALL NOT rely solely on the intent's declared MIME type or the stream URI's path to recognise HTML, because file managers frequently share `.html` files as `text/plain` or `application/octet-stream` and `content://` URIs carry no filename in their path. It SHALL treat an `EXTRA_STREAM` payload as HTML when any of the following hold: the intent MIME is `text/html`/`application/xhtml+xml`; the `ContentResolver`-resolved type is `text/html`/`application/xhtml+xml`; the resolver-provided display name (or, absent that, the URI path) ends in `.html`/`.htm`/`.xhtml`; or the leading bytes sniff as HTML (`<!doctype html`, `<html`, `<head`, or `<body`). The suggested title SHALL derive from the document `<title>` first and the resolver-provided display name second. The executor SHALL persist the HTML via `HtmlImportStorage` (same store used by the in-app file-import flow), create a `WebViewModel` with a synthesised `file:///webspace_import_<microseconds>.html` `initUrl`, register the new site, activate it, and apply the current theme. The picker's "open in existing site" and "bind to site" options SHALL NOT be offered for HTML payloads, because an existing site cannot meaningfully claim opaque file content (no host, no domain) — only the create path is sensible.
+When the OS hands the app an HTML file via share (Android `ACTION_SEND` carrying `EXTRA_STREAM`; iOS Share Extension via an app-group handoff), the dispatcher SHALL skip the LIR-010 picker entirely and emit `DispatchCreateSiteFromHtml(html, suggestedTitle)`. On iOS the Share Extension SHALL declare `NSExtensionActivationSupportsFileWithMaxCount` so HTML files surface the extension, read the shared document (from a `public.html` attachment, a `Data` attachment, or a file URL ending in `.html`/`.htm`/`.xhtml`), write the document into the shared app-group container (a URL scheme cannot carry a whole document), and wake the app with a bare `webspace://openhtml` trigger; the main app SHALL drain that container on its next share poll (`consumeLaunchHtml`), returning the content, `<title>`-or-filename title, and source filename, then delete the container copy so the same file is not imported twice. The Android intent handler SHALL NOT rely solely on the intent's declared MIME type or the stream URI's path to recognise HTML, because file managers frequently share `.html` files as `text/plain` or `application/octet-stream` and `content://` URIs carry no filename in their path. It SHALL treat an `EXTRA_STREAM` payload as HTML when any of the following hold: the intent MIME is `text/html`/`application/xhtml+xml`; the `ContentResolver`-resolved type is `text/html`/`application/xhtml+xml`; the resolver-provided display name (or, absent that, the URI path) ends in `.html`/`.htm`/`.xhtml`; or the leading bytes sniff as HTML (`<!doctype html`, `<html`, `<head`, or `<body`). The suggested title SHALL derive from the document `<title>` first and the resolver-provided display name second. The executor SHALL persist the HTML via `HtmlImportStorage` (same store used by the in-app file-import flow), create a `WebViewModel` with a synthesised `file:///webspace_import_<microseconds>.html` `initUrl`, register the new site, activate it, and apply the current theme. The picker's "open in existing site" and "bind to site" options SHALL NOT be offered for HTML payloads, because an existing site cannot meaningfully claim opaque file content (no host, no domain) — only the create path is sensible.
 
 #### Scenario: HTML payload short-circuits picker
 
@@ -277,6 +277,13 @@ When the OS hands the app an HTML file via share (Android `ACTION_SEND` carrying
 - **WHEN** the Android intent handler processes the `EXTRA_STREAM`
 - **THEN** the handler resolves the provider type / display name (or sniffs the bytes) and recognises the payload as HTML
 - **AND** the dispatcher emits `DispatchCreateSiteFromHtml` rather than silently dropping the share
+
+#### Scenario: iOS HTML file share creates a new site
+
+- **GIVEN** the user shares an `.html` file from Files (or another app) to WebSpace on iOS
+- **WHEN** the Share Extension reads the document, writes it to the app-group container, and wakes the app via `webspace://openhtml`
+- **THEN** the app's next `consumeLaunchHtml` poll drains the container and the dispatcher emits `DispatchCreateSiteFromHtml`
+- **AND** the app-group copy is deleted so a later poll does not re-import the same file
 
 #### Scenario: Empty HTML payload is unsupported
 

--- a/openspec/changes/default-app-for-links/tasks.md
+++ b/openspec/changes/default-app-for-links/tasks.md
@@ -33,13 +33,13 @@
 
 > Basic URL share already lands via PR #297 (`Register WebSpace as iOS share target`); the channel name and `consumeLaunchUrl` API are reused. The Share Extension target, App Group, and `webspace://` scheme registration are still pending.
 
-- [ ] 5.1 Add new target `WebSpaceShareExtension` in `ios/` with `NSExtensionActivationSupportsWebURLWithMaxCount=1`, `NSExtensionActivationSupportsText=1`, `NSExtensionActivationSupportsFileWithMaxCount=1` (HTML files for LIR-012). **Requires Xcode** — cannot land from headless tooling.
-- [ ] 5.2 Create App Group `group.com.theoden8.webspace`; entitlement on both main app and extension. **Requires Xcode**.
+- [x] 5.1 Share Extension target ships with `NSExtensionActivationSupportsWebURLWithMaxCount=1`, `NSExtensionActivationSupportsText=1`, and `NSExtensionActivationSupportsFileWithMaxCount=1` (HTML files for LIR-012) in `ios/ShareExtension/Info.plist`.
+- [x] 5.2 App Group `group.org.codeberg.theoden8.webspace` entitled on both main app and extension (`ios/ShareExtension/ShareExtension.entitlements`).
 - [x] 5.3 `webspace` scheme registered in `ios/Runner/Info.plist` `CFBundleURLTypes` (already in master before this change).
-- [x] 5.4 `application:openURL:options:` accepts `webspace://open?url=<encoded http(s)>`, `webspace://share?url=...` (legacy), and `webspace://qr/...`; pending URL is exposed to Dart via the existing `share_intent` channel. New no-op `consumeLaunchHtml` channel method returns null until the Share Extension target lands (5.1) — Dart side falls through to URL channel without raising MissingPluginException.
-- [ ] 5.5 Extension `ShareViewController` extracts URL via `NSItemProvider` (or HTML file content), writes `pending_link` / `pending_html` to shared `UserDefaults`, calls `extensionContext?.open(URL(string: "webspace://open?url=<encoded>")!)`, then `completeRequest`. **Requires Xcode**.
-- [ ] 5.6 Main app reads pending URL/HTML from launch URL or App Group, then clears the App Group key. App Group draining for the URL is already wired (`drainAppGroupPendingUrl` in AppDelegate.swift); HTML drain stays pending until 5.1 / 5.5.
-- [ ] 5.7 Manual smoke test: share URL from Safari, share HTML file from Files, tap `webspace://` URL in Notes.
+- [x] 5.4 `application:openURL:options:` accepts `webspace://open?url=<encoded http(s)>`, `webspace://share?url=...` (legacy), `webspace://qr/...`, and `webspace://openhtml` (HTML handoff trigger); pending URL is exposed to Dart via the existing `share_intent` channel. `consumeLaunchHtml` drains the app-group HTML container (see 5.6).
+- [x] 5.5 Extension `ShareViewController` extracts an HTTP(S) URL or an HTML document (`public.html` attachment, `Data`, or a file URL ending `.html`/`.htm`/`.xhtml`). URL → `pending_share_url` in app-group `UserDefaults` + `webspace://share?url=`. HTML → document written to `pending_share.html` in the shared app-group container, title/source in `UserDefaults`, then `webspace://openhtml`. HTML wins over URL.
+- [x] 5.6 Main app `consumeLaunchHtml` (`AppDelegate.swift`) reads `pending_share.html` from the App Group container plus title/source keys, returns them to Dart, then deletes the file + keys so the same file is not imported twice. URL drain via `drainAppGroupPendingUrl` unchanged.
+- [ ] 5.7 Manual smoke test (**requires device/Xcode**): share URL from Safari, share HTML file from Files, tap `webspace://` URL in Notes.
 
 ## 6. macOS integration
 


### PR DESCRIPTION
## Problem

Sharing an HTML file to WebSpace on **iOS** was refused instantly. The Share Extension ("Add to WebSpace") was wired for URLs and plain text only:

- Its activation rule declared only `NSExtensionActivationSupportsWebURLWithMaxCount` + `SupportsText`, and `extractURL` only looked for `public.url` / `public.plain-text` attachments. An HTML file conforms to neither, so nothing was extracted and the extension dismissed immediately.
- Even if a file had been captured, there was no path to carry HTML *content* to the app: the app side's `consumeLaunchHtml` was a hardcoded `result(nil)` ("HTML delivery isn't wired yet").

This is the iOS counterpart to the Android fix in #462 (which only covered Android's `ACTION_SEND` MIME/extension handling).

## Change

Native iOS only — the Dart dispatch side (`consumeLaunchHtml` → `DispatchCreateSiteFromHtml`) was already in place and polls on cold start and resume.

- **`ios/ShareExtension/Info.plist`** — add `NSExtensionActivationSupportsFileWithMaxCount` so HTML files surface the extension.
- **`ios/ShareExtension/ShareViewController.swift`** — extract an HTML document from a `public.html` attachment, a generic `Data` attachment whose suggested name ends in `.html`/`.htm`/`.xhtml`, or a file URL; write it to the shared **app-group container** (`pending_share.html`) with title/source in `UserDefaults`; wake the app with a bare `webspace://openhtml` trigger. HTML wins over URL, mirroring the Dart order. URL/text handling is unchanged.
- **`ios/Runner/AppDelegate.swift`** — implement `consumeLaunchHtml` to drain the app-group container (content + `<title>`-or-filename title + source), then delete the copy so the same file is not imported twice; recognize the `webspace://openhtml` host.

A URL scheme can't carry a whole document, hence the app-group container handoff (the URL scheme only foregrounds the app).

## Spec / tasks

- `link-intent-routing` LIR-012 updated: the "iOS future-equivalent" clause is replaced with the actual app-group handoff mechanism; added an iOS HTML-file scenario. LIR-006 notes file support.
- `default-app-for-links/tasks.md`: iOS tasks 5.1/5.2/5.4/5.5/5.6 marked done; corrected the app-group id to the one actually shipped (`group.org.codeberg.theoden8.webspace`).

## Tradeoff

With `SupportsFileWithMaxCount`, "Add to WebSpace" now appears for any single-file share; non-HTML files extract nothing and dismiss silently. A UTI predicate could scope it to HTML only, but that would replace the working URL/text dict rule and risks regressing URL sharing without on-device testing — so the lower-risk additive rule was chosen.

## Testing

Not build-tested: iOS cannot be built in this environment. **Needs manual verification on a real device / Xcode** (tasks 5.7 / 11.4): share an `.html` file from Files, Mail, and Safari's "share page"; confirm a new site is created with the right title, and that URL/text sharing still works. macOS HTML share (task 6.1b, requires a new extension target in Xcode) is still out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WksWMBkrhVFAPpXkxPMVRu)_