### PR TITLE
Capture nav state on navigation; restore it for auto-loaded sites

### DIFF
--- a/docs/bugs/003-cold-start-history-loss.md
+++ b/docs/bugs/003-cold-start-history-loss.md
@@ -1,0 +1,79 @@
+# BUG-003 — Back/forward history lost on cold start
+
+Status: open
+
+## Symptom
+
+After a cold start (phone reboot, OS kill, app-switcher swipe-kill), a site
+reopens with an empty back/forward stack: the back gesture does nothing, and
+on Android (which restores no display data without a stack) the session can
+also lose its place. The site's `currentUrl` usually survives (persisted to
+SharedPreferences on navigation), so the page looks right — the *history
+behind it* is gone.
+
+## Root mechanism / invariant
+
+Cross-restart history has two halves that must BOTH cover every path:
+
+1. **Capture**: `controller.saveState()` bytes must be on disk (encrypted,
+   `WebViewStateStorage`) and *fresh* at the moment the process dies.
+2. **Restore**: the first build of the site's webview after the restart must
+   consume those bytes (`schedulePendingRestoreState` →
+   `onControllerCreated` → `restoreState`).
+
+Every recurrence of this bug is one of the halves missing a path: a kill
+path that no capture point covered, or a load path that skipped the restore
+queue. The invariant: **any path that persists a webview's existence across
+a restart must pair a capture point (before death) with a restore queue
+(before first build).** Spec: PAUSE-008/009/019 in
+[openspec/specs/webview-pause-lifecycle/spec.md](../../openspec/specs/webview-pause-lifecycle/spec.md).
+
+## Fix attempts
+
+1. **2026-06-22 — PR #424** ("cold-start history restore"). Made
+   `_setCurrentIndex` fetch saved bytes for any site built fresh, not just
+   in-session `savedForRestore` re-activations — before this, cross-restart
+   restore never ran at all (the pre-existing PAUSE-008 storage was
+   in-session only). *Why partial*: capture-side, it deliberately rode the
+   existing points only (app-background, go-home, dispose/eviction — "no new
+   capture on the live navigation path"), leaving every kill path that skips
+   `AppLifecycleState.paused` (app-switcher swipe-kill delivers only
+   `inactive`, ignored per issue #308) and every background-site navigation
+   uncaptured. Restore-side, the fetch is gated on
+   `!_loadedIndices.contains(index)`, which silently excludes sites that
+   enter `_loadedIndices` outside `_setCurrentIndex`.
+
+2. **2026-06-26 — PR #448** ("Restore back/forward history on Android cold
+   start"). Android's `WebView.restoreState()` is dropped once the webview
+   has navigated, so applying it after the `initialUrlRequest` load lost the
+   stack on Android; deferred the initial load and materialized the restored
+   top entry with a reload. *Why partial*: fixed the apply-side ordering on
+   one platform; both capture-side gaps and the auto-loaded-site restore
+   skip from attempt 1 remained on all platforms.
+
+3. **2026-07-08 — this change** (branch
+   `claude/iphone-cold-start-history-ury2pl`). Two paths closed, one per
+   half. Capture: `WebViewModel.onNavigationCommitted` now feeds a per-site
+   3s trailing debounce (`NavStateCaptureDebouncer`) that captures state
+   after each navigation burst settles — covers switcher-kills and
+   background navigators (PAUSE-009 point 3). Restore: auto-loaded
+   notification sites (the one load path outside `_setCurrentIndex`, both
+   legacy pre-paint and container-mode `DeferredStartupEngine`) now queue
+   saved bytes before `markLoaded` (PAUSE-019). *Coverage note*: capture is
+   debounced, so a kill within ~3s of the last navigation can still lose
+   that final hop (older stack restores instead); accepted trade against
+   per-event `saveState()` IPC pressure.
+
+## Known open gaps
+
+- Kill inside the 3s debounce window loses the final navigation(s) of a
+  burst; the previously captured stack restores instead. By design.
+- App-version upgrades intentionally wipe all saved state and rotate the
+  AES key (`_clearCacheOnUpgrade`, PAUSE-008) — history is expected to
+  reset on the first launch after an update.
+- `alwaysOpenHome` / incognito / archive-tier sites intentionally forget
+  (AOH-002, `persistsNavState`).
+- Sites loaded but never navigated after their last capture keep a stale
+  stack (no event to debounce); harmless in practice since nothing changed.
+- Nested `InAppWebViewScreen` browsers have no persistence at all — their
+  history is session-ephemeral by design.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -58,6 +58,7 @@ import 'package:webspace/services/site_lifecycle_engine.dart';
 import 'package:webspace/services/site_lifecycle_promotion_engine.dart';
 import 'package:webspace/services/site_retention_priority.dart';
 import 'package:webspace/services/site_unload_engine.dart';
+import 'package:webspace/services/nav_state_capture_debouncer.dart';
 import 'package:webspace/services/webview_state_secure_storage.dart';
 import 'package:webspace/services/webview_state_storage.dart';
 import 'package:webspace/services/startup_restore_engine.dart';
@@ -1036,6 +1037,15 @@ class _WebSpacePageState extends State<WebSpacePage>
   final WebViewStateStorage _stateStorage =
       debugWebViewStateStorageOverride ?? SecureWebViewStateStorage();
 
+  // Trailing-edge debounce for navigation-driven state captures
+  // (PAUSE-009): one saveState() IPC per navigation burst, fired after
+  // the burst settles, so the on-disk back/forward stack stays fresh
+  // for kill paths that never deliver `paused` (app-switcher
+  // swipe-kill) and for background sites navigating while another site
+  // is current.
+  final NavStateCaptureDebouncer _navStateDebouncer =
+      NavStateCaptureDebouncer();
+
   // Track which webview indices have been loaded (for lazy loading)
   // Only webviews in this set will be created - others remain as placeholders
   final Set<int> _loadedIndices = {};
@@ -1357,6 +1367,7 @@ class _WebSpacePageState extends State<WebSpacePage>
   @override
   void dispose() {
     _foregroundPollTimer?.cancel();
+    _navStateDebouncer.dispose();
     _untrustSub?.cancel();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
@@ -4079,6 +4090,10 @@ class _WebSpacePageState extends State<WebSpacePage>
       for (int i = 0; i < _webViewModels.length; i++) {
         if (_webViewModels[i].effectiveNotificationsEnabled) {
           await _ensureSiteHtml(i);
+          // PAUSE-019: same pre-queue as the container-mode deferred
+          // path — once in _loadedIndices the activation restore is
+          // skipped, so the back/forward stack must be queued now.
+          await queueNavStateRestore(_webViewModels[i].siteId);
           _loadedIndices.add(i);
         }
       }
@@ -4322,6 +4337,31 @@ class _WebSpacePageState extends State<WebSpacePage>
     if (m != null) {
       await m.setTheme(_themeModeToWebViewTheme(_themeSettings.themeMode));
     }
+  }
+
+  /// PAUSE-019: pre-queue the saved back/forward stack for a site that
+  /// is about to enter `_loadedIndices` without going through
+  /// `_setCurrentIndex` (auto-loaded notification sites). Once it's in
+  /// the set, the activation path skips its restore fetch, so a queue
+  /// here is the only chance the bytes get applied on this run.
+  @override
+  Future<void> queueNavStateRestore(String siteId) async {
+    final model = _modelForSiteId(siteId);
+    if (model == null) return;
+    // A live controller can't consume queued bytes — restoreState only
+    // applies to a freshly-created one.
+    if (!model.persistsNavState || model.controller != null) return;
+    final bytes = await _stateStorage.loadState(siteId);
+    if (bytes == null) return;
+    // Re-resolve after the disk read: the site may have been deleted.
+    if (_modelForSiteId(siteId) == null) return;
+    model.schedulePendingRestoreState(bytes);
+    LogService.instance.log(
+      'WebViewState',
+      'Queued ${bytes.length} restore bytes for auto-loaded site '
+          '"${model.name}" (siteId: $siteId)',
+      sensitivity: LogSensitivity.sensitive,
+    );
   }
 
   @override
@@ -7251,6 +7291,22 @@ class _WebSpacePageState extends State<WebSpacePage>
                         // _currentIndex live at fire time; no-op off Android.
                         webViewModel.onControllerReady = () {
                           if (index == _currentIndex) _nudgeSurfaceRepaint();
+                        };
+
+                        // Keep the on-disk back/forward stack tracking
+                        // browsing (PAUSE-009): pause/dispose captures
+                        // alone go stale for background sites and are
+                        // skipped entirely when the app is killed from
+                        // the switcher (only `inactive` fires, which is
+                        // deliberately ignored — issue #308). Identity
+                        // check, not index: the list may have mutated
+                        // by the time the debounce fires.
+                        webViewModel.onNavigationCommitted = () {
+                          _navStateDebouncer.schedule(webViewModel.siteId, () {
+                            if (!mounted) return;
+                            if (!_webViewModels.contains(webViewModel)) return;
+                            unawaited(_captureStateBytes(webViewModel));
+                          });
                         };
 
                         // Single source of truth for which HTML store backs

--- a/lib/services/deferred_startup_engine.dart
+++ b/lib/services/deferred_startup_engine.dart
@@ -43,6 +43,13 @@ abstract class DeferredStartupHost {
 
   Future<void> preloadHtml(String siteId);
   Future<void> applyTheme(String siteId);
+
+  /// Queue the site's saved nav-state bytes (if any) on its model so the
+  /// first webview build applies `restoreState` — the cross-restart
+  /// back/forward restore for sites loaded outside `_setCurrentIndex`
+  /// (PAUSE-019). No-op when nothing is saved or a controller already
+  /// exists.
+  Future<void> queueNavStateRestore(String siteId);
   void requestRebuild();
 
   Future<bool> loadTimezoneDataset();
@@ -87,6 +94,13 @@ class DeferredStartupEngine {
       if (!host.isMounted) return;
       if (!host.isLive(siteId)) continue;
       await host.applyTheme(siteId);
+      if (!host.isMounted) return;
+      if (!host.isLive(siteId) || host.isLoaded(siteId)) continue;
+      // Before markLoaded: once the site is in _loadedIndices,
+      // _setCurrentIndex skips its restore fetch, so this is the only
+      // point where the previous session's back/forward stack can be
+      // queued for an auto-loaded site (PAUSE-019).
+      await host.queueNavStateRestore(siteId);
       if (!host.isMounted) return;
       if (!host.isLive(siteId) || host.isLoaded(siteId)) continue;
       host.markLoaded(siteId);

--- a/lib/services/nav_state_capture_debouncer.dart
+++ b/lib/services/nav_state_capture_debouncer.dart
@@ -1,0 +1,43 @@
+import 'dart:async';
+
+/// Per-site trailing-edge debounce for navigation-driven
+/// `controller.saveState()` captures (PAUSE-009).
+///
+/// SPA pseudo-navigations can fire many URL-change events per page
+/// (8+ observed on LinkedIn); `saveState()` is a cross-IPC into
+/// chromium returning up to tens of KB, plus an AES encrypt and a disk
+/// write. A trailing debounce coalesces a navigation burst into one
+/// capture after it settles, while still guaranteeing the *last*
+/// navigation before an OS kill lands on disk — which a leading-edge
+/// throttle (the `HtmlCacheService.shouldSave` shape) would drop.
+class NavStateCaptureDebouncer {
+  NavStateCaptureDebouncer({this.delay = const Duration(seconds: 3)});
+
+  final Duration delay;
+  final Map<String, Timer> _timers = {};
+
+  /// (Re)start the debounce window for [siteId]. [capture] runs once
+  /// [delay] elapses with no further [schedule] call for the same site.
+  /// The callback must do its own liveness checks (site deleted,
+  /// widget unmounted) — the debouncer only owns the timing.
+  void schedule(String siteId, void Function() capture) {
+    _timers[siteId]?.cancel();
+    _timers[siteId] = Timer(delay, () {
+      _timers.remove(siteId);
+      capture();
+    });
+  }
+
+  /// Drop any pending capture for [siteId] without running it.
+  void cancel(String siteId) {
+    _timers.remove(siteId)?.cancel();
+  }
+
+  /// Cancel every pending capture. Call from the host's `dispose()`.
+  void dispose() {
+    for (final t in _timers.values) {
+      t.cancel();
+    }
+    _timers.clear();
+  }
+}

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -525,6 +525,14 @@ class WebViewModel {
   /// webview does NOT recreate the controller, so it does not fire here —
   /// that path is nudged explicitly by `_setCurrentIndex`.
   Function? onControllerReady;
+  /// Host hook fired once per committed navigation (deduped across the
+  /// `onLoadStop` / `onUpdateVisitedHistory` double-fire). The host
+  /// debounces `controller.saveState()` captures off this so the
+  /// persisted back/forward stack tracks browsing instead of only
+  /// pause/dispose events (PAUSE-009) — the app-switcher swipe-kill
+  /// never delivers `paused`, and background notification sites
+  /// navigate while another site is current.
+  VoidCallback? onNavigationCommitted;
   FindMatchesResult findMatches = FindMatchesResult();
   WebViewTheme _currentTheme = WebViewTheme.light;
 
@@ -1092,6 +1100,7 @@ class WebViewModel {
             final currentNotifyUrl = urlChangedState.currentUrl;
             if (currentNotifyUrl != lastNotifiedUrl) {
               lastNotifiedUrl = currentNotifyUrl;
+              onNavigationCommitted?.call();
               // Each await below is a yield point where disposeWebView() can
               // null `controller`, so we re-check before every native call —
               // calling into a torn-down WebView peer can trip Chromium's

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -337,14 +337,15 @@ State bytes survive cold starts (unlike the in-memory `InMemoryWebViewStateStora
 **Then** `_stateStorage.removeOrphans({A, C})` is called
 **And** the file `B.enc` is deleted from disk
 
-### Requirement: PAUSE-009 — State Capture on Go-Home and App-Background
+### Requirement: PAUSE-009 — State Capture on Go-Home, App-Background, and Navigation
 
-The system SHALL capture `controller.saveState()` bytes opportunistically — without disposing the webview — at two additional lifecycle points beyond the dispose paths:
+The system SHALL capture `controller.saveState()` bytes opportunistically — without disposing the webview — at three additional lifecycle points beyond the dispose paths:
 
 1. **Go-home** (`_setCurrentIndex(null)`): when the user navigates to the home screen, the previously-active site's state is captured before its webview is paused. The webview stays loaded for fast resume; state is captured defensively in case the OS later reaps the app or the user comes back after a long delay.
 2. **App-background** (`didChangeAppLifecycleState(paused | inactive)`): the active site's state is captured fire-and-forget alongside the existing `pauseForAppLifecycle` call, so an OS-induced kill while we're backgrounded preserves restorable state.
+3. **Navigation-debounced** (`WebViewModel.onNavigationCommitted` → `NavStateCaptureDebouncer`): each committed navigation in a loaded webview (deduped across the `onLoadStop` / `onUpdateVisitedHistory` double-fire) restarts a per-site trailing debounce window (3s); when a navigation burst settles, that site's state is captured. This covers the kill paths the first two points miss: (a) killing the app from the app switcher delivers only `inactive` — which the lifecycle handler deliberately ignores (issue #308) — so the app-background capture never runs; (b) loaded-but-not-current sites (notification pollers, sites the user switched away from) navigate without ever hitting go-home or a dispose path, leaving their on-disk state stale until an eviction happens to capture them.
 
-Neither path mutates the model's `lifecycleState` — the field stays at `resident` because the webview is not actually disposed. Capture goes through `_captureStateBytes` (bytes-only) rather than `_captureStateForRestore` (bytes + flip-to-savedForRestore).
+None of these paths mutate the model's `lifecycleState` — the field stays at `resident` because the webview is not actually disposed. Capture goes through `_captureStateBytes` (bytes-only) rather than `_captureStateForRestore` (bytes + flip-to-savedForRestore). All three gate on `WebViewModel.persistsNavState` (no capture for incognito or archive-tier sites).
 
 #### Scenario: Go-home captures state for the previously-active site
 
@@ -373,6 +374,28 @@ Neither path mutates the model's `lifecycleState` — the field stays at `reside
 **And** `restoreState` re-populates the back/forward stack
 **And** the user can press the back gesture to return to `page2` and `home`
 
+#### Scenario: App-switcher kill after browsing still restores history
+
+**Given** the user browsed within site A (each navigation restarted the debounce; the last one's window elapsed and captured state)
+**When** the user opens the app switcher (only `inactive` fires — ignored per issue #308) and swipe-kills the app
+**Then** no `paused` capture ever ran for this session
+**And** the navigation-debounced capture already persisted A's stack through the last settled navigation
+**And** the next cold start restores it
+
+#### Scenario: SPA navigation storm coalesces into one capture
+
+**Given** site A fires 8 `onUpdateVisitedHistory` events for one page transition (SPA pseudo-navigations)
+**When** the events arrive within the debounce window
+**Then** each event restarts A's window; `saveState()` runs once, after the storm settles
+**Because** `saveState()` is a cross-IPC into chromium plus an AES encrypt and disk write — per-event capture would generate platform-channel pressure for no additional durability (regression test: `test/nav_state_capture_debouncer_test.dart`)
+
+#### Scenario: Background notification site's navigation is captured
+
+**Given** notification site B is loaded but not current while the user browses site A
+**When** B's poller navigates (its webview fires `onNavigationCommitted`)
+**Then** B's own debounce window runs and captures B's state
+**And** A's window is unaffected (per-site timers)
+
 ### Requirement: PAUSE-010 — State Storage Garbage Collection
 
 State files SHALL be reaped when their owning site is deleted, not when the user merely navigates away. Leaving state for sites that still exist (via go-home, app-background, memory-pressure disposal) is the entire point of save/restore.
@@ -387,12 +410,35 @@ State files SHALL be reaped when their owning site is deleted, not when the user
 **Then** the orphan sweep at the end of `_deleteSite` calls `_stateStorage.removeOrphans(activeSiteIds)`
 **And** A's state file is reaped (siteId no longer in active set)
 
+### Requirement: PAUSE-019 — Cold-Start Restore for Auto-Loaded Sites
+
+Sites that enter `_loadedIndices` without going through `_setCurrentIndex` — notification sites auto-loaded at startup, on both the legacy pre-paint loop in `_restoreAppState` and the container-mode `DeferredStartupEngine.autoLoadNotificationSites` — SHALL have their saved nav-state bytes fetched from `WebViewStateStorage` and queued on the model via `schedulePendingRestoreState` *before* they are marked loaded.
+
+`_setCurrentIndex` fetches restore bytes only when the target is NOT already in `_loadedIndices` (a loaded webview's controller won't be recreated, so a queued restore would go stale). An auto-loaded site is therefore skipped by the activation-path restore on every subsequent tap; without the pre-queue, its first build consumes no bytes and the previous session's back/forward stack is silently dropped on every cold start — precisely for the sites a user keeps notifications on for. The pre-queue goes through the same gates as the activation path (`persistsNavState`, no live controller) and re-checks site liveness after the disk read.
+
+#### Scenario: Notification site restores history on cold start
+
+**Given** site A has `notificationsEnabled` and state bytes on disk from the previous session
+**When** the app cold-starts and the auto-load path processes A
+**Then** A's bytes are queued on the model before `markLoaded`
+**And** A's first webview build applies `restoreState` in `onControllerCreated`
+**And** when the user later taps A, `_setCurrentIndex` skips its restore fetch (A is already loaded) but the stack is already live
+
+#### Scenario: Site deleted during the restore fetch is skipped
+
+**Given** notification sites A and B are being auto-loaded
+**When** A is deleted while its state bytes are being read from disk
+**Then** nothing is queued or marked loaded for A
+**And** B still loads and restores normally
+(regression test: `test/deferred_startup_engine_test.dart`)
+
 ### Requirement: PAUSE-011 — Race Protections for State Capture
 
 Concurrent paths that may capture state for the same site SHALL coexist without corruption:
 
 - Two `_handleMemoryPressure` events firing rapidly: dropped via `_isHandlingMemoryPressure` flag (the first runs to completion, the next event picks up the new state).
 - App-background `unawaited(_captureStateBytes)` racing with `_setCurrentIndex`: each path operates on per-site state independently; storage writes are last-writer-wins per siteId, both produce valid bytes.
+- Navigation-debounced capture firing while a dispose/pause path captures the same site: both go through `_captureStateBytes`; writes are last-writer-wins per siteId and both produce valid bytes. The debounce callback re-checks `mounted` and model identity (`_webViewModels.contains(model)`, not an index) before capturing, so a site deleted or a list reordered during the window is a no-op.
 - Re-activation of a `savedForRestore` site mid-fetch: the in-flight target is in `_activationInFlightIndex` (set sync before any await in `_setCurrentIndex`, cleared in finally); memory pressure includes that index in `protectedIndices`, so the picker excludes it.
 - Storage initialization concurrency: `if (!_initialized) await initialize()` may run twice on a cold race, but each invocation produces the same key from `FlutterSecureStorage` (existing key on read, generated once on first miss); the second call's redundant writes are no-ops.
 
@@ -407,9 +453,9 @@ Concurrent paths that may capture state for the same site SHALL coexist without 
 
 **Given** site A is loaded
 **When** A's `onLoadStop` fires after a navigation
-**Then** `HtmlCacheService.saveHtml` may run (debounced 10s, captures the rendered DOM for offline / fast-paint)
-**And** `WebViewStateStorage.saveState` does NOT run on `onLoadStop` — state capture is scoped to dispose paths + go-home + app-background
-**Because** state bytes can be tens of KB and capturing on every page load would generate platform-channel pressure for marginal benefit; the strategic capture points (going-to-be-evicted-or-killed) cover the realistic loss scenarios
+**Then** `HtmlCacheService.saveHtml` may run (throttled 10s leading-edge, captures the rendered DOM for offline / fast-paint)
+**And** `WebViewStateStorage.saveState` does NOT run per-event — it runs once per navigation burst, after the 3s trailing debounce settles (PAUSE-009 point 3)
+**Because** state bytes can be tens of KB and capturing on every event would generate platform-channel pressure for marginal benefit; the trailing debounce (unlike the HTML cache's leading-edge throttle) still guarantees the *last* navigation before an OS kill is on disk — the original "strategic capture points only" scoping missed the app-switcher-kill and background-navigator scenarios and shipped as BUG-003
 
 The two systems are complementary: HTML cache provides instant first-paint of the last rendered DOM; state storage restores the back/forward stack and (Apple) form data on top.
 

--- a/test/deferred_startup_engine_test.dart
+++ b/test/deferred_startup_engine_test.dart
@@ -48,9 +48,12 @@ class _FakeHost implements DeferredStartupHost {
   final List<({Set<String> active, Set<String> nonIncognito})> sweeps = [];
   final List<String> opLog = []; // 'persist' / 'sweep' — to assert ordering
 
+  final List<String> restoreQueued = [];
+
   // Await-point hooks: run *inside* the awaited call, i.e. "during the await".
   void Function(String siteId)? onPreloadHtml;
   void Function(String siteId)? onApplyTheme;
+  void Function(String siteId)? onQueueNavStateRestore;
   void Function()? onLoadDataset;
 
   _FakeSite? _find(String id) {
@@ -105,6 +108,17 @@ class _FakeHost implements DeferredStartupHost {
         reason: 'INVARIANT: applyTheme on dead site $siteId');
     themed.add(siteId);
     onApplyTheme?.call(siteId);
+  }
+
+  @override
+  Future<void> queueNavStateRestore(String siteId) async {
+    expect(isLive(siteId), isTrue,
+        reason: 'INVARIANT: queueNavStateRestore on dead site $siteId');
+    expect(isLoaded(siteId), isFalse,
+        reason: 'INVARIANT: restore queued after markLoaded for $siteId — '
+            'the first build may already have consumed (no) bytes');
+    restoreQueued.add(siteId);
+    onQueueNavStateRestore?.call(siteId);
   }
 
   @override
@@ -167,6 +181,32 @@ void main() {
       expect(host.markedLoaded.toSet(), {'a', 'b'});
       expect(host.isLoaded('plain'), isFalse);
       expect(host.rebuilds, 1);
+    });
+
+    test('queues nav-state restore before marking loaded (PAUSE-019)',
+        () async {
+      final host = _FakeHost([
+        _FakeSite('a', notif: true),
+        _FakeSite('b', notif: true),
+      ]);
+      await DeferredStartupEngine.autoLoadNotificationSites(host);
+      // The fake host's queueNavStateRestore asserts !isLoaded at call
+      // time, so this also proves the ordering, not just the coverage.
+      expect(host.restoreQueued, ['a', 'b']);
+    });
+
+    test('site deleted during its restore queue is not loaded (no throw)',
+        () async {
+      final host = _FakeHost([
+        _FakeSite('a', notif: true),
+        _FakeSite('b', notif: true),
+      ]);
+      host.onQueueNavStateRestore = (siteId) {
+        if (siteId == 'a') host.delete('a');
+      };
+      await DeferredStartupEngine.autoLoadNotificationSites(host);
+      expect(host.isLoaded('a'), isFalse, reason: 'deleted mid-flight');
+      expect(host.isLoaded('b'), isTrue);
     });
 
     test('site deleted during its own HTML preload is not loaded (no throw)',

--- a/test/nav_state_capture_debouncer_test.dart
+++ b/test/nav_state_capture_debouncer_test.dart
@@ -1,0 +1,89 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/nav_state_capture_debouncer.dart';
+
+void main() {
+  const delay = Duration(seconds: 3);
+
+  test('a navigation burst coalesces into one trailing capture', () {
+    fakeAsync((async) {
+      final d = NavStateCaptureDebouncer(delay: delay);
+      var captures = 0;
+      // 8 SPA pseudo-navigations 100ms apart (the LinkedIn storm shape).
+      for (var i = 0; i < 8; i++) {
+        d.schedule('a', () => captures++);
+        async.elapse(const Duration(milliseconds: 100));
+      }
+      expect(captures, 0, reason: 'window still open during the burst');
+      async.elapse(delay);
+      expect(captures, 1);
+    });
+  });
+
+  test('capture fires delay after the LAST navigation, not the first', () {
+    fakeAsync((async) {
+      final d = NavStateCaptureDebouncer(delay: delay);
+      var captures = 0;
+      d.schedule('a', () => captures++);
+      async.elapse(const Duration(seconds: 2));
+      d.schedule('a', () => captures++);
+      // 3s since the first schedule but only 1s since the second: a
+      // leading-edge throttle would have fired; trailing must not.
+      async.elapse(const Duration(seconds: 1));
+      expect(captures, 0);
+      async.elapse(const Duration(seconds: 2));
+      expect(captures, 1);
+    });
+  });
+
+  test('sites debounce independently', () {
+    fakeAsync((async) {
+      final d = NavStateCaptureDebouncer(delay: delay);
+      final fired = <String>[];
+      d.schedule('a', () => fired.add('a'));
+      async.elapse(const Duration(seconds: 2));
+      // b's navigation must not push back a's already-elapsing window.
+      d.schedule('b', () => fired.add('b'));
+      async.elapse(const Duration(seconds: 1));
+      expect(fired, ['a']);
+      async.elapse(const Duration(seconds: 2));
+      expect(fired, ['a', 'b']);
+    });
+  });
+
+  test('a new schedule after firing opens a fresh window', () {
+    fakeAsync((async) {
+      final d = NavStateCaptureDebouncer(delay: delay);
+      var captures = 0;
+      d.schedule('a', () => captures++);
+      async.elapse(delay);
+      expect(captures, 1);
+      d.schedule('a', () => captures++);
+      async.elapse(delay);
+      expect(captures, 2);
+    });
+  });
+
+  test('cancel drops the pending capture without running it', () {
+    fakeAsync((async) {
+      final d = NavStateCaptureDebouncer(delay: delay);
+      var captures = 0;
+      d.schedule('a', () => captures++);
+      d.cancel('a');
+      async.elapse(delay * 2);
+      expect(captures, 0);
+    });
+  });
+
+  test('dispose cancels every pending capture', () {
+    fakeAsync((async) {
+      final d = NavStateCaptureDebouncer(delay: delay);
+      var captures = 0;
+      d.schedule('a', () => captures++);
+      d.schedule('b', () => captures++);
+      d.dispose();
+      async.elapse(delay * 2);
+      expect(captures, 0);
+    });
+  });
+}


### PR DESCRIPTION
Cold-start history restore (#424, #448) missed both halves on real kill paths: capture only ran on pause/go-home/dispose, so app-switcher kills (only `inactive` fires) and background navigators left stale bytes; and notification sites auto-load into _loadedIndices before activation, so _setCurrentIndex never queued their saved stack at all. Debounce a per-site capture off each committed navigation (PAUSE-009) and pre-queue restore bytes before markLoaded on both auto-load paths (PAUSE-019). BUG-003 records the lineage.


Claude-Session: https://claude.ai/code/session_01Ybb781RCXWU12t4JgLdwHU