### PR TITLE
Upgrade TLAPS to 1.6.0-pre tarball, add --stretch timeout scaling

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -72,16 +72,25 @@ jobs:
         run: ./formal/check.sh
       # tlapm (the TLA+ Proof Manager) machine-checks the unbounded proofs in
       # formal/proofs/ -- formal verification of the same specs, so it sits in
-      # the validate tier next to OpenSpec validation and the TLC kernel. The
-      # installer is heavy (~145 MB, bundles Isabelle) but reuses the Java set
-      # up above, so a separate runner buys nothing.
+      # the validate tier next to OpenSpec validation and the TLC kernel. It
+      # reuses the Java set up above, so a separate runner buys nothing.
+      #
+      # Install the prebuilt 1.6.0-pre tarball, NOT the 1.5.0 .bin installer:
+      # that installer compiles Isabelle/Pure with its bundled Poly/ML 5.4.0,
+      # which aborts on the runner image ("scanaddrs.cpp:107: Assertion
+      # `val.IsDataPtr()' failed", tlaplus/tlapm#88). The tarball ships prebuilt
+      # Isabelle heaps, so nothing is compiled at install time. This is the same
+      # artifact tlaplus/Examples' own CI installs. 1.6.0-pre is a rolling tag
+      # (reattached on every main commit) and is the only prebuilt release
+      # upstream publishes, so this dependency is unpinned by necessity.
       - name: Install TLAPS
         run: |
-          curl -fsSL -o /tmp/tlaps.bin \
-            https://github.com/tlaplus/tlapm/releases/download/202210041448/tlaps-1.5.0-x86_64-linux-gnu-inst.bin
-          chmod +x /tmp/tlaps.bin
-          /tmp/tlaps.bin -d "$HOME/tlaps"
-          echo "$HOME/tlaps/bin" >> "$GITHUB_PATH"
+          curl -fsSL --retry 4 --retry-delay 2 -o /tmp/tlapm.tar.gz \
+            https://github.com/tlaplus/tlapm/releases/download/1.6.0-pre/tlapm-1.6.0-pre-x86_64-linux-gnu.tar.gz
+          tar -xzf /tmp/tlapm.tar.gz -C "$HOME"
+          rm -f /tmp/tlapm.tar.gz
+          echo "$HOME/tlapm/bin" >> "$GITHUB_PATH"
+          "$HOME/tlapm/bin/tlapm" --version
       - name: Verify TLAPS proofs
         run: ./formal/proofs/check_proofs.sh
       # Idempotent: if the cache restored a matching Chromium, this

--- a/formal/.gitignore
+++ b/formal/.gitignore
@@ -11,3 +11,4 @@ mc_*.tla
 mc_*.cfg
 # TLAPS proof-manager fingerprint cache.
 .tlacache/
+*.tlaps/

--- a/formal/proofs/README.md
+++ b/formal/proofs/README.md
@@ -34,18 +34,20 @@ TLC model it backs (same definitions — no re-modeling).
 - **`no_lost_update.tla`** — proves `[]Inv_NoLostUpdate` (every completed read-modify-write's
   key stays persisted — the secure-storage write serialisation) for all `N`: directly
   inductive, since the serialised (atomic) RMW makes the store grow monotonically, so a done
-  op's key is never dropped. Backs `store_serial.tla`.
+  op's key is never dropped. Backs `store_serial.tla`. **23 obligations, all proved.**
 - **`switch_guarded.tla`** — proves `[]Inv_NoWrongActivation` (a version-guarded site switch
   never commits against a stale index) for the good orchestration: directly inductive, since
   every good action leaves `wrong` unchanged while the `noguard` demonstrator latches it.
   Backs `switchguard.tla` (which has no size parameter, so this is the deductive companion
-  rather than an N-generalisation).
+  rather than an N-generalisation). **34 obligations, all proved.**
 - **`jar_repopulated.tla`** — proves `[]Inv_JarRepopulated` (the legacy shared cookie jar is
   never left empty when the engine returns to rest): directly inductive, since only the good
   restore reaches the rest state and it repopulates the jar. Backs `jar_nonempty.tla`.
+  **28 obligations, all proved.**
 - **`proxy_failclosed_safe.tla`** — proves `[]Inv_NoDirectWhenProxied` (a proxied site never
   egresses directly): directly inductive, since a config change clears egress and a good load
   never sets `direct` while the type is proxied. Backs `proxy_failclosed.tla`.
+  **28 obligations, all proved.**
 
 Together these prove every kernel *safety* invariant, the surface-repaint *liveness*
 (`RepaintLiveness` — BUG-001 itself), and every standalone model's safety invariant
@@ -77,6 +79,12 @@ prebuilt Isabelle heaps, so nothing is compiled on install. `1.6.0-pre` is a rol
 reattached on every upstream `main` commit; it is the only prebuilt release upstream
 publishes, and it is what `tlaplus/Examples`' own CI installs. On macOS swap in
 `tlapm-1.6.0-pre-arm64-darwin.tar.gz`.
+
+The obligation count listed per module above is **asserted** by `check_proofs.sh`, not just
+documentation: matching "all obligations proved" alone is not a gate, because
+`All 0 obligations proved.` matches it too, so a tlapm that silently checks nothing would
+read as green. If you add or remove proof steps, update the count here *and* in
+`min_obligations()`.
 
 `check_proofs.sh` skips (exit 0) when `tlapm` is not on `PATH`, so a workstation without
 it still runs the rest of the suite. CI installs it in the `validate` job, where the

--- a/formal/proofs/README.md
+++ b/formal/proofs/README.md
@@ -60,12 +60,28 @@ TLC's `N = 3`. The only TLC-bounded model left is `renderer.tla`, which has no s
 ./check_proofs.sh            # runs tlapm over every *.tla here
 ```
 
-Requires **tlapm** (the TLA+ Proof Manager). It is heavy (~145 MB, bundles Isabelle), so
-it is deliberately **not** in the default CI gate — the TLC suite is the fast gate; these
-proofs are the high-assurance backstop run on demand. Install: download
-`tlaps-1.5.0-x86_64-linux-gnu-inst.bin` from
-[github.com/tlaplus/tlapm/releases](https://github.com/tlaplus/tlapm/releases), run it
-with `-d <prefix>`, and add `<prefix>/bin` to `PATH`.
+Requires **tlapm** (the TLA+ Proof Manager), installed from the prebuilt tarball:
+
+```bash
+curl -fsSL -o /tmp/tlapm.tar.gz \
+  https://github.com/tlaplus/tlapm/releases/download/1.6.0-pre/tlapm-1.6.0-pre-x86_64-linux-gnu.tar.gz
+tar -xzf /tmp/tlapm.tar.gz -C "$HOME"     # -> $HOME/tlapm/bin/tlapm
+export PATH="$HOME/tlapm/bin:$PATH"
+```
+
+Use the tarball, **not** the 1.5.0 `-inst.bin` installer: that installer compiles
+Isabelle/Pure with its bundled Poly/ML 5.4.0, which aborts on current Linux
+(`scanaddrs.cpp:107: Assertion 'val.IsDataPtr()' failed`,
+[tlaplus/tlapm#88](https://github.com/tlaplus/tlapm/issues/88)). The tarball ships
+prebuilt Isabelle heaps, so nothing is compiled on install. `1.6.0-pre` is a rolling tag
+reattached on every upstream `main` commit; it is the only prebuilt release upstream
+publishes, and it is what `tlaplus/Examples`' own CI installs. On macOS swap in
+`tlapm-1.6.0-pre-arm64-darwin.tar.gz`.
+
+`check_proofs.sh` skips (exit 0) when `tlapm` is not on `PATH`, so a workstation without
+it still runs the rest of the suite. CI installs it in the `validate` job, where the
+proofs are a hard gate alongside the TLC suite. Backend timeouts are wall-clock, so the
+script passes `--stretch 5` to survive a loaded runner; override with `TLAPM_STRETCH`.
 
 ## Why both TLC and TLAPS
 

--- a/formal/proofs/check_proofs.sh
+++ b/formal/proofs/check_proofs.sh
@@ -26,17 +26,42 @@ KERNEL_DIR="$(cd .. && pwd)"
 # that a workstation proves. --stretch multiplies every timeout instead.
 STRETCH="${TLAPM_STRETCH:-5}"
 
+# Obligation count each module is known to discharge (the numbers in README.md).
+# Matching "all obligations proved" alone is NOT a gate: "All 0 obligations
+# proved." also matches, so a tlapm that silently checks nothing reads as green.
+# Assert the count instead. Bump a number only when you add or remove proof steps.
+min_obligations() {
+  case "$1" in
+    archive_identity.tla)      echo 25 ;;
+    containers_disjoint.tla)   echo 23 ;;
+    current_loaded.tla)        echo 51 ;;
+    jar_matches.tla)           echo 51 ;;
+    proxy_coherent.tla)        echo 29 ;;
+    repaint_liveness.tla)      echo 71 ;;
+    retention_safety.tla)      echo 22 ;;
+    # Directly-inductive companions; count not pinned in README, so just require
+    # that tlapm discharged something.
+    *)                         echo 1  ;;
+  esac
+}
+
 ok=1
 for f in *.tla; do
   echo "── $f ──"
   # Capture, then match: piping straight into `grep -q` lets grep exit on the
   # first hit and SIGPIPE tlapm, which `pipefail` then reports as a failure.
   out="$(tlapm -I "$KERNEL_DIR" --stretch "$STRETCH" "$f" 2>&1 || true)"
-  if grep -qE "All [0-9]+ obligations? proved" <<<"$out"; then
-    echo "  OK: all obligations proved"
+  proved="$(sed -nE 's/.*All ([0-9]+) obligations? proved.*/\1/p' <<<"$out" | tail -1)"
+  want="$(min_obligations "$f")"
+  if [ -n "$proved" ] && [ "$proved" -ge "$want" ]; then
+    echo "  OK: $proved obligations proved (>= $want)"
   else
-    echo "$out" | tail -40
-    echo "  FAIL: unproved obligations in $f" >&2
+    echo "$out"
+    if [ -n "$proved" ]; then
+      echo "  FAIL: $f proved only $proved obligations, expected >= $want" >&2
+    else
+      echo "  FAIL: $f produced no 'all obligations proved' summary" >&2
+    fi
     ok=0
   fi
 done

--- a/formal/proofs/check_proofs.sh
+++ b/formal/proofs/check_proofs.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 # Machine-check the TLAPS proofs (unbounded-N, deductive).
 #
-# Requires tlapm (the TLA+ Proof Manager). It is a heavy dependency (~145 MB,
-# bundles Isabelle), so this is NOT part of the default CI gate -- the TLC suite
-# (../check.sh) is the fast gate; these proofs are the unbounded backstop. To
-# install: download tlaps-1.5.0-x86_64-linux-gnu-inst.bin from
-# github.com/tlaplus/tlapm/releases and run it with `-d <prefix>`, then add
-# <prefix>/bin to PATH.
+# Requires tlapm (the TLA+ Proof Manager). Install the prebuilt tarball:
+#
+#   curl -fsSL -o /tmp/tlapm.tar.gz \
+#     https://github.com/tlaplus/tlapm/releases/download/1.6.0-pre/tlapm-1.6.0-pre-x86_64-linux-gnu.tar.gz
+#   tar -xzf /tmp/tlapm.tar.gz -C "$HOME"   # -> $HOME/tlapm/bin/tlapm
+#   export PATH="$HOME/tlapm/bin:$PATH"
+#
+# Use the tarball, not the 1.5.0 `-inst.bin` installer: that installer compiles
+# Isabelle/Pure with its bundled Poly/ML 5.4.0, which aborts on current Linux
+# ("scanaddrs.cpp:107: Assertion `val.IsDataPtr()' failed", tlaplus/tlapm#88).
+# The tarball ships prebuilt Isabelle heaps, so nothing is compiled on install.
+# On macOS swap in tlapm-1.6.0-pre-arm64-darwin.tar.gz.
 set -euo pipefail
 cd "$(dirname "$0")"
 
@@ -16,12 +22,20 @@ if ! command -v tlapm >/dev/null 2>&1; then
 fi
 
 KERNEL_DIR="$(cd .. && pwd)"
+# Backend timeouts are wall-clock, so a loaded CI runner can fail an obligation
+# that a workstation proves. --stretch multiplies every timeout instead.
+STRETCH="${TLAPM_STRETCH:-5}"
+
 ok=1
 for f in *.tla; do
   echo "── $f ──"
-  if tlapm -I "$KERNEL_DIR" "$f" 2>&1 | grep -qE "All [0-9]+ obligations proved"; then
+  # Capture, then match: piping straight into `grep -q` lets grep exit on the
+  # first hit and SIGPIPE tlapm, which `pipefail` then reports as a failure.
+  out="$(tlapm -I "$KERNEL_DIR" --stretch "$STRETCH" "$f" 2>&1 || true)"
+  if grep -qE "All [0-9]+ obligations? proved" <<<"$out"; then
     echo "  OK: all obligations proved"
   else
+    echo "$out" | tail -40
     echo "  FAIL: unproved obligations in $f" >&2
     ok=0
   fi

--- a/formal/proofs/check_proofs.sh
+++ b/formal/proofs/check_proofs.sh
@@ -36,11 +36,14 @@ min_obligations() {
     containers_disjoint.tla)   echo 23 ;;
     current_loaded.tla)        echo 51 ;;
     jar_matches.tla)           echo 51 ;;
+    jar_repopulated.tla)       echo 28 ;;
+    no_lost_update.tla)        echo 23 ;;
     proxy_coherent.tla)        echo 29 ;;
+    proxy_failclosed_safe.tla) echo 28 ;;
     repaint_liveness.tla)      echo 71 ;;
     retention_safety.tla)      echo 22 ;;
-    # Directly-inductive companions; count not pinned in README, so just require
-    # that tlapm discharged something.
+    switch_guarded.tla)        echo 34 ;;
+    # A new proof module is unpinned until someone records its count above.
     *)                         echo 1  ;;
   esac
 }


### PR DESCRIPTION
Replace the 1.5.0 `.bin` installer with the prebuilt 1.6.0-pre tarball. The installer compiles Isabelle/Pure with Poly/ML 5.4.0, which aborts on current Linux runners with "scanaddrs.cpp:107: Assertion 'val.IsDataPtr()' failed" (tlaplus/tlapm#88). The tarball ships prebuilt Isabelle heaps, avoiding compilation entirely.

Key changes:

- Update README and check_proofs.sh with tarball download and extraction instructions; document the 1.5.0 installer issue and macOS variant.
- Add `--stretch 5` flag to tlapm invocation to scale backend timeouts for loaded CI runners; make it configurable via `TLAPM_STRETCH` env var.
- Fix check_proofs.sh to capture tlapm output before grepping, preventing SIGPIPE on early grep exit.
- Update CI workflow to download and extract the tarball instead of running the installer; add `--version` check and cleanup.
- Add `*.tlaps/` to .gitignore for proof-manager fingerprint caches.

The 1.6.0-pre tag is rolling (reattached on every upstream main commit) and is the only prebuilt release upstream publishes; it matches what tlaplus/Examples' own CI installs.

https://claude.ai/code/session_01L2FacWnJhnsaANwYMZJ7Lh