### PR TITLE
Fix ShortcutsUIButton collapsing to an icon-only tile

### DIFF
--- a/ios/Runner/ShortcutsPlugin.swift
+++ b/ios/Runner/ShortcutsPlugin.swift
@@ -181,7 +181,9 @@ class ShortcutsLinkNativeView: NSObject, FlutterPlatformView {
     // matches this gate; below iOS 16 the view stays empty.
     #if canImport(AppIntents)
     if #available(iOS 16.0, *) {
-      let button = ShortcutsUIButton(style: .automatic)
+      // Outline variant: the filled styles drop a solid slab into the
+      // Material dialog; the outline takes the dialog background.
+      let button = ShortcutsUIButton(style: .automaticOutline)
       button.translatesAutoresizingMaskIntoConstraints = false
       button.addTarget(self, action: #selector(didTap), for: .touchUpInside)
       container.addSubview(button)

--- a/ios/Runner/ShortcutsPlugin.swift
+++ b/ios/Runner/ShortcutsPlugin.swift
@@ -146,12 +146,18 @@ class ShortcutsLinkViewFactory: NSObject, FlutterPlatformViewFactory {
     super.init()
   }
 
+  func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
+    return FlutterStandardMessageCodec.sharedInstance()
+  }
+
   func create(
     withFrame frame: CGRect,
     viewIdentifier viewId: Int64,
     arguments args: Any?
   ) -> FlutterPlatformView {
-    return ShortcutsLinkNativeView(frame: frame, viewId: viewId, messenger: messenger)
+    let dark = (args as? [AnyHashable: Any])?["dark"] as? Bool ?? false
+    return ShortcutsLinkNativeView(
+      frame: frame, viewId: viewId, messenger: messenger, dark: dark)
   }
 }
 
@@ -159,9 +165,13 @@ class ShortcutsLinkNativeView: NSObject, FlutterPlatformView {
   private let container: UIView
   private let channel: FlutterMethodChannel
 
-  init(frame: CGRect, viewId: Int64, messenger: FlutterBinaryMessenger) {
+  init(frame: CGRect, viewId: Int64, messenger: FlutterBinaryMessenger, dark: Bool) {
     container = UIView(frame: frame)
     container.backgroundColor = .clear
+    // The app's theme setting can diverge from the system appearance; the
+    // button's .automatic style reads the trait collection, so pin it to
+    // the theme the dialog is actually rendered in.
+    container.overrideUserInterfaceStyle = dark ? .dark : .light
     channel = FlutterMethodChannel(
       name: "\(ShortcutsLinkViewFactory.viewType)_\(viewId)",
       binaryMessenger: messenger
@@ -175,11 +185,14 @@ class ShortcutsLinkNativeView: NSObject, FlutterPlatformView {
       button.translatesAutoresizingMaskIntoConstraints = false
       button.addTarget(self, action: #selector(didTap), for: .touchUpInside)
       container.addSubview(button)
+      // Center-only constraints leave the button ambiguously sized and it
+      // degrades to an icon-only tile; pinning it to the platform view's
+      // bounds makes it lay out as the labeled capsule.
       NSLayoutConstraint.activate([
-        button.centerXAnchor.constraint(equalTo: container.centerXAnchor),
-        button.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-        button.widthAnchor.constraint(lessThanOrEqualTo: container.widthAnchor),
-        button.heightAnchor.constraint(lessThanOrEqualTo: container.heightAnchor),
+        button.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+        button.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+        button.topAnchor.constraint(equalTo: container.topAnchor),
+        button.bottomAnchor.constraint(equalTo: container.bottomAnchor),
       ])
     }
     #endif

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8023,10 +8023,14 @@ class _ShortcutsLinkButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      height: 56,
+      height: 52,
       width: double.maxFinite,
       child: UiKitView(
         viewType: _viewType,
+        creationParams: {
+          'dark': Theme.of(context).brightness == Brightness.dark,
+        },
+        creationParamsCodec: const StandardMessageCodec(),
         onPlatformViewCreated: (id) {
           MethodChannel('${_viewType}_$id').setMethodCallHandler((call) async {
             if (call.method == 'tapped') onOpened();


### PR DESCRIPTION
Follow-up to #489. On device the embedded `ShortcutsUIButton` rendered as an oversized icon-only white squircle instead of the labeled "Shortcuts" capsule.

Two causes, two fixes:

- Center-only constraints left the button ambiguously sized, so it degraded to the icon tile and overflowed its box. It is now pinned to the platform view's bounds (full dialog width, 52pt) so it lays out as the labeled capsule.
- The button's `.automatic` style reads the native trait collection, which follows the system appearance rather than WebSpace's theme setting. Dart now passes the app theme's brightness via creation params and the platform view applies it with `overrideUserInterfaceStyle`.

Needs a visual check on an iOS 16+ device; the Swift side is only compile-checked by the `ios-ipa` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YB2t1Sqev8RSZAhXuggbN9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YB2t1Sqev8RSZAhXuggbN9)_