### PR TITLE
Point DNS blocklist levels at upstream's current file layout

### DIFF
--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -133,14 +133,24 @@ const List<String> dnsBlockLevelNames = [
 ];
 
 /// Domain list file names for each level (index 0 is unused since level 0 = Off).
+///
+/// Upstream retired the flat `domains/` tree. The bare-domain-per-line
+/// equivalent now lives under `wildcard/` with an `-onlydomains` suffix.
+/// Not the plain `wildcard/*.txt` files: those prefix every entry with
+/// `*.`, which the parser would take literally.
 const List<String?> _levelFiles = [
   null, // 0: Off
-  'domains/light.txt', // 1: Light
-  'domains/multi.txt', // 2: Normal
-  'domains/pro.txt', // 3: Pro
-  'domains/pro.plus.txt', // 4: Pro++
-  'domains/ultimate.txt', // 5: Ultimate
+  'wildcard/light-onlydomains.txt', // 1: Light
+  'wildcard/multi-onlydomains.txt', // 2: Normal
+  'wildcard/pro-onlydomains.txt', // 3: Pro
+  'wildcard/pro.plus-onlydomains.txt', // 4: Pro++
+  'wildcard/ultimate-onlydomains.txt', // 5: Ultimate
 ];
+
+/// Smallest plausible entry count for a real Hagezi list. The smallest one
+/// ("Light") carries ~40K domains, so a body parsing to fewer than this is a
+/// mirror serving an error page or a truncated transfer, not a blocklist.
+const int _minPlausibleDomains = 1000;
 
 /// Mirror base URLs tried in order on failure.
 const List<String> _mirrorBaseUrls = [
@@ -148,6 +158,16 @@ const List<String> _mirrorBaseUrls = [
   'https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/',
   'https://codeberg.org/hagezi/mirror2/raw/branch/main/dns-blocklists/',
 ];
+
+/// Full mirror URLs tried, in order, for [level]. Empty for level 0 (Off)
+/// and for out-of-range levels.
+@visibleForTesting
+List<String> dnsMirrorUrlsForLevel(int level) {
+  if (level < 1 || level >= _levelFiles.length) return const <String>[];
+  final path = _levelFiles[level];
+  if (path == null) return const <String>[];
+  return [for (final base in _mirrorBaseUrls) '$base$path'];
+}
 
 /// Singleton service for downloading, caching, and querying Hagezi DNS blocklists.
 /// Blocks navigation to ad/malware/tracker domains at the webview level.
@@ -545,12 +565,21 @@ class DnsBlockService {
           continue;
         }
 
+        final domains = _extractDomains(response.body);
+        if (!looksLikeDomainList(domains)) {
+          LogService.instance.log(
+              'DnsBlock',
+              'Mirror returned ${response.body.length} bytes yielding '
+              '${domains.length} usable entries, not a domain list. Skipping.',
+              level: LogLevel.error);
+          continue;
+        }
+
         // Save to disk
         final file = await _getCacheFile();
         await file.writeAsString(response.body);
 
-        // Parse domains
-        _parseDomains(response.body);
+        _applyDomains(domains);
         _level = level;
 
         // Save level and timestamp
@@ -659,13 +688,35 @@ class DnsBlockService {
     _parseDomains(data);
   }
 
-  void _parseDomains(String data) {
+  void _parseDomains(String data) => _applyDomains(_extractDomains(data));
+
+  static Set<String> _extractDomains(String data) {
     final domains = <String>{};
     for (final line in data.split('\n')) {
       final trimmed = line.trim();
       if (trimmed.isEmpty || trimmed.startsWith('#')) continue;
       domains.add(trimmed);
     }
+    return domains;
+  }
+
+  /// Whether a freshly downloaded body is a domain list at all. Guards the
+  /// download path only: a mirror that answers 200 with an HTML error page
+  /// or a truncated body must not overwrite a working cached blocklist.
+  /// Samples the head rather than the whole set — a real list is uniform,
+  /// and a bad one goes wrong from the first entry.
+  @visibleForTesting
+  static bool looksLikeDomainList(Set<String> domains) {
+    if (domains.length < _minPlausibleDomains) return false;
+    var checked = 0;
+    for (final d in domains) {
+      if (!d.contains('.') || d.contains(' ') || d.contains('<')) return false;
+      if (++checked >= 50) break;
+    }
+    return true;
+  }
+
+  void _applyDomains(Set<String> domains) {
     _blockedDomains = domains;
     // Rebuild bloom filter eagerly so the first webview page load doesn't
     // pay the ~500ms build cost synchronously.

--- a/openspec/specs/dns-blocklist/spec.md
+++ b/openspec/specs/dns-blocklist/spec.md
@@ -47,6 +47,18 @@ Users SHALL be able to download a DNS blocklist at their chosen severity level. 
 **Then** a failure SnackBar is shown
 **And** any previously cached blocklist remains available
 
+#### Scenario: A mirror answers 200 with something that is not a blocklist
+
+**Given** a mirror returns HTTP 200 whose body parses to fewer than 1000
+entries, or whose entries are not bare domains (an error page, a truncated
+transfer)
+**When** the download is attempted
+**Then** the body is discarded without touching the on-disk cache or the
+in-memory domain set
+**And** the next mirror is tried
+**And** if no mirror yields a valid body, the previously cached blocklist
+remains available
+
 ---
 
 ### Requirement: DNS-002 - Severity Levels
@@ -56,11 +68,23 @@ The system SHALL support 6 levels (0–5), each corresponding to a specific Hage
 | Level | Name | File |
 |-------|------|------|
 | 0 | Off | — (clears blocklist) |
-| 1 | Light | `domains/light.txt` |
-| 2 | Normal | `domains/multi.txt` |
-| 3 | Pro | `domains/pro.txt` |
-| 4 | Pro++ | `domains/pro.plus.txt` |
-| 5 | Ultimate | `domains/ultimate.txt` |
+| 1 | Light | `wildcard/light-onlydomains.txt` |
+| 2 | Normal | `wildcard/multi-onlydomains.txt` |
+| 3 | Pro | `wildcard/pro-onlydomains.txt` |
+| 4 | Pro++ | `wildcard/pro.plus-onlydomains.txt` |
+| 5 | Ultimate | `wildcard/ultimate-onlydomains.txt` |
+
+Upstream publishes the same list in several syntaxes. Only the
+`-onlydomains` variant is one bare domain per line, which is what the
+parser expects; `wildcard/<level>.txt` prefixes every entry with `*.`
+and `adblock/<level>.txt` wraps them as `||domain^`. Upstream retired
+the flat `domains/` tree these levels used to point at.
+
+#### Scenario: Level paths track the upstream layout
+
+**Given** the app resolves the file path for any level 1-5
+**Then** the path names an `-onlydomains.txt` file
+**And** no path refers to the retired `domains/` tree
 
 #### Scenario: Set level to Off
 
@@ -776,6 +800,16 @@ Three mirrors are tried in order with 15-second timeouts:
 1. `https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/`
 2. `https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/`
 3. `https://codeberg.org/hagezi/mirror2/raw/branch/main/dns-blocklists/`
+
+Mirror bases and level paths are joined by `dnsMirrorUrlsForLevel`, which
+the regression test in `test/dns_block_service_test.dart` asserts against
+so a path that drifts from the upstream layout fails CI instead of
+surfacing as a download error at every severity level.
+
+A 200 response is not trusted on status alone. The body is parsed into a
+candidate set first and only committed (disk + memory + level + timestamp)
+once `DnsBlockService.looksLikeDomainList` accepts it, so a mirror serving
+an HTML error page cannot replace a working cached list with garbage.
 
 ### Per-Site DNS Statistics
 

--- a/test/dns_block_service_test.dart
+++ b/test/dns_block_service_test.dart
@@ -213,4 +213,57 @@ void main() {
       expect(bloom.contains('dnsonly.example'), isTrue);
     });
   });
+
+  group('mirror URLs (DNS-001, DNS-002)', () {
+    test('every level resolves to a bare-domain list on 3 mirrors', () {
+      for (var level = 1; level <= 5; level++) {
+        final urls = dnsMirrorUrlsForLevel(level);
+        expect(urls, hasLength(3), reason: 'level $level');
+        for (final url in urls) {
+          expect(url, endsWith('-onlydomains.txt'), reason: url);
+          // The retired flat tree. Every mirror 404s these paths, which is
+          // what made the download fail at every severity level.
+          expect(url, isNot(contains('/domains/')), reason: url);
+        }
+      }
+    });
+
+    test('level 0 and out-of-range levels have no mirror URLs', () {
+      expect(dnsMirrorUrlsForLevel(0), isEmpty);
+      expect(dnsMirrorUrlsForLevel(-1), isEmpty);
+      expect(dnsMirrorUrlsForLevel(6), isEmpty);
+    });
+
+    test('each level maps to a distinct file', () {
+      final firsts = [for (var l = 1; l <= 5; l++) dnsMirrorUrlsForLevel(l).first];
+      expect(firsts.toSet(), hasLength(5));
+    });
+  });
+
+  group('downloaded body validation', () {
+    Set<String> domainsOf(int n) =>
+        {for (var i = 0; i < n; i++) 'blocked$i.example.com'};
+
+    test('a plausible list is accepted', () {
+      expect(DnsBlockService.looksLikeDomainList(domainsOf(2000)), isTrue);
+    });
+
+    test('an error page body is rejected', () {
+      expect(
+        DnsBlockService.looksLikeDomainList({'<!DOCTYPE html>', '<html>'}),
+        isFalse,
+      );
+    });
+
+    test('a truncated body is rejected', () {
+      expect(DnsBlockService.looksLikeDomainList(domainsOf(50)), isFalse);
+    });
+
+    test('a large body of non-domain lines is rejected', () {
+      final prose = {
+        for (var i = 0; i < 2000; i++) 'Not Found: request $i failed.',
+      };
+      expect(DnsBlockService.looksLikeDomainList(prose), isFalse);
+    });
+  });
 }


### PR DESCRIPTION
Hagezi retired the flat domains/ tree, so every mirror 404s the old paths
and the download failed at every severity level. The bare-domain-per-line
equivalent is now wildcard/<level>-onlydomains.txt. Also validate a 200
body before it replaces a working cached list.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013bqvkrmuuTHoWR4hLx3jtN