### PR TITLE
Repaint Android surface on warm-start metrics signal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@ WebSpace: Flutter app managing multiple websites with per-site cookie isolation 
 ## Style (output, code, commits)
 
 - No preamble, no closing fluff, no em-dashes, no emoji.
+- Don't use the phrase "load-bearing".
 - Code first; explain only the non-obvious.
 - Default to **no code comments**. Only add when the *why* is non-obvious (hidden constraint, workaround for a specific bug, surprising behavior). Never restate what the code does. Never reference the current task or PR.
 - Commit messages: short subject (<70 chars, imperative), 1-2 line body for the *why* if needed. No marketing prose, no bullet lists of every changed file, no "this commit also...".

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -138,10 +138,23 @@ assumption that the nudge physically recomposites on the device (see the TLAPS r
 in gap #4 below).
 
 ### Attempt 8 — Repaint on the surface-attach signal for a warm start (`PAUSE-020`)
-**Date:** 2026-07-23 · **Files:** lib/main.dart, openspec/specs/webview-pause-lifecycle/spec.md
+**Date:** 2026-07-23 · **Files:** lib/main.dart, lib/services/surface_repaint_engine.dart,
+formal/warmstart.tla (+ cfgs, check.sh), test/surface_repaint_engine_test.dart,
+test/js/surface_repaint_funnel.test.js, openspec/specs/webview-pause-lifecycle/spec.md
 **What it did:** On `resumed`, `_openResumeRepaintWindow` opens a bounded (~3s)
 window; while open, the new `didChangeMetrics` override fires `_nudgeSurfaceRepaint`.
 Additive to Attempt 2's tail nudge in `_onResumed`, which still fires once.
+**Reproduced + proved (mechanism, not device):** the warm-start ordering the kernel
+could not express (gap #4) is reproduced as a model-checked counterexample in
+`formal/warmstart.tla` (`warmstart_bug.cfg`, Fix="none"): `Resume` schedules the one-shot
+nudge, it drains to `nudging=0` while still painted, then `SurfaceReattach` sets the
+surface blank and it stutters blank forever → `RepaintLiveness` violated. The fix
+(`warmstart.cfg`, Fix="attach": the reattach itself schedules a nudge) makes the property
+hold. Mirrored, runnable without TLC, in `test/surface_repaint_engine_test.dart`
+(`SurfaceRepaintEngine` gained `owed`/`attach()`; a late `attach()` with no re-nudge stays
+`owed`; the metrics re-nudge clears it), and gated in `surface_repaint_funnel.test.js`.
+These prove the *ordering* is real and that an attach-triggered re-nudge closes it; they do
+**not** prove the device link below.
 **Why:** Reported as a **white** screen on **warm-starting** a site (app backgrounded,
 then foregrounded — no activity recreation, so neither `onControllerReady` (Attempt 4)
 nor a back path (Attempts 5–6) runs; only the resume path (Attempt 2) does). On a warm
@@ -187,6 +200,20 @@ event) rather than closing it.
    code↔model bridge that is meant to catch gap #3 — `formal/trace/` plus the
    `surface_repaint_funnel` structural gate — is scoped to `lib/main.dart` back paths, not the
    memory-pressure/lifecycle path Attempt 7 covers, so that path is not yet gated.
+   **Attempt 8 partly addresses this for the warm-start ordering**: `formal/warmstart.tla`
+   drops the kernel's magic `WF_vars(Nudge)` and models the nudge as an event-triggered
+   one-shot with a *separate* async `SurfaceReattach`, so the bad interleaving (reattach after
+   the resume nudge drains) is now a reachable, model-checked counterexample instead of an
+   unmodeled path; the `surface_repaint_funnel` gate now also covers the `didChangeMetrics`
+   resume path. The kernel's TLAPS proof is still over the atomic-attach `GoodNext`, so the
+   two models disagree by design — `warmstart.tla` is the faithful one for this ordering.
+5. **The device link is unproven.** The whole fix rests on `didChangeMetrics` actually firing
+   when the webview `SurfaceView` re-attaches on a real warm resume. Flutter can dedupe
+   identical window metrics, and the callback tracks the main FlutterView, not the webview
+   platform view. If it does not fire on the affected device, Attempt 8 is a no-op there. The
+   new `SurfaceDiag` line `trigger=metrics-resume -> nudge` exists to confirm this from a
+   device log; until such a trace exists, the causal claim (this fixes the reported warm-start
+   white screen) is unverified.
 
 ## Guardrails now in place
 
@@ -194,11 +221,23 @@ event) rather than closing it.
   (every blank-surface attach is eventually repainted); the `bypass` demonstrator *is*
   this bug and TLC rejects it. Liveness backbone proved for unbounded N in
   [formal/proofs/repaint_liveness.tla](../../formal/proofs/repaint_liveness.tla).
+- **Warm-start model** ([formal/warmstart.tla](../../formal/warmstart.tla), run by
+  `formal/check.sh`): models the nudge as an event-triggered one-shot with a *separate*
+  async `SurfaceReattach` (no magic `WF(Nudge)`), so the warm-start ordering the kernel
+  can't see (gap #4) is a reachable counterexample. `warmstart_bug.cfg` (Fix="none")
+  reproduces BUG-001 (`RepaintLiveness` violated); `warmstart.cfg` (Fix="attach")
+  proves the attach-triggered re-nudge closes it; `warmstart_reach.cfg` proves the
+  ordering is reachable (non-vacuous).
+- **Engine characterization** ([test/surface_repaint_engine_test.dart](../../test/surface_repaint_engine_test.dart),
+  runs under `fvm flutter test`): the same ordering in runnable Dart. `SurfaceRepaintEngine`
+  tracks `owed`; a late `attach()` with no re-nudge stays `owed` (reproduction), the metrics
+  re-nudge clears it (fix), including a timing-faithful 800ms-reattach case.
 - **Structural gate** ([test/js/surface_repaint_funnel.test.js](../../test/js/surface_repaint_funnel.test.js),
   runs under `npm run test:js` in CI): on the main page, every Android `controller.goBack()`
   must route through `_goBackAndRepaint`. A new raw back path (the recurrence shape of
-  Attempts 2–5) fails CI. Partial: scoped to `lib/main.dart`; the nested screen (gap #1)
-  is not yet gated.
+  Attempts 2–5) fails CI. Now also asserts the warm-start wiring: `didChangeMetrics` re-nudges
+  within the post-resume window, and a resume opens that window. Partial: scoped to
+  `lib/main.dart`; the nested screen (gap #1) is not yet gated.
 
 ## Diagnostic checklist (when this recurs)
 

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -137,6 +137,32 @@ class. It also does not *prove* the memory-pressure event was this user's trigge
 assumption that the nudge physically recomposites on the device (see the TLAPS refinement gap
 in gap #4 below).
 
+### Attempt 8 — Repaint on the surface-attach signal for a warm start (`PAUSE-020`)
+**Date:** 2026-07-23 · **Files:** lib/main.dart, openspec/specs/webview-pause-lifecycle/spec.md
+**What it did:** On `resumed`, `_openResumeRepaintWindow` opens a bounded (~3s)
+window; while open, the new `didChangeMetrics` override fires `_nudgeSurfaceRepaint`.
+Additive to Attempt 2's tail nudge in `_onResumed`, which still fires once.
+**Why:** Reported as a **white** screen on **warm-starting** a site (app backgrounded,
+then foregrounded — no activity recreation, so neither `onControllerReady` (Attempt 4)
+nor a back path (Attempts 5–6) runs; only the resume path (Attempt 2) does). On a warm
+start the hybrid-composition `SurfaceView`'s surface is destroyed on background and
+**re-created on foreground**, and that re-attach can land a frame or more *after*
+`_onResumed`'s single tail nudge has already drained its ~0.7s budget — so the inset
+flips before the surface exists and the freshly-attached surface stays blank. A surface
+re-attach re-lays-out the window, which Flutter delivers as `didChangeMetrics`: the
+closest Dart-side signal to the *actual attach*, versus every prior attempt's reliance on
+a lifecycle *event* whose timing only approximates the attach. Nudging on the metrics
+signal lands a size-flip on the surface whenever it comes back, not at a fixed guessed
+delay. Bounded to the post-resume window so steady-state keyboard/rotation metric changes
+don't nudge; `_nudgeSurfaceRepaint` coalescing keeps a metrics burst on one loop.
+**Why partial:** Still not the durable single chokepoint (gap #3). `didChangeMetrics` is a
+*proxy* for the attach — it fires for the main FlutterView's metrics, which correlate with
+but are not identical to the webview platform-view's `SurfaceView` re-attach, and it is not
+*guaranteed* to fire on every device's warm resume (hence the tail nudge is kept as a
+fallback). The real fix is still a native surface-changed/-redrawn callback from the fork
+driving the repaint. This attempt narrows gap #3 (keys on an attach signal, not a lifecycle
+event) rather than closing it.
+
 ## Known open gaps (candidates for the next recurrence)
 
 1. ~~Nested `InAppWebViewScreen`~~ — **closed by Attempt 6** (now funneled + gated).
@@ -146,7 +172,10 @@ in gap #4 below).
 3. **The class isn't closed.** Every fix is per-path. The durable fix is a **single
    chokepoint** that nudges on *every* surface (re)attach — ideally a native
    surface-changed/-redrawn callback from the fork driving the repaint — instead of
-   enumerating Dart-side navigation paths forever.
+   enumerating Dart-side navigation paths forever. **Attempt 8 narrows this**: it keys the
+   warm-start repaint on `didChangeMetrics` (a Dart-side *proxy* for the surface attach)
+   rather than a lifecycle event, but a proxy is not the native callback and is not
+   guaranteed to fire on every device, so the gap stands.
 4. **The TLAPS proof doesn't cover the recurrence — by construction.**
    `RepaintLiveness` is proved over `GoodSpec`/`GoodNext`, a *fixed* set of attach actions
    (`Activate`, `Resume`, `ControllerAttach`, `Back`, `Forward`, `LoadSite`, `Evict`), each of

--- a/formal/check.sh
+++ b/formal/check.sh
@@ -76,6 +76,14 @@ expect renderer_noprobe.cfg renderer.tla "Temporal properties were violated" \
 expect renderer_reach.cfg renderer.tla "Reach_VisibleDead is violated" \
   "a visible dead renderer is reachable (Recovered not vacuous)"
 
+echo "── WARMSTART: BUG-001 warm-start white screen (PAUSE-020, Attempt 8) ──"
+expect warmstart.cfg warmstart.tla "No error has been found" \
+  "an attach-triggered nudge repaints every warm-start SurfaceView reattach"
+expect warmstart_bug.cfg warmstart.tla "Temporal propert(y|ies).*violated" \
+  "a reattach after the resume one-shot nudge drains is left blank (reproduced + caught)"
+expect warmstart_reach.cfg warmstart.tla "Reach_LateReattach is violated" \
+  "the late-reattach ordering is reachable (RepaintLiveness not vacuous)"
+
 echo "── PROXY: mutual exclusion (Android serialises mismatched-proxy sites) ──"
 expect proxy.cfg proxy.tla "No error has been found" \
   "every loaded site shares the active proxy"

--- a/formal/warmstart.cfg
+++ b/formal/warmstart.cfg
@@ -1,0 +1,12 @@
+\* BUG-001 warm-start FIXED (Attempt 8 / PAUSE-020): the SurfaceView reattach
+\* itself schedules a nudge (didChangeMetrics re-nudge within the post-resume
+\* window is the attach-signal proxy). Expect: RepaintLiveness holds.
+CONSTANTS
+    K = 2
+    Fix = "attach"
+SPECIFICATION Spec
+INVARIANTS
+    TypeOK
+PROPERTIES
+    RepaintLiveness
+CHECK_DEADLOCK FALSE

--- a/formal/warmstart.tla
+++ b/formal/warmstart.tla
@@ -1,0 +1,115 @@
+---------------------------- MODULE warmstart ----------------------------
+(***************************************************************************)
+(* BUG-001 warm-start white screen, formalized (PAUSE-020, Attempt 8).     *)
+(*                                                                         *)
+(* The kernel models the surface repaint with `Resume == Attach` (the      *)
+(* attach is ATOMIC with the resume event) plus `WF_vars(Nudge)` (a        *)
+(* repaint is ALWAYS eventually available whenever one is owed). Under      *)
+(* those two assumptions warm-start is trivially safe -- which is exactly   *)
+(* why the kernel cannot see this bug (docs/bugs/001-white-screen.md gap    *)
+(* #4). Both assumptions are false on a real warm start:                    *)
+(*                                                                         *)
+(*   1. The Android hybrid-composition SurfaceView is destroyed on          *)
+(*      background and RE-CREATED on foreground. That re-attach is a         *)
+(*      SEPARATE, asynchronous event -- it does not coincide with the       *)
+(*      `resumed` lifecycle callback and can land a frame or more LATER.     *)
+(*   2. `_nudgeSurfaceRepaint` is not a magic always-available repaint. It   *)
+(*      is a ONE-SHOT tick loop fired by a specific trigger and then         *)
+(*      drains. Once it drains it is gone.                                   *)
+(*                                                                         *)
+(* So the defect is an ORDERING: the resume one-shot nudge fires and drains  *)
+(* BEFORE the async SurfaceReattach, leaving a blank surface with nothing    *)
+(* left to repaint it. This module models the nudge realistically (an        *)
+(* event-triggered one-shot, WF on the tick, NOT on an abstract Nudge) and   *)
+(* the reattach as its own action, so the bad interleaving is reachable.     *)
+(*                                                                         *)
+(* Fix knob:                                                                *)
+(*   "none"   = pre-fix. Only Resume schedules a nudge. A reattach after the *)
+(*              resume nudge drains is never repainted -> RepaintLiveness     *)
+(*              is VIOLATED (this is the reproduction).                       *)
+(*   "attach" = Attempt 8. The reattach itself schedules a nudge (the        *)
+(*              didChangeMetrics re-nudge within the post-resume window is a  *)
+(*              proxy for the attach signal) -> RepaintLiveness HOLDS.        *)
+(*                                                                         *)
+(* This is the model counterpart of the durable fix in gap #3: nudge on the  *)
+(* ATTACH, not on a lifecycle event that only approximates its timing.       *)
+(***************************************************************************)
+EXTENDS Naturals
+
+CONSTANTS
+    K,     \* nudge ticks per one-shot loop (bounds the state space; K >= 1)
+    Fix    \* "none" | "attach" -- see header
+
+VARIABLES
+    surface,     \* visible site's Android surface: "painted" | "blank"
+    owed,        \* a repaint is owed: a blank surface attached, not yet repainted
+    nudging,     \* ticks remaining in the active one-shot nudge loop (0 = idle)
+    resumed,     \* a foreground resume has occurred (arms the warm-start reattach)
+    reattached   \* the warm-start SurfaceView reattach has fired (bounds the space)
+
+vars == << surface, owed, nudging, resumed, reattached >>
+
+TypeOK ==
+    /\ surface \in {"painted", "blank"}
+    /\ owed \in BOOLEAN
+    /\ nudging \in 0..K
+    /\ resumed \in BOOLEAN
+    /\ reattached \in BOOLEAN
+
+Init ==
+    /\ surface = "painted"
+    /\ owed = FALSE
+    /\ nudging = 0
+    /\ resumed = FALSE
+    /\ reattached = FALSE
+
+\* App returns to foreground. `_onResumed` fires its single tail nudge
+\* (PAUSE-015): schedule a one-shot loop. The surface has NOT necessarily
+\* re-attached yet -- that is the separate SurfaceReattach below.
+Resume ==
+    /\ ~resumed
+    /\ resumed' = TRUE
+    /\ nudging' = K
+    /\ UNCHANGED << surface, owed, reattached >>
+
+\* One nudge tick (`_nudgeSurfaceRepaint` toggling the 1px inset). A relayout
+\* repaints whatever surface is currently attached, so it clears any owed
+\* repaint. When owed is already false this is a harmless no-op tick.
+Tick ==
+    /\ nudging > 0
+    /\ nudging' = nudging - 1
+    /\ surface' = "painted"
+    /\ owed' = FALSE
+    /\ UNCHANGED << resumed, reattached >>
+
+\* The warm-start SurfaceView re-attaches blank -- the real BUG-001 mechanism,
+\* modeled as its own asynchronous event that can interleave anywhere after the
+\* resume. Under Fix="attach" the attach signal (didChangeMetrics within the
+\* post-resume window) schedules a nudge; under "none" it does not.
+SurfaceReattach ==
+    /\ resumed
+    /\ ~reattached
+    /\ reattached' = TRUE
+    /\ surface' = "blank"
+    /\ owed' = TRUE
+    /\ nudging' = IF Fix = "attach" THEN K ELSE nudging
+    /\ UNCHANGED << resumed >>
+
+Next == Resume \/ Tick \/ SurfaceReattach
+
+\* Weak fairness on the TICK, not on an abstract always-available repaint: a
+\* scheduled nudge loop runs to completion. Crucially, when no nudge is
+\* scheduled (nudging = 0) Tick is DISABLED, so fairness offers no rescue --
+\* that is the whole point, and what the kernel's WF_vars(Nudge) papered over.
+Spec == Init /\ [][Next]_vars /\ WF_vars(Tick)
+
+\* LIVENESS (BUG-001): every blank-surface attach is eventually repainted.
+\* Violated by Fix="none" (the warm-start reproduction); holds for "attach".
+RepaintLiveness == [] (surface = "blank" => <> (surface = "painted"))
+
+\* Anti-vacuity witness (expect violated): the bad ordering -- a reattach that
+\* lands after the resume nudge has fully drained -- is actually reachable, so
+\* the liveness check above is exercised against the real failure, not held
+\* vacuously.
+Reach_LateReattach == ~(owed = TRUE /\ nudging = 0 /\ reattached = TRUE)
+=============================================================================

--- a/formal/warmstart_bug.cfg
+++ b/formal/warmstart_bug.cfg
@@ -1,0 +1,12 @@
+\* BUG-001 warm-start REPRODUCTION (pre-Attempt-8): only Resume schedules a
+\* one-shot nudge, so an asynchronous reattach landing AFTER it drains is left
+\* blank with nothing to repaint it. Expect: RepaintLiveness VIOLATED.
+CONSTANTS
+    K = 2
+    Fix = "none"
+SPECIFICATION Spec
+INVARIANTS
+    TypeOK
+PROPERTIES
+    RepaintLiveness
+CHECK_DEADLOCK FALSE

--- a/formal/warmstart_reach.cfg
+++ b/formal/warmstart_reach.cfg
@@ -1,0 +1,10 @@
+\* Anti-vacuity witness: the bad ordering -- a reattach after the resume nudge
+\* has fully drained (owed, nudging=0) -- is actually reachable, so the liveness
+\* check is exercised against the real failure. Expect: Reach_LateReattach VIOLATED.
+CONSTANTS
+    K = 2
+    Fix = "none"
+SPECIFICATION Spec
+INVARIANTS
+    Reach_LateReattach
+CHECK_DEADLOCK FALSE

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1416,10 +1416,23 @@ class _WebSpacePageState extends State<WebSpacePage>
   @override
   void dispose() {
     _foregroundPollTimer?.cancel();
+    _resumeRepaintWindowTimer?.cancel();
     _navStateDebouncer.dispose();
     _untrustSub?.cancel();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
+  }
+
+  @override
+  void didChangeMetrics() {
+    super.didChangeMetrics();
+    // A warm-start SurfaceView re-attach re-lays-out the window and lands here,
+    // typically after `_onResumed`'s one-shot tail nudge has already drained.
+    // Re-nudge on this real attach signal, bounded to the post-resume window so
+    // steady-state metric changes (keyboard, rotation) don't nudge.
+    // `_nudgeSurfaceRepaint` coalesces, so a burst of metric changes keeps a
+    // single loop alive rather than spawning competing ones. PAUSE-020 / BUG-001.
+    if (_resumeRepaintWindowOpen) _nudgeSurfaceRepaint();
   }
 
   @override
@@ -1589,6 +1602,10 @@ class _WebSpacePageState extends State<WebSpacePage>
       if (_maskBackground) {
         setState(() => _maskBackground = false);
       }
+      // Open the warm-start repaint window before the async resume sequence, so
+      // a late SurfaceView re-attach (which surfaces as a metrics change) is
+      // caught even though `_onResumed`'s tail nudge fires only once. PAUSE-020.
+      _openResumeRepaintWindow();
       _startForegroundPollTimer();
       // Resume + shortcut + share are sequenced in _onResumed: the
       // app-lifecycle resume must finish before a shortcut intent switches
@@ -1607,6 +1624,33 @@ class _WebSpacePageState extends State<WebSpacePage>
   }
 
   bool _isResuming = false;
+
+  // Warm-start blank-surface repaint window (PAUSE-020 / BUG-001 Attempt 8).
+  // On Android the hybrid-composition webview SurfaceView can re-attach a frame
+  // or more AFTER `resumed` fires — later than the single tail nudge in
+  // `_onResumed`, so that nudge flips the 1px inset before the surface exists
+  // and the page comes back blank-white. A surface (re)attach re-lays-out the
+  // window, which Flutter delivers as `didChangeMetrics`. That is the closest
+  // Dart-side signal to the actual attach (every prior attempt nudged on a
+  // lifecycle event instead), so we re-nudge on it — but only inside a short
+  // window after resume, so steady-state metric changes (keyboard, rotation)
+  // don't nudge. Android-only; the timer is never armed off Android.
+  bool _resumeRepaintWindowOpen = false;
+  Timer? _resumeRepaintWindowTimer;
+
+  /// Open the post-resume repaint window (see [_resumeRepaintWindowOpen]).
+  /// While open, a `didChangeMetrics` — the surface (re)attach signal — fires
+  /// `_nudgeSurfaceRepaint`, catching a SurfaceView that comes back after the
+  /// `_onResumed` tail nudge has already drained.
+  void _openResumeRepaintWindow() {
+    if (!Platform.isAndroid) return;
+    _resumeRepaintWindowOpen = true;
+    _resumeRepaintWindowTimer?.cancel();
+    _resumeRepaintWindowTimer = Timer(const Duration(seconds: 3), () {
+      _resumeRepaintWindowOpen = false;
+      _resumeRepaintWindowTimer = null;
+    });
+  }
 
   /// Run the resume sequence in a fixed order. The app-lifecycle resume
   /// (drains the in-flight `pauseForAppLifecycle`, resumes process-global JS

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1432,7 +1432,15 @@ class _WebSpacePageState extends State<WebSpacePage>
     // steady-state metric changes (keyboard, rotation) don't nudge.
     // `_nudgeSurfaceRepaint` coalesces, so a burst of metric changes keeps a
     // single loop alive rather than spawning competing ones. PAUSE-020 / BUG-001.
-    if (_resumeRepaintWindowOpen) _nudgeSurfaceRepaint();
+    if (!_resumeRepaintWindowOpen) return;
+    // Non-sensitive one-liner (no site name / URL), safe to share: confirms
+    // on-device that a warm-start surface reattach actually surfaces here as a
+    // metrics change, the premise Attempt 8 depends on. Bounded to the window,
+    // so it is not emitted for steady-state metric changes. See PAUSE-020.
+    if (Platform.isAndroid) {
+      LogService.instance.log('SurfaceDiag', 'trigger=metrics-resume -> nudge');
+    }
+    _nudgeSurfaceRepaint();
   }
 
   @override
@@ -1627,7 +1635,7 @@ class _WebSpacePageState extends State<WebSpacePage>
 
   // Warm-start blank-surface repaint window (PAUSE-020 / BUG-001 Attempt 8).
   // On Android the hybrid-composition webview SurfaceView can re-attach a frame
-  // or more AFTER `resumed` fires — later than the single tail nudge in
+  // or more AFTER `resumed` fires, later than the single tail nudge in
   // `_onResumed`, so that nudge flips the 1px inset before the surface exists
   // and the page comes back blank-white. A surface (re)attach re-lays-out the
   // window, which Flutter delivers as `didChangeMetrics`. That is the closest
@@ -1639,7 +1647,7 @@ class _WebSpacePageState extends State<WebSpacePage>
   Timer? _resumeRepaintWindowTimer;
 
   /// Open the post-resume repaint window (see [_resumeRepaintWindowOpen]).
-  /// While open, a `didChangeMetrics` — the surface (re)attach signal — fires
+  /// While open, a `didChangeMetrics` (the surface (re)attach signal) fires
   /// `_nudgeSurfaceRepaint`, catching a SurfaceView that comes back after the
   /// `_onResumed` tail nudge has already drained.
   void _openResumeRepaintWindow() {

--- a/lib/services/surface_repaint_engine.dart
+++ b/lib/services/surface_repaint_engine.dart
@@ -39,12 +39,28 @@ class SurfaceRepaintEngine {
   int _ticksRemaining = 0;
   bool _looping = false;
   bool _inset = false;
+  bool _owed = false;
 
   /// Current 1px-inset state to render.
   bool get inset => _inset;
 
   /// Whether a tick loop is currently running.
   bool get isLooping => _looping;
+
+  /// Whether a blank-surface (re)attach is still owed a repaint. Mirrors
+  /// `owed` in formal/kernel.tla and formal/warmstart.tla: [attach] sets it,
+  /// a nudge [tick] clears it. The warm-start bug (BUG-001 Attempt 8 /
+  /// PAUSE-020) is precisely an [attach] that lands after the triggering
+  /// event's one-shot loop has drained, so no tick runs against it and this
+  /// stays true; see test/surface_repaint_engine_test.dart.
+  bool get owed => _owed;
+
+  /// A blank hybrid-composition SurfaceView (re)attached: a repaint is owed
+  /// until a nudge tick runs against it. The visible-surface counterpart of
+  /// `Attach` in the formal models. Idempotent.
+  void attach() {
+    _owed = true;
+  }
 
   /// True iff [t] re-attaches the visible surface and so must be followed by a
   /// repaint. The complete set is the contract; mirrors `Attach` in kernel.tla.
@@ -73,6 +89,10 @@ class SurfaceRepaintEngine {
     }
     _ticksRemaining--;
     _inset = !_inset;
+    // A relayout tick recomposites whatever surface is currently attached, so
+    // it clears any owed repaint. A late attach with no subsequent tick is the
+    // warm-start defect: `owed` stays true (formal/warmstart.tla, Fix="none").
+    _owed = false;
     return RepaintTick(inset: _inset, done: false);
   }
 

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -651,6 +651,8 @@ A surface (re)attach re-lays-out the window, which Flutter delivers to the host 
 
 This narrows BUG-001 open gap #3 (the fix should key on the attach, not the lifecycle event) without closing it: `didChangeMetrics` is a proxy for the attach, not a native surface-changed callback from the fork, which remains the durable single-chokepoint fix.
 
+The ordering is model-checked in [formal/warmstart.tla](../../../formal/warmstart.tla): with only the resume one-shot nudge (`Fix="none"`) an async `SurfaceReattach` landing after it drains leaves the surface blank forever and `RepaintLiveness` is violated (the reproduction); an attach-triggered re-nudge (`Fix="attach"`) makes it hold. This is the ordering the kernel's atomic `Resume == Attach` plus `WF_vars(Nudge)` cannot express (BUG-001 gap #4). The runnable counterpart is `test/surface_repaint_engine_test.dart` (the `SurfaceRepaintEngine` `owed`/`attach` characterization), and the wiring is held by the `surface_repaint_funnel` structural gate. The device premise (that `didChangeMetrics` fires on the webview surface reattach) is confirmed by the `SurfaceDiag` `trigger=metrics-resume` log line, not by these models.
+
 #### Scenario: SurfaceView re-attaches after the resume nudge drained
 
 **Given** a site is visible on Android and the user backgrounded the app, then returns (warm start, no activity recreation)

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -643,6 +643,29 @@ Every `_probeRendererAndRecover` call SHALL carry a `trigger` label and emit one
 
 ---
 
+### Requirement: PAUSE-020 — Warm-Start Repaint On The Surface-Attach Signal
+
+On Android, the system SHALL re-fire the surface repaint when the visible webview's `SurfaceView` re-attaches after a warm resume, not only once at the tail of `_onResumed`. On a warm start (the process stayed alive; the user backgrounded the app and returned) the hybrid-composition `SurfaceView`'s surface is destroyed on background and re-created on foreground. That re-attach can land a frame or more **after** `AppLifecycleState.resumed` fires — later than `_onResumed`'s single tail nudge (PAUSE-015), so the 1px inset toggles before the surface exists and the freshly-attached-but-unpainted surface stays blank (rendering **white**, the fresh surface's default fill). This is the same class as PAUSE-015/017/018 reached through a new trigger: every prior fix nudged on a Dart-side *lifecycle event*, but the defect is tied to the *surface (re)attach*, which those events only approximate in time.
+
+A surface (re)attach re-lays-out the window, which Flutter delivers to the host as `didChangeMetrics` — the closest Dart-side signal to the actual attach. The host SHALL, on `resumed`, open a bounded repaint window (`_openResumeRepaintWindow`, ~3s) and, while it is open, fire `_nudgeSurfaceRepaint` from `didChangeMetrics`. The window bound keeps steady-state metric changes (keyboard show/hide, rotation) from nudging; `_nudgeSurfaceRepaint` coalesces, so a burst of metric changes keeps a single tick loop alive rather than spawning competing loops. This is additive to PAUSE-015's tail nudge (which still covers the surface that was already attached by the time the sequence settled) and is a no-op off Android.
+
+This narrows BUG-001 open gap #3 (the fix should key on the attach, not the lifecycle event) without closing it: `didChangeMetrics` is a proxy for the attach, not a native surface-changed callback from the fork, which remains the durable single-chokepoint fix.
+
+#### Scenario: SurfaceView re-attaches after the resume nudge drained
+
+**Given** a site is visible on Android and the user backgrounded the app, then returns (warm start, no activity recreation)
+**And** the webview `SurfaceView` re-attaches blank after `_onResumed`'s tail `_nudgeSurfaceRepaint` has already settled
+**When** the re-attach re-lays-out the window and `didChangeMetrics` fires within the post-resume window
+**Then** `_nudgeSurfaceRepaint` runs again and recomposites the surface, so the page paints without the user rotating, locking, or switching tabs
+
+#### Scenario: Steady-state metric changes do not nudge
+
+**Given** the app has been foreground on Android longer than the post-resume window
+**When** `didChangeMetrics` fires for a keyboard show/hide or rotation
+**Then** the window is closed, so no repaint nudge runs and the visible site does not jitter
+
+---
+
 ### Requirement: PAUSE-016 — Android Per-Instance Pause Is a No-Op
 
 On Android the per-instance `pause()` / `resume()` (`WebView.onPause()` / `onResume()`) SHALL be no-ops. Android exposes no per-instance JavaScript pause — `onPause()` halts only animations and geolocation and explicitly does not pause JS, while the only JS-timer pause (`pauseTimers()`) is process-global. So per-instance pause contributes nothing to the lifecycle freeze, yet cycling the foreground hybrid-composition `SurfaceView` through onPause/onResume re-attaches it blank on the next paint — the white screen the user hits after a transient background or a navigation that follows a resume.

--- a/test/js/surface_repaint_funnel.test.js
+++ b/test/js/surface_repaint_funnel.test.js
@@ -66,3 +66,32 @@ for (const rel of GUARDED) {
     );
   });
 }
+
+// Warm-start repaint gate (PAUSE-020 / BUG-001 Attempt 8). The kernel's magic
+// WF(Nudge) hid the warm-start ordering (bug doc gap #4): the resume nudge is a
+// one-shot that can fire before the async SurfaceView reattach. The fix re-fires
+// the nudge on didChangeMetrics — the attach signal — inside a bounded
+// post-resume window. This gate keeps that wiring from being silently dropped;
+// its ordering is proved in formal/warmstart.tla and test/surface_repaint_engine_test.dart.
+{
+  const lines = linesOf('lib/main.dart');
+  const src = lines.join('\n');
+
+  test('lib/main.dart: didChangeMetrics re-nudges within the post-resume window', () => {
+    const defIdx = lines.findIndex((l) => /void\s+didChangeMetrics\s*\(/.test(l));
+    assert.ok(defIdx >= 0, 'didChangeMetrics override must exist');
+    const body = lines.slice(defIdx, defIdx + 20).join('\n');
+    assert.match(body, /_resumeRepaintWindowOpen/,
+      'didChangeMetrics must gate on the post-resume window');
+    assert.match(body, /_nudgeSurfaceRepaint\(\)/,
+      'didChangeMetrics must nudge the surface on the attach signal');
+  });
+
+  test('lib/main.dart: the post-resume repaint window is opened on resume', () => {
+    assert.match(src, /_openResumeRepaintWindow\(\)/,
+      'a resume must open the post-resume repaint window');
+    // >= 2: the definition plus at least one call site on the resume path.
+    const refs = (src.match(/_openResumeRepaintWindow\(/g) || []).length;
+    assert.ok(refs >= 2, `expected window-open definition + >=1 call site, found ${refs}`);
+  });
+}

--- a/test/surface_repaint_engine_test.dart
+++ b/test/surface_repaint_engine_test.dart
@@ -109,4 +109,87 @@ void main() {
       });
     });
   });
+
+  group('warm-start ordering (BUG-001 Attempt 8 / PAUSE-020)', () {
+    // Code-layer mirror of formal/warmstart.tla. The warm-start white screen is
+    // an ORDERING defect: on Android the SurfaceView is destroyed on background
+    // and re-created on foreground, and that reattach is asynchronous; it can
+    // land AFTER _onResumed's one-shot tail nudge has already drained, leaving a
+    // blank surface with no tick left to repaint it. Modeled here as: attach()
+    // sets `owed`; a nudge tick clears it; a late attach() with no subsequent
+    // nudge stays owed. Fix (Attempt 8): the attach signal (didChangeMetrics
+    // within the post-resume window) fires another nudge.
+
+    void drain(SurfaceRepaintEngine e) {
+      RepaintTick t;
+      do {
+        t = e.tick();
+      } while (!t.done);
+    }
+
+    test('reproduce: a reattach after the resume nudge drains is left owed', () {
+      final e = SurfaceRepaintEngine();
+      // _onResumed: the resume path (re)attaches and fires its single tail nudge.
+      e.attach();
+      e.request();
+      drain(e);
+      expect(e.owed, isFalse, reason: 'the resume nudge repainted the surface it saw');
+
+      // Warm start: the SurfaceView re-attaches blank AFTER the nudge drained,
+      // with no further trigger, the pre-Attempt-8 behavior.
+      e.attach();
+      expect(e.owed, isTrue,
+          reason: 'BUG-001: a late reattach with no re-nudge stays blank-white');
+    });
+
+    test('fix: an attach-signal re-nudge repaints the late reattach', () {
+      final e = SurfaceRepaintEngine();
+      e.attach();
+      e.request();
+      drain(e);
+
+      e.attach(); // late warm-start reattach
+      // Attempt 8: didChangeMetrics inside the post-resume window re-nudges.
+      e.request();
+      drain(e);
+      expect(e.owed, isFalse, reason: 'the attach-triggered re-nudge repainted it');
+    });
+
+    test('timing-faithful: late reattach at 800ms is caught only with the metrics re-nudge',
+        () {
+      // Host harness mirroring main.dart: _onResumed fires one nudge at resume;
+      // didChangeMetrics re-fires the nudge while the post-resume window is open.
+      // The resume nudge (6 ticks * 100ms = ~600ms) has drained by 800ms, when
+      // the SurfaceView actually re-attaches on this device.
+      for (final withMetricsRenudge in [false, true]) {
+        fakeAsync((async) {
+          final e = SurfaceRepaintEngine();
+          void nudge() {
+            if (!e.request()) return;
+            void tick() {
+              final t = e.tick();
+              if (t.done) return;
+              Future.delayed(const Duration(milliseconds: 100), tick);
+            }
+
+            tick();
+          }
+
+          // resume: tail nudge fires now.
+          nudge();
+          // warm-start SurfaceView reattaches blank at 800ms (after the nudge drained).
+          Future.delayed(const Duration(milliseconds: 800), () {
+            e.attach();
+            if (withMetricsRenudge) nudge(); // didChangeMetrics within the window
+          });
+          async.elapse(const Duration(seconds: 3));
+
+          expect(e.owed, withMetricsRenudge ? isFalse : isTrue,
+              reason: withMetricsRenudge
+                  ? 'metrics re-nudge repainted the late reattach'
+                  : 'reproduction: late reattach left blank without the re-nudge');
+        });
+      }
+    });
+  });
 }


### PR DESCRIPTION
On a warm start the hybrid-composition SurfaceView re-attaches after
_onResumed's one-shot tail nudge has drained, so the freshly-attached
but unpainted surface stays blank-white. Nudge again on didChangeMetrics
(the surface-attach signal) inside a bounded post-resume window. BUG-001
Attempt 8 / PAUSE-020.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011pdBZt7r4LjhkhJSVfSvAj