### PR TITLE
Add drag-to-reorder for tabs in tab strip and drawer

### DIFF
--- a/integration_test/site_editing_test.dart
+++ b/integration_test/site_editing_test.dart
@@ -1,9 +1,12 @@
 // Site-editing integration test.
 //
-// Drives the long-press → context-menu → Edit Site dialog flow on the
-// drawer's site tile. Touches no WebView path — the dialog opens
-// without activating the site, so the test runs cleanly under headless
-// Xvfb (where WebView mount hangs on EGL surface init).
+// Drives the overflow-menu → Edit Site dialog flow on the drawer's site
+// tile. Drawer tiles are reorderable (long-press starts a drag), so the
+// context menu opens from the per-tile overflow (⋮) button — the drawer
+// edit access point in the site-editing spec (EDIT-006). Touches no
+// WebView path — the dialog opens without activating the site, so the
+// test runs cleanly under headless Xvfb (where WebView mount hangs on
+// EGL surface init).
 //
 // Closes the test gap on the `site-editing` spec, which previously had
 // no automated coverage of any kind.
@@ -34,7 +37,7 @@ void main() {
     });
   });
 
-  testWidgets('long-press → Edit renames the site through the dialog',
+  testWidgets('overflow menu → Edit renames the site through the dialog',
       (tester) async {
     app.main();
     await tester.pumpAndSettle(const Duration(seconds: 30));
@@ -63,8 +66,17 @@ void main() {
     expect(siteTile, findsOneWidget,
         reason: 'seeded site should appear in the drawer with its initial name');
 
-    // Long-press → context menu (lib/main.dart `_showSiteContextMenu`).
-    await tester.longPress(siteTile);
+    // Open the context menu from the tile's overflow (⋮) button
+    // (lib/main.dart `_showSiteContextMenu`). Long-press is reserved for
+    // drag-to-reorder, so it no longer opens the menu. Scope the icon lookup
+    // to this tile — the app bar and bottom bar also render more_vert.
+    final tileMenuButton = find.descendant(
+      of: find.byKey(const Key('site_0')),
+      matching: find.byIcon(Icons.more_vert),
+    );
+    expect(tileMenuButton, findsOneWidget,
+        reason: 'reorderable drawer tile should expose an overflow menu button');
+    await tester.tap(tileMenuButton);
     await tester.pumpAndSettle(const Duration(seconds: 3));
 
     // The popup menu has rows for Refresh / Edit / Delete; tap Edit.
@@ -73,7 +85,7 @@ void main() {
       dumpTexts('context menu open');
     }
     expect(editMenuItem, findsOneWidget,
-        reason: 'Edit option should be available in the long-press context menu');
+        reason: 'Edit option should be available in the tile overflow menu');
     await tester.tap(editMenuItem);
     await tester.pumpAndSettle(const Duration(seconds: 3));
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6183,69 +6183,149 @@ class _WebSpacePageState extends State<WebSpacePage>
                 itemCount: filteredIndices.length,
                 padding: EdgeInsets.symmetric(horizontal: 4),
                 itemBuilder: (context, listIndex) {
-                  final siteIndex = filteredIndices[listIndex];
-                  final siteModel = _webViewModels[siteIndex];
-                  final isActive = siteIndex == _currentIndex;
-
-                  return GestureDetector(
-                    onTap: () async {
-                      await _setCurrentIndex(siteIndex);
-                      if (!mounted) return;
-                      setState(() {
-                        _tabBarOverlayVisible = false;
-                      });
-                      _saveCurrentIndex();
-                    },
-                    child: Container(
-                      constraints: BoxConstraints(maxWidth: _tabMaxWidth.toDouble()),
-                      margin: EdgeInsets.symmetric(horizontal: 2, vertical: 4),
-                      padding: EdgeInsets.symmetric(horizontal: 8),
-                      decoration: BoxDecoration(
-                        color: isActive
-                            ? theme.colorScheme.primaryContainer
-                            : (isDark ? Color(0xFF2A2A2A) : Colors.white),
-                        borderRadius: BorderRadius.circular(8),
-                        border: isActive
-                            ? Border.all(color: theme.colorScheme.primary, width: 1.5)
-                            : Border.all(
-                                color: isDark ? Color(0xFF3E3E3E) : Color(0xFFE0E0E0),
-                                width: 0.5,
-                              ),
-                      ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          UnifiedFaviconImage(
-                            url: siteModel.initUrl,
-                            size: 16,
-                            proxy: siteModel.proxySettings,
-                            customIcon: siteModel.customIconPng,
-                          ),
-                          SizedBox(width: 6),
-                          Flexible(
-                            child: Text(
-                              siteModel.getDisplayName(),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: TextStyle(
-                                fontSize: 12,
-                                fontWeight: isActive ? FontWeight.w600 : FontWeight.normal,
-                                color: isActive
-                                    ? theme.colorScheme.onPrimaryContainer
-                                    : theme.colorScheme.onSurface.withOpacity(0.8),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  );
+                  return _buildTabStripItem(
+                    context, listIndex, filteredIndices, theme, isDark);
                 },
               ),
             ),
             _buildBottomPopupMenu(),
           ],
         ),
+      ),
+    );
+  }
+
+  /// One tab in the bottom strip. Draggable-to-reorder when the current view
+  /// supports reordering (a named webspace or "All") and there is more than
+  /// one tab; a plain tappable chip otherwise. Uses a raw [Listener] for tap
+  /// detection rather than [GestureDetector] so the tap doesn't lose the
+  /// gesture-arena fight with [LongPressDraggable] (same pattern as the
+  /// drawer grid tiles).
+  Widget _buildTabStripItem(
+    BuildContext context,
+    int listIndex,
+    List<int> filteredIndices,
+    ThemeData theme,
+    bool isDark,
+  ) {
+    final siteIndex = filteredIndices[listIndex];
+    final siteModel = _webViewModels[siteIndex];
+    final isActive = siteIndex == _currentIndex;
+    final content = _buildTabStripItemContent(siteModel, isActive, theme, isDark);
+
+    void handleTap() {
+      () async {
+        await _setCurrentIndex(siteIndex);
+        if (!mounted) return;
+        setState(() {
+          _tabBarOverlayVisible = false;
+        });
+        _saveCurrentIndex();
+      }();
+    }
+
+    if (!_canReorderCurrentView || filteredIndices.length < 2) {
+      return GestureDetector(onTap: handleTap, child: content);
+    }
+
+    Offset? pointerDownPos;
+    Duration? pointerDownTime;
+    return DragTarget<int>(
+      onWillAcceptWithDetails: (details) => details.data != listIndex,
+      onAcceptWithDetails: (details) => _reorderSite(details.data, listIndex),
+      builder: (context, candidateData, rejectedData) {
+        final isHovered = candidateData.isNotEmpty;
+        return LongPressDraggable<int>(
+          data: listIndex,
+          feedback: Material(
+            color: Colors.transparent,
+            child: Opacity(opacity: 0.85, child: content),
+          ),
+          childWhenDragging: Opacity(opacity: 0.3, child: content),
+          child: Container(
+            decoration: isHovered
+                ? BoxDecoration(
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: theme.colorScheme.primary, width: 2),
+                  )
+                : null,
+            child: Listener(
+              behavior: HitTestBehavior.opaque,
+              onPointerDown: (event) {
+                pointerDownPos = event.position;
+                pointerDownTime = event.timeStamp;
+              },
+              onPointerUp: (event) {
+                if (pointerDownPos != null) {
+                  final distance = (event.position - pointerDownPos!).distance;
+                  final duration = event.timeStamp - pointerDownTime!;
+                  if (distance < 20 &&
+                      duration < const Duration(milliseconds: 300)) {
+                    handleTap();
+                  }
+                }
+                pointerDownPos = null;
+                pointerDownTime = null;
+              },
+              onPointerCancel: (_) {
+                pointerDownPos = null;
+                pointerDownTime = null;
+              },
+              child: content,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildTabStripItemContent(
+    WebViewModel siteModel,
+    bool isActive,
+    ThemeData theme,
+    bool isDark,
+  ) {
+    return Container(
+      constraints: BoxConstraints(maxWidth: _tabMaxWidth.toDouble()),
+      margin: EdgeInsets.symmetric(horizontal: 2, vertical: 4),
+      padding: EdgeInsets.symmetric(horizontal: 8),
+      decoration: BoxDecoration(
+        color: isActive
+            ? theme.colorScheme.primaryContainer
+            : (isDark ? Color(0xFF2A2A2A) : Colors.white),
+        borderRadius: BorderRadius.circular(8),
+        border: isActive
+            ? Border.all(color: theme.colorScheme.primary, width: 1.5)
+            : Border.all(
+                color: isDark ? Color(0xFF3E3E3E) : Color(0xFFE0E0E0),
+                width: 0.5,
+              ),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          UnifiedFaviconImage(
+            url: siteModel.initUrl,
+            size: 16,
+            proxy: siteModel.proxySettings,
+            customIcon: siteModel.customIconPng,
+          ),
+          SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              siteModel.getDisplayName(),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: isActive ? FontWeight.w600 : FontWeight.normal,
+                color: isActive
+                    ? theme.colorScheme.onPrimaryContainer
+                    : theme.colorScheme.onSurface.withOpacity(0.8),
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -6843,7 +6923,6 @@ class _WebSpacePageState extends State<WebSpacePage>
   }
 
   void _showSiteContextMenu(BuildContext context, int index, Offset position) {
-    final isCustomWebspace = _selectedWebspaceId != null && _selectedWebspaceId != kAllWebspaceId;
     final filteredIndices = _getFilteredSiteIndices();
     final listIndex = filteredIndices.indexOf(index);
     final isArchiveSite =
@@ -6863,9 +6942,9 @@ class _WebSpacePageState extends State<WebSpacePage>
         PopupMenuItem(value: 'refresh', child: ListTile(leading: Icon(Icons.refresh), title: Text(loc.homeRefreshTitleAndIcon), dense: true, visualDensity: VisualDensity.compact)),
         PopupMenuItem(value: 'edit', child: ListTile(leading: Icon(Icons.edit), title: Text(loc.commonEdit), dense: true, visualDensity: VisualDensity.compact)),
         PopupMenuItem(value: 'delete', child: ListTile(leading: Icon(Icons.delete, color: Colors.red), title: Text(loc.commonDelete, style: TextStyle(color: Colors.red)), dense: true, visualDensity: VisualDensity.compact)),
-        if (isCustomWebspace && listIndex > 0)
+        if (_canReorderCurrentView && listIndex > 0)
           PopupMenuItem(value: 'move_up', child: ListTile(leading: Icon(Icons.arrow_upward), title: Text(loc.homeMoveUp), dense: true, visualDensity: VisualDensity.compact)),
-        if (isCustomWebspace && listIndex >= 0 && listIndex < filteredIndices.length - 1)
+        if (_canReorderCurrentView && listIndex >= 0 && listIndex < filteredIndices.length - 1)
           PopupMenuItem(value: 'move_down', child: ListTile(leading: Icon(Icons.arrow_downward), title: Text(loc.homeMoveDown), dense: true, visualDensity: VisualDensity.compact)),
         if (canMoveToArchive)
           PopupMenuItem(value: 'move_to_archive', child: ListTile(leading: Icon(Icons.archive_outlined), title: Text(loc.homeMoveToArchive), dense: true, visualDensity: VisualDensity.compact)),
@@ -6931,13 +7010,35 @@ class _WebSpacePageState extends State<WebSpacePage>
           await _deleteSite(context, index);
           break;
         case 'move_up':
-          _reorderSiteInWebspace(listIndex, listIndex - 1);
+          _reorderSite(listIndex, listIndex - 1);
           break;
         case 'move_down':
-          _reorderSiteInWebspace(listIndex, listIndex + 1);
+          _reorderSite(listIndex, listIndex + 1);
           break;
       }
     });
+  }
+
+  /// Whether the currently-selected view supports drag/menu reordering.
+  /// Both a named webspace (reorders its `siteIds`) and the synthetic "All"
+  /// view (reorders `_webViewModels` globally) qualify; the null/home state
+  /// does not.
+  bool get _canReorderCurrentView => _selectedWebspaceId != null;
+
+  /// Reorder the site shown at [oldListIndex] to [newListIndex] within the
+  /// current view. Dispatches to the per-webspace `siteIds` reorder for a
+  /// named webspace, or the global `_webViewModels` reorder for "All".
+  /// [oldListIndex]/[newListIndex] are positions in `_getFilteredSiteIndices()`.
+  void _reorderSite(int oldListIndex, int newListIndex) {
+    final filtered = _getFilteredSiteIndices();
+    if (oldListIndex < 0 || oldListIndex >= filtered.length) return;
+    if (newListIndex < 0 || newListIndex >= filtered.length) return;
+    if (oldListIndex == newListIndex) return;
+    if (_selectedWebspaceId == kAllWebspaceId) {
+      _reorderAllSites(filtered[oldListIndex], filtered[newListIndex]);
+    } else {
+      _reorderSiteInWebspace(oldListIndex, newListIndex);
+    }
   }
 
   void _reorderSiteInWebspace(int oldListIndex, int newListIndex) {
@@ -6954,6 +7055,41 @@ class _WebSpacePageState extends State<WebSpacePage>
       _resolveWebspaceIndices();
     });
     _saveWebspaces();
+  }
+
+  /// Reorder the global `_webViewModels` list (the "All" view's order) by
+  /// moving the model at [oldModelIndex] to [newModelIndex]. The IndexedStack
+  /// children are keyed by `siteId`, so reordering the list preserves each
+  /// webview's State — only the positional trackers (`_loadedIndices`,
+  /// `_currentIndex`) need remapping, computed by `computeReorderPatch`.
+  void _reorderAllSites(int oldModelIndex, int newModelIndex) {
+    if (oldModelIndex < 0 || oldModelIndex >= _webViewModels.length) return;
+    if (newModelIndex < 0 || newModelIndex >= _webViewModels.length) return;
+    if (oldModelIndex == newModelIndex) return;
+    final patch = SiteLifecycleEngine.computeReorderPatch(
+      oldIndex: oldModelIndex,
+      newIndex: newModelIndex,
+      loadedIndices: _loadedIndices,
+      currentIndex: _currentIndex,
+    );
+    setState(() {
+      // Invalidate any in-flight `_setCurrentIndex`: it mutates
+      // `_loadedIndices`/`_currentIndex` by positional index across awaits,
+      // so a concurrent switch resuming against the reordered list would
+      // activate the wrong site (cross-site cookie exposure in legacy mode).
+      ++_setCurrentIndexVersion;
+      final moved = _webViewModels.removeAt(oldModelIndex);
+      _webViewModels.insert(newModelIndex, moved);
+      _loadedIndices
+        ..clear()
+        ..addAll(patch.newLoadedIndices);
+      _currentIndex = patch.newCurrentIndex;
+      // Webspace membership is siteId-keyed; rebuild the positional view.
+      _resolveWebspaceIndices();
+    });
+    _saveWebViewModels();
+    _saveWebspaces();
+    _saveCurrentIndex();
   }
 
   Future<void> _deleteSite(BuildContext context, int index) async {
@@ -7230,13 +7366,12 @@ class _WebSpacePageState extends State<WebSpacePage>
   Widget _buildSiteGridTile(BuildContext context, int index, int listIndex) {
     final isSelected = _currentIndex == index;
     final theme = Theme.of(context);
-    final isCustomWebspace = _selectedWebspaceId != null && _selectedWebspaceId != kAllWebspaceId;
     return Semantics(
       key: Key('site_$index'),
       label: _webViewModels[index].getDisplayName(),
       button: true,
       enabled: true,
-      child: isCustomWebspace
+      child: _canReorderCurrentView
         ? _buildDraggableSiteGridTile(context, index, listIndex, isSelected, theme)
         : _buildStaticSiteGridTile(context, index, isSelected, theme),
     );
@@ -7251,7 +7386,7 @@ class _WebSpacePageState extends State<WebSpacePage>
     return DragTarget<int>(
       onWillAcceptWithDetails: (details) => details.data != listIndex,
       onAcceptWithDetails: (details) {
-        _reorderSiteInWebspace(details.data, listIndex);
+        _reorderSite(details.data, listIndex);
       },
       builder: (context, candidateData, rejectedData) {
         final isHovered = candidateData.isNotEmpty;

--- a/lib/services/site_lifecycle_engine.dart
+++ b/lib/services/site_lifecycle_engine.dart
@@ -37,7 +37,55 @@ class SiteDeletionPatch {
   });
 }
 
+/// Pure state transform describing how `_loadedIndices` and the current-index
+/// pointer must be updated after a site is moved within `_webViewModels` via
+/// `removeAt(oldIndex); insert(newIndex, moved)`. Webspace `siteIndices` are
+/// siteId-keyed and rebuilt by `_resolveWebspaceIndices`, so they are not part
+/// of the patch.
+class SiteReorderPatch {
+  /// Loaded indices after the move, each remapped to the position its element
+  /// occupies once the moved element lands at `newIndex`.
+  final Set<int> newLoadedIndices;
+
+  /// Updated value for `_currentIndex`: `null` stays `null`, otherwise remapped
+  /// to the active site's new position.
+  final int? newCurrentIndex;
+
+  const SiteReorderPatch({
+    required this.newLoadedIndices,
+    required this.newCurrentIndex,
+  });
+}
+
 class SiteLifecycleEngine {
+  /// Computes the index-rewrite after moving the model at [oldIndex] to
+  /// [newIndex] in `_webViewModels` (`removeAt(oldIndex); insert(newIndex, moved)`).
+  /// Every tracked positional index is remapped to where its element ends up:
+  ///
+  ///   * the moved element               → `newIndex`
+  ///   * an element after `oldIndex`      → shifts down by one, then up by one
+  ///     if it now sits at/after `newIndex` (net: follows the moved element)
+  ///
+  /// Both indices must be valid positions in the pre-move list; `oldIndex ==
+  /// newIndex` is a no-op mapping (identity).
+  static SiteReorderPatch computeReorderPatch({
+    required int oldIndex,
+    required int newIndex,
+    required Set<int> loadedIndices,
+    required int? currentIndex,
+  }) {
+    int mapIndex(int i) {
+      if (i == oldIndex) return newIndex;
+      final afterRemoval = i > oldIndex ? i - 1 : i;
+      return afterRemoval >= newIndex ? afterRemoval + 1 : afterRemoval;
+    }
+
+    return SiteReorderPatch(
+      newLoadedIndices: {for (final i in loadedIndices) mapIndex(i)},
+      newCurrentIndex: currentIndex == null ? null : mapIndex(currentIndex),
+    );
+  }
+
   /// Computes the index-rewrite that must happen after `_webViewModels.removeAt(deletedIndex)`:
   ///
   ///   * `loadedIndices`: drop `deletedIndex`, shift `i > deletedIndex` to `i - 1`,

--- a/openspec/specs/webspaces/spec.md
+++ b/openspec/specs/webspaces/spec.md
@@ -154,6 +154,39 @@ When a site is deleted, all webspace indices SHALL be automatically updated.
 
 ---
 
+### Requirement: WEBSPACE-011 - Reorder Sites by Dragging
+
+Users SHALL be able to change the display order of sites by dragging, in
+both the bottom tab strip and the drawer grid. The new order SHALL persist
+across app restarts. This reorders the sites *within* the selected view; it
+does not move the webspace cards themselves (WEBSPACE-009 still holds — the
+"All" webspace card cannot be moved in the webspaces list).
+
+#### Scenario: Reorder sites within a named webspace
+
+**Given** the "Work" webspace is selected with sites [A, B, C] in that order
+**When** the user long-presses site C in the tab strip or drawer grid and drops it onto site A's position
+**Then** "Work"'s membership order becomes [C, A, B]
+**And** the change is written to the webspace's persisted `siteIds`
+**And** the global order of other webspaces is unaffected
+
+#### Scenario: Reorder sites within the "All" webspace
+
+**Given** the "All" webspace is selected showing every site in `_webViewModels` order
+**When** the user drags a site to a new position in the tab strip or drawer grid
+**Then** `_webViewModels` is reordered to match
+**And** the active site stays active (its `_currentIndex` follows it to its new position)
+**And** any loaded webviews keep their in-memory state (IndexedStack children are keyed by `siteId`, not position)
+**And** the new order is persisted
+
+#### Scenario: Single site is not draggable
+
+**Given** the selected view contains only one site
+**When** the user long-presses that site
+**Then** no drag begins (there is nothing to reorder)
+
+---
+
 ## Data Model
 
 ### Webspace
@@ -230,6 +263,15 @@ production):
   when a site is removed from `_webViewModels`, implementing
   WEBSPACE-010. The rewrite drops the deleted index and shifts every
   `i > deletedIndex` down by one.
+- [`SiteLifecycleEngine.computeReorderPatch`](../../../lib/services/site_lifecycle_engine.dart)
+  — implements the "All" branch of WEBSPACE-011. Given a move of the
+  model at `oldIndex` to `newIndex` (`removeAt` + `insert`), it remaps
+  `_loadedIndices` and `_currentIndex` to the positions their elements
+  occupy after the move, so the active site and every loaded webview
+  keep pointing at the same `siteId`. Reordering within a named
+  webspace needs no engine: it rewrites the webspace's siteId-keyed
+  `siteIds` list directly (`_reorderSiteInWebspace`), and
+  `_resolveWebspaceIndices` rebuilds the positional view.
 
 Tests live in [test/webspace_selection_engine_test.dart](../../../test/webspace_selection_engine_test.dart),
 [test/site_unload_engine_test.dart](../../../test/site_unload_engine_test.dart),

--- a/test/site_lifecycle_engine_test.dart
+++ b/test/site_lifecycle_engine_test.dart
@@ -164,4 +164,123 @@ void main() {
       expect(patch.newCurrentIndex, isNull);
     });
   });
+
+  group('SiteLifecycleEngine.computeReorderPatch', () {
+    // Ground truth: apply removeAt(old)+insert(new) to a labelled list and
+    // read back where each original index landed.
+    Map<int, int> groundTruthMapping(int oldIndex, int newIndex, int count) {
+      final list = List<int>.generate(count, (i) => i);
+      final moved = list.removeAt(oldIndex);
+      list.insert(newIndex, moved);
+      return {for (var pos = 0; pos < list.length; pos++) list[pos]: pos};
+    }
+
+    test('remaps loadedIndices to match removeAt+insert (move forward)', () {
+      // [0,1,2,3,4] move 1 -> 3 => [0,2,3,1,4]
+      final truth = groundTruthMapping(1, 3, 5);
+      final patch = SiteLifecycleEngine.computeReorderPatch(
+        oldIndex: 1,
+        newIndex: 3,
+        loadedIndices: {0, 1, 2, 3, 4},
+        currentIndex: null,
+      );
+      expect(patch.newLoadedIndices, truth.values.toSet());
+      expect(patch.newLoadedIndices, {truth[0], truth[1], truth[2], truth[3], truth[4]});
+    });
+
+    test('remaps loadedIndices to match removeAt+insert (move backward)', () {
+      // [0,1,2,3,4] move 4 -> 0 => [4,0,1,2,3]
+      final truth = groundTruthMapping(4, 0, 5);
+      final patch = SiteLifecycleEngine.computeReorderPatch(
+        oldIndex: 4,
+        newIndex: 0,
+        loadedIndices: {1, 4},
+        currentIndex: null,
+      );
+      expect(patch.newLoadedIndices, {truth[1], truth[4]});
+    });
+
+    test('moved element lands exactly at newIndex', () {
+      final patch = SiteLifecycleEngine.computeReorderPatch(
+        oldIndex: 2,
+        newIndex: 4,
+        loadedIndices: {2},
+        currentIndex: 2,
+      );
+      expect(patch.newLoadedIndices, {4});
+      expect(patch.newCurrentIndex, 4);
+    });
+
+    test('active site pointer follows the move when it is the moved site', () {
+      final patch = SiteLifecycleEngine.computeReorderPatch(
+        oldIndex: 0,
+        newIndex: 3,
+        loadedIndices: {0},
+        currentIndex: 0,
+      );
+      expect(patch.newCurrentIndex, 3);
+    });
+
+    test('active site pointer shifts when another site moves over it', () {
+      // active at 3, move 0 -> 4 => [1,2,3,4,0]; index 3 (site "3") -> pos 2
+      final truth = groundTruthMapping(0, 4, 5);
+      final patch = SiteLifecycleEngine.computeReorderPatch(
+        oldIndex: 0,
+        newIndex: 4,
+        loadedIndices: const {},
+        currentIndex: 3,
+      );
+      expect(patch.newCurrentIndex, truth[3]);
+      expect(patch.newCurrentIndex, 2);
+    });
+
+    test('active site pointer unchanged when the move is entirely after it', () {
+      final patch = SiteLifecycleEngine.computeReorderPatch(
+        oldIndex: 3,
+        newIndex: 4,
+        loadedIndices: const {},
+        currentIndex: 1,
+      );
+      expect(patch.newCurrentIndex, 1);
+    });
+
+    test('null currentIndex stays null', () {
+      final patch = SiteLifecycleEngine.computeReorderPatch(
+        oldIndex: 1,
+        newIndex: 2,
+        loadedIndices: const {},
+        currentIndex: null,
+      );
+      expect(patch.newCurrentIndex, isNull);
+    });
+
+    test('exhaustive: every index remap matches removeAt+insert ground truth', () {
+      const count = 6;
+      for (var oldIndex = 0; oldIndex < count; oldIndex++) {
+        for (var newIndex = 0; newIndex < count; newIndex++) {
+          final truth = groundTruthMapping(oldIndex, newIndex, count);
+          final patch = SiteLifecycleEngine.computeReorderPatch(
+            oldIndex: oldIndex,
+            newIndex: newIndex,
+            loadedIndices: {for (var i = 0; i < count; i++) i},
+            currentIndex: null,
+          );
+          for (var i = 0; i < count; i++) {
+            final single = SiteLifecycleEngine.computeReorderPatch(
+              oldIndex: oldIndex,
+              newIndex: newIndex,
+              loadedIndices: {i},
+              currentIndex: i,
+            );
+            expect(single.newLoadedIndices, {truth[i]},
+                reason: 'move $oldIndex->$newIndex, index $i');
+            expect(single.newCurrentIndex, truth[i],
+                reason: 'move $oldIndex->$newIndex, currentIndex $i');
+          }
+          // The full set is a permutation of 0..count-1.
+          expect(patch.newLoadedIndices, {for (var i = 0; i < count; i++) i});
+        }
+      }
+    });
+  });
 }


### PR DESCRIPTION
Tabs were only reorderable in the drawer grid, and only inside a named webspace. Make both the bottom tab strip and the drawer grid draggable, and support reordering the "All" view too. Named webspaces reorder their siteId list; "All" reorders _webViewModels globally, remapping the loaded set and current-index via the pure SiteLifecycleEngine.computeReorderPatch. IndexedStack children are keyed by siteId, so the global reorder preserves each webview's state.


Claude-Session: https://claude.ai/code/session_01PXp8U63Gq4njynxb6ZPLc3