### PR TITLE
Add SSRF guard, fix concurrency races, harden proxy/notification handling

### DIFF
--- a/formal/README.md
+++ b/formal/README.md
@@ -69,6 +69,17 @@ class.
   actions and holds fullscreen) + `Inv_LockMatchesSource` (lock ⇔ kiosk-shortcut launch); the
   `exitfs` and `chrome` demonstrators leave fullscreen / build the drawer while locked and are
   caught. Standalone (a pure UI state machine; no shared kernel state).
+- **`store_serial.tla`** + `store_serial*.cfg` — secure-storage write serialisation (specs:
+  `cookie-secure-storage`, `proxy-password-secure-storage`, ARCH-001). `Inv_NoLostUpdate`
+  (every completed read-modify-write's key stays persisted, because the static write lock makes
+  each RMW atomic); the `interleave` demonstrator splits the read and the write (the unlocked
+  path) and drops a concurrently-committed key. Standalone (a fixed N-op scenario).
+- **`switchguard.tla`** + `switchguard*.cfg` — site-switch version guard vs a concurrent
+  structural mutation (specs: `navigation`, `lazy-webview-loading`). `Inv_NoWrongActivation`
+  (a superseded switch bails rather than committing against a stale positional index); the
+  `noguard` demonstrator drops the version check and, after a delete/import/archive mutation,
+  activates the wrong site (the legacy-mode cross-site cookie exposure). Standalone (a UI
+  orchestration state machine; no shared kernel state).
 - **`trace/`** — the model↔code conformance bridge (below).
 - **`proofs/`** — TLAPS deductive proofs for **unbounded N** (the bounded-TLC backstop). See
   [proofs/README.md](proofs/README.md): `Inv_CurrentLoaded` is proved for all `N >= 1`

--- a/formal/check.sh
+++ b/formal/check.sh
@@ -110,6 +110,22 @@ expect kiosk_leak_chrome.cfg kiosk.tla "Inv_LockedIsSealed is violated" \
 expect kiosk_reach.cfg kiosk.tla "Reach_Locked is violated" \
   "a locked state is reachable (sealing not vacuous)"
 
+echo "── STORE: secure-storage write serialisation (no lost update) ──"
+expect store_serial.cfg store_serial.tla "No error has been found" \
+  "every completed read-modify-write's key stays persisted"
+expect store_serial_lost.cfg store_serial.tla "Inv_NoLostUpdate is violated" \
+  "an unlocked read-modify-write drops a concurrently-committed key (caught)"
+expect store_serial_reach.cfg store_serial.tla "Reach_TwoDone is violated" \
+  "two ops can both complete (no-lost-update not vacuous)"
+
+echo "── SWITCHGUARD: site-switch version guard vs structural mutation ──"
+expect switchguard.cfg switchguard.tla "No error has been found" \
+  "a superseded switch bails instead of activating the wrong site"
+expect switchguard_noguard.cfg switchguard.tla "Inv_NoWrongActivation is violated" \
+  "an unguarded commit after a mutation activates the wrong site (caught)"
+expect switchguard_reach.cfg switchguard.tla "Reach_Bailed is violated" \
+  "a mutation-during-switch bail is reachable (guard not vacuous)"
+
 echo "── TRACE CONFORMANCE: code stayed inside the model ──"
 case "$JAR" in /*) JAR_ABS="$JAR" ;; *) JAR_ABS="$(pwd)/$JAR" ;; esac
 TLA2TOOLS_JAR="$JAR_ABS" ./trace/check_trace.sh | sed 's/^/  /'

--- a/formal/proofs/README.md
+++ b/formal/proofs/README.md
@@ -31,13 +31,22 @@ TLC model it backs (same definitions — no re-modeling).
 - **`retention_safety.tla`** — proves `[](Inv_CurrentKept /\ Inv_NotifLast)` for all `N` and
   any tier assignment: the visible site is never evicted, and notification sites are evicted
   last (inductive via the eviction guard + monotonicity). **22 obligations, all proved.**
+- **`no_lost_update.tla`** — proves `[]Inv_NoLostUpdate` (every completed read-modify-write's
+  key stays persisted — the secure-storage write serialisation) for all `N`: directly
+  inductive, since the serialised (atomic) RMW makes the store grow monotonically, so a done
+  op's key is never dropped. Backs `store_serial.tla`.
+- **`switch_guarded.tla`** — proves `[]Inv_NoWrongActivation` (a version-guarded site switch
+  never commits against a stale index) for the good orchestration: directly inductive, since
+  every good action leaves `wrong` unchanged while the `noguard` demonstrator latches it.
+  Backs `switchguard.tla` (which has no size parameter, so this is the deductive companion
+  rather than an N-generalisation).
 
 Together these prove every kernel *safety* invariant, the surface-repaint *liveness*
 (`RepaintLiveness` — BUG-001 itself), and every standalone model's safety invariant
-(archive byte-identity, container disjointness, proxy coherence, retention order) for
-unbounded domains — not just at TLC's `N = 3`. The only TLC-bounded model left is
-`renderer.tla`, which has no size parameter (its state space is finite and fully
-enumerated), so an unbounded proof would be vacuous.
+(archive byte-identity, container disjointness, proxy coherence, retention order,
+secure-storage no-lost-update, site-switch version guard) for unbounded domains — not just at
+TLC's `N = 3`. The only TLC-bounded model left is `renderer.tla`, which has no size parameter
+(its state space is finite and fully enumerated), so an unbounded proof would be vacuous.
 
 ## Check
 

--- a/formal/proofs/no_lost_update.tla
+++ b/formal/proofs/no_lost_update.tla
@@ -1,0 +1,47 @@
+------------------------- MODULE no_lost_update -------------------------
+(***************************************************************************)
+(* TLAPS proof that Inv_NoLostUpdate (every completed read-modify-write's   *)
+(* key stays persisted -- no lost update) holds for the serialised store    *)
+(* and ALL N, by the standard inductive-invariant argument. TLC checks only  *)
+(* N = 3; this is the unbounded backstop. Companion of store_serial.tla.     *)
+(*                                                                          *)
+(* Directly inductive: the good engine's write is an atomic add, so both     *)
+(* `store` and `done` grow monotonically by the same key and `done` stays a  *)
+(* subset of `store`.                                                        *)
+(***************************************************************************)
+EXTENDS store_serial, TLAPS
+
+ASSUME NAssumption == N \in Nat \ {0}
+
+GoodSpec == Init /\ [][GoodNext]_vars
+
+IndInv == TypeOK /\ Inv_NoLostUpdate
+
+LEMMA InitInd == Init => IndInv
+  BY NAssumption DEF Init, IndInv, TypeOK, Inv_NoLostUpdate, Ops
+
+LEMMA StepInd == IndInv /\ [GoodNext]_vars => IndInv'
+  <1> SUFFICES ASSUME IndInv, [GoodNext]_vars
+               PROVE  IndInv'
+    OBVIOUS
+  <1> USE DEF IndInv, TypeOK, Inv_NoLostUpdate, Ops
+  <1>1. CASE GoodNext
+    <2>1. CASE \E o \in Ops : Rmw(o)
+      BY <2>1 DEF Rmw
+    <2> QED
+      BY <1>1, <2>1 DEF GoodNext
+  <1>2. CASE UNCHANGED vars
+    BY <1>2 DEF vars
+  <1> QED
+    BY <1>1, <1>2
+
+THEOREM Safety == GoodSpec => []Inv_NoLostUpdate
+  <1>1. Init => IndInv
+    BY InitInd
+  <1>2. IndInv /\ [GoodNext]_vars => IndInv'
+    BY StepInd
+  <1>3. IndInv => Inv_NoLostUpdate
+    BY DEF IndInv
+  <1> QED
+    BY <1>1, <1>2, <1>3, PTL DEF GoodSpec
+=============================================================================

--- a/formal/proofs/switch_guarded.tla
+++ b/formal/proofs/switch_guarded.tla
@@ -1,0 +1,54 @@
+------------------------- MODULE switch_guarded -------------------------
+(***************************************************************************)
+(* TLAPS proof that Inv_NoWrongActivation (a guarded site switch never      *)
+(* commits against a stale index) holds for the good orchestration and ALL  *)
+(* reachable states, by the standard inductive-invariant argument. The      *)
+(* model has no size parameter, so this is the deductive companion of        *)
+(* switchguard.tla rather than an N-generalisation: it shows `wrong` is      *)
+(* never set on any good path (every good action leaves it unchanged),       *)
+(* whereas the "noguard" demonstrator latches it. Directly inductive.        *)
+(***************************************************************************)
+EXTENDS switchguard, TLAPS
+
+GoodSpec == Init /\ [][GoodNext]_vars
+
+IndInv == TypeOK /\ Inv_NoWrongActivation
+
+LEMMA InitInd == Init => IndInv
+  BY DEF Init, IndInv, TypeOK, Inv_NoWrongActivation
+
+LEMMA StepInd == IndInv /\ [GoodNext]_vars => IndInv'
+  <1> SUFFICES ASSUME IndInv, [GoodNext]_vars
+               PROVE  IndInv'
+    OBVIOUS
+  <1> USE DEF IndInv, TypeOK, Inv_NoWrongActivation
+  <1>1. CASE GoodNext
+    \* Every good action leaves `wrong` unchanged and keeps `phase` in its
+    \* enum, so both conjuncts of IndInv are preserved.
+    <2>1. CASE StartSwitch
+      BY <2>1 DEF StartSwitch
+    <2>2. CASE Mutate
+      BY <2>2 DEF Mutate
+    <2>3. CASE CommitGood
+      BY <2>3 DEF CommitGood
+    <2>4. CASE Bail
+      BY <2>4 DEF Bail
+    <2>5. CASE Reset
+      BY <2>5 DEF Reset
+    <2> QED
+      BY <1>1, <2>1, <2>2, <2>3, <2>4, <2>5 DEF GoodNext
+  <1>2. CASE UNCHANGED vars
+    BY <1>2 DEF vars
+  <1> QED
+    BY <1>1, <1>2
+
+THEOREM Safety == GoodSpec => []Inv_NoWrongActivation
+  <1>1. Init => IndInv
+    BY InitInd
+  <1>2. IndInv /\ [GoodNext]_vars => IndInv'
+    BY StepInd
+  <1>3. IndInv => Inv_NoWrongActivation
+    BY DEF IndInv
+  <1> QED
+    BY <1>1, <1>2, <1>3, PTL DEF GoodSpec
+=============================================================================

--- a/formal/store_serial.cfg
+++ b/formal/store_serial.cfg
@@ -1,0 +1,9 @@
+\* Secure-storage serialisation, good: every read-modify-write is atomic
+\* (the static write lock), so the store only grows. Expect: invariants hold.
+CONSTANTS
+    N = 3
+    Conflict = "none"
+SPECIFICATION Spec
+INVARIANTS
+    TypeOK
+    Inv_NoLostUpdate

--- a/formal/store_serial.tla
+++ b/formal/store_serial.tla
@@ -1,0 +1,97 @@
+-------------------------- MODULE store_serial --------------------------
+(***************************************************************************)
+(* Secure-storage write serialisation (no lost update). The proxy-password  *)
+(* and cookie stores keep a single at-rest entry (a `key -> value` map) and  *)
+(* mutate it by read-modify-write. Several call sites -- and two separate    *)
+(* store instances that share the same storage key -- issue these           *)
+(* concurrently. Without serialisation a full-map write built from a stale   *)
+(* read snapshot clobbers a key another op just committed (a lost update:    *)
+(* a just-saved proxy password silently vanishes; an archive-tier cookie is  *)
+(* re-persisted into app-tier storage).                                      *)
+(*                                                                          *)
+(* The fix routes every mutation through a static write lock: each          *)
+(* read-modify-write runs as one atomic critical section. This model        *)
+(* abstracts that as an atomic `Rmw`. The "interleave" demonstrator splits   *)
+(* the read and the write (the unlocked path) and reaches a lost update.     *)
+(*                                                                          *)
+(*   Inv_NoLostUpdate == every completed op's key is still persisted        *)
+(*                                                                          *)
+(* Standalone model (a fixed N-op scenario; no shared kernel state), like   *)
+(* proxy.tla and archive.tla. Each op owns a distinct key (its own id), so  *)
+(* a dropped key is observable.                                             *)
+(***************************************************************************)
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+    N,         \* number of concurrent read-modify-write ops (TLC sets 3)
+    Conflict   \* "none" | "interleave"
+
+Ops == 1..N
+
+\* Each op persists its own id as a key. `store` is the set of keys currently
+\* committed to the shared entry; `done` the ops that have finished; `reading`
+\* + `snap` are the unlocked demonstrator's read snapshots.
+VARIABLES
+    store,     \* SUBSET Ops -- keys currently persisted
+    done,      \* SUBSET Ops -- ops that have completed their write
+    reading,   \* SUBSET Ops -- ops mid-way through an unlocked RMW
+    snap       \* Ops -> SUBSET Ops -- each mid-flight op's read snapshot
+
+vars == << store, done, reading, snap >>
+
+TypeOK ==
+    /\ store \subseteq Ops
+    /\ done \subseteq Ops
+    /\ reading \subseteq Ops
+    /\ snap \in [Ops -> SUBSET Ops]
+
+Init ==
+    /\ store = {}
+    /\ done = {}
+    /\ reading = {}
+    /\ snap = [o \in Ops |-> {}]
+
+\* GOOD path: the write lock makes read-modify-write one critical section.
+\* Modelled as an atomic add of this op's key -- the store only ever grows,
+\* so no committed key is dropped.
+Rmw(o) ==
+    /\ o \notin done
+    /\ o \notin reading
+    /\ store' = store \cup {o}
+    /\ done' = done \cup {o}
+    /\ UNCHANGED << reading, snap >>
+
+\* Demonstrator (unlocked): read the current key set into a snapshot, ...
+Read(o) ==
+    /\ o \notin done
+    /\ o \notin reading
+    /\ reading' = reading \cup {o}
+    /\ snap' = [snap EXCEPT ![o] = store]
+    /\ UNCHANGED << store, done >>
+
+\* ... then later write back the whole snapshot plus this op's key. A key
+\* another op committed after this op's read is not in `snap[o]`, so it is
+\* dropped -- the lost update.
+Write(o) ==
+    /\ o \in reading
+    /\ store' = snap[o] \cup {o}
+    /\ done' = done \cup {o}
+    /\ reading' = reading \ {o}
+    /\ UNCHANGED snap
+
+GoodNext == \E o \in Ops : Rmw(o)
+
+Next ==
+    \/ GoodNext
+    \/ (Conflict = "interleave" /\ \E o \in Ops : (Read(o) \/ Write(o)))
+
+Spec == Init /\ [][Next]_vars
+
+\* SAFETY: every op that finished still has its key persisted -- no committed
+\* write was lost. Broken by "interleave".
+Inv_NoLostUpdate == \A o \in Ops : o \in done => o \in store
+
+\* Anti-vacuity witness (expect violated): two ops can both complete, so the
+\* invariant is checked against real concurrent completion, not vacuously.
+Reach_TwoDone == ~(Cardinality(done) >= 2)
+=============================================================================

--- a/formal/store_serial.tla
+++ b/formal/store_serial.tla
@@ -53,10 +53,10 @@ Init ==
 
 \* GOOD path: the write lock makes read-modify-write one critical section.
 \* Modelled as an atomic add of this op's key -- the store only ever grows,
-\* so no committed key is dropped.
+\* so no committed key is dropped. Unguarded (a done op may idempotently
+\* re-save), so the action is perpetually enabled and the good model never
+\* deadlocks in a terminal all-done state (cf. proxy.tla's Activate).
 Rmw(o) ==
-    /\ o \notin done
-    /\ o \notin reading
     /\ store' = store \cup {o}
     /\ done' = done \cup {o}
     /\ UNCHANGED << reading, snap >>

--- a/formal/store_serial_lost.cfg
+++ b/formal/store_serial_lost.cfg
@@ -1,0 +1,9 @@
+\* Non-mix: the read and the write are split (the unlocked read-modify-write),
+\* so a full-map write from a stale snapshot drops a concurrently-committed
+\* key. Expect: Inv_NoLostUpdate VIOLATED.
+CONSTANTS
+    N = 3
+    Conflict = "interleave"
+SPECIFICATION Spec
+INVARIANTS
+    Inv_NoLostUpdate

--- a/formal/store_serial_reach.cfg
+++ b/formal/store_serial_reach.cfg
@@ -1,0 +1,9 @@
+\* Anti-vacuity: two ops can both complete. Expect: Reach_TwoDone VIOLATED
+\* (the counterexample is the proof that no-lost-update is checked against
+\* real concurrent completion).
+CONSTANTS
+    N = 3
+    Conflict = "none"
+SPECIFICATION Spec
+INVARIANTS
+    Reach_TwoDone

--- a/formal/switchguard.cfg
+++ b/formal/switchguard.cfg
@@ -1,0 +1,8 @@
+\* Site-switch version guard, good: a superseded switch bails instead of
+\* committing against a stale index. Expect: all invariants hold.
+CONSTANTS
+    Conflict = "none"
+SPECIFICATION Spec
+INVARIANTS
+    TypeOK
+    Inv_NoWrongActivation

--- a/formal/switchguard.tla
+++ b/formal/switchguard.tla
@@ -90,7 +90,7 @@ CommitNoGuard ==
     /\ phase = "running"
     /\ phase' = "committed"
     /\ dirty' = dirty
-    /\ wrong' = wrong \/ dirty
+    /\ wrong' = (wrong \/ dirty)
 
 GoodNext ==
     \/ StartSwitch

--- a/formal/switchguard.tla
+++ b/formal/switchguard.tla
@@ -1,0 +1,114 @@
+--------------------------- MODULE switchguard ---------------------------
+(***************************************************************************)
+(* Site-switch version guard vs a concurrent structural mutation. An        *)
+(* in-flight `_setCurrentIndex` captures a version at entry and, after each  *)
+(* await, activates the site at a positional index. A concurrent structural  *)
+(* mutation (`_deleteSite` / import / archive move) shifts that index and    *)
+(* bumps the version. The fix bumps `_setCurrentIndexVersion` on every such  *)
+(* mutation and re-checks it after each await, so a superseded switch bails  *)
+(* instead of resuming against a shifted list and activating the wrong site  *)
+(* (a cross-site cookie exposure in legacy mode).                            *)
+(*                                                                          *)
+(* This model abstracts the version counter as `dirty` (a mutation happened  *)
+(* since the switch started, i.e. the captured index is now stale). The      *)
+(* good commit is guarded by ~dirty (version unchanged) and otherwise bails; *)
+(* the "noguard" demonstrator commits regardless and, after a mutation,      *)
+(* latches a wrong activation.                                               *)
+(*                                                                          *)
+(*   Inv_NoWrongActivation == a committed switch never activated the wrong  *)
+(*                            site (never committed against a stale index)   *)
+(*                                                                          *)
+(* Standalone model (a UI-orchestration state machine; no shared kernel     *)
+(* state), like kiosk.tla and renderer.tla.                                  *)
+(***************************************************************************)
+EXTENDS Naturals
+
+CONSTANT Conflict   \* "none" | "noguard"
+
+VARIABLES
+    phase,   \* "idle" | "running" | "committed" | "bailed"
+    dirty,   \* a structural mutation occurred since this switch started
+    wrong    \* latched: a switch committed against a stale index (wrong site)
+
+vars == << phase, dirty, wrong >>
+
+TypeOK ==
+    /\ phase \in {"idle", "running", "committed", "bailed"}
+    /\ dirty \in BOOLEAN
+    /\ wrong \in BOOLEAN
+
+Init ==
+    /\ phase = "idle"
+    /\ dirty = FALSE
+    /\ wrong = FALSE
+
+\* Begin an in-flight switch: capture the (clean) version at entry.
+StartSwitch ==
+    /\ phase = "idle"
+    /\ phase' = "running"
+    /\ dirty' = FALSE
+    /\ wrong' = wrong
+
+\* A structural mutation during the switch (delete / import / archive move):
+\* it bumps the version, invalidating the captured index. Mutations outside a
+\* running switch have no captured index to invalidate, so are not modelled.
+Mutate ==
+    /\ phase = "running"
+    /\ dirty' = TRUE
+    /\ phase' = phase
+    /\ wrong' = wrong
+
+\* GOOD commit: the version guard passed (no mutation since entry), so the
+\* captured index still resolves to the intended site.
+CommitGood ==
+    /\ phase = "running"
+    /\ ~dirty
+    /\ phase' = "committed"
+    /\ dirty' = dirty
+    /\ wrong' = wrong
+
+\* GOOD bail: the version was bumped -> the guard fires, the switch aborts
+\* without activating anything.
+Bail ==
+    /\ phase = "running"
+    /\ dirty
+    /\ phase' = "bailed"
+    /\ dirty' = dirty
+    /\ wrong' = wrong
+
+\* Allow another switch episode; a latched wrong activation persists.
+Reset ==
+    /\ phase \in {"committed", "bailed"}
+    /\ phase' = "idle"
+    /\ dirty' = FALSE
+    /\ wrong' = wrong
+
+\* Demonstrator (unguarded): commit without the version check. If a mutation
+\* happened, the captured index is stale and the switch activates the wrong
+\* site.
+CommitNoGuard ==
+    /\ phase = "running"
+    /\ phase' = "committed"
+    /\ dirty' = dirty
+    /\ wrong' = wrong \/ dirty
+
+GoodNext ==
+    \/ StartSwitch
+    \/ Mutate
+    \/ CommitGood
+    \/ Bail
+    \/ Reset
+
+Next == GoodNext \/ (Conflict = "noguard" /\ CommitNoGuard)
+
+Spec == Init /\ [][Next]_vars
+
+\* SAFETY: no switch ever committed against a stale index. Broken by "noguard".
+Inv_NoWrongActivation == ~wrong
+
+\* Anti-vacuity witness (expect violated): a switch CAN reach the guarded-bail
+\* state -- i.e. the "mutation during an in-flight switch" scenario the guard
+\* protects against is actually reachable and handled by bailing (not by a
+\* wrong commit).
+Reach_Bailed == phase # "bailed"
+=============================================================================

--- a/formal/switchguard_noguard.cfg
+++ b/formal/switchguard_noguard.cfg
@@ -1,0 +1,8 @@
+\* Non-mix: the commit skips the version check, so a switch superseded by a
+\* structural mutation resumes against a shifted list and activates the wrong
+\* site. Expect: Inv_NoWrongActivation VIOLATED.
+CONSTANTS
+    Conflict = "noguard"
+SPECIFICATION Spec
+INVARIANTS
+    Inv_NoWrongActivation

--- a/formal/switchguard_reach.cfg
+++ b/formal/switchguard_reach.cfg
@@ -1,0 +1,8 @@
+\* Anti-vacuity: the guarded-bail state is reachable, so the guard actually
+\* fires on a mutation-during-switch. Expect: Reach_Bailed VIOLATED (the
+\* counterexample is the proof that the protected scenario really occurs).
+CONSTANTS
+    Conflict = "none"
+SPECIFICATION Spec
+INVARIANTS
+    Reach_Bailed

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2459,12 +2459,11 @@ class _WebSpacePageState extends State<WebSpacePage>
     // Mirror per-site proxy passwords into secure storage. The non-secret
     // proxy fields ride along in the SharedPreferences JSON via
     // `model.toJson()` (which omits password by default).
-    final existingPasswords = await _proxyPasswordStorage.loadAll();
-    final updatedPasswords = <String, String?>{...existingPasswords};
-    for (final m in appTierModels) {
-      updatedPasswords[m.siteId] = m.proxySettings.password;
-    }
-    await _proxyPasswordStorage.saveAll(updatedPasswords);
+    await _proxyPasswordStorage.mutate((draft) {
+      for (final m in appTierModels) {
+        draft[m.siteId] = m.proxySettings.password;
+      }
+    });
 
     // Save models to SharedPreferences (cookies will be empty in
     // SharedPreferences; proxy password is omitted by `toJson()` default —
@@ -2630,16 +2629,11 @@ class _WebSpacePageState extends State<WebSpacePage>
       await _cookieSecureStorage.saveCookiesForSite(sid, const []);
       await HtmlCacheService.instance.deleteCache(sid);
     }
-    final pwAll = await _proxyPasswordStorage.loadAll();
-    final pwPatch = <String, String?>{
-      ...pwAll,
-      for (final sid in slice.siteIds)
-        if (pwAll.containsKey(sid)) sid: null,
-    };
-    if (pwPatch.length != pwAll.length ||
-        slice.siteIds.any((sid) => pwAll.containsKey(sid))) {
-      await _proxyPasswordStorage.saveAll(pwPatch);
-    }
+    await _proxyPasswordStorage.mutate((draft) {
+      for (final sid in slice.siteIds) {
+        draft[sid] = null;
+      }
+    });
     final removedSet = slice.siteIds;
     // Invalidate any in-flight `_setCurrentIndex`: removing archive rows
     // shifts positions, and a concurrent switch bounds-checks but not by
@@ -2749,27 +2743,37 @@ class _WebSpacePageState extends State<WebSpacePage>
     // onCookiesChanged) when the webview hasn't been loaded.
     final capturedCookies = await _captureCookiesForTransfer(model);
 
+    // Derive the opaque archive container id up front so the tier flip below
+    // is atomic: never leave the model archive-tier with a null
+    // archiveContainerId (a webview rebuilt in that window would fall back to
+    // the cleartext `ws-<siteId>` container name).
+    final archiveContainerId =
+        await _deriveArchiveContainerId(target.key, model.siteId);
+
+    // Flip the tier (and bind the archive container) BEFORE dropping app-tier
+    // persistence (ARCH-001). A concurrent `_saveWebViewModels` filters on
+    // `!isArchiveTier` when it rebuilds the whole app-tier cookie/password
+    // maps; if the flip came after the clears, a save that snapshotted the
+    // site pre-flip could land after the clear and re-persist the
+    // archive-tier session into app-tier storage. Flipping first means any
+    // later snapshot excludes the site.
+    model.disposeWebView();
+    model.isArchiveTier = true;
+    model.archiveContainerId = archiveContainerId;
+    model.setPendingArchiveCookies(capturedCookies);
+
     // Drop app-tier persistence for this site so the next
     // _saveWebViewModels doesn't see it. The site's runtime row stays
     // in _webViewModels; only its tier and routing change.
     await _cookieSecureStorage.saveCookiesForSite(model.siteId, const []);
-    final passwords = await _proxyPasswordStorage.loadAll();
-    if (passwords.containsKey(model.siteId)) {
-      final next = <String, String?>{...passwords, model.siteId: null};
-      await _proxyPasswordStorage.saveAll(next);
-    }
+    await _proxyPasswordStorage.mutate((draft) {
+      draft[model.siteId] = null;
+    });
 
     // Drop the app-tier container (cleartext `ws-<siteId>`).
     if (_useContainers) {
       await _containerIsolation.onSiteDeleted(model.siteId);
     }
-
-    // Force a fresh webview that binds to the new opaque container.
-    model.disposeWebView();
-    model.isArchiveTier = true;
-    model.archiveContainerId =
-        await _deriveArchiveContainerId(target.key, model.siteId);
-    model.setPendingArchiveCookies(capturedCookies);
 
     // Track ownership for the close-archive flow.
     target.state.sites.add(model.toJson());
@@ -3427,7 +3431,11 @@ class _WebSpacePageState extends State<WebSpacePage>
       targetIndex: index,
       models: _webViewModels,
       loadedIndices: _loadedIndices,
-      proxyIsGlobal: Platform.isAndroid,
+      // Both Android and Linux drive a process-global, last-write-wins
+      // proxy (ProxyController fanned across sessions); a mismatched-proxy
+      // sibling left loaded would route its next request through the wrong
+      // proxy. iOS/macOS bind per-session, so no unload needed there.
+      proxyIsGlobal: Platform.isAndroid || Platform.isLinux,
     );
     for (final i in proxyMismatch) {
       LogService.instance.log(
@@ -3897,11 +3905,11 @@ class _WebSpacePageState extends State<WebSpacePage>
         }
       }
       if (legacyMigrations.isNotEmpty) {
-        final merged = <String, String?>{
-          ...secureProxyPasswords,
-          ...legacyMigrations,
-        };
-        await _proxyPasswordStorage.saveAll(merged);
+        await _proxyPasswordStorage.mutate((draft) {
+          // Don't overwrite an existing secure entry — the migration guard
+          // above only staged keys that were absent, so add-if-absent here.
+          legacyMigrations.forEach((k, v) => draft.putIfAbsent(k, () => v));
+        });
         await prefs.setStringList('webViewModels', cleanedJsonStrings);
         secureProxyPasswords.addAll(legacyMigrations);
         LogService.instance.log(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2299,7 +2299,9 @@ class _WebSpacePageState extends State<WebSpacePage>
       spoofTimezoneFromLocation: model.spoofTimezoneFromLocation,
       liveLocationGranularity: model.liveLocationGranularity,
       webRtcPolicy: model.webRtcPolicy,
-      userScripts: model.userScripts,
+      userAgent: model.userAgent.isNotEmpty ? model.userAgent : null,
+      javascriptEnabled: model.javascriptEnabled,
+      userScripts: model.combineUserScripts(_globalUserScripts),
       proxySettings: model.proxySettings,
       notificationsEnabled: model.effectiveNotificationsEnabled,
       externalLinksInBrowser: model.effectiveExternalLinksInBrowser,
@@ -2553,7 +2555,11 @@ class _WebSpacePageState extends State<WebSpacePage>
       // handle, no extra materialisation needed.
       return handle;
     }
-    _materialiseArchive(handle);
+    // Must complete before returning: callers (e.g. _moveSiteToArchive)
+    // mutate handle.state.sites and _archiveSlices[handle] as soon as this
+    // returns. A fire-and-forget here races the materialisation loop
+    // (ConcurrentModificationError) and leaves the slice unregistered.
+    await _materialiseArchive(handle);
     if (mounted) setState(() {});
     return handle;
   }
@@ -2562,7 +2568,7 @@ class _WebSpacePageState extends State<WebSpacePage>
   /// empty slice.
   Future<ArchiveHandle> _createArchive(String passphrase) async {
     final handle = await _archive.create(passphrase);
-    _materialiseArchive(handle);
+    await _materialiseArchive(handle);
     if (mounted) setState(() {});
     return handle;
   }
@@ -2635,6 +2641,10 @@ class _WebSpacePageState extends State<WebSpacePage>
       await _proxyPasswordStorage.saveAll(pwPatch);
     }
     final removedSet = slice.siteIds;
+    // Invalidate any in-flight `_setCurrentIndex`: removing archive rows
+    // shifts positions, and a concurrent switch bounds-checks but not by
+    // identity, so it could resume against the wrong site.
+    ++_setCurrentIndexVersion;
     if (_currentIndex != null) {
       final cur = _currentIndex!;
       if (cur < _webViewModels.length &&
@@ -4674,6 +4684,8 @@ class _WebSpacePageState extends State<WebSpacePage>
     bool spoofTimezoneFromLocation = false,
     LocationGranularity liveLocationGranularity = LocationGranularity.gps,
     WebRtcPolicy webRtcPolicy = WebRtcPolicy.defaultPolicy,
+    String? userAgent,
+    bool javascriptEnabled = true,
     required List<UserScriptConfig> userScripts,
     UserProxySettings? proxySettings,
     bool notificationsEnabled = false,
@@ -4708,6 +4720,8 @@ class _WebSpacePageState extends State<WebSpacePage>
           spoofTimezoneFromLocation: spoofTimezoneFromLocation,
           liveLocationGranularity: liveLocationGranularity,
           webRtcPolicy: webRtcPolicy,
+          userAgent: userAgent,
+          javascriptEnabled: javascriptEnabled,
           userScripts: userScripts,
           onConfirmScriptFetch: _confirmScriptFetch,
           onProtectedMediaRequest: _promptProtectedMedia,
@@ -5208,6 +5222,10 @@ class _WebSpacePageState extends State<WebSpacePage>
 
     // Apply the imported settings
     setState(() {
+      // Invalidate any in-flight `_setCurrentIndex`/`_selectWebspace` that
+      // captured the pre-import list: the clear+replace below shifts every
+      // index out from under them.
+      ++_setCurrentIndexVersion;
       // Clear existing data
       _webViewModels.clear();
       _webspaces.clear();
@@ -6184,6 +6202,8 @@ class _WebSpacePageState extends State<WebSpacePage>
                   spoofTimezoneFromLocation: model.spoofTimezoneFromLocation,
                   liveLocationGranularity: model.liveLocationGranularity,
                   webRtcPolicy: model.webRtcPolicy,
+                  userAgent: model.userAgent.isNotEmpty ? model.userAgent : null,
+                  javascriptEnabled: model.javascriptEnabled,
                   userScripts: model.combineUserScripts(_globalUserScripts),
                   proxySettings: model.proxySettings,
                   notificationsEnabled: model.notificationsEnabled,
@@ -6815,6 +6835,12 @@ class _WebSpacePageState extends State<WebSpacePage>
       currentIndex: _currentIndex,
     );
     setState(() {
+      // Invalidate any in-flight `_setCurrentIndex`: it mutates
+      // `_loadedIndices`/`_currentIndex` by positional index and only
+      // bounds-checks after its awaits, so a concurrent switch would
+      // otherwise resume against a shifted list and activate the wrong
+      // site (cross-site cookie exposure in legacy mode).
+      ++_setCurrentIndexVersion;
       _webViewModels.removeAt(currentModelIndex);
       _loadedIndices
         ..clear()

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -52,6 +52,10 @@ class InAppWebViewScreen extends StatefulWidget {
   /// over from the parent webview so cosmetic/privacy/custom scripts keep
   /// working when the user follows an outbound link into a nested screen.
   final List<UserScriptConfig> userScripts;
+  // Per-site posture that must not silently revert on the untrusted nested
+  // surface: a custom/desktop UA and a JS-disabled hardening choice.
+  final String? userAgent;
+  final bool javascriptEnabled;
   final Future<bool> Function(String url)? onConfirmScriptFetch;
   /// Protected-content (Widevine/EME) permission popup, forwarded from the
   /// parent so a DRM site followed through an outbound link prompts the
@@ -102,6 +106,8 @@ class InAppWebViewScreen extends StatefulWidget {
     this.liveLocationGranularity = LocationGranularity.gps,
     this.webRtcPolicy = WebRtcPolicy.defaultPolicy,
     this.userScripts = const [],
+    this.userAgent,
+    this.javascriptEnabled = true,
     this.onConfirmScriptFetch,
     this.onProtectedMediaRequest,
     this.onShowUrlBarChanged,
@@ -208,6 +214,8 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
         // mirroring the main screen's handleRendererGone.
         onRendererGone: (didCrash) => _handleRendererGone(didCrash),
         incognito: widget.incognito,
+        javascriptEnabled: widget.javascriptEnabled,
+        userAgent: widget.userAgent,
         thirdPartyCookiesEnabled: widget.thirdPartyCookiesEnabled,
         // Mirror parent: when umbrella protection is on, force the four
         // tracker-protection subordinates effectively-on regardless of

--- a/lib/services/cookie_isolation.dart
+++ b/lib/services/cookie_isolation.dart
@@ -153,12 +153,17 @@ class CookieIsolationEngine {
 
     // Step 3: nuke.
     await cookieManager.deleteAllCookies();
-    if (versionAtEntry != currentVersion()) return;
+    // No version-guard bail from here on. Once the shared jar is emptied it
+    // MUST be fully repopulated before returning: a bail here leaves the jar
+    // empty, and the next activation captures that emptiness in step 2 and
+    // persists it via saveCookiesForSite(siteId, []), which deletes every
+    // loaded site's stored session. Finishing the restore is cheap (writes
+    // known-good storage data back) and a superseding activation re-runs its
+    // own capture-nuke-restore against the now-consistent jar.
 
     // Step 4a: restore target's cookies.
     final cookies = await storage.loadCookiesForSite(model.siteId);
     model.cookies = cookies;
-    if (versionAtEntry != currentVersion()) return;
 
     LogService.instance.log(
       'CookieIsolation',
@@ -167,12 +172,10 @@ class CookieIsolationEngine {
     );
 
     await _setCookies(model, cookies);
-    if (versionAtEntry != currentVersion()) return;
 
     // Step 4b: restore every other still-loaded site's cookies.
     for (final other in otherLoadedModels) {
       await _setCookies(other, other.cookies);
-      if (versionAtEntry != currentVersion()) return;
     }
   }
 

--- a/lib/services/cookie_secure_storage.dart
+++ b/lib/services/cookie_secure_storage.dart
@@ -41,6 +41,19 @@ class CookieSecureStorage {
   final FlutterSecureStorage _secureStorage;
   bool _secureStorageAvailable = true;
 
+  /// Serializes every cookie-store mutation. Static so it is shared across
+  /// instances that write the same keys: a whole-map `saveCookies` rebuilt
+  /// from an in-memory snapshot must not interleave with a per-site
+  /// `saveCookiesForSite`, or one clobbers the other (dropped session, or an
+  /// archive-tier cookie re-persisted into app-tier storage — ARCH-001).
+  static Future<void> _writeLock = Future<void>.value();
+
+  Future<T> _synchronized<T>(Future<T> Function() action) {
+    final result = _writeLock.then((_) => action());
+    _writeLock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
   CookieSecureStorage({FlutterSecureStorage? secureStorage})
       : _secureStorage = secureStorage ?? const FlutterSecureStorage(
           aOptions: AndroidOptions(encryptedSharedPreferences: true),
@@ -74,7 +87,9 @@ class CookieSecureStorage {
     if (result.isEmpty) {
       final legacyCookies = await _loadLegacyFromSharedPreferences();
       if (legacyCookies.isNotEmpty) {
-        await saveCookies(legacyCookies);
+        // Unlocked: loadCookies runs inside the locked compound mutators
+        // below, so calling the locked saveCookies here would self-deadlock.
+        await _saveCookiesUnlocked(legacyCookies);
         await _markMigrationComplete();
         return legacyCookies;
       }
@@ -86,7 +101,11 @@ class CookieSecureStorage {
   /// Saves cookies with appropriate storage based on isSecure flag:
   /// - isSecure=true cookies → Flutter Secure Storage only
   /// - isSecure=false cookies → SharedPreferences
-  Future<void> saveCookies(Map<String, List<Cookie>> cookiesByUrl) async {
+  Future<void> saveCookies(Map<String, List<Cookie>> cookiesByUrl) {
+    return _synchronized(() => _saveCookiesUnlocked(cookiesByUrl));
+  }
+
+  Future<void> _saveCookiesUnlocked(Map<String, List<Cookie>> cookiesByUrl) async {
     if (isDemoMode) return; // Don't persist in demo mode
 
     // Split cookies by security flag
@@ -137,12 +156,14 @@ class CookieSecureStorage {
 
   /// Saves cookies for a single site URL.
   /// The URL is converted to a domain key before storing.
-  Future<void> saveCookiesForUrl(String url, List<Cookie> cookies) async {
-    if (isDemoMode) return; // Don't persist in demo mode
-    final domain = extractDomainFromUrl(url);
-    final existingCookies = await loadCookies();
-    existingCookies[domain] = cookies;
-    await saveCookies(existingCookies);
+  Future<void> saveCookiesForUrl(String url, List<Cookie> cookies) {
+    if (isDemoMode) return Future.value(); // Don't persist in demo mode
+    return _synchronized(() async {
+      final domain = extractDomainFromUrl(url);
+      final existingCookies = await loadCookies();
+      existingCookies[domain] = cookies;
+      await _saveCookiesUnlocked(existingCookies);
+    });
   }
 
   /// Loads cookies for a specific site by siteId.
@@ -153,35 +174,35 @@ class CookieSecureStorage {
   }
 
   /// Saves cookies for a specific site by siteId.
-  Future<void> saveCookiesForSite(String siteId, List<Cookie> cookies) async {
-    if (isDemoMode) return; // Don't persist in demo mode
-    final existingCookies = await loadCookies();
-    if (cookies.isEmpty) {
-      existingCookies.remove(siteId);
-    } else {
-      existingCookies[siteId] = cookies;
-    }
-    await saveCookies(existingCookies);
+  Future<void> saveCookiesForSite(String siteId, List<Cookie> cookies) {
+    if (isDemoMode) return Future.value(); // Don't persist in demo mode
+    return _synchronized(() async {
+      final existingCookies = await loadCookies();
+      if (cookies.isEmpty) {
+        existingCookies.remove(siteId);
+      } else {
+        existingCookies[siteId] = cookies;
+      }
+      await _saveCookiesUnlocked(existingCookies);
+    });
   }
 
   /// Removes cookies for siteIds not in the provided set of active siteIds.
   /// This cleans up orphaned cookies after sites are deleted or settings are imported.
   Future<void> removeOrphanedCookies(Set<String> activeSiteIds) async {
     if (isDemoMode) return; // Don't persist in demo mode
-    final allCookies = await loadCookies();
-    final siteIdsToRemove = allCookies.keys
-        .where((siteId) => !activeSiteIds.contains(siteId))
-        .toList();
-
-    if (siteIdsToRemove.isEmpty) {
-      return;
-    }
-
-    for (final siteId in siteIdsToRemove) {
-      allCookies.remove(siteId);
-    }
-
-    await saveCookies(allCookies);
+    final siteIdsToRemove = <String>[];
+    await _synchronized(() async {
+      final allCookies = await loadCookies();
+      siteIdsToRemove.addAll(allCookies.keys
+          .where((siteId) => !activeSiteIds.contains(siteId)));
+      if (siteIdsToRemove.isEmpty) return;
+      for (final siteId in siteIdsToRemove) {
+        allCookies.remove(siteId);
+      }
+      await _saveCookiesUnlocked(allCookies);
+    });
+    if (siteIdsToRemove.isEmpty) return;
     LogService.instance.log(
       'CookieStorage',
       'Removed orphaned cookies for siteIds: $siteIdsToRemove',

--- a/lib/services/outbound_http.dart
+++ b/lib/services/outbound_http.dart
@@ -101,7 +101,10 @@ class DefaultOutboundHttpFactory implements OutboundHttpFactory {
       case ProxyType.HTTPS:
         final addr = settings.address;
         if (addr == null || addr.isEmpty) {
-          return OutboundClientReady(IOClient(_newHttpClient()));
+          return OutboundClientBlocked(
+            'Proxy type is set but the address is empty. Outbound request '
+            'blocked to avoid leaking the device IP via a direct fallback.',
+          );
         }
         final hostPort = parseHostPort(addr);
         if (hostPort == null) {
@@ -129,7 +132,11 @@ class DefaultOutboundHttpFactory implements OutboundHttpFactory {
       case ProxyType.SOCKS5:
         final addr = settings.address;
         if (addr == null || addr.isEmpty) {
-          return OutboundClientReady(IOClient(_newHttpClient()));
+          return OutboundClientBlocked(
+            'SOCKS5 proxy type is set but the address is empty. Outbound '
+            'request blocked to avoid leaking the device IP via a direct '
+            'fallback.',
+          );
         }
         final hostPort = parseHostPort(addr);
         if (hostPort == null) {

--- a/lib/services/proxy_password_secure_storage.dart
+++ b/lib/services/proxy_password_secure_storage.dart
@@ -34,6 +34,20 @@ class ProxyPasswordSecureStorage {
   final FlutterSecureStorage _secureStorage;
   bool _secureStorageAvailable = true;
 
+  /// Serializes every mutation of the single `proxy_passwords` entry.
+  /// Static so it is shared across instances: the app keeps two separate
+  /// stores (per-site via `_WebSpacePageState`, global via
+  /// `GlobalOutboundProxy`) that both write this key, and an unsynchronized
+  /// load-modify-save on one would otherwise clobber a concurrent write from
+  /// the other (silently dropping a just-saved proxy password).
+  static Future<void> _writeLock = Future<void>.value();
+
+  Future<T> _synchronized<T>(Future<T> Function() action) {
+    final result = _writeLock.then((_) => action());
+    _writeLock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
   ProxyPasswordSecureStorage({FlutterSecureStorage? secureStorage})
       : _secureStorage = secureStorage ??
             const FlutterSecureStorage(
@@ -73,7 +87,16 @@ class ProxyPasswordSecureStorage {
 
   /// Replace the entire `key -> password` map in secure storage.
   /// Empty values are stripped; an empty resulting map deletes the entry.
-  Future<void> saveAll(Map<String, String?> passwords) async {
+  ///
+  /// Prefer [mutate] when the new map is derived from the current stored
+  /// state: a bare `loadAll` + `saveAll` pair is not atomic and can lose a
+  /// concurrent write. [saveAll] itself is serialized, but the caller's read
+  /// is not part of that critical section.
+  Future<void> saveAll(Map<String, String?> passwords) {
+    return _synchronized(() => _saveAllUnlocked(passwords));
+  }
+
+  Future<void> _saveAllUnlocked(Map<String, String?> passwords) async {
     if (!_secureStorageAvailable) return;
     final filtered = <String, String>{};
     passwords.forEach((k, v) {
@@ -98,15 +121,27 @@ class ProxyPasswordSecureStorage {
     }
   }
 
+  /// Atomically read the current map, apply [update] to a mutable draft, and
+  /// write the result back — all inside the write lock, so the read and the
+  /// write are one critical section and no concurrent writer can interleave.
+  /// Set a key to null in the draft to delete it.
+  Future<void> mutate(void Function(Map<String, String?> draft) update) {
+    return _synchronized(() async {
+      final draft = <String, String?>{...await loadAll()};
+      update(draft);
+      await _saveAllUnlocked(draft);
+    });
+  }
+
   /// Set or clear the password for a single key. Pass null/empty to delete.
-  Future<void> savePassword(String key, String? password) async {
-    final all = await loadAll();
-    if (password == null || password.isEmpty) {
-      all.remove(key);
-    } else {
-      all[key] = password;
-    }
-    await saveAll(all);
+  Future<void> savePassword(String key, String? password) {
+    return mutate((draft) {
+      if (password == null || password.isEmpty) {
+        draft.remove(key);
+      } else {
+        draft[key] = password;
+      }
+    });
   }
 
   /// Drop entries for keys not present in [activeKeys]. Mirrors
@@ -114,18 +149,18 @@ class ProxyPasswordSecureStorage {
   /// or restoring a backup so we don't accumulate stale passwords for sites
   /// that no longer exist.
   Future<void> removeOrphaned(Set<String> activeKeys) async {
-    final all = await loadAll();
     final removed = <String>[];
-    for (final key in all.keys.toList()) {
-      // Always preserve the global key; it's not tied to a site.
-      if (key == globalProxyKey) continue;
-      if (!activeKeys.contains(key)) {
-        all.remove(key);
-        removed.add(key);
+    await mutate((draft) {
+      for (final key in draft.keys.toList()) {
+        // Always preserve the global key; it's not tied to a site.
+        if (key == globalProxyKey) continue;
+        if (!activeKeys.contains(key)) {
+          draft.remove(key);
+          removed.add(key);
+        }
       }
-    }
+    });
     if (removed.isNotEmpty) {
-      await saveAll(all);
       LogService.instance.log(
         'ProxyPwdStore',
         'Removed orphaned proxy passwords for keys: $removed',

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -2425,10 +2425,21 @@ class WebViewFactory {
     // through to the app-global outbound proxy, so a site the user
     // hasn't customized still inherits a global Tor / corporate proxy.
     // Explicit per-site values win.
-    final inappProxy = (Platform.isIOS || Platform.isMacOS) &&
+    final effectiveProxy = (Platform.isIOS || Platform.isMacOS) &&
             config.proxySettings != null
-        ? _userProxyToInappProxy(resolveEffectiveProxy(config.proxySettings!))
+        ? resolveEffectiveProxy(config.proxySettings!)
         : null;
+    final inappProxy =
+        effectiveProxy != null ? _userProxyToInappProxy(effectiveProxy) : null;
+    // Fail closed: on iOS/macOS the per-site proxy is bound here via
+    // `proxySettings`. If the site expects a non-DEFAULT proxy but the
+    // address is malformed (e.g. a hand-edited backup that bypassed UI
+    // validation), `_userProxyToInappProxy` returns null and the webview
+    // would otherwise load over the device IP. Blank the initial load
+    // instead of leaking.
+    final proxyUnavailable = effectiveProxy != null &&
+        effectiveProxy.type != ProxyType.DEFAULT &&
+        inappProxy == null;
 
     LogService.instance.log(
       'DnsBlock',
@@ -2517,8 +2528,8 @@ class WebViewFactory {
     final inapp.InAppWebView webViewWidget = inapp.InAppWebView(
       key: config.key,
       initialUrlRequest: (renderInitialData || suppressInitialLoad) ? null : inapp.URLRequest(
-        url: inapp.WebUri(config.initialUrl),
-        headers: headers.isNotEmpty ? headers : null,
+        url: inapp.WebUri(proxyUnavailable ? 'about:blank' : config.initialUrl),
+        headers: proxyUnavailable || headers.isEmpty ? null : headers,
       ),
       initialData: renderInitialData ? inapp.InAppWebViewInitialData(
         data: config.initialHtml ?? buildFileImportFallbackHtml(config.initialUrl),

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1183,12 +1183,12 @@ String _notificationPolyfillScript({
       body: String(options.body || ''),
       icon: String(options.icon || ''),
       tag: String(options.tag || ''),
-      siteId: '$siteId'
+      siteId: ${jsonEncode(siteId)}
     });
   }
   Notification.permission = permission;
   Notification.requestPermission = function(cb) {
-    var p = window.flutter_inappwebview.callHandler('webNotificationRequestPermission', {siteId: '$siteId'})
+    var p = window.flutter_inappwebview.callHandler('webNotificationRequestPermission', {siteId: ${jsonEncode(siteId)}})
       .then(function(result) { permission = result; Notification.permission = result; return result; });
     if (typeof cb === 'function') p.then(cb);
     return p;
@@ -1899,6 +1899,9 @@ class WebViewFactory {
         groupName: 'language_override',
         source: '${buildLanguageShim(config.language!)}\n;null;',
         injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
+        // Must reach cross-origin iframes; otherwise a subframe reports the
+        // real OS locale, contradicting the spoofed top frame (fingerprint).
+        forMainFrameOnly: false,
       ));
     }
 
@@ -2822,7 +2825,10 @@ class WebViewFactory {
               final title = data['title'] as String? ?? '';
               final body = data['body'] as String? ?? '';
               final tag = data['tag'] as String?;
-              final siteId = data['siteId'] as String? ?? config.siteId!;
+              // Ignore any page-supplied siteId: a hostile script could
+              // otherwise attribute a notification (and its tap-target site
+              // switch) to another site the user never granted permission to.
+              final siteId = config.siteId!;
               await NotificationService.instance.show(
                 siteId: siteId,
                 title: title,

--- a/lib/settings/user_script.dart
+++ b/lib/settings/user_script.dart
@@ -77,6 +77,16 @@ ScriptFetchUrlStatus classifyScriptFetchUrl(String url) {
   final host = uri.host.toLowerCase();
   if (host.isEmpty) return ScriptFetchUrlStatus.blocked;
 
+  // SSRF guard: window.__wsFetch is a page-reachable global, so any script
+  // on a user-script-enabled site (including third-party page scripts) can
+  // drive this fetch. Block loopback / private / link-local literal hosts so
+  // it can't reach localhost services, the LAN, or cloud metadata
+  // (169.254.169.254). Hostnames that resolve to those ranges are not caught
+  // here (DNS rebinding); this blocks the direct IP-literal vector.
+  if (_isPrivateOrLoopbackHost(host)) {
+    return ScriptFetchUrlStatus.blocked;
+  }
+
   // Check whitelist: exact match or subdomain match
   for (final domain in scriptFetchWhitelist) {
     if (host == domain || host.endsWith('.$domain')) {
@@ -85,6 +95,47 @@ ScriptFetchUrlStatus classifyScriptFetchUrl(String url) {
   }
 
   return ScriptFetchUrlStatus.requiresConfirmation;
+}
+
+/// True if [host] is a loopback, private (RFC1918), unique-local, or
+/// link-local literal address (IPv4 or IPv6), or the `localhost` name.
+/// Used to fail-closed SSRF-style fetches from the page-reachable bridge.
+bool _isPrivateOrLoopbackHost(String host) {
+  if (host == 'localhost' || host.endsWith('.localhost')) return true;
+
+  // IPv6 literal (Uri.host strips the surrounding brackets).
+  if (host.contains(':')) {
+    final h = host.split('%').first; // drop any zone id
+    if (h == '::1' || h == '::') return true;
+    // fc00::/7 unique-local, fe80::/10 link-local.
+    if (h.startsWith('fc') || h.startsWith('fd')) return true;
+    if (h.startsWith('fe8') ||
+        h.startsWith('fe9') ||
+        h.startsWith('fea') ||
+        h.startsWith('feb')) {
+      return true;
+    }
+    return false;
+  }
+
+  // IPv4 dotted-quad.
+  final parts = host.split('.');
+  if (parts.length == 4) {
+    final octets = <int>[];
+    for (final p in parts) {
+      final v = int.tryParse(p);
+      if (v == null || v < 0 || v > 255) return false; // not an IPv4 literal
+      octets.add(v);
+    }
+    final a = octets[0], b = octets[1];
+    if (a == 0) return true; // 0.0.0.0/8
+    if (a == 127) return true; // loopback
+    if (a == 10) return true; // private
+    if (a == 172 && b >= 16 && b <= 31) return true; // private
+    if (a == 192 && b == 168) return true; // private
+    if (a == 169 && b == 254) return true; // link-local + cloud metadata
+  }
+  return false;
 }
 
 /// Generate a stable unique identifier for a user script.

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -712,6 +712,17 @@ class WebViewModel {
         // proxy (including archive-tier sites). Keep in the memory ring.
         sensitivity: LogSensitivity.sensitive,
       );
+      // Fail closed: ProxyManager.setProxySettings throws precisely to
+      // refuse a direct fallback (relay bind failure, malformed host:port).
+      // If the site expected a real proxy, swallowing the throw would let
+      // the already-initialized page load over the device IP. Blank the
+      // load instead of leaking.
+      if (proxySettings.type != ProxyType.DEFAULT) {
+        try {
+          await controller?.stopLoading();
+          await controller?.loadUrl('about:blank');
+        } catch (_) {}
+      }
     }
   }
 
@@ -768,7 +779,7 @@ class WebViewModel {
   }
 
   Widget getWebView(
-    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required bool localCdnEnabled, required bool trackingProtectionEnabled, bool letterboxEnabled, int? spoofWindowWidth, int? spoofWindowHeight, String? fingerprintResetNonce, required String? language, required int zoomPercent, LocationMode locationMode, double? spoofLatitude, double? spoofLongitude, double spoofAccuracy, String? spoofTimezone, bool spoofTimezoneFromLocation, LocationGranularity liveLocationGranularity, WebRtcPolicy webRtcPolicy, required List<UserScriptConfig> userScripts, UserProxySettings? proxySettings, bool notificationsEnabled, bool externalLinksInBrowser}) launchUrlFunc,
+    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required bool localCdnEnabled, required bool trackingProtectionEnabled, bool letterboxEnabled, int? spoofWindowWidth, int? spoofWindowHeight, String? fingerprintResetNonce, required String? language, required int zoomPercent, LocationMode locationMode, double? spoofLatitude, double? spoofLongitude, double spoofAccuracy, String? spoofTimezone, bool spoofTimezoneFromLocation, LocationGranularity liveLocationGranularity, WebRtcPolicy webRtcPolicy, String? userAgent, bool javascriptEnabled, required List<UserScriptConfig> userScripts, UserProxySettings? proxySettings, bool notificationsEnabled, bool externalLinksInBrowser}) launchUrlFunc,
     CookieManager cookieManager,
     ContainerCookieManager? containerCookieManager,
     Function saveFunc, {
@@ -979,7 +990,7 @@ class WebViewModel {
                   '  -> CANCEL (opening nested webview)',
                   sensitivity: LogSensitivity.sensitive,
                 );
-                launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, localCdnEnabled: localCdnEnabled, trackingProtectionEnabled: trackingProtectionEnabled, letterboxEnabled: letterboxEnabled, spoofWindowWidth: spoofWindowWidth, spoofWindowHeight: spoofWindowHeight, fingerprintResetNonce: fingerprintResetNonce, language: this.language, zoomPercent: zoomPercent, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, liveLocationGranularity: liveLocationGranularity, webRtcPolicy: webRtcPolicy, userScripts: combineUserScripts(globalUserScripts), proxySettings: proxySettings, notificationsEnabled: notificationsEnabled, externalLinksInBrowser: effectiveExternalLinksInBrowser);
+                launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, localCdnEnabled: localCdnEnabled, trackingProtectionEnabled: trackingProtectionEnabled, letterboxEnabled: letterboxEnabled, spoofWindowWidth: spoofWindowWidth, spoofWindowHeight: spoofWindowHeight, fingerprintResetNonce: fingerprintResetNonce, language: this.language, zoomPercent: zoomPercent, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, liveLocationGranularity: liveLocationGranularity, webRtcPolicy: webRtcPolicy, userAgent: userAgent.isNotEmpty ? userAgent : null, javascriptEnabled: javascriptEnabled, userScripts: combineUserScripts(globalUserScripts), proxySettings: proxySettings, notificationsEnabled: notificationsEnabled, externalLinksInBrowser: effectiveExternalLinksInBrowser);
                 return false;
               case NavigationDecision.blockOpenExternal:
                 LogService.instance.log(
@@ -1071,7 +1082,7 @@ class WebViewModel {
                     sensitivity: LogSensitivity.sensitive,
                   );
                   if (handled.launchNestedUrl != null) {
-                    launchUrlFunc(handled.launchNestedUrl!, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, localCdnEnabled: localCdnEnabled, trackingProtectionEnabled: trackingProtectionEnabled, letterboxEnabled: letterboxEnabled, spoofWindowWidth: spoofWindowWidth, spoofWindowHeight: spoofWindowHeight, fingerprintResetNonce: fingerprintResetNonce, language: this.language, zoomPercent: zoomPercent, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, liveLocationGranularity: liveLocationGranularity, webRtcPolicy: webRtcPolicy, userScripts: combineUserScripts(globalUserScripts), proxySettings: proxySettings, notificationsEnabled: notificationsEnabled, externalLinksInBrowser: effectiveExternalLinksInBrowser);
+                    launchUrlFunc(handled.launchNestedUrl!, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, localCdnEnabled: localCdnEnabled, trackingProtectionEnabled: trackingProtectionEnabled, letterboxEnabled: letterboxEnabled, spoofWindowWidth: spoofWindowWidth, spoofWindowHeight: spoofWindowHeight, fingerprintResetNonce: fingerprintResetNonce, language: this.language, zoomPercent: zoomPercent, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, liveLocationGranularity: liveLocationGranularity, webRtcPolicy: webRtcPolicy, userAgent: userAgent.isNotEmpty ? userAgent : null, javascriptEnabled: javascriptEnabled, userScripts: combineUserScripts(globalUserScripts), proxySettings: proxySettings, notificationsEnabled: notificationsEnabled, externalLinksInBrowser: effectiveExternalLinksInBrowser);
                   }
                   return;
                 case NavigationDecision.blockOpenExternal:
@@ -1279,7 +1290,7 @@ class WebViewModel {
   }
 
   WebViewController? getController(
-    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required bool localCdnEnabled, required bool trackingProtectionEnabled, bool letterboxEnabled, int? spoofWindowWidth, int? spoofWindowHeight, String? fingerprintResetNonce, required String? language, required int zoomPercent, LocationMode locationMode, double? spoofLatitude, double? spoofLongitude, double spoofAccuracy, String? spoofTimezone, bool spoofTimezoneFromLocation, LocationGranularity liveLocationGranularity, WebRtcPolicy webRtcPolicy, required List<UserScriptConfig> userScripts, UserProxySettings? proxySettings, bool notificationsEnabled, bool externalLinksInBrowser}) launchUrlFunc,
+    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required bool localCdnEnabled, required bool trackingProtectionEnabled, bool letterboxEnabled, int? spoofWindowWidth, int? spoofWindowHeight, String? fingerprintResetNonce, required String? language, required int zoomPercent, LocationMode locationMode, double? spoofLatitude, double? spoofLongitude, double spoofAccuracy, String? spoofTimezone, bool spoofTimezoneFromLocation, LocationGranularity liveLocationGranularity, WebRtcPolicy webRtcPolicy, String? userAgent, bool javascriptEnabled, required List<UserScriptConfig> userScripts, UserProxySettings? proxySettings, bool notificationsEnabled, bool externalLinksInBrowser}) launchUrlFunc,
     CookieManager cookieManager,
     ContainerCookieManager? containerCookieManager,
     Function saveFunc, {

--- a/test/outbound_http_test.dart
+++ b/test/outbound_http_test.dart
@@ -95,12 +95,11 @@ void main() {
       (result as OutboundClientReady).client.close();
     });
 
-    test('HTTP with empty address returns a Ready client (treated as DEFAULT)', () {
+    test('HTTP with empty address returns Blocked (no direct fallback)', () {
       final result = factory.clientFor(
         UserProxySettings(type: ProxyType.HTTP, address: ''),
       );
-      expect(result, isA<OutboundClientReady>());
-      (result as OutboundClientReady).client.close();
+      expect(result, isA<OutboundClientBlocked>());
     });
 
     test('HTTPS with malformed address returns Blocked (no direct fallback)', () {
@@ -129,12 +128,12 @@ void main() {
       expect((result as OutboundClientBlocked).reason, contains('SOCKS5'));
     });
 
-    test('SOCKS5 with empty address returns a Ready client (no override)', () {
+    test('SOCKS5 with empty address returns Blocked (no direct fallback)', () {
       final result = factory.clientFor(
         UserProxySettings(type: ProxyType.SOCKS5, address: ''),
       );
-      expect(result, isA<OutboundClientReady>());
-      (result as OutboundClientReady).client.close();
+      expect(result, isA<OutboundClientBlocked>());
+      expect((result as OutboundClientBlocked).reason, contains('SOCKS5'));
     });
   });
 

--- a/test/user_script_test.dart
+++ b/test/user_script_test.dart
@@ -304,37 +304,54 @@ void main() {
       );
     });
 
-    test('should require confirmation for http localhost', () {
+    // SSRF guard: __wsFetch is a page-reachable global, so loopback /
+    // private / link-local hosts must be blocked outright, not merely
+    // gated behind a confirmation prompt.
+    test('should block http localhost', () {
       expect(
         classifyScriptFetchUrl('http://localhost:8080/script.js'),
-        ScriptFetchUrlStatus.requiresConfirmation,
+        ScriptFetchUrlStatus.blocked,
       );
     });
 
-    test('should require confirmation for IPv4 address', () {
+    test('should block private IPv4 address', () {
       expect(
         classifyScriptFetchUrl('http://192.168.1.1/scripts/app.js'),
-        ScriptFetchUrlStatus.requiresConfirmation,
+        ScriptFetchUrlStatus.blocked,
       );
     });
 
-    test('should require confirmation for IPv4 with port', () {
+    test('should block private IPv4 with port', () {
       expect(
         classifyScriptFetchUrl('http://192.168.1.1:3000/bundle.js'),
-        ScriptFetchUrlStatus.requiresConfirmation,
+        ScriptFetchUrlStatus.blocked,
       );
     });
 
-    test('should require confirmation for IPv6 address', () {
+    test('should block loopback IPv6 address', () {
       expect(
         classifyScriptFetchUrl('http://[::1]/script.js'),
-        ScriptFetchUrlStatus.requiresConfirmation,
+        ScriptFetchUrlStatus.blocked,
       );
     });
 
-    test('should require confirmation for IPv6 with port', () {
+    test('should block loopback IPv6 with port', () {
       expect(
         classifyScriptFetchUrl('http://[::1]:8080/script.js'),
+        ScriptFetchUrlStatus.blocked,
+      );
+    });
+
+    test('should block cloud-metadata link-local address', () {
+      expect(
+        classifyScriptFetchUrl('http://169.254.169.254/latest/meta-data/'),
+        ScriptFetchUrlStatus.blocked,
+      );
+    });
+
+    test('still requires confirmation for a public IPv4 literal', () {
+      expect(
+        classifyScriptFetchUrl('http://93.184.216.34/script.js'),
         ScriptFetchUrlStatus.requiresConfirmation,
       );
     });


### PR DESCRIPTION
Security and correctness fixes across script fetching, state management, and proxy/notification handling.

**SSRF protection for user scripts**
- Add `_isPrivateOrLoopbackHost()` to block fetches to loopback, private (RFC1918), link-local, and cloud metadata addresses (169.254.169.254). Prevents third-party page scripts from reaching localhost services or LAN via the page-reachable `window.__wsFetch` bridge.
- Blocks IPv4 literals (0.0.0.0/8, 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16) and IPv6 literals (::1, fc00::/7, fe80::/10).
- DNS rebinding attacks (hostname → private IP) are not caught here; this blocks the direct IP-literal vector.

**Concurrency race fixes**
- Introduce `_setCurrentIndexVersion` counter to invalidate in-flight `_setCurrentIndex` and `_selectWebspace` calls when archive rows are removed or sites are imported. Prevents index shifts from causing wrong site activation (cross-site cookie exposure in legacy mode).
- Make `_materialiseArchive()` awaited in `_importArchive()` and `_createArchive()` to ensure callers' mutations of `handle.state.sites` and `_archiveSlices[handle]` don't race the materialisation loop.
- Remove premature version-guard bails in `CookieIsolationEngine.activate()` after the shared jar is emptied. Once cleared, the restore must complete to avoid persisting an empty jar state that would delete all loaded sites' cookies on the next activation.

**Proxy and notification hardening**
- Block outbound requests when proxy type is set but address is empty, instead of silently falling back to direct connection. Prevents device IP leakage.
- Fail closed in `WebViewModel.setProxySettings()`: if proxy setup throws, stop loading and load `about:blank` instead of letting the page load over device IP.
- Ignore page-supplied `siteId` in notification handler; use `config.siteId` only. Prevents hostile scripts from attributing notifications to sites the user never granted permission to.

**Language spoofing and nested webview fixes**
- Set `forMainFrameOnly: false` on language override user script so it reaches cross-origin iframes. Prevents subframes from reporting real OS locale and contradicting the spoofed top frame (fingerprint leak).
- Pass `userAgent` and `javascriptEnabled` to nested webviews opened via outbound links. Ensures custom UA and JS-disabled hardening choices persist across navigation.
- Update `InAppWebViewScreen` to accept and forward these per-site postures.

**Notification and webview script injection**
- Use `jsonEncode(siteId)` in notification polyfill to safely embed siteId in JavaScript strings, preventing injection.

https://claude.ai/code/session_01SSLJG3NPNx85bWTZAEmuqn