### PR TITLE
Add Android integration tests for home-shortcut behaviors

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -371,11 +371,14 @@ jobs:
           disable-animations: true
           script: echo "Generated AVD snapshot for caching."
 
-      # White-screen pixel scenarios (BUG-001 / INTEG-010): drive the known
-      # blank-screen entry paths on the booted emulator and assert on
-      # composited window pixels over the webview via SurfaceDiagPlugin's
-      # PixelCopy. Runs on every push/PR.
-      - name: Run white-screen pixel scenarios
+      # Emulator scenarios, run on every push/PR:
+      #   INTEG-010 white-screen pixels — drive the known blank-screen entry
+      #     paths and assert on composited window pixels over the webview via
+      #     SurfaceDiagPlugin's PixelCopy;
+      #   INTEG-013 home shortcuts — launch, menu gating, orphan routing and
+      #     the delete-time tile prompt through the real widget tree;
+      #   INTEG-011/012 lifecycle + background refresh, adb-driven.
+      - name: Run emulator integration scenarios
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34
@@ -387,9 +390,9 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true
           # The action runs each script line as a separate `sh -c`, so the
-          # test invocations live in single-command wrapper scripts. The
-          # lifecycle tier (INTEG-011) must run after the in-process suite:
-          # it replaces the test-entrypoint APK the suite installed.
+          # test invocations live in wrapper scripts. The lifecycle tier
+          # (INTEG-011) must run after the in-process suites: it replaces the
+          # test-entrypoint APK they installed.
           script: |
             adb wait-for-device
             adb shell input keyevent 82
@@ -750,6 +753,9 @@ jobs:
                 # Android-only (window PixelCopy); skip its no-op build here.
                 [ "$(basename "$t")" = "screenshot_test.dart" ] && continue
                 [ "$(basename "$t")" = "white_screen_test.dart" ] && continue
+                # Home-shortcut scenarios are Android-only (the menu, pin
+                # state and delete prompt are Platform.isAndroid-gated).
+                [ "$(basename "$t")" = "shortcut_behavior_test.dart" ] && continue
                 echo "::group::$t"
                 # Hard per-test wall-clock cap: a WebView mount can deadlock
                 # the platform thread below Dart timeout layer, which would
@@ -1011,6 +1017,8 @@ jobs:
             [ "$(basename "$t")" = "screenshot_test.dart" ] && continue
             # Android-only window-PixelCopy suite; skip its no-op build here.
             [ "$(basename "$t")" = "white_screen_test.dart" ] && continue
+            # Android-only home-shortcut scenarios; same reason.
+            [ "$(basename "$t")" = "shortcut_behavior_test.dart" ] && continue
             echo "::group::$t"
             if [ -n "$TIMEOUT" ]; then
               "$TIMEOUT" -k 30s 12m fvm flutter test "$t" -d macos --ci || status=$?

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -398,6 +398,7 @@ jobs:
             adb shell input keyevent 82
             adb shell settings put global hide_error_dialogs 1
             bash scripts/run_android_integration_tests.sh
+            bash scripts/run_android_shortcut_tests.sh
             bash scripts/run_android_background_audio_tests.sh
             bash scripts/run_android_lifecycle_tests.sh
 

--- a/integration_test/shortcut_behavior_test.dart
+++ b/integration_test/shortcut_behavior_test.dart
@@ -231,19 +231,27 @@ void main() {
     return (jsonDecode(raw) as Map).cast<String, dynamic>();
   }
 
-  /// Background and re-foreground the running app, optionally parking a
-  /// pending launch first — the lifecycle transition a launcher tap produces,
-  /// and the one `_onResumed` -> `_handleShortcutIntent` hangs off.
+  /// Re-foreground the running app, optionally parking a pending launch first
+  /// — the `didChangeAppLifecycleState(resumed)` a launcher tap produces, and
+  /// the event `_onResumed` -> `_handleShortcutIntent` hangs off.
+  ///
+  /// The round trip goes through `inactive`, never `paused`/`hidden`:
+  /// `SchedulerBinding` sets `framesEnabled = false` for those two, which makes
+  /// `scheduleFrame()` a no-op, so the next `tester.pump()` waits forever for a
+  /// frame nobody will schedule (observed as a 25-minute CI hang). The real
+  /// background/foreground cycle, with the pause work in between, is driven
+  /// out of process by the adb tier.
   Future<void> resumeApp(WidgetTester tester, {String? withLaunch}) async {
     pendingLaunch = withLaunch;
-    for (final state in const ['paused', 'resumed']) {
-      await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
-        'flutter/lifecycle',
-        const StringCodec().encodeMessage('AppLifecycleState.$state'),
-        (_) {},
-      );
-      await tester.pump();
-    }
+    Future<void> send(String state) =>
+        tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+          'flutter/lifecycle',
+          const StringCodec().encodeMessage('AppLifecycleState.$state'),
+          (_) {},
+        );
+    await send('inactive');
+    await send('resumed');
+    await tester.pump();
   }
 
   Future<void> openOverflowMenu(WidgetTester tester) async {
@@ -312,6 +320,7 @@ void main() {
       );
     },
     skip: skipOffAndroid,
+    timeout: const Timeout(Duration(minutes: 3)),
   );
 
   testWidgets(
@@ -332,6 +341,7 @@ void main() {
               'one must not be offered');
     },
     skip: skipOffAndroid,
+    timeout: const Timeout(Duration(minutes: 3)),
   );
 
   testWidgets(
@@ -355,6 +365,7 @@ void main() {
           reason: 'an existing tile already reaches this site');
     },
     skip: skipOffAndroid,
+    timeout: const Timeout(Duration(minutes: 3)),
   );
 
   testWidgets(
@@ -393,6 +404,7 @@ void main() {
       );
     },
     skip: skipOffAndroid,
+    timeout: const Timeout(Duration(minutes: 3)),
   );
 
   testWidgets(
@@ -442,6 +454,7 @@ void main() {
           reason: 'a remembered rebind must resolve without prompting');
     },
     skip: skipOffAndroid,
+    timeout: const Timeout(Duration(minutes: 3)),
   );
 
   testWidgets(
@@ -507,6 +520,7 @@ void main() {
       );
     },
     skip: skipOffAndroid,
+    timeout: const Timeout(Duration(minutes: 3)),
   );
 
   testWidgets(
@@ -578,5 +592,6 @@ void main() {
           reason: 'the site should still have been deleted');
     },
     skip: skipOffAndroid,
+    timeout: const Timeout(Duration(minutes: 3)),
   );
 }

--- a/integration_test/shortcut_behavior_test.dart
+++ b/integration_test/shortcut_behavior_test.dart
@@ -239,6 +239,12 @@ void main() {
     await pumpFor(tester, const Duration(seconds: 5));
     try {
       await body();
+      // Let anything the last action left in flight drain before the tree goes
+      // away: an app handler that resumes after its widget is gone throws on
+      // the first `context` it touches (observed as `Navigator.pop` inside
+      // `_deleteSite` failing its null check). Tests that can name their own
+      // completion signal should still wait on it; this is the backstop.
+      await pumpFor(tester, const Duration(seconds: 2));
     } finally {
       final previousOnError = FlutterError.onError;
       FlutterError.onError = (_) {};
@@ -299,7 +305,10 @@ void main() {
     );
   }
 
+  bool drawerIsOpen() => find.byType(Drawer).evaluate().isNotEmpty;
+
   Future<void> openSiteDrawer(WidgetTester tester) async {
+    if (drawerIsOpen()) return;
     // Tapping the already-selected webspace tile opens the drawer (the
     // same-id branch of _selectWebspace).
     await tester.tap(find.byKey(const ValueKey(kAllWebspaceId)));
@@ -310,6 +319,18 @@ void main() {
       reason: 'the site drawer should open',
     );
   }
+
+  /// Wait out a deletion: `_deleteSite` closes the drawer as its very last
+  /// statement, so a closed drawer is the signal that its whole async tail
+  /// (storage sweeps, cache deletes, the HS-013 prompt) has drained. Without
+  /// this the test can finish while the tail is still running, and tearing the
+  /// tree down under it throws from that final `Navigator.pop`.
+  Future<void> waitForDeleteToSettle(WidgetTester tester) => pumpUntil(
+    tester,
+    () => !drawerIsOpen(),
+    description: 'the deletion to finish and close the drawer',
+    timeout: const Duration(seconds: 60),
+  );
 
   Future<void> tapDialogButton(WidgetTester tester, String label) async {
     final button = find.descendant(
@@ -687,11 +708,14 @@ void main() {
               (await prefsMap('shortcutUrlLedger')).isEmpty,
           description: 'the disabled tiles\' rebind and ledger entries to drop',
         );
+        await waitForDeleteToSettle(tester);
 
         // Site B has no tile pointing at it: deleting it must prompt nothing.
+        // The drawer closing is itself the proof — the prompt would hold the
+        // deletion open until answered.
         calls.clear();
         await deleteFirstSite();
-        await pumpFor(tester, const Duration(seconds: 4));
+        await waitForDeleteToSettle(tester);
         expect(
           find.text('Home screen shortcut'),
           findsNothing,

--- a/integration_test/shortcut_behavior_test.dart
+++ b/integration_test/shortcut_behavior_test.dart
@@ -48,15 +48,17 @@ import 'package:webspace/services/log_service.dart';
 import 'package:webspace/web_view_model.dart';
 import 'package:webspace/webspace_model.dart';
 
-const _kShortcutChannel =
-    MethodChannel('org.codeberg.theoden8.webspace/shortcuts');
+const _kShortcutChannel = MethodChannel(
+  'org.codeberg.theoden8.webspace/shortcuts',
+);
 
 // Unreachable RFC 5737 test addresses: used only as ledger urls, so their base
 // domain differs from the loopback sites and no connection is ever needed.
 const _kOffDomainUrl = 'http://192.0.2.9/gone.html';
 const _kCreateUrl = 'http://192.0.2.10/fresh.html';
 
-String _solidPage(String cssColor) => '<!doctype html><html><head>'
+String _solidPage(String cssColor) =>
+    '<!doctype html><html><head>'
     '<meta name="viewport" content="width=device-width, initial-scale=1">'
     '<style>html,body{margin:0;height:100%;background:$cssColor;}</style>'
     '</head><body></body></html>';
@@ -100,25 +102,25 @@ void main() {
 
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(_kShortcutChannel, (call) async {
-      calls.add(call);
-      switch (call.method) {
-        case 'getLaunchSiteId':
-          final launch = pendingLaunch;
-          pendingLaunch = null;
-          return launch;
-        case 'getPinnedSiteIds':
-          return pinned.toList();
-        case 'pinShortcut':
-          pinned.add((call.arguments as Map)['siteId'] as String);
-          return true;
-        case 'disableShortcut':
-          pinned.remove((call.arguments as Map)['siteId'] as String);
-          return null;
-        default:
-          // removeShortcut, syncSites, getDiagSeed, isAppIntentsSupported.
-          return call.method == 'isAppIntentsSupported' ? false : null;
-      }
-    });
+          calls.add(call);
+          switch (call.method) {
+            case 'getLaunchSiteId':
+              final launch = pendingLaunch;
+              pendingLaunch = null;
+              return launch;
+            case 'getPinnedSiteIds':
+              return pinned.toList();
+            case 'pinShortcut':
+              pinned.add((call.arguments as Map)['siteId'] as String);
+              return true;
+            case 'disableShortcut':
+              pinned.remove((call.arguments as Map)['siteId'] as String);
+              return null;
+            default:
+              // removeShortcut, syncSites, getDiagSeed, isAppIntentsSupported.
+              return call.method == 'isAppIntentsSupported' ? false : null;
+          }
+        });
   });
 
   tearDownAll(() async {
@@ -128,16 +130,13 @@ void main() {
   });
 
   WebViewModel siteA({String? currentUrl}) => WebViewModel(
-        siteId: 'ws-hs-a',
-        initUrl: '$hostA/a.html',
-        currentUrl: currentUrl,
-        name: 'Site A',
-      );
-  WebViewModel siteB() => WebViewModel(
-        siteId: 'ws-hs-b',
-        initUrl: '$hostB/b.html',
-        name: 'Site B',
-      );
+    siteId: 'ws-hs-a',
+    initUrl: '$hostA/a.html',
+    currentUrl: currentUrl,
+    name: 'Site A',
+  );
+  WebViewModel siteB() =>
+      WebViewModel(siteId: 'ws-hs-b', initUrl: '$hostB/b.html', name: 'Site B');
 
   /// Seed the app's persisted state plus the mock launcher's pin set. Called
   /// before every `app.main()`; `setMockInitialValues` nullifies the
@@ -168,13 +167,16 @@ void main() {
     // ignore: avoid_print
     print('=== shortcut_behavior_test: $context');
     // ignore: avoid_print
-    print('Texts: ${find.byType(Text).evaluate().map((e) {
-      final w = e.widget;
-      return w is Text ? (w.data ?? '?') : '?';
-    }).take(40).toList()}');
+    print(
+      'Texts: ${find.byType(Text).evaluate().map((e) {
+        final w = e.widget;
+        return w is Text ? (w.data ?? '?') : '?';
+      }).take(40).toList()}',
+    );
     final entries = LogService.instance.allEntriesMerged;
-    for (final e
-        in entries.skip(entries.length < 40 ? 0 : entries.length - 40)) {
+    for (final e in entries.skip(
+      entries.length < 40 ? 0 : entries.length - 40,
+    )) {
       // ignore: avoid_print
       print('  [${e.tag}/${e.level.name}] ${e.message}');
     }
@@ -209,15 +211,42 @@ void main() {
     bool Function() predicate, {
     required String description,
     Duration timeout = const Duration(seconds: 45),
-  }) =>
-      pumpUntilAsync(tester, () async => predicate(),
-          description: description, timeout: timeout);
+  }) => pumpUntilAsync(
+    tester,
+    () async => predicate(),
+    description: description,
+    timeout: timeout,
+  );
 
-  Future<void> startApp(WidgetTester tester) async {
+  /// Boot a fresh app instance, run [body] against it, then unmount the tree
+  /// before the next test's `app.main()` can see it.
+  ///
+  /// The teardown is the point: leaving the outgoing tree mounted made the
+  /// incoming `MaterialApp` collide with it over the `ScaffoldMessenger`
+  /// GlobalKey, which truncates the widget tree, and unmounting a tree that
+  /// owns a live `InAppWebView` throws from the plugin's own dispose path
+  /// (`AndroidPullToRefreshController` disposing its channel twice). Both are
+  /// artifacts of restarting the app inside one test process — neither is a
+  /// path production can take — so errors are swallowed for the teardown
+  /// window only, and the next test starts from an empty root.
+  Future<void> withApp(
+    WidgetTester tester,
+    Future<void> Function() body,
+  ) async {
     app.main();
     // Settles the home screen (no webview is mounted until a site activates,
     // and a shortcut cold launch mounts one — hence the slice-pump fallback).
     await pumpFor(tester, const Duration(seconds: 5));
+    try {
+      await body();
+    } finally {
+      final previousOnError = FlutterError.onError;
+      FlutterError.onError = (_) {};
+      await tester.pumpWidget(const SizedBox.shrink());
+      await pumpFor(tester, const Duration(milliseconds: 500));
+      FlutterError.onError = previousOnError;
+      tester.takeException();
+    }
   }
 
   List<WebViewModel> models() => app.debugWebViewModels ?? const [];
@@ -256,12 +285,18 @@ void main() {
 
   Future<void> openOverflowMenu(WidgetTester tester) async {
     final button = find.byType(PopupMenuButton<String>);
-    expect(button, findsWidgets,
-        reason: 'the site view should expose an overflow menu');
+    expect(
+      button,
+      findsWidgets,
+      reason: 'the site view should expose an overflow menu',
+    );
     await tester.tap(button.last);
     await pumpFor(tester, const Duration(seconds: 1));
-    expect(find.text('Settings'), findsWidgets,
-        reason: 'the overflow menu should be open');
+    expect(
+      find.text('Settings'),
+      findsWidgets,
+      reason: 'the overflow menu should be open',
+    );
   }
 
   Future<void> openSiteDrawer(WidgetTester tester) async {
@@ -269,8 +304,11 @@ void main() {
     // same-id branch of _selectWebspace).
     await tester.tap(find.byKey(const ValueKey(kAllWebspaceId)));
     await pumpFor(tester, const Duration(seconds: 2));
-    expect(find.byType(Drawer), findsOneWidget,
-        reason: 'the site drawer should open');
+    expect(
+      find.byType(Drawer),
+      findsOneWidget,
+      reason: 'the site drawer should open',
+    );
   }
 
   Future<void> tapDialogButton(WidgetTester tester, String label) async {
@@ -292,32 +330,46 @@ void main() {
     'cold launch opens the pinned site at its initUrl (HS-002 / HS-006)',
     (tester) async {
       seed(
-        sites: [siteA(currentUrl: '$hostA/deep.html'), siteB()],
+        sites: [
+          siteA(currentUrl: '$hostA/deep.html'),
+          siteB(),
+        ],
         pinnedTiles: {'ws-hs-a'},
         launch: 'ws-hs-a',
       );
-      await startApp(tester);
+      await withApp(tester, () async {
+        await pumpUntil(
+          tester,
+          () => siteIsMounted('ws-hs-a'),
+          description: 'the launched site to activate',
+        );
+        final launched = models().firstWhere((m) => m.siteId == 'ws-hs-a');
+        expect(
+          launched.currentUrl,
+          launched.initUrl,
+          reason:
+              'a shortcut launch is the pinned entry point, so last '
+              'session\'s drift must be dropped (HS-006)',
+        );
+        expect(
+          siteIsMounted('ws-hs-b'),
+          isFalse,
+          reason: 'only the launched site should be activated',
+        );
 
-      await pumpUntil(tester, () => siteIsMounted('ws-hs-a'),
-          description: 'the launched site to activate');
-      final launched = models().firstWhere((m) => m.siteId == 'ws-hs-a');
-      expect(launched.currentUrl, launched.initUrl,
-          reason: 'a shortcut launch is the pinned entry point, so last '
-              'session\'s drift must be dropped (HS-006)');
-      expect(siteIsMounted('ws-hs-b'), isFalse,
-          reason: 'only the launched site should be activated');
-
-      // HS-012: on the initState/resume cadence the ledger records the url of
-      // every pinned site that still exists, so a later deletion leaves a
-      // routable trail. Asserted after a resume because the initState pass
-      // races `_restoreAppState` for the loaded model list.
-      await resumeApp(tester);
-      await pumpUntilAsync(
-        tester,
-        () async =>
-            (await prefsMap('shortcutUrlLedger'))['ws-hs-a'] == '$hostA/a.html',
-        description: 'the startup ledger reconcile to record the pinned url',
-      );
+        // HS-012: on the initState/resume cadence the ledger records the url of
+        // every pinned site that still exists, so a later deletion leaves a
+        // routable trail. Asserted after a resume because the initState pass
+        // races `_restoreAppState` for the loaded model list.
+        await resumeApp(tester);
+        await pumpUntilAsync(
+          tester,
+          () async =>
+              (await prefsMap('shortcutUrlLedger'))['ws-hs-a'] ==
+              '$hostA/a.html',
+          description: 'the startup ledger reconcile to record the pinned url',
+        );
+      });
     },
     skip: skipOffAndroid,
     timeout: const Timeout(Duration(minutes: 3)),
@@ -331,14 +383,22 @@ void main() {
         pinnedTiles: {'ws-hs-a'},
         launch: 'ws-hs-a',
       );
-      await startApp(tester);
-      await pumpUntil(tester, () => siteIsMounted('ws-hs-a'),
-          description: 'the pinned site to activate');
+      await withApp(tester, () async {
+        await pumpUntil(
+          tester,
+          () => siteIsMounted('ws-hs-a'),
+          description: 'the pinned site to activate',
+        );
 
-      await openOverflowMenu(tester);
-      expect(find.text('Home Shortcut'), findsNothing,
-          reason: 'the site already has a pinned tile, so pinning a second '
-              'one must not be offered');
+        await openOverflowMenu(tester);
+        expect(
+          find.text('Home Shortcut'),
+          findsNothing,
+          reason:
+              'the site already has a pinned tile, so pinning a second '
+              'one must not be offered',
+        );
+      });
     },
     skip: skipOffAndroid,
     timeout: const Timeout(Duration(minutes: 3)),
@@ -356,13 +416,20 @@ void main() {
         pinnedTiles: {'ws-hs-ghost'},
         launch: 'ws-hs-b',
       );
-      await startApp(tester);
-      await pumpUntil(tester, () => siteIsMounted('ws-hs-b'),
-          description: 'the rebound site to activate');
+      await withApp(tester, () async {
+        await pumpUntil(
+          tester,
+          () => siteIsMounted('ws-hs-b'),
+          description: 'the rebound site to activate',
+        );
 
-      await openOverflowMenu(tester);
-      expect(find.text('Home Shortcut'), findsNothing,
-          reason: 'an existing tile already reaches this site');
+        await openOverflowMenu(tester);
+        expect(
+          find.text('Home Shortcut'),
+          findsNothing,
+          reason: 'an existing tile already reaches this site',
+        );
+      });
     },
     skip: skipOffAndroid,
     timeout: const Timeout(Duration(minutes: 3)),
@@ -373,35 +440,43 @@ void main() {
     '(HS-004 / HS-001 / HS-012)',
     (tester) async {
       seed(sites: [siteA(), siteB()], launch: 'ws-hs-a');
-      await startApp(tester);
-      await pumpUntil(tester, () => siteIsMounted('ws-hs-a'),
-          description: 'the launched site to activate');
+      await withApp(tester, () async {
+        await pumpUntil(
+          tester,
+          () => siteIsMounted('ws-hs-a'),
+          description: 'the launched site to activate',
+        );
 
-      await openOverflowMenu(tester);
-      expect(find.text('Home Shortcut'), findsOneWidget,
-          reason: 'an unpinned site should offer the menu item on Android');
-      await tester.tap(find.text('Home Shortcut'));
+        await openOverflowMenu(tester);
+        expect(
+          find.text('Home Shortcut'),
+          findsOneWidget,
+          reason: 'an unpinned site should offer the menu item on Android',
+        );
+        await tester.tap(find.text('Home Shortcut'));
 
-      // The favicon is rasterized before the pin (HS-003), which reaches the
-      // loopback server first — poll rather than assume a settled frame.
-      await pumpUntil(
-        tester,
-        () => calls.any((c) => c.method == 'pinShortcut'),
-        description: 'the pin request to reach the platform channel',
-      );
-      final pin = calls.lastWhere((c) => c.method == 'pinShortcut');
-      final args = (pin.arguments as Map).cast<String, dynamic>();
-      expect(args['siteId'], 'ws-hs-a');
-      expect(args['label'], 'Site A');
+        // The favicon is rasterized before the pin (HS-003), which reaches the
+        // loopback server first — poll rather than assume a settled frame.
+        await pumpUntil(
+          tester,
+          () => calls.any((c) => c.method == 'pinShortcut'),
+          description: 'the pin request to reach the platform channel',
+        );
+        final pin = calls.lastWhere((c) => c.method == 'pinShortcut');
+        final args = (pin.arguments as Map).cast<String, dynamic>();
+        expect(args['siteId'], 'ws-hs-a');
+        expect(args['label'], 'Site A');
 
-      // HS-012: pinning records the url so a later delete+recreate can be
-      // routed by domain.
-      await pumpUntilAsync(
-        tester,
-        () async =>
-            (await prefsMap('shortcutUrlLedger'))['ws-hs-a'] == '$hostA/a.html',
-        description: 'the pin to record the site url in the ledger',
-      );
+        // HS-012: pinning records the url so a later delete+recreate can be
+        // routed by domain.
+        await pumpUntilAsync(
+          tester,
+          () async =>
+              (await prefsMap('shortcutUrlLedger'))['ws-hs-a'] ==
+              '$hostA/a.html',
+          description: 'the pin to record the site url in the ledger',
+        );
+      });
     },
     skip: skipOffAndroid,
     timeout: const Timeout(Duration(minutes: 3)),
@@ -419,39 +494,61 @@ void main() {
         ledger: {'ws-hs-ghost': '$hostA/gone.html'},
         pinnedTiles: {'ws-hs-ghost'},
       );
-      await startApp(tester);
-      expect(siteIsMounted('ws-hs-a'), isFalse,
-          reason: 'a plain launch activates no site');
+      await withApp(tester, () async {
+        expect(
+          siteIsMounted('ws-hs-a'),
+          isFalse,
+          reason: 'a plain launch activates no site',
+        );
 
-      // Declining leaves no trace, and a later tap asks again.
-      await resumeApp(tester, withLaunch: 'ws-hs-ghost');
-      await pumpUntil(tester, () => find.text('Open site?').evaluate().isNotEmpty,
-          description: 'the domain-match confirmation');
-      await tapDialogButton(tester, 'Cancel');
-      expect(siteIsMounted('ws-hs-a'), isFalse,
-          reason: 'declining must not open the matched site');
-      expect(await prefsMap('shortcutSiteRemap'), isEmpty,
-          reason: 'declining must not remember a rebind');
+        // Declining leaves no trace, and a later tap asks again.
+        await resumeApp(tester, withLaunch: 'ws-hs-ghost');
+        await pumpUntil(
+          tester,
+          () => find.text('Open site?').evaluate().isNotEmpty,
+          description: 'the domain-match confirmation',
+        );
+        await tapDialogButton(tester, 'Cancel');
+        expect(
+          siteIsMounted('ws-hs-a'),
+          isFalse,
+          reason: 'declining must not open the matched site',
+        );
+        expect(
+          await prefsMap('shortcutSiteRemap'),
+          isEmpty,
+          reason: 'declining must not remember a rebind',
+        );
 
-      // Confirming opens the match and remembers it.
-      await resumeApp(tester, withLaunch: 'ws-hs-ghost');
-      await pumpUntil(tester, () => find.text('Open site?').evaluate().isNotEmpty,
-          description: 'the confirmation to be offered again');
-      await tapDialogButton(tester, 'Open');
-      await pumpUntil(tester, () => siteIsMounted('ws-hs-a'),
-          description: 'the matched site to activate');
-      await pumpUntilAsync(
-        tester,
-        () async =>
-            (await prefsMap('shortcutSiteRemap'))['ws-hs-ghost'] == 'ws-hs-a',
-        description: 'the confirmed rebind to persist',
-      );
+        // Confirming opens the match and remembers it.
+        await resumeApp(tester, withLaunch: 'ws-hs-ghost');
+        await pumpUntil(
+          tester,
+          () => find.text('Open site?').evaluate().isNotEmpty,
+          description: 'the confirmation to be offered again',
+        );
+        await tapDialogButton(tester, 'Open');
+        await pumpUntil(
+          tester,
+          () => siteIsMounted('ws-hs-a'),
+          description: 'the matched site to activate',
+        );
+        await pumpUntilAsync(
+          tester,
+          () async =>
+              (await prefsMap('shortcutSiteRemap'))['ws-hs-ghost'] == 'ws-hs-a',
+          description: 'the confirmed rebind to persist',
+        );
 
-      // The remembered rebind resolves the next tap directly.
-      await resumeApp(tester, withLaunch: 'ws-hs-ghost');
-      await pumpFor(tester, const Duration(seconds: 3));
-      expect(find.text('Open site?'), findsNothing,
-          reason: 'a remembered rebind must resolve without prompting');
+        // The remembered rebind resolves the next tap directly.
+        await resumeApp(tester, withLaunch: 'ws-hs-ghost');
+        await pumpFor(tester, const Duration(seconds: 3));
+        expect(
+          find.text('Open site?'),
+          findsNothing,
+          reason: 'a remembered rebind must resolve without prompting',
+        );
+      });
     },
     skip: skipOffAndroid,
     timeout: const Timeout(Duration(minutes: 3)),
@@ -462,62 +559,66 @@ void main() {
     (tester) async {
       seed(
         sites: [siteB()],
-        ledger: {
-          'ws-hs-ghost1': _kOffDomainUrl,
-          'ws-hs-ghost2': _kCreateUrl,
-        },
+        ledger: {'ws-hs-ghost1': _kOffDomainUrl, 'ws-hs-ghost2': _kCreateUrl},
         pinnedTiles: {'ws-hs-ghost1', 'ws-hs-ghost2'},
       );
-      await startApp(tester);
+      await withApp(tester, () async {
+        await resumeApp(tester, withLaunch: 'ws-hs-ghost1');
+        await pumpUntil(
+          tester,
+          () => find.text('Shortcut site missing').evaluate().isNotEmpty,
+          description: 'the missing-site chooser',
+        );
+        await tapDialogButton(tester, 'Open another');
+        await pumpUntil(
+          tester,
+          () => find.text('Point shortcut at').evaluate().isNotEmpty,
+          description: 'the site picker',
+        );
+        await tester.tap(
+          find.descendant(
+            of: find.byType(AlertDialog),
+            matching: find.text('Site B'),
+          ),
+        );
+        await pumpUntil(
+          tester,
+          () => siteIsMounted('ws-hs-b'),
+          description: 'the rerouted site to activate',
+        );
+        await pumpUntilAsync(
+          tester,
+          () async =>
+              (await prefsMap('shortcutSiteRemap'))['ws-hs-ghost1'] ==
+              'ws-hs-b',
+          description: 'the reroute to be remembered',
+        );
 
-      await resumeApp(tester, withLaunch: 'ws-hs-ghost1');
-      await pumpUntil(
-        tester,
-        () => find.text('Shortcut site missing').evaluate().isNotEmpty,
-        description: 'the missing-site chooser',
-      );
-      await tapDialogButton(tester, 'Open another');
-      await pumpUntil(
-        tester,
-        () => find.text('Point shortcut at').evaluate().isNotEmpty,
-        description: 'the site picker',
-      );
-      await tester.tap(find.descendant(
-        of: find.byType(AlertDialog),
-        matching: find.text('Site B'),
-      ));
-      await pumpUntil(tester, () => siteIsMounted('ws-hs-b'),
-          description: 'the rerouted site to activate');
-      await pumpUntilAsync(
-        tester,
-        () async =>
-            (await prefsMap('shortcutSiteRemap'))['ws-hs-ghost1'] == 'ws-hs-b',
-        description: 'the reroute to be remembered',
-      );
-
-      // The create branch builds a site rooted at the ledger url and binds the
-      // tile to it. The url is unreachable, so the title probe times out first.
-      await resumeApp(tester, withLaunch: 'ws-hs-ghost2');
-      await pumpUntil(
-        tester,
-        () => find.text('Shortcut site missing').evaluate().isNotEmpty,
-        description: 'the missing-site chooser for the second tile',
-      );
-      await tapDialogButton(tester, 'Create');
-      await pumpUntil(
-        tester,
-        () => models().any((m) => m.initUrl == _kCreateUrl),
-        description: 'the site created for the ledger url',
-        timeout: const Duration(seconds: 60),
-      );
-      final created = models().firstWhere((m) => m.initUrl == _kCreateUrl);
-      await pumpUntilAsync(
-        tester,
-        () async =>
-            (await prefsMap('shortcutSiteRemap'))['ws-hs-ghost2'] ==
-            created.siteId,
-        description: 'the created site to be bound to the tile',
-      );
+        // The create branch builds a site rooted at the ledger url and
+        // binds the tile to it. The url is unreachable, so the title probe
+        // times out first.
+        await resumeApp(tester, withLaunch: 'ws-hs-ghost2');
+        await pumpUntil(
+          tester,
+          () => find.text('Shortcut site missing').evaluate().isNotEmpty,
+          description: 'the missing-site chooser for the second tile',
+        );
+        await tapDialogButton(tester, 'Create');
+        await pumpUntil(
+          tester,
+          () => models().any((m) => m.initUrl == _kCreateUrl),
+          description: 'the site created for the ledger url',
+          timeout: const Duration(seconds: 60),
+        );
+        final created = models().firstWhere((m) => m.initUrl == _kCreateUrl);
+        await pumpUntilAsync(
+          tester,
+          () async =>
+              (await prefsMap('shortcutSiteRemap'))['ws-hs-ghost2'] ==
+              created.siteId,
+          description: 'the created site to be bound to the tile',
+        );
+      });
     },
     skip: skipOffAndroid,
     timeout: const Timeout(Duration(minutes: 3)),
@@ -534,62 +635,74 @@ void main() {
         remap: {'ws-hs-tile': 'ws-hs-a'},
         pinnedTiles: {'ws-hs-a', 'ws-hs-tile'},
       );
-      await startApp(tester);
+      await withApp(tester, () async {
+        Future<void> deleteFirstSite() async {
+          await openSiteDrawer(tester);
+          await tester.tap(
+            find.descendant(
+              of: find.byKey(const Key('site_0')),
+              matching: find.byIcon(Icons.more_vert),
+            ),
+          );
+          await pumpFor(tester, const Duration(seconds: 1));
+          await tester.tap(find.text('Delete').last);
+          await pumpUntil(
+            tester,
+            () => find.text('Delete Site').evaluate().isNotEmpty,
+            description: 'the delete confirmation',
+          );
+          await tapDialogButton(tester, 'Delete');
+        }
 
-      Future<void> deleteFirstSite() async {
-        await openSiteDrawer(tester);
-        await tester.tap(find.descendant(
-          of: find.byKey(const Key('site_0')),
-          matching: find.byIcon(Icons.more_vert),
-        ));
-        await pumpFor(tester, const Duration(seconds: 1));
-        await tester.tap(find.text('Delete').last);
+        await deleteFirstSite();
         await pumpUntil(
           tester,
-          () => find.text('Delete Site').evaluate().isNotEmpty,
-          description: 'the delete confirmation',
+          () => find.text('Home screen shortcut').evaluate().isNotEmpty,
+          description: 'the HS-013 fate prompt',
         );
-        await tapDialogButton(tester, 'Delete');
-      }
+        expect(find.text('Keep'), findsOneWidget);
+        expect(find.text('Reassign'), findsOneWidget);
+        await tapDialogButton(tester, 'Disable');
 
-      await deleteFirstSite();
-      await pumpUntil(
-        tester,
-        () => find.text('Home screen shortcut').evaluate().isNotEmpty,
-        description: 'the HS-013 fate prompt',
-      );
-      expect(find.text('Keep'), findsOneWidget);
-      expect(find.text('Reassign'), findsOneWidget);
-      await tapDialogButton(tester, 'Disable');
+        await pumpUntil(
+          tester,
+          () => calls.where((c) => c.method == 'disableShortcut').length == 2,
+          description: 'both reaching tiles to be disabled',
+        );
+        final disabled = {
+          for (final c in calls.where((c) => c.method == 'disableShortcut'))
+            (c.arguments as Map)['siteId'] as String,
+        };
+        expect(
+          disabled,
+          {'ws-hs-a', 'ws-hs-tile'},
+          reason:
+              'the deleted site\'s own tile and the tile rebound to it '
+              'both reach it',
+        );
+        await pumpUntilAsync(
+          tester,
+          () async =>
+              (await prefsMap('shortcutSiteRemap')).isEmpty &&
+              (await prefsMap('shortcutUrlLedger')).isEmpty,
+          description: 'the disabled tiles\' rebind and ledger entries to drop',
+        );
 
-      await pumpUntil(
-        tester,
-        () => calls.where((c) => c.method == 'disableShortcut').length == 2,
-        description: 'both reaching tiles to be disabled',
-      );
-      final disabled = {
-        for (final c in calls.where((c) => c.method == 'disableShortcut'))
-          (c.arguments as Map)['siteId'] as String,
-      };
-      expect(disabled, {'ws-hs-a', 'ws-hs-tile'},
-          reason: 'the deleted site\'s own tile and the tile rebound to it '
-              'both reach it');
-      await pumpUntilAsync(
-        tester,
-        () async =>
-            (await prefsMap('shortcutSiteRemap')).isEmpty &&
-            (await prefsMap('shortcutUrlLedger')).isEmpty,
-        description: 'the disabled tiles\' rebind and ledger entries to drop',
-      );
-
-      // Site B has no tile pointing at it: deleting it must prompt nothing.
-      calls.clear();
-      await deleteFirstSite();
-      await pumpFor(tester, const Duration(seconds: 4));
-      expect(find.text('Home screen shortcut'), findsNothing,
-          reason: 'no pinned tile reaches this site');
-      expect(models().where((m) => m.siteId == 'ws-hs-b'), isEmpty,
-          reason: 'the site should still have been deleted');
+        // Site B has no tile pointing at it: deleting it must prompt nothing.
+        calls.clear();
+        await deleteFirstSite();
+        await pumpFor(tester, const Duration(seconds: 4));
+        expect(
+          find.text('Home screen shortcut'),
+          findsNothing,
+          reason: 'no pinned tile reaches this site',
+        );
+        expect(
+          models().where((m) => m.siteId == 'ws-hs-b'),
+          isEmpty,
+          reason: 'the site should still have been deleted',
+        );
+      });
     },
     skip: skipOffAndroid,
     timeout: const Timeout(Duration(minutes: 3)),

--- a/integration_test/shortcut_behavior_test.dart
+++ b/integration_test/shortcut_behavior_test.dart
@@ -1,0 +1,582 @@
+// Home-shortcut behavior scenarios (openspec/specs/home-shortcut/spec.md),
+// Android emulator/device only.
+//
+// The resolution rules themselves (StartupRestoreEngine.resolveLaunch, the
+// ledger reconcile, the effective-pinned widening) are unit-tested in
+// test/startup_restore_engine_test.dart. What no headless test reaches is the
+// *wiring* in lib/main.dart: which prompt a resolution raises, what the user's
+// answer persists, whether the menu item is offered, and what the delete flow
+// does with the launcher tiles that still point at the site. That is what this
+// suite drives, through the real widget tree.
+//
+// Scenario map (requirement -> test):
+//   HS-002 / HS-006  cold launch selects the site and drops currentUrl to
+//                    initUrl (the pinned entry point, not last session's drift)
+//   HS-005 / HS-004  "Home Shortcut" hidden for a pinned site, shown for an
+//                    unpinned one, hidden for a site an orphaned tile was
+//                    rebound to
+//   HS-001 / HS-012  tapping the item pins through the channel and records the
+//                    site's url in the ledger
+//   HS-011           orphaned tile with a domain match: cancel leaves no trace,
+//                    confirm opens and is remembered, the next tap is silent
+//   HS-011           orphaned tile with no match: reroute to an existing site,
+//                    or create a new one for the ledger url
+//   HS-013           deleting a site reachable by pinned tiles prompts
+//                    Keep/Reassign/Disable; Disable disables every reaching
+//                    tile and drops its ledger + rebind entries; deleting an
+//                    unreachable site prompts nothing
+//
+// The platform channel is mocked (a real launcher pin dialog is not drivable
+// from in-process), and the mock drains `getLaunchSiteId` on read exactly like
+// MainActivity's `intent.removeExtra`, so a re-poll on the next resume sees
+// nothing. Pages come from an in-process loopback server so a site activation
+// settles without network. The genuinely out-of-process half — a launcher tap
+// delivering a real intent to a running activity — lives in the adb tier
+// (scripts/run_android_lifecycle_tests.sh, INTEG-013).
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webspace/main.dart' as app;
+import 'package:webspace/demo_data.dart';
+import 'package:webspace/services/log_service.dart';
+import 'package:webspace/web_view_model.dart';
+import 'package:webspace/webspace_model.dart';
+
+const _kShortcutChannel =
+    MethodChannel('org.codeberg.theoden8.webspace/shortcuts');
+
+// Unreachable RFC 5737 test addresses: used only as ledger urls, so their base
+// domain differs from the loopback sites and no connection is ever needed.
+const _kOffDomainUrl = 'http://192.0.2.9/gone.html';
+const _kCreateUrl = 'http://192.0.2.10/fresh.html';
+
+String _solidPage(String cssColor) => '<!doctype html><html><head>'
+    '<meta name="viewport" content="width=device-width, initial-scale=1">'
+    '<style>html,body{margin:0;height:100%;background:$cssColor;}</style>'
+    '</head><body></body></html>';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  HttpServer? server;
+  late String hostA;
+  late String hostB;
+
+  // Mock launcher state. `pendingLaunch` is what the next `getLaunchSiteId`
+  // returns; reading it clears it, mirroring the native consume-on-read.
+  String? pendingLaunch;
+  var pinned = <String>{};
+  final calls = <MethodCall>[];
+
+  setUpAll(() async {
+    isDemoMode = true;
+
+    // anyIPv4 so both loopback names below reach the same server.
+    server = await HttpServer.bind(InternetAddress.anyIPv4, 0);
+    server!.listen((request) {
+      final page = switch (request.uri.path) {
+        '/a.html' => _solidPage('#123524'),
+        '/b.html' => _solidPage('#1d3f8c'),
+        '/deep.html' => _solidPage('#8c1d5a'),
+        _ => null,
+      };
+      final response = request.response;
+      if (page == null) {
+        response.statusCode = HttpStatus.notFound;
+      } else {
+        response.headers.contentType = ContentType.html;
+        response.write(page);
+      }
+      response.close();
+    });
+    hostA = 'http://127.0.0.1:${server!.port}';
+    hostB = 'http://localhost:${server!.port}';
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_kShortcutChannel, (call) async {
+      calls.add(call);
+      switch (call.method) {
+        case 'getLaunchSiteId':
+          final launch = pendingLaunch;
+          pendingLaunch = null;
+          return launch;
+        case 'getPinnedSiteIds':
+          return pinned.toList();
+        case 'pinShortcut':
+          pinned.add((call.arguments as Map)['siteId'] as String);
+          return true;
+        case 'disableShortcut':
+          pinned.remove((call.arguments as Map)['siteId'] as String);
+          return null;
+        default:
+          // removeShortcut, syncSites, getDiagSeed, isAppIntentsSupported.
+          return call.method == 'isAppIntentsSupported' ? false : null;
+      }
+    });
+  });
+
+  tearDownAll(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_kShortcutChannel, null);
+    await server?.close(force: true);
+  });
+
+  WebViewModel siteA({String? currentUrl}) => WebViewModel(
+        siteId: 'ws-hs-a',
+        initUrl: '$hostA/a.html',
+        currentUrl: currentUrl,
+        name: 'Site A',
+      );
+  WebViewModel siteB() => WebViewModel(
+        siteId: 'ws-hs-b',
+        initUrl: '$hostB/b.html',
+        name: 'Site B',
+      );
+
+  /// Seed the app's persisted state plus the mock launcher's pin set. Called
+  /// before every `app.main()`; `setMockInitialValues` nullifies the
+  /// SharedPreferences singleton, so each run starts from exactly this state.
+  void seed({
+    required List<WebViewModel> sites,
+    Map<String, String> ledger = const {},
+    Map<String, String> remap = const {},
+    Set<String> pinnedTiles = const {},
+    String? launch,
+  }) {
+    SharedPreferences.setMockInitialValues({
+      'webViewModels': [for (final s in sites) jsonEncode(s.toJson())],
+      // A shortcut launch enters fullscreen by default (FS-008), which hides
+      // the app bar the menu assertions need.
+      'fullscreenOnShortcut': false,
+      'shortcutUrlLedger': jsonEncode(ledger),
+      'shortcutSiteRemap': jsonEncode(remap),
+    });
+    pinned = {...pinnedTiles};
+    calls.clear();
+    pendingLaunch = launch;
+  }
+
+  void dumpDiagnostics(String context) {
+    // Test data is synthetic (loopback urls, seeded names), so the log ring is
+    // safe to print and is the only view of the resolution path (INTEG-006).
+    // ignore: avoid_print
+    print('=== shortcut_behavior_test: $context');
+    // ignore: avoid_print
+    print('Texts: ${find.byType(Text).evaluate().map((e) {
+      final w = e.widget;
+      return w is Text ? (w.data ?? '?') : '?';
+    }).take(40).toList()}');
+    final entries = LogService.instance.allEntriesMerged;
+    for (final e
+        in entries.skip(entries.length < 40 ? 0 : entries.length - 40)) {
+      // ignore: avoid_print
+      print('  [${e.tag}/${e.level.name}] ${e.message}');
+    }
+  }
+
+  // pumpAndSettle deadlocks once a webview is live (see
+  // lazy_webview_loading_test), so every wait polls in fixed slices instead.
+  Future<void> pumpFor(WidgetTester tester, Duration total) async {
+    final deadline = DateTime.now().add(total);
+    while (DateTime.now().isBefore(deadline)) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+  }
+
+  Future<void> pumpUntilAsync(
+    WidgetTester tester,
+    Future<bool> Function() predicate, {
+    required String description,
+    Duration timeout = const Duration(seconds: 45),
+  }) async {
+    final deadline = DateTime.now().add(timeout);
+    while (DateTime.now().isBefore(deadline)) {
+      await tester.pump(const Duration(milliseconds: 100));
+      if (await predicate()) return;
+    }
+    dumpDiagnostics('timed out waiting for $description');
+    fail('Timed out after ${timeout.inSeconds}s waiting for: $description');
+  }
+
+  Future<void> pumpUntil(
+    WidgetTester tester,
+    bool Function() predicate, {
+    required String description,
+    Duration timeout = const Duration(seconds: 45),
+  }) =>
+      pumpUntilAsync(tester, () async => predicate(),
+          description: description, timeout: timeout);
+
+  Future<void> startApp(WidgetTester tester) async {
+    app.main();
+    // Settles the home screen (no webview is mounted until a site activates,
+    // and a shortcut cold launch mounts one — hence the slice-pump fallback).
+    await pumpFor(tester, const Duration(seconds: 5));
+  }
+
+  List<WebViewModel> models() => app.debugWebViewModels ?? const [];
+
+  bool siteIsMounted(String siteId) =>
+      find.byKey(ValueKey(siteId), skipOffstage: false).evaluate().isNotEmpty;
+
+  Future<Map<String, dynamic>> prefsMap(String key) async {
+    final raw = (await SharedPreferences.getInstance()).getString(key);
+    if (raw == null || raw.isEmpty) return {};
+    return (jsonDecode(raw) as Map).cast<String, dynamic>();
+  }
+
+  /// Background and re-foreground the running app, optionally parking a
+  /// pending launch first — the lifecycle transition a launcher tap produces,
+  /// and the one `_onResumed` -> `_handleShortcutIntent` hangs off.
+  Future<void> resumeApp(WidgetTester tester, {String? withLaunch}) async {
+    pendingLaunch = withLaunch;
+    for (final state in const ['paused', 'resumed']) {
+      await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+        'flutter/lifecycle',
+        const StringCodec().encodeMessage('AppLifecycleState.$state'),
+        (_) {},
+      );
+      await tester.pump();
+    }
+  }
+
+  Future<void> openOverflowMenu(WidgetTester tester) async {
+    final button = find.byType(PopupMenuButton<String>);
+    expect(button, findsWidgets,
+        reason: 'the site view should expose an overflow menu');
+    await tester.tap(button.last);
+    await pumpFor(tester, const Duration(seconds: 1));
+    expect(find.text('Settings'), findsWidgets,
+        reason: 'the overflow menu should be open');
+  }
+
+  Future<void> openSiteDrawer(WidgetTester tester) async {
+    // Tapping the already-selected webspace tile opens the drawer (the
+    // same-id branch of _selectWebspace).
+    await tester.tap(find.byKey(const ValueKey(kAllWebspaceId)));
+    await pumpFor(tester, const Duration(seconds: 2));
+    expect(find.byType(Drawer), findsOneWidget,
+        reason: 'the site drawer should open');
+  }
+
+  Future<void> tapDialogButton(WidgetTester tester, String label) async {
+    final button = find.descendant(
+      of: find.byType(AlertDialog),
+      matching: find.text(label),
+    );
+    if (button.evaluate().isEmpty) dumpDiagnostics('no "$label" in the dialog');
+    expect(button, findsOneWidget, reason: 'dialog should offer "$label"');
+    await tester.tap(button);
+    await pumpFor(tester, const Duration(seconds: 1));
+  }
+
+  // The shortcut paths in lib/main.dart are Platform.isAndroid-gated; the
+  // desktop integration loops skip this file by basename as well.
+  final skipOffAndroid = !Platform.isAndroid;
+
+  testWidgets(
+    'cold launch opens the pinned site at its initUrl (HS-002 / HS-006)',
+    (tester) async {
+      seed(
+        sites: [siteA(currentUrl: '$hostA/deep.html'), siteB()],
+        pinnedTiles: {'ws-hs-a'},
+        launch: 'ws-hs-a',
+      );
+      await startApp(tester);
+
+      await pumpUntil(tester, () => siteIsMounted('ws-hs-a'),
+          description: 'the launched site to activate');
+      final launched = models().firstWhere((m) => m.siteId == 'ws-hs-a');
+      expect(launched.currentUrl, launched.initUrl,
+          reason: 'a shortcut launch is the pinned entry point, so last '
+              'session\'s drift must be dropped (HS-006)');
+      expect(siteIsMounted('ws-hs-b'), isFalse,
+          reason: 'only the launched site should be activated');
+
+      // HS-012: on the initState/resume cadence the ledger records the url of
+      // every pinned site that still exists, so a later deletion leaves a
+      // routable trail. Asserted after a resume because the initState pass
+      // races `_restoreAppState` for the loaded model list.
+      await resumeApp(tester);
+      await pumpUntilAsync(
+        tester,
+        () async =>
+            (await prefsMap('shortcutUrlLedger'))['ws-hs-a'] == '$hostA/a.html',
+        description: 'the startup ledger reconcile to record the pinned url',
+      );
+    },
+    skip: skipOffAndroid,
+  );
+
+  testWidgets(
+    'the Home Shortcut item hides for a pinned site (HS-005)',
+    (tester) async {
+      seed(
+        sites: [siteA(), siteB()],
+        pinnedTiles: {'ws-hs-a'},
+        launch: 'ws-hs-a',
+      );
+      await startApp(tester);
+      await pumpUntil(tester, () => siteIsMounted('ws-hs-a'),
+          description: 'the pinned site to activate');
+
+      await openOverflowMenu(tester);
+      expect(find.text('Home Shortcut'), findsNothing,
+          reason: 'the site already has a pinned tile, so pinning a second '
+              'one must not be offered');
+    },
+    skip: skipOffAndroid,
+  );
+
+  testWidgets(
+    'the Home Shortcut item hides for a site an orphaned tile was rebound to '
+    '(HS-005)',
+    (tester) async {
+      // A tile whose own site is gone, rebound to Site B by an earlier
+      // HS-011 prompt: B is already reachable from the launcher.
+      seed(
+        sites: [siteA(), siteB()],
+        remap: {'ws-hs-ghost': 'ws-hs-b'},
+        pinnedTiles: {'ws-hs-ghost'},
+        launch: 'ws-hs-b',
+      );
+      await startApp(tester);
+      await pumpUntil(tester, () => siteIsMounted('ws-hs-b'),
+          description: 'the rebound site to activate');
+
+      await openOverflowMenu(tester);
+      expect(find.text('Home Shortcut'), findsNothing,
+          reason: 'an existing tile already reaches this site');
+    },
+    skip: skipOffAndroid,
+  );
+
+  testWidgets(
+    'pinning an unpinned site goes through the channel and records the ledger '
+    '(HS-004 / HS-001 / HS-012)',
+    (tester) async {
+      seed(sites: [siteA(), siteB()], launch: 'ws-hs-a');
+      await startApp(tester);
+      await pumpUntil(tester, () => siteIsMounted('ws-hs-a'),
+          description: 'the launched site to activate');
+
+      await openOverflowMenu(tester);
+      expect(find.text('Home Shortcut'), findsOneWidget,
+          reason: 'an unpinned site should offer the menu item on Android');
+      await tester.tap(find.text('Home Shortcut'));
+
+      // The favicon is rasterized before the pin (HS-003), which reaches the
+      // loopback server first — poll rather than assume a settled frame.
+      await pumpUntil(
+        tester,
+        () => calls.any((c) => c.method == 'pinShortcut'),
+        description: 'the pin request to reach the platform channel',
+      );
+      final pin = calls.lastWhere((c) => c.method == 'pinShortcut');
+      final args = (pin.arguments as Map).cast<String, dynamic>();
+      expect(args['siteId'], 'ws-hs-a');
+      expect(args['label'], 'Site A');
+
+      // HS-012: pinning records the url so a later delete+recreate can be
+      // routed by domain.
+      await pumpUntilAsync(
+        tester,
+        () async =>
+            (await prefsMap('shortcutUrlLedger'))['ws-hs-a'] == '$hostA/a.html',
+        description: 'the pin to record the site url in the ledger',
+      );
+    },
+    skip: skipOffAndroid,
+  );
+
+  testWidgets(
+    'an orphaned tile with a domain match prompts, then is remembered '
+    '(HS-011)',
+    (tester) async {
+      // The tile's own site is gone; its ledger url shares Site A's base
+      // domain. The tile is still pinned, which is what keeps the ledger
+      // entry alive through the startup reconcile (HS-012).
+      seed(
+        sites: [siteA()],
+        ledger: {'ws-hs-ghost': '$hostA/gone.html'},
+        pinnedTiles: {'ws-hs-ghost'},
+      );
+      await startApp(tester);
+      expect(siteIsMounted('ws-hs-a'), isFalse,
+          reason: 'a plain launch activates no site');
+
+      // Declining leaves no trace, and a later tap asks again.
+      await resumeApp(tester, withLaunch: 'ws-hs-ghost');
+      await pumpUntil(tester, () => find.text('Open site?').evaluate().isNotEmpty,
+          description: 'the domain-match confirmation');
+      await tapDialogButton(tester, 'Cancel');
+      expect(siteIsMounted('ws-hs-a'), isFalse,
+          reason: 'declining must not open the matched site');
+      expect(await prefsMap('shortcutSiteRemap'), isEmpty,
+          reason: 'declining must not remember a rebind');
+
+      // Confirming opens the match and remembers it.
+      await resumeApp(tester, withLaunch: 'ws-hs-ghost');
+      await pumpUntil(tester, () => find.text('Open site?').evaluate().isNotEmpty,
+          description: 'the confirmation to be offered again');
+      await tapDialogButton(tester, 'Open');
+      await pumpUntil(tester, () => siteIsMounted('ws-hs-a'),
+          description: 'the matched site to activate');
+      await pumpUntilAsync(
+        tester,
+        () async =>
+            (await prefsMap('shortcutSiteRemap'))['ws-hs-ghost'] == 'ws-hs-a',
+        description: 'the confirmed rebind to persist',
+      );
+
+      // The remembered rebind resolves the next tap directly.
+      await resumeApp(tester, withLaunch: 'ws-hs-ghost');
+      await pumpFor(tester, const Duration(seconds: 3));
+      expect(find.text('Open site?'), findsNothing,
+          reason: 'a remembered rebind must resolve without prompting');
+    },
+    skip: skipOffAndroid,
+  );
+
+  testWidgets(
+    'an orphaned tile with no domain match offers reroute and create (HS-011)',
+    (tester) async {
+      seed(
+        sites: [siteB()],
+        ledger: {
+          'ws-hs-ghost1': _kOffDomainUrl,
+          'ws-hs-ghost2': _kCreateUrl,
+        },
+        pinnedTiles: {'ws-hs-ghost1', 'ws-hs-ghost2'},
+      );
+      await startApp(tester);
+
+      await resumeApp(tester, withLaunch: 'ws-hs-ghost1');
+      await pumpUntil(
+        tester,
+        () => find.text('Shortcut site missing').evaluate().isNotEmpty,
+        description: 'the missing-site chooser',
+      );
+      await tapDialogButton(tester, 'Open another');
+      await pumpUntil(
+        tester,
+        () => find.text('Point shortcut at').evaluate().isNotEmpty,
+        description: 'the site picker',
+      );
+      await tester.tap(find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.text('Site B'),
+      ));
+      await pumpUntil(tester, () => siteIsMounted('ws-hs-b'),
+          description: 'the rerouted site to activate');
+      await pumpUntilAsync(
+        tester,
+        () async =>
+            (await prefsMap('shortcutSiteRemap'))['ws-hs-ghost1'] == 'ws-hs-b',
+        description: 'the reroute to be remembered',
+      );
+
+      // The create branch builds a site rooted at the ledger url and binds the
+      // tile to it. The url is unreachable, so the title probe times out first.
+      await resumeApp(tester, withLaunch: 'ws-hs-ghost2');
+      await pumpUntil(
+        tester,
+        () => find.text('Shortcut site missing').evaluate().isNotEmpty,
+        description: 'the missing-site chooser for the second tile',
+      );
+      await tapDialogButton(tester, 'Create');
+      await pumpUntil(
+        tester,
+        () => models().any((m) => m.initUrl == _kCreateUrl),
+        description: 'the site created for the ledger url',
+        timeout: const Duration(seconds: 60),
+      );
+      final created = models().firstWhere((m) => m.initUrl == _kCreateUrl);
+      await pumpUntilAsync(
+        tester,
+        () async =>
+            (await prefsMap('shortcutSiteRemap'))['ws-hs-ghost2'] ==
+            created.siteId,
+        description: 'the created site to be bound to the tile',
+      );
+    },
+    skip: skipOffAndroid,
+  );
+
+  testWidgets(
+    'deleting a site pinned tiles reach prompts, and Disable kills the tiles '
+    '(HS-013)',
+    (tester) async {
+      // Two tiles reach Site A: its own, and an orphaned tile rebound to it.
+      seed(
+        sites: [siteA(), siteB()],
+        ledger: {'ws-hs-a': '$hostA/a.html', 'ws-hs-tile': _kOffDomainUrl},
+        remap: {'ws-hs-tile': 'ws-hs-a'},
+        pinnedTiles: {'ws-hs-a', 'ws-hs-tile'},
+      );
+      await startApp(tester);
+
+      Future<void> deleteFirstSite() async {
+        await openSiteDrawer(tester);
+        await tester.tap(find.descendant(
+          of: find.byKey(const Key('site_0')),
+          matching: find.byIcon(Icons.more_vert),
+        ));
+        await pumpFor(tester, const Duration(seconds: 1));
+        await tester.tap(find.text('Delete').last);
+        await pumpUntil(
+          tester,
+          () => find.text('Delete Site').evaluate().isNotEmpty,
+          description: 'the delete confirmation',
+        );
+        await tapDialogButton(tester, 'Delete');
+      }
+
+      await deleteFirstSite();
+      await pumpUntil(
+        tester,
+        () => find.text('Home screen shortcut').evaluate().isNotEmpty,
+        description: 'the HS-013 fate prompt',
+      );
+      expect(find.text('Keep'), findsOneWidget);
+      expect(find.text('Reassign'), findsOneWidget);
+      await tapDialogButton(tester, 'Disable');
+
+      await pumpUntil(
+        tester,
+        () => calls.where((c) => c.method == 'disableShortcut').length == 2,
+        description: 'both reaching tiles to be disabled',
+      );
+      final disabled = {
+        for (final c in calls.where((c) => c.method == 'disableShortcut'))
+          (c.arguments as Map)['siteId'] as String,
+      };
+      expect(disabled, {'ws-hs-a', 'ws-hs-tile'},
+          reason: 'the deleted site\'s own tile and the tile rebound to it '
+              'both reach it');
+      await pumpUntilAsync(
+        tester,
+        () async =>
+            (await prefsMap('shortcutSiteRemap')).isEmpty &&
+            (await prefsMap('shortcutUrlLedger')).isEmpty,
+        description: 'the disabled tiles\' rebind and ledger entries to drop',
+      );
+
+      // Site B has no tile pointing at it: deleting it must prompt nothing.
+      calls.clear();
+      await deleteFirstSite();
+      await pumpFor(tester, const Duration(seconds: 4));
+      expect(find.text('Home screen shortcut'), findsNothing,
+          reason: 'no pinned tile reaches this site');
+      expect(models().where((m) => m.siteId == 'ws-hs-b'), isEmpty,
+          reason: 'the site should still have been deleted');
+    },
+    skip: skipOffAndroid,
+  );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7469,7 +7469,11 @@ class _WebSpacePageState extends State<WebSpacePage>
     }
 
     if (!mounted) return;
-    Navigator.pop(context);
+    // closeDrawer() (not Navigator.pop): `context` belongs to the drawer tile
+    // of the site just removed, so by now its element can be defunct and
+    // Navigator.of would fail its null check — deterministically so when the
+    // deleted site was the last tile. Idempotent, like the other drawer taps.
+    _scaffoldKey.currentState?.closeDrawer();
   }
 
   /// Shared Keep/Reassign/Disable chooser for the delete-time shortcut prompt

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -595,6 +595,19 @@ no widget tree required.
 
 ## Testing
 
+### Automated
+
+| Layer | Covers |
+|---|---|
+| [test/startup_restore_engine_test.dart](../../../test/startup_restore_engine_test.dart) | the resolution rules themselves: `resolveLaunch` (HS-002/HS-011), ledger reconcile (HS-012), `effectivePinnedSiteIds` / `tilesReaching` (HS-005/HS-013), tombstone add + prune (HS-014) |
+| [test/shortcut_service_test.dart](../../../test/shortcut_service_test.dart) | the Dart channel surface: argument shapes, per-platform no-ops, degradation on `PlatformException` |
+| [integration_test/shortcut_behavior_test.dart](../../../integration_test/shortcut_behavior_test.dart) | the wiring in `lib/main.dart` on an Android emulator (INTEG-013): cold launch + initUrl reset (HS-002/HS-006), menu gating incl. the rebound site (HS-004/HS-005), pin + ledger record (HS-001/HS-012), orphan confirm / reroute / create and the remembered rebind (HS-011), delete-time Keep/Reassign/Disable (HS-013) |
+| [scripts/run_android_lifecycle_tests.sh](../../../scripts/run_android_lifecycle_tests.sh) | what needs a real intent: cold launch through the launcher `siteId` extra, warm tap switching sites (HS-002), warm tap preserving the live session (HS-006) |
+
+iOS/macOS App Intents (HS-008/HS-009/HS-010/HS-014) stay manual plus
+the structural `%@`-key check in `test/shortcut_service_test.dart`:
+Shortcuts.app cannot be driven from `simctl` headlessly.
+
 ### Manual Test: Create Shortcut
 
 1. Open a site in WebSpace

--- a/openspec/specs/home-shortcut/spec.md
+++ b/openspec/specs/home-shortcut/spec.md
@@ -601,7 +601,7 @@ no widget tree required.
 |---|---|
 | [test/startup_restore_engine_test.dart](../../../test/startup_restore_engine_test.dart) | the resolution rules themselves: `resolveLaunch` (HS-002/HS-011), ledger reconcile (HS-012), `effectivePinnedSiteIds` / `tilesReaching` (HS-005/HS-013), tombstone add + prune (HS-014) |
 | [test/shortcut_service_test.dart](../../../test/shortcut_service_test.dart) | the Dart channel surface: argument shapes, per-platform no-ops, degradation on `PlatformException` |
-| [integration_test/shortcut_behavior_test.dart](../../../integration_test/shortcut_behavior_test.dart) | the wiring in `lib/main.dart` on an Android emulator (INTEG-013): cold launch + initUrl reset (HS-002/HS-006), menu gating incl. the rebound site (HS-004/HS-005), pin + ledger record (HS-001/HS-012), orphan confirm / reroute / create and the remembered rebind (HS-011), delete-time Keep/Reassign/Disable (HS-013) |
+| [integration_test/shortcut_behavior_test.dart](../../../integration_test/shortcut_behavior_test.dart) (run by [scripts/run_android_shortcut_tests.sh](../../../scripts/run_android_shortcut_tests.sh)) | the wiring in `lib/main.dart` on an Android emulator (INTEG-013): cold launch + initUrl reset (HS-002/HS-006), menu gating incl. the rebound site (HS-004/HS-005), pin + ledger record (HS-001/HS-012), orphan confirm / reroute / create and the remembered rebind (HS-011), delete-time Keep/Reassign/Disable (HS-013) |
 | [scripts/run_android_lifecycle_tests.sh](../../../scripts/run_android_lifecycle_tests.sh) | what needs a real intent: cold launch through the launcher `siteId` extra, warm tap switching sites (HS-002), warm tap preserving the live session (HS-006) |
 
 iOS/macOS App Intents (HS-008/HS-009/HS-010/HS-014) stay manual plus

--- a/openspec/specs/integration-tests/spec.md
+++ b/openspec/specs/integration-tests/spec.md
@@ -590,8 +590,9 @@ sample (observed as exact per-channel halving of the page colors).
 #### Scenario: Runs in build-android after the in-process suite
 
 - **Given** the `Run emulator integration scenarios` emulator step ran
-  `run_android_integration_tests.sh`, whose `flutter test` installs an
-  APK with the *test* Dart entrypoint
+  the in-process wrapper scripts (`run_android_integration_tests.sh`,
+  `run_android_shortcut_tests.sh`, `run_android_background_audio_tests.sh`),
+  whose `flutter test` installs an APK with the *test* Dart entrypoint
 - **When** `run_android_lifecycle_tests.sh` runs next in the same step,
   rebuilds the default-entrypoint fdebug debug APK, reinstalls it, and
   clears package data for a pristine cold start
@@ -808,6 +809,16 @@ and the frame classifier.
   preserves the live session (HS-006), and a reset to `initUrl` would
   repaint the home page instead
 
+#### Scenario: Runs as its own wrapper script in build-android
+
+- **Given** the emulator step runs one wrapper script per in-process
+  suite (the runner executes each `script:` line as a separate `sh -c`,
+  so the device id has to stay in scope with `flutter test`)
+- **When** `run_android_shortcut_tests.sh` runs after
+  `run_android_integration_tests.sh` and before the lifecycle tier
+- **Then** the suite executes on every push/PR under its own 20-minute
+  wall-clock backstop, and a failure fails `build-android`
+
 #### Scenario: Desktop loops skip the Android-only suite
 
 - **Given** the Linux and macOS integration loops iterate
@@ -876,7 +887,9 @@ and the frame classifier.
 - [`integration_test/shortcut_behavior_test.dart`](../../../integration_test/shortcut_behavior_test.dart)
   — INTEG-013: [home-shortcut](../home-shortcut/spec.md) launch, menu
   gating, orphan routing and delete-time tile prompt through the widget
-  tree (Android emulator tier); the resolution rules themselves stay in
+  tree (Android emulator tier), run by
+  [`scripts/run_android_shortcut_tests.sh`](../../../scripts/run_android_shortcut_tests.sh);
+  the resolution rules themselves stay in
   [`test/startup_restore_engine_test.dart`](../../../test/startup_restore_engine_test.dart)
 - [`scripts/run_android_lifecycle_tests.sh`](../../../scripts/run_android_lifecycle_tests.sh)
   — INTEG-011: adb-driven lifecycle tier (warm start, bfcache back,

--- a/openspec/specs/integration-tests/spec.md
+++ b/openspec/specs/integration-tests/spec.md
@@ -733,6 +733,16 @@ Pages come from an in-process loopback server, and each test seeds its
 own `SharedPreferences` (site list, ledger, rebind map) before calling
 `app.main()`, so the runs share no state.
 
+A warm tap is delivered by driving the lifecycle round trip through
+`inactive` only — never `paused` or `hidden`. `SchedulerBinding` sets
+`framesEnabled = false` for those two states, which makes
+`scheduleFrame()` a no-op, so the next `tester.pump()` waits forever for
+a frame nobody schedules (observed as a full-cap CI hang). Any future
+integration test that drives app lifecycle SHALL follow the same rule.
+Each test SHALL also carry its own `timeout:` so a hang fails that test
+with its widget-tree and log dump rather than expiring the suite's
+wall-clock cap with no output.
+
 Warm taps SHALL stay in the adb tier: a tap on a pinned tile while the
 app runs is delivered as `onNewIntent` against the running activity,
 which an in-process test cannot produce. Those two scenarios live in

--- a/openspec/specs/integration-tests/spec.md
+++ b/openspec/specs/integration-tests/spec.md
@@ -29,15 +29,17 @@ fastlane-driven Android/iOS screenshot pipeline (see
 [`screenshots`](../screenshots/spec.md) — `build-android`'s
 `reactivecircus/android-emulator-runner` and `build-apple`'s
 `simctl boot`). The Android-emulator scenarios are wired in:
-`white_screen_test.dart` (INTEG-010) runs inside the `build-android`
-job on every push/PR, on the same AVD profile and snapshot cache the
-screenshots lane uses (the emulator prerequisite steps are ungated;
-only the screenshot generation itself stays `workflow_dispatch`),
-followed in the same emulator step by the adb-driven lifecycle tier
-(INTEG-011), which drives warm start, bfcache back navigation, and
-activity recreation from outside the app process. INTEG-010 is
-Android-only (window-level `PixelCopy`), so both desktop loops skip
-it by basename exactly as they skip `screenshot_test.dart`; the
+`white_screen_test.dart` (INTEG-010) and `shortcut_behavior_test.dart`
+(INTEG-013) run inside the `build-android` job on every push/PR, on the
+same AVD profile and snapshot cache the screenshots lane uses (the
+emulator prerequisite steps are ungated; only the screenshot generation
+itself stays `workflow_dispatch`), followed in the same emulator step by
+the adb-driven lifecycle tier (INTEG-011), which drives warm start,
+bfcache back navigation, activity recreation, and the warm
+home-shortcut taps from outside the app process. Both in-process
+Android suites are Android-only (window-level `PixelCopy`;
+`Platform.isAndroid`-gated shortcut paths), so both desktop loops skip
+them by basename exactly as they skip `screenshot_test.dart`; the
 lifecycle tier is a shell harness, not an `integration_test` target,
 so the desktop loops never see it. A broader mobile tier (iOS
 Simulator) remains future scope and would extend the same boot setup
@@ -496,7 +498,7 @@ test cannot produce; those belong to the adb-driven lifecycle tier
 - **Given** the `build-android` job has built the APKs and its
   emulator prerequisites (KVM, Android SDK, API 34 google_apis x86_64
   `pixel_5` AVD snapshot cache) are ungated
-- **When** the `Run white-screen pixel scenarios` step runs
+- **When** the `Run emulator integration scenarios` step runs
   `fvm flutter test integration_test/white_screen_test.dart -d <device> --flavor fdebug`
   inside the booted emulator with a 25-minute wall-clock cap
 - **Then** the suite executes on every push to master, every PR, and
@@ -587,7 +589,7 @@ sample (observed as exact per-channel halving of the page colors).
 
 #### Scenario: Runs in build-android after the in-process suite
 
-- **Given** the `Run white-screen pixel scenarios` emulator step ran
+- **Given** the `Run emulator integration scenarios` emulator step ran
   `run_android_integration_tests.sh`, whose `flutter test` installs an
   APK with the *test* Dart entrypoint
 - **When** `run_android_lifecycle_tests.sh` runs next in the same step,
@@ -708,6 +710,105 @@ tier for the non-background scenarios remains future scope.
 
 ---
 
+### Requirement: INTEG-013 — Home-shortcut behavior scenarios
+
+`integration_test/shortcut_behavior_test.dart` SHALL drive the Android
+home-shortcut flows of [home-shortcut](../home-shortcut/spec.md)
+through the real widget tree on an Android emulator/device, covering
+the *wiring* in `lib/main.dart` that the engine unit tests in
+`test/startup_restore_engine_test.dart` cannot reach: which prompt a
+`LaunchResolution` raises, what the user's answer persists, whether the
+"Home Shortcut" menu item is offered, and what deleting a site does to
+the launcher tiles that still reach it. The suite SHALL cover at least
+HS-002/HS-006 (cold launch), HS-004/HS-005 (menu gating, including the
+rebound-site case), HS-001/HS-012 (pin + ledger record), HS-011
+(orphan confirm / reroute / create, and the remembered rebind), and
+HS-013 (delete-time Keep/Reassign/Disable prompt).
+
+The platform channel SHALL be mocked, because a launcher pin dialog and
+a real pinned set are not reachable from in-process; the mock SHALL
+drain `getLaunchSiteId` on read, mirroring MainActivity's
+`intent.removeExtra`, so a resume-cadence re-poll cannot re-navigate.
+Pages come from an in-process loopback server, and each test seeds its
+own `SharedPreferences` (site list, ledger, rebind map) before calling
+`app.main()`, so the runs share no state.
+
+Warm taps SHALL stay in the adb tier: a tap on a pinned tile while the
+app runs is delivered as `onNewIntent` against the running activity,
+which an in-process test cannot produce. Those two scenarios live in
+`scripts/run_android_lifecycle_tests.sh` alongside the INTEG-011
+lifecycle scenarios, which already own the emulator, the page server,
+and the frame classifier.
+
+#### Scenario: Cold launch opens the pinned site at its home URL
+
+- **Given** a seeded site whose persisted `currentUrl` drifted away
+  from its `initUrl`, and a pending launch carrying its `siteId`
+- **When** the app cold-starts
+- **Then** that site is the activated one, no other site is mounted,
+  and its `currentUrl` is back at `initUrl` (HS-006)
+- **And** the startup reconcile has recorded the pinned site's url in
+  `shortcutUrlLedger` (HS-012)
+
+#### Scenario: Menu gating is asserted in both directions
+
+- **Given** sites in three pin states — pinned, unpinned, and rebound
+  to by an orphaned pinned tile
+- **When** the overflow menu is opened for each
+- **Then** "Home Shortcut" is absent for the pinned and the rebound
+  site and present for the unpinned one (HS-005), and tapping it
+  reaches `pinShortcut` on the channel with that site's id and label
+  and records its url in the ledger (HS-001 / HS-012)
+
+#### Scenario: An orphaned tile's prompt outcome is what gets persisted
+
+- **Given** a pinned tile whose site is gone but whose ledger url
+  matches a live site's base domain
+- **When** the tile is tapped and the user declines
+- **Then** no site is opened and no rebind is remembered, and the next
+  tap prompts again
+- **When** the user confirms instead
+- **Then** the matched site is activated, `shortcutSiteRemap` binds the
+  tile to it, and a subsequent tap opens it with no prompt (HS-011)
+
+#### Scenario: A tile with no domain match can be rerouted or given a new site
+
+- **Given** a pinned tile whose ledger url matches no live site
+- **When** the tile is tapped
+- **Then** the missing-site chooser offers reroute and create; choosing
+  reroute binds the tile to the picked site, and choosing create builds
+  a site rooted at the ledger url and binds the tile to it (HS-011)
+
+#### Scenario: Deleting a site prompts for every tile that reaches it
+
+- **Given** a site reachable by two pinned tiles — its own, and an
+  orphaned tile rebound to it
+- **When** the site is deleted and the user picks Disable
+- **Then** `disableShortcut` is called for both tiles and their ledger
+  and rebind entries are dropped (HS-013)
+- **And** deleting a site no pinned tile reaches raises no prompt
+
+#### Scenario: Warm taps are covered out of process
+
+- **Given** the app is running with the shortcut-seeded sites
+- **When** the adb harness issues `am start ... --es siteId <other>`
+- **Then** the other site composites (HS-002 "app already running")
+- **And** after driving a site off its `initUrl` and re-tapping its own
+  shortcut, the frame still shows the navigated page — a warm tap
+  preserves the live session (HS-006), and a reset to `initUrl` would
+  repaint the home page instead
+
+#### Scenario: Desktop loops skip the Android-only suite
+
+- **Given** the Linux and macOS integration loops iterate
+  `integration_test/*_test.dart`
+- **When** they reach `shortcut_behavior_test.dart`
+- **Then** both skip it by basename (like `white_screen_test.dart`),
+  because every path it drives is `Platform.isAndroid`-gated and the
+  file's own `skip:` guard would still cost a desktop debug build
+
+---
+
 ## Known Limitations
 
 - **Build time per test**: each `flutter test integration_test/<file>.dart`
@@ -762,10 +863,16 @@ tier for the non-background scenarios remains future scope.
   + [`lib/services/surface_diag_native.dart`](../../../lib/services/surface_diag_native.dart)
   (classification unit-tested in
   [`test/surface_diag_classification_test.dart`](../../../test/surface_diag_classification_test.dart))
+- [`integration_test/shortcut_behavior_test.dart`](../../../integration_test/shortcut_behavior_test.dart)
+  — INTEG-013: [home-shortcut](../home-shortcut/spec.md) launch, menu
+  gating, orphan routing and delete-time tile prompt through the widget
+  tree (Android emulator tier); the resolution rules themselves stay in
+  [`test/startup_restore_engine_test.dart`](../../../test/startup_restore_engine_test.dart)
 - [`scripts/run_android_lifecycle_tests.sh`](../../../scripts/run_android_lifecycle_tests.sh)
   — INTEG-011: adb-driven lifecycle tier (warm start, bfcache back,
   activity recreation, white control); INTEG-012: background-refresh
-  scenario (NOTIF-005-A). Frame classifier:
+  scenario (NOTIF-005-A); INTEG-013: warm home-shortcut taps. Frame
+  classifier:
   [`scripts/classify_window_pixels.py`](../../../scripts/classify_window_pixels.py);
   launch seeding: [`lib/services/diag_seed.dart`](../../../lib/services/diag_seed.dart)
   (`getDiagSeed` in MainActivity, debuggable builds only; parsing

--- a/scripts/run_android_integration_tests.sh
+++ b/scripts/run_android_integration_tests.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Android-emulator integration tier (INTEG-010): white-screen pixel
-# scenarios against the first connected device/emulator.
+# Android-emulator in-process integration tier: the white-screen pixel
+# scenarios (INTEG-010) and the home-shortcut behavior scenarios
+# (INTEG-013), against the first connected device/emulator.
 #
 # Single entry point because reactivecircus/android-emulator-runner
 # executes each script line as a separate `sh -c` invocation: a variable
@@ -16,8 +17,12 @@ if [ -z "$device_id" ]; then
   exit 1
 fi
 
-# Hard wall-clock cap: a webview mount can deadlock below the Dart timeout
-# layer (same rationale as the desktop integration loops).
-exec timeout -k 30s 25m fvm flutter test \
-  integration_test/white_screen_test.dart \
-  -d "$device_id" --flavor fdebug
+# Hard wall-clock cap per suite: a webview mount can deadlock below the
+# Dart timeout layer (same rationale as the desktop integration loops).
+for target in white_screen_test shortcut_behavior_test; do
+  echo "::group::integration_test/$target.dart"
+  timeout -k 30s 25m fvm flutter test \
+    "integration_test/$target.dart" \
+    -d "$device_id" --flavor fdebug
+  echo "::endgroup::"
+done

--- a/scripts/run_android_integration_tests.sh
+++ b/scripts/run_android_integration_tests.sh
@@ -19,6 +19,9 @@ fi
 
 # Hard wall-clock cap per suite: a webview mount can deadlock below the
 # Dart timeout layer (same rationale as the desktop integration loops).
+# It is the backstop, not the first line: each suite's tests carry their
+# own `timeout:` so a hung test fails with its diagnostics instead of
+# silently eating the cap and killing the step with exit 124.
 for target in white_screen_test shortcut_behavior_test; do
   echo "::group::integration_test/$target.dart"
   timeout -k 30s 25m fvm flutter test \

--- a/scripts/run_android_integration_tests.sh
+++ b/scripts/run_android_integration_tests.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# Android-emulator in-process integration tier: the white-screen pixel
-# scenarios (INTEG-010) and the home-shortcut behavior scenarios
-# (INTEG-013), against the first connected device/emulator.
+# Android-emulator integration tier (INTEG-010): white-screen pixel
+# scenarios against the first connected device/emulator.
 #
 # Single entry point because reactivecircus/android-emulator-runner
 # executes each script line as a separate `sh -c` invocation: a variable
@@ -17,15 +16,8 @@ if [ -z "$device_id" ]; then
   exit 1
 fi
 
-# Hard wall-clock cap per suite: a webview mount can deadlock below the
-# Dart timeout layer (same rationale as the desktop integration loops).
-# It is the backstop, not the first line: each suite's tests carry their
-# own `timeout:` so a hung test fails with its diagnostics instead of
-# silently eating the cap and killing the step with exit 124.
-for target in white_screen_test shortcut_behavior_test; do
-  echo "::group::integration_test/$target.dart"
-  timeout -k 30s 25m fvm flutter test \
-    "integration_test/$target.dart" \
-    -d "$device_id" --flavor fdebug
-  echo "::endgroup::"
-done
+# Hard wall-clock cap: a webview mount can deadlock below the Dart timeout
+# layer (same rationale as the desktop integration loops).
+exec timeout -k 30s 25m fvm flutter test \
+  integration_test/white_screen_test.dart \
+  -d "$device_id" --flavor fdebug

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -9,6 +9,10 @@
 # Flutter never draws so a matching dominant color proves the webview
 # composited.
 #
+# The same driver covers the warm home-shortcut taps (HS-002 / HS-006,
+# INTEG-013): a tap on a pinned tile while the app runs arrives as
+# onNewIntent, which no in-process test can produce.
+#
 # The in-process suite (run_android_integration_tests.sh) leaves an APK
 # whose Dart entrypoint is the *test* main, so this tier always rebuilds
 # and installs the default-entrypoint debug APK before driving it.
@@ -37,6 +41,7 @@ artifacts="$root/build/white_screen_adb"
 classify="$root/scripts/classify_window_pixels.py"
 dark=123524
 magenta=8c1d5a
+blue=1d3f8c
 mkdir -p "$artifacts"
 
 # System error dialogs: a launcher ANR on the loaded CI host parks a
@@ -75,6 +80,7 @@ page() { # $1 = css background, $2 = optional link target (full-page anchor)
 page '#123524' 'magenta.html' > "$www/dark.html"
 page '#8c1d5a' > "$www/magenta.html"
 page '#ffffff' > "$www/white.html"
+page '#1d3f8c' > "$www/blue.html"
 
 # Same dark fill, plus a JS Notification on every load: a forced
 # background refresh reloads the page, so a new OS notification is the
@@ -137,10 +143,20 @@ run_tag="adb-$(date +%s)"
 dark_site_id="ws-$run_tag-dark"
 white_site_id="ws-$run_tag-white"
 notif_site_id="ws-$run_tag-notif"
+blue_site_id="ws-$run_tag-blue"
+
+site_json() { # $1 = page basename, $2 = siteId, $3 = extra site fields (optional)
+  printf '{"name":"Diag","url":"%s/%s","siteId":"%s"%s}' \
+    "$base" "$1" "$2" "${3:-}"
+}
 
 seed_b64() { # $1 = page basename, $2 = siteId, $3 = extra site fields (optional)
-  printf '{"sites":[{"name":"Diag","url":"%s/%s","siteId":"%s"%s}]}' \
-    "$base" "$1" "$2" "${3:-}" | base64 | tr -d '\n'
+  printf '{"sites":[%s]}' "$(site_json "$1" "$2" "${3:-}")" | base64 | tr -d '\n'
+}
+
+seed_pair_b64() { # $1/$2 = first page + siteId, $3/$4 = second page + siteId
+  printf '{"sites":[%s,%s]}' \
+    "$(site_json "$1" "$2")" "$(site_json "$3" "$4")" | base64 | tr -d '\n'
 }
 
 echo "== Building default-entrypoint fdebug APK"
@@ -334,4 +350,37 @@ done
 adb shell am start -W -n "$component"
 wait_for_pixels notif-foreground-dark 90 --expect-dominant "$dark"
 
-echo "White-screen lifecycle tier passed."
+# ---- Warm home-shortcut taps (HS-002 / HS-006 / INTEG-013) ----
+#
+# A tap on a pinned tile while the app is running is delivered as
+# onNewIntent, not as a fresh launch: the siteId extra has to be drained
+# from the *replaced* intent and routed through _handleShortcutIntent on
+# the resume. Only an out-of-process driver produces that transition, so
+# the in-process suite (integration_test/shortcut_behavior_test.dart)
+# cannot cover these two.
+
+echo "== Scenario G: warm shortcut tap switches sites (HS-002)"
+adb shell am force-stop "$pkg"
+adb shell am start -W -n "$component" \
+  --es ws_diag_seed \
+  "$(seed_pair_b64 dark.html "$dark_site_id" blue.html "$blue_site_id")" \
+  --es siteId "$dark_site_id"
+wait_for_pixels shortcut-cold-dark 180 --expect-dominant "$dark"
+
+adb shell am start -W -n "$component" --es siteId "$blue_site_id"
+wait_for_pixels shortcut-warm-switch-blue 90 --expect-dominant "$blue"
+
+echo "== Scenario H: warm tap leaves the running session intact (HS-006)"
+# Back to the dark site, drive it off its initUrl (the full-page link),
+# then re-tap its shortcut: HS-006 resets to initUrl on cold launch only,
+# so the live session must survive. A regression repaints dark here.
+adb shell am start -W -n "$component" --es siteId "$dark_site_id"
+wait_for_pixels shortcut-warm-back-dark 90 --expect-dominant "$dark"
+adb shell input tap "$((w / 2))" "$((h / 2))"
+wait_for_pixels shortcut-session-magenta 90 --expect-dominant "$magenta"
+adb shell input keyevent 3
+sleep 5
+adb shell am start -W -n "$component" --es siteId "$dark_site_id"
+wait_for_pixels shortcut-warm-preserves-session 90 --expect-dominant "$magenta"
+
+echo "White-screen lifecycle + shortcut tier passed."

--- a/scripts/run_android_shortcut_tests.sh
+++ b/scripts/run_android_shortcut_tests.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Android-emulator home-shortcut tier (INTEG-013): drive the launch, menu
+# gating, orphan routing and delete-time tile prompts of the home-shortcut
+# spec against a real Android build, where the `Platform.isAndroid` gates in
+# lib/main.dart are actually live. The warm-tap half (a launcher tap arriving
+# as onNewIntent) is out of process, in run_android_lifecycle_tests.sh.
+#
+# Own entry point because reactivecircus/android-emulator-runner runs each CI
+# `script:` line as a separate `sh -c`, so the device id has to stay in scope
+# with the `flutter test` call.
+set -euo pipefail
+
+device_id="${1:-$(adb devices | grep -w 'device' | head -1 | awk '{print $1}' || true)}"
+if [ -z "$device_id" ]; then
+  echo "ERROR: no connected Android device/emulator found" >&2
+  adb devices >&2
+  exit 1
+fi
+
+# Hard wall-clock cap, like the sibling tiers. It is the backstop, not the
+# first line: every test in the suite carries its own `timeout:` so a hung one
+# fails with its widget-tree and log dump instead of silently eating the cap.
+exec timeout -k 30s 20m fvm flutter test \
+  integration_test/shortcut_behavior_test.dart \
+  -d "$device_id" --flavor fdebug


### PR DESCRIPTION
Covers the main.dart wiring the engine unit tests can't reach: which
prompt a LaunchResolution raises, what the answer persists, menu gating,
and the delete-time tile prompt. Warm taps stay in the adb tier, where a
real onNewIntent is producible.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QcLqKTwFozko8vm7tr52fp