### PR TITLE
Pop overlaying routes on warm shortcut tap

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1750,6 +1750,9 @@ class _WebSpacePageState extends State<WebSpacePage>
   Future<void> _handleShortcutIntent() async {
     final launch = await ShortcutService.getLaunch();
     if (!mounted || launch == null) return;
+    // A shortcut tap is an app entry point: any route pushed over the main
+    // page (nested webview, settings) would overlay the launched site.
+    Navigator.of(context).popUntil((route) => route.isFirst);
     final url = launch.url ??
         _shortcutUrlLedger[launch.siteId] ??
         _tombstoneUrlFor(launch.siteId);

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -50,6 +50,13 @@ The system SHALL navigate to the correct site when launched via a home screen sh
 **Then** the app is brought to the foreground
 **And** the correct site is selected
 
+#### Scenario: Shortcut tap dismisses overlaying routes
+
+**Given** WebSpace is running with a route pushed over the main page (a nested webview opened by a cross-domain link, or a settings screen)
+**When** the user taps a home screen shortcut
+**Then** the pushed routes are popped down to the main page
+**And** the launched site is visible, not covered by the previous overlay
+
 #### Scenario: Resume after shortcut launch does not re-navigate
 
 **Given** the user launched WebSpace via a home shortcut for site A


### PR DESCRIPTION
Opening a home shortcut while the app had a nested webview (or settings screen) pushed left that route overlaying the launched site: `_openShortcutIndex` switched `_currentIndex` on the root page but never touched the Navigator.

`_handleShortcutIntent` now pops the Navigator to the root route once a warm launch intent is confirmed, covering the direct, remapped, and HS-011 interactive paths. This also closes a kiosk gap where a kiosk shortcut locked the shell while a non-kiosk nested webview stayed visible. Cold launches are unaffected.

Adds a regression scenario to HS-002 in the home-shortcut spec.

Verified: `flutter analyze` (no new issues), all 1862 Dart tests pass, `openspec validate --all` 49/49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvTQZJhbNm8pecwcDTHFxW