### PR TITLE
Show page-load progress bar under the app bar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7749,6 +7749,31 @@ class _WebSpacePageState extends State<WebSpacePage>
                       ),
                     ),
                   ),
+                // Fullscreen sessions (including kiosk-locked, where
+                // fullscreen is forced and held — KIOSK-003) have no AppBar
+                // to host the load progress bar, so overlay it along the top
+                // edge instead. IgnorePointer keeps it transparent to
+                // pointers: it adds no tappable affordance, so the locked
+                // shell stays sealed (KIOSK-002) and web-app controls in the
+                // top corners keep receiving taps.
+                if (_isFullscreen &&
+                    _currentIndex != null &&
+                    _currentIndex! < _webViewModels.length &&
+                    _webViewModels[_currentIndex!].isLoading)
+                  Positioned(
+                    top: MediaQuery.of(context).padding.top,
+                    left: 0,
+                    right: 0,
+                    child: IgnorePointer(
+                      child: LinearProgressIndicator(
+                        value: _webViewModels[_currentIndex!].loadingProgress > 0
+                            ? _webViewModels[_currentIndex!].loadingProgress / 100
+                            : null,
+                        minHeight: _loadingBarHeight,
+                        backgroundColor: Colors.transparent,
+                      ),
+                    ),
+                  ),
                 // Fullscreen exit zone: touch target at the top edge with a
                 // visible handle just below the status bar / notch area.
                 // The back button/gesture keeps its normal behavior (web

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -968,6 +968,12 @@ class _WebSpacePageState extends State<WebSpacePage>
   bool _useContainers = false;
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
+  /// Height of the page-load progress bar pinned to the AppBar's bottom
+  /// edge. Reserved (as an empty strut) whenever a site is current, so the
+  /// webview surface below doesn't shift by a few pixels every time a
+  /// navigation starts or ends.
+  static const double _loadingBarHeight = 3.0;
+
   bool _isBackHandling = false;
   bool _isFindVisible = false;
   bool _isFullscreen = false; // Runtime fullscreen state (hides appBar, tabStrip, system UI)
@@ -5715,7 +5721,25 @@ class _WebSpacePageState extends State<WebSpacePage>
 
   AppBar _buildAppBar() {
     final loc = AppLocalizations.of(context);
+    final currentModel =
+        _currentIndex != null && _currentIndex! < _webViewModels.length
+            ? _webViewModels[_currentIndex!]
+            : null;
     return AppBar(
+      bottom: currentModel == null
+          ? null
+          : PreferredSize(
+              preferredSize: const Size.fromHeight(_loadingBarHeight),
+              child: currentModel.isLoading
+                  ? LinearProgressIndicator(
+                      value: currentModel.loadingProgress > 0
+                          ? currentModel.loadingProgress / 100
+                          : null,
+                      minHeight: _loadingBarHeight,
+                      backgroundColor: Colors.transparent,
+                    )
+                  : const SizedBox(height: _loadingBarHeight),
+            ),
       // KIOSK-002: no leading menu button when locked.
       automaticallyImplyLeading: !_kioskLocked,
       title: _currentIndex != null && _currentIndex! < _webViewModels.length

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -157,6 +157,12 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
   late bool _showUrlBar;
   FindMatchesResult findMatches = FindMatchesResult();
 
+  /// Transient load state for the AppBar progress bar, mirroring the main
+  /// screen's `WebViewModel.isLoading` / `loadingProgress`.
+  bool _isLoading = false;
+  int _loadingProgress = 0;
+  static const double _loadingBarHeight = 3.0;
+
   /// Race guard for the PopScope handler. Async swipe gestures (iOS edge
   /// swipe) can re-enter `onPopInvokedWithResult` while the previous
   /// invocation is still awaiting `goBack()` / URL diff, which would
@@ -286,6 +292,19 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
               _currentUrl = url;
             });
           }
+        },
+        onLoadingChanged: (loading) {
+          if (!mounted || _isLoading == loading) return;
+          setState(() {
+            _isLoading = loading;
+            if (loading) _loadingProgress = 0;
+          });
+        },
+        onProgressChanged: (progress) {
+          if (!mounted || _loadingProgress == progress) return;
+          setState(() {
+            _loadingProgress = progress;
+          });
         },
         onConsoleMessage: (message, level) {
           _devToolsHost.appendConsole(message, level);
@@ -587,6 +606,16 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
       },
       child: Scaffold(
       appBar: AppBar(
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(_loadingBarHeight),
+          child: _isLoading
+              ? LinearProgressIndicator(
+                  value: _loadingProgress > 0 ? _loadingProgress / 100 : null,
+                  minHeight: _loadingBarHeight,
+                  backgroundColor: Colors.transparent,
+                )
+              : const SizedBox(height: _loadingBarHeight),
+        ),
         // Custom back button that bypasses PopScope by calling
         // Navigator.pop directly (vs maybePop), so the AppBar back
         // arrow always closes the nested screen. Only the system back

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -539,6 +539,11 @@ class WebViewConfig {
   /// use this to swap a Refresh button with a Stop button while a
   /// navigation is in flight.
   final Function(bool isLoading)? onLoadingChanged;
+  /// Fires as the main-frame load advances, with progress in 0-100.
+  /// Driven by the platform's `onProgressChanged`. The call site can
+  /// use this to render a determinate loading bar while a navigation
+  /// is in flight ([onLoadingChanged] gates visibility).
+  final Function(int progress)? onProgressChanged;
   /// Callback for when a popup window is requested (e.g., Cloudflare challenges).
   /// Returns a widget (typically a WebView) to display in the popup.
   /// The callback receives the windowId for the popup and the requested URL.
@@ -691,6 +696,7 @@ class WebViewConfig {
     this.localCdnEnabled = true,
     this.onUrlChanged,
     this.onLoadingChanged,
+    this.onProgressChanged,
     this.onCookiesChanged,
     this.cookieManager,
     this.containerCookieManager,
@@ -3331,6 +3337,11 @@ class WebViewFactory {
       // useShouldInterceptRequest comment above. Sub-resource DNS blocking
       // and LocalCDN replacement are both handled by the native
       // FastSubresourceInterceptor attached via WebInterceptNative.
+      onProgressChanged: config.onProgressChanged == null
+          ? null
+          : (controller, progress) {
+              config.onProgressChanged!(progress);
+            },
       onLoadStart: (controller, url) async {
         LogService.instance.log(
           'WebViewLifecycle',

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -499,6 +499,12 @@ class WebViewModel {
   /// while a load is in flight.
   bool isLoading = false;
 
+  /// Main-frame load progress in 0-100. Driven by the
+  /// `WebViewConfig.onProgressChanged` callback wired in [getWebView];
+  /// reset to 0 when a navigation starts. Consumed by the app-bar
+  /// loading bar, which only renders it while [isLoading] is true.
+  int loadingProgress = 0;
+
   /// Runtime-only marker set when this model was materialised from an
   /// open [Archive] handle rather than restored from app-tier
   /// SharedPreferences. Never serialised. Per the archive feature audit
@@ -1104,10 +1110,19 @@ class WebViewModel {
           onLoadingChanged: (loading) {
             if (isLoading == loading) return;
             isLoading = loading;
+            // Reset on start so the bar doesn't flash the previous
+            // navigation's near-complete value.
+            if (loading) loadingProgress = 0;
             // Trigger a UI rebuild so the URL-bar action button can
             // swap between Refresh and Stop. saveFunc is intentionally
             // NOT called here — the loading bool is transient runtime
             // state, not part of the persisted site model.
+            stateSetterF?.call();
+          },
+          onProgressChanged: (progress) {
+            if (loadingProgress == progress) return;
+            loadingProgress = progress;
+            // Transient runtime state, same contract as onLoadingChanged.
             stateSetterF?.call();
           },
           onUrlChanged: (url) async {

--- a/test/js/nested_webview_posture_parity.test.js
+++ b/test/js/nested_webview_posture_parity.test.js
@@ -146,6 +146,7 @@ const PLUMBING = new Set([
   'backForwardGestures', // deliberate root-only: nested uses route-pop (NAV-008)
   'onUrlChanged', 'onCookiesChanged', 'cookieManager', 'containerCookieManager',
   'cookieSiteId', 'onFindResult', 'shouldOverrideUrlLoading', 'onLoadingChanged',
+  'onProgressChanged',
   'onWindowRequested', 'onHtmlLoaded', 'shouldFetchHtml', 'onConsoleMessage',
   'onConfirmScriptFetch', 'onExternalSchemeUrl', 'pullToRefreshController',
   'onRendererGone', 'onProtectedMediaRequest',


### PR DESCRIPTION
Surfaces the engine's onProgressChanged as a thin LinearProgressIndicator
pinned to the AppBar bottom on the main screen and nested browser. The
strut height is reserved while a site is current so the webview surface
does not shift when a load starts or ends.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ByaNgxbgvKexthE6PuVAgv