### PR TITLE
Fix use-after-free race in the native adblock JNI bridge

### DIFF
--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/AdblockEngineNative.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/AdblockEngineNative.kt
@@ -13,11 +13,21 @@
 package org.codeberg.theoden8.webspace
 
 import android.util.Log
+import java.util.concurrent.locks.ReentrantReadWriteLock
 
 /**
  * Singleton wrapper around the JNI bridge to adblock-rust. Thread-safe
- * for concurrent reads (`checkUrl`); writes (`setRules`, `dispose`)
- * are serialised via `synchronized`.
+ * for concurrent reads (`checkUrl`, `redirectFor`); writes (`setRules`,
+ * `dispose`) are exclusive.
+ *
+ * Concurrency: readers and the freeing writer are serialised through a
+ * [ReentrantReadWriteLock]. `checkUrl`/`redirectFor` hand the raw
+ * `enginePtr` to Rust, which dereferences it (`&(*(handle as *mut
+ * Engine))`). Without the lock a concurrent `dispose()`/`setRules()`
+ * could `Box::from_raw` the same pointer mid-deref — a use-after-free
+ * on the chromium IO thread. The read lock lets many `checkUrl` calls
+ * run at once (the design goal) while the write lock guarantees no free
+ * happens while any read is in flight.
  *
  * Lifecycle: Dart pushes rules text via the `setAdblockEngineRules`
  * method channel call when the user flips the toggle. We parse them
@@ -33,9 +43,16 @@ object AdblockEngineNative {
     @Volatile
     private var loaded: Boolean = false
 
-    /** Opaque pointer the Rust side hands back from `engineNew`. */
+    /**
+     * Opaque pointer the Rust side hands back from `engineNew`. Mutated
+     * only under [rwLock]'s write lock; read under the read lock on the
+     * hot path (and lock-free in the [active] getter, hence @Volatile).
+     */
     @Volatile
     private var enginePtr: Long = 0L
+
+    /** Guards free (write) against deref (read). See the class doc. */
+    private val rwLock = ReentrantReadWriteLock()
 
     init {
         try {
@@ -70,23 +87,28 @@ object AdblockEngineNative {
      * engine if any. Pass an empty string to tear down (same effect
      * as [dispose]).
      */
-    @Synchronized
     fun setRules(rulesText: String, enableUboResources: Boolean = true) {
         if (!loaded) return
-        if (enginePtr != 0L) {
-            nativeEngineFree(enginePtr)
-            enginePtr = 0L
+        val writeLock = rwLock.writeLock()
+        writeLock.lock()
+        try {
+            if (enginePtr != 0L) {
+                nativeEngineFree(enginePtr)
+                enginePtr = 0L
+            }
+            if (rulesText.isEmpty()) {
+                Log.i(TAG, "engine torn down")
+                return
+            }
+            val ptr = nativeEngineNew(rulesText, enableUboResources)
+            enginePtr = ptr
+            Log.i(TAG, if (ptr != 0L)
+                "engine built (${rulesText.length} bytes, handle=0x${java.lang.Long.toHexString(ptr)}, ubo=$enableUboResources)"
+            else
+                "engine build failed")
+        } finally {
+            writeLock.unlock()
         }
-        if (rulesText.isEmpty()) {
-            Log.i(TAG, "engine torn down")
-            return
-        }
-        val ptr = nativeEngineNew(rulesText, enableUboResources)
-        enginePtr = ptr
-        Log.i(TAG, if (ptr != 0L)
-            "engine built (${rulesText.length} bytes, handle=0x${java.lang.Long.toHexString(ptr)}, ubo=$enableUboResources)"
-        else
-            "engine build failed")
     }
 
     /**
@@ -95,9 +117,16 @@ object AdblockEngineNative {
      * [active] before calling — short-circuit happens here.
      */
     fun checkUrl(url: String, sourceUrl: String, requestType: String): Boolean {
-        val handle = enginePtr
-        if (!loaded || handle == 0L) return false
-        return nativeCheckUrl(handle, url, sourceUrl, requestType)
+        if (!loaded) return false
+        val readLock = rwLock.readLock()
+        readLock.lock()
+        try {
+            val handle = enginePtr
+            if (handle == 0L) return false
+            return nativeCheckUrl(handle, url, sourceUrl, requestType)
+        } finally {
+            readLock.unlock()
+        }
     }
 
     /**
@@ -114,18 +143,30 @@ object AdblockEngineNative {
      * resource keep working) or just an empty 200.
      */
     fun redirectFor(url: String, sourceUrl: String, requestType: String): String? {
-        val handle = enginePtr
-        if (!loaded || handle == 0L) return null
-        return nativeRedirectFor(handle, url, sourceUrl, requestType)
+        if (!loaded) return null
+        val readLock = rwLock.readLock()
+        readLock.lock()
+        try {
+            val handle = enginePtr
+            if (handle == 0L) return null
+            return nativeRedirectFor(handle, url, sourceUrl, requestType)
+        } finally {
+            readLock.unlock()
+        }
     }
 
     /** Tear down the engine; idempotent. */
-    @Synchronized
     fun dispose() {
-        if (enginePtr != 0L) {
-            nativeEngineFree(enginePtr)
-            enginePtr = 0L
-            Log.i(TAG, "engine disposed")
+        val writeLock = rwLock.writeLock()
+        writeLock.lock()
+        try {
+            if (enginePtr != 0L) {
+                nativeEngineFree(enginePtr)
+                enginePtr = 0L
+                Log.i(TAG, "engine disposed")
+            }
+        } finally {
+            writeLock.unlock()
         }
     }
 

--- a/android/app/src/test/kotlin/org/codeberg/theoden8/webspace/AdblockEngineNativeTest.kt
+++ b/android/app/src/test/kotlin/org/codeberg/theoden8/webspace/AdblockEngineNativeTest.kt
@@ -70,4 +70,30 @@ class AdblockEngineNativeTest {
         AdblockEngineNative.dispose()
         assertFalse(AdblockEngineNative.active)
     }
+
+    @Test
+    fun concurrentReadersAndWritersDoNotDeadlockOrThrow() {
+        // The read/write lock added to guard free-vs-deref must not
+        // deadlock when many threads pound the facade at once (the
+        // production shape: chromium IO threads call checkUrl while the
+        // toggle handler calls setRules/dispose). With the .so absent
+        // every call short-circuits, but the write-lock methods still
+        // acquire the lock, so this pins "no deadlock, no exception".
+        val threads = (0 until 16).map { i ->
+            Thread {
+                repeat(200) {
+                    when (i % 3) {
+                        0 -> AdblockEngineNative.checkUrl(
+                            "https://t.com/x", "https://s.com/a", "script")
+                        1 -> AdblockEngineNative.setRules("||t.com^\n")
+                        else -> AdblockEngineNative.dispose()
+                    }
+                }
+            }
+        }
+        threads.forEach { it.start() }
+        threads.forEach { it.join(5_000) }
+        threads.forEach { assertFalse("thread stuck / deadlocked", it.isAlive) }
+        assertFalse(AdblockEngineNative.active)
+    }
 }

--- a/rust/webspace_adblock/src/jni.rs
+++ b/rust/webspace_adblock/src/jni.rs
@@ -21,7 +21,11 @@
 //
 // Memory: ws_engine_free in lib.rs OR the Java-side `engineFree`
 // release the Box — call exactly one. Callers must not deref
-// after free.
+// after free. nativeCheckUrl / nativeRedirectFor deref the handle
+// with no internal synchronization, so the Kotlin facade serialises
+// free (write) against deref (read) via a ReentrantReadWriteLock —
+// see AdblockEngineNative.kt. Do not call these directly off a raw
+// handle that another thread can free.
 
 #![cfg(target_os = "android")]
 


### PR DESCRIPTION
From the native-surface pass of the security review.

## The race
`AdblockEngineNative.checkUrl` / `redirectFor` hand the raw `enginePtr` to Rust, which dereferences it directly (`&(*(handle as *mut Engine)).inner` in `jni.rs`). These run on chromium's IO thread, once per sub-resource. Meanwhile `setRules` / `dispose` call `nativeEngineFree` (`Box::from_raw`) on that same pointer when the user flips the content-blocker toggle.

The old code marked only the two writers `@Synchronized`; the readers ran fully lock-free (reading `enginePtr` into a local was enough to dodge a null-deref, but not enough to stop the box being freed mid-call). So a toggle-off concurrent with an in-flight `checkUrl` is a use-after-free in native code.

## The fix
Serialise free against deref with a `ReentrantReadWriteLock`:
- `checkUrl` / `redirectFor` take the **read** lock — many can run concurrently, preserving the parallel hot path the JNI bridge exists for.
- `setRules` / `dispose` take the **write** lock — exclusive, so `nativeEngineFree` cannot run while any reader holds the pointer.

`enginePtr` stays `@Volatile` for the lock-free `active` getter. Added a doc note in `jni.rs` that the native deref has no internal synchronization and relies on the Kotlin facade's lock.

## Verification
No Android SDK in this environment, so the Kotlin JVM tests run in CI. Added a concurrency smoke test (16 threads pounding `checkUrl`/`setRules`/`dispose`) that pins "no deadlock, no exception" and the existing library-absent no-op contract. `jni.rs` change is comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSLJG3NPNx85bWTZAEmuqn)_