### PR TITLE
Record native shared-state race class as BUG-007 + change checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,6 +292,42 @@ Orchestration (which sites unload on switch, how indices shift after delete, wha
 - Race protection: pass `(versionAtEntry, int Function() currentVersion)` so the engine can bail without knowing about widget state.
 - Tests import the engine directly with in-memory fakes that **model the interface** (e.g. `MockCookieManager` modeling RFC 6265 domain-match), not trivial stubs. See [test/cookie_isolation_integration_test.dart](test/cookie_isolation_integration_test.dart).
 
+## Adding native code that mutates shared state (BUG-007)
+
+A recurring class: native state touched by a callback / IO thread AND another path,
+with only *partial* synchronization (which looks safe and isn't). It has recurred across
+Rust/JNI (adblock UAF), Swift (BGTask double-complete), and Kotlin (intercept cache). Full
+lineage + the invariant: [docs/bugs/007-native-shared-state-races.md](docs/bugs/007-native-shared-state-races.md).
+
+When you add native state (a Kotlin plugin field, a Swift property, a Rust handle) that any
+callback, `expirationHandler`, WorkManager/coroutine, or chromium sub-resource IO thread can
+observe:
+
+- **Total synchronization or none-shared.** Either single-owner / immutable-snapshot /
+  message-passed, or *every* read, write, and eviction under one monitor / serial queue /
+  RW-lock. A lock on the writer but not the reader is BUG-007 — don't.
+- **One-shot resources are idempotent + identity-guarded.** A freed pointer or a completed
+  task: guard the second call to a no-op (`guard pendingRefreshTask === task`). Never
+  free/complete by re-reading shared state.
+- **Read-heavy hot path → RW-lock** (readers concurrent, writer exclusive); don't hold a lock
+  across a blocking call (read under lock, compute outside, write under lock).
+- **Encode a class-level guard** (practice, not optional): a JVM concurrency/stress test or a
+  structural CI gate so the *next* instance fails, not just this one. Templates:
+  `AdblockEngineNativeTest.kt`, `test/js/native_bgtask_completion_funnel.test.js`.
+- **Record recurrence in BUG-007**, not a new file — append a dated fix attempt with *why it
+  was partial* (which path it covered, which it missed). Cross-link the spec that owns the
+  state.
+
+## Logic engine vs rendering engine
+
+Orchestration (which sites unload on switch, how indices shift after delete, what cookies move during activation) → pure-Dart engine in `lib/services/*_engine.dart`. Template: [cookie_isolation.dart](lib/services/cookie_isolation.dart). Native webview / platform channels / `setState` stays at the call site.
+
+- Mutating `_webViewModels`/`_loadedIndices`/`_webspaces` with >1 line of index arithmetic? Engine.
+- `await native_call` then mutate shared state with scenario-dependent logic? Engine.
+- Engines never `import 'package:flutter/material.dart'`, never call `setState`, never touch `context`. Add interfaces on existing services (e.g. `CookieManager`) instead of reaching into concrete types.
+- Race protection: pass `(versionAtEntry, int Function() currentVersion)` so the engine can bail without knowing about widget state.
+- Tests import the engine directly with in-memory fakes that **model the interface** (e.g. `MockCookieManager` modeling RFC 6265 domain-match), not trivial stubs. See [test/cookie_isolation_integration_test.dart](test/cookie_isolation_integration_test.dart).
+
 ## DRY: tests delegate, don't reimplement
 
 Test harness re-implementing `switchToSite`/`deleteSite` = un-extracted engine. Wrap the real engine; never re-write the flow in a test. See [test/cookie_isolation_integration_test.dart:174-238](test/cookie_isolation_integration_test.dart).

--- a/docs/bugs/007-native-shared-state-races.md
+++ b/docs/bugs/007-native-shared-state-races.md
@@ -1,0 +1,116 @@
+# BUG-007: Native shared mutable state raced across threads (UAF / double-complete / cache corruption)
+
+**Status:** open (each instance is fixed, but the *class* is only closed when every native
+component that shares mutable state is audited against the invariant below — there is no
+universal structural guard, and known gaps remain, see the end)
+**Platform:** Android (Kotlin + Rust/JNI) and iOS/macOS (Swift) — anywhere native code holds
+state touched by more than one thread.
+**Spec:** the mutated state is owned by
+[per-site-containers](../../openspec/specs/per-site-containers/spec.md),
+[content-blocker](../../openspec/specs/content-blocker/spec.md), and
+[web-push-notifications](../../openspec/specs/web-push-notifications/spec.md); none carried a
+normative concurrency requirement — this file is the cross-cutting record.
+**Formal model:** none. Native thread interleavings sit outside the TLA+ kernel's observable
+projection ([formal/README.md](../../formal/README.md)); this class is guarded in code
+(concurrency smoke test + structural funnel gate), not in the model.
+**Tests:** [android/app/src/test/kotlin/.../AdblockEngineNativeTest.kt](../../android/app/src/test/kotlin/org/codeberg/theoden8/webspace/AdblockEngineNativeTest.kt)
+(concurrent readers/writers don't deadlock or throw) and
+[test/js/native_bgtask_completion_funnel.test.js](../../test/js/native_bgtask_completion_funnel.test.js)
+(structural gate: completion only through the funnel). The intercept cache (attempt 3) has
+no dedicated guard yet — see open gaps.
+
+## Symptom
+
+Three symptoms, one shape:
+
+- **Adblock:** rare native crash on the chromium IO thread when the user flipped the
+  content-blocker toggle while a page was loading sub-resources.
+- **iOS notifications:** process crash (`BGTask.setTaskCompleted` called twice) or silently
+  throttled background refresh (completion lost), when a background-refresh finished at the
+  same moment iOS fired the task's expiration handler.
+- **Content blocker (Android):** intermittent `ConcurrentModificationException` / an IO
+  thread spinning at 100% on a busy page, and a transient window where a blocked host could
+  slip through.
+
+## Root mechanism (the invariant behind every instance)
+
+A piece of **native mutable state is touched from more than one thread without total
+synchronization**. In every case a *callback / IO thread* (chromium's sub-resource
+`shouldInterceptRequest` workers, iOS's `expirationHandler`, the `BGTaskScheduler` launch
+queue) read or freed state that another path (a method-channel handler on the main/platform
+thread, a toggle, a timer) mutated concurrently — and the synchronization that existed was
+**partial**, which is worse than none because it *looks* safe:
+
+- adblock: only the two writers (`setRules`/`dispose`) were `@Synchronized`; the readers ran
+  lock-free, so a `Box::from_raw` could free the engine mid-`deref`.
+- iOS: `pendingRefreshTask` had no lock at all across three threads.
+- intercept cache: only `clearHostDecisionCache` was `@Synchronized` (on `this`); the reads,
+  writes, and FIFO eviction were lock-free.
+
+**The invariant:** native state that any callback/IO thread can observe MUST be either
+(a) not shared (single owner / immutable snapshot / message-passed), or (b) guarded by *total*
+synchronization — every read, write, and eviction under the same monitor, one-shot resources
+(a freed pointer, a completed task) made **idempotent and identity-guarded** so a second
+completion is a no-op. Half a lock does not satisfy this.
+
+## Fix attempts (chronological)
+
+### Attempt 1 — Adblock JNI engine: read/write lock around free-vs-deref
+**Date:** 2026-07-19 · **PR:** #495 · **Files:** `android/app/src/main/kotlin/.../AdblockEngineNative.kt`, `rust/webspace_adblock/src/jni.rs`
+**What it did:** `nativeCheckUrl`/`nativeRedirectFor` deref the raw `enginePtr` (a
+`Box<Engine>`) on the chromium IO thread while `setRules`/`dispose` `Box::from_raw` it.
+Replaced the writer-only `@Synchronized` with a `ReentrantReadWriteLock`: readers take the
+read lock (many concurrent, preserving the parallel hot path), writers take the write lock,
+so no free runs while any read holds the pointer. Added a JVM concurrency smoke test.
+**Why:** a use-after-free in native code is memory-unsafe and crashes the process.
+**Why it was partial:** it closed the adblock engine's pointer only. The *class* — native
+shared state raced across threads — still lived in the iOS background-task slot and the
+Android intercept cache.
+
+### Attempt 2 — iOS BGAppRefreshTask: funnel completion onto one queue, make it idempotent
+**Date:** 2026-07-20 · **PR:** #498 · **Files:** `ios/Runner/BackgroundTaskPlugin.swift`
+**What it did:** `pendingRefreshTask` was mutated and `setTaskCompleted` called from the
+launch queue, the `expirationHandler`, and the main-thread `bgRefreshDidComplete` callback,
+unsynchronized — so a completion racing an expiration could complete the task twice (crash)
+or lose it (iOS throttles future scheduling). Confined all pending-slot access to the main
+queue and made completion idempotent per task via a `completeTask(_:success:)` helper guarded
+on task identity (`guard pendingRefreshTask === task`). Added a structural CI gate.
+**Why:** `BGTask.setTaskCompleted` must fire exactly once; the notification-refresh contract
+(NOTIF-005-I) breaks silently otherwise.
+**Why it was partial:** it fixed the background-task slot. The Android sub-resource intercept
+cache was still an unguarded `LinkedHashMap` on concurrent IO threads.
+
+### Attempt 3 — Android intercept cache: one monitor for read, write, and eviction
+**Date:** 2026-07-20 · **PR:** #504 · **Files:** `android/app/src/main/kotlin/.../WebInterceptPlugin.kt`
+**What it did:** `FastSubresourceInterceptor.checkUrl` runs on chromium's concurrent
+sub-resource IO threads and read, wrote, and FIFO-evicted a plain `LinkedHashMap` while only
+`clearHostDecisionCache` was `@Synchronized`. Introduced a single `hostDecisionLock`; guarded
+the cache read, `putHostDecision` (including eviction), and the clear under it; made
+`checkCount` an `AtomicInteger`. Read the cache under the lock, computed on miss *outside* it
+(to avoid holding the lock across the blocking `awaitReady`), wrote under the lock.
+**Why:** concurrent structural mutation of a `LinkedHashMap` throws
+`ConcurrentModificationException` or, on resize, forms a cycle that spins the IO thread; a
+dropped `BLOCKED` entry is a transient filter-bypass.
+**Why it was partial:** it closes this cache, but the class is not closed for good — a *new*
+native component that shares mutable state can reintroduce it, and the fork + a few
+same-class reads remain (open gaps).
+
+## Known open gaps
+
+1. **No universal structural guard.** Each instance got its own guard (or none, for the
+   intercept cache). A new native plugin that shares mutable state across a callback/IO
+   thread and another path can reintroduce the class silently. Mitigation is process: the
+   CLAUDE.md "Adding native code that mutates shared state" checklist points here; hold every
+   new native component to the invariant above.
+2. **Fork `ContainerManager.swift` registry lost-update.** The `id → uuid` map's
+   read-modify-write (`loadIdMap` → mutate → `saveIdMap`) is guarded by `sharedStoresLock`
+   only inside `getOrCreateDataStore`; the same sequence in `deleteContainer`'s completion
+   handler and `registerContainerBinding` runs without the lock. Same class, lives in the
+   flutter_inappwebview fork (out of this repo's tree), not yet fixed. Consequence is a
+   stale/missing registry entry, not a crash. Fix before the next fork tag.
+3. **`WebInterceptPlugin` unsynchronized size checks.** The `cdnPatterns.isNotEmpty()` /
+   `cdnCacheIndex.isNotEmpty()` reads sit outside the `synchronized` blocks that guard their
+   real reads/writes. Benign (`isEmpty` can't throw), same class — fold into the lock.
+4. **CONT-005 silent degrade-to-shared.** If the native `containerId` bind ever fails, the
+   site falls back to the default store; the engine tolerates a zero-bind result but can't
+   detect the degraded (isolation-lost) state. Wants a native post-bind assertion.


### PR DESCRIPTION
Incorporates the "follow religiously" practices from the review retro — the recurring-bug system and encoding each fix as a class-level guard — for the one class that slipped through them.

The use-after-free (adblock JNI, #495), the `BGAppRefreshTask` double-complete (iOS, #498), and the intercept-cache corruption (Android, #504) are **one bug class** — native mutable state raced across a callback/IO thread and another path, with only partial synchronization — that recurred across Rust, Swift, and Kotlin but never got a `docs/bugs/` biography. That's exactly the process `docs/bugs/` exists for.

- **`docs/bugs/007-native-shared-state-races.md`** — the biography: symptom, the shared invariant behind all three, the three fixes in chronological order (each with date/PR/what/why/**why it was partial**), and known open gaps (no universal guard; the fork's `ContainerManager` registry lost-update; the `WebInterceptPlugin` size-check reads; CONT-005 silent degrade-to-shared).
- **CLAUDE.md** — a new "Adding native code that mutates shared state (BUG-007)" checklist next to the other "Adding a new X" guides: total-synchronization-or-none-shared, idempotent identity-guarded one-shots, RW-lock for read-heavy paths, **encode a class-level guard**, and record recurrence by appending to BUG-007 rather than starting fresh. Cross-links the owning specs (traceability).

Docs/process only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSLJG3NPNx85bWTZAEmuqn)_