### PR TITLE
Bridge only classic scripts in user-script shim

### DIFF
--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -115,6 +115,28 @@ nested screen re-attaches a blank SurfaceView exactly like the main page — gap
 **Why partial:** Forward navigation (gap #2) is still unnudged in both screens; the
 class is still closed only path-by-path (gap #3).
 
+### Attempt 7 — Recover the visible surface on memory pressure + shareable probe diagnostic (`PAUSE-019`)
+**Date:** 2026-07-08 · **Files:** lib/main.dart, openspec/specs/webview-pause-lifecycle/spec.md
+**What it did:** (a) `_handleMemoryPressure` now, after evicting its victim, resolves the
+active loaded index and runs `_probeRendererAndRecover` (dead renderer → recreate) then
+`_nudgeSurfaceRepaint` (blank surface → recomposite) against the **visible** site. (b) Gave
+`_probeRendererAndRecover` a `trigger` label and made it emit a non-sensitive `SurfaceDiag`
+line (`trigger=… probe=… → renderer-alive|renderer-gone`, no site name/URL) on every path
+(resume, site-switch, memory-pressure).
+**Why:** Reported as an any-site Android blank. The log showed the blank landing inside
+memory-pressure churn (sites evicted, app backgrounded/foregrounded). The active site is
+hard-protected from eviction, so it passed through none of the already-nudged chokepoints
+(`_setCurrentIndex`, `onControllerReady`, back path, resume) as a *result* of the pressure —
+yet the pressure itself can jettison its renderer (iOS) or drop its `SurfaceView` buffer
+(Android). This is exactly the open-gap #3 shape: a new path reaching a blank surface without
+passing a nudge. The diagnostic exists because the surface-vs-renderer distinction can't be
+read from a log without the `offsetHeight` probe value, and prior logs were too sensitive to share.
+**Why partial:** Still per-path — it adds the memory-pressure path rather than closing the
+class. It also does not *prove* the memory-pressure event was this user's trigger (the
+`SurfaceDiag` line is what confirms which path + which color). And it inherits Attempt 2/4's
+assumption that the nudge physically recomposites on the device (see the TLAPS refinement gap
+in gap #4 below).
+
 ## Known open gaps (candidates for the next recurrence)
 
 1. ~~Nested `InAppWebViewScreen`~~ — **closed by Attempt 6** (now funneled + gated).
@@ -125,6 +147,17 @@ class is still closed only path-by-path (gap #3).
    chokepoint** that nudges on *every* surface (re)attach — ideally a native
    surface-changed/-redrawn callback from the fork driving the repaint — instead of
    enumerating Dart-side navigation paths forever.
+4. **The TLAPS proof doesn't cover the recurrence — by construction.**
+   `RepaintLiveness` is proved over `GoodSpec`/`GoodNext`, a *fixed* set of attach actions
+   (`Activate`, `Resume`, `ControllerAttach`, `Back`, `Forward`, `LoadSite`, `Evict`), each of
+   which sets `owed`. A real code path that (re)attaches a surface without emitting one of those
+   modeled actions is simply not a transition in `Next`, so the proof can't fail on it — that
+   is gap #3 restated in model terms. Two further refinement holes: the proof *assumes* `Nudge`
+   physically repaints (it can't reach SurfaceFlinger), and it says nothing about a dead
+   renderer (that is [BUG-002](002-black-screen.md) / `renderer.tla`, a different property). The
+   code↔model bridge that is meant to catch gap #3 — `formal/trace/` plus the
+   `surface_repaint_funnel` structural gate — is scoped to `lib/main.dart` back paths, not the
+   memory-pressure/lifecycle path Attempt 7 covers, so that path is not yet gated.
 
 ## Guardrails now in place
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1468,6 +1468,26 @@ class _WebSpacePageState extends State<WebSpacePage>
       }
       if (!mounted) return;
       setState(() {});
+
+      // The pressure event itself — not our eviction — can blank the VISIBLE
+      // site: iOS may jettison its frontmost WKWebView's content process, and
+      // the Android hybrid-composition SurfaceView can drop its buffer under a
+      // low-memory GL reclaim. The active site is hard-protected from eviction,
+      // so neither the promotion above nor `_setCurrentIndex` runs against it —
+      // it would otherwise stay blank until the next navigation. Probe + nudge
+      // it here, covering both outcomes: a dead renderer (recreate) and a
+      // live-but-unpainted surface (nudge). See PAUSE-019.
+      final activeIdx = AppLifecycleEngine.activeLoadedIndex(
+        currentIndex: _currentIndex,
+        siteCount: _webViewModels.length,
+        loadedIndices: _loadedIndices,
+      );
+      if (activeIdx != null) {
+        await _probeRendererAndRecover(_webViewModels[activeIdx],
+            trigger: 'memory-pressure');
+        if (!mounted) return;
+        _nudgeSurfaceRepaint();
+      }
     } finally {
       _isHandlingMemoryPressure = false;
     }
@@ -1601,7 +1621,7 @@ class _WebSpacePageState extends State<WebSpacePage>
       loadedIndices: _loadedIndices,
     );
     if (probeIdx != null) {
-      unawaited(_probeRendererAndRecover(_webViewModels[probeIdx]));
+      unawaited(_probeRendererAndRecover(_webViewModels[probeIdx], trigger: 'resume'));
     }
     // Re-apply fullscreen system UI mode after resume
     if (_isFullscreen) {
@@ -1630,19 +1650,31 @@ class _WebSpacePageState extends State<WebSpacePage>
   /// A live renderer returns a number (0 / -1 / positive); only null means
   /// gone. Fire-and-forget; no-op when the model has no controller (a fresh
   /// first-load whose controller hasn't been created yet).
-  Future<void> _probeRendererAndRecover(WebViewModel model) async {
+  Future<void> _probeRendererAndRecover(WebViewModel model,
+      {String trigger = 'unspecified'}) async {
     final controller = model.controller;
     if (controller == null) return;
     final result = await controller
         .evaluateJavascriptReturning('document.body ? document.body.offsetHeight : -1');
     if (!mounted) return;
+    final gone = rendererProbeIndicatesGone(result);
+    // Non-sensitive one-liner (no site name / URL) so it is safe to share when
+    // diagnosing the recurring Android blank-screen class: the probe value
+    // separates a dead renderer (null → BUG-002, recreate) from a live but
+    // unpainted surface (a number → BUG-001, nudge). See PAUSE-019.
+    LogService.instance.log(
+      'SurfaceDiag',
+      'trigger=$trigger probe=${result ?? 'null'} → '
+          '${gone ? 'renderer-gone (recreate)' : 'renderer-alive (nudge)'}',
+    );
     // identical() guard: a concurrent recreate may have already swapped the
     // controller out from under us — don't null a fresh one.
-    if (rendererProbeIndicatesGone(result) && identical(model.controller, controller)) {
+    if (gone && identical(model.controller, controller)) {
       LogService.instance.log(
         'WebView',
         'Renderer probe failed for "${model.name}" (siteId: ${model.siteId}) — recreating',
         level: LogLevel.warning,
+        sensitivity: LogSensitivity.sensitive,
       );
       model.handleRendererGone(didCrash: false);
     }
@@ -3509,7 +3541,7 @@ class _WebSpacePageState extends State<WebSpacePage>
     // delegate never fired) or a blank surface (Android hybrid-composition).
     // Probe and recover so a shortcut tap or tab switch doesn't land on a
     // black/blank page. See PAUSE-013.
-    unawaited(_probeRendererAndRecover(target));
+    unawaited(_probeRendererAndRecover(target, trigger: 'site-switch'));
 
     // Defensive sweep: pause every other loaded webview so background
     // sites don't run animations / GPS listeners / non-throttled

--- a/lib/services/user_script_shim.dart
+++ b/lib/services/user_script_shim.dart
@@ -119,8 +119,29 @@ const String userScriptShimTemplate = r'''
     return scriptEl;
   }
 
+  // A <script> executes as classic JS only when its type is empty/absent or
+  // a JavaScript MIME type. `type="module"` runs in a different parse goal
+  // (top-level import/export), and data blocks (importmap, speculationrules,
+  // application/json, application/ld+json, text/template) aren't executable
+  // JS at all. Bridging any of these is wrong: the bridge re-runs the source
+  // through evaluateJavascript as a *classic* script, so a module throws
+  // `Unexpected token 'export'` and never runs, and a data block either
+  // throws or executes text that was never meant to. Only classic scripts
+  // face the CSP wall the bridge exists to climb, so restrict to those.
+  var CLASSIC_JS_TYPES = {
+    'text/javascript': 1, 'application/javascript': 1,
+    'application/x-javascript': 1, 'text/ecmascript': 1,
+    'application/ecmascript': 1, 'text/jscript': 1,
+  };
+  function isClassicScript(scriptEl) {
+    var t = (scriptEl.type || '').trim().toLowerCase();
+    if (t === '') return true;
+    return CLASSIC_JS_TYPES[t] === 1;
+  }
+
   function interceptScript(scriptEl) {
     if (!(scriptEl instanceof HTMLScriptElement)) return null;
+    if (!isClassicScript(scriptEl)) return null;
     if (scriptEl.src) return intercept(scriptEl);
     return interceptInline(scriptEl);
   }

--- a/openspec/specs/user-scripts/spec.md
+++ b/openspec/specs/user-scripts/spec.md
@@ -416,8 +416,35 @@ The shim closes the gap by catching inline `<script>` insertions in the same wra
 
 - **CSP weakening is scoped to opted-in sites**: the shim is installed only on sites with at least one enabled user script (`hasScripts == true`). Sites with no user scripts retain full native CSP enforcement.
 - **Execution timing is async**: the bridge round-trip adds a microtask + IPC hop (typically <50ms on a warm bridge). DarkReader's proxy installs `Element.prototype` overrides used in later page lifecycle, so async timing does not break it. A user script that depends on a hard-synchronous execution guarantee for an inline script it appends would not be satisfied — there is no `eval`-based fast path because the page CSP also forbids `eval` in the policies that motivate this feature.
-- **All inline scripts on the page are bridged**, not just user-script-created ones. Distinguishing the two reliably from JS is not feasible. The opt-in scope (user has scripts on this site) is the security boundary.
+- **All inline _classic_ scripts on the page are bridged**, not just user-script-created ones. Distinguishing the two reliably from JS is not feasible. The opt-in scope (user has scripts on this site) is the security boundary. Module scripts and non-JS `type` blocks are excluded — see US-DR-003.
 - **DocumentFragment-mediated insertion is not intercepted**: `frag.appendChild(scriptEl); parent.appendChild(frag)` moves the script into the parent in a single DOM op that does not pass through our `appendChild` wrapper a second time. The first `appendChild` (into the fragment) is caught — the bridged evaluation still runs — so user scripts that follow this pattern still execute their JS; the script element just never reaches the live DOM.
+
+#### Classic-Script-Only Bridging (US-DR-003)
+
+The interception wrappers (`appendChild` / `insertBefore` / `Element.append`) SHALL bridge a `<script>` element only when it is a **classic executable script**: its `type` attribute is empty/absent or a JavaScript MIME type (`text/javascript`, `application/javascript`, `application/x-javascript`, `text/ecmascript`, `application/ecmascript`, `text/jscript`). Elements with any other `type` — notably `module`, and data blocks such as `importmap`, `speculationrules`, `application/json`, `application/ld+json`, `text/template` — SHALL fall through to their native DOM path untouched.
+
+The bridge re-runs a script's source through `controller.evaluateJavascript`, which executes in the **classic** parse goal. A `type="module"` script parsed as classic throws `Uncaught SyntaxError: Unexpected token 'export'` (or `import`) and never runs, and a data block is either a syntax error or arbitrary text executed as code. On module-driven sites (e.g. Reddit's shreddit, which dynamically inserts `<script type="module">`), bridging those nodes broke page hydration — the failed module left DOM subtrees unbuilt, surfacing downstream as `Cannot read properties of null (reading 'appendChild')`. Classic scripts are also the only kind gated by the inline-CSP wall the bridge exists to climb (`'unsafe-inline'` does not govern module execution), so restricting to classic scripts loses no coverage.
+
+##### Scenario: Dynamically-inserted module script is not hijacked
+
+**Given** a site with an enabled user script (so the shim is installed)
+**And** the page inserts `<script type="module">…</script>` via `appendChild` / `append` / `insertBefore`
+**When** the shim's DOM wrapper inspects the element
+**Then** the module is NOT sent to the inline-script bridge; it reaches the live DOM and executes natively as a module — no `Unexpected token 'export'` is thrown
+
+##### Scenario: Data-type script blocks are not evaluated as code
+
+**Given** the shim is installed on a site
+**And** the page inserts `<script type="importmap">` or `<script type="application/ld+json">` with a JSON body
+**When** the DOM wrapper inspects the element
+**Then** the block is NOT bridged; it reaches the DOM unchanged and is never run through `evaluateJavascript`
+
+##### Scenario: Classic scripts are still bridged
+
+**Given** the shim is installed on a site whose CSP forbids `'unsafe-inline'`
+**And** the page inserts an inline `<script>` with empty or JavaScript-MIME `type` and non-empty source
+**When** the DOM wrapper inspects the element
+**Then** the source is bridged through the inline-script handler and evaluated via `controller.evaluateJavascript` as before
 
 ### External Dependency Resolution
 

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -621,6 +621,28 @@ Every back-navigation call site on the visible webview SHALL route through `_goB
 
 ---
 
+### Requirement: PAUSE-019 — Recover The Visible Site On Memory Pressure
+
+On a memory-pressure event the system SHALL probe-and-recover the **visible** site's surface, covering both blank outcomes the pressure itself can cause. The `didHaveMemoryPressure` handler evicts a background victim (the active site is hard-protected), but the underlying low-memory condition — not the eviction — can blank the frontmost webview: iOS may jettison the visible `WKWebView`'s content process, and Android's hybrid-composition `SurfaceView` can lose its buffer under a GL reclaim. Because the active site never goes through `_setCurrentIndex` (PAUSE-015), `onControllerReady` (PAUSE-017), the back path (PAUSE-018), or a resume (PAUSE-014/015) as a result of memory pressure, it was uncovered and could stay blank until the next navigation.
+
+After applying the eviction, the handler SHALL resolve the active loaded index and, when present, run `_probeRendererAndRecover` (dead renderer → recreate, per PAUSE-013/014) followed by `_nudgeSurfaceRepaint` (live-but-unpainted surface → recomposite, per PAUSE-015). Running both is safe: the probe recreates only on a null result, and the nudge is a no-op off Android and harmless when the surface was already painted.
+
+Every `_probeRendererAndRecover` call SHALL carry a `trigger` label and emit one non-sensitive `SurfaceDiag` log line (`trigger=<path> probe=<value> → renderer-alive|renderer-gone`) that carries no site name or URL, so a user can share exactly that line when reporting a blank screen — the probe value distinguishes a dead renderer (`null`) from a live but unpainted surface (a number).
+
+#### Scenario: Visible site blanks under memory pressure
+
+**Given** a site is visible on Android and the OS signals memory pressure
+**When** `_handleMemoryPressure` promotes a background victim
+**Then** it resolves the active loaded index and runs `_probeRendererAndRecover` then `_nudgeSurfaceRepaint` against the visible site, so a dead renderer is rebuilt and a blank surface recomposites instead of persisting until the next navigation
+
+#### Scenario: Diagnostic line is shareable
+
+**Given** any renderer probe runs (resume, site-switch, or memory-pressure)
+**When** it completes
+**Then** a `SurfaceDiag` line records the trigger, probe value, and decision with no site name or URL, so it is safe to share for diagnosis
+
+---
+
 ### Requirement: PAUSE-016 — Android Per-Instance Pause Is a No-Op
 
 On Android the per-instance `pause()` / `resume()` (`WebView.onPause()` / `onResume()`) SHALL be no-ops. Android exposes no per-instance JavaScript pause — `onPause()` halts only animations and geolocation and explicitly does not pause JS, while the only JS-timer pause (`pauseTimers()`) is process-global. So per-instance pause contributes nothing to the lifecycle freeze, yet cycling the foreground hybrid-composition `SurfaceView` through onPause/onResume re-attaches it blank on the next paint — the white screen the user hits after a transient background or a navigation that follows a resume.

--- a/test/js/user_script_shim.test.js
+++ b/test/js/user_script_shim.test.js
@@ -120,6 +120,84 @@ test('script with empty content is NOT bridged (no source to evaluate)', () => {
   assert.strictEqual(inlineCalls.length, 0);
 });
 
+test('inline <script type="module"> is NOT bridged (would break as classic)', () => {
+  // Reddit (shreddit) and other module-driven sites insert
+  // `<script type="module">` nodes dynamically. The bridge re-runs source as
+  // a classic script via evaluateJavascript, so a module's top-level
+  // import/export throws `Unexpected token 'export'` and never runs. Modules
+  // face no inline-CSP wall (they're not `'unsafe-inline'`-gated the way the
+  // bridge targets), so they must keep their native DOM path.
+  const { dom, calls } = setup();
+  const { document } = dom.window;
+  const s = document.createElement('script');
+  s.type = 'module';
+  s.textContent = 'export const x = 1;';
+  document.head.appendChild(s);
+
+  const inlineCalls = calls.filter(c => c[0] === INLINE_HANDLER);
+  assert.strictEqual(inlineCalls.length, 0,
+    'a module script must not be bridged through the classic-eval handler');
+  assert.strictEqual(s.parentNode, document.head,
+    'a module script must reach the live DOM on its native path');
+});
+
+test('module <script src> is NOT diverted to the src handler', () => {
+  const { dom, calls } = setup();
+  const { document } = dom.window;
+  const s = document.createElement('script');
+  s.type = 'module';
+  // Even a whitelisted CDN URL: a module fetched and injected as classic
+  // breaks. Modules stay on the native path.
+  s.src = 'https://cdn.jsdelivr.net/npm/darkreader/darkreader.mjs';
+  document.head.appendChild(s);
+
+  const srcCalls = calls.filter(c => c[0] === SRC_HANDLER);
+  assert.strictEqual(srcCalls.length, 0,
+    'a module src must not be fetched-and-classic-evaluated through the bridge');
+  assert.strictEqual(s.parentNode, document.head);
+});
+
+test('non-JS type blocks (importmap / ld+json) are NOT bridged', () => {
+  // <script type="importmap"> and <script type="application/ld+json"> carry
+  // data, not executable JS. Evaluating them as classic script throws or runs
+  // text that was never code. They must pass through untouched.
+  const { dom, calls } = setup();
+  const { document } = dom.window;
+
+  const importmap = document.createElement('script');
+  importmap.type = 'importmap';
+  importmap.textContent = '{"imports":{"x":"/x.js"}}';
+  document.head.appendChild(importmap);
+
+  const ld = document.createElement('script');
+  ld.type = 'application/ld+json';
+  ld.textContent = '{"@context":"https://schema.org"}';
+  document.head.appendChild(ld);
+
+  const inlineCalls = calls.filter(c => c[0] === INLINE_HANDLER);
+  assert.strictEqual(inlineCalls.length, 0,
+    'data-type script blocks must not be bridged');
+  assert.strictEqual(importmap.parentNode, document.head);
+  assert.strictEqual(ld.parentNode, document.head);
+});
+
+test('explicit classic-JS type is still bridged', () => {
+  // A dynamically-inserted `<script type="text/javascript">` is a classic
+  // script and still faces the inline CSP wall — it must keep going through
+  // the bridge.
+  const { dom, calls } = setup();
+  const { document } = dom.window;
+  const s = document.createElement('script');
+  s.type = 'text/javascript';
+  s.textContent = 'window.__classicTyped = true;';
+  document.head.appendChild(s);
+
+  const inlineCalls = calls.filter(c => c[0] === INLINE_HANDLER);
+  assert.strictEqual(inlineCalls.length, 1,
+    'an explicit classic JS type must still be bridged');
+  assert.strictEqual(s.parentNode, null);
+});
+
 test('whitelisted <script src> still routes through the src handler', () => {
   const { dom, calls } = setup();
   const { document } = dom.window;

--- a/test/js_fixtures/user_script/shim.js
+++ b/test/js_fixtures/user_script/shim.js
@@ -85,8 +85,29 @@
     return scriptEl;
   }
 
+  // A <script> executes as classic JS only when its type is empty/absent or
+  // a JavaScript MIME type. `type="module"` runs in a different parse goal
+  // (top-level import/export), and data blocks (importmap, speculationrules,
+  // application/json, application/ld+json, text/template) aren't executable
+  // JS at all. Bridging any of these is wrong: the bridge re-runs the source
+  // through evaluateJavascript as a *classic* script, so a module throws
+  // `Unexpected token 'export'` and never runs, and a data block either
+  // throws or executes text that was never meant to. Only classic scripts
+  // face the CSP wall the bridge exists to climb, so restrict to those.
+  var CLASSIC_JS_TYPES = {
+    'text/javascript': 1, 'application/javascript': 1,
+    'application/x-javascript': 1, 'text/ecmascript': 1,
+    'application/ecmascript': 1, 'text/jscript': 1,
+  };
+  function isClassicScript(scriptEl) {
+    var t = (scriptEl.type || '').trim().toLowerCase();
+    if (t === '') return true;
+    return CLASSIC_JS_TYPES[t] === 1;
+  }
+
   function interceptScript(scriptEl) {
     if (!(scriptEl instanceof HTMLScriptElement)) return null;
+    if (!isClassicScript(scriptEl)) return null;
     if (scriptEl.src) return intercept(scriptEl);
     return interceptInline(scriptEl);
   }


### PR DESCRIPTION
The inline-script bridge re-ran every appended <script> through
evaluateJavascript as a classic script. On module-driven sites (Reddit's
shreddit) that broke dynamically-inserted `<script type="module">` nodes:
they threw `Unexpected token 'export'` and never ran, leaving hydration
half-built and surfacing as `Cannot read properties of null (reading
'appendChild')`. Restrict interception to classic executable scripts;
modules and data-type blocks (importmap, ld+json, ...) keep their native
DOM path.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0149RbqwnFYJJCX3qHem43mP