### PR TITLE
Bump Android targetSdkVersion to 36 (Android 16)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -61,7 +61,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion flutter.minSdkVersion
-        targetSdkVersion 35
+        targetSdkVersion 36
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }


### PR DESCRIPTION
Google Play requires apps to target within one year of the latest Android release; from 2026-08-31 updates require API 36. compileSdk was already 36 and edge-to-edge is handled, so this is the target bump.