### PR TITLE
Add Android white-screen pixel scenario suite (BUG-001)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -387,11 +387,22 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true
           # The action runs each script line as a separate `sh -c`, so the
-          # test invocation lives in a single-command wrapper script.
+          # test invocations live in single-command wrapper scripts. The
+          # lifecycle tier (INTEG-011) must run after the in-process suite:
+          # it replaces the test-entrypoint APK the suite installed.
           script: |
             adb wait-for-device
             adb shell input keyevent 82
             bash scripts/run_android_integration_tests.sh
+            bash scripts/run_android_lifecycle_tests.sh
+
+      - name: Upload white-screen lifecycle diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: white-screen-adb-diagnostics
+          path: build/white_screen_adb/
+          if-no-files-found: ignore
 
       - name: Create AVD and generate screenshots
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -336,20 +336,20 @@ jobs:
           chmod +x magick
           sudo mv magick /usr/local/bin/magick
 
+      # Emulator prerequisites are ungated: the white-screen pixel suite
+      # below runs on every push/PR, not just the workflow_dispatch
+      # screenshots tier.
       - name: Enable KVM for emulator acceleration
-        if: github.event_name == 'workflow_dispatch'
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
       - name: Setup Android SDK
-        if: github.event_name == 'workflow_dispatch'
         uses: android-actions/setup-android@v3
 
       - name: AVD snapshot cache
         id: avd-cache
-        if: github.event_name == 'workflow_dispatch'
         uses: actions/cache@v4
         with:
           path: |
@@ -358,7 +358,7 @@ jobs:
           key: avd-api34-x86_64-google_apis-pixel_5-v1
 
       - name: Pre-warm AVD snapshot
-        if: github.event_name == 'workflow_dispatch' && steps.avd-cache.outputs.cache-hit != 'true'
+        if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34
@@ -370,6 +370,31 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true
           script: echo "Generated AVD snapshot for caching."
+
+      # White-screen pixel scenarios (BUG-001 / INTEG-010): drive the known
+      # blank-screen entry paths on the booted emulator and assert on
+      # composited window pixels over the webview via SurfaceDiagPlugin's
+      # PixelCopy. Runs on every push/PR.
+      - name: Run white-screen pixel scenarios
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          profile: pixel_5
+          disk-size: 4096M
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          disable-animations: true
+          script: |
+            adb wait-for-device
+            adb shell input keyevent 82
+            DEVICE_ID=$(adb devices | grep -w 'device' | head -1 | awk '{print $1}')
+            # Hard wall-clock cap: a webview mount can deadlock below the
+            # Dart timeout layer (same rationale as the desktop loops).
+            timeout -k 30s 25m fvm flutter test \
+              integration_test/white_screen_test.dart \
+              -d "$DEVICE_ID" --flavor fdebug
 
       - name: Create AVD and generate screenshots
         if: github.event_name == 'workflow_dispatch'
@@ -411,162 +436,6 @@ jobs:
           name: android-screenshots
           path: screenshots/android/*.png
           if-no-files-found: warn
-
-  # White-screen pixel scenarios (BUG-001 / INTEG-010): drive the known
-  # blank-screen entry paths on a booted emulator and assert on composited
-  # window pixels over the webview via SurfaceDiagPlugin's PixelCopy.
-  # Dedicated job (not build-android) so emulator flake stays isolated from
-  # release artifacts and the suite runs on every push/PR, not just the
-  # workflow_dispatch screenshots tier.
-  android-integration-tests:
-    name: Android integration tests (emulator)
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-          cache: 'gradle'
-
-      - name: Setup Flutter (for Dart SDK)
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.38.6'
-          channel: 'stable'
-
-      - name: Cache fvm Flutter SDK
-        uses: actions/cache@v4
-        with:
-          path: ~/.fvm/versions
-          key: fvm-${{ runner.os }}-${{ hashFiles('**/.fvmrc') }}
-          restore-keys: |
-            fvm-${{ runner.os }}-
-
-      - name: Install fvm
-        run: |
-          dart pub global activate fvm
-          echo "$HOME/.pub-cache/bin" >> $GITHUB_PATH
-
-      - name: Setup Flutter with fvm
-        run: |
-          fvm install
-          fvm use --force
-
-      - name: Cache pub dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.pub-cache
-            .dart_tool
-          key: pub-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            pub-${{ runner.os }}-
-
-      - name: Get dependencies
-        run: fvm flutter pub get --enforce-lockfile
-
-      # Distinct primary key so this job never races build-android's cache
-      # save; restore-keys still reuse its registry + target dir.
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            rust/webspace_adblock/target
-          key: cargo-android-emulator-${{ runner.os }}-${{ hashFiles('rust/webspace_adblock/Cargo.lock') }}
-          restore-keys: |
-            cargo-android-emulator-${{ runner.os }}-
-            cargo-android-${{ runner.os }}-
-
-      - name: Read Rust toolchain
-        id: rust
-        run: echo "channel=$(sed -n -E 's/channel = "(.*)"/\1/p' rust-toolchain.toml)" >> "$GITHUB_OUTPUT"
-
-      # Emulator is x86_64 only, so skip the other three Android targets
-      # build-android compiles.
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ steps.rust.outputs.channel }}
-          targets: x86_64-linux-android
-
-      - name: Install cargo-ndk
-        run: cargo install --locked "cargo-ndk@${CARGO_NDK_VERSION}"
-
-      - name: Setup Android NDK
-        uses: nttld/setup-ndk@v1
-        id: setup-ndk
-        with:
-          ndk-version: r26d
-          add-to-path: false
-
-      - name: Export ANDROID_NDK_HOME
-        run: echo "ANDROID_NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}" >> $GITHUB_ENV
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          gradle-version: "8.13"
-
-      - name: Generate launcher icons
-        run: fvm dart run flutter_launcher_icons
-
-      - name: Enable KVM for emulator acceleration
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      # Same AVD profile + cache key as the screenshots tier, so the two
-      # share one snapshot.
-      - name: AVD snapshot cache
-        id: avd-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-api34-x86_64-google_apis-pixel_5-v1
-
-      - name: Pre-warm AVD snapshot
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 34
-          target: google_apis
-          arch: x86_64
-          profile: pixel_5
-          disk-size: 4096M
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
-          disable-animations: true
-          script: echo "Generated AVD snapshot for caching."
-
-      - name: Run white-screen pixel scenarios
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 34
-          target: google_apis
-          arch: x86_64
-          profile: pixel_5
-          disk-size: 4096M
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
-          disable-animations: true
-          script: |
-            adb wait-for-device
-            adb shell input keyevent 82
-            DEVICE_ID=$(adb devices | grep -w 'device' | head -1 | awk '{print $1}')
-            # Hard wall-clock cap: a webview mount can deadlock below the
-            # Dart timeout layer (same rationale as the desktop loops).
-            timeout -k 30s 25m fvm flutter test \
-              integration_test/white_screen_test.dart \
-              -d "$DEVICE_ID" --flavor fdebug
 
   build-linux:
     name: Build Linux

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -393,6 +393,7 @@ jobs:
           script: |
             adb wait-for-device
             adb shell input keyevent 82
+            adb shell settings put global hide_error_dialogs 1
             bash scripts/run_android_integration_tests.sh
             bash scripts/run_android_lifecycle_tests.sh
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -394,6 +394,14 @@ jobs:
             # Run fastlane android screenshots using bundle
             bundle exec fastlane android screenshots
 
+            # White-screen pixel scenarios (BUG-001): drive the historical
+            # blank-screen entry paths and assert on composited window
+            # pixels over the webview via SurfaceDiagPlugin's PixelCopy.
+            DEVICE_ID=$(adb devices | grep -w 'device' | head -1 | awk '{print $1}')
+            timeout -k 30s 20m fvm flutter test \
+              integration_test/white_screen_test.dart \
+              -d "$DEVICE_ID" --flavor fdebug
+
       - name: Cache Fastlane frameit assets
         uses: actions/cache@v4
         with:
@@ -711,8 +719,10 @@ jobs:
               status=0
               for t in integration_test/*_test.dart; do
                 # Screenshot generator is an iOS/Android fastlane helper,
-                # not a Linux-runnable test.
+                # not a Linux-runnable test. The white-screen pixel suite is
+                # Android-only (window PixelCopy); skip its no-op build here.
                 [ "$(basename "$t")" = "screenshot_test.dart" ] && continue
+                [ "$(basename "$t")" = "white_screen_test.dart" ] && continue
                 echo "::group::$t"
                 # Hard per-test wall-clock cap: a WebView mount can deadlock
                 # the platform thread below Dart timeout layer, which would
@@ -972,6 +982,8 @@ jobs:
           status=0
           for t in integration_test/*_test.dart; do
             [ "$(basename "$t")" = "screenshot_test.dart" ] && continue
+            # Android-only window-PixelCopy suite; skip its no-op build here.
+            [ "$(basename "$t")" = "white_screen_test.dart" ] && continue
             echo "::group::$t"
             if [ -n "$TIMEOUT" ]; then
               "$TIMEOUT" -k 30s 12m fvm flutter test "$t" -d macos --ci || status=$?

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -386,15 +386,12 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true
+          # The action runs each script line as a separate `sh -c`, so the
+          # test invocation lives in a single-command wrapper script.
           script: |
             adb wait-for-device
             adb shell input keyevent 82
-            DEVICE_ID=$(adb devices | grep -w 'device' | head -1 | awk '{print $1}')
-            # Hard wall-clock cap: a webview mount can deadlock below the
-            # Dart timeout layer (same rationale as the desktop loops).
-            timeout -k 30s 25m fvm flutter test \
-              integration_test/white_screen_test.dart \
-              -d "$DEVICE_ID" --flavor fdebug
+            bash scripts/run_android_integration_tests.sh
 
       - name: Create AVD and generate screenshots
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -394,14 +394,6 @@ jobs:
             # Run fastlane android screenshots using bundle
             bundle exec fastlane android screenshots
 
-            # White-screen pixel scenarios (BUG-001): drive the historical
-            # blank-screen entry paths and assert on composited window
-            # pixels over the webview via SurfaceDiagPlugin's PixelCopy.
-            DEVICE_ID=$(adb devices | grep -w 'device' | head -1 | awk '{print $1}')
-            timeout -k 30s 20m fvm flutter test \
-              integration_test/white_screen_test.dart \
-              -d "$DEVICE_ID" --flavor fdebug
-
       - name: Cache Fastlane frameit assets
         uses: actions/cache@v4
         with:
@@ -419,6 +411,162 @@ jobs:
           name: android-screenshots
           path: screenshots/android/*.png
           if-no-files-found: warn
+
+  # White-screen pixel scenarios (BUG-001 / INTEG-010): drive the known
+  # blank-screen entry paths on a booted emulator and assert on composited
+  # window pixels over the webview via SurfaceDiagPlugin's PixelCopy.
+  # Dedicated job (not build-android) so emulator flake stays isolated from
+  # release artifacts and the suite runs on every push/PR, not just the
+  # workflow_dispatch screenshots tier.
+  android-integration-tests:
+    name: Android integration tests (emulator)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Flutter (for Dart SDK)
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.38.6'
+          channel: 'stable'
+
+      - name: Cache fvm Flutter SDK
+        uses: actions/cache@v4
+        with:
+          path: ~/.fvm/versions
+          key: fvm-${{ runner.os }}-${{ hashFiles('**/.fvmrc') }}
+          restore-keys: |
+            fvm-${{ runner.os }}-
+
+      - name: Install fvm
+        run: |
+          dart pub global activate fvm
+          echo "$HOME/.pub-cache/bin" >> $GITHUB_PATH
+
+      - name: Setup Flutter with fvm
+        run: |
+          fvm install
+          fvm use --force
+
+      - name: Cache pub dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            .dart_tool
+          key: pub-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            pub-${{ runner.os }}-
+
+      - name: Get dependencies
+        run: fvm flutter pub get --enforce-lockfile
+
+      # Distinct primary key so this job never races build-android's cache
+      # save; restore-keys still reuse its registry + target dir.
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            rust/webspace_adblock/target
+          key: cargo-android-emulator-${{ runner.os }}-${{ hashFiles('rust/webspace_adblock/Cargo.lock') }}
+          restore-keys: |
+            cargo-android-emulator-${{ runner.os }}-
+            cargo-android-${{ runner.os }}-
+
+      - name: Read Rust toolchain
+        id: rust
+        run: echo "channel=$(sed -n -E 's/channel = "(.*)"/\1/p' rust-toolchain.toml)" >> "$GITHUB_OUTPUT"
+
+      # Emulator is x86_64 only, so skip the other three Android targets
+      # build-android compiles.
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.rust.outputs.channel }}
+          targets: x86_64-linux-android
+
+      - name: Install cargo-ndk
+        run: cargo install --locked "cargo-ndk@${CARGO_NDK_VERSION}"
+
+      - name: Setup Android NDK
+        uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r26d
+          add-to-path: false
+
+      - name: Export ANDROID_NDK_HOME
+        run: echo "ANDROID_NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}" >> $GITHUB_ENV
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.13"
+
+      - name: Generate launcher icons
+        run: fvm dart run flutter_launcher_icons
+
+      - name: Enable KVM for emulator acceleration
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      # Same AVD profile + cache key as the screenshots tier, so the two
+      # share one snapshot.
+      - name: AVD snapshot cache
+        id: avd-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-api34-x86_64-google_apis-pixel_5-v1
+
+      - name: Pre-warm AVD snapshot
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          profile: pixel_5
+          disk-size: 4096M
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          disable-animations: true
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Run white-screen pixel scenarios
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          profile: pixel_5
+          disk-size: 4096M
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          disable-animations: true
+          script: |
+            adb wait-for-device
+            adb shell input keyevent 82
+            DEVICE_ID=$(adb devices | grep -w 'device' | head -1 | awk '{print $1}')
+            # Hard wall-clock cap: a webview mount can deadlock below the
+            # Dart timeout layer (same rationale as the desktop loops).
+            timeout -k 30s 25m fvm flutter test \
+              integration_test/white_screen_test.dart \
+              -d "$DEVICE_ID" --flavor fdebug
 
   build-linux:
     name: Build Linux

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -1,6 +1,7 @@
 package org.codeberg.theoden8.webspace
 
 import android.content.Intent
+import android.content.pm.ApplicationInfo
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Build
@@ -134,6 +135,15 @@ class MainActivity: FlutterActivity() {
                         )
                     }
                     result.success(true)
+                }
+                "getDiagSeed" -> {
+                    // Adb white-screen tier (INTEG-011). Debuggable builds
+                    // only: MainActivity is exported, so on a release build
+                    // a hostile launch intent must not be able to swap the
+                    // user's site list.
+                    val debuggable =
+                        (applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
+                    result.success(if (debuggable) intent?.getStringExtra("ws_diag_seed") else null)
                 }
                 "getLaunchSiteId" -> {
                     val siteId = intent?.getStringExtra("siteId")

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -21,6 +21,7 @@ class MainActivity: FlutterActivity() {
     private var webInterceptPlugin: WebInterceptPlugin? = null
     private var locationPlugin: LocationPlugin? = null
     private var webSpaceContainerPlugin: WebSpaceContainerPlugin? = null
+    private var surfaceDiagPlugin: SurfaceDiagPlugin? = null
     private var backgroundTaskPlugin: BackgroundTaskAndroidPlugin? = null
     private var proxyRelayPlugin: ProxyRelayPlugin? = null
     private var pendingShareUrl: String? = null
@@ -63,6 +64,7 @@ class MainActivity: FlutterActivity() {
         webInterceptPlugin = WebInterceptPlugin(this, flutterEngine)
         locationPlugin = LocationPlugin(this, flutterEngine)
         webSpaceContainerPlugin = WebSpaceContainerPlugin(flutterEngine)
+        surfaceDiagPlugin = SurfaceDiagPlugin(this, flutterEngine)
         backgroundTaskPlugin = BackgroundTaskAndroidPlugin(applicationContext, flutterEngine)
         proxyRelayPlugin = ProxyRelayPlugin(flutterEngine)
         captureSharePayload(intent)

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/SurfaceDiagPlugin.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/SurfaceDiagPlugin.kt
@@ -1,0 +1,122 @@
+package org.codeberg.theoden8.webspace
+
+import android.app.Activity
+import android.graphics.Bitmap
+import android.graphics.Rect
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.view.PixelCopy
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Samples the composited window pixels over a region of the screen.
+ *
+ * The webview is a hybrid-composition SurfaceView whose buffer is composited
+ * by the OS, out of band of both Flutter's raster tree and the renderer's own
+ * draw path. A JS probe or a WebView-level capture reports the renderer's
+ * content plane, which is healthy in every confirmed BUG-001 instance; only a
+ * window-level PixelCopy reads what the user actually sees. Uniform
+ * white/black over the webview rect while the renderer claims a painted
+ * document is the blank-surface symptom itself.
+ *
+ * Everything runs on the main looper (the method-channel handler, the
+ * PixelCopy callback, the 1024-pixel histogram), so there is no shared
+ * mutable state across threads (BUG-007: none-shared).
+ */
+class SurfaceDiagPlugin(private val activity: Activity, flutterEngine: FlutterEngine) {
+    companion object {
+        private const val CHANNEL = "org.codeberg.theoden8.webspace/surface_diag"
+        // PixelCopy scales the source rect into the destination bitmap, so the
+        // histogram cost is fixed at SAMPLE_SIZE^2 pixels regardless of the
+        // sampled region's on-screen size.
+        private const val SAMPLE_SIZE = 32
+    }
+
+    init {
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "sampleWindowRegion" -> {
+                    val left = call.argument<Int>("left")
+                    val top = call.argument<Int>("top")
+                    val width = call.argument<Int>("width")
+                    val height = call.argument<Int>("height")
+                    if (left == null || top == null || width == null || height == null) {
+                        result.error("INVALID_ARGS", "left/top/width/height required", null)
+                    } else {
+                        sampleWindowRegion(left, top, width, height, result)
+                    }
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    private fun sampleWindowRegion(
+        left: Int,
+        top: Int,
+        width: Int,
+        height: Int,
+        result: MethodChannel.Result,
+    ) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            result.success(mapOf("status" to "unsupported"))
+            return
+        }
+        val decor = activity.window?.decorView
+        if (decor == null || decor.width <= 0 || decor.height <= 0) {
+            result.success(mapOf("status" to "no-window"))
+            return
+        }
+        val region = Rect(left, top, left + width, top + height)
+        if (!region.intersect(Rect(0, 0, decor.width, decor.height)) ||
+            region.width() <= 0 || region.height() <= 0
+        ) {
+            result.success(mapOf("status" to "bad-region"))
+            return
+        }
+        val bitmap = Bitmap.createBitmap(SAMPLE_SIZE, SAMPLE_SIZE, Bitmap.Config.ARGB_8888)
+        try {
+            PixelCopy.request(
+                activity.window,
+                region,
+                bitmap,
+                { copyResult ->
+                    if (copyResult == PixelCopy.SUCCESS) {
+                        result.success(histogram(bitmap))
+                    } else {
+                        result.success(mapOf("status" to "copy-failed:$copyResult"))
+                    }
+                    bitmap.recycle()
+                },
+                Handler(Looper.getMainLooper()),
+            )
+        } catch (e: IllegalArgumentException) {
+            // Window surface not attached (mid-transition); transient, retry later.
+            bitmap.recycle()
+            result.success(mapOf("status" to "no-surface"))
+        }
+    }
+
+    private fun histogram(bitmap: Bitmap): Map<String, Any> {
+        val pixels = IntArray(SAMPLE_SIZE * SAMPLE_SIZE)
+        bitmap.getPixels(pixels, 0, SAMPLE_SIZE, 0, 0, SAMPLE_SIZE, SAMPLE_SIZE)
+        // Quantize to the top 4 bits per channel so dithering and slight
+        // gradients still land in one bucket; report an actual pixel from the
+        // dominant bucket rather than the quantized key.
+        val counts = HashMap<Int, Int>()
+        val representative = HashMap<Int, Int>()
+        for (p in pixels) {
+            val key = p and 0xF0F0F0F0.toInt()
+            counts[key] = (counts[key] ?: 0) + 1
+            if (!representative.containsKey(key)) representative[key] = p
+        }
+        val dominant = counts.maxByOrNull { it.value }!!
+        return mapOf(
+            "status" to "ok",
+            "dominantColor" to (representative[dominant.key] ?: dominant.key),
+            "uniformFraction" to dominant.value.toDouble() / pixels.size,
+        )
+    }
+}

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -330,7 +330,10 @@ causal claim is unverified, exactly as in Attempt 8.
   [scripts/classify_window_pixels.py](../../scripts/classify_window_pixels.py) with the
   in-app sampler's thresholds; a white control cold start proves this plane is not
   vacuous either. Site list is injected at launch by a debug-only `ws_diag_seed`
-  intent extra ([lib/services/diag_seed.dart](../../lib/services/diag_seed.dart)).
+  intent extra ([lib/services/diag_seed.dart](../../lib/services/diag_seed.dart)) and
+  activated through the production pinned-shortcut `siteId` extra (a plain cold start
+  shows the webspace picker with no site selected), so the cold-start scenario also
+  pixel-checks the shortcut launch path (Attempt 2's trigger).
   With this tier, every documented entry path (Attempts 3–9 plus gap #7) has
   symptom-level pixel coverage in CI; still emulator compositing, so a
   device-specific SurfaceFlinger race can outrun it (see INTEG-010's limitation note).

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -310,10 +310,10 @@ causal claim is unverified, exactly as in Attempt 8.
   path. Window-level `PixelCopy` reads the composited pixels the user actually sees —
   the plane no JS probe (renderer) or Flutter capture (raster tree, no platform views)
   can reach — and classifies uniform white/black over the webview rect. The integration
-  suite (`android-integration-tests` CI job, every push/PR) drives the in-process-drivable
-  entry paths (fresh first activation incl. gap #7, loaded-site switch, reload funnel,
-  memory pressure, fresh activation among live sites) and fails on a blank window, with a
-  white control page proving the detector is not vacuous. Warm start / activity recreation /
+  suite (emulator step in the `build-android` CI job, every push/PR) drives the
+  in-process-drivable entry paths (fresh first activation incl. gap #7, loaded-site
+  switch, reload funnel, memory pressure, fresh activation among live sites) and fails
+  on a blank window, with a white control page proving the detector is not vacuous. Warm start / activity recreation /
   bfcache back-nav still need an adb-driven tier. Not yet wired into production
   diagnostics; doing so would give `SurfaceDiag` log lines a `window=` classification.
 

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -313,13 +313,27 @@ causal claim is unverified, exactly as in Attempt 8.
   suite (emulator step in the `build-android` CI job, every push/PR) drives the
   in-process-drivable entry paths (fresh first activation incl. gap #7, loaded-site
   switch, reload funnel, memory pressure, fresh activation among live sites) and fails
-  on a blank window, with a white control page proving the detector is not vacuous. Warm start / activity recreation /
-  bfcache back-nav still need an adb-driven tier. Not yet wired into production
+  on a blank window, with a white control page proving the detector is not vacuous.
+  Not yet wired into production
   diagnostics; doing so would give `SurfaceDiag` log lines a `window=` classification.
   First emulator run confirmed the sampler reads real webview pixels on SwiftShader and
   surfaced a third signature: a platform view that has not composited at all samples as
   uniform 0x00000000 (alpha 0) — distinct from the white (fresh fill) and black
   (re-attach) blanks.
+- **Adb-driven lifecycle tier** ([scripts/run_android_lifecycle_tests.sh](../../scripts/run_android_lifecycle_tests.sh),
+  INTEG-011, same emulator step, every push/PR): the three entry paths an in-process
+  test cannot survive — **warm start** (Attempt 8's trigger), **activity recreation**
+  (the black variant's trigger), and **bfcache back navigation** (Attempts 5–6's
+  trigger, via the system BACK key through the production `_goBackAndRepaint` funnel) —
+  driven from outside the process via adb. Symptom read from the composited frame
+  (`screencap`, the SurfaceFlinger plane) and classified by
+  [scripts/classify_window_pixels.py](../../scripts/classify_window_pixels.py) with the
+  in-app sampler's thresholds; a white control cold start proves this plane is not
+  vacuous either. Site list is injected at launch by a debug-only `ws_diag_seed`
+  intent extra ([lib/services/diag_seed.dart](../../lib/services/diag_seed.dart)).
+  With this tier, every documented entry path (Attempts 3–9 plus gap #7) has
+  symptom-level pixel coverage in CI; still emulator compositing, so a
+  device-specific SurfaceFlinger race can outrun it (see INTEG-010's limitation note).
 
 ## Diagnostic checklist (when this recurs)
 

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -310,10 +310,10 @@ causal claim is unverified, exactly as in Attempt 8.
   path. Window-level `PixelCopy` reads the composited pixels the user actually sees —
   the plane no JS probe (renderer) or Flutter capture (raster tree, no platform views)
   can reach — and classifies uniform white/black over the webview rect. The integration
-  suite (Android emulator, screenshots CI tier) drives the in-process-drivable entry
-  paths (fresh first activation incl. gap #7, loaded-site switch, reload funnel, memory
-  pressure, fresh activation among live sites) and fails on a blank window, with a white
-  control page proving the detector is not vacuous. Warm start / activity recreation /
+  suite (`android-integration-tests` CI job, every push/PR) drives the in-process-drivable
+  entry paths (fresh first activation incl. gap #7, loaded-site switch, reload funnel,
+  memory pressure, fresh activation among live sites) and fails on a blank window, with a
+  white control page proving the detector is not vacuous. Warm start / activity recreation /
   bfcache back-nav still need an adb-driven tier. Not yet wired into production
   diagnostics; doing so would give `SurfaceDiag` log lines a `window=` classification.
 

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -262,6 +262,18 @@ causal claim is unverified, exactly as in Attempt 8.
    new `SurfaceDiag` line `trigger=metrics-resume -> nudge` exists to confirm this from a
    device log; until such a trace exists, the causal claim (this fixes the reported warm-start
    white screen) is unverified.
+7. **First activation of a fresh site is diagnostically dark and has no commit-side nudge.**
+   Reported 2026-08-13 (sanitized log export): user cold-started to the site picker, tapped a
+   not-yet-loaded site three minutes later, webview created from scratch, main-frame load
+   started, white screen. The log cannot classify it because this path emits *no* SurfaceDiag:
+   the `site-switch` probe early-returns silently when `model.controller == null`
+   (lib/main.dart, `_probeRendererAndRecover`), which is always true for a fresh creation.
+   Both nudges that do run — activation (`_setCurrentIndex`) and controller-ready
+   (Attempt 4) — fire and drain *before* the initial document commits, and the settled-side
+   re-nudge is latched only by `reloadIssued()` (Attempt 9), never by a first load. So if the
+   commit lands late, nothing repaints after it: the Attempt 8/9 ordering shape on one more
+   path. Undetermined whether that report was this bug or a load that never committed; the
+   window-pixel sampler below exists to make the next occurrence classifiable.
 
 ## Guardrails now in place
 
@@ -290,6 +302,20 @@ causal claim is unverified, exactly as in Attempt 8.
   `inappbrowser.dart` must sit inside a `reloadAndRepaint` funnel that latches the reload,
   `main.dart` must wire both host hooks to the engine, and each file must drive the repaint
   off the load-settled signal. A new raw reload fails CI.
+- **Window-pixel detector + scenario suite**
+  ([android/.../SurfaceDiagPlugin.kt](../../android/app/src/main/kotlin/org/codeberg/theoden8/webspace/SurfaceDiagPlugin.kt),
+  [lib/services/surface_diag_native.dart](../../lib/services/surface_diag_native.dart),
+  [integration_test/white_screen_test.dart](../../integration_test/white_screen_test.dart)):
+  the first guardrail that measures the *symptom* instead of inferring it from a trigger
+  path. Window-level `PixelCopy` reads the composited pixels the user actually sees —
+  the plane no JS probe (renderer) or Flutter capture (raster tree, no platform views)
+  can reach — and classifies uniform white/black over the webview rect. The integration
+  suite (Android emulator, screenshots CI tier) drives the in-process-drivable entry
+  paths (fresh first activation incl. gap #7, loaded-site switch, reload funnel, memory
+  pressure, fresh activation among live sites) and fails on a blank window, with a white
+  control page proving the detector is not vacuous. Warm start / activity recreation /
+  bfcache back-nav still need an adb-driven tier. Not yet wired into production
+  diagnostics; doing so would give `SurfaceDiag` log lines a `window=` classification.
 
 ## Diagnostic checklist (when this recurs)
 

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -316,6 +316,10 @@ causal claim is unverified, exactly as in Attempt 8.
   on a blank window, with a white control page proving the detector is not vacuous. Warm start / activity recreation /
   bfcache back-nav still need an adb-driven tier. Not yet wired into production
   diagnostics; doing so would give `SurfaceDiag` log lines a `window=` classification.
+  First emulator run confirmed the sampler reads real webview pixels on SwiftShader and
+  surfaced a third signature: a platform view that has not composited at all samples as
+  uniform 0x00000000 (alpha 0) — distinct from the white (fresh fill) and black
+  (re-attach) blanks.
 
 ## Diagnostic checklist (when this recurs)
 

--- a/integration_test/white_screen_test.dart
+++ b/integration_test/white_screen_test.dart
@@ -139,25 +139,10 @@ void main() {
   }
 
   // pumpAndSettle deadlocks on a live webview (see lazy_webview_loading_test),
-  // so poll in fixed slices until the predicate matches.
-  Future<void> pumpUntil(
-    WidgetTester tester,
-    String description,
-    bool Function() predicate, {
-    Duration timeout = const Duration(seconds: 45),
-  }) async {
-    final deadline = DateTime.now().add(timeout);
-    while (DateTime.now().isBefore(deadline)) {
-      await tester.pump(const Duration(milliseconds: 250));
-      if (predicate()) return;
-    }
-    dumpDiagnostics(tester, description);
-    fail('Timed out after ${timeout.inSeconds}s waiting for: $description');
-  }
-
-  // Same slicing, re-sampling the composited window each pass until the
-  // sample is accepted or the deadline passes. On timeout the last sample is
-  // the diagnostic: uniform white with an ok status IS a white screen.
+  // so poll in fixed slices, re-sampling the composited window each pass
+  // until the sample is accepted or the deadline passes. On timeout the last
+  // sample is the diagnostic: uniform white with an ok status IS a white
+  // screen.
   Future<WindowRegionSample> pollSite(
     WidgetTester tester,
     String siteId,
@@ -247,13 +232,20 @@ void main() {
       // Scenario 2: detector sensitivity control. A genuinely white page is
       // pixel-identical to the BUG-001 blank, so the sampler MUST classify it
       // uniformBlank; if this fails, every other scenario is vacuous.
+      // Require actual near-white pixels, not just the blank verdict: the
+      // first emulator run showed the pre-composite platform-view hole
+      // samples as uniform 0x00000000 (alpha 0), which also classifies
+      // blank; waiting for white proves the white *content* composited.
       await openSiteDrawer(tester);
       await tapSite(tester, 'White');
       await pollSite(
           tester,
           'ws-white',
           'scenario 2: white control page classifies as uniformBlank',
-          (s) => SurfaceDiagNative.classify(s) == WindowSampleVerdict.uniformBlank);
+          (s) =>
+              s.ok &&
+              colorNear(s.dominantColor, 0xFFFFFFFF) &&
+              SurfaceDiagNative.classify(s) == WindowSampleVerdict.uniformBlank);
 
       // Scenario 3: switch back to an already-loaded site (_setCurrentIndex
       // reuse path, Attempt 3's chokepoint).
@@ -262,13 +254,42 @@ void main() {
       await pollSite(tester, 'ws-dark',
           'scenario 3: loaded-site switch repaints dark content', darkVisible);
 
-      // Scenario 4: reload funnel (Attempt 9). The refresh button swaps to a
-      // stop icon while loading; wait for it to settle back, then reload and
-      // require the recommitted document on the window.
-      await pumpUntil(tester, 'scenario 4: refresh button settled',
-          () => find.byIcon(Icons.refresh).evaluate().isNotEmpty);
-      await tester.tap(find.byIcon(Icons.refresh).first);
-      await tester.pump();
+      // Scenario 4: reload funnel (Attempt 9). The Refresh action lives
+      // inside the AppBar's overflow popup menu (it swaps to Stop while
+      // loading), so the icon only exists in the tree while the menu is
+      // open: open the menu, tap Refresh, then require the recommitted
+      // document on the window. Menu contents are built at open time, so a
+      // menu showing Stop is dismissed and reopened until the load settles.
+      final refreshDeadline = DateTime.now().add(const Duration(seconds: 45));
+      var refreshTapped = false;
+      while (!refreshTapped) {
+        if (DateTime.now().isAfter(refreshDeadline)) {
+          dumpDiagnostics(tester, 'scenario 4: Refresh menu action not reachable');
+          fail('Timed out opening the overflow menu / finding Refresh');
+        }
+        final refresh = find.byIcon(Icons.refresh);
+        if (refresh.evaluate().isNotEmpty) {
+          await tester.tap(refresh.first);
+          await tester.pump();
+          refreshTapped = true;
+          break;
+        }
+        final menuOpen =
+            find.byType(PopupMenuItem<String>).evaluate().isNotEmpty;
+        if (menuOpen) {
+          // Menu is open but shows Stop: dismiss and reopen next pass.
+          await tester.tapAt(const Offset(5, 5));
+        } else {
+          final menuButton = find.descendant(
+              of: find.byType(AppBar),
+              matching: find.byType(PopupMenuButton<String>));
+          if (menuButton.evaluate().isNotEmpty) {
+            await tester.tap(menuButton.first);
+          }
+        }
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+      }
       await pollSite(tester, 'ws-dark',
           'scenario 4: reload recommits dark content', darkVisible);
 

--- a/integration_test/white_screen_test.dart
+++ b/integration_test/white_screen_test.dart
@@ -1,0 +1,306 @@
+// White-screen pixel scenarios (BUG-001), Android emulator/device only.
+//
+// Drives the historical blank-screen entry paths and asserts on the
+// *composited window pixels* over the webview slot via SurfaceDiagPlugin's
+// window-level PixelCopy. This is the only capture plane that sees what the
+// user sees: Flutter's own screenshot path misses hybrid-composition
+// platform views entirely (see screenshot_test.dart's native-screenshot
+// workaround), and a JS probe reports the renderer plane, which is healthy
+// in every confirmed BUG-001 instance.
+//
+// Scenario map (docs/bugs/001-white-screen.md):
+//   1. Fresh first activation of a site (the 2026-08-13 report: both nudges
+//      drain before the initial document commits; no SurfaceDiag coverage).
+//   2. Detector sensitivity control: a genuinely white page must classify
+//      as uniformBlank, proving the sampler reads webview pixels and the
+//      assertions in the other scenarios are not vacuously green.
+//   3. Loaded-site switch (_setCurrentIndex reuse path, Attempt 3).
+//   4. Reload funnel (reloadAndRepaint + load-settled re-nudge, Attempt 9).
+//   5. OS memory pressure against the visible site (Attempt 7).
+//   6. Fresh activation with other sites live (controller-attach nudge,
+//      Attempt 4).
+//
+// Warm start, activity recreation, and back/forward-cache restores need
+// real activity lifecycle transitions that an in-process integration test
+// cannot produce; those remain an adb-driven tier (see
+// openspec/specs/integration-tests/spec.md).
+//
+// Pages are served from an in-process loopback HTTP server so a network
+// failure can never masquerade as a white screen. Each content page is a
+// solid color Flutter never draws, so a matching dominant color proves the
+// sampled pixels came from the webview, not the app chrome.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webspace/main.dart' as app;
+import 'package:webspace/demo_data.dart';
+import 'package:webspace/services/log_service.dart';
+import 'package:webspace/services/surface_diag_native.dart';
+import 'package:webspace/web_view_model.dart';
+import 'package:webspace/webspace_model.dart';
+
+const int _kDarkColor = 0xFF123524;
+const int _kMagentaColor = 0xFF8C1D5A;
+
+String _solidPage(String cssColor) => '<!doctype html><html><head>'
+    '<meta name="viewport" content="width=device-width, initial-scale=1">'
+    '<style>html,body{margin:0;height:100%;background:$cssColor;}</style>'
+    '</head><body></body></html>';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  HttpServer? server;
+
+  setUpAll(() async {
+    isDemoMode = true;
+
+    server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    server!.listen((request) {
+      final page = switch (request.uri.path) {
+        '/dark.html' => _solidPage('#123524'),
+        '/white.html' => _solidPage('#ffffff'),
+        '/magenta.html' => _solidPage('#8c1d5a'),
+        _ => '<!doctype html><html><body>404</body></html>',
+      };
+      request.response
+        ..headers.contentType = ContentType.html
+        ..write(page);
+      request.response.close();
+    });
+    final base = 'http://127.0.0.1:${server!.port}';
+
+    final dark = WebViewModel(
+      siteId: 'ws-dark',
+      initUrl: '$base/dark.html',
+      name: 'Dark',
+    );
+    final white = WebViewModel(
+      siteId: 'ws-white',
+      initUrl: '$base/white.html',
+      name: 'White',
+    );
+    final magenta = WebViewModel(
+      siteId: 'ws-magenta',
+      initUrl: '$base/magenta.html',
+      name: 'Magenta',
+    );
+    SharedPreferences.setMockInitialValues({
+      'webViewModels': [
+        jsonEncode(dark.toJson()),
+        jsonEncode(white.toJson()),
+        jsonEncode(magenta.toJson()),
+      ],
+    });
+  });
+
+  tearDownAll(() async {
+    await server?.close(force: true);
+  });
+
+  bool colorNear(int? actual, int expected, {int tolerance = 28}) {
+    if (actual == null) return false;
+    for (final shift in const [16, 8, 0]) {
+      final a = (actual >> shift) & 0xFF;
+      final e = (expected >> shift) & 0xFF;
+      if ((a - e).abs() > tolerance) return false;
+    }
+    return true;
+  }
+
+  // The test data is synthetic (loopback URLs, seeded names), so dumping the
+  // sensitive log ring into the CI log leaks nothing; it is the only way to
+  // read onLoadStop/onReceivedError from a remote failure (INTEG-006).
+  void dumpDiagnostics(WidgetTester tester, String context) {
+    print('=== white_screen_test failure: $context');
+    print('Texts: ${find.byType(Text).evaluate().map((e) {
+      final w = e.widget;
+      return w is Text ? (w.data ?? '?') : '?';
+    }).take(30).toList()}');
+    final entries = LogService.instance.allEntriesMerged;
+    for (final e in entries.skip(entries.length < 60 ? 0 : entries.length - 60)) {
+      print('  [${e.tag}/${e.level.name}] ${e.message}');
+    }
+  }
+
+  Future<WindowRegionSample> sampleSite(WidgetTester tester, String siteId) {
+    final logical = tester.getRect(find.byKey(ValueKey(siteId)).first);
+    return SurfaceDiagNative.sampleWindowRegion(SurfaceDiagNative.physicalRect(
+      logicalRect: logical,
+      devicePixelRatio: tester.view.devicePixelRatio,
+      insetLogical: 12,
+    ));
+  }
+
+  // pumpAndSettle deadlocks on a live webview (see lazy_webview_loading_test),
+  // so poll in fixed slices until the predicate matches.
+  Future<void> pumpUntil(
+    WidgetTester tester,
+    String description,
+    bool Function() predicate, {
+    Duration timeout = const Duration(seconds: 45),
+  }) async {
+    final deadline = DateTime.now().add(timeout);
+    while (DateTime.now().isBefore(deadline)) {
+      await tester.pump(const Duration(milliseconds: 250));
+      if (predicate()) return;
+    }
+    dumpDiagnostics(tester, description);
+    fail('Timed out after ${timeout.inSeconds}s waiting for: $description');
+  }
+
+  // Same slicing, re-sampling the composited window each pass until the
+  // sample is accepted or the deadline passes. On timeout the last sample is
+  // the diagnostic: uniform white with an ok status IS a white screen.
+  Future<WindowRegionSample> pollSite(
+    WidgetTester tester,
+    String siteId,
+    String description,
+    bool Function(WindowRegionSample) accept, {
+    Duration timeout = const Duration(seconds: 90),
+  }) async {
+    final deadline = DateTime.now().add(timeout);
+    WindowRegionSample? last;
+    while (DateTime.now().isBefore(deadline)) {
+      await tester.pump(const Duration(milliseconds: 250));
+      if (find.byKey(ValueKey(siteId)).evaluate().isEmpty) continue;
+      last = await sampleSite(tester, siteId);
+      if (accept(last)) {
+        print('white_screen_test: $description -> $last');
+        return last;
+      }
+    }
+    dumpDiagnostics(tester, '$description; last sample: $last');
+    fail('Timed out after ${timeout.inSeconds}s waiting for: $description '
+        '(last sample: $last)');
+  }
+
+  Future<void> openSiteDrawer(WidgetTester tester) async {
+    for (var attempt = 0; attempt < 3; attempt++) {
+      if (find.byType(Drawer).evaluate().isNotEmpty) return;
+      final menuIcon = find.byIcon(Icons.menu);
+      if (menuIcon.evaluate().isNotEmpty) {
+        await tester.tap(menuIcon.first);
+      } else {
+        final scaffolds = find.byType(Scaffold).evaluate();
+        for (final element in scaffolds) {
+          final state = tester.state<ScaffoldState>(
+              find.byWidget(element.widget as Scaffold));
+          if (state.hasDrawer) {
+            state.openDrawer();
+            break;
+          }
+        }
+      }
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+    }
+    expect(find.byType(Drawer), findsOneWidget,
+        reason: 'site drawer should open for switching sites');
+  }
+
+  // The active site's name can also appear in the AppBar title, so scope to
+  // the open drawer when there is one; the drawer tile is the switch target.
+  Future<void> tapSite(WidgetTester tester, String siteName) async {
+    final drawer = find.byType(Drawer);
+    final tile = drawer.evaluate().isNotEmpty
+        ? find.descendant(of: drawer, matching: find.text(siteName))
+        : find.text(siteName);
+    if (tile.evaluate().isEmpty) {
+      dumpDiagnostics(tester, 'site tile "$siteName" not found');
+    }
+    expect(tile, findsWidgets,
+        reason: '$siteName should be visible in the site list');
+    await tester.tap(tile.first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+  }
+
+  testWidgets(
+    'BUG-001 entry paths keep the composited webview pixels non-blank',
+    (tester) async {
+      app.main();
+      await tester.pumpAndSettle(const Duration(seconds: 30));
+
+      bool darkVisible(WindowRegionSample s) =>
+          s.ok &&
+          colorNear(s.dominantColor, _kDarkColor) &&
+          (s.uniformFraction ?? 0) > 0.5;
+
+      // Scenario 1: fresh first activation. This is the reported path: the
+      // webview is created from scratch, both the activation and the
+      // controller-attach nudges drain before the initial document commits,
+      // and no settled-side nudge exists for a first load. The window must
+      // still end up showing the page.
+      await tester.tap(find.byKey(const ValueKey(kAllWebspaceId)));
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+      await tapSite(tester, 'Dark');
+      await pollSite(tester, 'ws-dark',
+          'scenario 1: fresh activation paints dark content', darkVisible);
+
+      // Scenario 2: detector sensitivity control. A genuinely white page is
+      // pixel-identical to the BUG-001 blank, so the sampler MUST classify it
+      // uniformBlank; if this fails, every other scenario is vacuous.
+      await openSiteDrawer(tester);
+      await tapSite(tester, 'White');
+      await pollSite(
+          tester,
+          'ws-white',
+          'scenario 2: white control page classifies as uniformBlank',
+          (s) => SurfaceDiagNative.classify(s) == WindowSampleVerdict.uniformBlank);
+
+      // Scenario 3: switch back to an already-loaded site (_setCurrentIndex
+      // reuse path, Attempt 3's chokepoint).
+      await openSiteDrawer(tester);
+      await tapSite(tester, 'Dark');
+      await pollSite(tester, 'ws-dark',
+          'scenario 3: loaded-site switch repaints dark content', darkVisible);
+
+      // Scenario 4: reload funnel (Attempt 9). The refresh button swaps to a
+      // stop icon while loading; wait for it to settle back, then reload and
+      // require the recommitted document on the window.
+      await pumpUntil(tester, 'scenario 4: refresh button settled',
+          () => find.byIcon(Icons.refresh).evaluate().isNotEmpty);
+      await tester.tap(find.byIcon(Icons.refresh).first);
+      await tester.pump();
+      await pollSite(tester, 'ws-dark',
+          'scenario 4: reload recommits dark content', darkVisible);
+
+      // Scenario 5: OS memory pressure with the site visible (Attempt 7).
+      // Delivered as the real platform message so it flows through
+      // ServicesBinding into didHaveMemoryPressure. The active site is
+      // hard-protected from eviction; the probe + nudge recovery must leave
+      // its pixels intact.
+      ServicesBinding.instance.channelBuffers.push(
+        'flutter/system',
+        const JSONMessageCodec()
+            .encodeMessage(<String, dynamic>{'type': 'memoryPressure'}),
+        (_) {},
+      );
+      await tester.pump();
+      await pollSite(tester, 'ws-dark',
+          'scenario 5: memory pressure keeps dark content', darkVisible);
+
+      // Scenario 6: fresh activation while other webviews are live
+      // (controller-attach nudge, Attempt 4's chokepoint).
+      await openSiteDrawer(tester);
+      await tapSite(tester, 'Magenta');
+      await pollSite(
+          tester,
+          'ws-magenta',
+          'scenario 6: fresh activation among live sites paints magenta',
+          (s) =>
+              s.ok &&
+              colorNear(s.dominantColor, _kMagentaColor) &&
+              (s.uniformFraction ?? 0) > 0.5);
+    },
+    skip: !Platform.isAndroid,
+    timeout: const Timeout(Duration(minutes: 15)),
+  );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,6 +48,7 @@ import 'package:webspace/services/settings_backup.dart';
 import 'package:webspace/services/cookie_isolation.dart';
 import 'package:webspace/services/resume_reload_engine.dart';
 import 'package:webspace/services/surface_repaint_engine.dart';
+import 'package:webspace/services/diag_seed.dart';
 import 'package:webspace/services/cookie_secure_storage.dart';
 import 'package:webspace/services/proxy_password_secure_storage.dart';
 import 'package:webspace/services/archive.dart';
@@ -585,6 +586,13 @@ void main() async {
   // Debug-only startup phase timing (see 'Startup' tag in the log screen /
   // console). Compiled out of release builds via kDebugMode.
   final swMain = kDebugMode ? (Stopwatch()..start()) : null;
+
+  // Adb white-screen tier (INTEG-011): a debug launch may carry a seeded
+  // site list in the intent extra; it must land in prefs before the page
+  // state reads them.
+  if (kDebugMode && Platform.isAndroid) {
+    await DiagSeed.applyFromLaunchIntent();
+  }
 
   // Imported HTML files are the only copy of user-supplied content, so they
   // live in their own persistent store and survive upgrades. The HTML cache

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -587,11 +587,12 @@ void main() async {
   // console). Compiled out of release builds via kDebugMode.
   final swMain = kDebugMode ? (Stopwatch()..start()) : null;
 
-  // Adb white-screen tier (INTEG-011): a debug launch may carry a seeded
-  // site list in the intent extra; it must land in prefs before the page
-  // state reads them.
-  if (kDebugMode && Platform.isAndroid) {
-    await DiagSeed.applyFromLaunchIntent();
+  // Externally-driven test tiers (INTEG-011/012): a debug launch may
+  // carry a seeded site list (Android intent extra, or WS_DIAG_SEED env
+  // for a simctl driver); it must land in prefs before the page state
+  // reads them.
+  if (kDebugMode) {
+    await DiagSeed.applyFromLaunch();
   }
 
   // Imported HTML files are the only copy of user-supplied content, so they

--- a/lib/services/diag_seed.dart
+++ b/lib/services/diag_seed.dart
@@ -84,6 +84,11 @@ class DiagSeed {
     await prefs.remove('webspaces');
     await prefs.setString('selectedWebspaceId', kAllWebspaceId);
     await prefs.setBool('showUrlBar', false);
+    // The harness activates sites through the shortcut path, which enters
+    // fullscreen by default; the first immersive entry pops Android's
+    // "viewing full screen" education bubble, whose screen-wide 50% dim
+    // corrupts every pixel sample.
+    await prefs.setBool('fullscreenOnShortcut', false);
     isDemoMode = true;
     LogService.instance.log('DiagSeed',
         'seeded ${seed.sites.length} sites: '

--- a/lib/services/diag_seed.dart
+++ b/lib/services/diag_seed.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -14,12 +15,13 @@ class DiagSeedData {
   const DiagSeedData({required this.sites});
 }
 
-/// Launch-time site seeding for the adb-driven white-screen tier
-/// (INTEG-011). The lifecycle scenarios (warm start, activity recreation,
-/// bfcache back navigation) drive the real APK from outside the process,
-/// where the in-process test's SharedPreferences mocking does not exist,
-/// so the harness passes a base64 JSON site list as an intent extra and
-/// the app seeds itself before the first prefs read.
+/// Launch-time site seeding for the externally-driven test tiers
+/// (INTEG-011/012). The lifecycle scenarios (warm start, activity
+/// recreation, bfcache back navigation, background refresh) drive the
+/// real app from outside the process, where the in-process test's
+/// SharedPreferences mocking does not exist, so the harness passes a
+/// base64 JSON site list (Android intent extra / `WS_DIAG_SEED` env)
+/// and the app seeds itself before the first prefs read.
 ///
 /// Debug builds only: the call is gated on [kDebugMode] and the Kotlin
 /// side refuses the extra on non-debuggable builds, so a release build
@@ -47,6 +49,7 @@ class DiagSeed {
           siteId: (raw as Map<String, dynamic>)['siteId'] as String?,
           initUrl: raw['url'] as String,
           name: raw['name'] as String? ?? 'Diag',
+          notificationsEnabled: raw['notificationsEnabled'] as bool? ?? false,
         ),
     ];
     if (sites.isEmpty) {
@@ -55,20 +58,24 @@ class DiagSeed {
     return DiagSeedData(sites: sites);
   }
 
-  /// Reads the `ws_diag_seed` launch-intent extra and, when present,
-  /// replaces the persisted site list with the seeded one and enables
-  /// demo mode. Returns whether a seed was applied. Must complete before
-  /// the page state loads models from prefs.
-  static Future<bool> applyFromLaunchIntent() async {
+  /// Reads the seed from the `ws_diag_seed` launch-intent extra (Android)
+  /// or the `WS_DIAG_SEED` process environment (iOS/macOS: `simctl launch`
+  /// forwards `SIMCTL_CHILD_`-prefixed host variables, so a future simctl
+  /// driver reuses this transport unchanged) and, when present, replaces
+  /// the persisted site list with the seeded one and enables demo mode.
+  /// Returns whether a seed was applied. Must complete before the page
+  /// state loads models from prefs.
+  static Future<bool> applyFromLaunch() async {
     if (!kDebugMode) return false;
     String? encoded;
     try {
       encoded = await _channel.invokeMethod<String>('getDiagSeed');
     } on MissingPluginException {
-      return false;
+      encoded = null;
     } on PlatformException {
-      return false;
+      encoded = null;
     }
+    encoded ??= Platform.environment['WS_DIAG_SEED'];
     if (encoded == null || encoded.isEmpty) return false;
     final DiagSeedData seed;
     try {

--- a/lib/services/diag_seed.dart
+++ b/lib/services/diag_seed.dart
@@ -10,9 +10,8 @@ import 'package:webspace/webspace_model.dart';
 
 class DiagSeedData {
   final List<WebViewModel> sites;
-  final int currentIndex;
 
-  const DiagSeedData({required this.sites, required this.currentIndex});
+  const DiagSeedData({required this.sites});
 }
 
 /// Launch-time site seeding for the adb-driven white-screen tier
@@ -30,10 +29,14 @@ class DiagSeed {
   static const _channel =
       MethodChannel('org.codeberg.theoden8.webspace/shortcuts');
 
-  /// Decode a base64 `{"sites":[{"name":...,"url":...}],"currentIndex":N}`
-  /// seed. siteIds are freshly generated each launch so state keyed by
-  /// siteId (cookies, nav-state capture, containers) from a previous
-  /// harness run can never bleed into this one.
+  /// Decode a base64 `{"sites":[{"name":...,"url":...,"siteId":...}]}`
+  /// seed. A site entry may carry an explicit siteId: the harness needs a
+  /// known id to activate the site through the production pinned-shortcut
+  /// `siteId` extra (a plain cold start lands on the webspace picker with
+  /// no site selected — the persisted currentIndex is never read back).
+  /// The harness keeps ids unique per run so state keyed by siteId
+  /// (cookies, nav-state capture, containers) cannot bleed across runs;
+  /// entries without one get a fresh generated id.
   static DiagSeedData parse(String encoded) {
     final obj =
         jsonDecode(utf8.decode(base64.decode(encoded))) as Map<String, dynamic>;
@@ -41,19 +44,15 @@ class DiagSeed {
     final sites = <WebViewModel>[
       for (final raw in rawSites)
         WebViewModel(
-          initUrl: (raw as Map<String, dynamic>)['url'] as String,
+          siteId: (raw as Map<String, dynamic>)['siteId'] as String?,
+          initUrl: raw['url'] as String,
           name: raw['name'] as String? ?? 'Diag',
         ),
     ];
     if (sites.isEmpty) {
       throw const FormatException('diag seed has no sites');
     }
-    final currentIndex = obj['currentIndex'] as int? ?? 0;
-    if (currentIndex < 0 || currentIndex >= sites.length) {
-      throw RangeError('currentIndex $currentIndex out of range '
-          '(${sites.length} sites)');
-    }
-    return DiagSeedData(sites: sites, currentIndex: currentIndex);
+    return DiagSeedData(sites: sites);
   }
 
   /// Reads the `ws_diag_seed` launch-intent extra and, when present,
@@ -84,11 +83,11 @@ class DiagSeed {
         seed.sites.map((s) => jsonEncode(s.toJson())).toList());
     await prefs.remove('webspaces');
     await prefs.setString('selectedWebspaceId', kAllWebspaceId);
-    await prefs.setInt('currentIndex', seed.currentIndex);
     await prefs.setBool('showUrlBar', false);
     isDemoMode = true;
     LogService.instance.log('DiagSeed',
-        'seeded ${seed.sites.length} sites, currentIndex=${seed.currentIndex}');
+        'seeded ${seed.sites.length} sites: '
+        '${seed.sites.map((s) => s.siteId).join(', ')}');
     return true;
   }
 }

--- a/lib/services/diag_seed.dart
+++ b/lib/services/diag_seed.dart
@@ -1,0 +1,94 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webspace/demo_data.dart' show isDemoMode;
+import 'package:webspace/services/log_service.dart';
+import 'package:webspace/web_view_model.dart';
+import 'package:webspace/webspace_model.dart';
+
+class DiagSeedData {
+  final List<WebViewModel> sites;
+  final int currentIndex;
+
+  const DiagSeedData({required this.sites, required this.currentIndex});
+}
+
+/// Launch-time site seeding for the adb-driven white-screen tier
+/// (INTEG-011). The lifecycle scenarios (warm start, activity recreation,
+/// bfcache back navigation) drive the real APK from outside the process,
+/// where the in-process test's SharedPreferences mocking does not exist,
+/// so the harness passes a base64 JSON site list as an intent extra and
+/// the app seeds itself before the first prefs read.
+///
+/// Debug builds only: the call is gated on [kDebugMode] and the Kotlin
+/// side refuses the extra on non-debuggable builds, so a release build
+/// never honors it. Seeding enables demo mode, so nothing from the run
+/// is persisted past the seeded values themselves.
+class DiagSeed {
+  static const _channel =
+      MethodChannel('org.codeberg.theoden8.webspace/shortcuts');
+
+  /// Decode a base64 `{"sites":[{"name":...,"url":...}],"currentIndex":N}`
+  /// seed. siteIds are freshly generated each launch so state keyed by
+  /// siteId (cookies, nav-state capture, containers) from a previous
+  /// harness run can never bleed into this one.
+  static DiagSeedData parse(String encoded) {
+    final obj =
+        jsonDecode(utf8.decode(base64.decode(encoded))) as Map<String, dynamic>;
+    final rawSites = obj['sites'] as List<dynamic>? ?? const [];
+    final sites = <WebViewModel>[
+      for (final raw in rawSites)
+        WebViewModel(
+          initUrl: (raw as Map<String, dynamic>)['url'] as String,
+          name: raw['name'] as String? ?? 'Diag',
+        ),
+    ];
+    if (sites.isEmpty) {
+      throw const FormatException('diag seed has no sites');
+    }
+    final currentIndex = obj['currentIndex'] as int? ?? 0;
+    if (currentIndex < 0 || currentIndex >= sites.length) {
+      throw RangeError('currentIndex $currentIndex out of range '
+          '(${sites.length} sites)');
+    }
+    return DiagSeedData(sites: sites, currentIndex: currentIndex);
+  }
+
+  /// Reads the `ws_diag_seed` launch-intent extra and, when present,
+  /// replaces the persisted site list with the seeded one and enables
+  /// demo mode. Returns whether a seed was applied. Must complete before
+  /// the page state loads models from prefs.
+  static Future<bool> applyFromLaunchIntent() async {
+    if (!kDebugMode) return false;
+    String? encoded;
+    try {
+      encoded = await _channel.invokeMethod<String>('getDiagSeed');
+    } on MissingPluginException {
+      return false;
+    } on PlatformException {
+      return false;
+    }
+    if (encoded == null || encoded.isEmpty) return false;
+    final DiagSeedData seed;
+    try {
+      seed = parse(encoded);
+    } catch (e) {
+      LogService.instance
+          .log('DiagSeed', 'ignoring unparseable seed: $e', level: LogLevel.error);
+      return false;
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList('webViewModels',
+        seed.sites.map((s) => jsonEncode(s.toJson())).toList());
+    await prefs.remove('webspaces');
+    await prefs.setString('selectedWebspaceId', kAllWebspaceId);
+    await prefs.setInt('currentIndex', seed.currentIndex);
+    await prefs.setBool('showUrlBar', false);
+    isDemoMode = true;
+    LogService.instance.log('DiagSeed',
+        'seeded ${seed.sites.length} sites, currentIndex=${seed.currentIndex}');
+    return true;
+  }
+}

--- a/lib/services/surface_diag_native.dart
+++ b/lib/services/surface_diag_native.dart
@@ -64,9 +64,12 @@ class SurfaceDiagNative {
         'height': physicalRect.height.round(),
       });
       if (res == null) return WindowRegionSample.unsupported;
+      // Kotlin sends a signed 32-bit ARGB int; normalize to unsigned so
+      // 0xFF123524 stays 0xFF123524 on the Dart side.
+      final rawColor = res['dominantColor'] as int?;
       return WindowRegionSample(
         status: res['status'] as String? ?? 'unsupported',
-        dominantColor: res['dominantColor'] as int?,
+        dominantColor: rawColor == null ? null : rawColor & 0xFFFFFFFF,
         uniformFraction: (res['uniformFraction'] as num?)?.toDouble(),
       );
     } on MissingPluginException {

--- a/lib/services/surface_diag_native.dart
+++ b/lib/services/surface_diag_native.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+/// Verdict over a sampled window region.
+///
+/// [uniformBlank] is BUG-001's symptom: the region the user sees is a flat
+/// white (fresh SurfaceView default fill) or black (re-attached surface)
+/// rectangle. A uniform region in any *other* color is [content]: a page
+/// legitimately painted a solid background, which no blank surface produces.
+enum WindowSampleVerdict { unavailable, uniformBlank, content }
+
+/// One window-level pixel sample. [status] is `ok` when the histogram ran;
+/// any other value (`unsupported`, `no-window`, `bad-region`, `no-surface`,
+/// `copy-failed:N`) means the composited pixels could not be read this time.
+class WindowRegionSample {
+  final String status;
+  final int? dominantColor;
+  final double? uniformFraction;
+
+  const WindowRegionSample({
+    required this.status,
+    this.dominantColor,
+    this.uniformFraction,
+  });
+
+  static const unsupported = WindowRegionSample(status: 'unsupported');
+
+  bool get ok => status == 'ok';
+
+  @override
+  String toString() {
+    final color = dominantColor == null
+        ? 'null'
+        : '0x${dominantColor!.toRadixString(16).padLeft(8, '0')}';
+    final fraction = uniformFraction?.toStringAsFixed(3) ?? 'null';
+    return 'WindowRegionSample(status=$status dominant=$color uniform=$fraction)';
+  }
+}
+
+/// Bridge to the Android window-pixel sampler ([SurfaceDiagPlugin.kt]).
+///
+/// The webview's hybrid-composition SurfaceView is composited by the OS,
+/// invisible to both the JS probe (renderer plane) and Flutter-side capture
+/// (raster tree without platform views). Window-level PixelCopy is the only
+/// signal that measures what the user actually sees, so it is the only way
+/// to *detect* the BUG-001 blank rather than infer it from a trigger path.
+class SurfaceDiagNative {
+  static const _channel =
+      MethodChannel('org.codeberg.theoden8.webspace/surface_diag');
+
+  /// Sample the composited window over [physicalRect] (physical pixels,
+  /// window coordinates). Non-Android platforms report [WindowRegionSample.unsupported]:
+  /// iOS's blank class is renderer jettison, which the JS probe already
+  /// detects, and the Flutter window there composites platform views in-tree.
+  static Future<WindowRegionSample> sampleWindowRegion(Rect physicalRect) async {
+    if (!Platform.isAndroid) return WindowRegionSample.unsupported;
+    try {
+      final res = await _channel
+          .invokeMapMethod<String, dynamic>('sampleWindowRegion', <String, int>{
+        'left': physicalRect.left.round(),
+        'top': physicalRect.top.round(),
+        'width': physicalRect.width.round(),
+        'height': physicalRect.height.round(),
+      });
+      if (res == null) return WindowRegionSample.unsupported;
+      return WindowRegionSample(
+        status: res['status'] as String? ?? 'unsupported',
+        dominantColor: res['dominantColor'] as int?,
+        uniformFraction: (res['uniformFraction'] as num?)?.toDouble(),
+      );
+    } on MissingPluginException {
+      return WindowRegionSample.unsupported;
+    } on PlatformException {
+      return WindowRegionSample.unsupported;
+    }
+  }
+
+  /// Map a logical-coordinate region to the physical-pixel window rect the
+  /// sampler needs. [insetLogical] shrinks the region on all sides so
+  /// borders, scrollbar gutters, and the pull-to-refresh edge glow don't
+  /// dilute the histogram.
+  static Rect physicalRect({
+    required Rect logicalRect,
+    required double devicePixelRatio,
+    double insetLogical = 0,
+  }) {
+    final inset = logicalRect.deflate(insetLogical);
+    return Rect.fromLTRB(
+      inset.left * devicePixelRatio,
+      inset.top * devicePixelRatio,
+      inset.right * devicePixelRatio,
+      inset.bottom * devicePixelRatio,
+    );
+  }
+
+  /// Pure classification of one sample. A verdict of [WindowSampleVerdict.uniformBlank]
+  /// means the region is (nearly) all one color AND that color is near-white
+  /// or near-black, the two fills a blank surface can show. Thresholds are
+  /// lenient on the uniform fraction because compositor dithering fragments
+  /// the histogram bucket at quantization boundaries.
+  static WindowSampleVerdict classify(
+    WindowRegionSample sample, {
+    double uniformThreshold = 0.98,
+  }) {
+    final color = sample.dominantColor;
+    final fraction = sample.uniformFraction;
+    if (!sample.ok || color == null || fraction == null) {
+      return WindowSampleVerdict.unavailable;
+    }
+    if (fraction < uniformThreshold) return WindowSampleVerdict.content;
+    final r = (color >> 16) & 0xFF;
+    final g = (color >> 8) & 0xFF;
+    final b = color & 0xFF;
+    final luma = 0.299 * r + 0.587 * g + 0.114 * b;
+    if (luma >= 243 || luma <= 12) return WindowSampleVerdict.uniformBlank;
+    return WindowSampleVerdict.content;
+  }
+}

--- a/openspec/specs/integration-tests/spec.md
+++ b/openspec/specs/integration-tests/spec.md
@@ -607,6 +607,74 @@ sample (observed as exact per-channel halving of the page colors).
   call is additionally compiled out of release via `kDebugMode`, so
   production behavior is unchanged
 
+#### Scenario: System error dialogs cannot corrupt samples
+
+- **Given** the CI emulator host is loaded enough that a foreign app
+  (e.g. the launcher) can ANR, parking a scrimmed system dialog over
+  the whole screen
+- **When** the harness starts
+- **Then** it sets `hide_error_dialogs`, dismisses any dialog already
+  showing, and restores the setting in its exit trap
+
+---
+
+### Requirement: INTEG-012 — Background refresh drives an observable notification
+
+The lifecycle harness SHALL verify the Android background-refresh
+contract (`NOTIF-005-A`, [web-push-notifications](../web-push-notifications/spec.md))
+end to end from outside the process: a site seeded with
+`notificationsEnabled` whose page posts a JS `Notification` on every
+load, the app backgrounded, and the WorkManager periodic job
+(`webspace-notification-refresh`) forced via
+`adb shell cmd jobscheduler run -f` — the OS notification that
+appears (read via `dumpsys notification`) is proof the full pipeline
+ran with no foreground activity: worker → engine dispatch →
+`onBackgroundRefresh` site reload → `Notification` polyfill →
+`flutter_local_notifications`.
+
+Cross-platform posture: the seed transport is platform-agnostic
+(`ws_diag_seed` intent extra on Android; `WS_DIAG_SEED` process
+environment elsewhere, which `simctl launch` forwards via its
+`SIMCTL_CHILD_` prefix), and the pixel classifier is already
+device-neutral, so a future `simctl` driver reuses both. The iOS
+background contract (`NOTIF-005-I`, `BGAppRefreshTask`) is NOT
+CI-drivable: `BGTaskScheduler` tasks can only be simulated with a
+debugger attached (the private
+`_simulateLaunchForTaskWithIdentifier:` LLDB call), which headless
+`simctl` cannot do — iOS keeps its structural coverage
+(`test/js/native_bgtask_completion_funnel.test.js`) and an iOS pixel
+tier for the non-background scenarios remains future scope.
+
+#### Scenario: Scheduling contract is asserted, not assumed
+
+- **Given** the seeded notification site is active
+- **When** the harness lists JobScheduler jobs for the app package
+- **Then** at least one `androidx.work` job exists, else the run
+  fails naming NOTIF-005-A (the periodic work was never scheduled)
+
+#### Scenario: Foreground pipeline is pinned before the background step
+
+- **Given** the notification site's page just painted
+- **When** the harness polls `dumpsys notification`
+- **Then** the foreground load itself must have posted a notification
+  (polyfill → local-notifications proven working), and that count is
+  the baseline the background assertion increments from
+
+#### Scenario: Forced periodic refresh posts a new notification while backgrounded
+
+- **Given** the app is backgrounded (HOME) with the process alive
+- **When** the harness forces the WorkManager job(s)
+- **Then** a new OS notification from the app appears within the
+  polling deadline, and on failure the harness saves the jobscheduler
+  dump, the notification dump, and a logcat tail as artifacts
+
+#### Scenario: The refreshed site still paints on return
+
+- **Given** the background refresh reloaded the site offscreen
+- **When** the app is foregrounded again
+- **Then** the composited frame reaches the page color (the BUG-001
+  assertion applied to the post-refresh surface)
+
 ---
 
 ## Known Limitations
@@ -665,7 +733,8 @@ sample (observed as exact per-channel halving of the page colors).
   [`test/surface_diag_classification_test.dart`](../../../test/surface_diag_classification_test.dart))
 - [`scripts/run_android_lifecycle_tests.sh`](../../../scripts/run_android_lifecycle_tests.sh)
   — INTEG-011: adb-driven lifecycle tier (warm start, bfcache back,
-  activity recreation, white control). Frame classifier:
+  activity recreation, white control); INTEG-012: background-refresh
+  scenario (NOTIF-005-A). Frame classifier:
   [`scripts/classify_window_pixels.py`](../../../scripts/classify_window_pixels.py);
   launch seeding: [`lib/services/diag_seed.dart`](../../../lib/services/diag_seed.dart)
   (`getDiagSeed` in MainActivity, debuggable builds only; parsing

--- a/openspec/specs/integration-tests/spec.md
+++ b/openspec/specs/integration-tests/spec.md
@@ -24,16 +24,18 @@ supplies both natively.
 The **mobile** targets — Android (`-d emulator-*`) and the iOS
 Simulator (`-d <udid>`) — are a separate harness: each needs a booted
 emulator/simulator before `flutter test` can attach, not just a window
-server. They are not wired into the integration_test tier yet. The
-device-boot plumbing already exists in this workflow for the
+server. The device-boot plumbing exists in this workflow for the
 fastlane-driven Android/iOS screenshot pipeline (see
 [`screenshots`](../screenshots/spec.md) — `build-android`'s
 `reactivecircus/android-emulator-runner` and `build-apple`'s
-`simctl boot`), so a future mobile integration_test tier would extend
-that boot setup rather than the desktop `-d` path. Screenshots are a
-different harness with a different goal (screenshot generation vs.
-assertion-driven UI testing), but they share the same emulator/
-simulator prerequisite.
+`simctl boot`). One Android-emulator scenario now rides that boot:
+`white_screen_test.dart` (INTEG-010) runs inside the same
+emulator session as the screenshots lane (`workflow_dispatch` tier),
+after `bundle exec fastlane android screenshots`. It is Android-only
+(window-level `PixelCopy`), so both desktop loops skip it by basename
+exactly as they skip `screenshot_test.dart`. A broader mobile tier
+(iOS Simulator, per-PR Android) remains future scope and would extend
+the same boot setup rather than the desktop `-d` path.
 
 ## Status
 
@@ -439,6 +441,70 @@ either target.
 
 ---
 
+### Requirement: INTEG-010 — Android white-screen pixel scenarios
+
+`integration_test/white_screen_test.dart` SHALL drive the
+in-process-drivable BUG-001 entry paths
+([docs/bugs/001-white-screen.md](../../../docs/bugs/001-white-screen.md))
+on an Android emulator/device and assert on the **composited window
+pixels** over the webview slot, sampled by
+`SurfaceDiagPlugin.sampleWindowRegion` (window-level `PixelCopy`).
+This is the only capture plane that shows what the user sees:
+Flutter's `convertFlutterSurfaceToImage` misses hybrid-composition
+platform views, and a JS probe reports the renderer plane, which is
+healthy in every confirmed BUG-001 instance. Pages come from an
+in-process loopback HTTP server so a network failure can never
+masquerade as a white screen, and each content page is a solid color
+Flutter never draws so a matching dominant color proves the sample
+came from the webview.
+
+The suite SHALL cover at least: fresh first activation (BUG-001 gap
+#7), loaded-site switch (`_setCurrentIndex` reuse), the reload funnel
+(`PAUSE-021`), memory pressure against the visible site
+(`PAUSE-019`), and fresh activation with other sites live
+(`PAUSE-017`). Warm start, activity recreation, and bfcache back
+navigation need real activity lifecycle transitions an in-process
+test cannot produce; they are future adb-driven scope.
+
+#### Scenario: White control page proves the detector is not vacuous
+
+- **Given** a seeded site whose page is genuinely all-white
+- **When** the suite activates it and samples the webview rect
+- **Then** `SurfaceDiagNative.classify` reports `uniformBlank`
+- **And** a sampler regression that stops seeing webview pixels
+  therefore fails this scenario instead of silently passing the rest
+
+#### Scenario: A blank window fails the run with the sample as diagnostic
+
+- **Given** any covered entry path leaves the composited webview
+  region uniform white/black after its settle window
+- **When** the polling assertion times out
+- **Then** the test fails and prints the last `WindowRegionSample`
+  (status, dominant color, uniform fraction) plus the in-memory
+  `LogService` tail, which is safe to surface because the test data
+  is synthetic (loopback URLs, seeded names)
+
+#### Scenario: Runs inside the screenshots emulator session
+
+- **Given** the `build-android` job's `workflow_dispatch` emulator
+  session has finished `bundle exec fastlane android screenshots`
+- **When** the same script step runs
+  `fvm flutter test integration_test/white_screen_test.dart -d <device> --flavor fdebug`
+- **Then** the suite executes against the booted emulator with a
+  20-minute wall-clock cap, and a failure fails the job
+
+#### Scenario: Desktop loops skip the Android-only suite
+
+- **Given** the Linux and macOS integration loops iterate
+  `integration_test/*_test.dart`
+- **When** they reach `white_screen_test.dart`
+- **Then** both skip it by basename (like `screenshot_test.dart`),
+  because the `PixelCopy` channel exists only on Android and the
+  `skip: !Platform.isAndroid` guard would still cost a desktop debug
+  build per run
+
+---
+
 ## Known Limitations
 
 - **Build time per test**: each `flutter test integration_test/<file>.dart`
@@ -454,11 +520,19 @@ either target.
   `cryptography>=46` and pydbus's `list[int]` buffer convention natively,
   drop the patches. No version pin in the workflow today; track
   https://github.com/mkhon/pass-secret-service for the fix.
-- **Webview rendering not exercised**: the smoke test reaches App Settings
-  without ever loading a webview; `settings_backup_roundtrip_test.dart`
+- **Webview rendering not exercised on desktop**: the smoke test reaches
+  App Settings without ever loading a webview; `settings_backup_roundtrip_test.dart`
   is the same. Webview-loading scenarios (Tier C of the integration
   test backlog) may surface a new class of headless rendering issues
-  that this spec doesn't cover.
+  that this spec doesn't cover. On Android, `white_screen_test.dart`
+  (INTEG-010) does exercise real webview rendering down to composited
+  pixels, but only in the `workflow_dispatch` emulator tier.
+- **Emulator compositing is not device compositing**: the emulator runs
+  `-gpu swiftshader_indirect`, so INTEG-010's scenarios exercise the
+  funnels and detector plumbing deterministically but may never
+  reproduce a device-specific SurfaceFlinger race (Mali/Adreno). A
+  green run means "no blank window on this compositor", not "BUG-001
+  cannot happen"; a red run is a real, labeled reproduction.
 - **proot is for local dev only**: locally on a non-sid host (eg. a
   Debian bookworm dev container) the harness can run inside a sid
   chroot via `proot -r /var/lib/sid-chroot`, but proot 5.1.0 (bookworm)
@@ -478,6 +552,13 @@ either target.
   `build-apple` job's `Run macOS integration tests` step (`-d macos`).
 
 ### Existing
+- [`integration_test/white_screen_test.dart`](../../../integration_test/white_screen_test.dart)
+  — INTEG-010: BUG-001 entry paths against composited window pixels
+  (Android emulator tier). Sampler:
+  [`android/.../SurfaceDiagPlugin.kt`](../../../android/app/src/main/kotlin/org/codeberg/theoden8/webspace/SurfaceDiagPlugin.kt)
+  + [`lib/services/surface_diag_native.dart`](../../../lib/services/surface_diag_native.dart)
+  (classification unit-tested in
+  [`test/surface_diag_classification_test.dart`](../../../test/surface_diag_classification_test.dart))
 - [`integration_test/settings_smoke_test.dart`](../../../integration_test/settings_smoke_test.dart)
   — harness pin
 - [`integration_test/settings_backup_roundtrip_test.dart`](../../../integration_test/settings_backup_roundtrip_test.dart)

--- a/openspec/specs/integration-tests/spec.md
+++ b/openspec/specs/integration-tests/spec.md
@@ -28,14 +28,14 @@ server. The device-boot plumbing exists in this workflow for the
 fastlane-driven Android/iOS screenshot pipeline (see
 [`screenshots`](../screenshots/spec.md) — `build-android`'s
 `reactivecircus/android-emulator-runner` and `build-apple`'s
-`simctl boot`). One Android-emulator scenario now rides that boot:
-`white_screen_test.dart` (INTEG-010) runs inside the same
-emulator session as the screenshots lane (`workflow_dispatch` tier),
-after `bundle exec fastlane android screenshots`. It is Android-only
-(window-level `PixelCopy`), so both desktop loops skip it by basename
-exactly as they skip `screenshot_test.dart`. A broader mobile tier
-(iOS Simulator, per-PR Android) remains future scope and would extend
-the same boot setup rather than the desktop `-d` path.
+`simctl boot`). The first Android-emulator scenario is wired in:
+`white_screen_test.dart` (INTEG-010) runs in the dedicated
+`android-integration-tests` job on every push/PR, which boots the
+same AVD profile (and shares its snapshot cache) as the screenshots
+tier. It is Android-only (window-level `PixelCopy`), so both desktop
+loops skip it by basename exactly as they skip `screenshot_test.dart`.
+A broader mobile tier (iOS Simulator) remains future scope and would
+extend the same boot setup rather than the desktop `-d` path.
 
 ## Status
 
@@ -484,14 +484,18 @@ test cannot produce; they are future adb-driven scope.
   `LogService` tail, which is safe to surface because the test data
   is synthetic (loopback URLs, seeded names)
 
-#### Scenario: Runs inside the screenshots emulator session
+#### Scenario: Dedicated emulator job on every push/PR
 
-- **Given** the `build-android` job's `workflow_dispatch` emulator
-  session has finished `bundle exec fastlane android screenshots`
-- **When** the same script step runs
+- **Given** the `android-integration-tests` job (ubuntu runner, KVM,
+  API 34 google_apis x86_64 `pixel_5` AVD, snapshot cache shared with
+  the screenshots tier)
+- **When** it runs
   `fvm flutter test integration_test/white_screen_test.dart -d <device> --flavor fdebug`
-- **Then** the suite executes against the booted emulator with a
-  20-minute wall-clock cap, and a failure fails the job
+  inside the booted emulator with a 25-minute wall-clock cap
+- **Then** the suite executes on every push to master, every PR, and
+  every manual dispatch, and a failure fails the job
+- **And** the job is separate from `build-android` so emulator flake
+  never blocks release artifact builds
 
 #### Scenario: Desktop loops skip the Android-only suite
 
@@ -526,7 +530,7 @@ test cannot produce; they are future adb-driven scope.
   test backlog) may surface a new class of headless rendering issues
   that this spec doesn't cover. On Android, `white_screen_test.dart`
   (INTEG-010) does exercise real webview rendering down to composited
-  pixels, but only in the `workflow_dispatch` emulator tier.
+  pixels on every push/PR via the `android-integration-tests` job.
 - **Emulator compositing is not device compositing**: the emulator runs
   `-gpu swiftshader_indirect`, so INTEG-010's scenarios exercise the
   funnels and detector plumbing deterministically but may never

--- a/openspec/specs/integration-tests/spec.md
+++ b/openspec/specs/integration-tests/spec.md
@@ -544,7 +544,11 @@ is never read back), so every seeded launch also carries the
 production pinned-shortcut `siteId` extra: activation goes through
 `StartupRestoreEngine.resolveLaunch`'s direct match — the same path
 a launcher shortcut tap takes, making the cold-start scenario itself
-a pixel check on the shortcut launch path (Attempt 2's trigger).
+a pixel check on the shortcut launch path (Attempt 2's trigger). The
+seed also disables `fullscreenOnShortcut`: the first immersive entry
+pops Android's "viewing full screen" education bubble, whose
+screen-wide 50% dim reaches the composited frame and corrupts every
+sample (observed as exact per-channel halving of the page colors).
 
 #### Scenario: Warm start repaints the re-attached surface
 

--- a/openspec/specs/integration-tests/spec.md
+++ b/openspec/specs/integration-tests/spec.md
@@ -537,8 +537,14 @@ as a white screen; each page is a solid color Flutter never draws so
 a matching dominant color proves the webview composited; and the app
 is launched with a `ws_diag_seed` intent extra (base64 JSON site
 list) that `DiagSeed.applyFromLaunchIntent` applies before the first
-prefs read, seeding fresh siteIds per launch and enabling demo mode
-so nothing persists across scenarios.
+prefs read, with per-run-unique explicit siteIds and demo mode on so
+nothing persists across runs. A plain cold start lands on the
+webspace picker with no site selected (the persisted `currentIndex`
+is never read back), so every seeded launch also carries the
+production pinned-shortcut `siteId` extra: activation goes through
+`StartupRestoreEngine.resolveLaunch`'s direct match — the same path
+a launcher shortcut tap takes, making the cold-start scenario itself
+a pixel check on the shortcut launch path (Attempt 2's trigger).
 
 #### Scenario: Warm start repaints the re-attached surface
 

--- a/openspec/specs/integration-tests/spec.md
+++ b/openspec/specs/integration-tests/spec.md
@@ -610,11 +610,16 @@ sample (observed as exact per-channel halving of the page colors).
 #### Scenario: System error dialogs cannot corrupt samples
 
 - **Given** the CI emulator host is loaded enough that a foreign app
-  (e.g. the launcher) can ANR, parking a scrimmed system dialog over
-  the whole screen
-- **When** the harness starts
-- **Then** it sets `hide_error_dialogs`, dismisses any dialog already
-  showing, and restores the setting in its exit trap
+  (in practice: the launcher, deterministically) ANRs, parking a
+  scrimmed, non-cancelable dialog over the whole screen
+- **When** the emulator session starts
+- **Then** the CI step sets `hide_error_dialogs` before the
+  in-process suite (the flag only gates future dialogs), the harness
+  sets it again first-thing for standalone runs, force-stops the
+  resolved HOME package to dismiss any dialog already parked (an ANR
+  dialog ignores BACK; killing its process is the only reliable
+  dismissal, and the launcher restarts on the next HOME press), and
+  restores the setting in its exit trap
 
 ---
 

--- a/openspec/specs/integration-tests/spec.md
+++ b/openspec/specs/integration-tests/spec.md
@@ -28,15 +28,20 @@ server. The device-boot plumbing exists in this workflow for the
 fastlane-driven Android/iOS screenshot pipeline (see
 [`screenshots`](../screenshots/spec.md) — `build-android`'s
 `reactivecircus/android-emulator-runner` and `build-apple`'s
-`simctl boot`). The first Android-emulator scenario is wired in:
+`simctl boot`). The Android-emulator scenarios are wired in:
 `white_screen_test.dart` (INTEG-010) runs inside the `build-android`
 job on every push/PR, on the same AVD profile and snapshot cache the
 screenshots lane uses (the emulator prerequisite steps are ungated;
-only the screenshot generation itself stays `workflow_dispatch`). It
-is Android-only (window-level `PixelCopy`), so both desktop loops
-skip it by basename exactly as they skip `screenshot_test.dart`. A
-broader mobile tier (iOS Simulator) remains future scope and would
-extend the same boot setup rather than the desktop `-d` path.
+only the screenshot generation itself stays `workflow_dispatch`),
+followed in the same emulator step by the adb-driven lifecycle tier
+(INTEG-011), which drives warm start, bfcache back navigation, and
+activity recreation from outside the app process. INTEG-010 is
+Android-only (window-level `PixelCopy`), so both desktop loops skip
+it by basename exactly as they skip `screenshot_test.dart`; the
+lifecycle tier is a shell harness, not an `integration_test` target,
+so the desktop loops never see it. A broader mobile tier (iOS
+Simulator) remains future scope and would extend the same boot setup
+rather than the desktop `-d` path.
 
 ## Status
 
@@ -465,7 +470,8 @@ The suite SHALL cover at least: fresh first activation (BUG-001 gap
 (`PAUSE-019`), and fresh activation with other sites live
 (`PAUSE-017`). Warm start, activity recreation, and bfcache back
 navigation need real activity lifecycle transitions an in-process
-test cannot produce; they are future adb-driven scope.
+test cannot produce; those belong to the adb-driven lifecycle tier
+(INTEG-011).
 
 #### Scenario: White control page proves the detector is not vacuous
 
@@ -508,6 +514,88 @@ test cannot produce; they are future adb-driven scope.
   because the `PixelCopy` channel exists only on Android and the
   `skip: !Platform.isAndroid` guard would still cost a desktop debug
   build per run
+
+---
+
+### Requirement: INTEG-011 — Adb-driven white-screen lifecycle tier
+
+`scripts/run_android_lifecycle_tests.sh` SHALL drive the BUG-001
+entry paths that require real activity lifecycle transitions — warm
+start (`PAUSE-020`), back navigation into a back/forward-cached entry
+(`PAUSE-018`), and activity recreation — from **outside** the app
+process via adb, because an in-process integration test dies with the
+activity it rides in. The symptom SHALL be read from the composited
+frame (`adb exec-out screencap`, i.e. SurfaceFlinger output, the same
+plane the in-app window sampler measures) and classified by
+`scripts/classify_window_pixels.py` with the same thresholds as
+`SurfaceDiagNative.classify` (>= 98% one quantized color at luma >=
+243 or <= 12 is the blank).
+
+Determinism contract: pages are served from the host (reachable as
+`10.0.2.2` from the emulator) so a network failure cannot masquerade
+as a white screen; each page is a solid color Flutter never draws so
+a matching dominant color proves the webview composited; and the app
+is launched with a `ws_diag_seed` intent extra (base64 JSON site
+list) that `DiagSeed.applyFromLaunchIntent` applies before the first
+prefs read, seeding fresh siteIds per launch and enabling demo mode
+so nothing persists across scenarios.
+
+#### Scenario: Warm start repaints the re-attached surface
+
+- **Given** the seeded dark site is visible
+- **When** the harness sends HOME, waits ~5s (surface destroyed), and
+  relaunches the singleTop activity via `am start`
+- **Then** the composited frame returns to the dark page color within
+  the polling deadline, else the run fails
+
+#### Scenario: Back into a bfcached entry repaints
+
+- **Given** the dark page carries a full-page link to the magenta page
+- **When** the harness taps the webview center, confirms magenta
+  composited, then sends the system BACK key (the production
+  `_goBackAndRepaint` path)
+- **Then** the composited frame returns to the dark page color within
+  the polling deadline
+
+#### Scenario: Activity recreation ends painted
+
+- **Given** `always_finish_activities` is enabled and the app is
+  backgrounded (activity destroyed, process kept)
+- **When** the harness relaunches with the seed extra and the engine
+  restarts
+- **Then** the composited frame reaches the dark page color, and the
+  harness restores `always_finish_activities` afterward (also on
+  failure, via its exit trap)
+
+#### Scenario: White control page proves the external detector is not vacuous
+
+- **Given** a cold start seeded onto the genuinely all-white page
+- **When** the harness polls the classifier
+- **Then** the verdict is the white blank (`blank-white`), proving the
+  screencap plane reads webview pixels and the dark-page assertions
+  cannot pass vacuously
+
+#### Scenario: Runs in build-android after the in-process suite
+
+- **Given** the `Run white-screen pixel scenarios` emulator step ran
+  `run_android_integration_tests.sh`, whose `flutter test` installs an
+  APK with the *test* Dart entrypoint
+- **When** `run_android_lifecycle_tests.sh` runs next in the same step,
+  rebuilds the default-entrypoint fdebug debug APK, reinstalls it, and
+  clears package data for a pristine cold start
+- **Then** the tier executes on every push/PR under a 25-minute
+  wall-clock cap, and on failure the step uploads
+  `build/white_screen_adb/` (failing screencap PNG, logcat tail, last
+  classification) as the `white-screen-adb-diagnostics` artifact
+
+#### Scenario: Seeding is inert outside the harness
+
+- **Given** a release (non-debuggable) build
+- **When** any launch intent carries `ws_diag_seed`
+- **Then** the Kotlin channel returns null (MainActivity is exported,
+  so a hostile intent must not swap the user's site list) and the Dart
+  call is additionally compiled out of release via `kDebugMode`, so
+  production behavior is unchanged
 
 ---
 
@@ -565,6 +653,13 @@ test cannot produce; they are future adb-driven scope.
   + [`lib/services/surface_diag_native.dart`](../../../lib/services/surface_diag_native.dart)
   (classification unit-tested in
   [`test/surface_diag_classification_test.dart`](../../../test/surface_diag_classification_test.dart))
+- [`scripts/run_android_lifecycle_tests.sh`](../../../scripts/run_android_lifecycle_tests.sh)
+  — INTEG-011: adb-driven lifecycle tier (warm start, bfcache back,
+  activity recreation, white control). Frame classifier:
+  [`scripts/classify_window_pixels.py`](../../../scripts/classify_window_pixels.py);
+  launch seeding: [`lib/services/diag_seed.dart`](../../../lib/services/diag_seed.dart)
+  (`getDiagSeed` in MainActivity, debuggable builds only; parsing
+  unit-tested in [`test/diag_seed_test.dart`](../../../test/diag_seed_test.dart))
 - [`integration_test/settings_smoke_test.dart`](../../../integration_test/settings_smoke_test.dart)
   — harness pin
 - [`integration_test/settings_backup_roundtrip_test.dart`](../../../integration_test/settings_backup_roundtrip_test.dart)

--- a/openspec/specs/integration-tests/spec.md
+++ b/openspec/specs/integration-tests/spec.md
@@ -29,12 +29,13 @@ fastlane-driven Android/iOS screenshot pipeline (see
 [`screenshots`](../screenshots/spec.md) — `build-android`'s
 `reactivecircus/android-emulator-runner` and `build-apple`'s
 `simctl boot`). The first Android-emulator scenario is wired in:
-`white_screen_test.dart` (INTEG-010) runs in the dedicated
-`android-integration-tests` job on every push/PR, which boots the
-same AVD profile (and shares its snapshot cache) as the screenshots
-tier. It is Android-only (window-level `PixelCopy`), so both desktop
-loops skip it by basename exactly as they skip `screenshot_test.dart`.
-A broader mobile tier (iOS Simulator) remains future scope and would
+`white_screen_test.dart` (INTEG-010) runs inside the `build-android`
+job on every push/PR, on the same AVD profile and snapshot cache the
+screenshots lane uses (the emulator prerequisite steps are ungated;
+only the screenshot generation itself stays `workflow_dispatch`). It
+is Android-only (window-level `PixelCopy`), so both desktop loops
+skip it by basename exactly as they skip `screenshot_test.dart`. A
+broader mobile tier (iOS Simulator) remains future scope and would
 extend the same boot setup rather than the desktop `-d` path.
 
 ## Status
@@ -484,18 +485,19 @@ test cannot produce; they are future adb-driven scope.
   `LogService` tail, which is safe to surface because the test data
   is synthetic (loopback URLs, seeded names)
 
-#### Scenario: Dedicated emulator job on every push/PR
+#### Scenario: Runs inside build-android on every push/PR
 
-- **Given** the `android-integration-tests` job (ubuntu runner, KVM,
-  API 34 google_apis x86_64 `pixel_5` AVD, snapshot cache shared with
-  the screenshots tier)
-- **When** it runs
+- **Given** the `build-android` job has built the APKs and its
+  emulator prerequisites (KVM, Android SDK, API 34 google_apis x86_64
+  `pixel_5` AVD snapshot cache) are ungated
+- **When** the `Run white-screen pixel scenarios` step runs
   `fvm flutter test integration_test/white_screen_test.dart -d <device> --flavor fdebug`
   inside the booted emulator with a 25-minute wall-clock cap
 - **Then** the suite executes on every push to master, every PR, and
-  every manual dispatch, and a failure fails the job
-- **And** the job is separate from `build-android` so emulator flake
-  never blocks release artifact builds
+  every manual dispatch, and a failure fails `build-android`
+- **And** the screenshot generation step after it remains gated on
+  `workflow_dispatch`, booting the emulator a second time on dispatch
+  runs
 
 #### Scenario: Desktop loops skip the Android-only suite
 
@@ -530,7 +532,7 @@ test cannot produce; they are future adb-driven scope.
   test backlog) may surface a new class of headless rendering issues
   that this spec doesn't cover. On Android, `white_screen_test.dart`
   (INTEG-010) does exercise real webview rendering down to composited
-  pixels on every push/PR via the `android-integration-tests` job.
+  pixels on every push/PR via the emulator step in `build-android`.
 - **Emulator compositing is not device compositing**: the emulator runs
   `-gpu swiftshader_indirect`, so INTEG-010's scenarios exercise the
   funnels and detector plumbing deterministically but may never

--- a/scripts/classify_window_pixels.py
+++ b/scripts/classify_window_pixels.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Classify a raw `adb exec-out screencap` frame over a cropped region.
+
+Host-side half of the adb white-screen tier (INTEG-011): the lifecycle
+scenarios (warm start, activity recreation, bfcache back nav) survive
+activity/process teardown, so the verdict must come from outside the app.
+`screencap` reads the final composited frame (SurfaceFlinger output),
+which includes the SurfaceView content that Flutter-side captures miss —
+the same plane the in-app window sampler (SurfaceDiagPlugin) reads.
+
+Prints one JSON line: {"status", "width", "height", "dominant", "uniform",
+"verdict"}. Verdict thresholds mirror SurfaceDiagNative.classify: a region
+>= 98% one quantized color whose luma is >= 243 (white) or <= 12 (black)
+is the BUG-001 blank; anything else is content.
+
+Exit codes: 0 = expectation met (or no expectation given), 3 =
+expectation not met, 2 = unreadable frame. Expectations:
+  --expect-dominant RRGGBB [--tolerance N] [--min-uniform F]
+      dominant pixel within per-channel tolerance and uniform fraction
+      at least F (the seeded solid-color pages make this a proof the
+      webview composited).
+  --expect-blank-white
+      verdict must be the white blank (detector sensitivity control).
+"""
+
+import argparse
+import json
+import struct
+import sys
+
+# Fractional (left, top, right, bottom) of the screen that is webview on a
+# portrait phone with the seeded layout (no URL bar): below status bar +
+# AppBar, above the gesture nav area, inset from the edges so scrollbars
+# and edge glow stay out of the histogram.
+DEFAULT_CROP = (0.15, 0.30, 0.85, 0.75)
+GRID = 64  # GRID^2 sampled pixels, like the in-app 32x32 PixelCopy histogram
+
+RGBA_8888 = 1
+
+
+def parse_frame(data):
+    if len(data) < 16:
+        return None, 'short frame (%d bytes)' % len(data)
+    w, h, fmt = struct.unpack_from('<III', data, 0)
+    if w == 0 or h == 0 or w > 16384 or h > 16384:
+        return None, 'implausible dimensions %dx%d' % (w, h)
+    if fmt != RGBA_8888:
+        return None, 'unsupported pixel format %d' % fmt
+    body = w * h * 4
+    # API 26+ prepends a 16-byte header (adds colorspace); older is 12.
+    for header in (16, 12):
+        if len(data) == header + body:
+            return (w, h, data[header:]), None
+    return None, 'size mismatch: %d bytes for %dx%d' % (len(data), w, h)
+
+
+def sample(w, h, pixels, crop):
+    left = int(w * crop[0])
+    top = int(h * crop[1])
+    right = int(w * crop[2])
+    bottom = int(h * crop[3])
+    counts = {}
+    representative = {}
+    for gy in range(GRID):
+        y = top + (bottom - 1 - top) * gy // (GRID - 1)
+        row = y * w * 4
+        for gx in range(GRID):
+            x = left + (right - 1 - left) * gx // (GRID - 1)
+            off = row + x * 4
+            r, g, b = pixels[off], pixels[off + 1], pixels[off + 2]
+            key = (r & 0xF0, g & 0xF0, b & 0xF0)
+            counts[key] = counts.get(key, 0) + 1
+            if key not in representative:
+                representative[key] = (r, g, b)
+    dominant_key = max(counts, key=counts.get)
+    return representative[dominant_key], counts[dominant_key] / (GRID * GRID)
+
+
+def verdict_of(rgb, uniform):
+    if uniform < 0.98:
+        return 'content'
+    luma = 0.299 * rgb[0] + 0.587 * rgb[1] + 0.114 * rgb[2]
+    if luma >= 243:
+        return 'blank-white'
+    if luma <= 12:
+        return 'blank-black'
+    return 'content'
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--file', help='raw screencap dump (default: stdin)')
+    ap.add_argument('--crop', help='fractional left,top,right,bottom')
+    ap.add_argument('--expect-dominant', metavar='RRGGBB')
+    ap.add_argument('--tolerance', type=int, default=28)
+    ap.add_argument('--min-uniform', type=float, default=0.5)
+    ap.add_argument('--expect-blank-white', action='store_true')
+    args = ap.parse_args()
+
+    crop = DEFAULT_CROP
+    if args.crop:
+        crop = tuple(float(v) for v in args.crop.split(','))
+        if len(crop) != 4 or not all(0 <= v <= 1 for v in crop) or \
+                crop[0] >= crop[2] or crop[1] >= crop[3]:
+            print(json.dumps({'status': 'bad-crop'}))
+            return 2
+
+    if args.file:
+        with open(args.file, 'rb') as f:
+            data = f.read()
+    else:
+        data = sys.stdin.buffer.read()
+
+    frame, err = parse_frame(data)
+    if frame is None:
+        print(json.dumps({'status': 'unreadable', 'error': err}))
+        return 2
+    w, h, pixels = frame
+    rgb, uniform = sample(w, h, pixels, crop)
+    verdict = verdict_of(rgb, uniform)
+    print(json.dumps({
+        'status': 'ok',
+        'width': w,
+        'height': h,
+        'dominant': '%02x%02x%02x' % rgb,
+        'uniform': round(uniform, 4),
+        'verdict': verdict,
+    }))
+
+    if args.expect_dominant:
+        want = int(args.expect_dominant, 16)
+        want_rgb = ((want >> 16) & 0xFF, (want >> 8) & 0xFF, want & 0xFF)
+        near = all(abs(a - e) <= args.tolerance
+                   for a, e in zip(rgb, want_rgb))
+        return 0 if near and uniform >= args.min_uniform else 3
+    if args.expect_blank_white:
+        return 0 if verdict == 'blank-white' else 3
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/run_android_integration_tests.sh
+++ b/scripts/run_android_integration_tests.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Android-emulator integration tier (INTEG-010): white-screen pixel
+# scenarios against the first connected device/emulator.
+#
+# Single entry point because reactivecircus/android-emulator-runner
+# executes each script line as a separate `sh -c` invocation: a variable
+# assignment does not survive to the next line, and a backslash-continued
+# command is split mid-line (observed as flutter test loading a target
+# literally named "\").
+set -euo pipefail
+
+device_id="${1:-$(adb devices | grep -w 'device' | head -1 | awk '{print $1}' || true)}"
+if [ -z "$device_id" ]; then
+  echo "ERROR: no connected Android device/emulator found" >&2
+  adb devices >&2
+  exit 1
+fi
+
+# Hard wall-clock cap: a webview mount can deadlock below the Dart timeout
+# layer (same rationale as the desktop integration loops).
+exec timeout -k 30s 25m fvm flutter test \
+  integration_test/white_screen_test.dart \
+  -d "$device_id" --flavor fdebug

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -39,6 +39,23 @@ dark=123524
 magenta=8c1d5a
 mkdir -p "$artifacts"
 
+# System error dialogs: a launcher ANR on the loaded CI host parks a
+# scrimmed, non-cancelable dialog over everything and corrupts every
+# pixel sample (two runs failed on exactly this, uniform=0.578 both
+# times). hide_error_dialogs only gates future dialogs — the CI step
+# also sets it before the in-process suite so the whole emulator
+# session is covered — and the only reliable dismissal of one already
+# parked is force-stopping the ANR'd process; the launcher restarts on
+# the next HOME press.
+adb shell settings put global hide_error_dialogs 1
+home_pkg="$(adb shell cmd package resolve-activity --brief \
+  -a android.intent.action.MAIN -c android.intent.category.HOME 2>/dev/null \
+  | tail -1 | cut -d/ -f1 | tr -d '[:space:]')"
+if [ -n "$home_pkg" ] && [ "$home_pkg" != "$pkg" ]; then
+  adb shell am force-stop "$home_pkg" 2>/dev/null || true
+fi
+adb shell am broadcast -a android.intent.action.CLOSE_SYSTEM_DIALOGS >/dev/null 2>&1 || true
+
 www="$(mktemp -d)"
 server_log="$www/server.log"
 server_pid=""
@@ -164,12 +181,6 @@ adb shell input keyevent KEYCODE_WAKEUP
 adb shell input keyevent 82
 adb shell svc power stayon true
 adb shell settings put global always_finish_activities 0
-# A system ANR/crash dialog (e.g. a launcher ANR on the loaded CI host)
-# parks a scrim over the whole screen and corrupts every pixel sample.
-# Hide future dialogs and dismiss any that is already showing.
-adb shell settings put global hide_error_dialogs 1
-adb shell input keyevent 4
-sleep 1
 
 echo "== Scenario A: pinned-shortcut cold start onto the seeded dark site"
 adb shell am force-stop "$pkg"

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -81,9 +81,19 @@ fi
 base="http://10.0.2.2:$port"
 echo "Serving diag pages from $base (host pid $server_pid)"
 
-seed_b64() { # $1 = page basename
-  printf '{"sites":[{"name":"Diag","url":"%s/%s"}],"currentIndex":0}' \
-    "$base" "$1" | base64 | tr -d '\n'
+# Per-run unique siteIds: no keyed state (cookies, containers, nav-state)
+# can bleed across runs, and the harness knows the id to activate. A plain
+# cold start lands on the webspace picker with no site selected, so every
+# seeded launch also passes the production pinned-shortcut `siteId` extra,
+# which StartupRestoreEngine.resolveLaunch matches directly — the same
+# path a launcher shortcut tap takes.
+run_tag="adb-$(date +%s)"
+dark_site_id="ws-$run_tag-dark"
+white_site_id="ws-$run_tag-white"
+
+seed_b64() { # $1 = page basename, $2 = siteId
+  printf '{"sites":[{"name":"Diag","url":"%s/%s","siteId":"%s"}]}' \
+    "$base" "$1" "$2" | base64 | tr -d '\n'
 }
 
 echo "== Building default-entrypoint fdebug APK"
@@ -127,9 +137,11 @@ adb shell input keyevent 82
 adb shell svc power stayon true
 adb shell settings put global always_finish_activities 0
 
-echo "== Scenario A: cold start onto the seeded dark site"
+echo "== Scenario A: pinned-shortcut cold start onto the seeded dark site"
 adb shell am force-stop "$pkg"
-adb shell am start -W -n "$component" --es ws_diag_seed "$(seed_b64 dark.html)"
+adb shell am start -W -n "$component" \
+  --es ws_diag_seed "$(seed_b64 dark.html "$dark_site_id")" \
+  --es siteId "$dark_site_id"
 wait_for_pixels cold-start-dark 180 --expect-dominant "$dark"
 
 echo "== Scenario B: warm start repaints the re-attached surface (PAUSE-020)"
@@ -151,13 +163,17 @@ echo "== Scenario D: activity recreation ends painted"
 adb shell settings put global always_finish_activities 1
 adb shell input keyevent 3
 sleep 5
-adb shell am start -W -n "$component" --es ws_diag_seed "$(seed_b64 dark.html)"
+adb shell am start -W -n "$component" \
+  --es ws_diag_seed "$(seed_b64 dark.html "$dark_site_id")" \
+  --es siteId "$dark_site_id"
 wait_for_pixels recreation-dark 180 --expect-dominant "$dark"
 adb shell settings put global always_finish_activities 0
 
 echo "== Scenario E: white control page must classify as the white blank"
 adb shell am force-stop "$pkg"
-adb shell am start -W -n "$component" --es ws_diag_seed "$(seed_b64 white.html)"
+adb shell am start -W -n "$component" \
+  --es ws_diag_seed "$(seed_b64 white.html "$white_site_id")" \
+  --es siteId "$white_site_id"
 wait_for_pixels white-control 180 --expect-blank-white
 
 echo "White-screen lifecycle tier passed."

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -46,6 +46,7 @@ server_pid=""
 cleanup() {
   if [ -n "$server_pid" ]; then kill "$server_pid" 2>/dev/null || true; fi
   adb shell settings put global always_finish_activities 0 >/dev/null 2>&1 || true
+  adb shell settings put global hide_error_dialogs 0 >/dev/null 2>&1 || true
   adb shell svc power stayon false >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
@@ -57,6 +58,28 @@ page() { # $1 = css background, $2 = optional link target (full-page anchor)
 page '#123524' 'magenta.html' > "$www/dark.html"
 page '#8c1d5a' > "$www/magenta.html"
 page '#ffffff' > "$www/white.html"
+
+# Same dark fill, plus a JS Notification on every load: a forced
+# background refresh reloads the page, so a new OS notification is the
+# outside-observable proof the whole NOTIF-005-A pipeline ran (worker ->
+# engine -> site reload -> polyfill -> flutter_local_notifications).
+cat > "$www/notif.html" <<'EOF'
+<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1">
+<style>html,body{margin:0;height:100%;background:#123524;}</style></head><body><script>
+(function () {
+  function fire() {
+    try { new Notification('ws-diag-bg', {body: String(Date.now())}); } catch (e) {}
+  }
+  if (typeof Notification === 'undefined') return;
+  if (Notification.permission === 'granted') { fire(); return; }
+  try {
+    Notification.requestPermission().then(function (p) {
+      if (p === 'granted') fire();
+    });
+  } catch (e) {}
+})();
+</script></body></html>
+EOF
 
 python3 - "$www" > "$server_log" 2>&1 <<'EOF' &
 import http.server, os, sys
@@ -90,10 +113,11 @@ echo "Serving diag pages from $base (host pid $server_pid)"
 run_tag="adb-$(date +%s)"
 dark_site_id="ws-$run_tag-dark"
 white_site_id="ws-$run_tag-white"
+notif_site_id="ws-$run_tag-notif"
 
-seed_b64() { # $1 = page basename, $2 = siteId
-  printf '{"sites":[{"name":"Diag","url":"%s/%s","siteId":"%s"}]}' \
-    "$base" "$1" "$2" | base64 | tr -d '\n'
+seed_b64() { # $1 = page basename, $2 = siteId, $3 = extra site fields (optional)
+  printf '{"sites":[{"name":"Diag","url":"%s/%s","siteId":"%s"%s}]}' \
+    "$base" "$1" "$2" "${3:-}" | base64 | tr -d '\n'
 }
 
 echo "== Building default-entrypoint fdebug APK"
@@ -106,7 +130,11 @@ fi
 adb install -r "$apk"
 # Pristine state: the in-process suite ran this package earlier in the
 # same emulator session and may have left containers/secure storage.
+# pm clear also resets runtime permission grants, so the notification
+# grant must come after it (pre-granted = no permission dialog steals
+# the screen when the notif scenario's page requests permission).
 adb shell pm clear "$pkg" >/dev/null
+adb shell pm grant "$pkg" android.permission.POST_NOTIFICATIONS
 
 sample="$www/frame.raw"
 wait_for_pixels() { # $1 = slug, $2 = deadline secs, rest = classifier expectation
@@ -136,6 +164,12 @@ adb shell input keyevent KEYCODE_WAKEUP
 adb shell input keyevent 82
 adb shell svc power stayon true
 adb shell settings put global always_finish_activities 0
+# A system ANR/crash dialog (e.g. a launcher ANR on the loaded CI host)
+# parks a scrim over the whole screen and corrupts every pixel sample.
+# Hide future dialogs and dismiss any that is already showing.
+adb shell settings put global hide_error_dialogs 1
+adb shell input keyevent 4
+sleep 1
 
 echo "== Scenario A: pinned-shortcut cold start onto the seeded dark site"
 adb shell am force-stop "$pkg"
@@ -175,5 +209,83 @@ adb shell am start -W -n "$component" \
   --es ws_diag_seed "$(seed_b64 white.html "$white_site_id")" \
   --es siteId "$white_site_id"
 wait_for_pixels white-control 180 --expect-blank-white
+
+# ---- Background refresh (NOTIF-005-A / INTEG-012) ----
+
+notif_count() {
+  adb shell dumpsys notification 2>/dev/null \
+    | grep -c "NotificationRecord.*$pkg" || true
+}
+
+dump_bg_diagnostics() { # $1 = slug
+  adb shell dumpsys jobscheduler 2>/dev/null | grep -B2 -A12 "$pkg" \
+    > "$artifacts/fail-$1.jobscheduler.txt" || true
+  adb shell dumpsys notification 2>/dev/null \
+    > "$artifacts/fail-$1.notifications.txt" || true
+  adb logcat -d -t 500 > "$artifacts/fail-$1.logcat.txt" 2>/dev/null || true
+}
+
+echo "== Scenario F: forced periodic refresh reloads the notif site in background"
+adb shell am force-stop "$pkg"
+adb shell am start -W -n "$component" \
+  --es ws_diag_seed "$(seed_b64 notif.html "$notif_site_id" ',"notificationsEnabled":true')" \
+  --es siteId "$notif_site_id"
+wait_for_pixels notif-cold-start 180 --expect-dominant "$dark"
+
+# The foreground load must itself post one notification first: pins the
+# polyfill -> flutter_local_notifications pipeline before any background
+# step, and makes the baseline deterministic (the foreground post can
+# land a beat after the pixels settle).
+deadline=$(( $(date +%s) + 60 ))
+while :; do
+  baseline="$(notif_count)"
+  [ "$baseline" -ge 1 ] && break
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "FAIL: foreground load posted no notification within 60s" >&2
+    dump_bg_diagnostics notif-foreground-post
+    exit 1
+  fi
+  sleep 2
+done
+echo "  notifications posted after foreground load: $baseline"
+adb shell input keyevent 3
+sleep 3
+
+# NOTIF-005-A schedules unique periodic work (webspace-notification-refresh)
+# whenever a notification site exists; WorkManager backs it with a
+# JobScheduler job. No job = the scheduling contract itself broke.
+job_ids="$(adb shell dumpsys jobscheduler 2>/dev/null \
+  | grep "$pkg/androidx.work" \
+  | sed -n 's/.*#u[0-9a]*\/\([0-9]\{1,\}\):.*/\1/p' | sort -u)"
+if [ -z "$job_ids" ]; then
+  echo "FAIL: no WorkManager job scheduled for $pkg (NOTIF-005-A)" >&2
+  dump_bg_diagnostics no-workmanager-job
+  exit 1
+fi
+echo "  forcing WorkManager job(s): $(echo "$job_ids" | tr '\n' ' ')"
+for id in $job_ids; do
+  adb shell cmd jobscheduler run -f "$pkg" "$id" || true
+done
+
+deadline=$(( $(date +%s) + 90 ))
+while :; do
+  count="$(notif_count)"
+  if [ "$count" -gt "$baseline" ]; then
+    echo "  background refresh posted a notification ($baseline -> $count)"
+    break
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "FAIL: no new notification within 90s of forcing the refresh job" >&2
+    echo "  count stayed at $count (baseline $baseline)" >&2
+    dump_bg_diagnostics notif-refresh
+    exit 1
+  fi
+  sleep 2
+done
+
+# Ties back into BUG-001: the site that just reloaded offscreen must
+# still paint when brought back onstage.
+adb shell am start -W -n "$component"
+wait_for_pixels notif-foreground-dark 90 --expect-dominant "$dark"
 
 echo "White-screen lifecycle tier passed."

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Adb-driven white-screen lifecycle tier (BUG-001 / INTEG-011): the entry
+# paths that need real activity transitions — warm start (PAUSE-020),
+# back navigation into a bfcached entry (PAUSE-018), activity recreation —
+# driven from outside the app process, with the symptom read from the
+# composited frame (screencap) by classify_window_pixels.py. Pages are
+# served from the host (10.0.2.2 from the emulator) so a network failure
+# cannot masquerade as a white screen, and each page is a solid color
+# Flutter never draws so a matching dominant color proves the webview
+# composited.
+#
+# The in-process suite (run_android_integration_tests.sh) leaves an APK
+# whose Dart entrypoint is the *test* main, so this tier always rebuilds
+# and installs the default-entrypoint debug APK before driving it.
+set -euo pipefail
+
+# Hard wall-clock cap, like the sibling script: a webview mount can
+# deadlock below every polling deadline.
+if [ "${WS_LIFECYCLE_WRAPPED:-}" != "1" ]; then
+  exec env WS_LIFECYCLE_WRAPPED=1 timeout -k 30s 25m "$0" "$@"
+fi
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+device_id="${1:-$(adb devices | grep -w 'device' | head -1 | awk '{print $1}' || true)}"
+if [ -z "$device_id" ]; then
+  echo "ERROR: no connected Android device/emulator found" >&2
+  adb devices >&2
+  exit 1
+fi
+export ANDROID_SERIAL="$device_id"
+
+pkg="org.codeberg.theoden8.webspace"
+component="$pkg/.MainActivity"
+artifacts="$root/build/white_screen_adb"
+classify="$root/scripts/classify_window_pixels.py"
+dark=123524
+magenta=8c1d5a
+mkdir -p "$artifacts"
+
+www="$(mktemp -d)"
+server_log="$www/server.log"
+server_pid=""
+
+cleanup() {
+  if [ -n "$server_pid" ]; then kill "$server_pid" 2>/dev/null || true; fi
+  adb shell settings put global always_finish_activities 0 >/dev/null 2>&1 || true
+  adb shell svc power stayon false >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+page() { # $1 = css background, $2 = optional link target (full-page anchor)
+  printf '<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1"><style>html,body{margin:0;height:100%%;background:%s;}a{position:fixed;inset:0;}</style></head><body>%s</body></html>' \
+    "$1" "${2:+<a href=\"$2\"></a>}"
+}
+page '#123524' 'magenta.html' > "$www/dark.html"
+page '#8c1d5a' > "$www/magenta.html"
+page '#ffffff' > "$www/white.html"
+
+python3 - "$www" > "$server_log" 2>&1 <<'EOF' &
+import http.server, os, sys
+os.chdir(sys.argv[1])
+srv = http.server.ThreadingHTTPServer(('0.0.0.0', 0),
+                                      http.server.SimpleHTTPRequestHandler)
+print(srv.server_address[1], flush=True)
+srv.serve_forever()
+EOF
+server_pid=$!
+port=""
+for _ in $(seq 1 50); do
+  port="$(head -1 "$server_log" 2>/dev/null || true)"
+  [ -n "$port" ] && break
+  sleep 0.2
+done
+if ! [[ "$port" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: page server failed to start" >&2
+  cat "$server_log" >&2
+  exit 1
+fi
+base="http://10.0.2.2:$port"
+echo "Serving diag pages from $base (host pid $server_pid)"
+
+seed_b64() { # $1 = page basename
+  printf '{"sites":[{"name":"Diag","url":"%s/%s"}],"currentIndex":0}' \
+    "$base" "$1" | base64 | tr -d '\n'
+}
+
+echo "== Building default-entrypoint fdebug APK"
+fvm flutter build apk --debug --flavor fdebug -t lib/main.dart
+apk="build/app/outputs/flutter-apk/app-fdebug-debug.apk"
+if [ ! -f "$apk" ]; then
+  echo "ERROR: $apk not produced" >&2
+  exit 1
+fi
+adb install -r "$apk"
+# Pristine state: the in-process suite ran this package earlier in the
+# same emulator session and may have left containers/secure storage.
+adb shell pm clear "$pkg" >/dev/null
+
+sample="$www/frame.raw"
+wait_for_pixels() { # $1 = slug, $2 = deadline secs, rest = classifier expectation
+  local slug="$1" deadline="$2" start now out
+  shift 2
+  start=$(date +%s)
+  while :; do
+    adb exec-out screencap > "$sample" 2>/dev/null || true
+    if out="$(python3 "$classify" --file "$sample" "$@")"; then
+      echo "  $slug: $out"
+      return 0
+    fi
+    now=$(date +%s)
+    if [ $((now - start)) -ge "$deadline" ]; then
+      echo "FAIL: $slug did not reach the expected pixels within ${deadline}s" >&2
+      echo "  last classification: $out" >&2
+      adb exec-out screencap -p > "$artifacts/fail-$slug.png" 2>/dev/null || true
+      adb logcat -d -t 500 > "$artifacts/fail-$slug.logcat.txt" 2>/dev/null || true
+      printf '%s\n' "$out" > "$artifacts/fail-$slug.classify.json" || true
+      exit 1
+    fi
+    sleep 1
+  done
+}
+
+adb shell input keyevent KEYCODE_WAKEUP
+adb shell input keyevent 82
+adb shell svc power stayon true
+adb shell settings put global always_finish_activities 0
+
+echo "== Scenario A: cold start onto the seeded dark site"
+adb shell am force-stop "$pkg"
+adb shell am start -W -n "$component" --es ws_diag_seed "$(seed_b64 dark.html)"
+wait_for_pixels cold-start-dark 180 --expect-dominant "$dark"
+
+echo "== Scenario B: warm start repaints the re-attached surface (PAUSE-020)"
+adb shell input keyevent 3
+sleep 5
+adb shell am start -W -n "$component"
+wait_for_pixels warm-start-dark 90 --expect-dominant "$dark"
+
+echo "== Scenario C: back into a bfcached entry repaints (PAUSE-018)"
+size="$(adb shell wm size | sed -n 's/.*: *\([0-9]*\)x\([0-9]*\).*/\1 \2/p' | head -1)"
+w="${size% *}"
+h="${size#* }"
+adb shell input tap "$((w / 2))" "$((h / 2))"
+wait_for_pixels forward-nav-magenta 90 --expect-dominant "$magenta"
+adb shell input keyevent 4
+wait_for_pixels back-nav-dark 90 --expect-dominant "$dark"
+
+echo "== Scenario D: activity recreation ends painted"
+adb shell settings put global always_finish_activities 1
+adb shell input keyevent 3
+sleep 5
+adb shell am start -W -n "$component" --es ws_diag_seed "$(seed_b64 dark.html)"
+wait_for_pixels recreation-dark 180 --expect-dominant "$dark"
+adb shell settings put global always_finish_activities 0
+
+echo "== Scenario E: white control page must classify as the white blank"
+adb shell am force-stop "$pkg"
+adb shell am start -W -n "$component" --es ws_diag_seed "$(seed_b64 white.html)"
+wait_for_pixels white-control 180 --expect-blank-white
+
+echo "White-screen lifecycle tier passed."

--- a/test/diag_seed_test.dart
+++ b/test/diag_seed_test.dart
@@ -40,6 +40,17 @@ void main() {
     expect(first, isNot(second));
   });
 
+  test('passes notificationsEnabled through, defaulting off', () {
+    final seed = DiagSeed.parse(encodeSeed({
+      'sites': [
+        {'name': 'N', 'url': 'http://h/n', 'notificationsEnabled': true},
+        {'name': 'P', 'url': 'http://h/p'},
+      ],
+    }));
+    expect(seed.sites[0].notificationsEnabled, isTrue);
+    expect(seed.sites[1].notificationsEnabled, isFalse);
+  });
+
   test('rejects an empty site list', () {
     expect(() => DiagSeed.parse(encodeSeed({'sites': []})),
         throwsFormatException);

--- a/test/diag_seed_test.dart
+++ b/test/diag_seed_test.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/diag_seed.dart';
+
+String encodeSeed(Object seed) => base64.encode(utf8.encode(jsonEncode(seed)));
+
+void main() {
+  test('parses sites and defaults currentIndex to 0', () {
+    final seed = DiagSeed.parse(encodeSeed({
+      'sites': [
+        {'name': 'Dark', 'url': 'http://10.0.2.2:1234/dark.html'},
+        {'name': 'White', 'url': 'http://10.0.2.2:1234/white.html'},
+      ],
+    }));
+    expect(seed.sites, hasLength(2));
+    expect(seed.sites[0].initUrl, 'http://10.0.2.2:1234/dark.html');
+    expect(seed.sites[0].name, 'Dark');
+    expect(seed.currentIndex, 0);
+  });
+
+  test('honors explicit currentIndex', () {
+    final seed = DiagSeed.parse(encodeSeed({
+      'sites': [
+        {'name': 'A', 'url': 'http://h/a'},
+        {'name': 'B', 'url': 'http://h/b'},
+      ],
+      'currentIndex': 1,
+    }));
+    expect(seed.currentIndex, 1);
+  });
+
+  test('generates fresh siteIds per parse so runs cannot share keyed state',
+      () {
+    final payload = encodeSeed({
+      'sites': [
+        {'name': 'A', 'url': 'http://h/a'},
+      ],
+    });
+    final first = DiagSeed.parse(payload).sites.single.siteId;
+    final second = DiagSeed.parse(payload).sites.single.siteId;
+    expect(first, isNot(second));
+  });
+
+  test('rejects an empty site list', () {
+    expect(() => DiagSeed.parse(encodeSeed({'sites': []})),
+        throwsFormatException);
+  });
+
+  test('rejects out-of-range currentIndex', () {
+    expect(
+        () => DiagSeed.parse(encodeSeed({
+              'sites': [
+                {'name': 'A', 'url': 'http://h/a'},
+              ],
+              'currentIndex': 3,
+            })),
+        throwsRangeError);
+  });
+
+  test('rejects non-base64 garbage', () {
+    expect(() => DiagSeed.parse('not base64!!'), throwsFormatException);
+  });
+}

--- a/test/diag_seed_test.dart
+++ b/test/diag_seed_test.dart
@@ -6,7 +6,7 @@ import 'package:webspace/services/diag_seed.dart';
 String encodeSeed(Object seed) => base64.encode(utf8.encode(jsonEncode(seed)));
 
 void main() {
-  test('parses sites and defaults currentIndex to 0', () {
+  test('parses site url and name', () {
     final seed = DiagSeed.parse(encodeSeed({
       'sites': [
         {'name': 'Dark', 'url': 'http://10.0.2.2:1234/dark.html'},
@@ -16,21 +16,19 @@ void main() {
     expect(seed.sites, hasLength(2));
     expect(seed.sites[0].initUrl, 'http://10.0.2.2:1234/dark.html');
     expect(seed.sites[0].name, 'Dark');
-    expect(seed.currentIndex, 0);
   });
 
-  test('honors explicit currentIndex', () {
+  test('passes an explicit siteId through so the harness can activate it',
+      () {
     final seed = DiagSeed.parse(encodeSeed({
       'sites': [
-        {'name': 'A', 'url': 'http://h/a'},
-        {'name': 'B', 'url': 'http://h/b'},
+        {'name': 'A', 'url': 'http://h/a', 'siteId': 'ws-adb-77-dark'},
       ],
-      'currentIndex': 1,
     }));
-    expect(seed.currentIndex, 1);
+    expect(seed.sites.single.siteId, 'ws-adb-77-dark');
   });
 
-  test('generates fresh siteIds per parse so runs cannot share keyed state',
+  test('generates fresh siteIds when absent so runs cannot share keyed state',
       () {
     final payload = encodeSeed({
       'sites': [
@@ -45,17 +43,6 @@ void main() {
   test('rejects an empty site list', () {
     expect(() => DiagSeed.parse(encodeSeed({'sites': []})),
         throwsFormatException);
-  });
-
-  test('rejects out-of-range currentIndex', () {
-    expect(
-        () => DiagSeed.parse(encodeSeed({
-              'sites': [
-                {'name': 'A', 'url': 'http://h/a'},
-              ],
-              'currentIndex': 3,
-            })),
-        throwsRangeError);
   });
 
   test('rejects non-base64 garbage', () {

--- a/test/surface_diag_classification_test.dart
+++ b/test/surface_diag_classification_test.dart
@@ -1,0 +1,64 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/surface_diag_native.dart';
+
+void main() {
+  group('SurfaceDiagNative.classify', () {
+    WindowRegionSample ok(int color, double fraction) => WindowRegionSample(
+        status: 'ok', dominantColor: color, uniformFraction: fraction);
+
+    test('uniform white is the BUG-001 fresh-surface fill', () {
+      expect(SurfaceDiagNative.classify(ok(0xFFFFFFFF, 1.0)),
+          WindowSampleVerdict.uniformBlank);
+      expect(SurfaceDiagNative.classify(ok(0xFFFAFAFA, 0.99)),
+          WindowSampleVerdict.uniformBlank);
+    });
+
+    test('uniform black is the BUG-001 re-attach fill', () {
+      expect(SurfaceDiagNative.classify(ok(0xFF000000, 1.0)),
+          WindowSampleVerdict.uniformBlank);
+      expect(SurfaceDiagNative.classify(ok(0xFF050505, 0.995)),
+          WindowSampleVerdict.uniformBlank);
+    });
+
+    test('a uniform colored page is content, not a blank surface', () {
+      expect(SurfaceDiagNative.classify(ok(0xFF123524, 1.0)),
+          WindowSampleVerdict.content);
+      expect(SurfaceDiagNative.classify(ok(0xFF8C1D5A, 1.0)),
+          WindowSampleVerdict.content);
+    });
+
+    test('a non-uniform region is content regardless of dominant color', () {
+      expect(SurfaceDiagNative.classify(ok(0xFFFFFFFF, 0.6)),
+          WindowSampleVerdict.content);
+    });
+
+    test('failed or unsupported samples are unavailable, never a verdict', () {
+      expect(SurfaceDiagNative.classify(WindowRegionSample.unsupported),
+          WindowSampleVerdict.unavailable);
+      expect(
+          SurfaceDiagNative.classify(
+              const WindowRegionSample(status: 'copy-failed:1')),
+          WindowSampleVerdict.unavailable);
+      expect(
+          SurfaceDiagNative.classify(
+              const WindowRegionSample(status: 'no-surface')),
+          WindowSampleVerdict.unavailable);
+    });
+  });
+
+  group('SurfaceDiagNative.physicalRect', () {
+    test('scales by devicePixelRatio and applies the logical inset', () {
+      final rect = SurfaceDiagNative.physicalRect(
+        logicalRect: const Rect.fromLTWH(10, 20, 100, 200),
+        devicePixelRatio: 2.5,
+        insetLogical: 4,
+      );
+      expect(rect.left, (10 + 4) * 2.5);
+      expect(rect.top, (20 + 4) * 2.5);
+      expect(rect.width, (100 - 8) * 2.5);
+      expect(rect.height, (200 - 8) * 2.5);
+    });
+  });
+}


### PR DESCRIPTION
Window-level PixelCopy is the only plane that shows what the user sees;
the emulator suite drives the known blank-screen entry paths against it
and records gap #7 (fresh first activation has no SurfaceDiag coverage).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KtHsefCVrZ2HhexDXDKx1x