### PR TITLE
Add custom site icon override with file picker

### DIFF
--- a/lib/l10n/app_af.arb
+++ b/lib/l10n/app_af.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Voer 'n pasgemaakte naam in",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Wenk: Sluit http:// in vir HTTP-webwerwe, of laat dit uit vir HTTPS",
+  "homeSiteIconPick": "Verander ikoon",
+  "homeSiteIconReset": "Gebruik outomatiese ikoon",
   "homeRefreshTitleAndIcon": "Verfris titel en ikoon",
   "homeMoveUp": "Skuif op",
   "homeMoveDown": "Skuif af",

--- a/lib/l10n/app_am.arb
+++ b/lib/l10n/app_am.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "ብጁ ስም አስገባ",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "ጠቃሚ ምክር: ለ HTTP ጣቢያዎች http:// አካትት፣ ወይም ለ HTTPS ተወው",
+  "homeSiteIconPick": "አዶ ቀይር",
+  "homeSiteIconReset": "ራስ-ሰር አዶ ተጠቀም",
   "homeRefreshTitleAndIcon": "ርዕስ እና አዶ አድስ",
   "homeMoveUp": "ወደ ላይ አንቀሳቅስ",
   "homeMoveDown": "ወደ ታች አንቀሳቅስ",

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "أدخل اسمًا مخصّصًا",
   "homeUrlLabel": "عنوان URL",
   "homeUrlSchemeTip": "تلميح: أدرج http:// لمواقع HTTP، أو احذفه لـ HTTPS",
+  "homeSiteIconPick": "تغيير الأيقونة",
+  "homeSiteIconReset": "استخدام الأيقونة التلقائية",
   "homeRefreshTitleAndIcon": "تحديث العنوان والأيقونة",
   "homeMoveUp": "تحريك لأعلى",
   "homeMoveDown": "تحريك لأسفل",

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Въведете персонализирано име",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Съвет: включете http:// за HTTP сайтове или го пропуснете за HTTPS",
+  "homeSiteIconPick": "Промени иконата",
+  "homeSiteIconReset": "Използвай автоматична икона",
   "homeRefreshTitleAndIcon": "Опресни заглавието и иконата",
   "homeMoveUp": "Премести нагоре",
   "homeMoveDown": "Премести надолу",

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "একটি কাস্টম নাম লিখুন",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "টিপ: HTTP সাইটের জন্য http:// অন্তর্ভুক্ত করুন, অথবা HTTPS-এর জন্য এটি বাদ দিন",
+  "homeSiteIconPick": "আইকন পরিবর্তন করুন",
+  "homeSiteIconReset": "স্বয়ংক্রিয় আইকন ব্যবহার করুন",
   "homeRefreshTitleAndIcon": "শিরোনাম ও আইকন রিফ্রেশ করুন",
   "homeMoveUp": "উপরে সরান",
   "homeMoveDown": "নিচে সরান",

--- a/lib/l10n/app_bs.arb
+++ b/lib/l10n/app_bs.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Unesite prilagođeni naziv",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Savjet: uključite http:// za HTTP stranice ili izostavite za HTTPS",
+  "homeSiteIconPick": "Promijeni ikonu",
+  "homeSiteIconReset": "Koristi automatsku ikonu",
   "homeRefreshTitleAndIcon": "Osvježi naslov i ikonu",
   "homeMoveUp": "Pomjeri gore",
   "homeMoveDown": "Pomjeri dolje",

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Introduïu un nom personalitzat",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Consell: incloeu http:// per a llocs HTTP, o ometeu-ho per a HTTPS",
+  "homeSiteIconPick": "Canvia la icona",
+  "homeSiteIconReset": "Fes servir la icona automàtica",
   "homeRefreshTitleAndIcon": "Actualitza el títol i la icona",
   "homeMoveUp": "Mou amunt",
   "homeMoveDown": "Mou avall",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Zadejte vlastní název",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Tip: pro stránky HTTP uveďte http://, nebo jej vynechejte pro HTTPS",
+  "homeSiteIconPick": "Změnit ikonu",
+  "homeSiteIconReset": "Použít automatickou ikonu",
   "homeRefreshTitleAndIcon": "Obnovit název a ikonu",
   "homeMoveUp": "Posunout nahoru",
   "homeMoveDown": "Posunout dolů",

--- a/lib/l10n/app_cy.arb
+++ b/lib/l10n/app_cy.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Rhowch enw personol",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Awgrym: Cynhwyswch http:// ar gyfer safleoedd HTTP, neu gadewch ef allan ar gyfer HTTPS",
+  "homeSiteIconPick": "Newid eicon",
+  "homeSiteIconReset": "Defnyddio'r eicon awtomatig",
   "homeRefreshTitleAndIcon": "Adnewyddu Teitl ac Eicon",
   "homeMoveUp": "Symud i Fyny",
   "homeMoveDown": "Symud i Lawr",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Indtast et brugerdefineret navn",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Tip: Inkludér http:// for HTTP-sider, eller udelad det for HTTPS",
+  "homeSiteIconPick": "Skift ikon",
+  "homeSiteIconReset": "Brug automatisk ikon",
   "homeRefreshTitleAndIcon": "Genopfrisk titel og ikon",
   "homeMoveUp": "Flyt op",
   "homeMoveDown": "Flyt ned",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Einen eigenen Namen eingeben",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Tipp: Fügen Sie http:// für HTTP-Seiten hinzu oder lassen Sie es für HTTPS weg",
+  "homeSiteIconPick": "Symbol ändern",
+  "homeSiteIconReset": "Automatisches Symbol verwenden",
   "homeRefreshTitleAndIcon": "Titel & Symbol aktualisieren",
   "homeMoveUp": "Nach oben verschieben",
   "homeMoveDown": "Nach unten verschieben",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Εισαγάγετε προσαρμοσμένο όνομα",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Συμβουλή: Συμπεριλάβετε το http:// για ιστότοπους HTTP, ή παραλείψτε το για HTTPS",
+  "homeSiteIconPick": "Αλλαγή εικονιδίου",
+  "homeSiteIconReset": "Χρήση αυτόματου εικονιδίου",
   "homeRefreshTitleAndIcon": "Ανανέωση τίτλου & εικονιδίου",
   "homeMoveUp": "Μετακίνηση πάνω",
   "homeMoveDown": "Μετακίνηση κάτω",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2891,6 +2891,14 @@
   "@homeUrlSchemeTip": {
     "description": "Tip below the URL field explaining scheme inference"
   },
+  "homeSiteIconPick": "Change icon",
+  "@homeSiteIconPick": {
+    "description": "Button in the edit-site dialog, next to a preview of the site's current icon, that opens a file picker so the user can select their own image to use as the site's icon instead of the fetched favicon"
+  },
+  "homeSiteIconReset": "Use automatic icon",
+  "@homeSiteIconReset": {
+    "description": "Tooltip of the button in the edit-site dialog that removes the user's custom site icon and reverts to the automatically fetched website favicon"
+  },
   "homeRefreshTitleAndIcon": "Refresh Title & Icon",
   "@homeRefreshTitleAndIcon": {
     "description": "Context menu item to refresh a site's title and favicon"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Introduce un nombre personalizado",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Consejo: incluye http:// para sitios HTTP, o déjalo fuera para HTTPS",
+  "homeSiteIconPick": "Cambiar icono",
+  "homeSiteIconReset": "Usar icono automático",
   "homeRefreshTitleAndIcon": "Actualizar título e icono",
   "homeMoveUp": "Subir",
   "homeMoveDown": "Bajar",

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Sisesta kohandatud nimi",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Näpunäide: lisa HTTP-saitide jaoks http:// või jäta see HTTPS-i jaoks välja",
+  "homeSiteIconPick": "Muuda ikooni",
+  "homeSiteIconReset": "Kasuta automaatset ikooni",
   "homeRefreshTitleAndIcon": "Värskenda pealkirja ja ikooni",
   "homeMoveUp": "Liiguta üles",
   "homeMoveDown": "Liiguta alla",

--- a/lib/l10n/app_eu.arb
+++ b/lib/l10n/app_eu.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Sartu izen pertsonalizatu bat",
   "homeUrlLabel": "URLa",
   "homeUrlSchemeTip": "Aholkua: sartu http:// HTTP guneetarako, edo utzi kanpoan HTTPSrako",
+  "homeSiteIconPick": "Aldatu ikonoa",
+  "homeSiteIconReset": "Erabili ikono automatikoa",
   "homeRefreshTitleAndIcon": "Berritu izenburua eta ikonoa",
   "homeMoveUp": "Eraman gora",
   "homeMoveDown": "Eraman behera",

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "یک نام سفارشی وارد کنید",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "نکته: برای سایت‌های HTTP عبارت http:// را بگنجانید، یا برای HTTPS آن را حذف کنید",
+  "homeSiteIconPick": "تغییر آیکن",
+  "homeSiteIconReset": "استفاده از آیکن خودکار",
   "homeRefreshTitleAndIcon": "تازه‌سازی عنوان و آیکن",
   "homeMoveUp": "انتقال به بالا",
   "homeMoveDown": "انتقال به پایین",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Syötä mukautettu nimi",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Vinkki: Sisällytä http:// HTTP-sivustoille tai jätä se pois HTTPS:lle",
+  "homeSiteIconPick": "Vaihda kuvake",
+  "homeSiteIconReset": "Käytä automaattista kuvaketta",
   "homeRefreshTitleAndIcon": "Päivitä otsikko ja kuvake",
   "homeMoveUp": "Siirrä ylös",
   "homeMoveDown": "Siirrä alas",

--- a/lib/l10n/app_fil.arb
+++ b/lib/l10n/app_fil.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Maglagay ng custom na pangalan",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Tip: Isama ang http:// para sa mga HTTP na site, o huwag ito isama para sa HTTPS",
+  "homeSiteIconPick": "Palitan ang icon",
+  "homeSiteIconReset": "Gamitin ang awtomatikong icon",
   "homeRefreshTitleAndIcon": "I-refresh ang Pamagat at Icon",
   "homeMoveUp": "Ilipat Pataas",
   "homeMoveDown": "Ilipat Pababa",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Saisir un nom personnalisé",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Astuce : incluez http:// pour les sites HTTP, ou omettez-le pour HTTPS",
+  "homeSiteIconPick": "Changer l'icône",
+  "homeSiteIconReset": "Utiliser l'icône automatique",
   "homeRefreshTitleAndIcon": "Actualiser le titre et l'icône",
   "homeMoveUp": "Monter",
   "homeMoveDown": "Descendre",

--- a/lib/l10n/app_ga.arb
+++ b/lib/l10n/app_ga.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Iontráil ainm saincheaptha",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Leid: Cuir http:// san áireamh do shuíomhanna HTTP, nó fág ar lár é le haghaidh HTTPS",
+  "homeSiteIconPick": "Athraigh an deilbhín",
+  "homeSiteIconReset": "Úsáid an deilbhín uathoibríoch",
   "homeRefreshTitleAndIcon": "Athnuaigh Teideal & Deilbhín",
   "homeMoveUp": "Bog Suas",
   "homeMoveDown": "Bog Síos",

--- a/lib/l10n/app_gl.arb
+++ b/lib/l10n/app_gl.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Introduce un nome personalizado",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Suxestión: Inclúe http:// para sitios HTTP, ou déixao fóra para HTTPS",
+  "homeSiteIconPick": "Cambiar a icona",
+  "homeSiteIconReset": "Usar a icona automática",
   "homeRefreshTitleAndIcon": "Actualizar título e icona",
   "homeMoveUp": "Subir",
   "homeMoveDown": "Baixar",

--- a/lib/l10n/app_gu.arb
+++ b/lib/l10n/app_gu.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "કસ્ટમ નામ દાખલ કરો",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "ટિપ: HTTP સાઇટ્સ માટે http:// શામેલ કરો, અથવા HTTPS માટે તેને છોડી દો",
+  "homeSiteIconPick": "આયકન બદલો",
+  "homeSiteIconReset": "સ્વચાલિત આયકન વાપરો",
   "homeRefreshTitleAndIcon": "શીર્ષક અને આયકન તાજું કરો",
   "homeMoveUp": "ઉપર ખસેડો",
   "homeMoveDown": "નીચે ખસેડો",

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "הזן שם מותאם אישית",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "טיפ: כלול http:// לאתרי HTTP, או השמט אותו עבור HTTPS",
+  "homeSiteIconPick": "שינוי סמל",
+  "homeSiteIconReset": "שימוש בסמל אוטומטי",
   "homeRefreshTitleAndIcon": "רענן כותרת וסמל",
   "homeMoveUp": "הזז למעלה",
   "homeMoveDown": "הזז למטה",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "एक कस्टम नाम दर्ज करें",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "सुझाव: HTTP साइटों के लिए http:// शामिल करें, या HTTPS के लिए इसे छोड़ दें",
+  "homeSiteIconPick": "आइकन बदलें",
+  "homeSiteIconReset": "स्वचालित आइकन उपयोग करें",
   "homeRefreshTitleAndIcon": "शीर्षक और आइकन रीफ़्रेश करें",
   "homeMoveUp": "ऊपर ले जाएँ",
   "homeMoveDown": "नीचे ले जाएँ",

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Unesite prilagođeni naziv",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Savjet: Uključite http:// za HTTP stranice ili izostavite za HTTPS",
+  "homeSiteIconPick": "Promijeni ikonu",
+  "homeSiteIconReset": "Koristi automatsku ikonu",
   "homeRefreshTitleAndIcon": "Osvježi naslov i ikonu",
   "homeMoveUp": "Pomakni gore",
   "homeMoveDown": "Pomakni dolje",

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Adjon meg egyéni nevet",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Tipp: HTTP-webhelyeknél írja be a http:// előtagot, HTTPS esetén hagyja el",
+  "homeSiteIconPick": "Ikon módosítása",
+  "homeSiteIconReset": "Automatikus ikon használata",
   "homeRefreshTitleAndIcon": "Cím és ikon frissítése",
   "homeMoveUp": "Mozgatás felfelé",
   "homeMoveDown": "Mozgatás lefelé",

--- a/lib/l10n/app_hy.arb
+++ b/lib/l10n/app_hy.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Մուտքագրեք հատուկ անուն",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Հուշում՝ ներառեք http:// HTTP կայքերի համար, կամ բաց թողեք HTTPS-ի համար",
+  "homeSiteIconPick": "Փոխել պատկերակը",
+  "homeSiteIconReset": "Օգտագործել ավտոմատ պատկերակը",
   "homeRefreshTitleAndIcon": "Թարմացնել վերնագիրն ու պատկերակը",
   "homeMoveUp": "Տեղափոխել վեր",
   "homeMoveDown": "Տեղափոխել ներքև",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Masukkan nama kustom",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Tip: Sertakan http:// untuk situs HTTP, atau biarkan kosong untuk HTTPS",
+  "homeSiteIconPick": "Ubah ikon",
+  "homeSiteIconReset": "Gunakan ikon otomatis",
   "homeRefreshTitleAndIcon": "Segarkan Judul & Ikon",
   "homeMoveUp": "Pindah ke Atas",
   "homeMoveDown": "Pindah ke Bawah",

--- a/lib/l10n/app_is.arb
+++ b/lib/l10n/app_is.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Sláðu inn sérsniðið heiti",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Ábending: Hafðu http:// með fyrir HTTP-svæði eða slepptu því fyrir HTTPS",
+  "homeSiteIconPick": "Breyta táknmynd",
+  "homeSiteIconReset": "Nota sjálfvirka táknmynd",
   "homeRefreshTitleAndIcon": "Endurnýja titil og táknmynd",
   "homeMoveUp": "Færa upp",
   "homeMoveDown": "Færa niður",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Inserisci un nome personalizzato",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Suggerimento: includi http:// per i siti HTTP, oppure ometterlo per HTTPS",
+  "homeSiteIconPick": "Cambia icona",
+  "homeSiteIconReset": "Usa icona automatica",
   "homeRefreshTitleAndIcon": "Aggiorna titolo e icona",
   "homeMoveUp": "Sposta su",
   "homeMoveDown": "Sposta giù",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "カスタム名を入力",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "ヒント: HTTPサイトには http:// を含め、HTTPSの場合は省略してください",
+  "homeSiteIconPick": "アイコンを変更",
+  "homeSiteIconReset": "自動アイコンを使用",
   "homeRefreshTitleAndIcon": "タイトルとアイコンを更新",
   "homeMoveUp": "上に移動",
   "homeMoveDown": "下に移動",

--- a/lib/l10n/app_ka.arb
+++ b/lib/l10n/app_ka.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "შეიყვანეთ მორგებული სახელი",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "რჩევა: ჩართეთ http:// HTTP საიტებისთვის, ან გამოტოვეთ HTTPS-ისთვის",
+  "homeSiteIconPick": "ხატულის შეცვლა",
+  "homeSiteIconReset": "ავტომატური ხატულის გამოყენება",
   "homeRefreshTitleAndIcon": "სათაურისა და ხატულის განახლება",
   "homeMoveUp": "მაღლა გადატანა",
   "homeMoveDown": "დაბლა გადატანა",

--- a/lib/l10n/app_km.arb
+++ b/lib/l10n/app_km.arb
@@ -590,6 +590,8 @@
   "homeSiteNameHint": "បញ្ចូលឈ្មោះផ្ទាល់ខ្លួន",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "គន្លឹះ: ដាក់ http:// សម្រាប់ HTTP sites ឬទុកចោលសម្រាប់ HTTPS",
+  "homeSiteIconPick": "ប្ដូររូបតំណាង",
+  "homeSiteIconReset": "ប្រើរូបតំណាងស្វ័យប្រវត្តិ",
   "homeRefreshTitleAndIcon": "ធ្វើឱ្យ Title & Icon ស្រស់",
   "homeMoveUp": "ឡើងលើ",
   "homeMoveDown": "ចុះក្រោម",

--- a/lib/l10n/app_kn.arb
+++ b/lib/l10n/app_kn.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "ಕಸ್ಟಮ್ ಹೆಸರು ನಮೂದಿಸಿ",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "ಸಲಹೆ: HTTP ಸೈಟ್‌ಗಳಿಗೆ http:// ಸೇರಿಸಿ, ಅಥವಾ HTTPS ಗಾಗಿ ಅದನ್ನು ಬಿಟ್ಟುಬಿಡಿ",
+  "homeSiteIconPick": "ಐಕಾನ್ ಬದಲಾಯಿಸಿ",
+  "homeSiteIconReset": "ಸ್ವಯಂಚಾಲಿತ ಐಕಾನ್ ಬಳಸಿ",
   "homeRefreshTitleAndIcon": "ಶೀರ್ಷಿಕೆ ಮತ್ತು ಐಕಾನ್ ರಿಫ್ರೆಶ್ ಮಾಡಿ",
   "homeMoveUp": "ಮೇಲಕ್ಕೆ ಸರಿಸಿ",
   "homeMoveDown": "ಕೆಳಕ್ಕೆ ಸರಿಸಿ",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "사용자 지정 이름 입력",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "팁: HTTP 사이트는 http://를 포함하고, HTTPS는 생략하세요",
+  "homeSiteIconPick": "아이콘 변경",
+  "homeSiteIconReset": "자동 아이콘 사용",
   "homeRefreshTitleAndIcon": "제목 및 아이콘 새로고침",
   "homeMoveUp": "위로 이동",
   "homeMoveDown": "아래로 이동",

--- a/lib/l10n/app_la.arb
+++ b/lib/l10n/app_la.arb
@@ -590,6 +590,8 @@
   "homeSiteNameHint": "Nomen proprium inscribere",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Consilium: Include http:// pro locis HTTP, vel omitte pro HTTPS",
+  "homeSiteIconPick": "Signum mutare",
+  "homeSiteIconReset": "Signum automatum adhibere",
   "homeRefreshTitleAndIcon": "Titulum et signum renovare",
   "homeMoveUp": "Sursum movere",
   "homeMoveDown": "Deorsum movere",

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Įveskite pasirinktinį pavadinimą",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Patarimas: įtraukite http:// HTTP svetainėms arba palikite be jo HTTPS atveju",
+  "homeSiteIconPick": "Keisti piktogramą",
+  "homeSiteIconReset": "Naudoti automatinę piktogramą",
   "homeRefreshTitleAndIcon": "Atnaujinti pavadinimą ir piktogramą",
   "homeMoveUp": "Perkelti aukštyn",
   "homeMoveDown": "Perkelti žemyn",

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Ievadiet pielāgotu nosaukumu",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Padoms: iekļaujiet http:// HTTP vietnēm vai izlaidiet to HTTPS gadījumā",
+  "homeSiteIconPick": "Mainīt ikonu",
+  "homeSiteIconReset": "Izmantot automātisko ikonu",
   "homeRefreshTitleAndIcon": "Atsvaidzināt nosaukumu un ikonu",
   "homeMoveUp": "Pārvietot augšup",
   "homeMoveDown": "Pārvietot lejup",

--- a/lib/l10n/app_mk.arb
+++ b/lib/l10n/app_mk.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Внеси прилагодено име",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Совет: вклучете http:// за HTTP страници, или изоставете го за HTTPS",
+  "homeSiteIconPick": "Промени икона",
+  "homeSiteIconReset": "Користи автоматска икона",
   "homeRefreshTitleAndIcon": "Освежи наслов и икона",
   "homeMoveUp": "Премести нагоре",
   "homeMoveDown": "Премести надолу",

--- a/lib/l10n/app_ml.arb
+++ b/lib/l10n/app_ml.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "ഒരു ഇഷ്ടാനുസൃത പേര് നൽകുക",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "സൂചന: HTTP സൈറ്റുകൾക്ക് http:// ഉൾപ്പെടുത്തുക, അല്ലെങ്കിൽ HTTPS-നായി അത് ഒഴിവാക്കുക",
+  "homeSiteIconPick": "ഐക്കൺ മാറ്റുക",
+  "homeSiteIconReset": "സ്വയമേവയുള്ള ഐക്കൺ ഉപയോഗിക്കുക",
   "homeRefreshTitleAndIcon": "ശീർഷകവും ഐക്കണും പുതുക്കുക",
   "homeMoveUp": "മുകളിലേക്ക് നീക്കുക",
   "homeMoveDown": "താഴേക്ക് നീക്കുക",

--- a/lib/l10n/app_mn.arb
+++ b/lib/l10n/app_mn.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Захиалгат нэр оруулна уу",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Зөвлөмж: HTTP сайтад http:// оруулна, эсвэл HTTPS-д орхино уу",
+  "homeSiteIconPick": "Дүрс тэмдэг өөрчлөх",
+  "homeSiteIconReset": "Автомат дүрс тэмдэг ашиглах",
   "homeRefreshTitleAndIcon": "Гарчиг ба дүрс тэмдэг сэргээх",
   "homeMoveUp": "Дээш зөөх",
   "homeMoveDown": "Доош зөөх",

--- a/lib/l10n/app_mr.arb
+++ b/lib/l10n/app_mr.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "सानुकूल नाव प्रविष्ट करा",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "टीप: HTTP साइटसाठी http:// समाविष्ट करा, किंवा HTTPS साठी ते वगळा",
+  "homeSiteIconPick": "चिन्ह बदला",
+  "homeSiteIconReset": "स्वयंचलित चिन्ह वापरा",
   "homeRefreshTitleAndIcon": "शीर्षक आणि चिन्ह रिफ्रेश करा",
   "homeMoveUp": "वर हलवा",
   "homeMoveDown": "खाली हलवा",

--- a/lib/l10n/app_ms.arb
+++ b/lib/l10n/app_ms.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Masukkan nama tersuai",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Petua: Sertakan http:// untuk tapak HTTP, atau tinggalkannya untuk HTTPS",
+  "homeSiteIconPick": "Tukar ikon",
+  "homeSiteIconReset": "Guna ikon automatik",
   "homeRefreshTitleAndIcon": "Muat Semula Tajuk & Ikon",
   "homeMoveUp": "Alih ke Atas",
   "homeMoveDown": "Alih ke Bawah",

--- a/lib/l10n/app_mt.arb
+++ b/lib/l10n/app_mt.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Daħħal isem personalizzat",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Tip: Inkludi http:// għal siti HTTP, jew ħalliha barra għal HTTPS",
+  "homeSiteIconPick": "Ibdel l-ikona",
+  "homeSiteIconReset": "Uża l-ikona awtomatika",
   "homeRefreshTitleAndIcon": "Aġġorna t-Titlu u l-Ikona",
   "homeMoveUp": "Mexxi 'l Fuq",
   "homeMoveDown": "Mexxi 'l Isfel",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Skriv inn et egendefinert navn",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Tips: Inkluder http:// for HTTP-nettsteder, eller utelat det for HTTPS",
+  "homeSiteIconPick": "Endre ikon",
+  "homeSiteIconReset": "Bruk automatisk ikon",
   "homeRefreshTitleAndIcon": "Oppdater tittel og ikon",
   "homeMoveUp": "Flytt opp",
   "homeMoveDown": "Flytt ned",

--- a/lib/l10n/app_ne.arb
+++ b/lib/l10n/app_ne.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "अनुकूलन नाम प्रविष्ट गर्नुहोस्",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "सुझाव: HTTP साइटहरूका लागि http:// समावेश गर्नुहोस्, वा HTTPS का लागि छोड्नुहोस्",
+  "homeSiteIconPick": "आइकन परिवर्तन गर्नुहोस्",
+  "homeSiteIconReset": "स्वचालित आइकन प्रयोग गर्नुहोस्",
   "homeRefreshTitleAndIcon": "शीर्षक र आइकन ताजा गर्नुहोस्",
   "homeMoveUp": "माथि सार्नुहोस्",
   "homeMoveDown": "तल सार्नुहोस्",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Voer een aangepaste naam in",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Tip: voeg http:// toe voor HTTP-sites, of laat het weg voor HTTPS",
+  "homeSiteIconPick": "Pictogram wijzigen",
+  "homeSiteIconReset": "Automatisch pictogram gebruiken",
   "homeRefreshTitleAndIcon": "Titel en pictogram vernieuwen",
   "homeMoveUp": "Omhoog verplaatsen",
   "homeMoveDown": "Omlaag verplaatsen",

--- a/lib/l10n/app_pa.arb
+++ b/lib/l10n/app_pa.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "ਇੱਕ ਕਸਟਮ ਨਾਮ ਦਰਜ ਕਰੋ",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "ਸੁਝਾਅ: HTTP ਸਾਈਟਾਂ ਲਈ http:// ਸ਼ਾਮਲ ਕਰੋ, ਜਾਂ HTTPS ਲਈ ਇਸਨੂੰ ਛੱਡ ਦਿਓ",
+  "homeSiteIconPick": "ਆਈਕਨ ਬਦਲੋ",
+  "homeSiteIconReset": "ਸਵੈਚਲਿਤ ਆਈਕਨ ਵਰਤੋ",
   "homeRefreshTitleAndIcon": "ਸਿਰਲੇਖ ਅਤੇ ਆਈਕਨ ਤਾਜ਼ਾ ਕਰੋ",
   "homeMoveUp": "ਉੱਪਰ ਲਿਜਾਓ",
   "homeMoveDown": "ਹੇਠਾਂ ਲਿਜਾਓ",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Wpisz niestandardową nazwę",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Wskazówka: dodaj http:// dla stron HTTP lub pomiń dla HTTPS",
+  "homeSiteIconPick": "Zmień ikonę",
+  "homeSiteIconReset": "Użyj automatycznej ikony",
   "homeRefreshTitleAndIcon": "Odśwież tytuł i ikonę",
   "homeMoveUp": "Przesuń w górę",
   "homeMoveDown": "Przesuń w dół",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Introduza um nome personalizado",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Sugestão: inclua http:// para sites HTTP ou deixe em branco para HTTPS",
+  "homeSiteIconPick": "Alterar ícone",
+  "homeSiteIconReset": "Usar ícone automático",
   "homeRefreshTitleAndIcon": "Atualizar título e ícone",
   "homeMoveUp": "Mover para cima",
   "homeMoveDown": "Mover para baixo",

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Digite um nome personalizado",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Dica: inclua http:// para sites HTTP, ou deixe de fora para HTTPS",
+  "homeSiteIconPick": "Alterar ícone",
+  "homeSiteIconReset": "Usar ícone automático",
   "homeRefreshTitleAndIcon": "Atualizar título e ícone",
   "homeMoveUp": "Mover para cima",
   "homeMoveDown": "Mover para baixo",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Introdu un nume personalizat",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Sfat: include http:// pentru site-uri HTTP, sau omite-l pentru HTTPS",
+  "homeSiteIconPick": "Schimbă pictograma",
+  "homeSiteIconReset": "Folosește pictograma automată",
   "homeRefreshTitleAndIcon": "Reîmprospătează titlul și pictograma",
   "homeMoveUp": "Mută în sus",
   "homeMoveDown": "Mută în jos",

--- a/lib/l10n/app_si.arb
+++ b/lib/l10n/app_si.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "අභිරුචි නමක් ඇතුළත් කරන්න",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "ඉඟිය: HTTP අඩවි සඳහා http:// ඇතුළත් කරන්න, හෝ HTTPS සඳහා එය හැර දමන්න",
+  "homeSiteIconPick": "අයිකනය වෙනස් කරන්න",
+  "homeSiteIconReset": "ස්වයංක්‍රීය අයිකනය භාවිතා කරන්න",
   "homeRefreshTitleAndIcon": "මාතෘකාව සහ අයිකනය නැවුම් කරන්න",
   "homeMoveUp": "ඉහළට ගෙන යන්න",
   "homeMoveDown": "පහළට ගෙන යන්න",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Zadajte vlastný názov",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Tip: Pre HTTP stránky uveďte http://, alebo ho vynechajte pre HTTPS",
+  "homeSiteIconPick": "Zmeniť ikonu",
+  "homeSiteIconReset": "Použiť automatickú ikonu",
   "homeRefreshTitleAndIcon": "Obnoviť názov a ikonu",
   "homeMoveUp": "Posunúť nahor",
   "homeMoveDown": "Posunúť nadol",

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Vnesite ime po meri",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Namig: vključite http:// za strani HTTP ali ga izpustite za HTTPS",
+  "homeSiteIconPick": "Spremeni ikono",
+  "homeSiteIconReset": "Uporabi samodejno ikono",
   "homeRefreshTitleAndIcon": "Osveži naslov in ikono",
   "homeMoveUp": "Premakni gor",
   "homeMoveDown": "Premakni dol",

--- a/lib/l10n/app_sq.arb
+++ b/lib/l10n/app_sq.arb
@@ -590,6 +590,8 @@
   "homeSiteNameHint": "Fut një emër të personalizuar",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Këshillë: Përfshi http:// për faqet HTTP, ose lëre jashtë për HTTPS",
+  "homeSiteIconPick": "Ndrysho ikonën",
+  "homeSiteIconReset": "Përdor ikonën automatike",
   "homeRefreshTitleAndIcon": "Rifresko titullin dhe ikonën",
   "homeMoveUp": "Lëviz lart",
   "homeMoveDown": "Lëviz poshtë",

--- a/lib/l10n/app_sr.arb
+++ b/lib/l10n/app_sr.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Унесите прилагођени назив",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Савет: укључите http:// за HTTP сајтове, или га изоставите за HTTPS",
+  "homeSiteIconPick": "Промени иконицу",
+  "homeSiteIconReset": "Користи аутоматску иконицу",
   "homeRefreshTitleAndIcon": "Освежи наслов и иконицу",
   "homeMoveUp": "Помери горе",
   "homeMoveDown": "Помери доле",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Ange ett anpassat namn",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Tips: Inkludera http:// för HTTP-webbplatser, eller utelämna det för HTTPS",
+  "homeSiteIconPick": "Byt ikon",
+  "homeSiteIconReset": "Använd automatisk ikon",
   "homeRefreshTitleAndIcon": "Uppdatera titel och ikon",
   "homeMoveUp": "Flytta upp",
   "homeMoveDown": "Flytta ner",

--- a/lib/l10n/app_sw.arb
+++ b/lib/l10n/app_sw.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Weka jina maalum",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Kidokezo: Jumuisha http:// kwa tovuti za HTTP, au liache kwa HTTPS",
+  "homeSiteIconPick": "Badilisha aikoni",
+  "homeSiteIconReset": "Tumia aikoni ya kiotomatiki",
   "homeRefreshTitleAndIcon": "Onyesha upya Kichwa na Aikoni",
   "homeMoveUp": "Sogeza Juu",
   "homeMoveDown": "Sogeza Chini",

--- a/lib/l10n/app_ta.arb
+++ b/lib/l10n/app_ta.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "தனிப்பயன் பெயரை உள்ளிடவும்",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "குறிப்பு: HTTP தளங்களுக்கு http:// ஐ சேர்க்கவும், அல்லது HTTPS க்கு அதை விட்டுவிடவும்",
+  "homeSiteIconPick": "ஐகானை மாற்று",
+  "homeSiteIconReset": "தானியங்கி ஐகானைப் பயன்படுத்து",
   "homeRefreshTitleAndIcon": "தலைப்பு & ஐகானைப் புதுப்பி",
   "homeMoveUp": "மேலே நகர்த்து",
   "homeMoveDown": "கீழே நகர்த்து",

--- a/lib/l10n/app_te.arb
+++ b/lib/l10n/app_te.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "అనుకూల పేరును నమోదు చేయండి",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "చిట్కా: HTTP సైట్‌ల కోసం http:// చేర్చండి, లేదా HTTPS కోసం దాన్ని వదిలివేయండి",
+  "homeSiteIconPick": "ఐకాన్ మార్చు",
+  "homeSiteIconReset": "స్వయంచాలక ఐకాన్ ఉపయోగించు",
   "homeRefreshTitleAndIcon": "శీర్షిక & ఐకాన్ రిఫ్రెష్ చేయి",
   "homeMoveUp": "పైకి జరుపు",
   "homeMoveDown": "కిందకు జరుపు",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "ป้อนชื่อที่กำหนดเอง",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "เคล็ดลับ: ใส่ http:// สำหรับเว็บไซต์ HTTP หรือเว้นไว้สำหรับ HTTPS",
+  "homeSiteIconPick": "เปลี่ยนไอคอน",
+  "homeSiteIconReset": "ใช้ไอคอนอัตโนมัติ",
   "homeRefreshTitleAndIcon": "รีเฟรชชื่อและไอคอน",
   "homeMoveUp": "เลื่อนขึ้น",
   "homeMoveDown": "เลื่อนลง",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Özel bir ad girin",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "İpucu: HTTP siteleri için http:// ekleyin veya HTTPS için boş bırakın",
+  "homeSiteIconPick": "Simgeyi Değiştir",
+  "homeSiteIconReset": "Otomatik Simgeyi Kullan",
   "homeRefreshTitleAndIcon": "Başlık ve Simgeyi Yenile",
   "homeMoveUp": "Yukarı Taşı",
   "homeMoveDown": "Aşağı Taşı",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "Введіть власну назву",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "Підказка: додайте http:// для HTTP-сайтів або не вказуйте для HTTPS",
+  "homeSiteIconPick": "Змінити значок",
+  "homeSiteIconReset": "Використовувати автоматичний значок",
   "homeRefreshTitleAndIcon": "Оновити назву та значок",
   "homeMoveUp": "Перемістити вгору",
   "homeMoveDown": "Перемістити вниз",

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "حسب ضرورت نام درج کریں",
   "homeUrlLabel": "URL",
   "homeUrlSchemeTip": "تجویز: HTTP سائٹس کے لیے http:// شامل کریں، یا HTTPS کے لیے اسے چھوڑ دیں",
+  "homeSiteIconPick": "آئیکن تبدیل کریں",
+  "homeSiteIconReset": "خودکار آئیکن استعمال کریں",
   "homeRefreshTitleAndIcon": "عنوان اور آئیکن ریفریش کریں",
   "homeMoveUp": "اوپر منتقل کریں",
   "homeMoveDown": "نیچے منتقل کریں",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "輸入自訂名稱",
   "homeUrlLabel": "網址",
   "homeUrlSchemeTip": "提示：HTTP 網站請包含 http://，HTTPS 則可省略",
+  "homeSiteIconPick": "變更圖示",
+  "homeSiteIconReset": "使用自動圖示",
   "homeRefreshTitleAndIcon": "重新整理標題與圖示",
   "homeMoveUp": "上移",
   "homeMoveDown": "下移",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -588,6 +588,8 @@
   "homeSiteNameHint": "輸入自訂名稱",
   "homeUrlLabel": "網址",
   "homeUrlSchemeTip": "提示：HTTP 網站請包含 http://，HTTPS 則可省略",
+  "homeSiteIconPick": "變更圖示",
+  "homeSiteIconReset": "使用自動圖示",
   "homeRefreshTitleAndIcon": "重新整理標題與圖示",
   "homeMoveUp": "上移",
   "homeMoveDown": "下移",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:webspace/l10n/gen/app_localizations.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp
     show InAppWebViewController, ServiceWorkerController, SslCertificate;
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:http/http.dart' as http;
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:html/parser.dart' as html_parser;
@@ -26,6 +27,7 @@ import 'package:webspace/screens/settings.dart';
 import 'package:webspace/screens/app_settings.dart';
 import 'package:webspace/services/icon_service.dart';
 import 'package:webspace/services/icon_png_export.dart';
+import 'package:webspace/services/custom_icon.dart';
 import 'package:webspace/services/startup_init_engine.dart';
 import 'package:webspace/screens/inappbrowser.dart';
 import 'package:webspace/screens/webspaces_list.dart';
@@ -1306,11 +1308,13 @@ class _WebSpacePageState extends State<WebSpacePage>
       // can't decode SVG, so an SVG favicon would otherwise fall back to the
       // WebSpace app icon. exportIconAsPng also normalizes ICO/PNG and applies
       // the site's proxy. iconUrl stays as a native-side fallback if it fails.
-      final iconBytes = await exportIconAsPng(
-        model.initUrl,
-        resolvedIconUrl: faviconUrl,
-        proxy: model.proxySettings,
-      );
+      // A user-chosen icon is already normalized PNG and wins outright.
+      final iconBytes = model.customIconPng ??
+          await exportIconAsPng(
+            model.initUrl,
+            resolvedIconUrl: faviconUrl,
+            proxy: model.proxySettings,
+          );
       if (!mounted) return;
       await ShortcutService.pinShortcut(
         siteId: model.siteId,
@@ -6115,6 +6119,7 @@ class _WebSpacePageState extends State<WebSpacePage>
                             url: siteModel.initUrl,
                             size: 16,
                             proxy: siteModel.proxySettings,
+                            customIcon: siteModel.customIconPng,
                           ),
                           SizedBox(width: 6),
                           Flexible(
@@ -6547,72 +6552,167 @@ class _WebSpacePageState extends State<WebSpacePage>
   }
 
   void _editSite(int index) async {
-    final nameController = TextEditingController(text: _webViewModels[index].name);
-    final urlController = TextEditingController(text: _webViewModels[index].initUrl);
+    final model = _webViewModels[index];
+    final nameController = TextEditingController(text: model.name);
+    final urlController = TextEditingController(text: model.initUrl);
 
     final loc = AppLocalizations.of(context);
     final urlHint = 'http://example.com:8080';
-    final result = await showDialog<Map<String, String>>(
+    Uint8List? pendingIcon = model.customIconPng;
+    var iconChanged = false;
+    var isPickingIcon = false;
+    final result = await showDialog<Map<String, Object?>>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: Text(loc.homeEditSiteTitle),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            TextField(
-              controller: nameController,
-              autofocus: true,
-              autocorrect: false,
-              enableSuggestions: false,
-              decoration: InputDecoration(
-                labelText: loc.homeSiteNameLabel,
-                hintText: loc.homeSiteNameHint,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setDialogState) => AlertDialog(
+          title: Text(loc.homeEditSiteTitle),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: nameController,
+                autofocus: true,
+                autocorrect: false,
+                enableSuggestions: false,
+                decoration: InputDecoration(
+                  labelText: loc.homeSiteNameLabel,
+                  hintText: loc.homeSiteNameHint,
+                ),
               ),
-            ),
-            SizedBox(height: 16),
-            TextField(
-              controller: urlController,
-              autocorrect: false,
-              enableSuggestions: false,
-              keyboardType: TextInputType.url,
-              decoration: InputDecoration(
-                labelText: loc.homeUrlLabel,
-                hintText: urlHint,
+              SizedBox(height: 16),
+              TextField(
+                controller: urlController,
+                autocorrect: false,
+                enableSuggestions: false,
+                keyboardType: TextInputType.url,
+                decoration: InputDecoration(
+                  labelText: loc.homeUrlLabel,
+                  hintText: urlHint,
+                ),
               ),
+              SizedBox(height: 8),
+              Text(
+                loc.homeUrlSchemeTip,
+                style: TextStyle(fontSize: 11, color: Colors.grey),
+              ),
+              SizedBox(height: 16),
+              Row(
+                children: [
+                  SizedBox(
+                    width: 32,
+                    height: 32,
+                    child: pendingIcon != null
+                        ? Image.memory(
+                            pendingIcon!,
+                            width: 32,
+                            height: 32,
+                            fit: BoxFit.contain,
+                            gaplessPlayback: true,
+                          )
+                        : UnifiedFaviconImage(
+                            url: model.initUrl,
+                            size: 32,
+                            proxy: model.proxySettings,
+                          ),
+                  ),
+                  SizedBox(width: 12),
+                  Expanded(
+                    child: Align(
+                      alignment: AlignmentDirectional.centerStart,
+                      child: TextButton.icon(
+                        icon: Icon(Icons.image_outlined),
+                        label: Text(loc.homeSiteIconPick),
+                        onPressed: () async {
+                          if (isPickingIcon) return;
+                          isPickingIcon = true;
+                          final messenger = ScaffoldMessenger.of(context);
+                          try {
+                            final picked = await FilePicker.pickFiles(
+                              type: FileType.custom,
+                              allowedExtensions: [
+                                'png', 'jpg', 'jpeg', 'webp', 'gif', 'bmp', 'ico',
+                              ],
+                              allowMultiple: false,
+                            );
+                            if (picked == null || picked.files.isEmpty) return;
+                            final file = picked.files.first;
+                            Uint8List? raw = file.bytes;
+                            if (raw == null && file.path != null) {
+                              raw = await File(file.path!).readAsBytes();
+                            }
+                            final processed = raw == null
+                                ? null
+                                : await processCustomIconImageAsync(raw);
+                            if (processed == null) {
+                              messenger.showSnackBar(
+                                SnackBar(content: Text(loc.addSiteFileReadError)),
+                              );
+                              return;
+                            }
+                            setDialogState(() {
+                              pendingIcon = processed;
+                              iconChanged = true;
+                            });
+                          } finally {
+                            isPickingIcon = false;
+                          }
+                        },
+                      ),
+                    ),
+                  ),
+                  if (pendingIcon != null)
+                    IconButton(
+                      icon: Icon(Icons.restart_alt),
+                      tooltip: loc.homeSiteIconReset,
+                      onPressed: () {
+                        setDialogState(() {
+                          pendingIcon = null;
+                          iconChanged = true;
+                        });
+                      },
+                    ),
+                ],
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(loc.commonCancel),
             ),
-            SizedBox(height: 8),
-            Text(
-              loc.homeUrlSchemeTip,
-              style: TextStyle(fontSize: 11, color: Colors.grey),
+            TextButton(
+              onPressed: () {
+                final name = nameController.text.trim();
+                var url = urlController.text.trim();
+
+                // Infer protocol if not specified
+                url = ensureUrlScheme(url);
+
+                Navigator.pop(context, <String, Object?>{
+                  'name': name,
+                  'url': url,
+                  'iconChanged': iconChanged,
+                  'icon': pendingIcon,
+                });
+              },
+              child: Text(loc.commonSave),
             ),
           ],
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: Text(loc.commonCancel),
-          ),
-          TextButton(
-            onPressed: () {
-              final name = nameController.text.trim();
-              var url = urlController.text.trim();
-
-              // Infer protocol if not specified
-              url = ensureUrlScheme(url);
-
-              Navigator.pop(context, {'name': name, 'url': url});
-            },
-            child: Text(loc.commonSave),
-          ),
-        ],
       ),
     );
 
     if (result == null || !mounted) return;
     if (index >= _webViewModels.length) return;
 
-    final newName = result['name'];
-    final newUrl = result['url'];
+    final newName = result['name'] as String?;
+    final newUrl = result['url'] as String?;
+
+    if (result['iconChanged'] == true) {
+      setState(() {
+        _webViewModels[index].customIconPng = result['icon'] as Uint8List?;
+      });
+    }
 
     if (newName != null && newName.isNotEmpty) {
       setState(() {
@@ -6991,6 +7091,7 @@ class _WebSpacePageState extends State<WebSpacePage>
                     url: m.initUrl,
                     size: 32,
                     proxy: m.proxySettings,
+                    customIcon: m.customIconPng,
                   ),
                 ),
                 title: Text(
@@ -7179,6 +7280,7 @@ class _WebSpacePageState extends State<WebSpacePage>
                                 url: _webViewModels[index].initUrl,
                                 size: 28,
                                 proxy: _webViewModels[index].proxySettings,
+                                customIcon: _webViewModels[index].customIconPng,
                               ),
                             ),
                           ),
@@ -7221,6 +7323,7 @@ class _WebSpacePageState extends State<WebSpacePage>
                                 url: _webViewModels[index].initUrl,
                                 size: 36,
                                 proxy: _webViewModels[index].proxySettings,
+                                customIcon: _webViewModels[index].customIconPng,
                               ),
                             ),
                           ),
@@ -7273,6 +7376,7 @@ class _WebSpacePageState extends State<WebSpacePage>
                           url: _webViewModels[index].initUrl,
                           size: 28,
                           proxy: _webViewModels[index].proxySettings,
+                          customIcon: _webViewModels[index].customIconPng,
                         ),
                       ),
                     ),
@@ -7315,6 +7419,7 @@ class _WebSpacePageState extends State<WebSpacePage>
                           url: _webViewModels[index].initUrl,
                           size: 36,
                           proxy: _webViewModels[index].proxySettings,
+                          customIcon: _webViewModels[index].customIconPng,
                         ),
                       ),
                     ),
@@ -8015,6 +8120,7 @@ class _DispatchPickerSheetState extends State<_DispatchPickerSheet> {
           url: site.initUrl,
           size: 32,
           proxy: site.proxySettings,
+          customIcon: site.customIconPng,
         ),
       );
 

--- a/lib/screens/add_site.dart
+++ b/lib/screens/add_site.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
@@ -82,12 +83,16 @@ class UnifiedFaviconImage extends StatefulWidget {
   /// app-global outbound proxy applies. When set, [resolveEffectiveProxy]
   /// chooses per-site if explicit, or global if the per-site type is DEFAULT.
   final UserProxySettings? proxy;
+  /// User-chosen icon bytes (`WebViewModel.customIconPng`). When set, they
+  /// render directly and no favicon is fetched for this widget.
+  final Uint8List? customIcon;
 
   const UnifiedFaviconImage({
     required this.url,
     required this.size,
     this.domain,
     this.proxy,
+    this.customIcon,
   });
 
   @override
@@ -113,12 +118,16 @@ class _UnifiedFaviconImageState extends State<UnifiedFaviconImage> {
     // fetch that originally died on CERTIFICATE_VERIFY_FAILED — listen
     // for invalidations targeting our URL and reset.
     _invalidationSub = faviconInvalidations.listen((invalidatedUrl) {
-      if (invalidatedUrl == widget.url && mounted) {
+      if (invalidatedUrl == widget.url && mounted && widget.customIcon == null) {
         FaviconUrlCache.invalidate(widget.url);
         _resetAndLoad();
       }
     });
-    _loadIcon();
+    if (widget.customIcon == null) {
+      _loadIcon();
+    } else {
+      _isLoading = false;
+    }
   }
 
   @override
@@ -130,7 +139,8 @@ class _UnifiedFaviconImageState extends State<UnifiedFaviconImage> {
   @override
   void didUpdateWidget(UnifiedFaviconImage oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.url != widget.url) {
+    if (widget.customIcon != null) return; // build() renders the bytes directly
+    if (oldWidget.url != widget.url || oldWidget.customIcon != null) {
       _resetAndLoad();
     } else if (_currentIconUrl != null && FaviconUrlCache.get(widget.url) == null) {
       // Cache was invalidated (e.g. by refresh) — re-fetch
@@ -222,6 +232,23 @@ class _UnifiedFaviconImageState extends State<UnifiedFaviconImage> {
 
   @override
   Widget build(BuildContext context) {
+    final customIcon = widget.customIcon;
+    if (customIcon != null) {
+      return Image.memory(
+        customIcon,
+        width: widget.size,
+        height: widget.size,
+        fit: BoxFit.contain,
+        filterQuality: FilterQuality.high,
+        gaplessPlayback: true,
+        errorBuilder: (context, error, stackTrace) => Icon(
+          Icons.language,
+          size: widget.size,
+          color: Theme.of(context).colorScheme.primary,
+        ),
+      );
+    }
+
     // Show current best icon, or loading indicator if nothing yet
     if (_currentIconUrl == null) {
       if (_isLoading) {

--- a/lib/screens/webspace_detail.dart
+++ b/lib/screens/webspace_detail.dart
@@ -146,6 +146,7 @@ class _WebspaceDetailScreenState extends State<WebspaceDetailScreen> {
                             url: site.initUrl,
                             size: 32,
                             proxy: site.proxySettings,
+                            customIcon: site.customIconPng,
                           ),
                           title: Text(site.getDisplayName()),
                           subtitle: Text(extractDomain(site.initUrl)),

--- a/lib/services/custom_icon.dart
+++ b/lib/services/custom_icon.dart
@@ -1,0 +1,44 @@
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart' show compute;
+import 'package:image/image.dart' as img;
+
+/// Longest side of a stored custom icon. Matches the size home-shortcut
+/// export rasterizes at; in-app renderings are 16-36px.
+const int kCustomIconMaxDimension = 256;
+
+/// Normalize a user-picked image into the bytes stored on
+/// `WebViewModel.customIconPng`: decode any raster format the `image`
+/// package understands (PNG/JPEG/WebP/GIF/BMP/ICO/TIFF), downscale so the
+/// longest side is at most [maxDimension] (never upscale), and re-encode
+/// as PNG. Returns null when the bytes are not a decodable image.
+Uint8List? processCustomIconImage(
+  Uint8List raw, {
+  int maxDimension = kCustomIconMaxDimension,
+}) {
+  img.Image? decoded;
+  try {
+    decoded = img.decodeImage(raw);
+  } catch (_) {
+    return null;
+  }
+  if (decoded == null) return null;
+  final longest =
+      decoded.width > decoded.height ? decoded.width : decoded.height;
+  if (longest > maxDimension) {
+    final scale = maxDimension / longest;
+    decoded = img.copyResize(
+      decoded,
+      width: (decoded.width * scale).round().clamp(1, maxDimension),
+      height: (decoded.height * scale).round().clamp(1, maxDimension),
+      interpolation: img.Interpolation.average,
+    );
+  }
+  return Uint8List.fromList(img.encodePng(decoded));
+}
+
+/// [processCustomIconImage] off the UI thread — decoding a camera-sized
+/// JPEG takes long enough to drop frames.
+Future<Uint8List?> processCustomIconImageAsync(Uint8List raw) {
+  return compute(processCustomIconImage, raw);
+}

--- a/lib/services/site_settings_qr_codec.dart
+++ b/lib/services/site_settings_qr_codec.dart
@@ -67,6 +67,9 @@ class SiteSettingsQrCodec {
     'userScripts',
     'enabledGlobalScriptIds',
     'blockedCookies',
+    // Base64 PNG bytes: would blow QR capacity, and an icon is
+    // device-local cosmetics, not shareable configuration.
+    'customIconPng',
   };
 
   /// Strip a full `WebViewModel.toJson()` to the QR-shareable subset.

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert' show base64Decode, base64Encode;
 import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
@@ -423,6 +424,15 @@ class WebViewModel {
   /// fingerprint on upgrade. Regenerate via [rerollFingerprint].
   String? fingerprintResetNonce;
 
+  /// User-chosen icon for this site, normalized to PNG (longest side
+  /// <= 256px) by `processCustomIconImage`. When set, it overrides the
+  /// fetched favicon everywhere the site's icon renders and in pinned
+  /// home shortcuts; null means the automatic favicon. Stored inline in
+  /// the model JSON (base64) so it rides settings backups and, for
+  /// archive-tier sites, lives only inside the encrypted archive slice —
+  /// no per-siteId plaintext file appears on disk (ARCH-006).
+  Uint8List? customIconPng;
+
   /// User-defined domain-claim list used by `LinkRoutingService` to route
   /// inbound share/open-intent URLs to a site (LIR-001..LIR-010). When
   /// null, the resolver behaves as if the site claimed
@@ -594,6 +604,7 @@ class WebViewModel {
     this.spoofWindowWidth,
     this.spoofWindowHeight,
     this.fingerprintResetNonce,
+    this.customIconPng,
     this.domainClaims,
     this.stateSetterF,
     this.isArchiveTier = false,
@@ -1716,6 +1727,8 @@ class WebViewModel {
         if (spoofWindowHeight != null) 'spoofWindowHeight': spoofWindowHeight,
         if (fingerprintResetNonce != null)
           'fingerprintResetNonce': fingerprintResetNonce,
+        if (customIconPng != null)
+          'customIconPng': base64Encode(customIconPng!),
         if (domainClaims != null && domainClaims!.isNotEmpty)
           'domainClaims': domainClaims!.map((c) => c.toJson()).toList(),
       };
@@ -1807,12 +1820,22 @@ class WebViewModel {
       spoofWindowWidth: (json['spoofWindowWidth'] as num?)?.toInt(),
       spoofWindowHeight: (json['spoofWindowHeight'] as num?)?.toInt(),
       fingerprintResetNonce: json['fingerprintResetNonce'] as String?,
+      customIconPng: _decodeCustomIconPng(json['customIconPng']),
       domainClaims: (json['domainClaims'] as List<dynamic>?)
           ?.map((e) => DomainClaim.fromJson(e as Map<String, dynamic>))
           .toList(),
       stateSetterF: stateSetterF,
       isArchiveTier: isArchiveTier,
     )..pageTitle = dropUrl ? null : json['pageTitle'];
+  }
+}
+
+Uint8List? _decodeCustomIconPng(Object? raw) {
+  if (raw is! String || raw.isEmpty) return null;
+  try {
+    return base64Decode(raw);
+  } catch (_) {
+    return null;
   }
 }
 

--- a/openspec/specs/icon-fetching/spec.md
+++ b/openspec/specs/icon-fetching/spec.md
@@ -4,6 +4,11 @@
 
 Comprehensive icon fetching system for the Webspace app that provides high-quality favicons through multiple sources, progressive loading, and intelligent selection.
 
+A user-set custom icon (`WebViewModel.customIconPng`, see EDIT-008 in
+[site-editing](../site-editing/spec.md)) takes precedence over every fetched
+source: when present, `UnifiedFaviconImage` renders it directly and skips
+fetching entirely.
+
 ## Status
 
 - **Date**: 2026-01-25

--- a/openspec/specs/site-editing/spec.md
+++ b/openspec/specs/site-editing/spec.md
@@ -117,6 +117,55 @@ Page titles SHALL persist across app restarts.
 
 ---
 
+### Requirement: EDIT-008 - Custom Site Icon
+
+Users SHALL be able to override a site's automatically fetched favicon with an
+image of their own from the edit dialog, and revert to the automatic icon later.
+
+The chosen image is normalized to PNG with a longest side of at most 256px and
+stored inline on the site model (`WebViewModel.customIconPng`, base64 in JSON).
+Because it lives in the model JSON it automatically rides settings backups, and
+for archive-tier sites it is persisted only inside the encrypted archive slice —
+no per-`siteId` plaintext file is written (ARCH-006 audit: no disk, background
+scheduling, or OS-UI surface beyond the existing home-shortcut path). The field
+is excluded from the QR share payload (`SiteSettingsQrCodec.excludedKeys`):
+image bytes would blow QR capacity and an icon is device-local cosmetics.
+
+#### Scenario: Set a custom icon
+
+**Given** a site whose URL yields no favicon (or an unwanted one)
+**When** the user opens the edit dialog, taps "Change icon", and picks a raster
+image (PNG/JPEG/WebP/GIF/BMP/ICO)
+**And** saves
+**Then** the chosen image is shown for that site everywhere the site icon
+renders (drawer list/grid, tab strip, webspace detail, site dispatch)
+**And** no favicon fetch is performed for those renders
+**And** the icon persists across app restarts
+
+#### Scenario: Custom icon feeds home shortcuts
+
+**Given** a site with a custom icon
+**When** the user pins the site to the Android home screen
+**Then** the pinned shortcut uses the custom icon bytes instead of the fetched
+favicon
+
+#### Scenario: Revert to the automatic icon
+
+**Given** a site with a custom icon
+**When** the user opens the edit dialog and taps the reset button
+**And** saves
+**Then** the custom icon is removed
+**And** the automatically fetched favicon (icon-fetching spec) is displayed again
+
+#### Scenario: Undecodable image is rejected
+
+**Given** the user picks a file that is not a decodable raster image
+**When** processing runs
+**Then** the site's icon is left unchanged
+**And** a snackbar explains the file could not be read
+
+---
+
 ## Data Model
 
 ```dart

--- a/test/custom_icon_test.dart
+++ b/test/custom_icon_test.dart
@@ -1,0 +1,70 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:webspace/services/custom_icon.dart';
+import 'package:webspace/services/site_settings_qr_codec.dart';
+import 'package:webspace/web_view_model.dart';
+
+Uint8List _pngOfSize(int w, int h) {
+  final im = img.Image(width: w, height: h);
+  img.fill(im, color: img.ColorRgb8(30, 120, 200));
+  return Uint8List.fromList(img.encodePng(im));
+}
+
+void main() {
+  group('processCustomIconImage', () {
+    test('downscales oversized images preserving aspect ratio', () {
+      final out = processCustomIconImage(_pngOfSize(1024, 512));
+      expect(out, isNotNull);
+      final decoded = img.decodePng(out!);
+      expect(decoded!.width, kCustomIconMaxDimension);
+      expect(decoded.height, kCustomIconMaxDimension ~/ 2);
+    });
+
+    test('keeps small images at their size and re-encodes as PNG', () {
+      final jpg = Uint8List.fromList(
+          img.encodeJpg(img.Image(width: 40, height: 40)));
+      final out = processCustomIconImage(jpg);
+      expect(out, isNotNull);
+      final decoded = img.decodePng(out!);
+      expect(decoded, isNotNull);
+      expect(decoded!.width, 40);
+      expect(decoded.height, 40);
+    });
+
+    test('returns null for undecodable bytes', () {
+      final garbage = Uint8List.fromList(List<int>.filled(64, 7));
+      expect(processCustomIconImage(garbage), isNull);
+    });
+  });
+
+  group('WebViewModel.customIconPng', () {
+    test('round-trips through toJson/fromJson', () {
+      final icon = _pngOfSize(16, 16);
+      final model = WebViewModel(
+        initUrl: 'https://example.com',
+        customIconPng: icon,
+      );
+      final restored = WebViewModel.fromJson(model.toJson(), null);
+      expect(restored.customIconPng, icon);
+    });
+
+    test('omitted from JSON when unset; malformed base64 tolerated', () {
+      final model = WebViewModel(initUrl: 'https://example.com');
+      expect(model.toJson().containsKey('customIconPng'), isFalse);
+
+      final json = model.toJson()..['customIconPng'] = 'not-base64!!!';
+      expect(WebViewModel.fromJson(json, null).customIconPng, isNull);
+    });
+
+    test('never rides the QR share payload (EDIT-008)', () {
+      final model = WebViewModel(
+        initUrl: 'https://example.com',
+        customIconPng: _pngOfSize(16, 16),
+      );
+      final shared = SiteSettingsQrCodec.shareableSubset(model.toJson());
+      expect(shared.containsKey('customIconPng'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Allow users to override a site's automatically fetched favicon with a custom image from the file picker, and revert to the automatic icon later.

**Changes:**
- New `custom_icon.dart` service: `processCustomIconImage()` normalizes user-picked raster images (PNG/JPEG/WebP/GIF/BMP/ICO) to PNG with longest side ≤256px, and `processCustomIconImageAsync()` runs it off the UI thread.
- `WebViewModel.customIconPng`: new `Uint8List?` field storing the normalized PNG inline (base64 in JSON), rides settings backups and archive-tier encryption; excluded from QR share payload to preserve capacity.
- Edit dialog (`_editSite`) now uses `StatefulBuilder` to show icon preview, "Change icon" button (file picker), and reset button. Dialog result includes `iconChanged` flag and icon bytes.
- `UnifiedFaviconImage` widget accepts optional `customIcon` parameter; when set, renders the bytes directly and skips favicon fetch.
- All site icon renders throughout the app (drawer, tab strip, webspace detail, dispatch sheet) now pass `customIconPng` to `UnifiedFaviconImage`.
- Home shortcut pinning (`ShortcutService.pinShortcut`) uses custom icon bytes if present, falling back to fetched favicon.
- Comprehensive test coverage in `custom_icon_test.dart`: downscaling, format re-encoding, JSON round-trip, QR exclusion.
- Localization strings added across all language files (`homeSiteIconPick`, `homeSiteIconReset`).
- Spec requirement EDIT-008 documented in `openspec/specs/site-editing/spec.md`.

https://claude.ai/code/session_01Wut4Bz5Dctu3o8wmL46K4F