### PR TITLE
Repaint Android surface after a reload

### DIFF
--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -2,7 +2,7 @@
 
 **Status:** open (recurring — each fix has closed one entry path; new paths keep surfacing)
 **Platform:** Android only (hybrid-composition `SurfaceView`)
-**Spec:** [openspec/specs/webview-pause-lifecycle/spec.md](../../openspec/specs/webview-pause-lifecycle/spec.md) — requirements `PAUSE-013`…`PAUSE-018`
+**Spec:** [openspec/specs/webview-pause-lifecycle/spec.md](../../openspec/specs/webview-pause-lifecycle/spec.md) — requirements `PAUSE-013`…`PAUSE-021`
 **Formal model:** [formal/kernel.tla](../../formal/kernel.tla) — `RepaintLiveness` ("every blank-surface attach is eventually repainted"). The `kernel_conflict.cfg` demonstrator is a back path that bypasses the chokepoint — i.e. this exact bug — and TLC rejects it with a counterexample.
 
 ## Symptom
@@ -176,6 +176,40 @@ fallback). The real fix is still a native surface-changed/-redrawn callback from
 driving the repaint. This attempt narrows gap #3 (keys on an attach signal, not a lifecycle
 event) rather than closing it.
 
+### Attempt 9 — Repaint after a reload, latched to the document recommit (`PAUSE-021`)
+**Date:** 2026-07-29 · **Files:** lib/services/surface_repaint_engine.dart, lib/web_view_model.dart,
+lib/main.dart, lib/screens/inappbrowser.dart, lib/services/webview.dart,
+test/surface_repaint_engine_test.dart, test/js/surface_repaint_funnel.test.js,
+openspec/specs/webview-pause-lifecycle/spec.md
+**What it did:** Routed every reload through a funnel that latches on the engine
+(`SurfaceRepaintEngine.reloadIssued`) and nudges, then nudges *again* when the next
+main-frame load settles (`consumeLoadSettled`, driven by `onLoadingChanged(false)`).
+Funnels: `WebViewModel.reloadAndRepaint` on the main page (Refresh button and
+Clear-cookies via `userDrivenReload`, pull-to-refresh, the `restoreState` materialize
+reload, the notification background refresh) and `_reloadAndRepaint` in
+`InAppWebViewScreen` (menu Refresh, pull-to-refresh). The factory's own cached-HTML
+one-shot live refresh reports through the new `WebViewConfig.onReloadIssued` so it
+latches identically. Both host hooks are gated on the model being the visible site.
+**Why:** Reported as a **white** screen after a plain in-app **refresh**. A reload keeps
+the same site and the same controller, so it passes through none of the existing
+chokepoints — not `_setCurrentIndex` (Attempt 3), not `onControllerReady` (Attempt 4),
+not a back path (Attempts 5–6), not a resume (Attempts 2/8): gap #3's shape again.
+The reload also has the Attempt-8 *ordering* on top of that: `reload()` throws away the
+painted frame immediately but commits the replacement an unbounded time later, so a
+nudge fired at issue time drains its ~0.6s budget against the old surface and the
+recommitted one is left blank. The load-settled signal is the closest Dart-side proxy for
+that recommit, which is why the repaint is latched across the gap rather than fired once.
+**Why partial:** Still per-path (gap #3): it enumerates reload call sites instead of
+keying on a native surface callback. `onLoadingChanged(false)` is a *proxy* for the
+commit, one step removed like `didChangeMetrics` — it maps to `onLoadStop`, which fires
+after the document is parsed rather than at the compositor's first frame, so a page that
+paints materially later than load-stop can still outrun the second nudge. The latch is
+also single-slot on a per-screen engine shared by all sites: a site switch between a
+reload and its load-stop lets the incoming site's settle consume it (a harmless extra
+nudge, not a missed one). And the device link is unproven for the same reason as
+Attempt 8 — no `SurfaceDiag` trace from an affected device confirms the reload was this
+user's trigger or that the second nudge lands after the recommit.
+
 ## Known open gaps (candidates for the next recurrence)
 
 1. ~~Nested `InAppWebViewScreen`~~ — **closed by Attempt 6** (now funneled + gated).
@@ -188,7 +222,17 @@ event) rather than closing it.
    enumerating Dart-side navigation paths forever. **Attempt 8 narrows this**: it keys the
    warm-start repaint on `didChangeMetrics` (a Dart-side *proxy* for the surface attach)
    rather than a lifecycle event, but a proxy is not the native callback and is not
-   guaranteed to fire on every device, so the gap stands.
+   guaranteed to fire on every device, so the gap stands. **Attempt 9 is the same shape
+   once more** — a reload, keyed on the load-settled proxy — and is the second recurrence
+   in a row whose fix was an *ordering* one (nudge at the trigger, re-nudge at the attach
+   proxy). Two data points that the durable fix is the native callback, not a longer list
+   of triggers.
+6. **Proxies fire before the compositor.** Both attach proxies now in use are upstream of
+   the actual first paint: `didChangeMetrics` (Attempt 8) tracks the main FlutterView's
+   metrics, and `onLoadingChanged(false)` (Attempt 9) maps to `onLoadStop`, i.e. document
+   parse rather than frame commit. A surface that receives its first frame materially
+   later than either signal still outruns the nudge budget. This is gap #3 seen from the
+   timing side: the native callback is the only signal that *is* the attach.
 4. **The TLAPS proof doesn't cover the recurrence — by construction.**
    `RepaintLiveness` is proved over `GoodSpec`/`GoodNext`, a *fixed* set of attach actions
    (`Activate`, `Resume`, `ControllerAttach`, `Back`, `Forward`, `LoadSite`, `Evict`), each of
@@ -238,6 +282,10 @@ event) rather than closing it.
   Attempts 2–5) fails CI. Now also asserts the warm-start wiring: `didChangeMetrics` re-nudges
   within the post-resume window, and a resume opens that window. Partial: scoped to
   `lib/main.dart`; the nested screen (gap #1) is not yet gated.
+  Attempt 9 adds the reload half: every `controller.reload()` in `web_view_model.dart` and
+  `inappbrowser.dart` must sit inside a `reloadAndRepaint` funnel that latches the reload,
+  `main.dart` must wire both host hooks to the engine, and each file must drive the repaint
+  off the load-settled signal. A new raw reload fails CI.
 
 ## Diagnostic checklist (when this recurs)
 

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -190,7 +190,9 @@ reload, the notification background refresh) and `_reloadAndRepaint` in
 `InAppWebViewScreen` (menu Refresh, pull-to-refresh). The factory's own cached-HTML
 one-shot live refresh reports through the new `WebViewConfig.onReloadIssued` so it
 latches identically. Both host hooks are gated on the model being the visible site.
-**Why:** Reported as a **white** screen after a plain in-app **refresh**. A reload keeps
+**Why:** Reported as a **white** screen after a plain in-app **refresh**, and the reporter
+**confirmed the refresh was the trigger** — unlike Attempts 7 and 8, the entry path here is
+not inferred from a log, it is stated. A reload keeps
 the same site and the same controller, so it passes through none of the existing
 chokepoints — not `_setCurrentIndex` (Attempt 3), not `onControllerReady` (Attempt 4),
 not a back path (Attempts 5–6), not a resume (Attempts 2/8): gap #3's shape again.
@@ -206,9 +208,11 @@ after the document is parsed rather than at the compositor's first frame, so a p
 paints materially later than load-stop can still outrun the second nudge. The latch is
 also single-slot on a per-screen engine shared by all sites: a site switch between a
 reload and its load-stop lets the incoming site's settle consume it (a harmless extra
-nudge, not a missed one). And the device link is unproven for the same reason as
-Attempt 8 — no `SurfaceDiag` trace from an affected device confirms the reload was this
-user's trigger or that the second nudge lands after the recommit.
+nudge, not a missed one). The **trigger** is confirmed, but the **remedy** is not: no
+`SurfaceDiag` trace from an affected device yet shows the settled re-nudge landing after the
+recommit, which is what the fix rests on. The `trigger=reload -> nudge` /
+`trigger=reload-settled -> nudge` pair exists to close that; until such a trace exists the
+causal claim is unverified, exactly as in Attempt 8.
 
 ## Known open gaps (candidates for the next recurrence)
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7839,14 +7839,27 @@ class _WebSpacePageState extends State<WebSpacePage>
                         // (PAUSE-021). Nudge now for a fast recommit, and
                         // latch so the settled load nudges again — the
                         // recommit can land long after this loop drains.
+                        // Non-sensitive one-liners (no site name / URL), safe
+                        // to share: the pair confirms on-device that the
+                        // settled re-nudge actually follows the recommit, and
+                        // how long after the issue-time nudge it lands — the
+                        // premise this fix rests on. See PAUSE-021.
                         webViewModel.onReloadIssued = () {
                           if (index != _currentIndex) return;
                           _surfaceRepaint.reloadIssued();
+                          if (Platform.isAndroid) {
+                            LogService.instance
+                                .log('SurfaceDiag', 'trigger=reload -> nudge');
+                          }
                           _nudgeSurfaceRepaint();
                         };
                         webViewModel.onLoadSettled = () {
                           if (index != _currentIndex) return;
                           if (!_surfaceRepaint.consumeLoadSettled()) return;
+                          if (Platform.isAndroid) {
+                            LogService.instance.log(
+                                'SurfaceDiag', 'trigger=reload-settled -> nudge');
+                          }
                           _nudgeSurfaceRepaint();
                         };
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4723,11 +4723,10 @@ class _WebSpacePageState extends State<WebSpacePage>
       if (!m.effectiveNotificationsEnabled) continue;
       if (excludeActive && i == _currentIndex) continue;
       if (!_loadedIndices.contains(i)) continue;
-      try {
-        await m.controller?.reload();
-      } catch (_) {
-        // Controller may have been disposed mid-iteration.
-      }
+      // Funnelled: the BGAppRefreshTask path does not exclude the active
+      // site, so this can reload the visible webview and blank its surface
+      // exactly like a user refresh (PAUSE-021).
+      await m.reloadAndRepaint();
     }
   }
 
@@ -7832,6 +7831,23 @@ class _WebSpacePageState extends State<WebSpacePage>
                         // _currentIndex live at fire time; no-op off Android.
                         webViewModel.onControllerReady = () {
                           if (index == _currentIndex) _nudgeSurfaceRepaint();
+                        };
+
+                        // A reload of the visible site blanks the surface
+                        // between discarding the old frame and committing
+                        // the new one, and nothing relayouts it in between
+                        // (PAUSE-021). Nudge now for a fast recommit, and
+                        // latch so the settled load nudges again — the
+                        // recommit can land long after this loop drains.
+                        webViewModel.onReloadIssued = () {
+                          if (index != _currentIndex) return;
+                          _surfaceRepaint.reloadIssued();
+                          _nudgeSurfaceRepaint();
+                        };
+                        webViewModel.onLoadSettled = () {
+                          if (index != _currentIndex) return;
+                          if (!_surfaceRepaint.consumeLoadSettled()) return;
+                          _nudgeSurfaceRepaint();
                         };
 
                         // Keep the on-disk back/forward stack tracking

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -207,7 +207,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
     _pullToRefreshController = isMobile ? inapp.PullToRefreshController(
       settings: inapp.PullToRefreshSettings(enabled: true),
       onRefresh: () async {
-        _controller?.reload();
+        await _reloadAndRepaint();
       },
     ) : null;
     _webView = WebViewFactory.createWebView(
@@ -293,12 +293,21 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
             });
           }
         },
+        onReloadIssued: () {
+          _surfaceRepaint.reloadIssued();
+          _nudgeSurfaceRepaint();
+        },
         onLoadingChanged: (loading) {
           if (!mounted || _isLoading == loading) return;
           setState(() {
             _isLoading = loading;
             if (loading) _loadingProgress = 0;
           });
+          // The reloaded document commits onto the surface here, which is
+          // where the repaint has to land (PAUSE-021).
+          if (!loading && _surfaceRepaint.consumeLoadSettled()) {
+            _nudgeSurfaceRepaint();
+          }
         },
         onProgressChanged: (progress) {
           if (!mounted || _loadingProgress == progress) return;
@@ -417,6 +426,19 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
   Future<void> _goBackAndRepaint(WebViewController controller) async {
     await controller.goBack();
     _nudgeSurfaceRepaint();
+  }
+
+  /// Reload funnel for the nested webview, mirroring
+  /// `WebViewModel.reloadAndRepaint`. A reload drops the painted frame and
+  /// recommits it later, leaving the Android surface blank in between with no
+  /// relayout to clear it (BUG-001 / PAUSE-021). Nudge now for a fast
+  /// recommit; the latch makes the settled load nudge again for a slow one.
+  Future<void> _reloadAndRepaint() async {
+    final controller = _controller;
+    if (controller == null) return;
+    _surfaceRepaint.reloadIssued();
+    _nudgeSurfaceRepaint();
+    await controller.reload();
   }
 
   /// Destroy-and-rebuild this nested webview after its renderer process is gone
@@ -725,7 +747,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
                   await widget.onShowUrlBarChanged?.call(_showUrlBar);
                   break;
                 case 'refresh':
-                  _controller?.reload();
+                  await _reloadAndRepaint();
                   break;
                 case 'devTools':
                   Navigator.push(

--- a/lib/services/surface_repaint_engine.dart
+++ b/lib/services/surface_repaint_engine.dart
@@ -18,6 +18,7 @@ enum SurfaceTransition {
   controllerAttach, // fresh controller mounts a new SurfaceView (PAUSE-017)
   back, // bfcache restore reuses the controller (PAUSE-018)
   forward, // bfcache restore reuses the controller (PAUSE-018)
+  reload, // reload discards the painted frame, recommits later (PAUSE-021)
   goHome, // dispose + rebuild at initUrl (PAUSE-017)
   rendererRebuilt, // renderer-gone recovery rebuild (PAUSE-017)
   appBackground, // app going to background: no attach, no repaint owed
@@ -66,6 +67,33 @@ class SurfaceRepaintEngine {
   /// repaint. The complete set is the contract; mirrors `Attach` in kernel.tla.
   static bool mustRepaint(SurfaceTransition t) =>
       t != SurfaceTransition.appBackground;
+
+  bool _reloadPending = false;
+
+  /// Whether a reload has been issued whose new document has not yet settled.
+  bool get reloadPending => _reloadPending;
+
+  /// A reload was issued on the visible webview (PAUSE-021). Unlike every
+  /// other transition here, the surface does not go blank when the *call* is
+  /// made: the reload discards the painted frame and the new document commits
+  /// onto the surface some unbounded time later, so the one-shot nudge fired
+  /// at issue time can drain before the recommit lands — the same ordering
+  /// `formal/warmstart.tla` model-checks for the warm-start resume. This latch
+  /// carries the debt across that gap; [consumeLoadSettled] pays it.
+  void reloadIssued() {
+    _reloadPending = true;
+  }
+
+  /// A main-frame load settled on the visible webview. Returns true iff it
+  /// completes a pending reload, in which case the host MUST nudge: the
+  /// recommit is the reload's real surface attach. Consumes the latch, so a
+  /// later unrelated navigation does not nudge.
+  bool consumeLoadSettled() {
+    if (!_reloadPending) return false;
+    _reloadPending = false;
+    attach();
+    return true;
+  }
 
   /// Request a nudge. Refills the tick budget and returns whether the host
   /// should START the tick loop (true), or an already-running loop absorbed

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -540,6 +540,13 @@ class WebViewConfig {
   /// use this to swap a Refresh button with a Stop button while a
   /// navigation is in flight.
   final Function(bool isLoading)? onLoadingChanged;
+  /// Fires when this webview reloads itself (the cached-HTML one-shot live
+  /// refresh below). A reload discards the painted frame and recommits it
+  /// later, so on Android the hybrid-composition surface sits blank in
+  /// between with nothing to relayout it (BUG-001 / PAUSE-021). Host-driven
+  /// reloads funnel through `WebViewModel.reloadAndRepaint`; this is the
+  /// same signal for the ones the factory issues on its own.
+  final VoidCallback? onReloadIssued;
   /// Fires as the main-frame load advances, with progress in 0-100.
   /// Driven by the platform's `onProgressChanged`. The call site can
   /// use this to render a determinate loading bar while a navigation
@@ -697,6 +704,7 @@ class WebViewConfig {
     this.localCdnEnabled = true,
     this.onUrlChanged,
     this.onLoadingChanged,
+    this.onReloadIssued,
     this.onProgressChanged,
     this.onCookiesChanged,
     this.cookieManager,
@@ -3504,6 +3512,7 @@ class WebViewFactory {
             if (!online) return;
             if (navigationGen != genAtSchedule) return;
             try {
+              config.onReloadIssued?.call();
               controller.reload();
             } catch (_) {}
           });

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -597,6 +597,18 @@ class WebViewModel {
   /// webview does NOT recreate the controller, so it does not fire here —
   /// that path is nudged explicitly by `_setCurrentIndex`.
   Function? onControllerReady;
+  /// Host hook fired when a reload is issued for this model's webview
+  /// ([reloadAndRepaint], the funnel every reload goes through). A reload
+  /// discards the document's painted frame and recommits it later, so on
+  /// Android the hybrid-composition surface can sit blank in between
+  /// (BUG-001 / PAUSE-021). The host latches the reload here and nudges;
+  /// [onLoadSettled] closes the pair when the new document commits.
+  VoidCallback? onReloadIssued;
+  /// Host hook fired when a main-frame load settles (`onLoadingChanged`
+  /// false). Only meaningful paired with [onReloadIssued]: it is the
+  /// closest Dart-side signal to the reloaded document committing onto
+  /// the surface, which is the moment the repaint has to land (PAUSE-021).
+  VoidCallback? onLoadSettled;
   /// Host hook fired once per committed navigation (deduped across the
   /// `onLoadStop` / `onUpdateVisitedHistory` double-fire). The host
   /// debounces `controller.saveState()` captures off this so the
@@ -1107,12 +1119,17 @@ class WebViewModel {
                 return false;
             }
           },
+          onReloadIssued: () => onReloadIssued?.call(),
           onLoadingChanged: (loading) {
             if (isLoading == loading) return;
             isLoading = loading;
             // Reset on start so the bar doesn't flash the previous
             // navigation's near-complete value.
             if (loading) loadingProgress = 0;
+            // A settled load is the reloaded document committing onto the
+            // surface; the host repaints there rather than at reload-issue
+            // time, when there is nothing yet to paint (PAUSE-021).
+            if (!loading) onLoadSettled?.call();
             // Trigger a UI rebuild so the URL-bar action button can
             // swap between Refresh and Stop. saveFunc is intentionally
             // NOT called here — the loading bool is transient runtime
@@ -1372,7 +1389,7 @@ class WebViewModel {
                   // !ok: nothing was restored, so just load the saved URL or
                   // the suppressed-initial-load webview would stay blank.
                   if (ok) {
-                    await ctrl.reload();
+                    await reloadAndRepaint(ctrl);
                   } else {
                     await ctrl.loadUrl(restoreUrl);
                   }
@@ -1623,8 +1640,27 @@ class WebViewModel {
       HtmlCacheService.instance.evictInMemory(siteId);
     }
     await clearWebViewCache();
+    await reloadAndRepaint();
+  }
+
+  /// The single funnel every reload of this site's webview goes through.
+  ///
+  /// A reload throws away the currently painted compositor frame and commits
+  /// a new one an unbounded time later. On Android the hybrid-composition
+  /// `SurfaceView` in between is blank, and nothing re-lays it out on its
+  /// own, so a reload that recommits slowly leaves a white screen until some
+  /// unrelated relayout happens (BUG-001 / PAUSE-021). [onReloadIssued] lets
+  /// the host latch the reload and nudge now; the paired [onLoadSettled]
+  /// nudges again when the new document actually lands.
+  ///
+  /// [target] overrides the controller for callers that hold a fresh one
+  /// before [controller] is published (the `restoreState` materialize path).
+  Future<void> reloadAndRepaint([WebViewController? target]) async {
+    final ctrl = target ?? controller;
+    if (ctrl == null) return;
+    onReloadIssued?.call();
     try {
-      await controller!.reload();
+      await ctrl.reload();
     } catch (_) {
       // Controller may have been disposed between the cache clear and the reload.
     }

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -668,6 +668,39 @@ The ordering is model-checked in [formal/warmstart.tla](../../../formal/warmstar
 
 ---
 
+### Requirement: PAUSE-021 — Repaint After A Reload
+
+On Android, the system SHALL recomposite the surface after the visible webview reloads, and SHALL do so again when the reloaded document commits. A reload discards the currently painted compositor frame at the moment `reload()` is called and commits the replacement an unbounded time later (network, parse, script). In between, the hybrid-composition `SurfaceView` holds no frame and nothing re-lays it out, so the page renders **white** — the same blank-surface class as PAUSE-015/017/018/020, reached through the reload trigger. A reload keeps the same site and the same controller, so it passes through none of the existing chokepoints: not `_setCurrentIndex` (PAUSE-015), not `onControllerReady` (PAUSE-017), not the back path (PAUSE-018), not a resume (PAUSE-020).
+
+Repainting only when `reload()` is issued is insufficient, and for the same ordering reason as PAUSE-020: the nudge's tick budget (~0.6s) drains against the *old* surface while the new document is still in flight, so a reload slower than the budget leaves the recommitted surface unpainted. The host SHALL therefore latch the reload (`SurfaceRepaintEngine.reloadIssued`) and repaint **twice**: once at issue time, and again when the next main-frame load settles (`SurfaceRepaintEngine.consumeLoadSettled`, driven by `onLoadingChanged(false)`) — the closest Dart-side signal to the reloaded document committing onto the surface. The latch is one-shot, so an ordinary navigation's load-stop does not nudge.
+
+Every reload of a webview SHALL go through a funnel that fires the latch: `WebViewModel.reloadAndRepaint` for the main page (covering the Refresh button and Clear-cookies via `userDrivenReload`, pull-to-refresh, the `restoreState` materialize reload, and the notification background refresh) and `_reloadAndRepaint` in `InAppWebViewScreen` for the nested screen (menu Refresh and pull-to-refresh). Reloads the webview factory issues on its own — the cached-HTML one-shot live refresh — SHALL report through `WebViewConfig.onReloadIssued` so they latch identically. The funnels are held by the `surface_repaint_funnel` structural gate; a new raw `controller.reload()` fails CI. All of it is a no-op off Android.
+
+This is per-path like every prior attempt and does not close BUG-001 open gap #3; a native surface-changed callback from the fork remains the durable fix.
+
+The ordering is the one already model-checked in [formal/warmstart.tla](../../../formal/warmstart.tla) (a one-shot nudge draining before an async attach violates `RepaintLiveness`; an attach-triggered re-nudge restores it), with the reload's commit playing the part of `SurfaceReattach`. The runnable counterpart is the reload group in `test/surface_repaint_engine_test.dart`, including the timing-faithful case where a 2s reload is recovered only by the settled re-nudge.
+
+#### Scenario: A slow reload does not leave a white screen
+
+**Given** a site is visible on Android
+**When** the user taps Refresh (or pulls to refresh) and the page takes longer to commit than the repaint nudge's tick budget
+**Then** the reload is latched at issue time and, when the load settles, `_nudgeSurfaceRepaint` runs again against the recommitted surface
+**And** the page paints without the user rotating, locking, or switching tabs
+
+#### Scenario: Ordinary navigation does not nudge
+
+**Given** a site is visible on Android with no reload in flight
+**When** the user follows a link and that load settles
+**Then** the reload latch is empty, so no repaint nudge runs and the visible site does not jitter
+
+#### Scenario: A background site's reload does not repaint the visible one
+
+**Given** the notification background refresh reloads a loaded site that is not the current one
+**When** that site's load settles
+**Then** neither the latch nor the nudge fires, because both host hooks are gated on the model being the visible site
+
+---
+
 ### Requirement: PAUSE-016 — Android Per-Instance Pause Is a No-Op
 
 On Android the per-instance `pause()` / `resume()` (`WebView.onPause()` / `onResume()`) SHALL be no-ops. Android exposes no per-instance JavaScript pause — `onPause()` halts only animations and geolocation and explicitly does not pause JS, while the only JS-timer pause (`pauseTimers()`) is process-global. So per-instance pause contributes nothing to the lifecycle freeze, yet cycling the foreground hybrid-composition `SurfaceView` through onPause/onResume re-attaches it blank on the next paint — the white screen the user hits after a transient background or a navigation that follows a resume.

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -680,6 +680,8 @@ This is per-path like every prior attempt and does not close BUG-001 open gap #3
 
 The ordering is the one already model-checked in [formal/warmstart.tla](../../../formal/warmstart.tla) (a one-shot nudge draining before an async attach violates `RepaintLiveness`; an attach-triggered re-nudge restores it), with the reload's commit playing the part of `SurfaceReattach`. The runnable counterpart is the reload group in `test/surface_repaint_engine_test.dart`, including the timing-faithful case where a 2s reload is recovered only by the settled re-nudge.
 
+Both nudges SHALL emit a non-sensitive `SurfaceDiag` line (`trigger=reload -> nudge`, `trigger=reload-settled -> nudge`; no site name or URL, Android only) so a shareable device log can show whether the settled re-nudge in fact follows the recommit — the premise the fix depends on and which no model can establish. Same contract as the PAUSE-019/020 diagnostics.
+
 #### Scenario: A slow reload does not leave a white screen
 
 **Given** a site is visible on Android

--- a/test/js/nested_webview_posture_parity.test.js
+++ b/test/js/nested_webview_posture_parity.test.js
@@ -146,7 +146,7 @@ const PLUMBING = new Set([
   'backForwardGestures', // deliberate root-only: nested uses route-pop (NAV-008)
   'onUrlChanged', 'onCookiesChanged', 'cookieManager', 'containerCookieManager',
   'cookieSiteId', 'onFindResult', 'shouldOverrideUrlLoading', 'onLoadingChanged',
-  'onProgressChanged',
+  'onProgressChanged', 'onReloadIssued',
   'onWindowRequested', 'onHtmlLoaded', 'shouldFetchHtml', 'onConsoleMessage',
   'onConfirmScriptFetch', 'onExternalSchemeUrl', 'pullToRefreshController',
   'onRendererGone', 'onProtectedMediaRequest',

--- a/test/js/surface_repaint_funnel.test.js
+++ b/test/js/surface_repaint_funnel.test.js
@@ -24,6 +24,11 @@ function linesOf(rel) {
   return fs.readFileSync(path.join(repoRoot, rel), 'utf8').split('\n');
 }
 
+// The `before` lines above and `after` lines below line `i`, joined.
+function context(lines, i, before, after) {
+  return lines.slice(Math.max(0, i - before), i + after + 1).join('\n');
+}
+
 for (const rel of GUARDED) {
   const lines = linesOf(rel);
   const src = lines.join('\n');
@@ -64,6 +69,86 @@ for (const rel of GUARDED) {
         'On Android, route back navigation through _goBackAndRepaint ' +
         '(PAUSE-018 / BUG-001); the iOS/macOS path is exempt.',
     );
+  });
+}
+
+// Reload repaint gate (PAUSE-021 / BUG-001 Attempt 9). A reload discards the
+// painted frame and recommits it an unbounded time later, so the Android
+// SurfaceView sits blank in between with nothing to relayout it. Every reload
+// of a webview MUST go through a funnel that latches the reload and nudges,
+// and the paired load-settled signal MUST re-nudge — the issue-time nudge
+// alone drains before a slow page recommits (proved in
+// test/surface_repaint_engine_test.dart).
+{
+  // Reload funnels, per file: name -> the raw call it must wrap.
+  const RELOAD_FUNNELS = [
+    {
+      file: 'lib/web_view_model.dart',
+      funnel: /Future<void>\s+reloadAndRepaint\s*\(/,
+      latch: /onReloadIssued\?\.call\(\)/,
+      settled: /onLoadSettled\?\.call\(\)/,
+    },
+    {
+      file: 'lib/screens/inappbrowser.dart',
+      funnel: /Future<void>\s+_reloadAndRepaint\s*\(/,
+      latch: /_surfaceRepaint\.reloadIssued\(\)/,
+      settled: /_surfaceRepaint\.consumeLoadSettled\(\)/,
+    },
+  ];
+
+  for (const { file, funnel, latch, settled } of RELOAD_FUNNELS) {
+    const lines = linesOf(file);
+    const src = lines.join('\n');
+
+    test(`${file}: the reload funnel latches the reload and repaints`, () => {
+      const defIdx = lines.findIndex((l) => funnel.test(l));
+      assert.ok(defIdx >= 0, 'a reload funnel must be defined');
+      const body = lines.slice(defIdx, defIdx + 14).join('\n');
+      assert.match(body, /\.reload\(\)/, 'funnel must issue the reload');
+      assert.match(body, latch, 'funnel must latch the reload for the settled re-nudge');
+    });
+
+    test(`${file}: a settled load repaints the recommitted surface`, () => {
+      assert.match(src, settled,
+        'the load-settled signal must drive the reload repaint (PAUSE-021)');
+    });
+
+    test(`${file}: no raw reload() outside the funnel (PAUSE-021 gate)`, () => {
+      const offenders = [];
+      lines.forEach((l, i) => {
+        if (/^\s*(\/\/|\*)/.test(l)) return; // prose, not a call site
+        if (!/(?:controller|ctrl|_controller)[!?]?\.reload\(\)/.test(l)) return;
+        // Exempt the funnel definition itself (reload sits a few lines under
+        // the signature, past the null check and the latch call).
+        if (funnel.test(context(lines, i, 14, 0))) return;
+        offenders.push(i + 1);
+      });
+      assert.deepEqual(
+        offenders,
+        [],
+        `raw reload() outside the funnel at line(s) ${offenders.join(', ')}. ` +
+          'Route reloads through the reloadAndRepaint funnel (PAUSE-021 / BUG-001).',
+      );
+    });
+  }
+
+  // main.dart holds no controller of its own — it reloads through the model —
+  // so its obligation is to wire the two host hooks to the engine.
+  test('lib/main.dart: reload hooks drive the surface repaint engine', () => {
+    const src = linesOf('lib/main.dart').join('\n');
+    assert.match(src, /onReloadIssued\s*=\s*\(\)\s*\{/,
+      'main.dart must handle onReloadIssued for the visible site');
+    assert.match(src, /_surfaceRepaint\.reloadIssued\(\)/,
+      'the reload must be latched on the engine');
+    assert.match(src, /_surfaceRepaint\.consumeLoadSettled\(\)/,
+      'the settled load must re-nudge (PAUSE-021)');
+    const offenders = [];
+    linesOf('lib/main.dart').forEach((l, i) => {
+      if (/\.controller\?\.reload\(\)/.test(l)) offenders.push(i + 1);
+    });
+    assert.deepEqual(offenders, [],
+      `raw controller reload in main.dart at line(s) ${offenders.join(', ')}; ` +
+        'call WebViewModel.reloadAndRepaint instead.');
   });
 }
 

--- a/test/surface_repaint_engine_test.dart
+++ b/test/surface_repaint_engine_test.dart
@@ -18,6 +18,10 @@ void main() {
       expect(SurfaceRepaintEngine.mustRepaint(SurfaceTransition.back), isTrue);
       expect(SurfaceRepaintEngine.mustRepaint(SurfaceTransition.forward), isTrue);
     });
+
+    test('reload owes a repaint (PAUSE-021 / BUG-001)', () {
+      expect(SurfaceRepaintEngine.mustRepaint(SurfaceTransition.reload), isTrue);
+    });
   });
 
   group('coalescing tick machine', () {
@@ -188,6 +192,97 @@ void main() {
               reason: withMetricsRenudge
                   ? 'metrics re-nudge repainted the late reattach'
                   : 'reproduction: late reattach left blank without the re-nudge');
+        });
+      }
+    });
+  });
+
+  group('reload ordering (BUG-001 Attempt 9 / PAUSE-021)', () {
+    // Same ordering as the warm start above, reached through a different
+    // trigger: a reload discards the painted frame at issue time and commits
+    // the new one an unbounded time later. The nudge fired when reload() is
+    // called drains against the OLD surface; the recommit lands afterwards and
+    // nothing relayouts it. The latch carries the debt to the load-settled
+    // signal, which is the reload's real attach.
+
+    void drain(SurfaceRepaintEngine e) {
+      RepaintTick t;
+      do {
+        t = e.tick();
+      } while (!t.done);
+    }
+
+    test('reproduce: the issue-time nudge drains before the recommit', () {
+      final e = SurfaceRepaintEngine();
+      e.reloadIssued();
+      e.request();
+      drain(e);
+      expect(e.owed, isFalse, reason: 'nothing has re-attached yet');
+
+      // The new document commits onto the surface only now. Pre-Attempt-9
+      // there was no signal here, so no nudge ran against it.
+      expect(e.consumeLoadSettled(), isTrue);
+      expect(e.owed, isTrue,
+          reason: 'BUG-001: the recommitted surface is left unpainted');
+    });
+
+    test('fix: the load-settled re-nudge repaints the recommit', () {
+      final e = SurfaceRepaintEngine();
+      e.reloadIssued();
+      e.request();
+      drain(e);
+
+      expect(e.consumeLoadSettled(), isTrue);
+      e.request();
+      drain(e);
+      expect(e.owed, isFalse);
+    });
+
+    test('the latch is one-shot: a later unrelated load does not nudge', () {
+      final e = SurfaceRepaintEngine();
+      e.reloadIssued();
+      expect(e.consumeLoadSettled(), isTrue);
+      expect(e.reloadPending, isFalse);
+      expect(e.consumeLoadSettled(), isFalse,
+          reason: 'an ordinary navigation must not trigger a repaint');
+    });
+
+    test('a load settling with no reload in flight owes nothing', () {
+      final e = SurfaceRepaintEngine();
+      expect(e.consumeLoadSettled(), isFalse);
+      expect(e.owed, isFalse);
+    });
+
+    test('timing-faithful: a 2s reload is caught only with the settled re-nudge',
+        () {
+      // Host harness mirroring main.dart: onReloadIssued nudges immediately
+      // (~600ms of ticks), the page recommits at 2s. Only the settled re-nudge
+      // still has a tick left for it.
+      for (final withSettledRenudge in [false, true]) {
+        fakeAsync((async) {
+          final e = SurfaceRepaintEngine();
+          void nudge() {
+            if (!e.request()) return;
+            void tick() {
+              final t = e.tick();
+              if (t.done) return;
+              Future.delayed(const Duration(milliseconds: 100), tick);
+            }
+
+            tick();
+          }
+
+          e.reloadIssued();
+          nudge();
+          Future.delayed(const Duration(seconds: 2), () {
+            if (e.consumeLoadSettled() && withSettledRenudge) nudge();
+          });
+          async.elapse(const Duration(seconds: 5));
+
+          expect(e.owed, withSettledRenudge ? isFalse : isTrue,
+              reason: withSettledRenudge
+                  ? 'settled re-nudge repainted the recommitted surface'
+                  : 'reproduction: slow reload left blank-white');
         });
       }
     });


### PR DESCRIPTION
A reload drops the painted frame at issue time and recommits it an
unbounded time later; the SurfaceView is blank in between and nothing
relayouts it. Latch the reload and nudge again when the load settles.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0168jSvA2VmewgKJPZtiW7bJ