### PR TITLE
Concurrency cleanups: init double-run, stale-index handlers, drawer double-pop

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2256,10 +2256,15 @@ class _WebSpacePageState extends State<WebSpacePage>
     }
     final model = _webViewModels[index];
     await _maybeSwitchToAllForSite(model, index);
+    if (!mounted) return;
     if (a.disposeBeforeLoad) {
       _evictCacheIfOnline(model.siteId);
       model.disposeWebView();
-      _loadedIndices.remove(index);
+      // Re-resolve by identity: `_loadedIndices` is positional and the site
+      // list may have shifted (a lower-indexed delete) across the await, so
+      // the captured `index` could now name a different site.
+      final idx = _webViewModels.indexOf(model);
+      if (idx >= 0) _loadedIndices.remove(idx);
       model.currentUrl = model.initUrl;
     }
     if (a.wipeContainer) {
@@ -2268,8 +2273,11 @@ class _WebSpacePageState extends State<WebSpacePage>
     if (a.clearInMemoryCookies) {
       model.cookies = const [];
     }
-    if (index != _currentIndex) {
-      await _setCurrentIndex(index);
+    if (!mounted) return;
+    final activateIndex = _webViewModels.indexOf(model);
+    if (activateIndex < 0) return; // deleted during the awaits above
+    if (activateIndex != _currentIndex) {
+      await _setCurrentIndex(activateIndex);
     }
     if (!mounted) return;
     final controller = model.getController(
@@ -5083,20 +5091,27 @@ class _WebSpacePageState extends State<WebSpacePage>
         );
 
         for (final index in indicesToUnload) {
-          if (index >= 0 && index < _webViewModels.length) {
-            // Capture state before dispose so re-activation can
-            // restore the back/forward stack and (Apple) form data.
-            // Skipped for incognito sites inside the helper.
-            await _captureStateForRestore(_webViewModels[index]);
-            if (!mounted || version != _selectWebspaceVersion) return;
-            _webViewModels[index].disposeWebView();
-            _loadedIndices.remove(index);
-            LogService.instance.log(
-              'WebspaceSwitch',
-              'Unloaded site $index: "${_webViewModels[index].name}"',
-              sensitivity: LogSensitivity.sensitive,
-            );
-          }
+          if (index < 0 || index >= _webViewModels.length) continue;
+          // Capture the model by identity before the await: this loop's guard
+          // tracks `_selectWebspaceVersion`, which a concurrent `_deleteSite`
+          // does NOT bump (it bumps `_setCurrentIndexVersion`), so a delete
+          // could shift positions under us and make `_webViewModels[index]`
+          // a different site after the capture await.
+          final model = _webViewModels[index];
+          // Capture state before dispose so re-activation can
+          // restore the back/forward stack and (Apple) form data.
+          // Skipped for incognito sites inside the helper.
+          await _captureStateForRestore(model);
+          if (!mounted || version != _selectWebspaceVersion) return;
+          final curIndex = _webViewModels.indexOf(model);
+          if (curIndex < 0) continue; // deleted during the capture await
+          model.disposeWebView();
+          _loadedIndices.remove(curIndex);
+          LogService.instance.log(
+            'WebspaceSwitch',
+            'Unloaded site $curIndex: "${model.name}"',
+            sensitivity: LogSensitivity.sensitive,
+          );
         }
       } else {
         LogService.instance.log('WebspaceSwitch', 'Offline - preserving loaded webviews');
@@ -7222,7 +7237,10 @@ class _WebSpacePageState extends State<WebSpacePage>
                       final distance = (event.position - pointerDownPos!).distance;
                       final duration = event.timeStamp - pointerDownTime!;
                       if (distance < 20 && duration < const Duration(milliseconds: 300)) {
-                        Navigator.pop(context);
+                        // closeDrawer() (not Navigator.pop) is idempotent: a
+                        // rapid second tap won't pop the underlying page route
+                        // once the drawer is already closing.
+                        _scaffoldKey.currentState?.closeDrawer();
                         () async {
                           await _webspaceSwitchCompleter?.future;
                           await _setCurrentIndex(index);
@@ -7280,7 +7298,7 @@ class _WebSpacePageState extends State<WebSpacePage>
       child: InkWell(
           borderRadius: BorderRadius.circular(12),
           onTap: () async {
-            Navigator.pop(context);
+            _scaffoldKey.currentState?.closeDrawer();
             await _webspaceSwitchCompleter?.future;
             await _setCurrentIndex(index);
             if (!mounted) return;
@@ -7894,7 +7912,7 @@ class _WebSpacePageState extends State<WebSpacePage>
                         await _saveSelectedWebspaceId();
                         await _saveCurrentIndex();
                         if (!mounted) return;
-                        Navigator.pop(context);
+                        _scaffoldKey.currentState?.closeDrawer();
                       },
                       child: Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
@@ -7933,7 +7951,7 @@ class _WebSpacePageState extends State<WebSpacePage>
                           await _saveSelectedWebspaceId();
                           await _saveCurrentIndex();
                           if (!mounted) return;
-                          Navigator.pop(context);
+                          _scaffoldKey.currentState?.closeDrawer();
                         },
                         icon: Icon(Icons.arrow_back, size: 16),
                         label: Text(loc.homeBackToWebspaces, style: TextStyle(fontSize: 12)),

--- a/lib/services/webview_state_secure_storage.dart
+++ b/lib/services/webview_state_secure_storage.dart
@@ -53,6 +53,7 @@ class SecureWebViewStateStorage implements WebViewStateStorage {
   encrypt.Encrypter? _encrypter;
   encrypt.IV? _iv;
   bool _initialized = false;
+  Future<void>? _initInFlight;
 
   SecureWebViewStateStorage({
     FlutterSecureStorage? secureStorage,
@@ -65,8 +66,17 @@ class SecureWebViewStateStorage implements WebViewStateStorage {
   /// Initialize the storage. Idempotent. Must complete before any
   /// save/load — the AES key is provisioned here (or rotated on app
   /// upgrade) and the cache directory is created if missing.
-  Future<void> initialize() async {
-    if (_initialized) return;
+  Future<void> initialize() {
+    if (_initialized) return Future.value();
+    // Memoize the in-flight future so two concurrent first-touch callers
+    // (e.g. a first loadState racing a first saveState) share one run instead
+    // of both entering _initEncryption and generating/persisting different
+    // keys — which would leave _encrypter using a key that isn't the stored
+    // one, making the next launch's reads fail.
+    return _initInFlight ??= _doInitialize();
+  }
+
+  Future<void> _doInitialize() async {
     final appDir = _overrideAppDir ?? await getApplicationDocumentsDirectory();
     _cacheDirectory = Directory('${appDir.path}/$_cacheDir');
     await _initEncryption();
@@ -75,6 +85,7 @@ class SecureWebViewStateStorage implements WebViewStateStorage {
       await _cacheDirectory!.create(recursive: true);
     }
     _initialized = true;
+    _initInFlight = null;
   }
 
   Future<void> _initEncryption() async {


### PR DESCRIPTION
The three remaining low-severity concurrency items from the review, all verified locally (full Flutter suite: 1832 tests).

- **`SecureWebViewStateStorage.initialize()` double-init** — it set `_initialized` only after its awaits, so two concurrent first-touch callers both ran `_initEncryption` and generated/persisted different keys, leaving `_encrypter` on a key that isn't the stored one (next-launch reads then fail). Memoized the in-flight future, same pattern as `NotificationService.init`.
- **Stale-index handlers** — `_executeOpenInMain` and the `_selectWebspace` unload loop resolved indices, awaited, then mutated `_loadedIndices` / disposed webviews by the captured index; a concurrent `_deleteSite` shifts positions (and bumps a *different* version counter), so they could hit the wrong site. Both now re-resolve by model identity after the awaits and bail if the model was removed.
- **Drawer double-pop** — the drawer site/home tap handlers called `Navigator.pop(context)` after awaits, so a rapid second tap popped the underlying page route. Switched to the idempotent `_scaffoldKey.currentState?.closeDrawer()`.

Verified: `flutter analyze` clean on changed files; full suite 1832 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSLJG3NPNx85bWTZAEmuqn)_