### PR TITLE
Stop unscoped global cookie clears under containers, pin fork privacy-v6

### DIFF
--- a/docs/bugs/007-native-shared-state-races.md
+++ b/docs/bugs/007-native-shared-state-races.md
@@ -129,6 +129,35 @@ funnel only covers `deleteAllCookies`; the other unscoped ops (`setCookie`,
 unguarded, and gap 2 below (the fork's Swift registry lost-update) is the same class in the
 same fork, still open.
 
+### Attempt 5 — Structural gate on the pinned fork source
+**Date:** 2026-08-12 · **PR:** #526 ·
+**Files:** `test/fork_cookie_manager_invariant_test.dart`
+**What it did:** attempt 4 left the fork side guarded by a comment on the field, on the
+reasoning that a JVM test belongs in the fork's tree. That skipped a third option: the fork
+is consumed here at a *git ref*, so `pub get` puts its real source on disk and this repo can
+read what it actually resolved. The test resolves `flutter_inappwebview_android` through
+`.dart_tool/package_config.json` (never a globbed pub-cache path, so it always inspects the
+ref this checkout pinned) and asserts, on `MyCookieManager.java`: the scoped lookup is never
+assigned into the static memo; every `cookieManagerForContainerOf` call site captures its
+result in a local or returns it; no method that calls the scoped lookup also references the
+bare static; and `flush` still fans out via `ProfileStore.getAllProfileNames` (PAUSE-023
+depends on that, and before the tag a flush skipped every container). Comments and string
+literals are blanked before matching, so prose about the invariant cannot satisfy it. Three
+anchor assertions fail loudly if the fork renames the field, the lookup, or the fan-out,
+rather than passing vacuously. Verified by mutation: six pre-fix shapes (memo poisoned from
+the scoped path, scoped method reading the static, fan-out call dropped, and each of the
+three anchors renamed) each turn it red, naming the offending line.
+**Why:** the fork is pinned to a mutable branch that gets tagged per release, so "fixed in
+v6" is a statement about a ref that can move. A gate that reads the resolved source turns
+the next reintroduction into a red build at `flutter test` time instead of sporadic logouts
+in the field.
+**Why it was partial:** it is a *shape* check on one file, not a behavioral one. It cannot
+see a poisoning that happens through a helper it does not know about, and it says nothing
+about whether the runtime actually routes to the right jar (that still needs a device with
+`MULTI_PROFILE` and two live profiles, untested at any tier). It covers only Android's
+`MyCookieManager`: gap 2 below, the same class in the same fork's Swift tree, remains
+unguarded and is the obvious next file to point this technique at.
+
 ## Known open gaps
 
 1. **No universal structural guard.** Each instance got its own guard (or none, for the

--- a/docs/bugs/007-native-shared-state-races.md
+++ b/docs/bugs/007-native-shared-state-races.md
@@ -95,6 +95,40 @@ dropped `BLOCKED` entry is a transient filter-bypass.
 native component that shares mutable state can reintroduce it, and the fork + a few
 same-class reads remain (open gaps).
 
+### Attempt 4 — Fork `MyCookieManager` static memo poisoned by container-scoped reads
+**Date:** 2026-08-12 · **PR:** #526 (app side) + fork tag `v6.2.0-beta.3-privacy-v6` ·
+**Files:** fork `flutter_inappwebview_android/.../MyCookieManager.java`,
+`lib/services/orphan_sweep_engine.dart`, `lib/main.dart`,
+`test/js/global_cookie_clear_funnel.test.js`
+**What it did:** `MyCookieManager` memoizes the Android `CookieManager` in a `public static`
+field, lazily via `getCookieManager()` (a null-only check, so the first value written is
+sticky until process death). The container patch added two `webViewId`-scoped entry points,
+`getCookies` and `deleteCookie`, and both assigned the profile-scoped manager *into that
+static* — matching the file's house style, where every method opens with
+`cookieManager = getCookieManager();`. From the first container-scoped read onward the memo
+held some site's `Profile.getCookieManager()`, and every unscoped op in the class
+(`setCookie`, `deleteCookies`, `deleteAllCookies`, `removeSessionCookies`, `flush`,
+`getAllCookies`) silently addressed that container's jar instead of the default one. The fork
+moved both scoped lookups into method locals and documented the invariant on the field. The
+app side stopped issuing the unscoped op that made it reachable: `OrphanSweepEngine` only
+clears the legacy global jar when `useContainers` is false, the post-import clear is gated the
+same way, and a structural gate fails CI on a new ungated `deleteAllCookies()` call site.
+**Why:** the app's post-paint orphan sweep ends in `deleteAllCookies()`, which under
+containers is meant to reclaim the unused default jar. With the memo poisoned it wiped a live
+container instead — and `removeAllCookies` is followed by `flush()`, so the wipe was durable.
+Users saw a site logged out one launch later. It reproduced only via home-shortcut launches,
+because that is the sole cold start where a site loads (and its load-stop cookie read poisons
+the memo) *before* the deferred sweep runs; an icon launch opens the home screen, leaves the
+memo null, and the clear correctly hits the default jar. Reported as issues #524 and #525.
+**Why it was partial:** the same file still writes the memo from unscoped methods, so the
+field remains process-global mutable state one careless scoped assignment away from
+recurrence — the fork's guard is a comment plus code review, not a test (the JVM-side gate
+that would catch it belongs in the fork's tree, which this repo cannot gate). The app-side
+funnel only covers `deleteAllCookies`; the other unscoped ops (`setCookie`,
+`removeSessionCookies`, `getAllCookies`) are still reachable from legacy paths and are
+unguarded, and gap 2 below (the fork's Swift registry lost-update) is the same class in the
+same fork, still open.
+
 ## Known open gaps
 
 1. **No universal structural guard.** Each instance got its own guard (or none, for the

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -62,6 +62,7 @@ import 'package:webspace/services/site_data_clear_engine.dart';
 import 'package:webspace/services/site_lifecycle_engine.dart';
 import 'package:webspace/services/site_lifecycle_promotion_engine.dart';
 import 'package:webspace/services/site_retention_priority.dart';
+import 'package:webspace/services/orphan_sweep_engine.dart';
 import 'package:webspace/services/site_unload_engine.dart';
 import 'package:webspace/services/nav_state_capture_debouncer.dart';
 import 'package:webspace/services/webview_state_secure_storage.dart';
@@ -1588,7 +1589,14 @@ class _WebSpacePageState extends State<WebSpacePage>
         siteCount: _webViewModels.length,
         loadedIndices: _loadedIndices,
         notificationsEnabled: (i) => _webViewModels[i].effectiveNotificationsEnabled,
+        cookieFlushSupported: CookieManager.flushSupported,
       );
+      // Backgrounding is the last moment we control before the OS may kill
+      // the process, and Chromium commits cookies to disk lazily. Unawaited:
+      // durability is best-effort and nothing downstream depends on it.
+      if (pausePlan.flushCookies) {
+        unawaited(_cookieManager.flush());
+      }
       if (pausePlan.jsPauseIndex != null) {
         _lifecyclePauseFuture =
             _webViewModels[pausePlan.jsPauseIndex!].pauseForAppLifecycle();
@@ -4702,16 +4710,12 @@ class _WebSpacePageState extends State<WebSpacePage>
     Set<String> nonIncognitoSiteIds,
   ) async {
     try {
-      await _cookieSecureStorage.removeOrphanedCookies(nonIncognitoSiteIds);
-      await _proxyPasswordStorage.removeOrphaned(activeSiteIds);
-      await HtmlCacheService.instance.removeOrphanedCaches(nonIncognitoSiteIds);
-      await HtmlImportStorage.instance.removeOrphanedImports(activeSiteIds);
-      await _stateStorage.removeOrphans(nonIncognitoSiteIds);
-      // Clears residual cookies of deleted/legacy sites from the global
-      // (legacy) jar. Container-mode sites read their own jar; legacy-mode
-      // re-nukes + restores on each activation, so this only matters for the
-      // never-activated home-screen launch.
-      await _cookieManager.deleteAllCookies();
+      await OrphanSweepEngine.sweep(
+        targets: _OrphanSweepTargets(this),
+        activeSiteIds: activeSiteIds,
+        nonIncognitoSiteIds: nonIncognitoSiteIds,
+        useContainers: _useContainers,
+      );
     } catch (e) {
       LogService.instance.log(
         'Startup',
@@ -5536,7 +5540,10 @@ class _WebSpacePageState extends State<WebSpacePage>
     // If no site is activated, _setCurrentIndex returns without routing
     // through _restoreCookiesForSite — which means pre-import cookies from
     // the previously-active site remain in the native jar. Nuke explicitly.
-    if (indexToRestore == null) {
+    // Legacy engine only: container-mode sites never shared that jar, so the
+    // clear reclaims nothing there, and an unscoped clear issued while live
+    // containers exist is the shape BUG-007 turned into a wiped session.
+    if (indexToRestore == null && !_useContainers) {
       await _cookieManager.deleteAllCookies();
     }
     await _setCurrentIndex(indexToRestore);
@@ -8499,6 +8506,38 @@ class _SiteRouteAdapter implements DispatchableSite {
 
   @override
   String get navigationDomain => getNormalizedDomain(model.initUrl);
+}
+
+/// Binds [OrphanSweepEngine]'s targets to the concrete storage services.
+/// Kept out of `_WebSpacePageState` so the sweep's ordering and its
+/// container-mode carve-out stay unit-testable against fakes.
+class _OrphanSweepTargets implements OrphanSweepTargets {
+  final _WebSpacePageState state;
+  const _OrphanSweepTargets(this.state);
+
+  @override
+  Future<void> removeOrphanedCookies(Set<String> nonIncognitoSiteIds) =>
+      state._cookieSecureStorage.removeOrphanedCookies(nonIncognitoSiteIds);
+
+  @override
+  Future<void> removeOrphanedProxyPasswords(Set<String> activeSiteIds) =>
+      state._proxyPasswordStorage.removeOrphaned(activeSiteIds);
+
+  @override
+  Future<void> removeOrphanedHtmlCaches(Set<String> nonIncognitoSiteIds) =>
+      HtmlCacheService.instance.removeOrphanedCaches(nonIncognitoSiteIds);
+
+  @override
+  Future<void> removeOrphanedHtmlImports(Set<String> activeSiteIds) =>
+      HtmlImportStorage.instance.removeOrphanedImports(activeSiteIds);
+
+  @override
+  Future<void> removeOrphanedWebViewState(Set<String> nonIncognitoSiteIds) =>
+      state._stateStorage.removeOrphans(nonIncognitoSiteIds);
+
+  @override
+  Future<void> clearLegacyGlobalCookieJar() =>
+      state._cookieManager.deleteAllCookies();
 }
 
 sealed class _DispatchChoice {

--- a/lib/services/app_lifecycle_engine.dart
+++ b/lib/services/app_lifecycle_engine.dart
@@ -21,9 +21,16 @@ class LifecycleBackgroundPlan {
   /// is not gated on notifications — any loaded active site is captured.
   final int? captureStateIndex;
 
+  /// Commit pending cookie writes to disk before the OS can kill the process.
+  /// Chromium's cookie store commits lazily, so a session cookie set moments
+  /// before backgrounding is otherwise lost on a swipe-kill and the user
+  /// returns logged out (issues #524, #525).
+  final bool flushCookies;
+
   const LifecycleBackgroundPlan({
     required this.jsPauseIndex,
     required this.captureStateIndex,
+    required this.flushCookies,
   });
 }
 
@@ -45,26 +52,36 @@ class AppLifecycleEngine {
   /// Plan for `AppLifecycleState.paused`. The active site's JS timers pause
   /// only when it is loaded and NOT a notification site; restore-state is
   /// captured for any loaded active site.
+  ///
+  /// [cookieFlushSupported] is the caller's platform answer for
+  /// `CookieManager.flush` (Android only — everywhere else the platform
+  /// interface's default throws). The flush is independent of the active
+  /// site: any loaded webview may have written a cookie the platform has not
+  /// committed to disk yet, notification sites very much included.
   static LifecycleBackgroundPlan backgroundPlan({
     required int? currentIndex,
     required int siteCount,
     required Set<int> loadedIndices,
     required bool Function(int index) notificationsEnabled,
+    required bool cookieFlushSupported,
   }) {
+    final flushCookies = cookieFlushSupported && loadedIndices.isNotEmpty;
     final active = activeLoadedIndex(
       currentIndex: currentIndex,
       siteCount: siteCount,
       loadedIndices: loadedIndices,
     );
     if (active == null) {
-      return const LifecycleBackgroundPlan(
+      return LifecycleBackgroundPlan(
         jsPauseIndex: null,
         captureStateIndex: null,
+        flushCookies: flushCookies,
       );
     }
     return LifecycleBackgroundPlan(
       jsPauseIndex: notificationsEnabled(active) ? null : active,
       captureStateIndex: active,
+      flushCookies: flushCookies,
     );
   }
 

--- a/lib/services/orphan_sweep_engine.dart
+++ b/lib/services/orphan_sweep_engine.dart
@@ -1,0 +1,57 @@
+/// Storage reclaimed by the post-paint orphan sweep. Each method drops
+/// everything keyed by a siteId outside the live set it is handed.
+///
+/// Two different live sets are in play, and which one a target gets is part
+/// of the contract: session residue (cookies, cached HTML, saved navigation
+/// state) measures against the non-incognito set, so an incognito site's
+/// remnants are reclaimed every launch (issue #298), while configuration
+/// (proxy passwords, imported HTML) measures against the full active set and
+/// survives for incognito sites like any other.
+abstract class OrphanSweepTargets {
+  Future<void> removeOrphanedCookies(Set<String> nonIncognitoSiteIds);
+  Future<void> removeOrphanedProxyPasswords(Set<String> activeSiteIds);
+  Future<void> removeOrphanedHtmlCaches(Set<String> nonIncognitoSiteIds);
+  Future<void> removeOrphanedHtmlImports(Set<String> activeSiteIds);
+  Future<void> removeOrphanedWebViewState(Set<String> nonIncognitoSiteIds);
+
+  /// Empties the single shared cookie jar the legacy engine partitions by
+  /// hand. Only meaningful when [OrphanSweepEngine.sweep] runs with
+  /// `useContainers: false`.
+  Future<void> clearLegacyGlobalCookieJar();
+}
+
+/// Reclaims storage left behind by sites deleted in previous sessions. Runs
+/// after first paint: the launched site reads its cookies from its own
+/// container (or, under the legacy engine, from its hydrated model), so
+/// nothing here is on the first-paint path.
+class OrphanSweepEngine {
+  OrphanSweepEngine._();
+
+  /// Sweeps every per-site storage, then clears the shared cookie jar when
+  /// the legacy engine owns it.
+  ///
+  /// The jar clear is skipped entirely under containers. It would reclaim
+  /// nothing there (each site owns its jar, and this call carries no site to
+  /// address), and issuing an unscoped "empty a cookie jar" op while live
+  /// containers exist is what made BUG-007's plugin-side mislabel reachable:
+  /// a container-scoped read had poisoned the plugin's `CookieManager` memo,
+  /// so the clear landed on a live container and wiped a real session, which
+  /// surfaced a launch later as a logged-out site (issues #524, #525). Fixed
+  /// in the fork at `v6.2.0-beta.3-privacy-v6`; not issuing the op keeps the
+  /// class of mistake unreachable from here rather than merely fixed once.
+  static Future<void> sweep({
+    required OrphanSweepTargets targets,
+    required Set<String> activeSiteIds,
+    required Set<String> nonIncognitoSiteIds,
+    required bool useContainers,
+  }) async {
+    await targets.removeOrphanedCookies(nonIncognitoSiteIds);
+    await targets.removeOrphanedProxyPasswords(activeSiteIds);
+    await targets.removeOrphanedHtmlCaches(nonIncognitoSiteIds);
+    await targets.removeOrphanedHtmlImports(activeSiteIds);
+    await targets.removeOrphanedWebViewState(nonIncognitoSiteIds);
+    if (!useContainers) {
+      await targets.clearLegacyGlobalCookieJar();
+    }
+  }
+}

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -211,6 +211,30 @@ class CookieManager {
   Future<void> deleteAllCookies() async {
     await _manager.deleteAllCookies();
   }
+
+  /// Commit pending cookie writes to persistent storage.
+  ///
+  /// Android only: the fork implements `flush` there (fanning out across every
+  /// container's jar, not just the default one), and the platform interface's
+  /// default throws `UnimplementedError` everywhere else. Callers gate on
+  /// [flushSupported] rather than calling and catching, so an unsupported
+  /// platform costs no channel round-trip. Failures are swallowed: a flush is
+  /// an optimization over the platform's own lazy commit, never a correctness
+  /// requirement.
+  static bool get flushSupported => Platform.isAndroid;
+
+  Future<void> flush() async {
+    if (!flushSupported) return;
+    try {
+      await _manager.flush();
+    } catch (e) {
+      LogService.instance.log(
+        'CookieManager',
+        'flush() failed: $e',
+        level: LogLevel.warning,
+      );
+    }
+  }
 }
 
 /// Find matches result

--- a/openspec/specs/per-site-containers/spec.md
+++ b/openspec/specs/per-site-containers/spec.md
@@ -509,6 +509,57 @@ deletable because the operation happens in the native cookie store.
   the existing `CookieManager` path, byte-identical to
   pre-Profile-API behaviour
 
+### Requirement: CONT-008 — No Unscoped Global Cookie Ops in Profile Mode
+
+In profile mode the app SHALL NOT issue a cookie operation that carries
+no site with it. Concretely, `CookieManager.deleteAllCookies()` (the
+global-jar clear, which the plugin resolves against its own internal
+state rather than an argument) SHALL only run when
+`_useContainers == false`.
+
+The clear reclaims nothing in profile mode — each site owns its jar and
+the default jar is unused (CONT-006) — so the op is pure risk. It is the
+shape that made [BUG-007](../../../docs/bugs/007-native-shared-state-races.md)
+attempt 4 destructive: a container-scoped read had poisoned the fork's
+static `CookieManager` memo, so an unscoped clear emptied a live
+container's jar and flushed the wipe to disk, surfacing a launch later
+as a logged-out site (issues #524, #525). The fork's memo is fixed as of
+`v6.2.0-beta.3-privacy-v6`; this requirement keeps the app from
+depending on that fix being correct.
+
+Enforcement is two-layer: [`OrphanSweepEngine`](../../../lib/services/orphan_sweep_engine.dart)
+owns the branch (`clearLegacyGlobalCookieJar` runs only under
+`!useContainers`), and a structural CI gate
+([test/js/global_cookie_clear_funnel.test.js](../../../test/js/global_cookie_clear_funnel.test.js))
+fails on a new ungated call site.
+
+#### Scenario: Post-paint orphan sweep in profile mode
+
+**Given** profile mode is active and the app has just painted after a
+  home-shortcut cold launch, with Site A loaded
+**When** the deferred startup GC runs `sweepOrphanStorage`
+**Then** every per-site storage sweep runs (cookies, proxy passwords,
+  HTML caches, HTML imports, webview state)
+**And** `CookieManager.deleteAllCookies()` is NOT called
+**And** Site A's profile cookie jar still holds its session
+
+#### Scenario: Post-paint orphan sweep in legacy mode
+
+**Given** legacy mode (`_useContainers == false`)
+**When** the deferred startup GC runs `sweepOrphanStorage`
+**Then** the per-site sweeps run first
+**And** `CookieManager.deleteAllCookies()` runs last, clearing residue
+  of deleted sites from the single shared jar — byte-identical to
+  pre-container behaviour
+
+#### Scenario: Settings import with no site to activate
+
+**Given** a settings backup is imported and the restored
+  `currentIndex` is null, so no site is activated
+**When** the import completes
+**Then** the pre-import global-jar clear runs only in legacy mode
+**And** in profile mode each site's jar is left to its own container
+
 ### Requirement: CONT-007 — No GMS in Shipped Artifacts
 
 The Profile API plugin SHALL NOT introduce any

--- a/openspec/specs/per-site-containers/spec.md
+++ b/openspec/specs/per-site-containers/spec.md
@@ -527,11 +527,14 @@ as a logged-out site (issues #524, #525). The fork's memo is fixed as of
 `v6.2.0-beta.3-privacy-v6`; this requirement keeps the app from
 depending on that fix being correct.
 
-Enforcement is two-layer: [`OrphanSweepEngine`](../../../lib/services/orphan_sweep_engine.dart)
+Enforcement is three-layer: [`OrphanSweepEngine`](../../../lib/services/orphan_sweep_engine.dart)
 owns the branch (`clearLegacyGlobalCookieJar` runs only under
-`!useContainers`), and a structural CI gate
+`!useContainers`), a structural CI gate
 ([test/js/global_cookie_clear_funnel.test.js](../../../test/js/global_cookie_clear_funnel.test.js))
-fails on a new ungated call site.
+fails on a new ungated call site, and
+[test/fork_cookie_manager_invariant_test.dart](../../../test/fork_cookie_manager_invariant_test.dart)
+reads the fork source this checkout actually resolved and fails if a bump
+reintroduces the memo mislabel underneath the app-side gate.
 
 #### Scenario: Post-paint orphan sweep in profile mode
 

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -857,8 +857,11 @@ when the app backgrounds.
 From fork tag `v6.2.0-beta.3-privacy-v6` the Android `flush` fans out
 across every container's `CookieManager` via `ProfileStore`, not just
 the default jar; before that tag a flush would silently skip every
-per-site container (CONT-002). The call is best-effort: it is unawaited
-at the call site and failures are logged, never surfaced.
+per-site container (CONT-002). That fan-out is a dependency of this
+requirement, not an implementation detail of the fork, so
+[test/fork_cookie_manager_invariant_test.dart](../../../test/fork_cookie_manager_invariant_test.dart)
+asserts it survives a fork bump. The call is best-effort: it is
+unawaited at the call site and failures are logged, never surfaced.
 
 #### Scenario: Backgrounding after a login
 

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -830,6 +830,68 @@ The site-switch pause SHALL respect the `_setCurrentIndexVersion` race guard so 
 
 ---
 
+### Requirement: PAUSE-023 — Commit Pending Cookie Writes On Background
+
+On `AppLifecycleState.paused` the app SHALL ask the plugin to commit
+pending cookie writes to persistent storage, whenever at least one
+webview is loaded and the platform implements `CookieManager.flush`
+(Android only — the plugin's platform interface throws
+`UnimplementedError` elsewhere).
+
+Chromium's cookie store commits to disk lazily, so a session cookie set
+shortly before the app is backgrounded is not durable. When the OS then
+kills the process (a swipe from recents, or a background-memory reclaim)
+those writes are lost and the user returns to a logged-out site even
+though nothing in the app deleted anything (issues #524, #525). Sites
+that rotate a session cookie on a short interval lose the session on the
+last few minutes of writes alone.
+
+Backgrounding is the last point the app controls, so the flush belongs
+in [`AppLifecycleEngine.backgroundPlan`](../../../lib/services/app_lifecycle_engine.dart)
+as `flushCookies`. The flush is independent of the active site: any
+loaded webview may hold uncommitted writes. Notification sites are
+exempt from the per-instance JS pause (NOTIF-004) and MUST NOT inherit
+that exemption here — they are the most likely to be alive and writing
+when the app backgrounds.
+
+From fork tag `v6.2.0-beta.3-privacy-v6` the Android `flush` fans out
+across every container's `CookieManager` via `ProfileStore`, not just
+the default jar; before that tag a flush would silently skip every
+per-site container (CONT-002). The call is best-effort: it is unawaited
+at the call site and failures are logged, never surfaced.
+
+#### Scenario: Backgrounding after a login
+
+**Given** Android, a loaded site whose page has just set a session cookie
+**When** the app is backgrounded (`AppLifecycleState.paused`)
+**Then** `backgroundPlan.flushCookies` is true
+**And** `CookieManager.flush()` is called
+**And** the cookie survives the OS killing the process
+
+#### Scenario: Notification site is active
+
+**Given** Android and the active loaded site has notifications enabled
+**When** the app is backgrounded
+**Then** `backgroundPlan.jsPauseIndex` is null (the site keeps ticking)
+**And** `backgroundPlan.flushCookies` is still true
+
+#### Scenario: Platform without flush support
+
+**Given** iOS, macOS, or Linux, where the plugin does not implement flush
+**When** the app is backgrounded
+**Then** `backgroundPlan.flushCookies` is false
+**And** no flush call is made, so no `UnimplementedError` is raised
+
+#### Scenario: Nothing loaded
+
+**Given** the app is backgrounded from the home screen with no webview
+  loaded this session
+**When** `AppLifecycleState.paused` fires
+**Then** `backgroundPlan.flushCookies` is false — no page could have
+  written a cookie, so there is nothing pending to commit
+
+---
+
 ## Implementation
 
 ### API Surface

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -327,8 +327,8 @@ packages:
     dependency: "direct main"
     description:
       path: flutter_inappwebview
-      ref: "v6.2.0-beta.3-privacy-v5"
-      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
+      ref: "v6.2.0-beta.3-privacy-v6"
+      resolved-ref: e890f461eb13ec81274e93df2b9843bcd74c049c
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "6.2.0-beta.3"
@@ -336,8 +336,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_android
-      ref: "v6.2.0-beta.3-privacy-v5"
-      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
+      ref: "v6.2.0-beta.3-privacy-v6"
+      resolved-ref: e890f461eb13ec81274e93df2b9843bcd74c049c
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.2.0-beta.3"
@@ -353,8 +353,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_ios
-      ref: "v6.2.0-beta.3-privacy-v5"
-      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
+      ref: "v6.2.0-beta.3-privacy-v6"
+      resolved-ref: e890f461eb13ec81274e93df2b9843bcd74c049c
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.2.0-beta.3"
@@ -362,8 +362,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_linux
-      ref: "v6.2.0-beta.3-privacy-v5"
-      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
+      ref: "v6.2.0-beta.3-privacy-v6"
+      resolved-ref: e890f461eb13ec81274e93df2b9843bcd74c049c
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "0.1.0-beta.2"
@@ -371,8 +371,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_macos
-      ref: "v6.2.0-beta.3-privacy-v5"
-      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
+      ref: "v6.2.0-beta.3-privacy-v6"
+      resolved-ref: e890f461eb13ec81274e93df2b9843bcd74c049c
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.2.0-beta.3"
@@ -380,8 +380,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_inappwebview_platform_interface
-      ref: "v6.2.0-beta.3-privacy-v5"
-      resolved-ref: fac0996928128bff343e8077ce155a17cb17760f
+      ref: "v6.2.0-beta.3-privacy-v6"
+      resolved-ref: e890f461eb13ec81274e93df2b9843bcd74c049c
       url: "https://github.com/theoden8/flutter_inappwebview"
     source: git
     version: "1.4.0-beta.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -98,32 +98,32 @@ dependency_overrides:
   flutter_inappwebview:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-privacy-v5
+      ref: v6.2.0-beta.3-privacy-v6
       path: flutter_inappwebview
   flutter_inappwebview_android:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-privacy-v5
+      ref: v6.2.0-beta.3-privacy-v6
       path: flutter_inappwebview_android
   flutter_inappwebview_ios:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-privacy-v5
+      ref: v6.2.0-beta.3-privacy-v6
       path: flutter_inappwebview_ios
   flutter_inappwebview_macos:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-privacy-v5
+      ref: v6.2.0-beta.3-privacy-v6
       path: flutter_inappwebview_macos
   flutter_inappwebview_linux:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-privacy-v5
+      ref: v6.2.0-beta.3-privacy-v6
       path: flutter_inappwebview_linux
   flutter_inappwebview_platform_interface:
     git:
       url: https://github.com/theoden8/flutter_inappwebview
-      ref: v6.2.0-beta.3-privacy-v5
+      ref: v6.2.0-beta.3-privacy-v6
       path: flutter_inappwebview_platform_interface
 
 flutter:

--- a/test/app_lifecycle_engine_test.dart
+++ b/test/app_lifecycle_engine_test.dart
@@ -63,6 +63,7 @@ void main() {
         siteCount: 2,
         loadedIndices: {0, 1},
         notificationsEnabled: (_) => false,
+        cookieFlushSupported: true,
       );
       expect(plan.jsPauseIndex, isNull);
       expect(plan.captureStateIndex, isNull);
@@ -74,6 +75,7 @@ void main() {
         siteCount: 3,
         loadedIndices: {0, 1},
         notificationsEnabled: (_) => false,
+        cookieFlushSupported: true,
       );
       expect(plan.jsPauseIndex, isNull);
       expect(plan.captureStateIndex, isNull);
@@ -85,6 +87,7 @@ void main() {
         siteCount: 3,
         loadedIndices: {0, 1},
         notificationsEnabled: (_) => false,
+        cookieFlushSupported: true,
       );
       expect(plan.jsPauseIndex, 1);
       expect(plan.captureStateIndex, 1);
@@ -96,6 +99,7 @@ void main() {
         siteCount: 3,
         loadedIndices: {0, 1},
         notificationsEnabled: (i) => i == 1,
+        cookieFlushSupported: true,
       );
       expect(plan.jsPauseIndex, isNull);
       expect(plan.captureStateIndex, 1);
@@ -116,6 +120,7 @@ void main() {
         siteCount: 3,
         loadedIndices: {0, 1, 2},
         notificationsEnabled: (_) => false,
+        cookieFlushSupported: true,
       );
       expect(plan.jsPauseIndex, flaggedIndex);
       expect(plan.captureStateIndex, flaggedIndex);
@@ -123,6 +128,81 @@ void main() {
       // site; the only signals are pause + capture, identical to a plain site.
       expect(urlEphemeral(flaggedIndex), isTrue,
           reason: 'sanity: the index under test is the flagged one');
+    });
+  });
+
+  // Chromium commits cookies to disk lazily, so a session cookie written
+  // moments before the OS kills a backgrounded app is never persisted and the
+  // user comes back logged out (issues #524, #525). Backgrounding is the last
+  // point we control, so the plan asks for a flush there.
+  group('AppLifecycleEngine.backgroundPlan cookie flush', () {
+    test('loaded site on a flush-capable platform: flush', () {
+      final plan = AppLifecycleEngine.backgroundPlan(
+        currentIndex: 1,
+        siteCount: 3,
+        loadedIndices: {0, 1},
+        notificationsEnabled: (_) => false,
+        cookieFlushSupported: true,
+      );
+      expect(plan.flushCookies, isTrue);
+    });
+
+    // `CookieManager.flush` is implemented on Android only; the platform
+    // interface's default throws UnimplementedError, so asking for a flush
+    // anywhere else turns a durability hook into a crash on every background.
+    test('platform without flush support: never flush', () {
+      final plan = AppLifecycleEngine.backgroundPlan(
+        currentIndex: 1,
+        siteCount: 3,
+        loadedIndices: {0, 1},
+        notificationsEnabled: (_) => false,
+        cookieFlushSupported: false,
+      );
+      expect(plan.flushCookies, isFalse);
+    });
+
+    test('nothing loaded: no flush', () {
+      // No webview loaded this session means no page could have written a
+      // cookie, so there is nothing pending to commit.
+      final plan = AppLifecycleEngine.backgroundPlan(
+        currentIndex: null,
+        siteCount: 3,
+        loadedIndices: const {},
+        notificationsEnabled: (_) => false,
+        cookieFlushSupported: true,
+      );
+      expect(plan.flushCookies, isFalse);
+    });
+
+    // Notification sites are exempt from the per-instance JS pause, and the
+    // flush must not inherit that exemption: they are the sites most likely to
+    // be alive and writing cookies when the app is backgrounded.
+    test('notification active site: no JS pause, but still flush', () {
+      final plan = AppLifecycleEngine.backgroundPlan(
+        currentIndex: 1,
+        siteCount: 3,
+        loadedIndices: {0, 1},
+        notificationsEnabled: (i) => i == 1,
+        cookieFlushSupported: true,
+      );
+      expect(plan.jsPauseIndex, isNull);
+      expect(plan.flushCookies, isTrue);
+    });
+
+    // A site can be loaded without being the active one (background tab, or
+    // the user backgrounded the app from the home screen). Its cookie writes
+    // are just as unflushed.
+    test('loaded but no active site: still flush', () {
+      final plan = AppLifecycleEngine.backgroundPlan(
+        currentIndex: null,
+        siteCount: 3,
+        loadedIndices: {0, 2},
+        notificationsEnabled: (_) => false,
+        cookieFlushSupported: true,
+      );
+      expect(plan.jsPauseIndex, isNull);
+      expect(plan.captureStateIndex, isNull);
+      expect(plan.flushCookies, isTrue);
     });
   });
 

--- a/test/fork_cookie_manager_invariant_test.dart
+++ b/test/fork_cookie_manager_invariant_test.dart
@@ -1,0 +1,330 @@
+// Structural gate on the pinned fork's MyCookieManager (BUG-007 attempt 4,
+// issues #524 / #525).
+//
+// The fork memoizes the Android CookieManager in a `public static` field with a
+// null-only lazy check, so the first value written is sticky until process
+// death. The container patch added two webViewId-scoped entry points, and when
+// those assigned their profile-scoped manager into that static, every unscoped
+// op in the class (setCookie, deleteCookies, deleteAllCookies,
+// removeSessionCookies, flush, getAllCookies) silently addressed some site's
+// container instead of the default jar. deleteAllCookies then wiped a live
+// session and flushed the wipe to disk.
+//
+// The fork's own guard is a comment on the field. A JVM test would live in the
+// fork's tree, but the fork is consumed here at a mutable git ref, so this repo
+// can read what it actually resolved and assert the invariant holds in the
+// source it is about to compile. That is the part this repo can own: CONT-008
+// keeps the app from issuing the unscoped op, and this keeps a fork bump from
+// silently reintroducing the mislabel underneath it.
+//
+// A failure here is not necessarily a regression. If the fork restructured the
+// file, re-audit the new shape against the invariant, then update the anchors
+// below.
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _forkPackage = 'flutter_inappwebview_android';
+const _sourcePath =
+    'android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/'
+    'MyCookieManager.java';
+
+/// The sticky memo. Must only ever hold the default profile's manager.
+const _memoField = 'cookieManager';
+
+/// The container-scoped lookup whose result must stay in a method local.
+const _scopedLookup = 'cookieManagerForContainerOf';
+
+/// Fans the flush out across every profile's jar. PAUSE-023 depends on it:
+/// without the fan-out, the on-background flush commits the default jar only
+/// and every container's session cookies stay unwritten.
+const _flushFanOut = 'flushContainerCookieManagers';
+
+void main() {
+  late List<String> lines;
+  late List<int> depth;
+
+  setUpAll(() {
+    final source = File(_resolveForkSource());
+    expect(
+      source.existsSync(),
+      isTrue,
+      reason:
+          'Cannot find $_sourcePath in the resolved $_forkPackage package. The '
+          'fork moved or renamed it, so the invariant below is unverified: '
+          're-audit and update the path.',
+    );
+    lines = _stripCommentsAndLiterals(source.readAsStringSync()).split('\n');
+    depth = _braceDepthBefore(lines);
+  });
+
+  group('fork MyCookieManager static memo', () {
+    test('the anchors this gate reads still exist', () {
+      // Each anchor is a thing the invariant is stated in terms of. Losing one
+      // silently would turn every assertion below into a vacuous pass.
+      expect(
+        _joined(lines),
+        matches(RegExp(r'public\s+static\s+CookieManager\s+' + _memoField)),
+        reason: 'the static memo is gone: re-audit, this gate assumes it exists',
+      );
+      expect(
+        _classLevelDeclarationOf(_scopedLookup, lines, depth),
+        isNotNull,
+        reason: '$_scopedLookup is gone: the scoped lookup was renamed or '
+            'removed, so this gate no longer covers it',
+      );
+      expect(
+        _classLevelDeclarationOf(_flushFanOut, lines, depth),
+        isNotNull,
+        reason: '$_flushFanOut is gone: PAUSE-023 assumes flush reaches every '
+            "container's jar",
+      );
+    });
+
+    test('the scoped lookup is never assigned into the static memo', () {
+      final offenders = <String>[];
+      for (var i = 0; i < lines.length; i++) {
+        if (RegExp('(?<![.\\w])$_memoField\\s*=\\s*$_scopedLookup\\s*\\(')
+            .hasMatch(lines[i])) {
+          offenders.add('MyCookieManager.java:${i + 1}');
+        }
+      }
+      expect(
+        offenders,
+        isEmpty,
+        reason: 'assigning a container-scoped manager into the static memo '
+            'redirects every unscoped op in the class to that container',
+      );
+    });
+
+    test('every scoped lookup call site keeps the result in a local', () {
+      final callSites = _callSitesOf(_scopedLookup, lines, depth);
+      expect(
+        callSites,
+        isNotEmpty,
+        reason: 'no call sites found: the scoped entry points changed shape',
+      );
+
+      final offenders = <String>[];
+      for (final i in callSites) {
+        final assignsToLocal = RegExp(
+          r'^\s*(?:return\s+|(?:final\s+)?CookieManager\s+\w+\s*=\s*)' +
+              _scopedLookup +
+              r'\s*\(',
+        ).hasMatch(lines[i]);
+        if (!assignsToLocal) offenders.add('MyCookieManager.java:${i + 1}');
+      }
+      expect(
+        offenders,
+        isEmpty,
+        reason: 'a scoped lookup must be captured as `CookieManager <local> = '
+            '$_scopedLookup(...)` or returned directly',
+      );
+    });
+
+    test('scoped methods do not fall back to the static memo', () {
+      // Resolving a local and then operating on the static is the same defect
+      // wearing a different shape: the op still lands on the wrong jar.
+      final offenders = <String>[];
+      for (final i in _callSitesOf(_scopedLookup, lines, depth)) {
+        final body = _enclosingMethodBody(i, lines, depth);
+        for (final j in body) {
+          if (RegExp('(?<![.\\w])$_memoField(?![\\w(])').hasMatch(lines[j])) {
+            offenders.add('MyCookieManager.java:${j + 1}');
+          }
+        }
+      }
+      expect(
+        offenders,
+        isEmpty,
+        reason: 'a webViewId-scoped method referenced the unscoped static memo',
+      );
+    });
+  });
+
+  group('fork flush fan-out (PAUSE-023)', () {
+    test('flush reaches every container jar, not just the default one', () {
+      final flushBody = _methodBodyOf('flush', lines, depth);
+      expect(
+        flushBody,
+        isNotNull,
+        reason: 'flush() is gone: the on-background durability hook has no '
+            'implementation to call',
+      );
+      expect(
+        _joined(flushBody!.map((i) => lines[i])),
+        contains('$_flushFanOut()'),
+        reason: 'flush() commits the default jar only, so container sessions '
+            'stay unwritten when the OS kills the app',
+      );
+
+      final fanOutBody = _methodBodyOf(_flushFanOut, lines, depth)!;
+      final fanOut = _joined(fanOutBody.map((i) => lines[i]));
+      expect(fanOut, contains('ProfileStore'));
+      expect(
+        fanOut,
+        contains('getAllProfileNames'),
+        reason: 'the fan-out must enumerate profiles rather than flushing a '
+            'fixed set',
+      );
+    });
+  });
+}
+
+String _joined(Iterable<String> lines) => lines.join('\n');
+
+/// Absolute path of the fork source, via the package resolution `pub get`
+/// wrote. Reading it this way rather than globbing the pub cache means the
+/// gate always inspects the ref this checkout actually resolved.
+String _resolveForkSource() {
+  final config = File('.dart_tool/package_config.json');
+  if (!config.existsSync()) {
+    fail('.dart_tool/package_config.json is missing: run `flutter pub get`');
+  }
+  final packages =
+      (jsonDecode(config.readAsStringSync())['packages'] as List<dynamic>)
+          .cast<Map<String, dynamic>>();
+  final fork = packages.firstWhere(
+    (p) => p['name'] == _forkPackage,
+    orElse: () => fail('$_forkPackage is not in package_config.json'),
+  );
+  var rootUri = Uri.parse(fork['rootUri'] as String);
+  if (!rootUri.hasScheme) {
+    rootUri =
+        Uri.file('${Directory.current.path}/.dart_tool/').resolveUri(rootUri);
+  }
+  // Without a trailing slash, resolve() would replace the package directory
+  // instead of descending into it.
+  if (!rootUri.path.endsWith('/')) {
+    rootUri = rootUri.replace(path: '${rootUri.path}/');
+  }
+  return File.fromUri(rootUri.resolve(_sourcePath)).path;
+}
+
+/// Blanks comments and string/char literals, preserving line numbering, so the
+/// regexes below cannot match prose about the invariant or a brace inside a
+/// literal.
+String _stripCommentsAndLiterals(String src) {
+  final out = StringBuffer();
+  var inLineComment = false;
+  var inBlockComment = false;
+  var inString = false;
+  var inChar = false;
+
+  for (var i = 0; i < src.length; i++) {
+    final c = src[i];
+    final next = i + 1 < src.length ? src[i + 1] : '';
+
+    if (inLineComment) {
+      if (c == '\n') {
+        inLineComment = false;
+        out.write(c);
+      } else {
+        out.write(' ');
+      }
+      continue;
+    }
+    if (inBlockComment) {
+      if (c == '*' && next == '/') {
+        inBlockComment = false;
+        out.write('  ');
+        i++;
+      } else {
+        out.write(c == '\n' ? '\n' : ' ');
+      }
+      continue;
+    }
+    if (inString || inChar) {
+      if (c == r'\' && next.isNotEmpty) {
+        out.write('  ');
+        i++;
+        continue;
+      }
+      if ((inString && c == '"') || (inChar && c == "'")) {
+        inString = false;
+        inChar = false;
+      }
+      out.write(c == '\n' ? '\n' : ' ');
+      continue;
+    }
+    if (c == '/' && next == '/') {
+      inLineComment = true;
+      out.write('  ');
+      i++;
+      continue;
+    }
+    if (c == '/' && next == '*') {
+      inBlockComment = true;
+      out.write('  ');
+      i++;
+      continue;
+    }
+    if (c == '"') {
+      inString = true;
+      out.write(' ');
+      continue;
+    }
+    if (c == "'") {
+      inChar = true;
+      out.write(' ');
+      continue;
+    }
+    out.write(c);
+  }
+  return out.toString();
+}
+
+/// Brace nesting depth at the START of each line. Class members sit at depth 1,
+/// so a method opener is a depth-1 line that opens a brace.
+List<int> _braceDepthBefore(List<String> lines) {
+  final depths = <int>[];
+  var current = 0;
+  for (final line in lines) {
+    depths.add(current);
+    current += '{'.allMatches(line).length - '}'.allMatches(line).length;
+  }
+  return depths;
+}
+
+int? _classLevelDeclarationOf(
+    String name, List<String> lines, List<int> depth) {
+  for (var i = 0; i < lines.length; i++) {
+    if (depth[i] == 1 &&
+        RegExp('(?<![.\\w])$name\\s*\\(').hasMatch(lines[i]) &&
+        lines[i].contains('{')) {
+      return i;
+    }
+  }
+  return null;
+}
+
+/// Lines that CALL [name], excluding its declaration (which sits at depth 1).
+List<int> _callSitesOf(String name, List<String> lines, List<int> depth) {
+  final sites = <int>[];
+  for (var i = 0; i < lines.length; i++) {
+    if (depth[i] > 1 && RegExp('(?<![.\\w])$name\\s*\\(').hasMatch(lines[i])) {
+      sites.add(i);
+    }
+  }
+  return sites;
+}
+
+/// Line indices of the method body containing [line], opener through closer.
+List<int> _enclosingMethodBody(int line, List<String> lines, List<int> depth) {
+  var start = line;
+  while (start > 0 && !(depth[start] == 1 && lines[start].contains('{'))) {
+    start--;
+  }
+  var end = line;
+  while (end < lines.length - 1 && depth[end + 1] > 1) {
+    end++;
+  }
+  return [for (var i = start; i <= end; i++) i];
+}
+
+List<int>? _methodBodyOf(String name, List<String> lines, List<int> depth) {
+  final start = _classLevelDeclarationOf(name, lines, depth);
+  if (start == null) return null;
+  return _enclosingMethodBody(start + 1, lines, depth);
+}

--- a/test/js/global_cookie_clear_funnel.test.js
+++ b/test/js/global_cookie_clear_funnel.test.js
@@ -1,0 +1,99 @@
+// Unscoped global cookie-clear gate (BUG-007, issues #524 / #525).
+//
+// `CookieManager.deleteAllCookies()` carries no site with it: the plugin
+// resolves which jar to empty from its own state. Under the container engine
+// every site owns its jar and that state is the only thing standing between
+// "clear the unused default jar" and "wipe a live site's session" — which is
+// exactly what happened when a container-scoped read poisoned the plugin's
+// static CookieManager memo (fixed in the fork at v6.2.0-beta.3-privacy-v6).
+//
+// The app-side invariant that keeps the class unreachable: never issue an
+// unscoped clear while containers are in use. Every call must be gated on the
+// engine selection, either lexically (`!_useContainers`) or by sitting behind
+// OrphanSweepEngine's `useContainers: false` branch (the
+// `clearLegacyGlobalCookieJar` funnel). A new ungated call site re-opens it.
+//
+// Structural rather than behavioral: reproducing the real defect needs an
+// Android device with WebViewFeature.MULTI_PROFILE and two live profiles,
+// which no CI tier here has. See test/orphan_sweep_engine_test.dart for the
+// behavioral half (the sweep must not ask for the clear under containers).
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+/// The one place allowed to call it unconditionally: the legacy engine, which
+/// only ever runs when containers are unsupported, plus the wrapper's own
+/// definition.
+const EXEMPT_FILES = new Set([
+  'lib/services/cookie_isolation.dart',
+  'lib/services/webview.dart',
+]);
+
+/// Name of the OrphanSweepTargets method whose only caller is the engine's
+/// `if (!useContainers)` branch.
+const FUNNEL_METHOD = 'clearLegacyGlobalCookieJar';
+
+function dartSources(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...dartSources(full));
+    else if (entry.name.endsWith('.dart')) out.push(full);
+  }
+  return out;
+}
+
+function callSites() {
+  const sites = [];
+  for (const file of dartSources(path.join(repoRoot, 'lib'))) {
+    const rel = path.relative(repoRoot, file);
+    if (EXEMPT_FILES.has(rel)) continue;
+    const lines = fs.readFileSync(file, 'utf8').split('\n');
+    lines.forEach((line, i) => {
+      // `deleteAllCookiesForUrl` is URL-scoped and therefore not this class.
+      if (!/\.deleteAllCookies\(\)/.test(line)) return;
+      sites.push({ rel, line: i + 1, context: lines.slice(Math.max(0, i - 8), i + 1) });
+    });
+  }
+  return sites;
+}
+
+test('every unscoped global cookie clear is gated on the engine selection', () => {
+  const ungated = callSites().filter(({ context }) => {
+    const window = context.join('\n');
+    return !window.includes('_useContainers') && !window.includes(FUNNEL_METHOD);
+  });
+
+  assert.deepEqual(
+    ungated.map((s) => `${s.rel}:${s.line}`),
+    [],
+    'unscoped deleteAllCookies() must be gated on !_useContainers or reached ' +
+      `via ${FUNNEL_METHOD} — an ungated call can empty a live container's jar`,
+  );
+});
+
+test('the sweep funnel is still routed through the engine', () => {
+  // Guards the other half: the funnel method must stay behind the engine's
+  // container check rather than being called directly from the host.
+  const engine = fs.readFileSync(
+    path.join(repoRoot, 'lib/services/orphan_sweep_engine.dart'),
+    'utf8',
+  );
+  assert.match(
+    engine,
+    /if \(!useContainers\) \{\s*await targets\.clearLegacyGlobalCookieJar\(\);/,
+    'OrphanSweepEngine must only clear the legacy jar when containers are off',
+  );
+
+  const main = fs.readFileSync(path.join(repoRoot, 'lib/main.dart'), 'utf8');
+  const directCalls = main.match(/clearLegacyGlobalCookieJar\(\)/g) ?? [];
+  assert.equal(
+    directCalls.length,
+    1,
+    'main.dart should only define the funnel override, never call it directly',
+  );
+});

--- a/test/orphan_sweep_engine_test.dart
+++ b/test/orphan_sweep_engine_test.dart
@@ -1,0 +1,138 @@
+// Post-paint orphan sweep: which per-site storages get reclaimed, and which
+// live set each one is measured against.
+//
+// The load-bearing case is the legacy global cookie jar clear. Under the
+// container engine every site owns its jar, so the global clear reclaims
+// nothing — but it is an "empty a cookie jar" instruction issued with no site
+// in hand, and a plugin-side mislabel (BUG-007, fork privacy-v5) once pointed
+// it at a live container and wiped a real session a launch later. The engine
+// must not issue it at all when containers are in use.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/orphan_sweep_engine.dart';
+
+class _FakeTargets implements OrphanSweepTargets {
+  /// Ordered op log, so tests can assert both membership and sequencing.
+  final List<String> ops = [];
+
+  /// Live set each per-site sweep was handed, keyed by op name.
+  final Map<String, Set<String>> liveSets = {};
+
+  void _record(String op, [Set<String>? live]) {
+    ops.add(op);
+    if (live != null) liveSets[op] = live;
+  }
+
+  @override
+  Future<void> removeOrphanedCookies(Set<String> live) async =>
+      _record('cookies', live);
+
+  @override
+  Future<void> removeOrphanedProxyPasswords(Set<String> live) async =>
+      _record('proxyPasswords', live);
+
+  @override
+  Future<void> removeOrphanedHtmlCaches(Set<String> live) async =>
+      _record('htmlCaches', live);
+
+  @override
+  Future<void> removeOrphanedHtmlImports(Set<String> live) async =>
+      _record('htmlImports', live);
+
+  @override
+  Future<void> removeOrphanedWebViewState(Set<String> live) async =>
+      _record('webViewState', live);
+
+  @override
+  Future<void> clearLegacyGlobalCookieJar() async =>
+      _record('globalCookieJar');
+}
+
+void main() {
+  const active = {'a', 'b', 'incog'};
+  const nonIncognito = {'a', 'b'};
+
+  group('OrphanSweepEngine.sweep', () {
+    test('container mode never clears the global cookie jar', () async {
+      final targets = _FakeTargets();
+
+      await OrphanSweepEngine.sweep(
+        targets: targets,
+        activeSiteIds: active,
+        nonIncognitoSiteIds: nonIncognito,
+        useContainers: true,
+      );
+
+      expect(targets.ops, isNot(contains('globalCookieJar')));
+    });
+
+    test('container mode still reclaims every per-site storage', () async {
+      final targets = _FakeTargets();
+
+      await OrphanSweepEngine.sweep(
+        targets: targets,
+        activeSiteIds: active,
+        nonIncognitoSiteIds: nonIncognito,
+        useContainers: true,
+      );
+
+      expect(targets.ops, [
+        'cookies',
+        'proxyPasswords',
+        'htmlCaches',
+        'htmlImports',
+        'webViewState',
+      ]);
+    });
+
+    test('legacy mode clears the global jar, after the per-site sweeps',
+        () async {
+      final targets = _FakeTargets();
+
+      await OrphanSweepEngine.sweep(
+        targets: targets,
+        activeSiteIds: active,
+        nonIncognitoSiteIds: nonIncognito,
+        useContainers: false,
+      );
+
+      expect(targets.ops.last, 'globalCookieJar');
+      expect(targets.ops.length, 6);
+    });
+
+    test('session-scoped storages measure against the non-incognito set',
+        () async {
+      // Incognito sites are deliberately treated as orphans for anything that
+      // must not outlive the process (issue #298): cookies, cached HTML, and
+      // saved navigation state.
+      final targets = _FakeTargets();
+
+      await OrphanSweepEngine.sweep(
+        targets: targets,
+        activeSiteIds: active,
+        nonIncognitoSiteIds: nonIncognito,
+        useContainers: true,
+      );
+
+      expect(targets.liveSets['cookies'], nonIncognito);
+      expect(targets.liveSets['htmlCaches'], nonIncognito);
+      expect(targets.liveSets['webViewState'], nonIncognito);
+    });
+
+    test('config-scoped storages measure against the full active set',
+        () async {
+      // Proxy passwords and imported HTML are configuration, not session
+      // residue — an incognito site keeps both across launches.
+      final targets = _FakeTargets();
+
+      await OrphanSweepEngine.sweep(
+        targets: targets,
+        activeSiteIds: active,
+        nonIncognitoSiteIds: nonIncognito,
+        useContainers: true,
+      );
+
+      expect(targets.liveSets['proxyPasswords'], active);
+      expect(targets.liveSets['htmlImports'], active);
+    });
+  });
+}


### PR DESCRIPTION
Fixes the logged-out-a-launch-later reports (#524, #525) on both sides: pin the fork tag that repairs the plugin bug, and stop the app from issuing the operation that made it reachable.

## Fork pin: privacy-v6

`dependency_overrides` and the matching `pubspec.lock` entries move from `v6.2.0-beta.3-privacy-v5` to `v6.2.0-beta.3-privacy-v6` (resolved ref `e890f461eb13ec81274e93df2b9843bcd74c049c`) across core, Android, iOS, macOS, Linux, and the platform interface.

What the tag carries:

- `MyCookieManager` no longer writes its `public static` `CookieManager` memo from the container-scoped `getCookies` / `deleteCookie` entry points. Previously the first container-scoped read left some site's profile manager in that static, and every unscoped op in the class addressed that container's jar instead of the default one.
- Android `flush` fans out across every container's jar via `ProfileStore`, not just the default one.

## App side

- **`OrphanSweepEngine`** (new, `lib/services/orphan_sweep_engine.dart`) owns the post-paint startup sweep: the five per-site reclaims in order, then the global cookie jar clear only when `useContainers` is false. The clear reclaims nothing under containers (each site owns its jar), so it was pure risk. The engine also encodes which live set each target measures against: session residue against the non-incognito set, configuration against the full active set.
- The post-import clear in `_importSettings` is gated the same way.
- **Cookie flush on background** (`AppLifecycleEngine.backgroundPlan` gains `flushCookies`): Chromium commits cookies lazily, so a session cookie set shortly before a swipe-kill was never persisted. Flushes when any webview is loaded and the platform implements it (Android only; the platform interface throws elsewhere, hence `CookieManager.flushSupported`). Unawaited and failure-logged, never surfaced. Notification sites are exempt from the per-instance JS pause but not from this.

Why it only reproduced from a home shortcut: that is the sole cold start where a site loads, and its load-stop cookie read poisons the memo, before the deferred sweep runs. An icon launch opens the home screen, leaves the memo null, and the clear correctly hits the default jar.

## Regression gates

- `test/js/global_cookie_clear_funnel.test.js`: structural gate on ungated `deleteAllCookies()` call sites. Verified red against `dbdf881`, where it names both pre-fix sites (`lib/main.dart:4714`, `lib/main.dart:5540`).
- `test/fork_cookie_manager_invariant_test.dart`: reads the fork source `pub get` actually resolved, via `.dart_tool/package_config.json` rather than a globbed pub-cache path, and asserts the memo invariant holds in the Java about to be compiled: the scoped lookup is never assigned into the static, every call site keeps its result in a local, no scoped method falls back to the static, and `flush` still fans out via `ProfileStore.getAllProfileNames`. Comments and string literals are blanked before matching. Three anchor assertions fail loudly rather than passing vacuously if the fork renames the field, the lookup, or the fan-out. Verified by mutation: six pre-fix shapes each turn it red, naming the offending line. This exists because the fork is pinned at a mutable ref, so "fixed in v6" describes a tag that can move.
- `test/orphan_sweep_engine_test.dart`: sweep behavior against fakes (op set, ordering, per-target live sets).
- `test/app_lifecycle_engine_test.dart`: flush plan cases.

Still not covered: runtime behavior under real containers. Confirming the ops land in the right jar needs a device with `MULTI_PROFILE` and two live profiles, which no CI tier here has, so the gates above are shape checks, not proof of routing.

## Specs and docs

- `CONT-008` (per-site-containers): no unscoped global cookie ops in profile mode, with scenarios for the sweep in both engines and for the import path.
- `PAUSE-023` (webview-pause-lifecycle): commit pending cookie writes on background, with the platform-support and nothing-loaded carve-outs.
- `docs/bugs/007-native-shared-state-races.md`: attempt 4 (the fix) and attempt 5 (the fork-source gate), each with why it was partial.

https://claude.ai/code/session_01UraFkp2CNTsBGAAyBJu1aq