### PR TITLE
Validate imported per-site language tag against header injection

### DIFF
--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -73,6 +73,20 @@ String? sanitizedSiteId(Object? raw) {
   return _kSiteIdPattern.hasMatch(raw) ? raw : null;
 }
 
+/// The per-site `language` is a constrained dropdown in the UI, but an
+/// imported backup or scanned QR can carry an arbitrary string. It is
+/// interpolated raw into the `Accept-Language` request header, so a value
+/// with CRLF could smuggle extra headers into the site's requests. Accept
+/// only a BCP-47-shaped tag (`en`, `zh-CN`, …); anything else returns null
+/// (system default), matching the siteId hardening.
+final RegExp _kLanguageTagPattern =
+    RegExp(r'^[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*$');
+
+String? sanitizedLanguageTag(Object? raw) {
+  if (raw is! String || raw.isEmpty) return null;
+  return _kLanguageTagPattern.hasMatch(raw) ? raw : null;
+}
+
 /// Generates a fresh per-site fingerprint reset nonce. Uses [Random.secure]
 /// so a site can't predict the post-reset fingerprint.
 String generateFingerprintResetNonce() {
@@ -1839,7 +1853,7 @@ class WebViewModel {
       incognito: isIncognito,
       alwaysOpenHome: isAlwaysOpenHome,
       kioskMode: json['kioskMode'] as bool? ?? false,
-      language: json['language'],
+      language: sanitizedLanguageTag(json['language']),
       zoomPercent: clampZoomPercent(
           (json['zoomPercent'] as num?)?.toInt() ?? kDefaultZoomPercent),
       clearUrlEnabled: json['clearUrlEnabled'] ?? true,

--- a/test/web_view_model_test.dart
+++ b/test/web_view_model_test.dart
@@ -1049,4 +1049,39 @@ void main() {
       expect(sanitizedSiteId(null), isNull);
     });
   });
+
+  group('fromJson language header-injection hardening', () {
+    Map<String, dynamic> baseJson(String? language) => {
+          'initUrl': 'https://example.com',
+          'cookies': <dynamic>[],
+          'proxySettings': {'type': 0, 'address': null},
+          'javascriptEnabled': true,
+          'userAgent': '',
+          'thirdPartyCookiesEnabled': false,
+          if (language != null) 'language': language,
+        };
+
+    test('a valid BCP-47 language tag is preserved', () {
+      for (final ok in ['en', 'fr', 'zh-CN', 'zh-TW', 'pt-BR']) {
+        final m = WebViewModel.fromJson(baseJson(ok), null);
+        expect(m.language, equals(ok));
+      }
+    });
+
+    test('a CRLF-bearing language is dropped to system default', () {
+      final m = WebViewModel.fromJson(
+          baseJson('en\r\nX-Injected: 1'), null);
+      expect(m.language, isNull);
+    });
+
+    test('sanitizedLanguageTag helper', () {
+      expect(sanitizedLanguageTag('en'), equals('en'));
+      expect(sanitizedLanguageTag('zh-CN'), equals('zh-CN'));
+      expect(sanitizedLanguageTag('en\r\nEvil: 1'), isNull);
+      expect(sanitizedLanguageTag('en, *;q=0.5'), isNull);
+      expect(sanitizedLanguageTag(''), isNull);
+      expect(sanitizedLanguageTag(42), isNull);
+      expect(sanitizedLanguageTag(null), isNull);
+    });
+  });
 }


### PR DESCRIPTION
Result of the JS-shim-injection review pass.

## What I checked
Every per-site *string* value that reaches injected `DOCUMENT_START` JS — an untrusted vector because a scanned QR or imported backup carries these values from someone else. Traced each shim builder:
- `language_shim`, `location_spoof_service` (timezone), `anti_fingerprinting_shim` (siteId seed) → all `jsonEncode` their strings.
- `user_agent_metadata_builder` → structured object, regex-parsed, never string-interpolated.
- `desktop_mode_shim` → only an enum→fixed-string platform token, escaped via `_jsString`; the raw UA never reaches JS.

**No JS-injection defect found — the shim surface is consistently hardened.** (Modern webviews are ES2019+, so `jsonEncode`'s unescaped U+2028/2029 isn't a string break-out either.)

## The one residual
`WebViewService…loadUrl` builds `Accept-Language: <language>, *;q=0.5` by **raw interpolation**. `language` is a constrained dropdown in the UI, but `WebViewModel.fromJson` (backup import / QR share) accepts any string. A CRLF-bearing value could smuggle extra request headers. Native HTTP stacks reject CRLF in header values, so this is defense-in-depth, but it's the only un-guarded raw interpolation of an untrusted per-site string.

## Fix
Add `sanitizedLanguageTag` at the `fromJson` boundary (mirroring #494's `sanitizedSiteId`): accept only a BCP-47-shaped tag (`^[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*$`), else fall back to system default. Covers both the backup and QR paths (QR hydrates through `fromJson`).

Verified locally: `web_view_model_test`, `site_settings_qr_codec_test`, `settings_backup_test` all green; `flutter analyze` clean on the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSLJG3NPNx85bWTZAEmuqn)_