### PR TITLE
Open the app's own App Shortcuts page from the iOS HS-010 dialog

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -37,6 +37,12 @@ import UserNotifications
       locationPlugin = LocationPlugin(messenger: controller.binaryMessenger)
       backgroundTaskPlugin = BackgroundTaskPlugin(messenger: controller.binaryMessenger)
       shortcutsPlugin = ShortcutsPlugin(messenger: controller.binaryMessenger)
+      if let registrar = self.registrar(forPlugin: "WebSpaceShortcutsLink") {
+        registrar.register(
+          ShortcutsLinkViewFactory(messenger: controller.binaryMessenger),
+          withId: ShortcutsLinkViewFactory.viewType
+        )
+      }
       registerShareChannel(controller.binaryMessenger)
     }
     if let url = launchOptions?[.url] as? URL {

--- a/ios/Runner/ShortcutsPlugin.swift
+++ b/ios/Runner/ShortcutsPlugin.swift
@@ -12,8 +12,10 @@ import AppIntents
 /// iOS has no equivalent public API, so on iOS the menu defers to the
 /// Shortcuts app: this plugin keeps an App Group-backed site list in sync so
 /// `WebSpaceShortcuts` / `SiteEntityQuery` (iOS 16+) can surface the user's
-/// real sites in the action picker, and deep-links to `shortcuts://` when
-/// the user taps "Add to Home Screen" on iOS.
+/// real sites in the action picker. The HS-010 dialog embeds a
+/// `ShortcutsUIButton` (see `ShortcutsLinkNativeView` below) that lands on
+/// WebSpace's own App Shortcuts page; the `shortcuts://` deep link is kept
+/// as the `pinShortcut` fallback.
 ///
 /// When an `OpenSiteIntent` runs, it stashes the chosen siteId in App Group
 /// UserDefaults; `getLaunchSiteId` drains that key the next time Flutter
@@ -127,5 +129,65 @@ class ShortcutsPlugin: NSObject {
         result(success)
       }
     }
+  }
+}
+
+/// Platform-view factory for the HS-010 dialog's "open this app's
+/// shortcuts" button. `ShortcutsUIButton` (AppIntents, iOS 16+) is the only
+/// public API that opens WebSpace's own App Shortcuts page — the
+/// `shortcuts://` scheme can only reach the app's main view, and the
+/// per-app deep links are undocumented.
+class ShortcutsLinkViewFactory: NSObject, FlutterPlatformViewFactory {
+  static let viewType = "org.codeberg.theoden8.webspace/shortcuts-link"
+  private let messenger: FlutterBinaryMessenger
+
+  init(messenger: FlutterBinaryMessenger) {
+    self.messenger = messenger
+    super.init()
+  }
+
+  func create(
+    withFrame frame: CGRect,
+    viewIdentifier viewId: Int64,
+    arguments args: Any?
+  ) -> FlutterPlatformView {
+    return ShortcutsLinkNativeView(frame: frame, viewId: viewId, messenger: messenger)
+  }
+}
+
+class ShortcutsLinkNativeView: NSObject, FlutterPlatformView {
+  private let container: UIView
+  private let channel: FlutterMethodChannel
+
+  init(frame: CGRect, viewId: Int64, messenger: FlutterBinaryMessenger) {
+    container = UIView(frame: frame)
+    container.backgroundColor = .clear
+    channel = FlutterMethodChannel(
+      name: "\(ShortcutsLinkViewFactory.viewType)_\(viewId)",
+      binaryMessenger: messenger
+    )
+    super.init()
+    // The Dart side only builds this view when _appIntentsSupported, which
+    // matches this gate; below iOS 16 the view stays empty.
+    #if canImport(AppIntents)
+    if #available(iOS 16.0, *) {
+      let button = ShortcutsUIButton(style: .automatic)
+      button.translatesAutoresizingMaskIntoConstraints = false
+      button.addTarget(self, action: #selector(didTap), for: .touchUpInside)
+      container.addSubview(button)
+      NSLayoutConstraint.activate([
+        button.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+        button.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+        button.widthAnchor.constraint(lessThanOrEqualTo: container.widthAnchor),
+        button.heightAnchor.constraint(lessThanOrEqualTo: container.heightAnchor),
+      ])
+    }
+    #endif
+  }
+
+  func view() -> UIView { container }
+
+  @objc private func didTap() {
+    channel.invokeMethod("tapped", arguments: nil)
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1334,18 +1334,40 @@ class _WebSpacePageState extends State<WebSpacePage>
     }
     if ((Platform.isIOS || Platform.isMacOS) && _appIntentsSupported) {
       final loc = AppLocalizations.of(context);
-      final isMac = Platform.isMacOS;
+      // iOS embeds the AppIntents ShortcutsUIButton, which lands on
+      // WebSpace's own App Shortcuts page; the bare shortcuts:// scheme
+      // (still used on macOS, where that button doesn't exist) can only
+      // open the Shortcuts app's main view.
+      if (Platform.isIOS) {
+        await showDialog<void>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: Text(loc.homeAddToHomeScreenTitle),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(loc.homeAddToHomeScreenIosBody(model.name)),
+                const SizedBox(height: 16),
+                _ShortcutsLinkButton(onOpened: () {
+                  if (Navigator.of(ctx).canPop()) Navigator.of(ctx).pop();
+                }),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(),
+                child: Text(loc.commonCancel),
+              ),
+            ],
+          ),
+        );
+        return;
+      }
       final confirmed = await showDialog<bool>(
         context: context,
         builder: (ctx) => AlertDialog(
-          title: Text(isMac
-              ? loc.homeAddShortcutTitleMacos
-              : loc.homeAddToHomeScreenTitle),
-          content: Text(
-            isMac
-                ? loc.homeAddShortcutMacosBody(model.name)
-                : loc.homeAddToHomeScreenIosBody(model.name),
-          ),
+          title: Text(loc.homeAddShortcutTitleMacos),
+          content: Text(loc.homeAddShortcutMacosBody(model.name)),
           actions: [
             TextButton(
               onPressed: () => Navigator.of(ctx).pop(false),
@@ -7983,6 +8005,35 @@ class _WebSpacePageState extends State<WebSpacePage>
               child: Icon(Icons.add),
             ),
     ),
+    );
+  }
+}
+
+/// HS-010: native AppIntents `ShortcutsUIButton` (iOS 16+) that opens
+/// WebSpace's App Shortcuts page in Shortcuts.app. The button renders and
+/// opens Shortcuts natively; [onOpened] fires on the same tap so the caller
+/// can dismiss the hosting dialog.
+class _ShortcutsLinkButton extends StatelessWidget {
+  static const _viewType = 'org.codeberg.theoden8.webspace/shortcuts-link';
+
+  final VoidCallback onOpened;
+
+  const _ShortcutsLinkButton({required this.onOpened});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 56,
+      width: double.maxFinite,
+      child: UiKitView(
+        viewType: _viewType,
+        onPlatformViewCreated: (id) {
+          MethodChannel('${_viewType}_$id').setMethodCallHandler((call) async {
+            if (call.method == 'tapped') onOpened();
+            return null;
+          });
+        },
+      ),
     );
   }
 }

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -230,20 +230,33 @@ The system SHALL keep the App Intents site picker in sync with the user's actual
 
 ### Requirement: HS-010 - "Add to Home Screen" Dialog (iOS/macOS)
 
-On iOS and macOS, tapping the "Home Shortcut" menu item SHALL show an instructional dialog explaining that the OS surfaces WebSpace sites through the Shortcuts app, with a primary button that deep-links to Shortcuts.app. The dialog copy SHALL match the platform (iOS: "Add to Home Screen" from the share menu; macOS: add to the Dock / run from the menu bar). The system SHALL NOT attempt to pin a shortcut programmatically (neither OS has such a public API).
+On iOS and macOS, tapping the "Home Shortcut" menu item SHALL show an instructional dialog explaining that the OS surfaces WebSpace sites through the Shortcuts app. The dialog copy SHALL match the platform (iOS: "Add to Home Screen" from the share menu; macOS: add to the Dock / run from the menu bar). The system SHALL NOT attempt to pin a shortcut programmatically (neither OS has such a public API).
+
+The dialog's primary affordance differs per platform:
+
+- **iOS 16+** — the dialog embeds the AppIntents `ShortcutsUIButton` (via a platform view, `ShortcutsLinkNativeView`), the only public API that opens **WebSpace's own App Shortcuts page** rather than the Shortcuts app's main view. The bare `shortcuts://` scheme cannot reach that page, and the per-app deep links (`shortcuts://app-shortcut-*?bundleID=`) are undocumented, so they MUST NOT be used.
+- **macOS 13+** — `ShortcutsUIButton`/`ShortcutsLink` do not exist on macOS, so the dialog keeps a plain "Open Shortcuts" button that opens `shortcuts://` (the Shortcuts app's main view) via `NSWorkspace.shared.open`.
 
 #### Scenario: Dialog content
 
 **Given** the user is on iOS 16+ or macOS 13+
 **When** the user taps "Home Shortcut" in the overflow menu
 **Then** an `AlertDialog` is shown explaining the flow ("find the Open Site action under WebSpace, pick this site, then add it")
-**And** the dialog has an "Open Shortcuts" primary button and a "Cancel" button
+**And** on iOS the dialog shows the native Shortcuts button and a "Cancel" button
+**And** on macOS the dialog has an "Open Shortcuts" primary button and a "Cancel" button
 
-#### Scenario: User confirms
+#### Scenario: iOS — user taps the Shortcuts button
 
-**Given** the instructional dialog is shown
+**Given** the iOS instructional dialog is shown
+**When** the user taps the embedded `ShortcutsUIButton`
+**Then** Shortcuts.app opens on WebSpace's App Shortcuts page (listing the per-site "Open ... in WebSpace" entries)
+**And** the dialog dismisses (the button's tap is mirrored to Dart over the `org.codeberg.theoden8.webspace/shortcuts-link_<viewId>` channel)
+
+#### Scenario: macOS — user confirms
+
+**Given** the macOS instructional dialog is shown
 **When** the user taps "Open Shortcuts"
-**Then** the system opens the URL `shortcuts://` (`UIApplication.shared.open` on iOS, `NSWorkspace.shared.open` on macOS)
+**Then** the system opens the URL `shortcuts://` via `NSWorkspace.shared.open`
 **And** the Shortcuts.app launches
 
 #### Scenario: User cancels
@@ -496,7 +509,7 @@ This requirement applies only to **process-startup** launches (cold or post-kill
 Both Android and iOS share the channel `MethodChannel('org.codeberg.theoden8.webspace/shortcuts')`.
 
 Methods:
-- `pinShortcut({siteId, label, iconUrl})` — **Android**: requests a pinned shortcut via `ShortcutManagerCompat.requestPinShortcut()`. **iOS 16+**: opens `shortcuts://` (the Dart UI shows the HS-010 instructional dialog first).
+- `pinShortcut({siteId, label, iconUrl})` — **Android**: requests a pinned shortcut via `ShortcutManagerCompat.requestPinShortcut()`. **macOS 13+**: opens `shortcuts://` (the Dart UI shows the HS-010 instructional dialog first). **iOS**: retained fallback that opens `shortcuts://`; the HS-010 dialog no longer calls it — its embedded `ShortcutsUIButton` opens WebSpace's App Shortcuts page directly.
 - `removeShortcut(siteId)` — Android: removes any dynamic shortcut copy but leaves the pinned launcher tile ENABLED, so an HS-011 tap on the now-orphaned shortcut still launches the app and re-routes via the ledger. (It MUST NOT call `disableShortcuts`, which makes the launcher reject the tap with "shortcut isn't available".) iOS: no-op (the App Intents site list is recomputed from `_webViewModels` on every save via HS-009).
 - `getLaunchSiteId()` — **Android**: returns the bare `siteId` string from the launch intent extra, then drains it (`intent.removeExtra("siteId")`) so it fires once per tap. **iOS**: drains `pending_shortcut_site_id` + `pending_shortcut_url` from App Group UserDefaults (written by `OpenSiteIntent.perform()`) and returns a `{siteId, url}` map. Both platforms MUST consume-on-read: `_handleShortcutIntent` re-polls on every `AppLifecycleState.resumed`, so a non-draining read would re-navigate to the pinned site on a plain background/return with no new tap. The Dart `ShortcutService.getLaunch()` tolerates both shapes (`ShortcutLaunch`); for HS-011 the caller uses `launch.url ?? shortcutUrlLedger[siteId]` (iOS carries the url, Android supplies it from the ledger).
 - `getPinnedSiteIds()` — Android: returns the set of `siteId`s currently pinned, derived from `ShortcutManagerCompat.getShortcuts(FLAG_MATCH_PINNED)` by stripping the `site_` prefix. iOS: always returns an empty list (no public API for pin-state introspection).
@@ -560,7 +573,7 @@ no widget tree required.
 - `lib/services/shortcut_service.dart` — Flutter wrapper around the platform channel (Android pin + iOS sync/launch)
 - `lib/services/startup_restore_engine.dart` — `resolveLaunchTarget` shortcut→index resolution
 - `ios/Runner/WebSpaceAppIntents.swift` — `SiteEntity`, `SiteEntityQuery`, `OpenSiteIntent`, `WebSpaceShortcuts` (iOS 16+)
-- `ios/Runner/ShortcutsPlugin.swift` — iOS method-channel handler
+- `ios/Runner/ShortcutsPlugin.swift` — iOS method-channel handler + `ShortcutsLinkViewFactory`/`ShortcutsLinkNativeView` platform view hosting the HS-010 `ShortcutsUIButton`
 - `test/startup_restore_engine_test.dart` — unit tests for the resolution rule
 - `test/shortcut_service_test.dart` — unit tests for the Dart service surface
 - `openspec/specs/home-shortcut/spec.md` — this specification


### PR DESCRIPTION
shortcuts:// can only reach the Shortcuts app's main view and the
per-app deep links are undocumented, so embed the AppIntents
ShortcutsUIButton (iOS 16+) as a platform view instead. macOS keeps
the shortcuts:// button (no such API there).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YB2t1Sqev8RSZAhXuggbN9