### PR TITLE
Re-issue a load stranded by the background on resume

### DIFF
--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -293,6 +293,14 @@ causal claim is unverified, exactly as in Attempt 8.
 
 ## Diagnostic checklist (when this recurs)
 
+- Confirm there is a **document to paint** at all. A load the OS stranded while the app
+  was backgrounded (background network restrictions, a per-app firewall such as
+  CalyxOS/Datura) leaves either the engine's "connection failed" page or a page that
+  never commits — the latter is white and looks exactly like this bug with a different
+  cause. Tell them apart by the report: a blank that a rotate/tab-switch instantly clears
+  is this bug; a blank that survives a relayout, or a visible "connection failed", is
+  `PAUSE-022` (`ResumeReloadEngine`), which re-issues the load on resume. No nudge can
+  fix that one.
 - Confirm it's the **surface**, not a dead renderer: does the page respond to taps /
   does a rotate or tab-switch instantly fix it? If yes → surface, use the nudge. If a
   rotate doesn't fix it and JS is dead → renderer death, a different bug:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,6 +46,7 @@ import 'package:webspace/services/timezone_spoof_policy.dart';
 import 'package:webspace/services/html_import_storage.dart';
 import 'package:webspace/services/settings_backup.dart';
 import 'package:webspace/services/cookie_isolation.dart';
+import 'package:webspace/services/resume_reload_engine.dart';
 import 'package:webspace/services/surface_repaint_engine.dart';
 import 'package:webspace/services/cookie_secure_storage.dart';
 import 'package:webspace/services/proxy_password_secure_storage.dart';
@@ -1593,7 +1594,13 @@ class _WebSpacePageState extends State<WebSpacePage>
             _webViewModels[pausePlan.jsPauseIndex!].pauseForAppLifecycle();
       }
       if (pausePlan.captureStateIndex != null) {
-        unawaited(_captureStateBytes(_webViewModels[pausePlan.captureStateIndex!]));
+        final model = _webViewModels[pausePlan.captureStateIndex!];
+        unawaited(_captureStateBytes(model));
+        // Remember whether a navigation was caught mid-flight: a background
+        // process can lose the network under it (Android background limits,
+        // a per-app firewall) and come back to an error page or to a page
+        // that never arrives. See PAUSE-022.
+        model.resumeReload.noteAppBackgrounded();
       }
       // iOS: open a ~30s background-task window so notification webviews
       // can flush in-flight setTimeouts before iOS suspends the process.
@@ -1685,9 +1692,71 @@ class _WebSpacePageState extends State<WebSpacePage>
       // was recreated and the platform-view surface came back blank. See
       // PAUSE-015.
       _nudgeSurfaceRepaint();
+      // A repaint cannot recover a page that never loaded. Re-issue a load
+      // the OS stranded while we were backgrounded, against the same
+      // now-final visible site. Runs long (bounded retries with a backoff),
+      // so it is not awaited inside the resume sequence. See PAUSE-022.
+      final retryIdx = AppLifecycleEngine.activeLoadedIndex(
+        currentIndex: _currentIndex,
+        siteCount: _webViewModels.length,
+        loadedIndices: _loadedIndices,
+      );
+      if (retryIdx != null) {
+        unawaited(_retryIncompleteLoadOnResume(_webViewModels[retryIdx]));
+      }
     } finally {
       _isResuming = false;
     }
+  }
+
+  /// Re-entry guard for [_retryIncompleteLoadOnResume]: `resumed` can fire
+  /// again (or a shortcut can re-enter the resume sequence) while a retry is
+  /// still awaiting its backoff, and two loops would fight over the same
+  /// webview's navigation.
+  bool _isRetryingIncompleteLoad = false;
+
+  /// Drive [ResumeReloadEngine]'s recovery for the visible site after a
+  /// resume (PAUSE-022). The engine decides *whether* and *what* to re-issue;
+  /// this owns the clock, the connectivity gate and the controller call.
+  ///
+  /// Bails on every await boundary if the user switched sites, the webview
+  /// went away, or the app went back to the background — the retry only ever
+  /// touches the site the user is currently looking at.
+  Future<void> _retryIncompleteLoadOnResume(WebViewModel model) async {
+    if (_isRetryingIncompleteLoad) return;
+    _isRetryingIncompleteLoad = true;
+    try {
+      for (var i = 0; i < ResumeReloadEngine.maxAttempts; i++) {
+        var plan = model.resumeReload.planRetry();
+        if (plan.action == ResumeRetryAction.waitAndReplan) {
+          await Future.delayed(plan.delay);
+          if (!_retryTargetStillVisible(model)) return;
+          model.resumeReload.noteStallGraceElapsed();
+          plan = model.resumeReload.planRetry();
+        }
+        if (plan.action != ResumeRetryAction.retryNow) return;
+        // Offline is an honest error page — re-issuing just reprints it.
+        if (!await ConnectivityService.instance.isOnline()) return;
+        if (!_retryTargetStillVisible(model)) return;
+        model.resumeReload.noteRetryIssued();
+        LogService.instance.log(
+          'ResumeReload',
+          'attempt=${model.resumeReload.attempts} -> reissuing stranded load',
+        );
+        await model.reissueLoadAndRepaint(plan.url!);
+        await Future.delayed(ResumeReloadEngine.retryBackoff);
+        if (!_retryTargetStillVisible(model)) return;
+      }
+    } finally {
+      _isRetryingIncompleteLoad = false;
+    }
+  }
+
+  bool _retryTargetStillVisible(WebViewModel model) {
+    if (!mounted) return false;
+    if (model.controller == null) return false;
+    final idx = _webViewModels.indexOf(model);
+    return idx >= 0 && idx == _currentIndex;
   }
 
   Future<void> _resumeAfterLifecyclePause() async {

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -8,7 +9,9 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'package:webspace/l10n/gen/app_localizations.dart';
 import 'package:webspace/screens/dev_tools.dart';
+import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/log_service.dart';
+import 'package:webspace/services/resume_reload_engine.dart';
 import 'package:webspace/services/surface_repaint_engine.dart';
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/settings/location.dart';
@@ -177,6 +180,12 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
   final SurfaceRepaintEngine _surfaceRepaint = SurfaceRepaintEngine();
   bool _repaintNudge = false;
 
+  /// Recovery state for a load the OS stranded while the app was backgrounded
+  /// (PAUSE-022). The nested screen is as exposed as the main page: it is the
+  /// visible webview when the user switches away mid-navigation.
+  final ResumeReloadEngine _resumeReload = ResumeReloadEngine();
+  bool _isRetryingIncompleteLoad = false;
+
   /// Bumped on renderer-gone recovery (BUG-002 gap #1). Wraps the webview in a
   /// `KeyedSubtree` whose changing key remounts a fresh `InAppWebView` — the
   /// nested analog of the main screen's destroy-and-rebuild. Recovery reloads
@@ -297,6 +306,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
           _surfaceRepaint.reloadIssued();
           _nudgeSurfaceRepaint();
         },
+        onMainFrameLoad: _resumeReload.noteLoad,
         onLoadingChanged: (loading) {
           if (!mounted || _isLoading == loading) return;
           setState(() {
@@ -441,6 +451,43 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
     await controller.reload();
   }
 
+  /// Nested counterpart of `_WebSpacePageState._retryIncompleteLoadOnResume`
+  /// (PAUSE-022): re-issue a load the OS stranded while the app was in the
+  /// background. Loads the URL explicitly rather than reloading — the webview
+  /// may be sitting on an error page or on the previous document — and reports
+  /// through the same repaint latch as a real reload.
+  Future<void> _retryIncompleteLoadOnResume() async {
+    if (_isRetryingIncompleteLoad) return;
+    _isRetryingIncompleteLoad = true;
+    try {
+      for (var i = 0; i < ResumeReloadEngine.maxAttempts; i++) {
+        var plan = _resumeReload.planRetry();
+        if (plan.action == ResumeRetryAction.waitAndReplan) {
+          await Future.delayed(plan.delay);
+          if (!mounted || _controller == null) return;
+          _resumeReload.noteStallGraceElapsed();
+          plan = _resumeReload.planRetry();
+        }
+        if (plan.action != ResumeRetryAction.retryNow) return;
+        if (!await ConnectivityService.instance.isOnline()) return;
+        final controller = _controller;
+        if (!mounted || controller == null) return;
+        _resumeReload.noteRetryIssued();
+        _surfaceRepaint.reloadIssued();
+        _nudgeSurfaceRepaint();
+        try {
+          await controller.loadUrl(plan.url!, language: widget.language);
+        } catch (_) {
+          // Controller may have been disposed while the retry was in flight.
+        }
+        await Future.delayed(ResumeReloadEngine.retryBackoff);
+        if (!mounted || _controller == null) return;
+      }
+    } finally {
+      _isRetryingIncompleteLoad = false;
+    }
+  }
+
   /// Destroy-and-rebuild this nested webview after its renderer process is gone
   /// (BUG-002 gap #1). Bumping `_rendererGen` remounts a fresh `InAppWebView`;
   /// the dead controller is dropped (a fresh one arrives via onControllerCreated).
@@ -473,8 +520,11 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.resumed) {
+    if (state == AppLifecycleState.paused) {
+      _resumeReload.noteAppBackgrounded();
+    } else if (state == AppLifecycleState.resumed) {
       _probeNestedRenderer();
+      unawaited(_retryIncompleteLoadOnResume());
     }
   }
 

--- a/lib/services/resume_reload_engine.dart
+++ b/lib/services/resume_reload_engine.dart
@@ -1,0 +1,213 @@
+/// Pure-Dart decision engine for PAUSE-022: a main-frame load that never
+/// finished because the app was in the background.
+///
+/// Distinct from the blank-surface class (BUG-001 / `SurfaceRepaintEngine`):
+/// there the document is committed and painted-over-nothing, here there is no
+/// committed document at all — the OS (or a per-app background network policy
+/// such as CalyxOS/Datura, or Android's own background restrictions) cut the
+/// connection out from under an in-flight navigation, so the user comes back
+/// to a browser error page or to a page that never appears. A repaint nudge
+/// cannot fix that; only re-issuing the load can.
+///
+/// The engine owns the state machine and the decision; the host owns the
+/// clock, the connectivity probe and the controller call. It never imports
+/// Flutter, so it unit-tests without a widget. See
+/// test/resume_reload_engine_test.dart.
+library;
+
+/// Where a main-frame navigation is in its lifecycle, as reported by the
+/// webview factory (`onLoadStart` / `onLoadStop` / `onReceivedError`).
+enum MainFrameLoadPhase { started, settled, failed }
+
+/// One main-frame load lifecycle event. [url] is the navigation target
+/// ([MainFrameLoadPhase.settled] carries none); [errorType] is the platform
+/// `WebResourceErrorType.toValue()` string and is set only for
+/// [MainFrameLoadPhase.failed].
+class MainFrameLoadSignal {
+  final MainFrameLoadPhase phase;
+  final String? url;
+  final String? errorType;
+
+  const MainFrameLoadSignal.started(String this.url)
+      : phase = MainFrameLoadPhase.started,
+        errorType = null;
+
+  const MainFrameLoadSignal.settled()
+      : phase = MainFrameLoadPhase.settled,
+        url = null,
+        errorType = null;
+
+  const MainFrameLoadSignal.failed(String this.url, String this.errorType)
+      : phase = MainFrameLoadPhase.failed;
+}
+
+/// What the host should do next for this webview.
+enum ResumeRetryAction {
+  /// Nothing to recover.
+  none,
+
+  /// Re-issue [ResumeRetryPlan.url] now (subject to the host's connectivity
+  /// gate).
+  retryNow,
+
+  /// A navigation was still in flight when the app was backgrounded and still
+  /// is. Wait [ResumeRetryPlan.delay] and ask again: a load that was merely
+  /// slow finishes on its own and needs no retry, while one whose socket the
+  /// OS dropped stays stuck and comes back as [retryNow].
+  waitAndReplan,
+}
+
+class ResumeRetryPlan {
+  final ResumeRetryAction action;
+
+  /// URL to re-issue. Non-null exactly when [action] is
+  /// [ResumeRetryAction.retryNow].
+  final String? url;
+
+  /// How long to wait before re-planning. Meaningful only for
+  /// [ResumeRetryAction.waitAndReplan].
+  final Duration delay;
+
+  const ResumeRetryPlan.none()
+      : action = ResumeRetryAction.none,
+        url = null,
+        delay = Duration.zero;
+
+  const ResumeRetryPlan.retryNow(String this.url)
+      : action = ResumeRetryAction.retryNow,
+        delay = Duration.zero;
+
+  const ResumeRetryPlan.waitAndReplan(this.delay)
+      : action = ResumeRetryAction.waitAndReplan,
+        url = null;
+}
+
+/// Per-webview recovery state. One instance per `WebViewModel` (and one per
+/// nested `InAppWebViewScreen`).
+class ResumeReloadEngine {
+  /// Main-frame failures worth re-issuing once the app is foreground again:
+  /// everything whose cause can plausibly be "the network was not reachable
+  /// from a backgrounded process". Deliberately excludes failures a retry
+  /// cannot change (bad URL, unsupported scheme, file not found), failures a
+  /// retry makes worse (redirect loops, rate limiting), and everything the TLS
+  /// path in `webview.dart` already owns (certificate + handshake errors) —
+  /// silently re-issuing those would paper over a prompt the user must see.
+  ///
+  /// `UNKNOWN` is included because Android maps several chromium `net::`
+  /// connectivity errors onto `ERROR_UNKNOWN` (-1) rather than a specific
+  /// code, and it is the code a firewall-dropped connection most often
+  /// surfaces as.
+  static const Set<String> retryableErrorTypes = {
+    'HOST_LOOKUP',
+    'CANNOT_CONNECT_TO_HOST',
+    'CANNOT_LOAD_FROM_NETWORK',
+    'CONNECTION_ABORTED',
+    'DATA_NOT_ALLOWED',
+    'IO',
+    'NETWORK_CONNECTION_LOST',
+    'NOT_CONNECTED_TO_INTERNET',
+    'RESET',
+    'SERVER_UNREACHABLE',
+    'TIMEOUT',
+    'UNKNOWN',
+  };
+
+  /// Re-issues allowed per foreground session. The budget refills on
+  /// [noteAppBackgrounded] (every return to the app is a fresh chance —
+  /// the user may have just fixed connectivity) and on a load that settles
+  /// without an error.
+  static const int maxAttempts = 2;
+
+  /// How long to let a navigation that was already in flight at background
+  /// time keep running after the resume before treating it as stuck.
+  static const Duration stallGrace = Duration(seconds: 2);
+
+  /// How long to let a re-issued load run before planning the next attempt.
+  static const Duration retryBackoff = Duration(seconds: 3);
+
+  static bool isRetryable(String errorType) =>
+      retryableErrorTypes.contains(errorType);
+
+  bool _inFlight = false;
+  String? _inFlightUrl;
+  String? _failedUrl;
+  bool _backgroundedWhileLoading = false;
+  bool _stallGraceSpent = false;
+  int _attempts = 0;
+
+  /// Whether a main-frame navigation is currently running.
+  bool get isLoading => _inFlight;
+
+  /// URL of the last main-frame load that failed retryably and has not been
+  /// re-issued yet, or null.
+  String? get failedUrl => _failedUrl;
+
+  int get attempts => _attempts;
+
+  void noteLoad(MainFrameLoadSignal signal) {
+    switch (signal.phase) {
+      case MainFrameLoadPhase.started:
+        _inFlight = true;
+        _inFlightUrl = signal.url;
+        // A new navigation supersedes the previous failure — including the
+        // one a retry is currently re-issuing.
+        _failedUrl = null;
+      case MainFrameLoadPhase.settled:
+        _inFlight = false;
+        // `onReceivedError` precedes `onLoadStop` for the same navigation, so
+        // a recorded failure survives the settle that reports the error page.
+        if (_failedUrl == null) {
+          _attempts = 0;
+          _backgroundedWhileLoading = false;
+          _stallGraceSpent = false;
+        }
+      case MainFrameLoadPhase.failed:
+        _failedUrl = isRetryable(signal.errorType!) ? signal.url : null;
+    }
+  }
+
+  /// The app went to the background. Records whether a navigation was caught
+  /// mid-flight (the case the OS is about to strand) and refills the budget.
+  void noteAppBackgrounded() {
+    _backgroundedWhileLoading = _inFlight;
+    _stallGraceSpent = false;
+    _attempts = 0;
+  }
+
+  /// The host waited [stallGrace] after the resume and the load is still
+  /// stuck, so the next plan escalates from "wait" to "re-issue".
+  void noteStallGraceElapsed() {
+    _stallGraceSpent = true;
+  }
+
+  ResumeRetryPlan planRetry() {
+    if (_attempts >= maxAttempts) return const ResumeRetryPlan.none();
+    final failed = _failedUrl;
+    if (failed != null) return ResumeRetryPlan.retryNow(failed);
+    if (_backgroundedWhileLoading && _inFlight) {
+      if (!_stallGraceSpent) return const ResumeRetryPlan.waitAndReplan(stallGrace);
+      final pending = _inFlightUrl;
+      if (pending != null) return ResumeRetryPlan.retryNow(pending);
+    }
+    return const ResumeRetryPlan.none();
+  }
+
+  /// The host issued the re-load from [planRetry]. Spends one attempt and
+  /// clears the triggering condition, so an unchanged state cannot re-fire.
+  void noteRetryIssued() {
+    _attempts++;
+    _failedUrl = null;
+    _backgroundedWhileLoading = false;
+    _stallGraceSpent = false;
+  }
+
+  /// Drop all recovery state (fresh controller, site recreated).
+  void reset() {
+    _inFlight = false;
+    _inFlightUrl = null;
+    _failedUrl = null;
+    _backgroundedWhileLoading = false;
+    _stallGraceSpent = false;
+    _attempts = 0;
+  }
+}

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -14,6 +14,7 @@ import 'package:webspace/services/language_shim.dart';
 import 'package:webspace/services/launch_nonce.dart';
 import 'package:webspace/services/letterbox.dart';
 import 'package:webspace/services/proxy_relay.dart';
+import 'package:webspace/services/resume_reload_engine.dart';
 import 'package:webspace/services/target_blank_rewrite.dart';
 import 'package:webspace/services/theme_color_scheme_shim.dart';
 import 'package:webspace/services/connectivity_service.dart';
@@ -548,6 +549,12 @@ class WebViewConfig {
   /// reloads funnel through `WebViewModel.reloadAndRepaint`; this is the
   /// same signal for the ones the factory issues on its own.
   final VoidCallback? onReloadIssued;
+  /// Fires on every main-frame load lifecycle transition (start / settle /
+  /// failure). Feeds `ResumeReloadEngine`, which decides whether a load the
+  /// OS stranded while the app was backgrounded has to be re-issued on the
+  /// next resume (PAUSE-022). Distinct from [onLoadingChanged], which is
+  /// UI state and carries neither the URL nor the failure.
+  final void Function(MainFrameLoadSignal signal)? onMainFrameLoad;
   /// Fires as the main-frame load advances, with progress in 0-100.
   /// Driven by the platform's `onProgressChanged`. The call site can
   /// use this to render a determinate loading bar while a navigation
@@ -706,6 +713,7 @@ class WebViewConfig {
     this.onUrlChanged,
     this.onLoadingChanged,
     this.onReloadIssued,
+    this.onMainFrameLoad,
     this.onProgressChanged,
     this.onCookiesChanged,
     this.cookieManager,
@@ -3453,6 +3461,10 @@ class WebViewFactory {
         // Notify the call site that a navigation just started so the
         // Refresh button can swap to a Stop button while loading.
         config.onLoadingChanged?.call(true);
+        if (url != null) {
+          config.onMainFrameLoad
+              ?.call(MainFrameLoadSignal.started(url.toString()));
+        }
 
         // Track that this URL has a real page load (not SPA navigation)
         lastLoadStartUrl = url?.toString();
@@ -3522,6 +3534,7 @@ class WebViewFactory {
         // the loading-state UI is independent of the cache/snapshot
         // logic gated below.
         config.onLoadingChanged?.call(false);
+        config.onMainFrameLoad?.call(const MainFrameLoadSignal.settled());
         if (url == null) return;
         final urlStr = url.toString();
 
@@ -3728,7 +3741,15 @@ class WebViewFactory {
           if (handled) return;
         }
         final externalInfo = ExternalUrlParser.parse(reqUrl);
-        if (externalInfo == null) return;
+        if (externalInfo == null) {
+          // Ordinary load failure (no external scheme, TLS already handled
+          // above). Report it so the host can re-issue the load on the next
+          // resume when the cause was the OS cutting the network out from
+          // under a backgrounded process — PAUSE-022.
+          config.onMainFrameLoad?.call(
+              MainFrameLoadSignal.failed(reqUrl, error.type.toValue()));
+          return;
+        }
         if (ExternalUrlSuppressor.isSuppressedInfo(externalInfo)) {
           if (!Platform.isAndroid) {
             // WebKit reports a policy-cancelled external-scheme nav as

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -16,6 +16,7 @@ import 'package:webspace/services/html_cache_service.dart';
 import 'package:webspace/services/link_routing_service.dart' show LinkRoutingService;
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/navigation_decision_engine.dart';
+import 'package:webspace/services/resume_reload_engine.dart';
 import 'package:webspace/services/firefox_user_agent_service.dart';
 import 'package:webspace/services/site_lifecycle_promotion_engine.dart';
 import 'package:webspace/services/tab_bar_corner.dart';
@@ -498,6 +499,11 @@ class WebViewModel {
   /// Consumed by the URL-bar action button to swap Refresh ↔ Stop
   /// while a load is in flight.
   bool isLoading = false;
+
+  /// Recovery state for a main-frame load the OS stranded while the app was
+  /// backgrounded (PAUSE-022). Fed by the `WebViewConfig.onMainFrameLoad`
+  /// signals wired in [getWebView]; consulted by the host on resume.
+  final ResumeReloadEngine resumeReload = ResumeReloadEngine();
 
   /// Main-frame load progress in 0-100. Driven by the
   /// `WebViewConfig.onProgressChanged` callback wired in [getWebView];
@@ -1120,6 +1126,7 @@ class WebViewModel {
             }
           },
           onReloadIssued: () => onReloadIssued?.call(),
+          onMainFrameLoad: resumeReload.noteLoad,
           onLoadingChanged: (loading) {
             if (isLoading == loading) return;
             isLoading = loading;
@@ -1486,6 +1493,7 @@ class WebViewModel {
     );
     webview = null;
     controller = null;
+    resumeReload.reset();
     stateSetterF?.call();
   }
 
@@ -1592,6 +1600,7 @@ class WebViewModel {
     );
     webview = null;
     controller = null;
+    resumeReload.reset();
   }
 
   /// Drop the in-memory cache (decoded image cache + HTTP response
@@ -1663,6 +1672,24 @@ class WebViewModel {
       await ctrl.reload();
     } catch (_) {
       // Controller may have been disposed between the cache clear and the reload.
+    }
+  }
+
+  /// Re-issue a main-frame load that never finished because the app was
+  /// backgrounded (PAUSE-022). Loads [url] explicitly rather than calling
+  /// `reload()`: the webview may be sitting on a committed error page or on
+  /// the *previous* document with the failed navigation already discarded, so
+  /// there is nothing reliable to reload. Reports through [onReloadIssued] so
+  /// the surface repaint latches exactly as it does for a real reload
+  /// (PAUSE-021) — the incoming document lands on the same blank surface.
+  Future<void> reissueLoadAndRepaint(String url) async {
+    final ctrl = controller;
+    if (ctrl == null) return;
+    onReloadIssued?.call();
+    try {
+      await ctrl.loadUrl(url, language: language);
+    } catch (_) {
+      // Controller may have been disposed while the retry was in flight.
     }
   }
 

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -703,6 +703,60 @@ Both nudges SHALL emit a non-sensitive `SurfaceDiag` line (`trigger=reload -> nu
 
 ---
 
+### Requirement: PAUSE-022 — Resume Re-Issues A Load Stranded By The Background
+
+The system SHALL re-issue, on `AppLifecycleState.resumed`, a main-frame load of the visible webview that never completed because the app was in the background.
+
+This is **not** the blank-surface class of PAUSE-015/017/018/020/021 and no repaint can fix it. A backgrounded process can lose the network under an in-flight navigation: Android's own background restrictions, a per-app firewall (CalyxOS/Datura and equivalents), or a doze transition drop the connection mid-load. Two outcomes reach the user, and both look like the app is broken:
+
+- the navigation **fails** and the engine commits its own error page, so returning to the app shows "connection failed";
+- the navigation is **stranded in flight** with no error and no commit, so returning to the app shows a blank page that never resolves — visually identical to BUG-001's white screen, with a different cause.
+
+Decisions live in the pure-Dart `ResumeReloadEngine` ([lib/services/resume_reload_engine.dart](../../../lib/services/resume_reload_engine.dart)); the host owns the clock, the connectivity probe, and the controller call.
+
+1. **Signals.** The webview factory SHALL report every main-frame load transition through `WebViewConfig.onMainFrameLoad`: `started(url)` from `onLoadStart`, `settled()` from `onLoadStop`, and `failed(url, errorType)` from `onReceivedError` for main-frame errors that the TLS path (`_handleSslLoadError`) and the external-scheme path have not already claimed. `onLoadingChanged` is UI state and is not a substitute: it carries neither the URL nor the failure.
+2. **Retryable failures.** Only failures whose cause can plausibly be "no network from a backgrounded process" are re-issued (`ResumeReloadEngine.retryableErrorTypes`: `HOST_LOOKUP`, `CANNOT_CONNECT_TO_HOST`, `IO`, `TIMEOUT`, `NOT_CONNECTED_TO_INTERNET`, `NETWORK_CONNECTION_LOST`, `UNKNOWN`, and siblings). Failures a retry cannot fix (`BAD_URL`, `FILE_NOT_FOUND`, `UNSUPPORTED_SCHEME`), failures a retry makes worse (`TOO_MANY_REDIRECTS`, `TOO_MANY_REQUESTS`), and every certificate/handshake error SHALL NOT be re-issued — silently reloading the last would paper over a prompt the user must see.
+3. **Stranded loads get a grace period.** A load that was in flight when `paused` fired and is still in flight after the resume SHALL first be given `stallGrace` (2s) to finish on its own; only if it is still stuck after that is it re-issued. A merely slow load is never interrupted.
+4. **Re-issue, not reload.** The recovery SHALL `loadUrl` the recorded URL rather than calling `reload()`: the webview may be sitting on a committed error page or still on the *previous* document with the failed navigation already discarded, so there is nothing reliable to reload. It SHALL report through `onReloadIssued` so the PAUSE-021 repaint latch covers the incoming document exactly as it covers a real reload.
+5. **Bounded and gated.** At most `maxAttempts` (2) re-issues per foreground session, separated by `retryBackoff` (3s). The budget refills when a load settles without error and when the app is next backgrounded (a return to the app is a fresh chance — the user may have just fixed connectivity). Each attempt is gated on `ConnectivityService.isOnline()`: while genuinely offline the error page is honest and re-issuing only reprints it. The loop bails at every await boundary if the user switched sites, the controller went away, or the widget unmounted, and is re-entrancy guarded.
+6. **Both screens.** The main page (`_WebSpacePageState._retryIncompleteLoadOnResume`, run at the tail of `_onResumed` against the now-final visible site) and the nested `InAppWebViewScreen` (`_retryIncompleteLoadOnResume`, run from its own lifecycle observer) SHALL each carry the recovery — the nested screen is the visible webview when the user switches away mid-navigation.
+
+The recovery is platform-neutral by construction (nothing in the engine is Android-specific), but the stranding it recovers from is what Android's background network policy produces; on platforms that do not strand loads the engine simply never plans a retry.
+
+#### Scenario: Load killed by the background firewall is re-issued
+
+**Given** a site is loading when the user switches away from the app, and the OS drops the connection so the load fails with `HOST_LOOKUP`
+**When** the user switches back to the app
+**Then** the engine plans a retry of the failed URL, the host confirms connectivity, and the load is re-issued through the repaint funnel
+**And** the user sees the site load instead of the engine's "connection failed" page
+
+#### Scenario: Stranded in-flight load is given a grace period first
+
+**Given** a navigation was still in flight when the app was backgrounded
+**When** the user returns and the navigation is still in flight
+**Then** the host waits `stallGrace` and re-plans
+**And** if the load settled during the grace nothing is re-issued; if it is still stuck the pending URL is re-issued
+
+#### Scenario: A certificate failure is never silently re-issued
+
+**Given** a load failed with `SERVER_CERTIFICATE_UNTRUSTED` while the app was backgrounded
+**When** the user returns to the app
+**Then** the engine plans nothing, because the TLS prompt path owns that failure
+
+#### Scenario: A permanently broken page does not loop
+
+**Given** a load fails with a retryable error and both re-issues fail the same way
+**When** the resume retry loop re-plans
+**Then** the attempt budget is spent and no further load is issued until the app is backgrounded again or a load settles cleanly
+
+#### Scenario: Retry never touches a site the user is no longer looking at
+
+**Given** a retry is awaiting its backoff after the first re-issue
+**When** the user switches to a different site
+**Then** the loop bails without issuing another load
+
+---
+
 ### Requirement: PAUSE-016 — Android Per-Instance Pause Is a No-Op
 
 On Android the per-instance `pause()` / `resume()` (`WebView.onPause()` / `onResume()`) SHALL be no-ops. Android exposes no per-instance JavaScript pause — `onPause()` halts only animations and geolocation and explicitly does not pause JS, while the only JS-timer pause (`pauseTimers()`) is process-global. So per-instance pause contributes nothing to the lifecycle freeze, yet cycling the foreground hybrid-composition `SurfaceView` through onPause/onResume re-attaches it blank on the next paint — the white screen the user hits after a transient background or a navigation that follows a resume.
@@ -857,6 +911,8 @@ class _WebViewController implements WebViewController {
 ### Added
 
 - `test/webview_pause_lifecycle_test.dart` — contract tests for the API split.
+- `lib/services/resume_reload_engine.dart` — PAUSE-022 decision engine.
+- `test/resume_reload_engine_test.dart` — PAUSE-022 characterization tests.
 - `openspec/specs/webview-pause-lifecycle/spec.md` — this document.
 
 ## Related Specs

--- a/test/js/nested_webview_posture_parity.test.js
+++ b/test/js/nested_webview_posture_parity.test.js
@@ -146,7 +146,7 @@ const PLUMBING = new Set([
   'backForwardGestures', // deliberate root-only: nested uses route-pop (NAV-008)
   'onUrlChanged', 'onCookiesChanged', 'cookieManager', 'containerCookieManager',
   'cookieSiteId', 'onFindResult', 'shouldOverrideUrlLoading', 'onLoadingChanged',
-  'onProgressChanged', 'onReloadIssued',
+  'onProgressChanged', 'onReloadIssued', 'onMainFrameLoad',
   'onWindowRequested', 'onHtmlLoaded', 'shouldFetchHtml', 'onConsoleMessage',
   'onConfirmScriptFetch', 'onExternalSchemeUrl', 'pullToRefreshController',
   'onRendererGone', 'onProtectedMediaRequest',

--- a/test/resume_reload_engine_test.dart
+++ b/test/resume_reload_engine_test.dart
@@ -1,0 +1,200 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/resume_reload_engine.dart';
+
+/// Drive a full failed navigation: start, error, load-stop (the error page).
+/// Mirrors the platform callback order — `onReceivedError` precedes
+/// `onLoadStop` for the same navigation.
+void _failNavigation(ResumeReloadEngine e, String url, String errorType) {
+  e.noteLoad(MainFrameLoadSignal.started(url));
+  e.noteLoad(MainFrameLoadSignal.failed(url, errorType));
+  e.noteLoad(const MainFrameLoadSignal.settled());
+}
+
+void _completeNavigation(ResumeReloadEngine e, String url) {
+  e.noteLoad(MainFrameLoadSignal.started(url));
+  e.noteLoad(const MainFrameLoadSignal.settled());
+}
+
+void main() {
+  group('error classification (PAUSE-022)', () {
+    test('connectivity failures are retryable', () {
+      for (final type in [
+        'HOST_LOOKUP',
+        'CANNOT_CONNECT_TO_HOST',
+        'IO',
+        'TIMEOUT',
+        'NOT_CONNECTED_TO_INTERNET',
+        'NETWORK_CONNECTION_LOST',
+        'UNKNOWN',
+      ]) {
+        expect(ResumeReloadEngine.isRetryable(type), isTrue, reason: type);
+      }
+    });
+
+    test('failures a retry cannot or must not fix are not retryable', () {
+      for (final type in [
+        'BAD_URL',
+        'FILE_NOT_FOUND',
+        'UNSUPPORTED_SCHEME',
+        'TOO_MANY_REDIRECTS',
+        'TOO_MANY_REQUESTS',
+        'UNSAFE_RESOURCE',
+        'FAILED_SSL_HANDSHAKE',
+        'SERVER_CERTIFICATE_UNTRUSTED',
+        'SECURE_CONNECTION_FAILED',
+        'USER_AUTHENTICATION_FAILED',
+      ]) {
+        expect(ResumeReloadEngine.isRetryable(type), isFalse, reason: type);
+      }
+    });
+  });
+
+  group('failed load is re-issued on resume', () {
+    test('a network failure plans a retry of the failed URL', () {
+      final e = ResumeReloadEngine();
+      _failNavigation(e, 'https://example.com/', 'HOST_LOOKUP');
+      e.noteAppBackgrounded();
+
+      final plan = e.planRetry();
+      expect(plan.action, ResumeRetryAction.retryNow);
+      expect(plan.url, 'https://example.com/');
+    });
+
+    test('a non-retryable failure plans nothing', () {
+      final e = ResumeReloadEngine();
+      _failNavigation(e, 'https://example.com/', 'BAD_URL');
+      e.noteAppBackgrounded();
+
+      expect(e.planRetry().action, ResumeRetryAction.none);
+    });
+
+    test('a page that loaded fine plans nothing', () {
+      final e = ResumeReloadEngine();
+      _completeNavigation(e, 'https://example.com/');
+      e.noteAppBackgrounded();
+
+      expect(e.planRetry().action, ResumeRetryAction.none);
+    });
+
+    test('issuing the retry clears the trigger so it cannot re-fire', () {
+      final e = ResumeReloadEngine();
+      _failNavigation(e, 'https://example.com/', 'TIMEOUT');
+      e.noteRetryIssued();
+
+      expect(e.planRetry().action, ResumeRetryAction.none);
+    });
+
+    test('a retry that fails again is retried once more, then the budget stops it',
+        () {
+      final e = ResumeReloadEngine();
+      _failNavigation(e, 'https://example.com/', 'HOST_LOOKUP');
+
+      expect(e.planRetry().action, ResumeRetryAction.retryNow);
+      e.noteRetryIssued();
+      _failNavigation(e, 'https://example.com/', 'HOST_LOOKUP');
+
+      expect(e.planRetry().action, ResumeRetryAction.retryNow);
+      e.noteRetryIssued();
+      _failNavigation(e, 'https://example.com/', 'HOST_LOOKUP');
+
+      expect(e.attempts, ResumeReloadEngine.maxAttempts);
+      expect(e.planRetry().action, ResumeRetryAction.none);
+    });
+
+    test('a successful load refills the budget', () {
+      final e = ResumeReloadEngine();
+      _failNavigation(e, 'https://example.com/', 'HOST_LOOKUP');
+      e.noteRetryIssued();
+      e.noteRetryIssued();
+      expect(e.planRetry().action, ResumeRetryAction.none);
+
+      _completeNavigation(e, 'https://example.com/');
+      expect(e.attempts, 0);
+    });
+
+    test('returning to the app refills the budget — connectivity may be fixed',
+        () {
+      final e = ResumeReloadEngine();
+      _failNavigation(e, 'https://example.com/', 'HOST_LOOKUP');
+      e.noteRetryIssued();
+      e.noteRetryIssued();
+      expect(e.planRetry().action, ResumeRetryAction.none);
+
+      e.noteAppBackgrounded();
+      _failNavigation(e, 'https://example.com/', 'HOST_LOOKUP');
+      expect(e.planRetry().action, ResumeRetryAction.retryNow);
+    });
+  });
+
+  group('load still in flight at background time', () {
+    test('a load stranded mid-flight waits out the grace before being re-issued',
+        () {
+      final e = ResumeReloadEngine();
+      e.noteLoad(MainFrameLoadSignal.started('https://example.com/'));
+      e.noteAppBackgrounded();
+
+      final first = e.planRetry();
+      expect(first.action, ResumeRetryAction.waitAndReplan);
+      expect(first.delay, ResumeReloadEngine.stallGrace);
+
+      e.noteStallGraceElapsed();
+      final second = e.planRetry();
+      expect(second.action, ResumeRetryAction.retryNow);
+      expect(second.url, 'https://example.com/');
+    });
+
+    test('a merely slow load that finishes during the grace is left alone', () {
+      final e = ResumeReloadEngine();
+      e.noteLoad(MainFrameLoadSignal.started('https://example.com/'));
+      e.noteAppBackgrounded();
+      expect(e.planRetry().action, ResumeRetryAction.waitAndReplan);
+
+      e.noteLoad(const MainFrameLoadSignal.settled());
+      e.noteStallGraceElapsed();
+      expect(e.planRetry().action, ResumeRetryAction.none);
+    });
+
+    test('a load started after the resume is not treated as stranded', () {
+      final e = ResumeReloadEngine();
+      _completeNavigation(e, 'https://example.com/');
+      e.noteAppBackgrounded();
+      e.noteLoad(MainFrameLoadSignal.started('https://example.com/next'));
+
+      expect(e.planRetry().action, ResumeRetryAction.none);
+    });
+
+    test('a stranded load that errors during the grace retries the failed URL',
+        () {
+      final e = ResumeReloadEngine();
+      e.noteLoad(MainFrameLoadSignal.started('https://example.com/'));
+      e.noteAppBackgrounded();
+      expect(e.planRetry().action, ResumeRetryAction.waitAndReplan);
+
+      e.noteLoad(
+          MainFrameLoadSignal.failed('https://example.com/', 'HOST_LOOKUP'));
+      e.noteLoad(const MainFrameLoadSignal.settled());
+      final plan = e.planRetry();
+      expect(plan.action, ResumeRetryAction.retryNow);
+      expect(plan.url, 'https://example.com/');
+    });
+  });
+
+  test('a fresh navigation supersedes a pending failure', () {
+    final e = ResumeReloadEngine();
+    _failNavigation(e, 'https://example.com/', 'HOST_LOOKUP');
+    e.noteLoad(MainFrameLoadSignal.started('https://elsewhere.example/'));
+
+    expect(e.failedUrl, isNull);
+    expect(e.planRetry().action, ResumeRetryAction.none);
+  });
+
+  test('reset drops all recovery state', () {
+    final e = ResumeReloadEngine();
+    _failNavigation(e, 'https://example.com/', 'HOST_LOOKUP');
+    e.reset();
+
+    expect(e.failedUrl, isNull);
+    expect(e.attempts, 0);
+    expect(e.planRetry().action, ResumeRetryAction.none);
+  });
+}


### PR DESCRIPTION
Background network cutoffs (Android background limits, per-app firewalls) kill an in-flight navigation, so returning to the app shows the engine's error page or a page that never commits. No repaint can fix that; the load has to be re-issued. PAUSE-022.


Claude-Session: https://claude.ai/code/session_013qXNEfuFV4CXNNahoS3FcK