### PR TITLE
Add version 24 changelog

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/24.txt
+++ b/fastlane/metadata/android/en-US/changelogs/24.txt
@@ -1,0 +1,9 @@
+✨ New Features:
+• Drag to reorder tabs
+
+🔧 Improvements:
+• Monochrome app icon
+
+🐛 Bug Fixes:
+• DNS blocklist downloads work again
+• Blank page after resume or reload


### PR DESCRIPTION
Headline fix is the DNS blocklist download URLs.