### PR TITLE
CI: reclaim disk before macOS integration loop

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -841,6 +841,45 @@ jobs:
           fvm flutter build macos --release
           bash scripts/verify_adblock_shipped.sh macos
 
+      # Reclaim disk before the macOS integration loop. The macos-latest
+      # runner has a tight disk budget, and by this point three build trees
+      # coexist: the iOS release archive (build/ios), the macOS *release*
+      # tree (build/macos, Release config), and — about to be created — the
+      # macOS *debug* tree the loop rebuilds 12 times. That coexistence is
+      # what filled the disk mid-loop: the run failed on the 4th test file
+      # with cascading write errors (rsync "Input/output error" copying
+      # App.framework, "unable to write manifest", a truncated
+      # Flutter-Generated.xcconfig, then `git mmap failed` once the Flutter
+      # SDK itself got corrupted).
+      #
+      # The Debug builds never reuse the Release intermediates (Xcode keys
+      # object files by configuration), and they never touch build/ios, so
+      # dropping both is free — no extra rebuild cost, the first Debug build
+      # was always going to compile the Debug pods from scratch. We keep
+      # only the two deliverables the post-loop steps still need: the IPA
+      # (build/ios/ipa) and the Release .app (build/macos/Build/Products/
+      # Release, zipped after the loop). rust/webspace_adblock/target is
+      # deliberately left intact — the pod's always-out-of-date script phase
+      # re-runs `build_rust.sh apple` on every Debug build, and an intact
+      # target/ keeps cargo a fast no-op instead of a 4-minute recompile ×12.
+      - name: Reclaim disk before macOS integration tests
+        run: |
+          set -x
+          # Report the volume the build actually writes to; on macOS APFS
+          # `df -h /` shows the sealed read-only system volume, not the
+          # writable Data volume the checkout lives on.
+          df -h .
+          # iOS: keep the IPA, drop the .xcarchive + iphoneos intermediates.
+          if [ -d build/ios ]; then
+            find build/ios -mindepth 1 -maxdepth 1 ! -name ipa \
+              -exec rm -rf {} +
+          fi
+          # macOS: keep the Release .app products, drop the Release
+          # intermediates (the bulk: every Pod + Runner .o for a config the
+          # Debug loop won't reuse).
+          rm -rf build/macos/Build/Intermediates.noindex
+          df -h .
+
       # Integration tests on macOS desktop — the same cross-platform
       # integration_test/*.dart harness the Linux job runs, driven against
       # the native macOS (WKWebView + AppKit) runtime via `-d macos`. None

--- a/openspec/specs/integration-tests/spec.md
+++ b/openspec/specs/integration-tests/spec.md
@@ -411,6 +411,32 @@ either target.
   checks out fresh and release builds keep the committed entitlements
   plus a real signing identity
 
+#### Scenario: Disk is reclaimed before the macOS integration loop
+
+- **Given** the `build-apple` job has built the iOS IPA and the macOS
+  release app, so the iOS archive tree (`build/ios`) and the macOS
+  release build tree (`build/macos`, Release config) both sit on the
+  runner's tight disk
+- **And** the `Run macOS integration tests` step is about to rebuild the
+  macOS app once per file in the *debug* configuration, which Xcode keys
+  separately from the release objects and never reuses
+- **When** a `Reclaim disk before macOS integration tests` step runs
+  before the loop
+- **Then** it removes `build/macos/Build/Intermediates.noindex` (the
+  release object files) and everything under `build/ios` except
+  `build/ios/ipa`, leaving the two post-loop deliverables intact — the
+  IPA (`Upload IPA`) and the Release `.app` under
+  `build/macos/Build/Products/Release` (`Create macOS ZIP archive`)
+- **And** it does not touch `rust/webspace_adblock/target`, because the
+  webspace_adblock pod's always-out-of-date script phase re-invokes
+  `scripts/build_rust.sh apple` on every debug build and an intact
+  `target/` keeps cargo an incremental no-op instead of a full
+  five-slice recompile per file
+- **And** without this reclamation the loop exhausts the disk mid-run
+  (observed: the 4th file failing on rsync `Input/output error` copying
+  `App.framework`, then a truncated `Flutter-Generated.xcconfig` and a
+  corrupted Flutter SDK for every file after)
+
 ---
 
 ## Known Limitations


### PR DESCRIPTION
The macos-latest disk filled mid-loop once the iOS release archive, the
macOS release build tree, and the debug tree the loop rebuilds per file
all coexisted; the 4th test failed on rsync I/O errors and a corrupted
Flutter SDK. Drop the release intermediates and the iOS archive (both
unused by the debug builds) before the loop, keeping the IPA and the
Release .app the upload steps need. Leave rust target/ intact so the
pod's per-build cargo stays an incremental no-op.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GnjW2fbt7aXoy9CZaQAwMP