### PR TITLE
Encrypt caches with AES-GCM; harden download taskId + stale-index handlers

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6739,34 +6739,38 @@ class _WebSpacePageState extends State<WebSpacePage>
     );
 
     if (result == null || !mounted) return;
-    if (index >= _webViewModels.length) return;
+    // Apply by the captured model identity, not the index: a concurrent
+    // delete of a lower-indexed site while the dialog was open shifts
+    // positions, so `index` could now target a different site. Bail if this
+    // model was deleted meanwhile.
+    if (!_webViewModels.contains(model)) return;
 
     final newName = result['name'] as String?;
     final newUrl = result['url'] as String?;
 
     if (result['iconChanged'] == true) {
       setState(() {
-        _webViewModels[index].customIconPng = result['icon'] as Uint8List?;
+        model.customIconPng = result['icon'] as Uint8List?;
       });
     }
 
     if (newName != null && newName.isNotEmpty) {
       setState(() {
-        _webViewModels[index].name = newName;
+        model.name = newName;
       });
     }
 
-    if (newUrl != null && newUrl != _webViewModels[index].initUrl) {
+    if (newUrl != null && newUrl != model.initUrl) {
       // Snapshot belongs to the old URL; deleteCache must run before the
       // rebuild's getHtmlSync, which is why the sync in-memory eviction
       // (inside deleteCache) is fired before setState rather than awaited.
-      final siteId = _webViewModels[index].siteId;
+      final siteId = model.siteId;
       final deleteCache = HtmlCacheService.instance.deleteCache(siteId);
       setState(() {
-        _webViewModels[index].initUrl = newUrl;
-        _webViewModels[index].currentUrl = newUrl;
-        _webViewModels[index].webview = null; // Force recreation with new URL
-        _webViewModels[index].controller = null;
+        model.initUrl = newUrl;
+        model.currentUrl = newUrl;
+        model.webview = null; // Force recreation with new URL
+        model.controller = null;
       });
       await deleteCache;
     }
@@ -6832,16 +6836,20 @@ class _WebSpacePageState extends State<WebSpacePage>
           );
           break;
         case 'refresh':
-          final url = _webViewModels[index].initUrl;
+          final model = _webViewModels[index];
+          final url = model.initUrl;
           await FaviconUrlCache.invalidate(url);
           if (!mounted) return;
           final title = await getPageTitle(url);
           if (!mounted) return;
-          if (index >= _webViewModels.length) return;
+          // Re-resolve by identity, not by the captured index: a concurrent
+          // delete of a lower-indexed site shifts positions, so `index` could
+          // now point at a different site. Bail if this model was deleted.
+          if (!_webViewModels.contains(model)) return;
           if (title != null && title.isNotEmpty) {
             setState(() {
-              _webViewModels[index].name = title;
-              _webViewModels[index].pageTitle = title;
+              model.name = title;
+              model.pageTitle = title;
             });
             await _saveWebViewModels();
             if (!mounted) return;

--- a/lib/services/download_manager.dart
+++ b/lib/services/download_manager.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/foundation.dart';
 
 enum DownloadState { downloading, completed, failed, cancelled }
@@ -46,6 +48,13 @@ class DownloadsService extends ChangeNotifier {
 
   final List<DownloadTask> _tasks = [];
   int _counter = 0;
+  static final Random _rng = Random.secure();
+
+  static String _randomToken() {
+    final a = _rng.nextInt(1 << 32).toRadixString(16).padLeft(8, '0');
+    final b = _rng.nextInt(1 << 32).toRadixString(16).padLeft(8, '0');
+    return '$a$b';
+  }
 
   List<DownloadTask> get tasks => List.unmodifiable(_tasks);
   bool get hasActive => _tasks.any((t) => t.isActive);
@@ -60,7 +69,12 @@ class DownloadsService extends ChangeNotifier {
     int? bytesTotal,
   }) {
     final task = DownloadTask(
-      id: 'dl-${++_counter}',
+      // Unguessable id: the blob-download JS handlers
+      // (_webspaceBlobProgress / _webspaceBlobDownload / *Error) are
+      // page-reachable and take a taskId, so a sequential `dl-N` would let a
+      // hostile page enumerate and interfere with another site's in-flight
+      // download. A 64-bit secure-random suffix defeats guessing.
+      id: 'dl-${++_counter}-${_randomToken()}',
       filename: filename,
       url: url,
       bytesTotal: bytesTotal,

--- a/lib/services/html_cache_service.dart
+++ b/lib/services/html_cache_service.dart
@@ -29,7 +29,6 @@ class HtmlCacheService {
 
   Directory? _cacheDirectory;
   encrypt.Encrypter? _encrypter;
-  encrypt.IV? _iv;
 
   /// In-memory cache for sync access during build
   final Map<String, String> _memoryCache = {};
@@ -134,9 +133,13 @@ class HtmlCacheService {
 
       final keyBytes = base64.decode(keyBase64);
       final key = encrypt.Key(Uint8List.fromList(keyBytes));
-      // Use a fixed IV derived from key (first 16 bytes) for deterministic encryption
-      _iv = encrypt.IV(Uint8List.fromList(keyBytes.sublist(0, 16)));
-      _encrypter = encrypt.Encrypter(encrypt.AES(key, mode: encrypt.AESMode.cbc));
+      // AES-GCM (authenticated): a fresh random nonce per blob is generated in
+      // [_encrypt] and prepended to the ciphertext. The previous AES-CBC with
+      // a fixed key-derived IV was deterministic (leaked plaintext equality)
+      // and unauthenticated (malleable); legacy CBC blobs fail GCM auth in
+      // [_decrypt] and are dropped as a cache miss (the cache is also cleared
+      // on upgrade).
+      _encrypter = encrypt.Encrypter(encrypt.AES(key, mode: encrypt.AESMode.gcm));
 
       LogService.instance.log('HtmlCache', 'Encryption initialized');
     } catch (e) {
@@ -145,21 +148,34 @@ class HtmlCacheService {
   }
 
   String? _encrypt(String plaintext) {
-    if (_encrypter == null || _iv == null) return null;
+    if (_encrypter == null) return null;
     try {
-      return _encrypter!.encrypt(plaintext, iv: _iv).base64;
+      final iv = encrypt.IV.fromSecureRandom(12);
+      final enc = _encrypter!.encrypt(plaintext, iv: iv);
+      // Wire: nonce(12) || ciphertext || GCM tag(16).
+      final wire = Uint8List(iv.bytes.length + enc.bytes.length)
+        ..setRange(0, iv.bytes.length, iv.bytes)
+        ..setRange(iv.bytes.length, iv.bytes.length + enc.bytes.length, enc.bytes);
+      return base64.encode(wire);
     } catch (e) {
       LogService.instance.log('HtmlCache', 'Encryption error: $e', level: LogLevel.error);
       return null;
     }
   }
 
-  String? _decrypt(String ciphertext) {
-    if (_encrypter == null || _iv == null) return null;
+  String? _decrypt(String wireBase64) {
+    if (_encrypter == null) return null;
     try {
-      return _encrypter!.decrypt64(ciphertext, iv: _iv);
+      final wire = base64.decode(wireBase64);
+      // 12-byte nonce + 16-byte minimum GCM tag. Shorter blobs, and legacy
+      // fixed-IV CBC blobs, fail authentication below and are dropped.
+      if (wire.length < 12 + 16) return null;
+      final iv = encrypt.IV(Uint8List.fromList(wire.sublist(0, 12)));
+      final body = encrypt.Encrypted(Uint8List.fromList(wire.sublist(12)));
+      return _encrypter!.decrypt(body, iv: iv);
     } catch (e) {
-      LogService.instance.log('HtmlCache', 'Decryption error: $e', level: LogLevel.error);
+      // Legacy CBC blob or tampered ciphertext: treat as a cache miss so it
+      // is re-cached fresh under GCM. Not logged (expected during migration).
       return null;
     }
   }

--- a/lib/services/webview_state_secure_storage.dart
+++ b/lib/services/webview_state_secure_storage.dart
@@ -51,7 +51,6 @@ class SecureWebViewStateStorage implements WebViewStateStorage {
 
   Directory? _cacheDirectory;
   encrypt.Encrypter? _encrypter;
-  encrypt.IV? _iv;
   bool _initialized = false;
 
   SecureWebViewStateStorage({
@@ -91,9 +90,12 @@ class SecureWebViewStateStorage implements WebViewStateStorage {
       }
       final keyBytes = base64.decode(keyBase64);
       final key = encrypt.Key(Uint8List.fromList(keyBytes));
-      _iv = encrypt.IV(Uint8List.fromList(keyBytes.sublist(0, 16)));
+      // AES-GCM (authenticated) with a fresh random nonce per save (prepended
+      // to the ciphertext). Replaces AES-CBC with a fixed key-derived IV,
+      // which was deterministic and unauthenticated; legacy blobs fail GCM
+      // auth on load and are discarded.
       _encrypter = encrypt.Encrypter(
-        encrypt.AES(key, mode: encrypt.AESMode.cbc),
+        encrypt.AES(key, mode: encrypt.AESMode.gcm),
       );
     } catch (e) {
       LogService.instance.log(
@@ -164,11 +166,15 @@ class SecureWebViewStateStorage implements WebViewStateStorage {
   Future<void> saveState(String siteId, Uint8List state) async {
     if (state.isEmpty) return;
     if (!_initialized) await initialize();
-    if (_cacheDirectory == null || _encrypter == null || _iv == null) return;
+    if (_cacheDirectory == null || _encrypter == null) return;
     try {
       final encoded = base64.encode(state);
-      final cipher = _encrypter!.encrypt(encoded, iv: _iv).base64;
-      await _fileFor(siteId).writeAsString(cipher);
+      final iv = encrypt.IV.fromSecureRandom(12);
+      final enc = _encrypter!.encrypt(encoded, iv: iv);
+      final wire = Uint8List(iv.bytes.length + enc.bytes.length)
+        ..setRange(0, iv.bytes.length, iv.bytes)
+        ..setRange(iv.bytes.length, iv.bytes.length + enc.bytes.length, enc.bytes);
+      await _fileFor(siteId).writeAsString(base64.encode(wire));
       LogService.instance.log(
         'WebViewState',
         'Saved ${state.length} bytes for site $siteId (encrypted)',
@@ -187,14 +193,19 @@ class SecureWebViewStateStorage implements WebViewStateStorage {
   @override
   Future<Uint8List?> loadState(String siteId) async {
     if (!_initialized) await initialize();
-    if (_cacheDirectory == null || _encrypter == null || _iv == null) {
+    if (_cacheDirectory == null || _encrypter == null) {
       return null;
     }
     try {
       final f = _fileFor(siteId);
       if (!await f.exists()) return null;
-      final cipher = await f.readAsString();
-      final decoded = _encrypter!.decrypt64(cipher, iv: _iv);
+      final wire = base64.decode(await f.readAsString());
+      // 12-byte nonce + 16-byte minimum GCM tag; legacy fixed-IV CBC blobs
+      // are shorter-prefixed and fail auth, handled by the catch below.
+      if (wire.length < 12 + 16) throw const FormatException('short blob');
+      final iv = encrypt.IV(Uint8List.fromList(wire.sublist(0, 12)));
+      final body = encrypt.Encrypted(Uint8List.fromList(wire.sublist(12)));
+      final decoded = _encrypter!.decrypt(body, iv: iv);
       final bytes = base64.decode(decoded);
       return Uint8List.fromList(bytes);
     } catch (e) {

--- a/test/webview_state_secure_storage_test.dart
+++ b/test/webview_state_secure_storage_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -170,10 +171,38 @@ void main() {
       expect(loaded, bytes);
     });
 
+    test('AES-GCM: identical plaintext yields different on-disk ciphertext', () async {
+      final storage = newStorage();
+      final bytes = Uint8List.fromList(List.filled(64, 7));
+      await storage.saveState('a', bytes);
+      await storage.saveState('b', bytes);
+      final files =
+          tempDir.listSync(recursive: true).whereType<File>().toList();
+      expect(files.length, greaterThanOrEqualTo(2));
+      final c0 = await files[0].readAsString();
+      final c1 = await files[1].readAsString();
+      expect(c0, isNot(equals(c1)),
+          reason: 'a fresh per-save GCM nonce must make identical plaintext '
+              'encrypt to different ciphertext (no deterministic fixed IV)');
+    });
+
+    test('AES-GCM: a tampered blob is rejected on load (authenticated)',
+        () async {
+      final storage = newStorage();
+      await storage.saveState(
+          't', Uint8List.fromList(List.generate(64, (i) => i)));
+      final file = tempDir.listSync(recursive: true).whereType<File>().first;
+      final wire = base64.decode(await file.readAsString());
+      wire[wire.length - 1] ^= 0xFF; // flip a byte of the GCM tag
+      await file.writeAsString(base64.encode(wire));
+      expect(await storage.loadState('t'), isNull,
+          reason: 'GCM authentication must reject a tampered ciphertext');
+    });
+
     test('round-trip preserves exact byte content for binary blob', () async {
       final storage = newStorage();
-      // Pseudo-random binary, not just incrementing — covers padding /
-      // alignment / null-byte edges in the AES-CBC path.
+      // Pseudo-random binary, not just incrementing — covers null-byte and
+      // alignment edges in the AES-GCM path.
       final raw = List<int>.generate(
         1234,
         (i) => (i * 31 + 7) & 0xFF,


### PR DESCRIPTION
The remaining review items, each verified locally (full Flutter test suite passes: 1834 tests).

## Encrypted-cache AEAD (the last substantive security item)
`html_cache_service.dart` and `webview_state_secure_storage.dart` used AES-CBC with a fixed key-derived IV — deterministic (leaked plaintext equality across blobs) and unauthenticated (malleable; cached HTML is later injected as page content). Both now use **AES-GCM** with a fresh random 12-byte nonce per write, prepended to the ciphertext. Legacy CBC blobs fail GCM authentication on read and are dropped as a cache miss (both caches also clear on app upgrade), so no explicit migration step is needed. Added nonce-uniqueness and tamper-rejection pins.

## Low-severity hardening
- **Unguessable download taskIds** — the blob-download JS handlers are page-reachable and key on a taskId; the sequential `dl-N` let a hostile page enumerate and interfere with another site's download. Appended a 64-bit secure-random suffix.
- **Identity-based edit/refresh** — `_editSite` and the context-menu refresh captured an index, awaited a dialog / `getPageTitle`, then wrote back via `_webViewModels[index]` with only a bounds check; a concurrent delete of a lower-indexed site landed the change on the wrong site. Both now operate on the captured model reference and bail if it was removed.

Verified locally: `html_cache_service_test`, `webview_state_secure_storage_test` (incl. 2 new AEAD property tests), `download_manager_test`, `download_engine_test`, and the full suite (1834 passed, 0 failed); `flutter analyze` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSLJG3NPNx85bWTZAEmuqn)_