### PR TITLE
Stop user-script fetch shim from dropping same-origin sessions

### DIFF
--- a/lib/services/user_script_shim.dart
+++ b/lib/services/user_script_shim.dart
@@ -180,12 +180,22 @@ const String userScriptShimTemplate = r'''
   // Only catches TypeError (which browsers throw for CORS and network
   // failures), not application errors like 404. This avoids breaking
   // video/binary fetches that fail for non-CORS reasons.
+  //
+  // Scoped to cross-origin URLs. __wsFetch reissues the request through the
+  // Dart bridge, which carries none of the WebView's cookies, so retrying a
+  // same-origin request there silently drops the user's session — a logged-in
+  // site (github.com) starts demanding login. A same-origin TypeError is a
+  // genuine network error, not CORS, so rethrow it untouched.
+  function isCrossOrigin(u) {
+    try { return new URL(u, location.href).origin !== location.origin; }
+    catch (e) { return false; }
+  }
   var _origFetch = window.fetch.bind(window);
   window.fetch = function(input, init) {
     return _origFetch(input, init).catch(function(err) {
       if (err instanceof TypeError) {
         var url = typeof input === 'string' ? input : (input && input.url ? input.url : '');
-        if (isFetchableUrl(url)) {
+        if (isFetchableUrl(url) && isCrossOrigin(url)) {
           return window.__wsFetch(url);
         }
       }

--- a/test/js/user_script_shim.test.js
+++ b/test/js/user_script_shim.test.js
@@ -27,6 +27,7 @@ const { makeDom, readFixture, runInDom } = require('./helpers/load_shim.js');
 const SHIM = readFixture('user_script/shim.js');
 const INLINE_HANDLER = '__ws_i_test';
 const SRC_HANDLER = '__ws_s_test';
+const FETCH_HANDLER = '__ws_f_test';
 
 // Build a jsdom + install a callHandler stub before the shim runs, so
 // the shim's lazy bridge capture finds it. Returns { dom, calls } where
@@ -176,4 +177,130 @@ test('shim is idempotent — running it twice does not double-wrap', () => {
   const inlineCalls = calls.filter(c => c[0] === INLINE_HANDLER);
   assert.strictEqual(inlineCalls.length, 1,
     're-installation must be a no-op, not a double-intercept');
+});
+
+// ── window.fetch CORS-fallback layer ──
+//
+// The shim patches window.fetch to retry TypeError failures through
+// __wsFetch (the Dart bridge). That bridge carries none of the WebView's
+// cookies, so retrying a *same-origin* request there silently drops the
+// user's session (a logged-in github.com starts demanding login). The
+// fallback must be scoped to cross-origin URLs only.
+//
+// The rejection must be a jsdom-realm TypeError: the shim runs via
+// window.eval, so its `err instanceof TypeError` checks the jsdom TypeError,
+// not Node's.
+function setupFetch({ url = 'https://site.example/', rejectWith } = {}) {
+  const dom = makeDom({ url });
+  const calls = [];
+  const err = rejectWith === undefined
+    ? new dom.window.TypeError('Failed to fetch')
+    : rejectWith;
+  dom.window.fetch = function stubFetch() {
+    return Promise.reject(err);
+  };
+  dom.window.flutter_inappwebview = {
+    callHandler(name, ...args) {
+      calls.push([name, ...args]);
+      return Promise.resolve({ status: 200, body: 'ok', contentType: 'text/plain' });
+    },
+  };
+  // __wsFetch builds `new Response(...)`; jsdom may omit it.
+  if (typeof dom.window.Response !== 'function') {
+    dom.window.Response = function Response(body, init) {
+      this.body = body;
+      this.status = (init && init.status) || 200;
+    };
+  }
+  runInDom(dom, SHIM);
+  return { dom, calls, err };
+}
+
+test('same-origin fetch TypeError is NOT retried through the cookie-less bridge', async () => {
+  const { dom, calls, err } = setupFetch({ url: 'https://github.example/' });
+  await assert.rejects(
+    dom.window.fetch('https://github.example/session/check'),
+    (e) => e === err,
+    'same-origin failure must propagate unchanged, not fall back');
+  assert.strictEqual(calls.filter(c => c[0] === FETCH_HANDLER).length, 0,
+    'same-origin request must never hit __wsFetch — it would drop the session cookie');
+});
+
+test('relative-URL fetch TypeError stays same-origin (no bridge fallback)', async () => {
+  const { dom, calls } = setupFetch({ url: 'https://github.example/' });
+  await assert.rejects(dom.window.fetch('/notifications/indicator'));
+  assert.strictEqual(calls.filter(c => c[0] === FETCH_HANDLER).length, 0,
+    'a relative URL resolves same-origin and must not fall back');
+});
+
+test('cross-origin fetch TypeError DOES fall back to __wsFetch', async () => {
+  const { dom, calls } = setupFetch({ url: 'https://github.example/' });
+  try { await dom.window.fetch('https://cdn.other.example/lib.css'); } catch (_) { /* Response shape irrelevant */ }
+  const fetchCalls = calls.filter(c => c[0] === FETCH_HANDLER);
+  assert.strictEqual(fetchCalls.length, 1,
+    'a genuine cross-origin CORS failure should still use the bridge fallback');
+  assert.strictEqual(fetchCalls[0][1], 'https://cdn.other.example/lib.css');
+});
+
+test('non-TypeError fetch rejection is never intercepted', async () => {
+  // Application errors (e.g. an abort) must propagate untouched, even
+  // cross-origin — only a TypeError signals a CORS/network failure.
+  const abort = new Error('aborted');
+  const { dom, calls } = setupFetch({ url: 'https://github.example/', rejectWith: abort });
+  await assert.rejects(dom.window.fetch('https://cdn.other.example/x'), (e) => e === abort);
+  assert.strictEqual(calls.filter(c => c[0] === FETCH_HANDLER).length, 0,
+    'non-TypeError rejections are not CORS failures and must not fall back');
+});
+
+// ── window.__wsFetch direct usage (setFetchMethod pattern) ──
+
+test('__wsFetch rejects non-http(s) URLs', async () => {
+  const { dom } = setup();
+  await assert.rejects(dom.window.__wsFetch('ftp://example/x'), /only http\/https/);
+});
+
+test('__wsFetch rejects when the Dart bridge is unavailable', async () => {
+  const dom = makeDom({ url: 'https://site.example/' });
+  dom.window.fetch = () => Promise.reject(new dom.window.TypeError('x'));
+  // No flutter_inappwebview bridge installed.
+  runInDom(dom, SHIM);
+  await assert.rejects(dom.window.__wsFetch('https://cdn.example/x'), /bridge not available/);
+});
+
+// ── whitelisted <script src> load lifecycle (dedup / onload / onerror) ──
+
+test('whitelisted src is fetched once; a repeat append dedupes and still fires onload', async () => {
+  const { dom, calls } = setup();
+  const { document } = dom.window;
+  const url = 'https://cdn.jsdelivr.net/npm/x/x.js';
+  const s1 = document.createElement('script');
+  s1.src = url;
+  document.head.appendChild(s1);
+  await new Promise(r => setTimeout(r, 0));   // let the handler resolve (ok) and mark _loadedUrls
+
+  const s2 = document.createElement('script');
+  s2.src = url;
+  let onloadFired = false;
+  s2.onload = () => { onloadFired = true; };
+  document.head.appendChild(s2);
+  await new Promise(r => setTimeout(r, 0));
+
+  assert.strictEqual(calls.filter(c => c[0] === SRC_HANDLER).length, 1,
+    'the second append of an already-loaded URL must not re-fetch');
+  assert.ok(onloadFired, 'the dedup path must still fire onload for the caller');
+});
+
+test('whitelisted src whose bridge fetch fails fires onerror', async () => {
+  const dom = makeDom({ url: 'https://linkedin.example/' });
+  dom.window.fetch = () => Promise.reject(new dom.window.TypeError('x'));
+  dom.window.flutter_inappwebview = { callHandler: () => Promise.resolve(false) };
+  runInDom(dom, SHIM);
+  const { document } = dom.window;
+  const s = document.createElement('script');
+  s.src = 'https://cdn.jsdelivr.net/npm/x/x.js';
+  let errFired = false;
+  s.onerror = () => { errFired = true; };
+  document.head.appendChild(s);
+  await new Promise(r => setTimeout(r, 0));
+  assert.ok(errFired, 'a failed (ok=false) bridge fetch must fire onerror');
 });

--- a/test/js_fixtures/user_script/shim.js
+++ b/test/js_fixtures/user_script/shim.js
@@ -146,12 +146,22 @@
   // Only catches TypeError (which browsers throw for CORS and network
   // failures), not application errors like 404. This avoids breaking
   // video/binary fetches that fail for non-CORS reasons.
+  //
+  // Scoped to cross-origin URLs. __wsFetch reissues the request through the
+  // Dart bridge, which carries none of the WebView's cookies, so retrying a
+  // same-origin request there silently drops the user's session — a logged-in
+  // site (github.com) starts demanding login. A same-origin TypeError is a
+  // genuine network error, not CORS, so rethrow it untouched.
+  function isCrossOrigin(u) {
+    try { return new URL(u, location.href).origin !== location.origin; }
+    catch (e) { return false; }
+  }
   var _origFetch = window.fetch.bind(window);
   window.fetch = function(input, init) {
     return _origFetch(input, init).catch(function(err) {
       if (err instanceof TypeError) {
         var url = typeof input === 'string' ? input : (input && input.url ? input.url : '');
-        if (isFetchableUrl(url)) {
+        if (isFetchableUrl(url) && isCrossOrigin(url)) {
           return window.__wsFetch(url);
         }
       }

--- a/test/user_script_build_test.dart
+++ b/test/user_script_build_test.dart
@@ -1,0 +1,101 @@
+// Coverage for UserScriptService.buildInitialUserScripts() and the
+// once-per-document guard — the injection-list assembly that decides which
+// scripts reach the webview, in what order, at which injection time, and
+// wrapped in which guard. Controller-free (no webview needed).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
+import 'package:webspace/services/user_script_service.dart';
+import 'package:webspace/settings/user_script.dart';
+
+void main() {
+  group('buildInitialUserScripts', () {
+    test('no enabled scripts produces an empty list and no shim', () {
+      final svc = UserScriptService(scripts: [
+        UserScriptConfig(name: 'off', source: 'noop;', enabled: false),
+      ]);
+      expect(svc.hasScripts, isFalse);
+      expect(svc.buildInitialUserScripts(), isEmpty);
+    });
+
+    test('shim is injected first at DOCUMENT_START, then the guarded script', () {
+      final svc = UserScriptService(scripts: [
+        UserScriptConfig(
+          id: 'abc',
+          name: 't',
+          source: 'MARK_A();',
+          injectionTime: UserScriptInjectionTime.atDocumentStart,
+        ),
+      ]);
+      final scripts = svc.buildInitialUserScripts();
+      expect(scripts.length, 2);
+
+      expect(scripts[0].groupName, 'script_fetch_shim');
+      expect(scripts[0].injectionTime,
+          inapp.UserScriptInjectionTime.AT_DOCUMENT_START);
+      expect(scripts[0].source, contains('Node.prototype.appendChild'));
+
+      expect(scripts[1].groupName, 'user_scripts');
+      expect(scripts[1].injectionTime,
+          inapp.UserScriptInjectionTime.AT_DOCUMENT_START);
+      expect(scripts[1].source, contains('MARK_A();'));
+      expect(scripts[1].source, contains('window.__wsRan_abc'));
+    });
+
+    test('disabled and empty-source scripts are skipped', () {
+      final svc = UserScriptService(scripts: [
+        UserScriptConfig(name: 'a', source: 'KEEP_A();'),
+        UserScriptConfig(name: 'b', source: 'DROP_B();', enabled: false),
+        UserScriptConfig(name: 'c', source: ''),
+      ]);
+      final userScripts = svc
+          .buildInitialUserScripts()
+          .where((s) => s.groupName == 'user_scripts')
+          .toList();
+      expect(userScripts.length, 1);
+      expect(userScripts.single.source, contains('KEEP_A();'));
+      expect(userScripts.single.source, isNot(contains('DROP_B();')));
+    });
+
+    test('atDocumentEnd script maps to DOCUMENT_END injection time', () {
+      final svc = UserScriptService(scripts: [
+        UserScriptConfig(
+          name: 't',
+          source: 'END();',
+          injectionTime: UserScriptInjectionTime.atDocumentEnd,
+        ),
+      ]);
+      final user = svc
+          .buildInitialUserScripts()
+          .firstWhere((s) => s.groupName == 'user_scripts');
+      expect(user.injectionTime, inapp.UserScriptInjectionTime.AT_DOCUMENT_END);
+    });
+
+    test('urlSource library is concatenated before the user source', () {
+      final svc = UserScriptService(scripts: [
+        UserScriptConfig(
+          name: 't',
+          source: 'INIT();',
+          urlSource: 'LIB();',
+        ),
+      ]);
+      final user = svc
+          .buildInitialUserScripts()
+          .firstWhere((s) => s.groupName == 'user_scripts');
+      final libAt = user.source.indexOf('LIB();');
+      final initAt = user.source.indexOf('INIT();');
+      expect(libAt, greaterThanOrEqualTo(0));
+      expect(initAt, greaterThan(libAt));
+    });
+
+    test('guard sanitizes non-alphanumeric characters in the script id', () {
+      final svc = UserScriptService(scripts: [
+        UserScriptConfig(id: 'a-b.c', name: 't', source: 'X();'),
+      ]);
+      final user = svc
+          .buildInitialUserScripts()
+          .firstWhere((s) => s.groupName == 'user_scripts');
+      expect(user.source, contains('window.__wsRan_a_b_c'));
+    });
+  });
+}

--- a/test/user_script_handlers_test.dart
+++ b/test/user_script_handlers_test.dart
@@ -1,11 +1,11 @@
 // Coverage for the Dart-side JS-bridge handlers and re-injection
-// orchestration in UserScriptService — the paths that were previously
-// untested because they need an InAppWebViewController and the outbound
-// HTTP client.
+// orchestration in UserScriptService — the paths that need an
+// InAppWebViewController and the outbound HTTP client.
 //
-// The controller is faked (extends Fake) to capture the registered handler
-// callbacks and record evaluateJavascript sources. The network layer is
-// swapped via the documented `outboundHttp` seam with a MockClient.
+// The controller is faked via noSuchMethod (intercepting the two methods
+// the service actually calls, by Symbol) rather than typed overrides, so
+// the test does not depend on the fork's exact method signatures. The
+// network layer is swapped through the documented `outboundHttp` seam.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
@@ -33,28 +33,30 @@ class _FakeFactory implements OutboundHttpFactory {
 }
 
 /// Captures the registered handler callbacks and records injected sources.
+/// Intercepts by Symbol so it is immune to the controller's exact method
+/// signatures in the fork.
 class _FakeController extends Fake implements inapp.InAppWebViewController {
-  final Map<String, inapp.JavaScriptHandlerCallback> handlers = {};
+  final Map<String, Function> handlers = {};
   final List<String> evaluated = [];
 
   @override
-  void addJavaScriptHandler({
-    required String handlerName,
-    required inapp.JavaScriptHandlerCallback callback,
-  }) {
-    handlers[handlerName] = callback;
+  dynamic noSuchMethod(Invocation invocation) {
+    if (invocation.memberName == #addJavaScriptHandler) {
+      final name =
+          invocation.namedArguments[const Symbol('handlerName')] as String;
+      handlers[name] =
+          invocation.namedArguments[const Symbol('callback')] as Function;
+      return null;
+    }
+    if (invocation.memberName == #evaluateJavascript) {
+      evaluated
+          .add(invocation.namedArguments[const Symbol('source')] as String);
+      return Future<dynamic>.value(null);
+    }
+    return super.noSuchMethod(invocation);
   }
 
-  @override
-  Future<dynamic> evaluateJavascript({
-    required String source,
-    inapp.ContentWorld? contentWorld,
-  }) async {
-    evaluated.add(source);
-    return null;
-  }
-
-  inapp.JavaScriptHandlerCallback handler(String prefix) =>
+  Function handler(String prefix) =>
       handlers.entries.firstWhere((e) => e.key.startsWith(prefix)).value;
 
   bool evaluatedAny(String needle) => evaluated.any((s) => s.contains(needle));
@@ -66,10 +68,10 @@ UserScriptService _serviceWith(
 }) =>
     UserScriptService(scripts: scripts, onConfirmScriptFetch: confirm);
 
-final _oneScript = [UserScriptConfig(name: 't', source: 'noop;')];
+List<UserScriptConfig> get _oneScript =>
+    [UserScriptConfig(name: 't', source: 'noop;')];
 
 void main() {
-  // Handler names are randomized per instance but keep stable prefixes.
   const scriptPrefix = '__ws_s_';
   const inlinePrefix = '__ws_i_';
   const fetchPrefix = '__ws_f_';
@@ -81,9 +83,8 @@ void main() {
       final ctrl = _FakeController();
       _serviceWith(_oneScript).registerHandlers(ctrl);
 
-      final res = await ctrl.handler(fetchPrefix)(['https://example.com/x.css'])
-          as Map;
-      expect(res['status'], 200);
+      final res = await ctrl.handler(fetchPrefix)(['https://example.com/x.css']);
+      expect((res as Map)['status'], 200);
       expect(res['body'], 'BODY');
       expect(res['contentType'], 'text/css');
     });
@@ -94,9 +95,8 @@ void main() {
       final ctrl = _FakeController();
       _serviceWith(_oneScript).registerHandlers(ctrl);
 
-      final res =
-          await ctrl.handler(fetchPrefix)(['data:text/html,x']) as Map;
-      expect(res['status'], 403);
+      final res = await ctrl.handler(fetchPrefix)(['data:text/html,x']);
+      expect((res as Map)['status'], 403);
       expect(factory.requested, isEmpty);
     });
 
@@ -106,9 +106,8 @@ void main() {
       final ctrl = _FakeController();
       _serviceWith(_oneScript).registerHandlers(ctrl);
 
-      final res =
-          await ctrl.handler(fetchPrefix)(['https://example.com/big']) as Map;
-      expect(res['status'], 413);
+      final res = await ctrl.handler(fetchPrefix)(['https://example.com/big']);
+      expect((res as Map)['status'], 413);
     });
 
     test('non-string argument returns a 400', () async {
@@ -116,8 +115,8 @@ void main() {
       final ctrl = _FakeController();
       _serviceWith(_oneScript).registerHandlers(ctrl);
 
-      final res = await ctrl.handler(fetchPrefix)([42]) as Map;
-      expect(res['status'], 400);
+      final res = await ctrl.handler(fetchPrefix)([42]);
+      expect((res as Map)['status'], 400);
     });
   });
 

--- a/test/user_script_handlers_test.dart
+++ b/test/user_script_handlers_test.dart
@@ -33,27 +33,28 @@ class _FakeFactory implements OutboundHttpFactory {
 }
 
 /// Captures the registered handler callbacks and records injected sources.
-/// Intercepts by Symbol so it is immune to the controller's exact method
-/// signatures in the fork.
+/// Signatures mirror the fork's InAppWebViewController: the handler callback
+/// is a bare `Function`, and evaluateJavascript takes an optional
+/// `ContentWorld`.
 class _FakeController extends Fake implements inapp.InAppWebViewController {
   final Map<String, Function> handlers = {};
   final List<String> evaluated = [];
 
   @override
-  dynamic noSuchMethod(Invocation invocation) {
-    if (invocation.memberName == #addJavaScriptHandler) {
-      final name =
-          invocation.namedArguments[const Symbol('handlerName')] as String;
-      handlers[name] =
-          invocation.namedArguments[const Symbol('callback')] as Function;
-      return null;
-    }
-    if (invocation.memberName == #evaluateJavascript) {
-      evaluated
-          .add(invocation.namedArguments[const Symbol('source')] as String);
-      return Future<dynamic>.value(null);
-    }
-    return super.noSuchMethod(invocation);
+  void addJavaScriptHandler({
+    required String handlerName,
+    required Function callback,
+  }) {
+    handlers[handlerName] = callback;
+  }
+
+  @override
+  Future<dynamic> evaluateJavascript({
+    required String source,
+    inapp.ContentWorld? contentWorld,
+  }) async {
+    evaluated.add(source);
+    return null;
   }
 
   Function handler(String prefix) =>

--- a/test/user_script_handlers_test.dart
+++ b/test/user_script_handlers_test.dart
@@ -1,0 +1,242 @@
+// Coverage for the Dart-side JS-bridge handlers and re-injection
+// orchestration in UserScriptService — the paths that were previously
+// untested because they need an InAppWebViewController and the outbound
+// HTTP client.
+//
+// The controller is faked (extends Fake) to capture the registered handler
+// callbacks and record evaluateJavascript sources. The network layer is
+// swapped via the documented `outboundHttp` seam with a MockClient.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:webspace/services/outbound_http.dart';
+import 'package:webspace/services/user_script_service.dart';
+import 'package:webspace/settings/proxy.dart';
+import 'package:webspace/settings/user_script.dart';
+
+/// Serves a configurable response for every outbound fetch.
+class _FakeFactory implements OutboundHttpFactory {
+  final http.Response Function(http.Request request) responder;
+  final List<Uri> requested = [];
+  _FakeFactory(this.responder);
+
+  @override
+  OutboundClient clientFor(UserProxySettings settings) {
+    return OutboundClientReady(MockClient((req) async {
+      requested.add(req.url);
+      return responder(req);
+    }));
+  }
+}
+
+/// Captures the registered handler callbacks and records injected sources.
+class _FakeController extends Fake implements inapp.InAppWebViewController {
+  final Map<String, inapp.JavaScriptHandlerCallback> handlers = {};
+  final List<String> evaluated = [];
+
+  @override
+  void addJavaScriptHandler({
+    required String handlerName,
+    required inapp.JavaScriptHandlerCallback callback,
+  }) {
+    handlers[handlerName] = callback;
+  }
+
+  @override
+  Future<dynamic> evaluateJavascript({
+    required String source,
+    inapp.ContentWorld? contentWorld,
+  }) async {
+    evaluated.add(source);
+    return null;
+  }
+
+  inapp.JavaScriptHandlerCallback handler(String prefix) =>
+      handlers.entries.firstWhere((e) => e.key.startsWith(prefix)).value;
+
+  bool evaluatedAny(String needle) => evaluated.any((s) => s.contains(needle));
+}
+
+UserScriptService _serviceWith(
+  List<UserScriptConfig> scripts, {
+  Future<bool> Function(String url)? confirm,
+}) =>
+    UserScriptService(scripts: scripts, onConfirmScriptFetch: confirm);
+
+final _oneScript = [UserScriptConfig(name: 't', source: 'noop;')];
+
+void main() {
+  // Handler names are randomized per instance but keep stable prefixes.
+  const scriptPrefix = '__ws_s_';
+  const inlinePrefix = '__ws_i_';
+  const fetchPrefix = '__ws_f_';
+
+  group('__wsFetch resource handler', () {
+    test('returns status/body/contentType for an allowed URL', () async {
+      outboundHttp = _FakeFactory((_) =>
+          http.Response('BODY', 200, headers: {'content-type': 'text/css'}));
+      final ctrl = _FakeController();
+      _serviceWith(_oneScript).registerHandlers(ctrl);
+
+      final res = await ctrl.handler(fetchPrefix)(['https://example.com/x.css'])
+          as Map;
+      expect(res['status'], 200);
+      expect(res['body'], 'BODY');
+      expect(res['contentType'], 'text/css');
+    });
+
+    test('blocks dangerous schemes with 403 without fetching', () async {
+      final factory = _FakeFactory((_) => http.Response('x', 200));
+      outboundHttp = factory;
+      final ctrl = _FakeController();
+      _serviceWith(_oneScript).registerHandlers(ctrl);
+
+      final res =
+          await ctrl.handler(fetchPrefix)(['data:text/html,x']) as Map;
+      expect(res['status'], 403);
+      expect(factory.requested, isEmpty);
+    });
+
+    test('rejects an oversize response with 413', () async {
+      final big = 'a' * (5 * 1024 * 1024 + 1);
+      outboundHttp = _FakeFactory((_) => http.Response(big, 200));
+      final ctrl = _FakeController();
+      _serviceWith(_oneScript).registerHandlers(ctrl);
+
+      final res =
+          await ctrl.handler(fetchPrefix)(['https://example.com/big']) as Map;
+      expect(res['status'], 413);
+    });
+
+    test('non-string argument returns a 400', () async {
+      outboundHttp = _FakeFactory((_) => http.Response('x', 200));
+      final ctrl = _FakeController();
+      _serviceWith(_oneScript).registerHandlers(ctrl);
+
+      final res = await ctrl.handler(fetchPrefix)([42]) as Map;
+      expect(res['status'], 400);
+    });
+  });
+
+  group('script fetch handler', () {
+    test('fetches a whitelisted URL and injects the body', () async {
+      outboundHttp = _FakeFactory((_) => http.Response('CODE_A();', 200));
+      final ctrl = _FakeController();
+      _serviceWith(_oneScript).registerHandlers(ctrl);
+
+      final ok = await ctrl
+          .handler(scriptPrefix)(['https://cdn.jsdelivr.net/npm/x/x.js']);
+      expect(ok, isTrue);
+      expect(ctrl.evaluatedAny('CODE_A();'), isTrue);
+    });
+
+    test('blocks a non-whitelisted URL when there is no confirm handler',
+        () async {
+      final factory = _FakeFactory((_) => http.Response('CODE;', 200));
+      outboundHttp = factory;
+      final ctrl = _FakeController();
+      _serviceWith(_oneScript).registerHandlers(ctrl);
+
+      final ok =
+          await ctrl.handler(scriptPrefix)(['https://evil.example/x.js']);
+      expect(ok, isFalse);
+      expect(factory.requested, isEmpty);
+      expect(ctrl.evaluatedAny('CODE;'), isFalse);
+    });
+
+    test('fetches a non-whitelisted URL after the user confirms', () async {
+      outboundHttp = _FakeFactory((_) => http.Response('CONFIRMED();', 200));
+      final ctrl = _FakeController();
+      _serviceWith(_oneScript, confirm: (_) async => true).registerHandlers(ctrl);
+
+      final ok =
+          await ctrl.handler(scriptPrefix)(['https://ok.example/x.js']);
+      expect(ok, isTrue);
+      expect(ctrl.evaluatedAny('CONFIRMED();'), isTrue);
+    });
+
+    test('returns false and injects nothing on a non-200 response', () async {
+      outboundHttp = _FakeFactory((_) => http.Response('nope', 404));
+      final ctrl = _FakeController();
+      _serviceWith(_oneScript).registerHandlers(ctrl);
+
+      final ok = await ctrl
+          .handler(scriptPrefix)(['https://cdn.jsdelivr.net/npm/x/x.js']);
+      expect(ok, isFalse);
+      expect(ctrl.evaluated, isEmpty);
+    });
+  });
+
+  group('inline script handler', () {
+    test('evaluates the bridged inline source', () async {
+      final ctrl = _FakeController();
+      _serviceWith(_oneScript).registerHandlers(ctrl);
+      await ctrl.handler(inlinePrefix)(['window.__x = 1;']);
+      expect(ctrl.evaluatedAny('window.__x = 1;'), isTrue);
+    });
+
+    test('ignores empty inline source', () async {
+      final ctrl = _FakeController();
+      _serviceWith(_oneScript).registerHandlers(ctrl);
+      await ctrl.handler(inlinePrefix)(['']);
+      expect(ctrl.evaluated, isEmpty);
+    });
+  });
+
+  group('re-injection orchestration', () {
+    List<UserScriptConfig> mixed() => [
+          UserScriptConfig(
+              id: 's1',
+              name: 'start',
+              source: 'START();',
+              injectionTime: UserScriptInjectionTime.atDocumentStart),
+          UserScriptConfig(
+              id: 's2',
+              name: 'end',
+              source: 'END();',
+              injectionTime: UserScriptInjectionTime.atDocumentEnd),
+          UserScriptConfig(
+              id: 's3',
+              name: 'lib',
+              source: 'INIT();',
+              urlSource: 'LIB();',
+              injectionTime: UserScriptInjectionTime.atDocumentStart),
+          UserScriptConfig(
+              id: 's4',
+              name: 'off',
+              source: 'OFF();',
+              injectionTime: UserScriptInjectionTime.atDocumentStart,
+              enabled: false),
+        ];
+
+    test('onLoadStart re-runs the shim and only atStart non-library scripts',
+        () async {
+      final ctrl = _FakeController();
+      await _serviceWith(mixed()).reinjectOnLoadStart(ctrl);
+
+      expect(ctrl.evaluatedAny('Node.prototype.appendChild'), isTrue,
+          reason: 'shim must be re-injected at load start');
+      expect(ctrl.evaluatedAny('START();'), isTrue);
+      expect(ctrl.evaluatedAny('window.__wsRan_s1'), isTrue);
+      expect(ctrl.evaluatedAny('END();'), isFalse);
+      expect(ctrl.evaluatedAny('LIB();'), isFalse,
+          reason: 'urlSource libraries are handled by initialUserScripts');
+      expect(ctrl.evaluatedAny('OFF();'), isFalse);
+    });
+
+    test('onLoadStop re-runs only atEnd non-library scripts, no shim',
+        () async {
+      final ctrl = _FakeController();
+      await _serviceWith(mixed()).reinjectOnLoadStop(ctrl);
+
+      expect(ctrl.evaluatedAny('Node.prototype.appendChild'), isFalse,
+          reason: 'load stop must not re-inject the shim');
+      expect(ctrl.evaluatedAny('END();'), isTrue);
+      expect(ctrl.evaluatedAny('START();'), isFalse);
+      expect(ctrl.evaluatedAny('LIB();'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Symptom

With a user script enabled, a logged-in site (github.com observed) starts demanding login even though the session is valid.

## Root cause

The user-script shim ([user_script_shim.dart](lib/services/user_script_shim.dart)) patches `window.fetch` to retry `TypeError` failures through `__wsFetch` — a Dart-bridge fetch that carries **none of the WebView's cookies** ([user_script_service.dart:205](lib/services/user_script_service.dart): plain `client.get(url)`).

It was retrying **same-origin** failures too. So when a page's own `fetch()` fails with a `TypeError` (e.g. a request blocked by the content blocker), the shim re-issued it credential-less; GitHub returned logged-out fragments → "please login." On-device logs showed `__wsFetch: https://github.com/...` firing for the site's own endpoints.

## Fix

Scope the fallback to **cross-origin** URLs only. A same-origin `TypeError` is a genuine network error, not a CORS block, and is rethrown untouched — so the page's session is never silently dropped. The cross-origin CORS-bypass use (reading third-party stylesheets etc.) is unchanged.

```js
function isCrossOrigin(u) {
  try { return new URL(u, location.href).origin !== location.origin; }
  catch (e) { return false; }
}
...
if (isFetchableUrl(url) && isCrossOrigin(url)) return window.__wsFetch(url);
```

Template + dumped fixture (`test/js_fixtures/user_script/shim.js`) updated in lockstep (drift-checked).

## Why tests didn't catch it

The shim's node tests only covered the **script-interception** half. The `window.fetch` fallback was explicitly stubbed out and never exercised ("*nothing in these tests exercises the fetch fallback path*").

## Coverage added (this PR)

**JS (`test/js/user_script_shim.test.js`, 8 → 16):**
- `window.fetch` fallback: same-origin / relative → no fallback; cross-origin → falls back; non-`TypeError` → rethrown.
- `__wsFetch` direct: non-http(s) rejected, bridge-unavailable rejected.
- whitelisted `<script src>` lifecycle: dedup of an already-loaded URL (fires `onload`, no re-fetch), `onerror` on a failed bridge fetch.

**Dart (`test/user_script_build_test.dart`, `test/user_script_handlers_test.dart`, new):**
- `buildInitialUserScripts`: shim ordering, `_guarded` wrapping + id sanitization, disabled/empty skip, injection-time mapping, `urlSource` concatenation.
- JS-bridge handler callbacks (via a `Fake` controller + the `outboundHttp` `MockClient` seam): script fetch whitelist/confirm/size-cap/non-200, `__wsFetch` resource fetch/block/oversize/bad-arg, inline eval.
- `reinjectOnLoadStart` / `reinjectOnLoadStop`: shim re-run only at start, atStart-vs-atEnd filtering, `urlSource` + disabled skip.

`classifyScriptFetchUrl` policy was already well-covered in `test/user_script_test.dart`.

## Testing

- `npm run test:js` green (271/271).
- The new Dart tests could **not** be run locally — installing the pinned Flutter SDK requires cloning `flutter/flutter`, which the egress policy blocks (403) — so they're being validated by CI. The controller-fake tests are isolated in their own file so a signature mismatch can't break the rest of the suite.
- Template/fixture blocks are byte-identical (verified by diff), so `js_fixtures_drift_test.dart` should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)