### PR TITLE
Fix BGTask completion race, intent fallback scheme, archive incognito

### DIFF
--- a/ios/Runner/BackgroundTaskPlugin.swift
+++ b/ios/Runner/BackgroundTaskPlugin.swift
@@ -66,25 +66,44 @@ class BackgroundTaskPlugin: NSObject {
 
   /// Called by AppDelegate when iOS hands us a refresh task. Forwards to
   /// Dart and re-schedules the next refresh.
+  ///
+  /// `pendingRefreshTask` is touched from three threads: this handler (the
+  /// `BGTaskScheduler` launch queue, off-main), the `expirationHandler`
+  /// (iOS's own thread), and `bgRefreshDidComplete` (the Flutter platform /
+  /// main thread). `BGTask.setTaskCompleted` must fire exactly once per
+  /// task; an unsynchronised double-call crashes the process and a lost
+  /// write leaks the completion (iOS then throttles future scheduling). So
+  /// every access to the pending slot is funnelled onto the main queue and
+  /// completion is made idempotent per task via [completeTask].
   func handleRefreshTask(_ task: BGAppRefreshTask) {
-    pendingRefreshTask?.setTaskCompleted(success: false)
-    pendingRefreshTask = task
-
-    task.expirationHandler = { [weak self] in
-      guard let self = self, let pending = self.pendingRefreshTask else { return }
-      self.pendingRefreshTask = nil
-      pending.setTaskCompleted(success: false)
+    task.expirationHandler = { [weak self, weak task] in
+      guard let self = self, let task = task else { return }
+      DispatchQueue.main.async { self.completeTask(task, success: false) }
     }
 
-    channel.invokeMethod("onBackgroundRefresh", arguments: nil) { [weak self] _ in
-      // Dart will call back via `bgRefreshDidComplete`; the success result
-      // here just confirms the channel delivered the message. Don't mark
-      // the task complete from here, otherwise rapid-completion races
-      // setTaskCompleted with the Dart-side reload.
-      _ = self
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self else { return }
+      // A previous task that never reported completion loses its slot to
+      // this one — complete it (once) before taking over.
+      if let previous = self.pendingRefreshTask {
+        self.completeTask(previous, success: false)
+      }
+      self.pendingRefreshTask = task
+      // Dart calls back via `bgRefreshDidComplete`; don't mark the task
+      // complete from the channel result or it races the Dart-side reload.
+      self.channel.invokeMethod("onBackgroundRefresh", arguments: nil, result: nil)
+      self.scheduleNextRefresh()
     }
+  }
 
-    scheduleNextRefresh()
+  /// Complete [task] exactly once. Must run on the main queue. The identity
+  /// guard makes a second call (e.g. expiration firing after Dart already
+  /// reported completion, or vice versa) a no-op, and prevents a stale
+  /// expiration handler from completing a newer task.
+  private func completeTask(_ task: BGAppRefreshTask, success: Bool) {
+    guard pendingRefreshTask === task else { return }
+    pendingRefreshTask = nil
+    task.setTaskCompleted(success: success)
   }
 
   /// Submits a new BGAppRefreshTaskRequest. Idempotent: BGTaskScheduler
@@ -121,8 +140,12 @@ class BackgroundTaskPlugin: NSObject {
       } else {
         success = true
       }
-      pendingRefreshTask?.setTaskCompleted(success: success)
-      pendingRefreshTask = nil
+      // Runs on the Flutter platform (main) thread, the same queue the
+      // pending slot is confined to. Complete via the funnel so a racing
+      // expiration handler can't also complete the task.
+      if let task = pendingRefreshTask {
+        completeTask(task, success: success)
+      }
       result(nil)
     default:
       result(FlutterMethodNotImplemented)

--- a/lib/services/external_url_engine.dart
+++ b/lib/services/external_url_engine.dart
@@ -149,6 +149,19 @@ class ExternalUrlParser {
     return null;
   }
 
+  /// Whether [url] is a plain http(s) URL safe to hand to `loadUrl` or an
+  /// external "open in browser" launch. The intent `browser_fallback_url`
+  /// is attacker-influenced (a page hands us the whole `intent://…` string),
+  /// so before *loading* a fallback we must re-check its scheme — a
+  /// `file://` / `javascript:` / `data:` fallback would otherwise disclose
+  /// app-private files or run script in the current document. [toWebUrl]
+  /// already enforces this on the silent route; call sites that load a
+  /// fallback from the confirmation dialog MUST gate on this too.
+  static bool isLoadableWebUrl(String url) {
+    final scheme = Uri.tryParse(url)?.scheme.toLowerCase();
+    return scheme == 'http' || scheme == 'https';
+  }
+
   /// Resolves an [ExternalUrlInfo] for an intent:// URL to an equivalent
   /// http(s) URL the webview can load: prefers the explicit
   /// `S.browser_fallback_url` extra; otherwise reconstructs from

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -539,6 +539,17 @@ class WebViewModel {
   /// - **incognito**: navigation state is meant to be ephemeral.
   bool get persistsNavState => !isArchiveTier && !incognito;
 
+  /// Effective incognito decision for the webview container. Archive-tier
+  /// sites are always incognito (ARCH-006): otherwise the container writes
+  /// localStorage / IndexedDB / ServiceWorker registrations / HTTP cache to
+  /// its on-disk directory in cleartext WebKit storage for as long as the
+  /// archive is open. A clean archive close tears the container down, but an
+  /// unclean process exit (OS kill, force-stop, reboot) would leave that
+  /// browsing state on disk, contradicting the spec's "nothing survives a
+  /// session beyond cookies." The stored value is preserved for when the
+  /// site is moved back out of the archive.
+  bool get effectiveIncognito => isArchiveTier ? true : incognito;
+
   /// Effective protected-content (Widevine/EME) decision. Archive-tier
   /// sites never grant DRM regardless of stored value: a grant provisions
   /// a per-container Widevine device identifier on disk and the prompt is
@@ -755,7 +766,7 @@ class WebViewModel {
         javascriptEnabled: javascriptEnabled,
         userAgent: effectiveUserAgentOrNull,
         thirdPartyCookiesEnabled: thirdPartyCookiesEnabled,
-        incognito: incognito,
+        incognito: effectiveIncognito,
       );
       // Apply current theme preference
       await c.setThemePreference(_currentTheme);
@@ -955,7 +966,7 @@ class WebViewModel {
           javascriptEnabled: javascriptEnabled,
           userAgent: effectiveUserAgentOrNull,
           thirdPartyCookiesEnabled: thirdPartyCookiesEnabled,
-          incognito: incognito,
+          incognito: effectiveIncognito,
           // Root site webview sits at the MaterialApp root route: on iOS/macOS
           // there is no Flutter route-pop edge-swipe here, so opt into
           // WKWebView's native back/forward swipe. Nested screens don't (NAV-008).
@@ -1078,7 +1089,7 @@ class WebViewModel {
                   '  -> CANCEL (opening nested webview)',
                   sensitivity: LogSensitivity.sensitive,
                 );
-                launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, localCdnEnabled: localCdnEnabled, trackingProtectionEnabled: trackingProtectionEnabled, letterboxEnabled: letterboxEnabled, spoofWindowWidth: spoofWindowWidth, spoofWindowHeight: spoofWindowHeight, fingerprintResetNonce: fingerprintResetNonce, language: this.language, zoomPercent: zoomPercent, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, liveLocationGranularity: liveLocationGranularity, webRtcPolicy: webRtcPolicy, userAgent: effectiveUserAgentOrNull, javascriptEnabled: javascriptEnabled, userScripts: combineUserScripts(globalUserScripts), proxySettings: proxySettings, notificationsEnabled: notificationsEnabled, externalLinksInBrowser: effectiveExternalLinksInBrowser);
+                launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: effectiveIncognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, localCdnEnabled: localCdnEnabled, trackingProtectionEnabled: trackingProtectionEnabled, letterboxEnabled: letterboxEnabled, spoofWindowWidth: spoofWindowWidth, spoofWindowHeight: spoofWindowHeight, fingerprintResetNonce: fingerprintResetNonce, language: this.language, zoomPercent: zoomPercent, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, liveLocationGranularity: liveLocationGranularity, webRtcPolicy: webRtcPolicy, userAgent: effectiveUserAgentOrNull, javascriptEnabled: javascriptEnabled, userScripts: combineUserScripts(globalUserScripts), proxySettings: proxySettings, notificationsEnabled: notificationsEnabled, externalLinksInBrowser: effectiveExternalLinksInBrowser);
                 return false;
               case NavigationDecision.blockOpenExternal:
                 LogService.instance.log(
@@ -1170,7 +1181,7 @@ class WebViewModel {
                     sensitivity: LogSensitivity.sensitive,
                   );
                   if (handled.launchNestedUrl != null) {
-                    launchUrlFunc(handled.launchNestedUrl!, homeTitle: name, siteId: siteId, incognito: incognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, localCdnEnabled: localCdnEnabled, trackingProtectionEnabled: trackingProtectionEnabled, letterboxEnabled: letterboxEnabled, spoofWindowWidth: spoofWindowWidth, spoofWindowHeight: spoofWindowHeight, fingerprintResetNonce: fingerprintResetNonce, language: this.language, zoomPercent: zoomPercent, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, liveLocationGranularity: liveLocationGranularity, webRtcPolicy: webRtcPolicy, userAgent: effectiveUserAgentOrNull, javascriptEnabled: javascriptEnabled, userScripts: combineUserScripts(globalUserScripts), proxySettings: proxySettings, notificationsEnabled: notificationsEnabled, externalLinksInBrowser: effectiveExternalLinksInBrowser);
+                    launchUrlFunc(handled.launchNestedUrl!, homeTitle: name, siteId: siteId, incognito: effectiveIncognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, localCdnEnabled: localCdnEnabled, trackingProtectionEnabled: trackingProtectionEnabled, letterboxEnabled: letterboxEnabled, spoofWindowWidth: spoofWindowWidth, spoofWindowHeight: spoofWindowHeight, fingerprintResetNonce: fingerprintResetNonce, language: this.language, zoomPercent: zoomPercent, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, liveLocationGranularity: liveLocationGranularity, webRtcPolicy: webRtcPolicy, userAgent: effectiveUserAgentOrNull, javascriptEnabled: javascriptEnabled, userScripts: combineUserScripts(globalUserScripts), proxySettings: proxySettings, notificationsEnabled: notificationsEnabled, externalLinksInBrowser: effectiveExternalLinksInBrowser);
                   }
                   return;
                 case NavigationDecision.blockOpenExternal:

--- a/lib/widgets/external_url_prompt.dart
+++ b/lib/widgets/external_url_prompt.dart
@@ -150,7 +150,12 @@ Future<void> confirmAndLaunchExternalUrl(
       }
     }
 
-    final hasFallback = cleanedFallback.isNotEmpty;
+    // Only offer "Open in browser" for an http(s) fallback. The fallback is
+    // attacker-influenced (extracted from the page's `intent://…` string), so
+    // a `file://` / `javascript:` / `data:` value must never reach loadUrl —
+    // it would disclose app-private files or run script in the document.
+    final hasFallback = cleanedFallback.isNotEmpty &&
+        ExternalUrlParser.isLoadableWebUrl(cleanedFallback);
     final loc = AppLocalizations.of(context);
     final packageName = info.package;
     final choice = await showDialog<_ExternalUrlChoice>(
@@ -217,7 +222,19 @@ Future<void> confirmAndLaunchExternalUrl(
         // same-domain vs cross-domain (nested webview). When no
         // controller is available — e.g. tel:/mailto: with no fallback —
         // fall back to handing the URL to the OS.
-        if (loadInWebView != null && cleanedFallback.isNotEmpty) {
+        // Defense in depth: hasFallback already required an http(s)
+        // fallback for this branch to be reachable, but re-check before
+        // loading / launching so a future refactor can't reintroduce a
+        // file:/javascript:/data: load here.
+        if (!ExternalUrlParser.isLoadableWebUrl(cleanedFallback)) {
+          LogService.instance.log(
+            'ExternalUrl',
+            'refused non-http(s) fallback',
+            sensitivity: LogSensitivity.sensitive,
+          );
+          return;
+        }
+        if (loadInWebView != null) {
           try {
             await loadInWebView.loadUrl(cleanedFallback);
           } catch (e) {

--- a/test/archive_neutrality_test.dart
+++ b/test/archive_neutrality_test.dart
@@ -62,14 +62,21 @@ void main() {
         initUrl: 'https://example.com',
         notificationsEnabled: true,
         localCdnEnabled: true,
+        incognito: false,
         isArchiveTier: true,
       );
       expect(m.effectiveNotificationsEnabled, isFalse);
       expect(m.effectiveLocalCdnEnabled, isFalse);
+      // ARCH-006: an archive-tier site is always incognito so its container
+      // never writes localStorage/IDB/SW/HTTP-cache to disk in cleartext.
+      // The webview config sites (setOptions, WebViewConfig, both nested
+      // launchUrlFunc calls) all read effectiveIncognito, not the raw field.
+      expect(m.effectiveIncognito, isTrue);
       // Stored values are preserved so the user's preferences round-trip
       // through any future eject flow.
       expect(m.notificationsEnabled, isTrue);
       expect(m.localCdnEnabled, isTrue);
+      expect(m.incognito, isFalse);
     });
 
     test('effective getters pass through for app-tier sites', () {
@@ -77,9 +84,17 @@ void main() {
         initUrl: 'https://example.com',
         notificationsEnabled: true,
         localCdnEnabled: false,
+        incognito: false,
       );
       expect(m.effectiveNotificationsEnabled, isTrue);
       expect(m.effectiveLocalCdnEnabled, isFalse);
+      // App-tier respects the stored incognito value both ways.
+      expect(m.effectiveIncognito, isFalse);
+      expect(
+        WebViewModel(initUrl: 'https://e.com', incognito: true)
+            .effectiveIncognito,
+        isTrue,
+      );
     });
 
     // persistsNavState is the single gate all three production call sites

--- a/test/external_url_engine_test.dart
+++ b/test/external_url_engine_test.dart
@@ -195,4 +195,78 @@ void main() {
       expect(ExternalUrlParser.toWebUrl(fb), isNull);
     });
   });
+
+  group('intent browser_fallback_url scheme allowlist', () {
+    // A page hands us the whole intent:// string, so browser_fallback_url is
+    // attacker-influenced. A non-http(s) fallback must never resolve to a
+    // loadable URL (silent route) and must never pass isLoadableWebUrl (the
+    // gate the confirmation-dialog "Open in browser" button relies on).
+    String intentWithFallback(String fallback) {
+      final enc = Uri.encodeComponent(fallback);
+      return 'intent://scan/#Intent;scheme=zxing;'
+          'S.browser_fallback_url=$enc;end';
+    }
+
+    for (final hostile in const [
+      'javascript:alert(document.cookie)',
+      'file:///data/data/org.codeberg.theoden8.webspace/shared_prefs/x.xml',
+      'data:text/html,<script>alert(1)</script>',
+      'intent://evil/#Intent;scheme=zxing;end',
+      'content://com.evil/secret',
+    ]) {
+      test('rejects $hostile fallback', () {
+        final info = ExternalUrlParser.parse(intentWithFallback(hostile))!;
+        expect(ExternalUrlParser.intentToWebUrl(info), isNull);
+        expect(ExternalUrlParser.toWebUrl(info), isNull);
+        expect(ExternalUrlParser.isLoadableWebUrl(hostile), isFalse);
+      });
+    }
+
+    test('accepts an http(s) fallback', () {
+      final info =
+          ExternalUrlParser.parse(intentWithFallback('https://example.com/x'))!;
+      expect(ExternalUrlParser.toWebUrl(info), 'https://example.com/x');
+      expect(ExternalUrlParser.isLoadableWebUrl('https://example.com/x'), isTrue);
+      expect(ExternalUrlParser.isLoadableWebUrl('http://example.com'), isTrue);
+    });
+
+    test('toWebUrl never yields a non-http(s) string for hostile intents', () {
+      for (final hostile in const [
+        'javascript:alert(1)',
+        'file:///etc/passwd',
+        'data:text/html,x',
+        'intent://x/#Intent;scheme=zxing;end',
+      ]) {
+        final info = ExternalUrlParser.parse(
+            'intent://x/#Intent;scheme=zxing;'
+            'S.browser_fallback_url=${Uri.encodeComponent(hostile)};end')!;
+        final resolved = ExternalUrlParser.toWebUrl(info);
+        if (resolved != null) {
+          expect(ExternalUrlParser.isLoadableWebUrl(resolved), isTrue);
+        }
+      }
+    });
+  });
+
+  group('isLoadableWebUrl', () {
+    test('only http and https are loadable', () {
+      expect(ExternalUrlParser.isLoadableWebUrl('https://x'), isTrue);
+      expect(ExternalUrlParser.isLoadableWebUrl('http://x'), isTrue);
+      expect(ExternalUrlParser.isLoadableWebUrl('HTTPS://X'), isTrue);
+      for (final bad in const [
+        'file:///etc/passwd',
+        'javascript:alert(1)',
+        'data:text/html,x',
+        'intent://x',
+        'tel:+1',
+        'x-safari-https://x',
+        'about:blank',
+        '',
+        'not a url with spaces',
+      ]) {
+        expect(ExternalUrlParser.isLoadableWebUrl(bad), isFalse,
+            reason: '$bad must not be loadable');
+      }
+    });
+  });
 }

--- a/test/js/native_bgtask_completion_funnel.test.js
+++ b/test/js/native_bgtask_completion_funnel.test.js
@@ -1,0 +1,64 @@
+// BGAppRefreshTask completion funnel gate (native concurrency).
+//
+// `BGTask.setTaskCompleted(success:)` must be called exactly once per task.
+// `pendingRefreshTask` is touched from three threads (the BGTaskScheduler
+// launch queue, iOS's expirationHandler thread, and the Flutter platform /
+// main thread via `bgRefreshDidComplete`), so completion is funnelled onto
+// the main queue through a single idempotent `completeTask` helper. A future
+// edit that reintroduces a raw `pendingRefreshTask?.setTaskCompleted(...)`
+// off that funnel re-opens the double-complete crash / lost-completion race.
+//
+// No iOS SDK/Xcode is available in CI for this repo's Dart+JS test tiers, so
+// this is a structural guard (like surface_repaint_funnel) rather than an
+// XCTest under ThreadSanitizer.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const rel = 'ios/Runner/BackgroundTaskPlugin.swift';
+const src = fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+
+test('a single completeTask funnel exists', () => {
+  assert.match(src, /private func completeTask\(_ task: BGAppRefreshTask, success: Bool\)/,
+    `${rel} must funnel completion through completeTask(_:success:)`);
+});
+
+test('the funnel guards on task identity for idempotency', () => {
+  // The guard is what makes a second completion (expiration after Dart's
+  // callback, or vice versa) a no-op and stops a stale expiration handler
+  // from completing a newer task.
+  assert.match(src, /guard pendingRefreshTask === task else \{ return \}/,
+    'completeTask must no-op when the pending slot no longer holds this task');
+});
+
+test('no raw setTaskCompleted on the pending slot (the racy shape)', () => {
+  // The pre-fix bug called `pendingRefreshTask?.setTaskCompleted(...)` and
+  // `pending.setTaskCompleted(...)` directly, unsynchronised. Forbid every
+  // shape that completes via the shared property instead of a captured task.
+  for (const bad of [
+    /pendingRefreshTask\?\.setTaskCompleted/,
+    /pendingRefreshTask!\.setTaskCompleted/,
+    /\bpending\.setTaskCompleted/,
+  ]) {
+    assert.ok(!bad.test(src),
+      `${rel} completes via the shared pending slot (${bad}); route through completeTask instead`);
+  }
+});
+
+test('setTaskCompleted only appears in the funnel and the register fallback', () => {
+  // Exactly two legitimate call sites: the `completeTask` helper, and the
+  // static launch-handler fallback for a task that is not a BGAppRefreshTask.
+  const count = (src.match(/\.setTaskCompleted\(/g) || []).length;
+  assert.equal(count, 2,
+    `expected exactly 2 setTaskCompleted( call sites (completeTask + register fallback), found ${count}`);
+});
+
+test('pending-slot access is hopped onto the main queue', () => {
+  // The handler body and the expiration handler must hop to main so all
+  // pendingRefreshTask access serialises on one thread.
+  assert.match(src, /DispatchQueue\.main\.async/,
+    'handleRefreshTask/expirationHandler must confine pending-slot access to main');
+});

--- a/test/shim_injection_safety_test.dart
+++ b/test/shim_injection_safety_test.dart
@@ -1,0 +1,80 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/anti_fingerprinting_shim.dart';
+import 'package:webspace/services/desktop_mode_shim.dart';
+import 'package:webspace/services/language_shim.dart';
+import 'package:webspace/services/location_spoof_service.dart';
+import 'package:webspace/settings/location.dart';
+
+/// Regression guard for the per-site JS-shim injection surface.
+///
+/// Per-site string settings (language, spoofTimezone, the anti-fingerprint
+/// seed) reach shim JS injected at DOCUMENT_START. Those values are NOT
+/// always author-controlled: a scanned QR or an imported backup carries them
+/// from someone else. If any shim interpolated such a string raw instead of
+/// JSON-encoding it, a crafted value could break out of the string literal
+/// and run attacker JS in the fresh isolated site's context.
+///
+/// These tests feed a break-out payload through every string-interpolating
+/// shim builder and assert the value only ever appears as a properly encoded
+/// JS string literal. A future edit that swaps `jsonEncode(x)` for `$x`
+/// fails here.
+void main() {
+  // A payload that, interpolated raw into `var x = "PAYLOAD";`, would close
+  // the string and start a new statement. Includes a quote, statement break,
+  // backslash, CRLF, a </script> sequence, and the JS line separators
+  // (U+2028/U+2029) that pre-ES2019 engines treated as string terminators.
+  const payload =
+      'x"; window.__ws_pwned = 1; var y = "\\\r\n</script>  ';
+
+  // The encoded form is the safe embedding: a valid JS string literal with
+  // the quote, backslash and control chars escaped.
+  final encoded = jsonEncode(payload);
+
+  // The payload's unique marker. It legitimately appears once, inside the
+  // encoded literal. If it appears ANYWHERE ELSE, the value escaped its
+  // string context — a real break-out.
+  const marker = '__ws_pwned';
+
+  void expectNoBreakout(String shim, String label) {
+    expect(shim.contains(encoded), isTrue,
+        reason: '$label must embed the value as a jsonEncode()d literal');
+    // Remove the (safe) encoded literal; the marker must not survive.
+    final remainder = shim.replaceAll(encoded, '');
+    expect(remainder.contains(marker), isFalse,
+        reason: '$label leaked the value outside its JS string literal');
+  }
+
+  test('language shim json-encodes the language tag', () {
+    expectNoBreakout(buildLanguageShim(payload), 'buildLanguageShim');
+  });
+
+  test('location shim json-encodes the spoofed timezone', () {
+    final shim = LocationSpoofService.buildScript(
+      locationMode: LocationMode.spoof,
+      spoofLatitude: 40.0,
+      spoofLongitude: -74.0,
+      spoofAccuracy: 25.0,
+      spoofTimezone: payload,
+      webRtcPolicy: WebRtcPolicy.defaultPolicy,
+    );
+    expect(shim, isNotNull);
+    expectNoBreakout(shim!, 'LocationSpoofService.buildScript');
+  });
+
+  test('anti-fingerprinting shim json-encodes the seed', () {
+    expectNoBreakout(
+        buildAntiFingerprintingShim(payload), 'buildAntiFingerprintingShim');
+  });
+
+  test('desktop-mode shim never emits the raw user-agent string', () {
+    // The UA is only classified into a fixed platform token; its raw text
+    // must never reach the injected JS. Feed a UA carrying the payload and
+    // assert none of it (encoded or raw) appears in the output.
+    final shim = buildDesktopModeShim(
+        'Mozilla/5.0 (X11; Linux x86_64; $payload) Firefox/151.0');
+    expect(shim.contains(marker), isFalse,
+        reason: 'raw user-agent text must not reach desktop-mode shim JS');
+  });
+}


### PR DESCRIPTION
Four changes, each with a regression test. Dart + JS suites green locally.

**BGAppRefreshTask completion race** — `pendingRefreshTask` was mutated and `setTaskCompleted` called from three threads (launch queue, `expirationHandler`, main-thread `bgRefreshDidComplete`) unsynchronized, so a completion racing an expiration could call `setTaskCompleted` twice (crash) or lose it (iOS throttles scheduling). Funnel all access onto the main queue; complete idempotently per task via `completeTask` guarded on task identity. Structural CI guard added.

**intent:// fallback scheme** — the "Open in browser" button loaded a crafted `browser_fallback_url` (`file:///…`, `javascript:`, `data:`) via `loadUrl` with no scheme check. Gate the affordance and load site on a shared `isLoadableWebUrl` (http/https only), matching the silent route. Tests cover the allowlist.

**Archive incognito** — archive-tier sites inherited the raw `incognito` field (default false), so their container wrote localStorage/IDB/SW/HTTP-cache to disk in cleartext while open; an unclean exit left it behind (ARCH-006). Add `effectiveIncognito` (always true for archive tier), routed through `setOptions`, `WebViewConfig`, and both nested `launchUrlFunc` sites. Neutrality test extended.

**Shim encoding guard** — no defect found; every per-site string reaching shim JS is `jsonEncode`d. Added a test that feeds a break-out payload through each builder so a future raw `$x` fails CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)