### PR TITLE
Dirty-track kiosk mode in site settings; gate snapshot coverage

### DIFF
--- a/docs/bugs/006-settings-silent-discard.md
+++ b/docs/bugs/006-settings-silent-discard.md
@@ -1,0 +1,61 @@
+# BUG-006 — Site settings silently drop unsaved changes on leave
+
+Status: closed (structural gate `test/js/site_settings_dirty_snapshot.test.js`
+subsumes per-field fixes: a form field loaded in `_loadFromModel` but missing
+from `_currentSnapshot` now fails CI instead of shipping unguarded)
+
+**Spec:** [openspec/specs/site-editing/spec.md](../../openspec/specs/site-editing/spec.md) — EDIT-009
+
+## Symptom
+
+The user edits something on the per-site settings screen, leaves without
+tapping Save (system back, app-bar back, iOS edge swipe), and the change is
+gone — no "Discard changes?" prompt, no snackbar, nothing. Reads as the
+setting not working at all when the user later finds it unchanged.
+
+## Root mechanism / invariant
+
+The screen decides whether to warn by diffing the live form against a
+snapshot map (`_currentSnapshot`) captured on open and after each save;
+`PopScope.canPop` is `!_isDirty()`. The map is a **hand-enumerated list of
+fields**. Any form field that exists in the UI but is not registered in the
+map is invisible to the diff: editing only that field leaves `_isDirty()`
+false, `canPop` stays true, and the pop proceeds silently. So every new
+per-site setting added to the screen re-opens the symptom for its own field
+unless its author remembers the registration step. The invariant: **every
+field `_loadFromModel` assigns must be referenced in `_currentSnapshot`,
+except fields fully derived from an already-registered field.**
+
+## Fix attempts
+
+1. **2026-06-13 — PR #418 (`100843d`).** Added the mechanism: snapshot map,
+   `_isDirty()`, `PopScope` + discard dialog; text controllers poke
+   `setState` so `canPop` re-evaluates per keystroke. *Why partial*: the
+   snapshot enumerates fields by hand with nothing enforcing completeness.
+   Correct for every field that existed on that date, silently wrong for
+   any field added later without registration.
+
+2. **2026-06-27 — PR #454 (`2fe004f`).** Not a fix — the regression.
+   Added kiosk mode as a new settings tile (`_kioskMode`: loaded, rendered,
+   saved) but never registered it in `_currentSnapshot`. Toggling only
+   Kiosk Mode and leaving discarded the change with no warning.
+
+3. **2026-07-17 — this branch.** Registered `_kioskMode` in
+   `_currentSnapshot`, and closed the class with a structural gate
+   (`test/js/site_settings_dirty_snapshot.test.js`): it parses
+   `_loadFromModel` assignment targets and asserts each is referenced in
+   `_currentSnapshot`, with a justified allowlist for derived fields
+   (currently `_liveGpsApproximate`, covered by
+   `_liveLocationGranularity`). A forgotten registration now fails
+   `npm run test:js` in CI naming the field.
+
+## Known open gaps
+
+- The gate keys off `_loadFromModel`. A hypothetical form field initialized
+  elsewhere (inline initializer only, never loaded from the model) would
+  escape it — though such a field also wouldn't reflect persisted state, so
+  it would be broken in a more visible way first.
+- Sub-screens reached from settings (user scripts, domain claims, QR
+  import) apply their changes immediately via callbacks rather than through
+  the Save flow; they are outside this mechanism by design and do not
+  silently drop anything.

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -207,6 +207,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         'thirdPartyCookiesEnabled': _thirdPartyCookiesEnabled,
         'incognito': _incognito,
         'alwaysOpenHome': _alwaysOpenHome,
+        'kioskMode': _kioskMode,
         'clearUrlEnabled': _clearUrlEnabled,
         'dnsBlockEnabled': _dnsBlockEnabled,
         'contentBlockEnabled': _contentBlockEnabled,

--- a/openspec/specs/site-editing/spec.md
+++ b/openspec/specs/site-editing/spec.md
@@ -166,6 +166,50 @@ favicon
 
 ---
 
+### Requirement: EDIT-009 - Unsaved Site Settings Warn Before Discard
+
+The per-site settings screen SHALL NOT silently discard unsaved edits. It
+SHALL compare the live form against a snapshot captured when the screen
+opened (and re-captured after each successful save), and when any field
+differs it SHALL intercept every route-leaving affordance (system back,
+app-bar back, iOS edge swipe) with a confirmation dialog offering "Keep
+editing" and "Discard".
+
+Every form field assigned in `_loadFromModel` MUST be registered in the
+`_currentSnapshot` map, except fields fully derived from an
+already-registered field. This registration is enforced structurally by
+`test/js/site_settings_dirty_snapshot.test.js` (runs in CI via
+`npm run test:js`); a derived-field exemption lives in that test's
+allowlist with a written justification.
+
+History: [docs/bugs/006-settings-silent-discard.md](../../../docs/bugs/006-settings-silent-discard.md).
+
+#### Scenario: Leaving with an unsaved change prompts
+
+**Given** the site settings screen is open
+**When** the user changes any setting (e.g. flips the Kiosk Mode toggle)
+**And** triggers back without saving
+**Then** a "Discard changes?" dialog appears
+**And** "Keep editing" returns to the form with the edit intact
+**And** "Discard" leaves the screen without applying the edit
+
+#### Scenario: Leaving with no changes does not prompt
+
+**Given** the site settings screen is open
+**When** the user triggers back without editing anything (or after a save)
+**Then** the screen pops immediately with no dialog
+
+#### Scenario: New form field is dirty-tracked (regression BUG-006)
+
+**Given** a developer adds a new per-site setting to the settings form,
+loading it in `_loadFromModel`
+**When** the field is not registered in `_currentSnapshot` (and not
+allowlisted as derived)
+**Then** `test/js/site_settings_dirty_snapshot.test.js` fails CI naming the
+field
+
+---
+
 ## Data Model
 
 ```dart

--- a/test/js/site_settings_dirty_snapshot.test.js
+++ b/test/js/site_settings_dirty_snapshot.test.js
@@ -1,0 +1,93 @@
+// Dirty-snapshot registration gate (EDIT-009 / BUG-006). The site settings
+// screen decides "warn before discarding unsaved changes?" by diffing the
+// form against a hand-enumerated snapshot map (_currentSnapshot). A form
+// field that is loaded in _loadFromModel but never registered in the
+// snapshot is invisible to the diff: editing only that field lets the pop
+// through silently and the change is dropped — exactly how kiosk mode
+// (#454) regressed after the warning shipped. This gate makes the next
+// forgotten field fail CI instead of shipping.
+//
+// Rule: every instance field assigned in _loadFromModel() must be
+// referenced in _currentSnapshot(), unless it is fully derived from a
+// field that already is (allowlist below, each entry justified).
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const SETTINGS = 'lib/screens/settings.dart';
+
+// Derived fields: excluded from the snapshot on purpose. Every entry must
+// say which registered field makes it redundant.
+const DERIVED = {
+  // UI-only mirror of _liveLocationGranularity (registered): every toggle
+  // of the approximate sub-switch also rewrites the granularity, and the
+  // switch is hidden while granularity is gsm, so it can never be the
+  // only difference.
+  _liveGpsApproximate: '_liveLocationGranularity',
+};
+
+function extractBody(src, headerRe, label) {
+  const m = headerRe.exec(src);
+  assert.ok(m, `${label} not found in ${SETTINGS}`);
+  const open = src.indexOf('{', m.index);
+  assert.ok(open >= 0, `${label}: no opening brace`);
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') {
+      depth--;
+      if (depth === 0) return src.slice(open + 1, i);
+    }
+  }
+  assert.fail(`${label}: unbalanced braces`);
+}
+
+test('settings form fields loaded from the model are all dirty-tracked', () => {
+  const src = fs.readFileSync(path.join(repoRoot, SETTINGS), 'utf8');
+
+  const loadBody = extractBody(
+    src,
+    /void\s+_loadFromModel\s*\(\s*\)\s*\{/,
+    '_loadFromModel',
+  );
+  const snapshotBody = extractBody(
+    src,
+    /Map<String,\s*Object\?>\s+_currentSnapshot\s*\(\s*\)\s*(?:=>)?\s*\{/,
+    '_currentSnapshot',
+  );
+
+  // Assignment targets: `_field = ...` or `_field.member = ...` at the
+  // start of a statement line. `=(?!=)` keeps `==` comparisons on the RHS
+  // from matching.
+  const fields = new Set();
+  for (const line of loadBody.split('\n')) {
+    const m = /^\s*(_[A-Za-z0-9_]+)(?:\.[A-Za-z0-9_]+)?\s*=(?!=)/.exec(line);
+    if (m) fields.add(m[1]);
+  }
+  assert.ok(
+    fields.size >= 20,
+    `expected _loadFromModel to assign many form fields, got ${fields.size} — extraction broke?`,
+  );
+
+  const missing = [];
+  for (const f of fields) {
+    if (f in DERIVED) {
+      assert.ok(
+        new RegExp(`\\b${DERIVED[f]}\\b`).test(snapshotBody),
+        `${f} is allowlisted as derived from ${DERIVED[f]}, but ${DERIVED[f]} is not in _currentSnapshot`,
+      );
+      continue;
+    }
+    if (!new RegExp(`\\b${f}\\b`).test(snapshotBody)) missing.push(f);
+  }
+  assert.deepEqual(
+    missing,
+    [],
+    `form fields loaded in _loadFromModel but absent from _currentSnapshot ` +
+      `(unsaved edits to them are silently dropped on back — BUG-006): ${missing.join(', ')}. ` +
+      `Register each in _currentSnapshot, or add it to DERIVED here with a justification.`,
+  );
+});


### PR DESCRIPTION
Kiosk mode (#454) was never registered in _currentSnapshot, so editing only that toggle left _isDirty() false and back popped without the discard prompt, silently dropping the change. Register the field and add a structural test failing CI when a _loadFromModel field is missing from the snapshot (BUG-006, EDIT-009).


Claude-Session: https://claude.ai/code/session_01U13GVt84W2GuWfqMhop77i