### PR TITLE
Add engine-consistent navigator-identity shim for per-site UAs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,7 @@ Specs live under `openspec/specs/<slug>/spec.md` (Given/When/Then). **Read the r
 | settings-backup | JSON import/export |
 | site-editing | URL + custom name |
 | tracking-protection | umbrella per-site ETP: forces ClearURLs/DNS/content blocker/LocalCDN + injects anti-fingerprinting shim (Canvas/WebGL/audio/fonts/screen/hardware/timing/clientrects) seeded by siteId |
+| user-agent-identity | engine-consistent navigator identity for the per-site UA (vendor/productSub/oscpu/buildID/platform/userAgentData); complements desktop-mode |
 | user-scripts | per-site JS injection w/ timing control |
 | web-push-notifications | per-site `notificationsEnabled` toggle: JS Notification polyfill → flutter_local_notifications, auto-loads + skips per-instance pause for notif sites, iOS `beginBackgroundTask` grace + `BGAppRefreshTask` reload, Android mirrors via `WorkManager` periodic refresh (no foreground service) |
 | archive | passphrase-gated archived webspaces in a fixed slot pool; active state stays byte-identical when no archive is open |

--- a/lib/services/anti_fingerprinting_shim.dart
+++ b/lib/services/anti_fingerprinting_shim.dart
@@ -11,7 +11,10 @@
 //   * Text metrics   — Canvas/Offscreen measureText jitter, document.fonts.check
 //                      restricted to a small common-fonts allowlist
 //   * Screen         — width/height/availWidth/availHeight/colorDepth/pixelDepth;
-//                      in letterbox mode screen.* mirrors the real window.inner*
+//                      in letterbox mode screen.* mirrors the real window.inner*;
+//                      matchMedia (min-|max-)device-width/height answers against
+//                      the same dimensions so CSS media queries can't recover
+//                      the real screen size
 //   * Hardware       — navigator.hardwareConcurrency, navigator.deviceMemory
 //   * Plugins/MIME   — navigator.plugins / navigator.mimeTypes -> empty
 //   * Battery        — navigator.getBattery() -> fixed values
@@ -231,6 +234,64 @@ String buildAntiFingerprintingShim(
       }
       defineGetterOnProto(Screen.prototype, 'colorDepth', COLOR_DEPTH);
       defineGetterOnProto(Screen.prototype, 'pixelDepth', COLOR_DEPTH);
+    }
+  } catch (e) {}
+
+  // --- matchMedia device-dimension agreement ---
+  // screen.* is spoofed above, but CSS `(min-|max-)device-width/height`
+  // media queries resolve against the REAL screen. A fingerprinter
+  // binary-searching `(max-device-width: Npx)` recovers the true device
+  // size and contradicts screen.width (CreepJS's "CSS Media Queries" leak).
+  // Intercept single-feature device-width/height queries and answer against
+  // the SAME dimensions screen.* reports: window.inner* in letterbox mode
+  // (the box is physically real), the pinned SCREEN_W/H otherwise.
+  try {
+    if (typeof window.matchMedia === 'function') {
+      var _origMatchMedia = window.matchMedia.bind(window);
+      var DEVICE_DIM_RE =
+        /^\\(\\s*(min-|max-)?device-(width|height)\\s*:\\s*([\\d.]+)px\\s*\\)\$/i;
+      function _targetDim(which) {
+        if (LETTERBOX) {
+          return which === 'width' ? window.innerWidth : window.innerHeight;
+        }
+        return which === 'width' ? SCREEN_W : SCREEN_H;
+      }
+      function _syntheticMql(query, matches) {
+        var listeners = [];
+        return {
+          matches: matches,
+          media: query,
+          onchange: null,
+          addListener: function(l) { if (l) listeners.push(l); },
+          removeListener: function(l) {
+            var i = listeners.indexOf(l); if (i >= 0) listeners.splice(i, 1);
+          },
+          addEventListener: function(_t, l) { if (l) listeners.push(l); },
+          removeEventListener: function(_t, l) {
+            var i = listeners.indexOf(l); if (i >= 0) listeners.splice(i, 1);
+          },
+          dispatchEvent: function() { return false; },
+        };
+      }
+      var _patchedMatchMedia = function matchMedia(query) {
+        try {
+          if (typeof query === 'string') {
+            var m = DEVICE_DIM_RE.exec(query.trim());
+            if (m) {
+              var actual = _targetDim(m[2].toLowerCase());
+              var val = parseFloat(m[3]);
+              var prefix = (m[1] || '').toLowerCase();
+              var matches = prefix === 'min-'
+                ? actual >= val
+                : (prefix === 'max-' ? actual <= val : actual === val);
+              return _syntheticMql(query, matches);
+            }
+          }
+        } catch (e) {}
+        return _origMatchMedia(query);
+      };
+      asNative(_patchedMatchMedia, 'matchMedia');
+      window.matchMedia = _patchedMatchMedia;
     }
   } catch (e) {}
 

--- a/lib/services/language_shim.dart
+++ b/lib/services/language_shim.dart
@@ -1,11 +1,25 @@
 // Per-site language override JavaScript shim.
 //
-// Sets `navigator.language`, `navigator.languages`, and
-// `Intl.DateTimeFormat().resolvedOptions().locale` so client-rendered SPAs
-// (React i18n, date formatters) see the per-site language instead of the
-// OS locale. The Accept-Language header on the wire is a separate axis;
-// these JS surfaces don't follow it. Must be injected at DOCUMENT_START to
-// beat the page's own JS read.
+// Sets `navigator.language`, `navigator.languages`, and — critically — forces
+// the *actual* locale used by the whole `Intl` subsystem and the
+// `Date`/`Number` `toLocale*` methods, so client-rendered SPAs (React i18n,
+// date/number formatters) both report AND format in the per-site language
+// instead of the OS locale.
+//
+// The naive approach (only relabelling `navigator.language` and
+// `Intl.DateTimeFormat().resolvedOptions().locale`) is detectable: a
+// fingerprinter reads `navigator.language` (spoofed) then formats a date /
+// number with a locale-less `Intl` formatter and sees the OS locale in the
+// output ("julio", "21 millones") — a contradiction. CreepJS flags exactly
+// this. We instead inject the per-site tag as the default `locales` argument
+// of every `Intl` constructor (and the `toLocale*` methods) whenever the
+// caller omits it, so `resolvedOptions().locale` AND the formatted output are
+// genuinely the per-site language. Sites that pass an explicit locale are
+// left untouched (that is legitimate and real browsers honour it).
+//
+// Must be injected at DOCUMENT_START to beat the page's own JS read. The
+// Accept-Language header on the wire is a separate axis; these JS surfaces
+// don't follow it.
 
 import 'dart:convert';
 
@@ -16,25 +30,114 @@ String buildLanguageShim(String language) {
   final encoded = jsonEncode(language);
   return '''
 (function() {
+  'use strict';
+  if (window.__ws_language_shim__) return;
+  window.__ws_language_shim__ = true;
+
+  var lang = $encoded;
+  var langs = Object.freeze([lang]);
+
+  // Shared Function.prototype.toString funnel (same WeakMap as the other
+  // shims) so every wrapper stringifies as `[native code]`.
+  var _origFnToString = Function.prototype.toString;
+  var _stubs = window.__wsFnStubs || new WeakMap();
+  window.__wsFnStubs = _stubs;
+  function asNative(fn, name) {
+    try { _stubs.set(fn, 'function ' + name + '() { [native code] }'); } catch (e) {}
+    return fn;
+  }
+  if (!window.__wsFnToStringPatched) {
+    window.__wsFnToStringPatched = true;
+    var patched = function toString() {
+      var stub = _stubs.get(this);
+      return stub !== undefined ? stub : _origFnToString.call(this);
+    };
+    try { _stubs.set(patched, 'function toString() { [native code] }'); } catch (e) {}
+    try { Function.prototype.toString = patched; } catch (e) {}
+  }
+
   try {
-    var lang = $encoded;
-    var langs = Object.freeze([lang]);
     Object.defineProperty(Navigator.prototype, 'language', {
-      configurable: true, get: function() { return lang; }
+      configurable: true, enumerable: true,
+      get: asNative(function language() { return lang; }, 'language'),
     });
     Object.defineProperty(Navigator.prototype, 'languages', {
-      configurable: true, get: function() { return langs; }
+      configurable: true, enumerable: true,
+      get: asNative(function languages() { return langs; }, 'languages'),
     });
-    if (typeof Intl !== 'undefined' && Intl.DateTimeFormat) {
-      var proto = Intl.DateTimeFormat.prototype;
-      var orig = proto.resolvedOptions;
-      proto.resolvedOptions = function() {
-        var r = orig.apply(this, arguments);
-        r.locale = lang;
-        return r;
-      };
-    }
   } catch (e) {}
+
+  // True when the caller omitted the `locales` argument (or passed an empty
+  // list) — the only case in which a real engine falls back to the default
+  // locale, and thus the only case we override.
+  function localeOmitted(args) {
+    if (args.length === 0) return true;
+    var l = args[0];
+    return l === undefined || (Array.isArray(l) && l.length === 0);
+  }
+
+  // Wrap an Intl constructor so an omitted `locales` defaults to `lang`
+  // instead of the OS locale. Both `resolvedOptions().locale` and the
+  // formatted output then reflect the per-site tag. Delegates to whatever
+  // `Intl[name]` currently is, so it composes with the location shim's
+  // `Intl.DateTimeFormat` timezone wrapper regardless of injection order.
+  function wrapIntlCtor(name) {
+    try {
+      if (typeof Intl === 'undefined') return;
+      var Native = Intl[name];
+      if (typeof Native !== 'function') return;
+      function Wrapped() {
+        var args = localeOmitted(arguments)
+          ? [lang].concat(Array.prototype.slice.call(arguments, 1))
+          : arguments;
+        // Called without `new`: mirror the native behaviour exactly —
+        // DateTimeFormat/NumberFormat/Collator return an instance, the
+        // others throw. `Native.apply(null, ...)` reproduces both.
+        if (!(this instanceof Wrapped)) return Native.apply(null, args);
+        switch (args.length) {
+          case 0: return new Native();
+          case 1: return new Native(args[0]);
+          default: return new Native(args[0], args[1]);
+        }
+      }
+      Wrapped.prototype = Native.prototype;
+      if (typeof Native.supportedLocalesOf === 'function') {
+        Wrapped.supportedLocalesOf = asNative(function supportedLocalesOf() {
+          return Native.supportedLocalesOf.apply(Native, arguments);
+        }, 'supportedLocalesOf');
+      }
+      asNative(Wrapped, name);
+      try { Intl[name] = Wrapped; } catch (e) {}
+    } catch (e) {}
+  }
+
+  [
+    'DateTimeFormat', 'NumberFormat', 'RelativeTimeFormat', 'DisplayNames',
+    'ListFormat', 'PluralRules', 'Collator', 'Segmenter',
+  ].forEach(wrapIntlCtor);
+
+  // Date/Number toLocale* fall back to the default locale when called with no
+  // (or `undefined`) first argument. Inject `lang` there too so a locale-less
+  // `date.toLocaleString()` matches the Intl output above.
+  function wrapLocaleMethod(proto, method) {
+    try {
+      if (!proto) return;
+      var orig = proto[method];
+      if (typeof orig !== 'function') return;
+      var wrapped = function () {
+        if (arguments.length === 0 || arguments[0] === undefined) {
+          return orig.call(this, lang, arguments[1]);
+        }
+        return orig.apply(this, arguments);
+      };
+      asNative(wrapped, method);
+      try { proto[method] = wrapped; } catch (e) {}
+    } catch (e) {}
+  }
+  wrapLocaleMethod(Date.prototype, 'toLocaleString');
+  wrapLocaleMethod(Date.prototype, 'toLocaleDateString');
+  wrapLocaleMethod(Date.prototype, 'toLocaleTimeString');
+  wrapLocaleMethod(Number.prototype, 'toLocaleString');
 })();
 ''';
 }

--- a/lib/services/user_agent_classifier.dart
+++ b/lib/services/user_agent_classifier.dart
@@ -40,6 +40,44 @@ bool isDesktopUserAgent(String? ua) {
   return true;
 }
 
+/// The rendering/JS engine a UA string claims. Drives the engine-consistent
+/// navigator-identity shim (`user_agent_identity_shim.dart`): `navigator`
+/// fields like `vendor`, `productSub`, `oscpu`, and `buildID` are set by the
+/// engine, not the OS, so a spoofed UA whose engine disagrees with the
+/// underlying WebView (e.g. a Gecko UA on iOS WebKit) leaks unless these
+/// are made to match the *claimed* engine.
+enum UaEngine { gecko, webkit, blink, unknown }
+
+final RegExp _geckoBuildToken = RegExp(r'gecko/\d');
+
+/// Infer the JS engine a [ua] claims. iOS mandates WebKit, so any Apple
+/// mobile-browser brand token (FxiOS/CriOS/EdgiOS/OPiOS) classifies as
+/// [UaEngine.webkit] regardless of brand. Real Gecko carries a `Gecko/<digits>`
+/// build token plus `Firefox/`; every WebKit/Blink UA only carries the
+/// `(KHTML, like Gecko)` marker (no `Gecko/<digits>`). Returns
+/// [UaEngine.unknown] for empty or unrecognized strings (the shim then
+/// injects nothing).
+UaEngine inferUaEngine(String? ua) {
+  if (ua == null || ua.isEmpty) return UaEngine.unknown;
+  final lower = ua.toLowerCase();
+  final hasAppleWebKit = lower.contains('applewebkit/');
+  if (!hasAppleWebKit &&
+      _geckoBuildToken.hasMatch(lower) &&
+      lower.contains('firefox/')) {
+    return UaEngine.gecko;
+  }
+  if (hasAppleWebKit) {
+    final iosBrand = lower.contains('crios/') ||
+        lower.contains('fxios/') ||
+        lower.contains('edgios/') ||
+        lower.contains('opios/');
+    final isBlink = !iosBrand &&
+        (lower.contains('chrome/') || lower.contains('chromium/'));
+    return isBlink ? UaEngine.blink : UaEngine.webkit;
+  }
+  return UaEngine.unknown;
+}
+
 /// Which desktop-platform substring a UA carries. Used by the JS shim to
 /// emit the matching `navigator.platform` value.
 enum DesktopUaPlatform { linux, macos, windows }

--- a/lib/services/user_agent_identity_shim.dart
+++ b/lib/services/user_agent_identity_shim.dart
@@ -1,0 +1,179 @@
+// Engine-consistent navigator-identity shim.
+//
+// A per-site User-Agent changes only the wire-level `User-Agent` header and
+// (for desktop UAs) the surfaces `desktop_mode_shim.dart` patches. It does NOT
+// change the navigator fields the JS engine itself populates — `vendor`,
+// `vendorSub`, `productSub`, `oscpu`, `buildID`, `userAgentData` — nor
+// `navigator.platform` on mobile. Those are set by the underlying WebView's
+// real engine (WebKit on iOS, Blink on Android), so a spoofed UA whose engine
+// disagrees with the host leaks a contradiction a fingerprinter (CreepJS,
+// fingerprintjs) trivially catches: e.g. a Firefox-for-Android (Gecko) UA on
+// an iOS WebView still reports `navigator.vendor = "Apple Computer, Inc."`
+// (Firefox is `""`) and `navigator.platform = "iPhone"` (Firefox-Android is
+// `"Linux armv8l"`).
+//
+// This shim derives the engine from the per-site UA ([inferUaEngine]) and
+// forces the navigator identity fields to the values that engine really emits.
+// Constants are engine-level (the same on every OS for a given engine) except
+// `oscpu`/`platform`, which vary per OS. Values and their sources:
+//
+//   * vendor      Gecko "" · WebKit "Apple Computer, Inc." · Blink "Google Inc."
+//   * vendorSub   "" on every engine
+//   * productSub  Gecko "20100101" · WebKit/Blink "20030107"
+//   * oscpu       Gecko only (absent elsewhere): desktop per-OS token,
+//                 Firefox-Android frozen to "Linux armv8l" since FF123
+//   * buildID     Gecko only (absent elsewhere): frozen "20181001000000"
+//                 for web content since Firefox 64 (bug 583181)
+//   * platform    mobile only (desktop is owned by desktop_mode_shim):
+//                 Firefox/Chrome-Android "Linux armv8l", iOS WebKit "iPhone"
+//   * userAgentData  Blink only; removed for Gecko/WebKit UAs
+//
+// `oscpu`, `buildID`, and `userAgentData` are *presence-sensitive*: a
+// consistency check does `'oscpu' in navigator`, so on the engines that lack
+// them the property must be genuinely absent, not defined as `undefined`. The
+// shim deletes rather than stubs.
+//
+// Runs at DOCUMENT_START, `forMainFrameOnly: false`, for every per-site UA
+// (desktop and mobile). It only touches identity fields; it does not overlap
+// with `desktop_mode_shim.dart` (platform/userAgentData/maxTouchPoints for
+// desktop, matchMedia pointer/hover, viewport) or the anti-fingerprinting
+// shim.
+
+import 'dart:convert';
+
+import 'package:webspace/services/user_agent_classifier.dart';
+import 'package:webspace/services/user_agent_identity.dart';
+
+/// Build the engine-consistent navigator-identity shim for [userAgent], or
+/// `null` when the engine can't be classified (nothing to enforce) or the UA
+/// is empty. Pure-Dart so it is reachable from `tool/dump_shim_js.dart` and
+/// the drift check.
+String? buildUserAgentIdentityShim(String userAgent) {
+  final engine = inferUaEngine(userAgent);
+  if (engine == UaEngine.unknown) return null;
+
+  final os = describeUserAgent(userAgent).os;
+  final isGecko = engine == UaEngine.gecko;
+  final isMobile = !isDesktopUserAgent(userAgent);
+
+  final vendor = switch (engine) {
+    UaEngine.gecko => '',
+    UaEngine.webkit => 'Apple Computer, Inc.',
+    UaEngine.blink => 'Google Inc.',
+    UaEngine.unknown => '',
+  };
+  final productSub = isGecko ? '20100101' : '20030107';
+
+  final String? oscpu = isGecko
+      ? switch (os) {
+          UaOs.linux => 'Linux x86_64',
+          UaOs.windows => 'Windows NT 10.0; Win64; x64',
+          UaOs.macos => 'Intel Mac OS X 10.15',
+          UaOs.android => 'Linux armv8l',
+          _ => null,
+        }
+      : null;
+
+  // Desktop platform is owned by desktop_mode_shim; only fix mobile, where the
+  // host engine's platform ("iPhone" / "Linux armv8l") may contradict the UA.
+  final String? platform = isMobile
+      ? switch ((engine, os)) {
+          (UaEngine.gecko, UaOs.android) => 'Linux armv8l',
+          (UaEngine.blink, UaOs.android) => 'Linux armv8l',
+          (UaEngine.webkit, UaOs.ios) => 'iPhone',
+          _ => null,
+        }
+      : null;
+
+  // userAgentData exists only on Blink. Remove it for Gecko/WebKit UAs
+  // (desktop_mode_shim already removes it for desktop UAs, so only mobile
+  // needs it here).
+  final removeUserAgentData = isMobile && engine != UaEngine.blink;
+
+  final defs = <String>[
+    "def('vendor', ${jsonEncode(vendor)});",
+    "def('vendorSub', '');",
+    "def('productSub', ${jsonEncode(productSub)});",
+  ];
+
+  if (isGecko) {
+    if (oscpu != null) {
+      defs.add("def('oscpu', ${jsonEncode(oscpu)});");
+    } else {
+      defs.add("removeProp('oscpu');");
+    }
+    defs.add("def('buildID', '20181001000000');");
+  } else {
+    defs.add("removeProp('oscpu');");
+    defs.add("removeProp('buildID');");
+  }
+
+  if (platform != null) {
+    defs.add("def('platform', ${jsonEncode(platform)});");
+  }
+  if (removeUserAgentData) {
+    defs.add("removeProp('userAgentData');");
+  }
+
+  final defsJs = defs.map((d) => '  $d').join('\n');
+
+  return '''
+(function() {
+  'use strict';
+  if (window.__ws_ua_identity_shim__) return;
+  window.__ws_ua_identity_shim__ = true;
+
+  // Shared Function.prototype.toString funnel (same WeakMap as the other
+  // shims) so every getter stringifies as `[native code]`.
+  var _origFnToString = Function.prototype.toString;
+  var _stubs = window.__wsFnStubs || new WeakMap();
+  window.__wsFnStubs = _stubs;
+  function asNative(fn, name) {
+    try { _stubs.set(fn, 'function ' + name + '() { [native code] }'); } catch (e) {}
+    return fn;
+  }
+  if (!window.__wsFnToStringPatched) {
+    window.__wsFnToStringPatched = true;
+    var patched = function toString() {
+      var stub = _stubs.get(this);
+      return stub !== undefined ? stub : _origFnToString.call(this);
+    };
+    try { _stubs.set(patched, 'function toString() { [native code] }'); } catch (e) {}
+    try { Function.prototype.toString = patched; } catch (e) {}
+  }
+
+  var NavProto = (typeof Navigator !== 'undefined') ? Navigator.prototype : null;
+
+  // Define on Navigator.prototype (never the instance — an own-property on
+  // `navigator` would self-incriminate), matching how real engines carry
+  // these accessors.
+  function def(name, value) {
+    if (!NavProto) return;
+    try {
+      Object.defineProperty(NavProto, name, {
+        configurable: true, enumerable: true,
+        get: asNative(function() { return value; }, name),
+      });
+    } catch (e) {}
+  }
+
+  // Make a property genuinely absent (delete), so `name in navigator` is
+  // false. Falls back to an undefined getter only if the delete is refused
+  // (non-configurable), which is still better than a populated value.
+  function removeProp(name) {
+    try { if (NavProto) delete NavProto[name]; } catch (e) {}
+    try { delete navigator[name]; } catch (e) {}
+    try {
+      if (NavProto && (name in NavProto)) {
+        Object.defineProperty(NavProto, name, {
+          configurable: true, enumerable: false,
+          get: asNative(function() { return undefined; }, name),
+        });
+      }
+    } catch (e) {}
+  }
+
+$defsJs
+})();
+''';
+}

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -23,6 +23,7 @@ import 'package:webspace/services/procedural_cosmetic_shim.dart';
 import 'package:webspace/services/current_location_service.dart';
 import 'package:webspace/services/desktop_mode_shim.dart';
 import 'package:webspace/services/user_agent_classifier.dart';
+import 'package:webspace/services/user_agent_identity_shim.dart';
 import 'package:webspace/services/user_agent_metadata_builder.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/services/trusted_hosts_service.dart';
@@ -1743,6 +1744,27 @@ class WebViewFactory {
         // (iOS WKUserScript defaults to main-frame-only).
         forMainFrameOnly: false,
       ));
+    }
+
+    // Engine-consistent navigator identity: a per-site UA changes the UA
+    // string but not the navigator fields the host engine populates
+    // (vendor / productSub / oscpu / buildID / platform / userAgentData).
+    // A Gecko UA on an iOS WebKit host, or a Firefox UA on Android Blink,
+    // otherwise leaks the real engine. Run for every classifiable per-site
+    // UA (desktop and mobile); complements desktop_mode_shim, no overlap.
+    final uaValue = config.userAgent;
+    if (uaValue != null && uaValue.isNotEmpty) {
+      final identityShim = buildUserAgentIdentityShim(uaValue);
+      if (identityShim != null) {
+        userScripts.add(inapp.UserScript(
+          groupName: 'ua_identity_shim',
+          source: '$identityShim\n;null;',
+          injectionTime: inapp.UserScriptInjectionTime.AT_DOCUMENT_START,
+          // Reach cross-origin iframes so a subframe can't report the real
+          // engine's identity and contradict the top frame.
+          forMainFrameOnly: false,
+        ));
+      }
     }
 
     // WebKit (iOS/macOS) zooms out and latches a stuck fractional scale

--- a/openspec/specs/language/spec.md
+++ b/openspec/specs/language/spec.md
@@ -73,13 +73,31 @@ page and all its inline scripts:
 1. `Navigator.prototype.language` — returns the per-site tag
 2. `Navigator.prototype.languages` — returns a frozen single-element array
    containing the per-site tag
-3. `Intl.DateTimeFormat.prototype.resolvedOptions` — returns the original
-   result with `locale` rewritten to the per-site tag
+3. The **actual formatting locale** of the whole `Intl` subsystem — the
+   `Intl.DateTimeFormat`, `NumberFormat`, `RelativeTimeFormat`, `DisplayNames`,
+   `ListFormat`, `PluralRules`, `Collator`, and `Segmenter` constructors, plus
+   `Date.prototype.toLocaleString` / `toLocaleDateString` / `toLocaleTimeString`
+   and `Number.prototype.toLocaleString` — MUST default to the per-site tag
+   when the caller omits the `locales` argument, so both
+   `resolvedOptions().locale` AND the formatted output reflect the per-site
+   language.
+
+Relabelling only (rewriting `resolvedOptions().locale` while leaving the
+formatted output in the OS locale) is INSUFFICIENT and detectable: a
+fingerprinter that reads `navigator.language` then formats a locale-less date
+or number sees the OS locale in the output ("julio", "21 millones") — a
+contradiction. The override therefore injects the tag as the default `locales`
+argument of the real constructors, not a post-hoc label rewrite.
+
+A caller that passes an **explicit** `locales` argument MUST be honoured
+unchanged (real browsers do; forcing the per-site tag there would be a new,
+detectable lie). Only the omitted/`undefined`/empty-list case is overridden.
 
 The override MUST run before any of the page's own JavaScript so SPAs picking
-a locale at boot observe the override, not the OS value. The script is
-omitted entirely when no per-site language is set — the OS values remain
-visible.
+a locale at boot observe the override, not the OS value. It composes with the
+per-site timezone override (which wraps `Intl.DateTimeFormat` to inject a
+`timeZone`) regardless of injection order. The script is omitted entirely when
+no per-site language is set — the OS values remain visible.
 
 The tag is interpolated into the script via JSON encoding so that a tag
 containing quotes, backslashes, or Unicode characters cannot break out of the
@@ -93,6 +111,21 @@ JS string literal.
 **Then** `navigator.language` is `"es"`
 **And** `navigator.languages` is `["es"]`
 **And** `new Intl.DateTimeFormat().resolvedOptions().locale` is `"es"`
+
+#### Scenario: Locale-less formatters produce output in the per-site language
+
+**Given** the user selects French (`fr-FR`) for a site
+**When** the page calls `new Intl.NumberFormat().format(0.5)`
+**Then** the result is `"0,5"` (French comma decimal), not `"0.5"`
+**And** `new Intl.DateTimeFormat(undefined, {month: 'long'}).format(...)` for a
+  July date is `"juillet"`
+**And** `(0.5).toLocaleString()` is `"0,5"`
+
+#### Scenario: Explicit locale argument is honoured
+
+**Given** the user selects French (`fr-FR`) for a site
+**When** the page calls `new Intl.NumberFormat('de-DE')`
+**Then** `resolvedOptions().locale` is `"de-DE"` (not forced to `fr-FR`)
 
 #### Scenario: No override when unset
 
@@ -190,47 +223,37 @@ Format: `'{language}, *;q=0.5'`, e.g. `Accept-Language: es, *;q=0.5`.
 
 ### Client-Side Override Script
 
-`_languageOverrideScript(tag)` builds a small IIFE injected at
-`UserScriptInjectionTime.AT_DOCUMENT_START` via `inapp.UserScript` with
-group name `language_override`. The script:
+`buildLanguageShim(tag)` ([lib/services/language_shim.dart](../../../lib/services/language_shim.dart))
+builds an IIFE injected at `UserScriptInjectionTime.AT_DOCUMENT_START` via
+`inapp.UserScript` with group name `language_override`
+(`forMainFrameOnly: false` so it reaches cross-origin iframes). The script:
 
-```dart
-String _languageOverrideScript(String language) {
-  final encoded = jsonEncode(language);
-  return '''
-(function() {
-  try {
-    var lang = $encoded;
-    var langs = Object.freeze([lang]);
-    Object.defineProperty(Navigator.prototype, 'language', {
-      configurable: true, get: function() { return lang; }
-    });
-    Object.defineProperty(Navigator.prototype, 'languages', {
-      configurable: true, get: function() { return langs; }
-    });
-    if (typeof Intl !== 'undefined' && Intl.DateTimeFormat) {
-      var proto = Intl.DateTimeFormat.prototype;
-      var orig = proto.resolvedOptions;
-      proto.resolvedOptions = function() {
-        var r = orig.apply(this, arguments);
-        r.locale = lang;
-        return r;
-      };
-    }
-  } catch (e) {}
-})();
-''';
-}
-```
+- Defines `language` / `languages` getters on `Navigator.prototype`.
+- Wraps each `Intl` constructor (`DateTimeFormat`, `NumberFormat`,
+  `RelativeTimeFormat`, `DisplayNames`, `ListFormat`, `PluralRules`,
+  `Collator`, `Segmenter`) so an omitted `locales` argument defaults to the
+  per-site tag. It mirrors native call semantics (constructors callable
+  without `new` still work; the others throw as usual) and delegates to
+  whatever `Intl[name]` currently is, so it composes with the location shim's
+  `Intl.DateTimeFormat` timezone wrapper in either injection order.
+- Wraps `Date.prototype.toLocale{,Date,Time}String` and
+  `Number.prototype.toLocaleString` to inject the tag when the locale is
+  omitted.
 
 Design notes:
 
-- The properties are defined on `Navigator.prototype`, not on the `navigator`
-  instance, because some WebView builds (notably older WebKit) treat the
-  instance accessors as non-configurable.
-- The `languages` array is frozen so callers that try to push/splice into it
-  don't silently mutate shared state.
-- The function is wrapped in `try {}` so a failure in one override (for
+- Overrides are defined on `Navigator.prototype` (and the `Intl` /
+  `Date` / `Number` prototypes), not on instances, because some WebView builds
+  (notably older WebKit) treat instance accessors as non-configurable, and an
+  own-property leak would self-incriminate.
+- The `languages` array is frozen so callers that push/splice into it don't
+  silently mutate shared state.
+- A re-entrance guard (`window.__ws_language_shim__`) makes re-injection on
+  every frame idempotent (WebKit/Android WebView re-run initial user scripts
+  per frame), and every wrapper funnels through the shared
+  `Function.prototype.toString` stub (`window.__wsFnStubs`) so it stringifies
+  as `[native code]`.
+- Each section is wrapped in `try {}` so a failure in one override (for
   example if `Intl` is absent on a stripped-down engine) does not block the
   others.
 - The JS source is followed by `\n;null;` when attached to `UserScript` to

--- a/openspec/specs/tracking-protection/spec.md
+++ b/openspec/specs/tracking-protection/spec.md
@@ -329,10 +329,29 @@ self-incriminate) so:
   PluginArray-shaped objects (with `length`, `item`, `namedItem`, and
   for plugins `refresh`).
 
+The shim SHALL ALSO wrap `window.matchMedia` so single-feature
+`(min-|max-)?device-width` / `device-height` media queries resolve against
+the SAME dimensions `screen.*` reports — the pinned `SCREEN_W`/`SCREEN_H`
+(1920x1080) normally, or the live `window.inner*` in letterbox mode
+(ETP-020). Without this, a fingerprinter binary-searching
+`(max-device-width: Npx)` recovers the real screen size and contradicts
+`screen.width` (CreepJS's "CSS Media Queries" leak). Non-device queries fall
+through to the real implementation, and the wrapper stringifies as
+`[native code]`.
+
 #### Scenario: screen dimensions pinned
 
 **Given** the shim is loaded under jsdom
 **Then** `window.screen.width === 1920` and `window.screen.height === 1080`
+
+#### Scenario: device-dimension media queries agree with screen.*
+
+**Given** the shim is loaded (non-letterbox)
+**Then** `matchMedia('(max-device-width: 1920px)').matches` is `true`
+**And** `matchMedia('(max-device-width: 1919px)').matches` is `false`
+**And** `matchMedia('(device-height: 1080px)').matches` is `true`
+**And** a non-device query such as `(min-width: 100px)` is delegated to the
+real `matchMedia`
 
 #### Scenario: Overrides do NOT leak as own-properties
 

--- a/openspec/specs/user-agent-identity/spec.md
+++ b/openspec/specs/user-agent-identity/spec.md
@@ -1,0 +1,150 @@
+# User-Agent Identity Consistency Specification
+
+## Status
+**Implemented**
+
+## Purpose
+
+Make the JavaScript `navigator` identity fields consistent with the *engine a
+per-site User-Agent claims*, so a spoofed UA does not leak the real underlying
+WebView engine.
+
+Setting a per-site UA changes only the wire-level `User-Agent` header and (for
+desktop UAs) the surfaces `desktop-mode` patches. It does NOT change the
+`navigator` fields the JS engine itself populates — `vendor`, `vendorSub`,
+`productSub`, `oscpu`, `buildID`, `userAgentData` — nor `navigator.platform` on
+mobile. Those come from the real host engine (WebKit on iOS, Blink on Android),
+so a UA whose engine disagrees with the host is internally contradictory and
+trivially detected by fingerprinting suites (CreepJS, fingerprintjs): e.g. a
+Firefox-for-Android (Gecko) UA on an iOS WebView still reports
+`navigator.vendor = "Apple Computer, Inc."` (Firefox is `""`) and
+`navigator.platform = "iPhone"` (Firefox-Android is `"Linux armv8l"`).
+
+This feature derives the engine from the per-site UA and forces the identity
+fields to the values that engine really emits. It complements — and does not
+overlap with — `desktop-mode` (which owns platform / userAgentData /
+maxTouchPoints for *desktop* UAs, matchMedia pointer/hover, and viewport) and
+`tracking-protection` (which owns the anti-fingerprinting noise).
+
+---
+
+## Requirements
+
+### Requirement: UAID-001 - Engine classification from the UA string
+
+The app SHALL classify a UA string into one of `{gecko, webkit, blink,
+unknown}` (`inferUaEngine`). Any Apple mobile-browser brand token
+(`FxiOS`/`CriOS`/`EdgiOS`/`OPiOS`) classifies as `webkit` regardless of brand,
+because iOS mandates WebKit. Real Gecko carries a `Gecko/<digits>` build token
+plus `Firefox/`; every WebKit/Blink UA carries only the `(KHTML, like Gecko)`
+marker. An empty or unrecognized string is `unknown`, and no shim is injected.
+
+#### Scenario: iOS browsers are WebKit regardless of brand
+
+**Given** a Firefox-for-iOS UA (`... FxiOS/152.0 ... Safari/604.1`)
+**When** the engine is inferred
+**Then** the engine is `webkit` (not `gecko`)
+**And** a Chrome-for-iOS UA (`... CriOS/120 ...`) is also `webkit` (not `blink`)
+
+#### Scenario: Desktop and Android Chrome are Blink; Firefox is Gecko
+
+**Given** `... AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 ...`
+**Then** the engine is `blink`
+**And** a `... Gecko/20100101 Firefox/152.0` UA is `gecko`
+**And** `curl/8.0` is `unknown`
+
+---
+
+### Requirement: UAID-002 - Engine-consistent navigator identity
+
+When a per-site UA is set and classifiable, the app SHALL inject a
+`UserScriptInjectionTime.AT_DOCUMENT_START` script (`forMainFrameOnly: false`)
+that defines, on `Navigator.prototype`, the identity values the claimed engine
+emits:
+
+* `vendor` — Gecko `""`, WebKit `"Apple Computer, Inc."`, Blink `"Google Inc."`
+* `vendorSub` — `""` on every engine
+* `productSub` — Gecko `"20100101"`, WebKit/Blink `"20030107"`
+* `oscpu` (Gecko only) — desktop per-OS token (`"Linux x86_64"`,
+  `"Windows NT 10.0; Win64; x64"`, `"Intel Mac OS X 10.15"`), Firefox-Android
+  frozen to `"Linux armv8l"` (FF123+)
+* `buildID` (Gecko only) — frozen `"20181001000000"` (Firefox 64+ default for
+  web content)
+* `platform` (mobile only) — Firefox/Chrome-Android `"Linux armv8l"`, iOS
+  WebKit `"iPhone"`
+
+Getters are defined on the prototype (never the instance — an own-property on
+`navigator` would self-incriminate) and stringify as `[native code]`.
+
+#### Scenario: Gecko-Android identity
+
+**Given** a Firefox-for-Android UA
+**When** the page reads navigator
+**Then** `navigator.vendor === ""`
+**And** `navigator.productSub === "20100101"`
+**And** `navigator.oscpu === "Linux armv8l"`
+**And** `navigator.buildID === "20181001000000"`
+**And** `navigator.platform === "Linux armv8l"`
+
+#### Scenario: WebKit and Blink vendors
+
+**Given** a Firefox-for-iOS UA
+**Then** `navigator.vendor === "Apple Computer, Inc."` and
+`navigator.productSub === "20030107"`
+**And** for a Chrome-for-Android UA, `navigator.vendor === "Google Inc."`
+
+---
+
+### Requirement: UAID-003 - Presence-sensitive fields are absent, not stubbed
+
+The shim SHALL make presence-sensitive fields (`oscpu`, `buildID`,
+`userAgentData`) genuinely absent (delete) on engines that lack them — NOT
+defined as `undefined` — because consistency checks do `'oscpu' in navigator`.
+
+* `oscpu` / `buildID` — removed for WebKit and Blink UAs (Gecko-only).
+* `userAgentData` — removed for Gecko and WebKit UAs (Blink-only); Blink UAs
+  keep it. (Desktop UAs already have it removed by `desktop-mode`; the shim
+  handles mobile.)
+
+#### Scenario: WebKit UA has no oscpu/buildID
+
+**Given** a Firefox-for-iOS UA
+**Then** `'oscpu' in navigator` is `false`
+**And** `'buildID' in navigator` is `false`
+**And** `'userAgentData' in navigator` is `false`
+
+#### Scenario: Blink UA keeps userAgentData
+
+**Given** a Chrome-for-Android UA
+**Then** the shim does NOT remove `navigator.userAgentData`
+
+---
+
+### Requirement: UAID-004 - Scope and non-overlap
+
+The shim SHALL run for every classifiable per-site UA (desktop and mobile) and
+SHALL propagate to nested webviews opened via `launchUrl` (it is built inside
+`WebViewFactory.createWebView`, which every nested `InAppWebViewScreen` uses,
+from the per-site `userAgent`). `navigator.platform` and `userAgentData` are
+set here ONLY for mobile UAs; for desktop UAs those remain owned by
+`desktop-mode` so the two shims never both define the same property.
+
+#### Scenario: Desktop UA does not double-set platform
+
+**Given** a Firefox desktop UA
+**When** the identity shim runs
+**Then** it sets `vendor` / `productSub` / `oscpu` / `buildID`
+**And** it does NOT define `navigator.platform` (owned by `desktop-mode`)
+
+---
+
+## Files
+
+- `lib/services/user_agent_classifier.dart` — `UaEngine` + `inferUaEngine`
+- `lib/services/user_agent_identity_shim.dart` — `buildUserAgentIdentityShim`
+- `lib/services/webview.dart` — `UserScript` registration (group
+  `ua_identity_shim`) in `WebViewFactory.createWebView`
+- `test/user_agent_identity_shim_test.dart` — Dart builder + engine tests
+- `test/js/user_agent_identity_shim.test.js` — jsdom behavioural tests
+- `test/js_fixtures/ua_identity/*.js` — dumped fixtures (one per engine × form
+  factor)

--- a/test/js/anti_fingerprinting_shim.test.js
+++ b/test/js/anti_fingerprinting_shim.test.js
@@ -147,6 +147,21 @@ function installFpStubs(window) {
       ready: Promise.resolve(),
     },
   });
+
+  // jsdom omits window.matchMedia. Provide an always-false stub so the shim's
+  // device-dimension wrapper installs over it and any non-device query the
+  // wrapper delegates lands here (matches:false).
+  if (typeof window.matchMedia !== 'function') {
+    window.matchMedia = function matchMedia(query) {
+      record('matchMedia', [query]);
+      return {
+        matches: false, media: query, onchange: null,
+        addListener() {}, removeListener() {},
+        addEventListener() {}, removeEventListener() {},
+        dispatchEvent() { return false; },
+      };
+    };
+  }
 }
 
 function makeDom({ url = 'https://example.com/' } = {}) {
@@ -222,6 +237,54 @@ test('non-letterbox leaves window.inner* untouched (real values)', () => {
   // is pinned (asserted above), and the real viewport stands.
   const dom = loadShim(ALPHA);
   assert.equal(dom.window.innerWidth, 1024); // jsdom default, unmodified
+});
+
+// --- matchMedia device-dimension agreement ---
+
+test('non-letterbox: (max/min-device-width) resolve against the pinned 1920', () => {
+  const mm = loadShim(ALPHA).window.matchMedia;
+  assert.equal(mm('(max-device-width: 1920px)').matches, true);
+  assert.equal(mm('(max-device-width: 1919px)').matches, false);
+  assert.equal(mm('(min-device-width: 1920px)').matches, true);
+  assert.equal(mm('(min-device-width: 1921px)').matches, false);
+  assert.equal(mm('(device-width: 1920px)').matches, true);
+});
+
+test('non-letterbox: device-height resolves against the pinned 1080', () => {
+  const mm = loadShim(ALPHA).window.matchMedia;
+  assert.equal(mm('(max-device-height: 1080px)').matches, true);
+  assert.equal(mm('(min-device-height: 1081px)').matches, false);
+  assert.equal(mm('(device-height: 1080px)').matches, true);
+});
+
+test('letterbox: device dims track window.inner* (agree with screen.*)', () => {
+  const dom = loadShim(ALPHA_LETTERBOX);
+  const w = dom.window;
+  // screen.* mirrors window.inner* in letterbox mode; device-* media queries
+  // must agree, or a binary search recovers the real screen.
+  assert.equal(w.matchMedia(`(device-width: ${w.innerWidth}px)`).matches, true);
+  assert.equal(w.matchMedia(`(device-height: ${w.innerHeight}px)`).matches, true);
+  // A re-snap (rotation) changes window.inner*; the wrapper follows it.
+  Object.defineProperty(w, 'innerWidth', { configurable: true, value: 800 });
+  assert.equal(w.matchMedia('(device-width: 800px)').matches, true);
+  assert.equal(w.matchMedia('(device-width: 1024px)').matches, false);
+});
+
+test('matchMedia delegates non-device queries to the real implementation', () => {
+  const dom = loadShim(ALPHA);
+  // A width (viewport, not device) query is not intercepted — it reaches the
+  // stub, which reports matches:false.
+  const r = dom.window.matchMedia('(min-width: 100px)');
+  assert.equal(r.matches, false);
+  assert.equal(r.media, '(min-width: 100px)');
+  const delegated = dom.window.__calls.filter(c => c.name === 'matchMedia');
+  assert.ok(delegated.length >= 1, 'non-device query was not delegated');
+});
+
+test('patched matchMedia stringifies as [native code]', () => {
+  const dom = loadShim(ALPHA);
+  const s = dom.window.Function.prototype.toString.call(dom.window.matchMedia);
+  assert.match(s, /\[native code\]/);
 });
 
 // --- navigator.* ---

--- a/test/js/language_shim.test.js
+++ b/test/js/language_shim.test.js
@@ -48,6 +48,73 @@ test('Intl.DateTimeFormat().resolvedOptions().locale reports spoofed lang', () =
   assert.equal(locale, 'ja');
 });
 
+// --- Actual formatting locale (not just the resolvedOptions label) ---
+// The whole point of the rewrite: a locale-less Intl formatter must FORMAT
+// in the per-site language, not merely report it. Node is full-ICU so the
+// output is real.
+
+test('locale-less Intl.NumberFormat FORMATS in the spoofed language', () => {
+  const fr = loadShim('language/fr_FR.js');
+  // French uses a comma decimal separator; English a dot. If only the label
+  // were spoofed (the old bug) this would still format as "0.5".
+  assert.equal(new fr.window.Intl.NumberFormat().format(0.5), '0,5');
+  const en = loadShim('language/en.js');
+  assert.equal(new en.window.Intl.NumberFormat().format(0.5), '0.5');
+});
+
+test('locale-less Intl.DateTimeFormat FORMATS month names in the spoofed language', () => {
+  const july = Date.UTC(2020, 6, 1);
+  const fr = loadShim('language/fr_FR.js');
+  const frMonth = new fr.window.Intl.DateTimeFormat(undefined, {
+    timeZone: 'UTC', month: 'long',
+  }).format(new fr.window.Date(july));
+  assert.equal(frMonth, 'juillet');
+  const ja = loadShim('language/ja.js');
+  const jaMonth = new ja.window.Intl.DateTimeFormat(undefined, {
+    timeZone: 'UTC', month: 'long',
+  }).format(new ja.window.Date(july));
+  assert.equal(jaMonth, '7月');
+});
+
+test('Intl.NumberFormat / RelativeTimeFormat resolvedOptions locale is spoofed', () => {
+  const dom = loadShim('language/fr_FR.js');
+  assert.equal(new dom.window.Intl.NumberFormat().resolvedOptions().locale, 'fr-FR');
+  assert.equal(
+    new dom.window.Intl.RelativeTimeFormat().resolvedOptions().locale, 'fr-FR');
+});
+
+test('an EXPLICIT locale argument is honoured, not overridden', () => {
+  // We only inject the default when the caller omits locales. A site that
+  // explicitly asks for German must still get German — anything else would
+  // be a new (and detectable) lie.
+  const dom = loadShim('language/fr_FR.js');
+  const loc = new dom.window.Intl.NumberFormat('de-DE').resolvedOptions().locale;
+  assert.equal(loc, 'de-DE');
+  assert.equal(new dom.window.Intl.NumberFormat('de-DE').format(0.5), '0,5');
+  assert.equal(new dom.window.Intl.NumberFormat('en-US').format(1000), '1,000');
+});
+
+test('Date.prototype.toLocaleDateString with no locale uses the spoofed lang', () => {
+  const fr = loadShim('language/fr_FR.js');
+  const s = new fr.window.Date(Date.UTC(2020, 6, 1)).toLocaleDateString(undefined, {
+    timeZone: 'UTC', month: 'long',
+  });
+  assert.equal(s, 'juillet');
+});
+
+test('Number.prototype.toLocaleString with no args uses the spoofed lang', () => {
+  const fr = loadShim('language/fr_FR.js');
+  // Evaluate inside the jsdom realm so the patched Number.prototype is used.
+  assert.equal(fr.window.eval('(0.5).toLocaleString()'), '0,5');
+});
+
+test('re-running the shim does not compound (idempotent)', () => {
+  const dom = loadShim('language/fr_FR.js');
+  dom.window.eval(require('./helpers/load_shim').readFixture('language/fr_FR.js'));
+  assert.equal(new dom.window.Intl.NumberFormat().format(0.5), '0,5');
+  assert.equal(dom.window.navigator.language, 'fr-FR');
+});
+
 test('shim defines language on Navigator.prototype, not the instance', () => {
   // A clean navigator carries `language` on Navigator.prototype only;
   // if we leaked `language` as an own-property of navigator a

--- a/test/js/user_agent_identity_shim.test.js
+++ b/test/js/user_agent_identity_shim.test.js
@@ -1,0 +1,122 @@
+// Tier 1 — jsdom assertions for the engine-consistent navigator-identity shim
+// (lib/services/user_agent_identity_shim.dart, dumped to
+// test/js_fixtures/ua_identity/*.js).
+//
+// The shim forces navigator.vendor / vendorSub / productSub / oscpu /
+// buildID / platform to the values the UA's *claimed* engine really emits,
+// so a spoofed UA on a mismatched host engine (Gecko UA on iOS WebKit, etc.)
+// doesn't leak the real engine. `oscpu` / `buildID` / `userAgentData` are
+// presence-sensitive: on the engines that lack them the property must be
+// genuinely absent (`in` === false), not defined as undefined.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { loadShim } = require('./helpers/load_shim');
+
+const FX_ANDROID = 'ua_identity/firefox_android.js';
+const FX_LINUX_DESKTOP = 'ua_identity/firefox_linux_desktop.js';
+const FXIOS = 'ua_identity/fxios.js';
+const CHROME_ANDROID = 'ua_identity/chrome_android.js';
+
+// --- Gecko mobile (Firefox for Android) ---
+
+test('Firefox-Android: Gecko vendor / productSub', () => {
+  const nav = loadShim(FX_ANDROID).window.navigator;
+  assert.equal(nav.vendor, '');
+  assert.equal(nav.vendorSub, '');
+  assert.equal(nav.productSub, '20100101');
+});
+
+test('Firefox-Android: Gecko-only oscpu / buildID present with frozen values', () => {
+  const dom = loadShim(FX_ANDROID);
+  const nav = dom.window.navigator;
+  assert.equal('oscpu' in nav, true);
+  assert.equal(nav.oscpu, 'Linux armv8l');
+  assert.equal('buildID' in nav, true);
+  assert.equal(nav.buildID, '20181001000000');
+});
+
+test('Firefox-Android: platform is the frozen "Linux armv8l", not the host', () => {
+  assert.equal(loadShim(FX_ANDROID).window.navigator.platform, 'Linux armv8l');
+});
+
+// --- Gecko desktop (platform owned by desktop_mode_shim, so NOT set here) ---
+
+test('Firefox-desktop: Gecko identity with desktop oscpu, no platform override', () => {
+  const dom = loadShim(FX_LINUX_DESKTOP);
+  const nav = dom.window.navigator;
+  assert.equal(nav.vendor, '');
+  assert.equal(nav.productSub, '20100101');
+  assert.equal(nav.oscpu, 'Linux x86_64');
+  assert.equal(nav.buildID, '20181001000000');
+  // No `def('platform', ...)` on the desktop path — desktop_mode_shim owns it.
+  const src = require('./helpers/load_shim').readFixture(FX_LINUX_DESKTOP);
+  assert.equal(/def\('platform'/.test(src), false);
+});
+
+// --- WebKit mobile (Firefox for iOS — Safari-shaped) ---
+
+test('FxiOS: WebKit vendor / productSub', () => {
+  const nav = loadShim(FXIOS).window.navigator;
+  assert.equal(nav.vendor, 'Apple Computer, Inc.');
+  assert.equal(nav.productSub, '20030107');
+});
+
+test('FxiOS: oscpu / buildID are ABSENT (in === false), not undefined', () => {
+  const nav = loadShim(FXIOS).window.navigator;
+  assert.equal('oscpu' in nav, false);
+  assert.equal('buildID' in nav, false);
+});
+
+test('FxiOS: platform is "iPhone"', () => {
+  assert.equal(loadShim(FXIOS).window.navigator.platform, 'iPhone');
+});
+
+// --- Blink mobile (Chrome for Android) ---
+
+test('Chrome-Android: Blink vendor / productSub, no oscpu', () => {
+  const nav = loadShim(CHROME_ANDROID).window.navigator;
+  assert.equal(nav.vendor, 'Google Inc.');
+  assert.equal(nav.productSub, '20030107');
+  assert.equal('oscpu' in nav, false);
+  assert.equal(nav.platform, 'Linux armv8l');
+});
+
+test('Chrome-Android: userAgentData is NOT removed (Blink keeps it)', () => {
+  // The shim removes userAgentData only for Gecko/WebKit; the Blink fixture
+  // must not carry a removeProp('userAgentData') line.
+  const src = require('./helpers/load_shim').readFixture(CHROME_ANDROID);
+  assert.equal(/removeProp\('userAgentData'\)/.test(src), false);
+});
+
+test('FxiOS DOES remove userAgentData (WebKit lacks it)', () => {
+  const src = require('./helpers/load_shim').readFixture(FXIOS);
+  assert.equal(/removeProp\('userAgentData'\)/.test(src), true);
+});
+
+// --- Detection hardening ---
+
+test('identity getters land on Navigator.prototype, not the instance', () => {
+  const dom = loadShim(FX_ANDROID);
+  const own = Object.getOwnPropertyNames(dom.window.navigator);
+  for (const leaked of ['vendor', 'vendorSub', 'productSub', 'oscpu',
+                        'buildID', 'platform']) {
+    assert.equal(own.includes(leaked), false,
+      `${leaked} leaks as own-property: ${JSON.stringify(own)}`);
+  }
+});
+
+test('identity getters stringify as [native code]', () => {
+  const dom = loadShim(FX_ANDROID);
+  const desc = Object.getOwnPropertyDescriptor(
+    dom.window.Navigator.prototype, 'vendor');
+  const s = dom.window.Function.prototype.toString.call(desc.get);
+  assert.match(s, /\[native code\]/);
+});
+
+test('shim loads cleanly and is idempotent under jsdom', () => {
+  const dom = loadShim(FX_ANDROID);
+  assert.doesNotThrow(() =>
+    dom.window.eval(require('./helpers/load_shim').readFixture(FX_ANDROID)));
+  assert.equal(dom.window.navigator.vendor, '');
+});

--- a/test/js_fixtures/anti_fingerprinting/shim_seed_alpha.js
+++ b/test/js_fixtures/anti_fingerprinting/shim_seed_alpha.js
@@ -112,6 +112,64 @@
     }
   } catch (e) {}
 
+  // --- matchMedia device-dimension agreement ---
+  // screen.* is spoofed above, but CSS `(min-|max-)device-width/height`
+  // media queries resolve against the REAL screen. A fingerprinter
+  // binary-searching `(max-device-width: Npx)` recovers the true device
+  // size and contradicts screen.width (CreepJS's "CSS Media Queries" leak).
+  // Intercept single-feature device-width/height queries and answer against
+  // the SAME dimensions screen.* reports: window.inner* in letterbox mode
+  // (the box is physically real), the pinned SCREEN_W/H otherwise.
+  try {
+    if (typeof window.matchMedia === 'function') {
+      var _origMatchMedia = window.matchMedia.bind(window);
+      var DEVICE_DIM_RE =
+        /^\(\s*(min-|max-)?device-(width|height)\s*:\s*([\d.]+)px\s*\)$/i;
+      function _targetDim(which) {
+        if (LETTERBOX) {
+          return which === 'width' ? window.innerWidth : window.innerHeight;
+        }
+        return which === 'width' ? SCREEN_W : SCREEN_H;
+      }
+      function _syntheticMql(query, matches) {
+        var listeners = [];
+        return {
+          matches: matches,
+          media: query,
+          onchange: null,
+          addListener: function(l) { if (l) listeners.push(l); },
+          removeListener: function(l) {
+            var i = listeners.indexOf(l); if (i >= 0) listeners.splice(i, 1);
+          },
+          addEventListener: function(_t, l) { if (l) listeners.push(l); },
+          removeEventListener: function(_t, l) {
+            var i = listeners.indexOf(l); if (i >= 0) listeners.splice(i, 1);
+          },
+          dispatchEvent: function() { return false; },
+        };
+      }
+      var _patchedMatchMedia = function matchMedia(query) {
+        try {
+          if (typeof query === 'string') {
+            var m = DEVICE_DIM_RE.exec(query.trim());
+            if (m) {
+              var actual = _targetDim(m[2].toLowerCase());
+              var val = parseFloat(m[3]);
+              var prefix = (m[1] || '').toLowerCase();
+              var matches = prefix === 'min-'
+                ? actual >= val
+                : (prefix === 'max-' ? actual <= val : actual === val);
+              return _syntheticMql(query, matches);
+            }
+          }
+        } catch (e) {}
+        return _origMatchMedia(query);
+      };
+      asNative(_patchedMatchMedia, 'matchMedia');
+      window.matchMedia = _patchedMatchMedia;
+    }
+  } catch (e) {}
+
   // --- navigator.hardwareConcurrency / deviceMemory ---
   var NavProto = (typeof Navigator !== 'undefined') ? Navigator.prototype : null;
   try {

--- a/test/js_fixtures/anti_fingerprinting/shim_seed_alpha_launch_one.js
+++ b/test/js_fixtures/anti_fingerprinting/shim_seed_alpha_launch_one.js
@@ -112,6 +112,64 @@
     }
   } catch (e) {}
 
+  // --- matchMedia device-dimension agreement ---
+  // screen.* is spoofed above, but CSS `(min-|max-)device-width/height`
+  // media queries resolve against the REAL screen. A fingerprinter
+  // binary-searching `(max-device-width: Npx)` recovers the true device
+  // size and contradicts screen.width (CreepJS's "CSS Media Queries" leak).
+  // Intercept single-feature device-width/height queries and answer against
+  // the SAME dimensions screen.* reports: window.inner* in letterbox mode
+  // (the box is physically real), the pinned SCREEN_W/H otherwise.
+  try {
+    if (typeof window.matchMedia === 'function') {
+      var _origMatchMedia = window.matchMedia.bind(window);
+      var DEVICE_DIM_RE =
+        /^\(\s*(min-|max-)?device-(width|height)\s*:\s*([\d.]+)px\s*\)$/i;
+      function _targetDim(which) {
+        if (LETTERBOX) {
+          return which === 'width' ? window.innerWidth : window.innerHeight;
+        }
+        return which === 'width' ? SCREEN_W : SCREEN_H;
+      }
+      function _syntheticMql(query, matches) {
+        var listeners = [];
+        return {
+          matches: matches,
+          media: query,
+          onchange: null,
+          addListener: function(l) { if (l) listeners.push(l); },
+          removeListener: function(l) {
+            var i = listeners.indexOf(l); if (i >= 0) listeners.splice(i, 1);
+          },
+          addEventListener: function(_t, l) { if (l) listeners.push(l); },
+          removeEventListener: function(_t, l) {
+            var i = listeners.indexOf(l); if (i >= 0) listeners.splice(i, 1);
+          },
+          dispatchEvent: function() { return false; },
+        };
+      }
+      var _patchedMatchMedia = function matchMedia(query) {
+        try {
+          if (typeof query === 'string') {
+            var m = DEVICE_DIM_RE.exec(query.trim());
+            if (m) {
+              var actual = _targetDim(m[2].toLowerCase());
+              var val = parseFloat(m[3]);
+              var prefix = (m[1] || '').toLowerCase();
+              var matches = prefix === 'min-'
+                ? actual >= val
+                : (prefix === 'max-' ? actual <= val : actual === val);
+              return _syntheticMql(query, matches);
+            }
+          }
+        } catch (e) {}
+        return _origMatchMedia(query);
+      };
+      asNative(_patchedMatchMedia, 'matchMedia');
+      window.matchMedia = _patchedMatchMedia;
+    }
+  } catch (e) {}
+
   // --- navigator.hardwareConcurrency / deviceMemory ---
   var NavProto = (typeof Navigator !== 'undefined') ? Navigator.prototype : null;
   try {

--- a/test/js_fixtures/anti_fingerprinting/shim_seed_alpha_launch_two.js
+++ b/test/js_fixtures/anti_fingerprinting/shim_seed_alpha_launch_two.js
@@ -112,6 +112,64 @@
     }
   } catch (e) {}
 
+  // --- matchMedia device-dimension agreement ---
+  // screen.* is spoofed above, but CSS `(min-|max-)device-width/height`
+  // media queries resolve against the REAL screen. A fingerprinter
+  // binary-searching `(max-device-width: Npx)` recovers the true device
+  // size and contradicts screen.width (CreepJS's "CSS Media Queries" leak).
+  // Intercept single-feature device-width/height queries and answer against
+  // the SAME dimensions screen.* reports: window.inner* in letterbox mode
+  // (the box is physically real), the pinned SCREEN_W/H otherwise.
+  try {
+    if (typeof window.matchMedia === 'function') {
+      var _origMatchMedia = window.matchMedia.bind(window);
+      var DEVICE_DIM_RE =
+        /^\(\s*(min-|max-)?device-(width|height)\s*:\s*([\d.]+)px\s*\)$/i;
+      function _targetDim(which) {
+        if (LETTERBOX) {
+          return which === 'width' ? window.innerWidth : window.innerHeight;
+        }
+        return which === 'width' ? SCREEN_W : SCREEN_H;
+      }
+      function _syntheticMql(query, matches) {
+        var listeners = [];
+        return {
+          matches: matches,
+          media: query,
+          onchange: null,
+          addListener: function(l) { if (l) listeners.push(l); },
+          removeListener: function(l) {
+            var i = listeners.indexOf(l); if (i >= 0) listeners.splice(i, 1);
+          },
+          addEventListener: function(_t, l) { if (l) listeners.push(l); },
+          removeEventListener: function(_t, l) {
+            var i = listeners.indexOf(l); if (i >= 0) listeners.splice(i, 1);
+          },
+          dispatchEvent: function() { return false; },
+        };
+      }
+      var _patchedMatchMedia = function matchMedia(query) {
+        try {
+          if (typeof query === 'string') {
+            var m = DEVICE_DIM_RE.exec(query.trim());
+            if (m) {
+              var actual = _targetDim(m[2].toLowerCase());
+              var val = parseFloat(m[3]);
+              var prefix = (m[1] || '').toLowerCase();
+              var matches = prefix === 'min-'
+                ? actual >= val
+                : (prefix === 'max-' ? actual <= val : actual === val);
+              return _syntheticMql(query, matches);
+            }
+          }
+        } catch (e) {}
+        return _origMatchMedia(query);
+      };
+      asNative(_patchedMatchMedia, 'matchMedia');
+      window.matchMedia = _patchedMatchMedia;
+    }
+  } catch (e) {}
+
   // --- navigator.hardwareConcurrency / deviceMemory ---
   var NavProto = (typeof Navigator !== 'undefined') ? Navigator.prototype : null;
   try {

--- a/test/js_fixtures/anti_fingerprinting/shim_seed_alpha_letterbox.js
+++ b/test/js_fixtures/anti_fingerprinting/shim_seed_alpha_letterbox.js
@@ -112,6 +112,64 @@
     }
   } catch (e) {}
 
+  // --- matchMedia device-dimension agreement ---
+  // screen.* is spoofed above, but CSS `(min-|max-)device-width/height`
+  // media queries resolve against the REAL screen. A fingerprinter
+  // binary-searching `(max-device-width: Npx)` recovers the true device
+  // size and contradicts screen.width (CreepJS's "CSS Media Queries" leak).
+  // Intercept single-feature device-width/height queries and answer against
+  // the SAME dimensions screen.* reports: window.inner* in letterbox mode
+  // (the box is physically real), the pinned SCREEN_W/H otherwise.
+  try {
+    if (typeof window.matchMedia === 'function') {
+      var _origMatchMedia = window.matchMedia.bind(window);
+      var DEVICE_DIM_RE =
+        /^\(\s*(min-|max-)?device-(width|height)\s*:\s*([\d.]+)px\s*\)$/i;
+      function _targetDim(which) {
+        if (LETTERBOX) {
+          return which === 'width' ? window.innerWidth : window.innerHeight;
+        }
+        return which === 'width' ? SCREEN_W : SCREEN_H;
+      }
+      function _syntheticMql(query, matches) {
+        var listeners = [];
+        return {
+          matches: matches,
+          media: query,
+          onchange: null,
+          addListener: function(l) { if (l) listeners.push(l); },
+          removeListener: function(l) {
+            var i = listeners.indexOf(l); if (i >= 0) listeners.splice(i, 1);
+          },
+          addEventListener: function(_t, l) { if (l) listeners.push(l); },
+          removeEventListener: function(_t, l) {
+            var i = listeners.indexOf(l); if (i >= 0) listeners.splice(i, 1);
+          },
+          dispatchEvent: function() { return false; },
+        };
+      }
+      var _patchedMatchMedia = function matchMedia(query) {
+        try {
+          if (typeof query === 'string') {
+            var m = DEVICE_DIM_RE.exec(query.trim());
+            if (m) {
+              var actual = _targetDim(m[2].toLowerCase());
+              var val = parseFloat(m[3]);
+              var prefix = (m[1] || '').toLowerCase();
+              var matches = prefix === 'min-'
+                ? actual >= val
+                : (prefix === 'max-' ? actual <= val : actual === val);
+              return _syntheticMql(query, matches);
+            }
+          }
+        } catch (e) {}
+        return _origMatchMedia(query);
+      };
+      asNative(_patchedMatchMedia, 'matchMedia');
+      window.matchMedia = _patchedMatchMedia;
+    }
+  } catch (e) {}
+
   // --- navigator.hardwareConcurrency / deviceMemory ---
   var NavProto = (typeof Navigator !== 'undefined') ? Navigator.prototype : null;
   try {

--- a/test/js_fixtures/anti_fingerprinting/shim_seed_beta.js
+++ b/test/js_fixtures/anti_fingerprinting/shim_seed_beta.js
@@ -112,6 +112,64 @@
     }
   } catch (e) {}
 
+  // --- matchMedia device-dimension agreement ---
+  // screen.* is spoofed above, but CSS `(min-|max-)device-width/height`
+  // media queries resolve against the REAL screen. A fingerprinter
+  // binary-searching `(max-device-width: Npx)` recovers the true device
+  // size and contradicts screen.width (CreepJS's "CSS Media Queries" leak).
+  // Intercept single-feature device-width/height queries and answer against
+  // the SAME dimensions screen.* reports: window.inner* in letterbox mode
+  // (the box is physically real), the pinned SCREEN_W/H otherwise.
+  try {
+    if (typeof window.matchMedia === 'function') {
+      var _origMatchMedia = window.matchMedia.bind(window);
+      var DEVICE_DIM_RE =
+        /^\(\s*(min-|max-)?device-(width|height)\s*:\s*([\d.]+)px\s*\)$/i;
+      function _targetDim(which) {
+        if (LETTERBOX) {
+          return which === 'width' ? window.innerWidth : window.innerHeight;
+        }
+        return which === 'width' ? SCREEN_W : SCREEN_H;
+      }
+      function _syntheticMql(query, matches) {
+        var listeners = [];
+        return {
+          matches: matches,
+          media: query,
+          onchange: null,
+          addListener: function(l) { if (l) listeners.push(l); },
+          removeListener: function(l) {
+            var i = listeners.indexOf(l); if (i >= 0) listeners.splice(i, 1);
+          },
+          addEventListener: function(_t, l) { if (l) listeners.push(l); },
+          removeEventListener: function(_t, l) {
+            var i = listeners.indexOf(l); if (i >= 0) listeners.splice(i, 1);
+          },
+          dispatchEvent: function() { return false; },
+        };
+      }
+      var _patchedMatchMedia = function matchMedia(query) {
+        try {
+          if (typeof query === 'string') {
+            var m = DEVICE_DIM_RE.exec(query.trim());
+            if (m) {
+              var actual = _targetDim(m[2].toLowerCase());
+              var val = parseFloat(m[3]);
+              var prefix = (m[1] || '').toLowerCase();
+              var matches = prefix === 'min-'
+                ? actual >= val
+                : (prefix === 'max-' ? actual <= val : actual === val);
+              return _syntheticMql(query, matches);
+            }
+          }
+        } catch (e) {}
+        return _origMatchMedia(query);
+      };
+      asNative(_patchedMatchMedia, 'matchMedia');
+      window.matchMedia = _patchedMatchMedia;
+    }
+  } catch (e) {}
+
   // --- navigator.hardwareConcurrency / deviceMemory ---
   var NavProto = (typeof Navigator !== 'undefined') ? Navigator.prototype : null;
   try {

--- a/test/js_fixtures/language/en.js
+++ b/test/js_fixtures/language/en.js
@@ -1,21 +1,110 @@
 (function() {
+  'use strict';
+  if (window.__ws_language_shim__) return;
+  window.__ws_language_shim__ = true;
+
+  var lang = "en";
+  var langs = Object.freeze([lang]);
+
+  // Shared Function.prototype.toString funnel (same WeakMap as the other
+  // shims) so every wrapper stringifies as `[native code]`.
+  var _origFnToString = Function.prototype.toString;
+  var _stubs = window.__wsFnStubs || new WeakMap();
+  window.__wsFnStubs = _stubs;
+  function asNative(fn, name) {
+    try { _stubs.set(fn, 'function ' + name + '() { [native code] }'); } catch (e) {}
+    return fn;
+  }
+  if (!window.__wsFnToStringPatched) {
+    window.__wsFnToStringPatched = true;
+    var patched = function toString() {
+      var stub = _stubs.get(this);
+      return stub !== undefined ? stub : _origFnToString.call(this);
+    };
+    try { _stubs.set(patched, 'function toString() { [native code] }'); } catch (e) {}
+    try { Function.prototype.toString = patched; } catch (e) {}
+  }
+
   try {
-    var lang = "en";
-    var langs = Object.freeze([lang]);
     Object.defineProperty(Navigator.prototype, 'language', {
-      configurable: true, get: function() { return lang; }
+      configurable: true, enumerable: true,
+      get: asNative(function language() { return lang; }, 'language'),
     });
     Object.defineProperty(Navigator.prototype, 'languages', {
-      configurable: true, get: function() { return langs; }
+      configurable: true, enumerable: true,
+      get: asNative(function languages() { return langs; }, 'languages'),
     });
-    if (typeof Intl !== 'undefined' && Intl.DateTimeFormat) {
-      var proto = Intl.DateTimeFormat.prototype;
-      var orig = proto.resolvedOptions;
-      proto.resolvedOptions = function() {
-        var r = orig.apply(this, arguments);
-        r.locale = lang;
-        return r;
-      };
-    }
   } catch (e) {}
+
+  // True when the caller omitted the `locales` argument (or passed an empty
+  // list) — the only case in which a real engine falls back to the default
+  // locale, and thus the only case we override.
+  function localeOmitted(args) {
+    if (args.length === 0) return true;
+    var l = args[0];
+    return l === undefined || (Array.isArray(l) && l.length === 0);
+  }
+
+  // Wrap an Intl constructor so an omitted `locales` defaults to `lang`
+  // instead of the OS locale. Both `resolvedOptions().locale` and the
+  // formatted output then reflect the per-site tag. Delegates to whatever
+  // `Intl[name]` currently is, so it composes with the location shim's
+  // `Intl.DateTimeFormat` timezone wrapper regardless of injection order.
+  function wrapIntlCtor(name) {
+    try {
+      if (typeof Intl === 'undefined') return;
+      var Native = Intl[name];
+      if (typeof Native !== 'function') return;
+      function Wrapped() {
+        var args = localeOmitted(arguments)
+          ? [lang].concat(Array.prototype.slice.call(arguments, 1))
+          : arguments;
+        // Called without `new`: mirror the native behaviour exactly —
+        // DateTimeFormat/NumberFormat/Collator return an instance, the
+        // others throw. `Native.apply(null, ...)` reproduces both.
+        if (!(this instanceof Wrapped)) return Native.apply(null, args);
+        switch (args.length) {
+          case 0: return new Native();
+          case 1: return new Native(args[0]);
+          default: return new Native(args[0], args[1]);
+        }
+      }
+      Wrapped.prototype = Native.prototype;
+      if (typeof Native.supportedLocalesOf === 'function') {
+        Wrapped.supportedLocalesOf = asNative(function supportedLocalesOf() {
+          return Native.supportedLocalesOf.apply(Native, arguments);
+        }, 'supportedLocalesOf');
+      }
+      asNative(Wrapped, name);
+      try { Intl[name] = Wrapped; } catch (e) {}
+    } catch (e) {}
+  }
+
+  [
+    'DateTimeFormat', 'NumberFormat', 'RelativeTimeFormat', 'DisplayNames',
+    'ListFormat', 'PluralRules', 'Collator', 'Segmenter',
+  ].forEach(wrapIntlCtor);
+
+  // Date/Number toLocale* fall back to the default locale when called with no
+  // (or `undefined`) first argument. Inject `lang` there too so a locale-less
+  // `date.toLocaleString()` matches the Intl output above.
+  function wrapLocaleMethod(proto, method) {
+    try {
+      if (!proto) return;
+      var orig = proto[method];
+      if (typeof orig !== 'function') return;
+      var wrapped = function () {
+        if (arguments.length === 0 || arguments[0] === undefined) {
+          return orig.call(this, lang, arguments[1]);
+        }
+        return orig.apply(this, arguments);
+      };
+      asNative(wrapped, method);
+      try { proto[method] = wrapped; } catch (e) {}
+    } catch (e) {}
+  }
+  wrapLocaleMethod(Date.prototype, 'toLocaleString');
+  wrapLocaleMethod(Date.prototype, 'toLocaleDateString');
+  wrapLocaleMethod(Date.prototype, 'toLocaleTimeString');
+  wrapLocaleMethod(Number.prototype, 'toLocaleString');
 })();

--- a/test/js_fixtures/language/fr_FR.js
+++ b/test/js_fixtures/language/fr_FR.js
@@ -1,21 +1,110 @@
 (function() {
+  'use strict';
+  if (window.__ws_language_shim__) return;
+  window.__ws_language_shim__ = true;
+
+  var lang = "fr-FR";
+  var langs = Object.freeze([lang]);
+
+  // Shared Function.prototype.toString funnel (same WeakMap as the other
+  // shims) so every wrapper stringifies as `[native code]`.
+  var _origFnToString = Function.prototype.toString;
+  var _stubs = window.__wsFnStubs || new WeakMap();
+  window.__wsFnStubs = _stubs;
+  function asNative(fn, name) {
+    try { _stubs.set(fn, 'function ' + name + '() { [native code] }'); } catch (e) {}
+    return fn;
+  }
+  if (!window.__wsFnToStringPatched) {
+    window.__wsFnToStringPatched = true;
+    var patched = function toString() {
+      var stub = _stubs.get(this);
+      return stub !== undefined ? stub : _origFnToString.call(this);
+    };
+    try { _stubs.set(patched, 'function toString() { [native code] }'); } catch (e) {}
+    try { Function.prototype.toString = patched; } catch (e) {}
+  }
+
   try {
-    var lang = "fr-FR";
-    var langs = Object.freeze([lang]);
     Object.defineProperty(Navigator.prototype, 'language', {
-      configurable: true, get: function() { return lang; }
+      configurable: true, enumerable: true,
+      get: asNative(function language() { return lang; }, 'language'),
     });
     Object.defineProperty(Navigator.prototype, 'languages', {
-      configurable: true, get: function() { return langs; }
+      configurable: true, enumerable: true,
+      get: asNative(function languages() { return langs; }, 'languages'),
     });
-    if (typeof Intl !== 'undefined' && Intl.DateTimeFormat) {
-      var proto = Intl.DateTimeFormat.prototype;
-      var orig = proto.resolvedOptions;
-      proto.resolvedOptions = function() {
-        var r = orig.apply(this, arguments);
-        r.locale = lang;
-        return r;
-      };
-    }
   } catch (e) {}
+
+  // True when the caller omitted the `locales` argument (or passed an empty
+  // list) — the only case in which a real engine falls back to the default
+  // locale, and thus the only case we override.
+  function localeOmitted(args) {
+    if (args.length === 0) return true;
+    var l = args[0];
+    return l === undefined || (Array.isArray(l) && l.length === 0);
+  }
+
+  // Wrap an Intl constructor so an omitted `locales` defaults to `lang`
+  // instead of the OS locale. Both `resolvedOptions().locale` and the
+  // formatted output then reflect the per-site tag. Delegates to whatever
+  // `Intl[name]` currently is, so it composes with the location shim's
+  // `Intl.DateTimeFormat` timezone wrapper regardless of injection order.
+  function wrapIntlCtor(name) {
+    try {
+      if (typeof Intl === 'undefined') return;
+      var Native = Intl[name];
+      if (typeof Native !== 'function') return;
+      function Wrapped() {
+        var args = localeOmitted(arguments)
+          ? [lang].concat(Array.prototype.slice.call(arguments, 1))
+          : arguments;
+        // Called without `new`: mirror the native behaviour exactly —
+        // DateTimeFormat/NumberFormat/Collator return an instance, the
+        // others throw. `Native.apply(null, ...)` reproduces both.
+        if (!(this instanceof Wrapped)) return Native.apply(null, args);
+        switch (args.length) {
+          case 0: return new Native();
+          case 1: return new Native(args[0]);
+          default: return new Native(args[0], args[1]);
+        }
+      }
+      Wrapped.prototype = Native.prototype;
+      if (typeof Native.supportedLocalesOf === 'function') {
+        Wrapped.supportedLocalesOf = asNative(function supportedLocalesOf() {
+          return Native.supportedLocalesOf.apply(Native, arguments);
+        }, 'supportedLocalesOf');
+      }
+      asNative(Wrapped, name);
+      try { Intl[name] = Wrapped; } catch (e) {}
+    } catch (e) {}
+  }
+
+  [
+    'DateTimeFormat', 'NumberFormat', 'RelativeTimeFormat', 'DisplayNames',
+    'ListFormat', 'PluralRules', 'Collator', 'Segmenter',
+  ].forEach(wrapIntlCtor);
+
+  // Date/Number toLocale* fall back to the default locale when called with no
+  // (or `undefined`) first argument. Inject `lang` there too so a locale-less
+  // `date.toLocaleString()` matches the Intl output above.
+  function wrapLocaleMethod(proto, method) {
+    try {
+      if (!proto) return;
+      var orig = proto[method];
+      if (typeof orig !== 'function') return;
+      var wrapped = function () {
+        if (arguments.length === 0 || arguments[0] === undefined) {
+          return orig.call(this, lang, arguments[1]);
+        }
+        return orig.apply(this, arguments);
+      };
+      asNative(wrapped, method);
+      try { proto[method] = wrapped; } catch (e) {}
+    } catch (e) {}
+  }
+  wrapLocaleMethod(Date.prototype, 'toLocaleString');
+  wrapLocaleMethod(Date.prototype, 'toLocaleDateString');
+  wrapLocaleMethod(Date.prototype, 'toLocaleTimeString');
+  wrapLocaleMethod(Number.prototype, 'toLocaleString');
 })();

--- a/test/js_fixtures/language/ja.js
+++ b/test/js_fixtures/language/ja.js
@@ -1,21 +1,110 @@
 (function() {
+  'use strict';
+  if (window.__ws_language_shim__) return;
+  window.__ws_language_shim__ = true;
+
+  var lang = "ja";
+  var langs = Object.freeze([lang]);
+
+  // Shared Function.prototype.toString funnel (same WeakMap as the other
+  // shims) so every wrapper stringifies as `[native code]`.
+  var _origFnToString = Function.prototype.toString;
+  var _stubs = window.__wsFnStubs || new WeakMap();
+  window.__wsFnStubs = _stubs;
+  function asNative(fn, name) {
+    try { _stubs.set(fn, 'function ' + name + '() { [native code] }'); } catch (e) {}
+    return fn;
+  }
+  if (!window.__wsFnToStringPatched) {
+    window.__wsFnToStringPatched = true;
+    var patched = function toString() {
+      var stub = _stubs.get(this);
+      return stub !== undefined ? stub : _origFnToString.call(this);
+    };
+    try { _stubs.set(patched, 'function toString() { [native code] }'); } catch (e) {}
+    try { Function.prototype.toString = patched; } catch (e) {}
+  }
+
   try {
-    var lang = "ja";
-    var langs = Object.freeze([lang]);
     Object.defineProperty(Navigator.prototype, 'language', {
-      configurable: true, get: function() { return lang; }
+      configurable: true, enumerable: true,
+      get: asNative(function language() { return lang; }, 'language'),
     });
     Object.defineProperty(Navigator.prototype, 'languages', {
-      configurable: true, get: function() { return langs; }
+      configurable: true, enumerable: true,
+      get: asNative(function languages() { return langs; }, 'languages'),
     });
-    if (typeof Intl !== 'undefined' && Intl.DateTimeFormat) {
-      var proto = Intl.DateTimeFormat.prototype;
-      var orig = proto.resolvedOptions;
-      proto.resolvedOptions = function() {
-        var r = orig.apply(this, arguments);
-        r.locale = lang;
-        return r;
-      };
-    }
   } catch (e) {}
+
+  // True when the caller omitted the `locales` argument (or passed an empty
+  // list) — the only case in which a real engine falls back to the default
+  // locale, and thus the only case we override.
+  function localeOmitted(args) {
+    if (args.length === 0) return true;
+    var l = args[0];
+    return l === undefined || (Array.isArray(l) && l.length === 0);
+  }
+
+  // Wrap an Intl constructor so an omitted `locales` defaults to `lang`
+  // instead of the OS locale. Both `resolvedOptions().locale` and the
+  // formatted output then reflect the per-site tag. Delegates to whatever
+  // `Intl[name]` currently is, so it composes with the location shim's
+  // `Intl.DateTimeFormat` timezone wrapper regardless of injection order.
+  function wrapIntlCtor(name) {
+    try {
+      if (typeof Intl === 'undefined') return;
+      var Native = Intl[name];
+      if (typeof Native !== 'function') return;
+      function Wrapped() {
+        var args = localeOmitted(arguments)
+          ? [lang].concat(Array.prototype.slice.call(arguments, 1))
+          : arguments;
+        // Called without `new`: mirror the native behaviour exactly —
+        // DateTimeFormat/NumberFormat/Collator return an instance, the
+        // others throw. `Native.apply(null, ...)` reproduces both.
+        if (!(this instanceof Wrapped)) return Native.apply(null, args);
+        switch (args.length) {
+          case 0: return new Native();
+          case 1: return new Native(args[0]);
+          default: return new Native(args[0], args[1]);
+        }
+      }
+      Wrapped.prototype = Native.prototype;
+      if (typeof Native.supportedLocalesOf === 'function') {
+        Wrapped.supportedLocalesOf = asNative(function supportedLocalesOf() {
+          return Native.supportedLocalesOf.apply(Native, arguments);
+        }, 'supportedLocalesOf');
+      }
+      asNative(Wrapped, name);
+      try { Intl[name] = Wrapped; } catch (e) {}
+    } catch (e) {}
+  }
+
+  [
+    'DateTimeFormat', 'NumberFormat', 'RelativeTimeFormat', 'DisplayNames',
+    'ListFormat', 'PluralRules', 'Collator', 'Segmenter',
+  ].forEach(wrapIntlCtor);
+
+  // Date/Number toLocale* fall back to the default locale when called with no
+  // (or `undefined`) first argument. Inject `lang` there too so a locale-less
+  // `date.toLocaleString()` matches the Intl output above.
+  function wrapLocaleMethod(proto, method) {
+    try {
+      if (!proto) return;
+      var orig = proto[method];
+      if (typeof orig !== 'function') return;
+      var wrapped = function () {
+        if (arguments.length === 0 || arguments[0] === undefined) {
+          return orig.call(this, lang, arguments[1]);
+        }
+        return orig.apply(this, arguments);
+      };
+      asNative(wrapped, method);
+      try { proto[method] = wrapped; } catch (e) {}
+    } catch (e) {}
+  }
+  wrapLocaleMethod(Date.prototype, 'toLocaleString');
+  wrapLocaleMethod(Date.prototype, 'toLocaleDateString');
+  wrapLocaleMethod(Date.prototype, 'toLocaleTimeString');
+  wrapLocaleMethod(Number.prototype, 'toLocaleString');
 })();

--- a/test/js_fixtures/ua_identity/chrome_android.js
+++ b/test/js_fixtures/ua_identity/chrome_android.js
@@ -1,0 +1,62 @@
+(function() {
+  'use strict';
+  if (window.__ws_ua_identity_shim__) return;
+  window.__ws_ua_identity_shim__ = true;
+
+  // Shared Function.prototype.toString funnel (same WeakMap as the other
+  // shims) so every getter stringifies as `[native code]`.
+  var _origFnToString = Function.prototype.toString;
+  var _stubs = window.__wsFnStubs || new WeakMap();
+  window.__wsFnStubs = _stubs;
+  function asNative(fn, name) {
+    try { _stubs.set(fn, 'function ' + name + '() { [native code] }'); } catch (e) {}
+    return fn;
+  }
+  if (!window.__wsFnToStringPatched) {
+    window.__wsFnToStringPatched = true;
+    var patched = function toString() {
+      var stub = _stubs.get(this);
+      return stub !== undefined ? stub : _origFnToString.call(this);
+    };
+    try { _stubs.set(patched, 'function toString() { [native code] }'); } catch (e) {}
+    try { Function.prototype.toString = patched; } catch (e) {}
+  }
+
+  var NavProto = (typeof Navigator !== 'undefined') ? Navigator.prototype : null;
+
+  // Define on Navigator.prototype (never the instance — an own-property on
+  // `navigator` would self-incriminate), matching how real engines carry
+  // these accessors.
+  function def(name, value) {
+    if (!NavProto) return;
+    try {
+      Object.defineProperty(NavProto, name, {
+        configurable: true, enumerable: true,
+        get: asNative(function() { return value; }, name),
+      });
+    } catch (e) {}
+  }
+
+  // Make a property genuinely absent (delete), so `name in navigator` is
+  // false. Falls back to an undefined getter only if the delete is refused
+  // (non-configurable), which is still better than a populated value.
+  function removeProp(name) {
+    try { if (NavProto) delete NavProto[name]; } catch (e) {}
+    try { delete navigator[name]; } catch (e) {}
+    try {
+      if (NavProto && (name in NavProto)) {
+        Object.defineProperty(NavProto, name, {
+          configurable: true, enumerable: false,
+          get: asNative(function() { return undefined; }, name),
+        });
+      }
+    } catch (e) {}
+  }
+
+  def('vendor', "Google Inc.");
+  def('vendorSub', '');
+  def('productSub', "20030107");
+  removeProp('oscpu');
+  removeProp('buildID');
+  def('platform', "Linux armv8l");
+})();

--- a/test/js_fixtures/ua_identity/firefox_android.js
+++ b/test/js_fixtures/ua_identity/firefox_android.js
@@ -1,0 +1,63 @@
+(function() {
+  'use strict';
+  if (window.__ws_ua_identity_shim__) return;
+  window.__ws_ua_identity_shim__ = true;
+
+  // Shared Function.prototype.toString funnel (same WeakMap as the other
+  // shims) so every getter stringifies as `[native code]`.
+  var _origFnToString = Function.prototype.toString;
+  var _stubs = window.__wsFnStubs || new WeakMap();
+  window.__wsFnStubs = _stubs;
+  function asNative(fn, name) {
+    try { _stubs.set(fn, 'function ' + name + '() { [native code] }'); } catch (e) {}
+    return fn;
+  }
+  if (!window.__wsFnToStringPatched) {
+    window.__wsFnToStringPatched = true;
+    var patched = function toString() {
+      var stub = _stubs.get(this);
+      return stub !== undefined ? stub : _origFnToString.call(this);
+    };
+    try { _stubs.set(patched, 'function toString() { [native code] }'); } catch (e) {}
+    try { Function.prototype.toString = patched; } catch (e) {}
+  }
+
+  var NavProto = (typeof Navigator !== 'undefined') ? Navigator.prototype : null;
+
+  // Define on Navigator.prototype (never the instance — an own-property on
+  // `navigator` would self-incriminate), matching how real engines carry
+  // these accessors.
+  function def(name, value) {
+    if (!NavProto) return;
+    try {
+      Object.defineProperty(NavProto, name, {
+        configurable: true, enumerable: true,
+        get: asNative(function() { return value; }, name),
+      });
+    } catch (e) {}
+  }
+
+  // Make a property genuinely absent (delete), so `name in navigator` is
+  // false. Falls back to an undefined getter only if the delete is refused
+  // (non-configurable), which is still better than a populated value.
+  function removeProp(name) {
+    try { if (NavProto) delete NavProto[name]; } catch (e) {}
+    try { delete navigator[name]; } catch (e) {}
+    try {
+      if (NavProto && (name in NavProto)) {
+        Object.defineProperty(NavProto, name, {
+          configurable: true, enumerable: false,
+          get: asNative(function() { return undefined; }, name),
+        });
+      }
+    } catch (e) {}
+  }
+
+  def('vendor', "");
+  def('vendorSub', '');
+  def('productSub', "20100101");
+  def('oscpu', "Linux armv8l");
+  def('buildID', '20181001000000');
+  def('platform', "Linux armv8l");
+  removeProp('userAgentData');
+})();

--- a/test/js_fixtures/ua_identity/firefox_linux_desktop.js
+++ b/test/js_fixtures/ua_identity/firefox_linux_desktop.js
@@ -1,0 +1,61 @@
+(function() {
+  'use strict';
+  if (window.__ws_ua_identity_shim__) return;
+  window.__ws_ua_identity_shim__ = true;
+
+  // Shared Function.prototype.toString funnel (same WeakMap as the other
+  // shims) so every getter stringifies as `[native code]`.
+  var _origFnToString = Function.prototype.toString;
+  var _stubs = window.__wsFnStubs || new WeakMap();
+  window.__wsFnStubs = _stubs;
+  function asNative(fn, name) {
+    try { _stubs.set(fn, 'function ' + name + '() { [native code] }'); } catch (e) {}
+    return fn;
+  }
+  if (!window.__wsFnToStringPatched) {
+    window.__wsFnToStringPatched = true;
+    var patched = function toString() {
+      var stub = _stubs.get(this);
+      return stub !== undefined ? stub : _origFnToString.call(this);
+    };
+    try { _stubs.set(patched, 'function toString() { [native code] }'); } catch (e) {}
+    try { Function.prototype.toString = patched; } catch (e) {}
+  }
+
+  var NavProto = (typeof Navigator !== 'undefined') ? Navigator.prototype : null;
+
+  // Define on Navigator.prototype (never the instance — an own-property on
+  // `navigator` would self-incriminate), matching how real engines carry
+  // these accessors.
+  function def(name, value) {
+    if (!NavProto) return;
+    try {
+      Object.defineProperty(NavProto, name, {
+        configurable: true, enumerable: true,
+        get: asNative(function() { return value; }, name),
+      });
+    } catch (e) {}
+  }
+
+  // Make a property genuinely absent (delete), so `name in navigator` is
+  // false. Falls back to an undefined getter only if the delete is refused
+  // (non-configurable), which is still better than a populated value.
+  function removeProp(name) {
+    try { if (NavProto) delete NavProto[name]; } catch (e) {}
+    try { delete navigator[name]; } catch (e) {}
+    try {
+      if (NavProto && (name in NavProto)) {
+        Object.defineProperty(NavProto, name, {
+          configurable: true, enumerable: false,
+          get: asNative(function() { return undefined; }, name),
+        });
+      }
+    } catch (e) {}
+  }
+
+  def('vendor', "");
+  def('vendorSub', '');
+  def('productSub', "20100101");
+  def('oscpu', "Linux x86_64");
+  def('buildID', '20181001000000');
+})();

--- a/test/js_fixtures/ua_identity/fxios.js
+++ b/test/js_fixtures/ua_identity/fxios.js
@@ -1,0 +1,63 @@
+(function() {
+  'use strict';
+  if (window.__ws_ua_identity_shim__) return;
+  window.__ws_ua_identity_shim__ = true;
+
+  // Shared Function.prototype.toString funnel (same WeakMap as the other
+  // shims) so every getter stringifies as `[native code]`.
+  var _origFnToString = Function.prototype.toString;
+  var _stubs = window.__wsFnStubs || new WeakMap();
+  window.__wsFnStubs = _stubs;
+  function asNative(fn, name) {
+    try { _stubs.set(fn, 'function ' + name + '() { [native code] }'); } catch (e) {}
+    return fn;
+  }
+  if (!window.__wsFnToStringPatched) {
+    window.__wsFnToStringPatched = true;
+    var patched = function toString() {
+      var stub = _stubs.get(this);
+      return stub !== undefined ? stub : _origFnToString.call(this);
+    };
+    try { _stubs.set(patched, 'function toString() { [native code] }'); } catch (e) {}
+    try { Function.prototype.toString = patched; } catch (e) {}
+  }
+
+  var NavProto = (typeof Navigator !== 'undefined') ? Navigator.prototype : null;
+
+  // Define on Navigator.prototype (never the instance — an own-property on
+  // `navigator` would self-incriminate), matching how real engines carry
+  // these accessors.
+  function def(name, value) {
+    if (!NavProto) return;
+    try {
+      Object.defineProperty(NavProto, name, {
+        configurable: true, enumerable: true,
+        get: asNative(function() { return value; }, name),
+      });
+    } catch (e) {}
+  }
+
+  // Make a property genuinely absent (delete), so `name in navigator` is
+  // false. Falls back to an undefined getter only if the delete is refused
+  // (non-configurable), which is still better than a populated value.
+  function removeProp(name) {
+    try { if (NavProto) delete NavProto[name]; } catch (e) {}
+    try { delete navigator[name]; } catch (e) {}
+    try {
+      if (NavProto && (name in NavProto)) {
+        Object.defineProperty(NavProto, name, {
+          configurable: true, enumerable: false,
+          get: asNative(function() { return undefined; }, name),
+        });
+      }
+    } catch (e) {}
+  }
+
+  def('vendor', "Apple Computer, Inc.");
+  def('vendorSub', '');
+  def('productSub', "20030107");
+  removeProp('oscpu');
+  removeProp('buildID');
+  def('platform', "iPhone");
+  removeProp('userAgentData');
+})();

--- a/test/shim_injection_safety_test.dart
+++ b/test/shim_injection_safety_test.dart
@@ -5,6 +5,7 @@ import 'package:webspace/services/anti_fingerprinting_shim.dart';
 import 'package:webspace/services/desktop_mode_shim.dart';
 import 'package:webspace/services/language_shim.dart';
 import 'package:webspace/services/location_spoof_service.dart';
+import 'package:webspace/services/user_agent_identity_shim.dart';
 import 'package:webspace/settings/location.dart';
 
 /// Regression guard for the per-site JS-shim injection surface.
@@ -76,5 +77,17 @@ void main() {
         'Mozilla/5.0 (X11; Linux x86_64; $payload) Firefox/151.0');
     expect(shim.contains(marker), isFalse,
         reason: 'raw user-agent text must not reach desktop-mode shim JS');
+  });
+
+  test('ua-identity shim never emits the raw user-agent string', () {
+    // Only the engine-derived constants (vendor/oscpu/...) reach the JS; the
+    // UA text is classified, never interpolated. A Gecko-shaped UA carrying
+    // the payload must yield a shim with no trace of it.
+    final shim = buildUserAgentIdentityShim(
+        'Mozilla/5.0 (Android 16; Mobile; rv:151.0; $payload) '
+        'Gecko/151.0 Firefox/151.0');
+    expect(shim, isNotNull);
+    expect(shim!.contains(marker), isFalse,
+        reason: 'raw user-agent text must not reach ua-identity shim JS');
   });
 }

--- a/test/user_agent_identity_shim_test.dart
+++ b/test/user_agent_identity_shim_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webspace/services/user_agent_classifier.dart';
+import 'package:webspace/services/user_agent_identity_shim.dart';
+
+const _chromeAndroid =
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 '
+    '(KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36';
+const _safariMac =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 '
+    '(KHTML, like Gecko) Version/17.4 Safari/605.1.15';
+const _criOs =
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) '
+    'AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.0.0 '
+    'Mobile/15E148 Safari/604.1';
+
+void main() {
+  group('inferUaEngine', () {
+    test('Gecko: Firefox desktop + Android', () {
+      expect(inferUaEngine(firefoxLinuxDesktopUserAgent), UaEngine.gecko);
+      expect(inferUaEngine(buildFirefoxAndroidUserAgent('152.0')),
+          UaEngine.gecko);
+    });
+
+    test('WebKit: Safari, FxiOS, and CriOS (iOS is always WebKit)', () {
+      expect(inferUaEngine(_safariMac), UaEngine.webkit);
+      expect(inferUaEngine(buildFirefoxIosUserAgent('152.0')), UaEngine.webkit);
+      // CriOS carries no "Chrome/" token and is iOS => WebKit, not Blink.
+      expect(inferUaEngine(_criOs), UaEngine.webkit);
+    });
+
+    test('Blink: Chrome for Android and desktop', () {
+      expect(inferUaEngine(_chromeAndroid), UaEngine.blink);
+      expect(
+          inferUaEngine(
+              'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+              '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'),
+          UaEngine.blink);
+    });
+
+    test('unknown for empty / unrecognized', () {
+      expect(inferUaEngine(null), UaEngine.unknown);
+      expect(inferUaEngine(''), UaEngine.unknown);
+      expect(inferUaEngine('curl/8.0'), UaEngine.unknown);
+    });
+  });
+
+  group('buildUserAgentIdentityShim', () {
+    test('returns null when the engine is unclassifiable', () {
+      expect(buildUserAgentIdentityShim(''), isNull);
+      expect(buildUserAgentIdentityShim('curl/8.0'), isNull);
+    });
+
+    test('Gecko mobile (Firefox-Android): empty vendor, gecko productSub, '
+        'frozen oscpu/buildID, mobile platform', () {
+      final s = buildUserAgentIdentityShim(buildFirefoxAndroidUserAgent('152.0'))!;
+      expect(s, contains("def('vendor', \"\");"));
+      expect(s, contains("def('vendorSub', '');"));
+      expect(s, contains("def('productSub', \"20100101\");"));
+      expect(s, contains("def('oscpu', \"Linux armv8l\");"));
+      expect(s, contains("def('buildID', '20181001000000');"));
+      expect(s, contains("def('platform', \"Linux armv8l\");"));
+      expect(s, contains('__ws_ua_identity_shim__'));
+      // The builder must NOT append the evaluator-return; the call site does.
+      expect(s.trimRight().endsWith('})();'), isTrue);
+    });
+
+    test('Gecko desktop: desktop oscpu, and NO platform override '
+        '(desktop_mode_shim owns platform)', () {
+      final s = buildUserAgentIdentityShim(firefoxLinuxDesktopUserAgent)!;
+      expect(s, contains("def('oscpu', \"Linux x86_64\");"));
+      expect(s, contains("def('buildID', '20181001000000');"));
+      expect(s, isNot(contains("def('platform'")));
+    });
+
+    test('Gecko desktop windows/macos oscpu tokens', () {
+      expect(buildUserAgentIdentityShim(firefoxWindowsDesktopUserAgent)!,
+          contains("def('oscpu', \"Windows NT 10.0; Win64; x64\");"));
+      expect(buildUserAgentIdentityShim(firefoxMacosDesktopUserAgent)!,
+          contains("def('oscpu', \"Intel Mac OS X 10.15\");"));
+    });
+
+    test('WebKit mobile (FxiOS): Apple vendor, webkit productSub, '
+        'oscpu/buildID/userAgentData removed, iPhone platform', () {
+      final s = buildUserAgentIdentityShim(buildFirefoxIosUserAgent('152.0'))!;
+      expect(s, contains("def('vendor', \"Apple Computer, Inc.\");"));
+      expect(s, contains("def('productSub', \"20030107\");"));
+      expect(s, contains("removeProp('oscpu');"));
+      expect(s, contains("removeProp('buildID');"));
+      expect(s, contains("removeProp('userAgentData');"));
+      expect(s, contains("def('platform', \"iPhone\");"));
+    });
+
+    test('Blink mobile (Chrome-Android): Google vendor, webkit productSub, '
+        'no oscpu, keeps userAgentData', () {
+      final s = buildUserAgentIdentityShim(_chromeAndroid)!;
+      expect(s, contains("def('vendor', \"Google Inc.\");"));
+      expect(s, contains("def('productSub', \"20030107\");"));
+      expect(s, contains("removeProp('oscpu');"));
+      expect(s, contains("def('platform', \"Linux armv8l\");"));
+      // Blink keeps userAgentData — it must NOT be removed.
+      expect(s, isNot(contains("removeProp('userAgentData')")));
+    });
+  });
+}

--- a/tool/dump_shim_js.dart
+++ b/tool/dump_shim_js.dart
@@ -30,6 +30,7 @@ import 'package:webspace/services/target_blank_rewrite.dart';
 import 'package:webspace/services/location_spoof_service.dart';
 import 'package:webspace/services/theme_color_scheme_shim.dart';
 import 'package:webspace/services/user_agent_classifier.dart';
+import 'package:webspace/services/user_agent_identity_shim.dart';
 import 'package:webspace/services/user_script_shim.dart';
 import 'package:webspace/settings/location.dart';
 
@@ -171,6 +172,22 @@ Map<String, String> buildAllFixtures() {
   fixtures['language/en.js'] = buildLanguageShim('en');
   fixtures['language/fr_FR.js'] = buildLanguageShim('fr-FR');
   fixtures['language/ja.js'] = buildLanguageShim('ja');
+
+  // Engine-consistent navigator identity, one fixture per engine × form
+  // factor: Gecko mobile (Firefox-Android — vendor "", oscpu/buildID set,
+  // platform "Linux armv8l"), Gecko desktop (no platform override), WebKit
+  // mobile (FxiOS — Apple vendor, no oscpu/buildID, userAgentData removed),
+  // Blink mobile (Chrome-Android — Google vendor, userAgentData kept).
+  fixtures['ua_identity/firefox_android.js'] =
+      buildUserAgentIdentityShim(buildFirefoxAndroidUserAgent('152.0'))!;
+  fixtures['ua_identity/firefox_linux_desktop.js'] =
+      buildUserAgentIdentityShim(firefoxLinuxDesktopUserAgent)!;
+  fixtures['ua_identity/fxios.js'] =
+      buildUserAgentIdentityShim(buildFirefoxIosUserAgent('152.0'))!;
+  fixtures['ua_identity/chrome_android.js'] = buildUserAgentIdentityShim(
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 '
+    '(KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+  )!;
 
   fixtures['theme_color_scheme/light.js'] = buildThemeColorSchemeShim('light');
   fixtures['theme_color_scheme/dark.js'] = buildThemeColorSchemeShim('dark');


### PR DESCRIPTION
Implements the User-Agent Identity Consistency feature (UAID spec) to prevent fingerprinting leaks when a per-site UA is set.

When a spoofed UA is applied, the wire-level User-Agent header changes but the navigator identity fields (`vendor`, `vendorSub`, `productSub`, `oscpu`, `buildID`, `platform`, `userAgentData`) remain from the host engine. This creates a detectable contradiction: e.g., a Firefox-for-Android (Gecko) UA on iOS WebKit still reports `navigator.vendor = "Apple Computer, Inc."` and `navigator.platform = "iPhone"`, which fingerprinting suites (CreepJS, fingerprintjs) trivially catch.

**Key changes:**

- **New shim builder** (`lib/services/user_agent_identity_shim.dart`): Derives the claimed engine from the per-site UA via `inferUaEngine()`, then generates a JavaScript shim that forces navigator identity fields to the values that engine actually emits. Handles engine-specific constants (vendor, productSub) and OS-specific values (oscpu, platform). Presence-sensitive properties (oscpu, buildID, userAgentData) are deleted rather than stubbed so `'oscpu' in navigator` consistency checks pass.

- **Engine classification** (`lib/services/user_agent_classifier.dart`): Added `UaEngine` enum and `inferUaEngine()` function. iOS mandates WebKit, so any Apple mobile-browser brand token (FxiOS/CriOS/EdgiOS/OPiOS) classifies as webkit regardless of brand. Real Gecko carries `Gecko/<digits>` build token plus `Firefox/`; WebKit/Blink carry only the `(KHTML, like Gecko)` marker.

- **Shim injection** (`lib/services/webview.dart`): Integrated the identity shim into the webview injection pipeline alongside existing shims (language, anti-fingerprinting, desktop-mode).

- **Language shim enhancement** (`lib/services/language_shim.dart`): Expanded to force the *actual* formatting locale of the entire `Intl` subsystem (DateTimeFormat, NumberFormat, RelativeTimeFormat, etc.) and `Date`/`Number` `toLocale*` methods, not just relabel `resolvedOptions().locale`. The naive approach (only relabelling) is detectable: a fingerprinter reads `navigator.language` then formats a locale-less date and sees the OS locale in the output. Now injects the per-site tag as the default `locales` argument when the caller omits it, so both the label and the formatted output reflect the per-site language. Sites passing explicit locales are left untouched.

- **Anti-fingerprinting enhancement** (`lib/services/anti_fingerprinting_shim.dart`): Added `window.matchMedia` wrapper for device-dimension queries. CSS `(min-|max-)device-width/height` media queries previously resolved against the real screen, allowing fingerprinters to binary-search and recover true device size (CreepJS's "CSS Media Queries" leak). Now intercepts single-feature device-width/height queries and answers against the same dimensions `screen.*` reports.

- **Comprehensive tests**: Dart unit tests for engine classification and shim generation; JavaScript tests (jsdom) validating navigator identity consistency across Gecko/WebKit/Blink and mobile/desktop; language shim tests confirming actual formatting output (not just labels) matches the per-site language; anti-fingerprinting tests for matchMedia device-dimension agreement.

- **Formal spec** (`openspec/specs/user-agent-identity/spec.md`): Documents requirements, engine classification rules, and identity field mappings per engine and OS.

The shim runs at DOCUMENT_START, forMainFrameOnly: false, for every per-site UA. It only touches identity fields and does not overlap with desktop_mode_shim (which owns platform/userAgentData/maxTouchPoints for desktop UAs, matchMedia pointer/hover, viewport) or the anti-fingerprinting shim.

https://claude.ai/code/session_01RvpnjrMXNqbhEXP7nER8Q2