### PR TITLE
Implement Web Notifications replacement semantics (NOTIF-009)

### DIFF
--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -5,9 +5,45 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:webspace/services/log_service.dart';
 
+/// The OS-side identity of one posted notification. Android collapses on the
+/// `(tag, id)` pair and iOS/macOS on the identifier, so this pair decides
+/// whether a post replaces an earlier one or lands beside it.
+@immutable
+class NotificationTarget {
+  final String tag;
+  final int id;
+
+  const NotificationTarget({required this.tag, required this.id});
+
+  /// Web Notifications semantics: a post carrying a `tag` replaces the site's
+  /// earlier post with that tag; a post without one is always a new
+  /// notification. The tag stays namespaced to the site so two sites can use
+  /// the same page-level tag without clobbering each other.
+  ///
+  /// [sequence] is only read for untagged posts and must differ per post.
+  static NotificationTarget resolve({
+    required String siteId,
+    required String? tag,
+    required int sequence,
+  }) {
+    final pageTag = (tag == null || tag.isEmpty) ? null : tag;
+    return NotificationTarget(
+      tag: siteId,
+      id: pageTag == null
+          ? sequence & 0x7fffffff
+          : Object.hash(siteId, pageTag) & 0x7fffffff,
+    );
+  }
+}
+
 class NotificationService {
   static final instance = NotificationService._();
   NotificationService._();
+
+  /// Seeded from the clock so ids stay distinct across process restarts —
+  /// a fresh process must not reuse an id still held by a notification the
+  /// previous process posted.
+  int _sequence = DateTime.now().microsecondsSinceEpoch;
 
   final _plugin = FlutterLocalNotificationsPlugin();
   bool _initialized = false;
@@ -141,13 +177,19 @@ class NotificationService {
       return;
     }
 
+    final target = NotificationTarget.resolve(
+      siteId: siteId,
+      tag: tag,
+      sequence: _sequence++,
+    );
+
     final androidDetails = AndroidNotificationDetails(
       'webspace_web_notifications',
       'Web Notifications',
       channelDescription: 'Notifications from websites loaded in WebSpace',
       importance: Importance.high,
       priority: Priority.high,
-      tag: tag ?? siteId,
+      tag: target.tag,
     );
 
     const iosDetails = DarwinNotificationDetails(
@@ -163,9 +205,8 @@ class NotificationService {
     );
 
     final payload = jsonEncode({'siteId': siteId});
-    final id = siteId.hashCode ^ title.hashCode;
 
-    await _plugin.show(id: id, title: title, body: body.isNotEmpty ? body : null, notificationDetails: details, payload: payload);
+    await _plugin.show(id: target.id, title: title, body: body.isNotEmpty ? body : null, notificationDetails: details, payload: payload);
     LogService.instance.log(
       'Notification',
       'Showed notification: "$title" for siteId: $siteId',

--- a/openspec/changes/web-push-notifications/specs/web-push-notifications/spec.md
+++ b/openspec/changes/web-push-notifications/specs/web-push-notifications/spec.md
@@ -307,6 +307,32 @@ Because the wake-up chain (OS scheduler -> webview reload -> page JS -> `webNoti
 **Then** `NotificationService.show` posts a local notification for that `siteId`
 **And** the OS permission gate and delivery are exercised independently of any page JS
 
+### Requirement: NOTIF-009 - Notification Replacement Semantics
+
+The system SHALL follow Web Notifications replacement semantics when mapping a
+page post onto the OS notification identity (`NotificationTarget.resolve`):
+a post carrying a `tag` replaces the same site's earlier post with that tag; a
+post without one is always a new notification. Android collapses on the
+`(tag, id)` pair and iOS/macOS on the identifier, so an untagged post SHALL
+draw a per-post-unique id — deriving the id from the title (or any other
+value constant across posts) silently swallows every repeat of a site's
+"New message". The id sequence SHALL be seeded so a fresh process cannot reuse
+an id still held by a notification the previous process posted, and the OS tag
+SHALL stay the `siteId` so a tap still routes to the originating site.
+
+#### Scenario: Untagged posts accumulate
+
+**Given** a site with notification permission granted
+**When** the page calls `new Notification("New message")` three times without a `tag`
+**Then** three separate OS notifications are posted, none replacing another
+
+#### Scenario: A page tag replaces the site's earlier post with that tag
+
+**Given** a site posted `new Notification("2 unread", {tag: "inbox"})`
+**When** it posts `new Notification("3 unread", {tag: "inbox"})`
+**Then** the second post lands on the same `(tag, id)` pair and replaces the first
+**And** a different page tag, or the same page tag on another site, lands beside it
+
 ## Manual Test Procedure
 
 Use the HTML test fixture at `test/fixtures/notification_test.html`. Import it via "Import HTML file" on the Add Site screen. **Requires container mode support** (iOS 17+ or Android with System WebView 110+).

--- a/openspec/specs/integration-tests/spec.md
+++ b/openspec/specs/integration-tests/spec.md
@@ -637,6 +637,19 @@ ran with no foreground activity: worker → engine dispatch →
 `onBackgroundRefresh` site reload → `Notification` polyfill →
 `flutter_local_notifications`.
 
+Observation contract: "a new notification" SHALL be read as a set
+difference over notification **identities** (the `user|pkg|id|tag|uid`
+key from `StatusBarNotification.getKey`), never as a record count. A
+count cannot see a repost — the OS collapses on the `(tag, id)` pair,
+so a second post with the same pair updates the existing record and the
+count stays put (`NOTIF-009` is what makes successive untagged posts
+distinct identities in the first place) — and the same record
+transiently appears in more than one `dumpsys` section while it is
+being enqueued, which made a count-based assertion pass or fail on
+whether the poll landed inside that window. The page SHALL also fire a
+`/beacon` request at the host server on every load, so a failure can
+name which leg broke instead of only that no notification arrived.
+
 Cross-platform posture: the seed transport is platform-agnostic
 (`ws_diag_seed` intent extra on Android; `WS_DIAG_SEED` process
 environment elsewhere, which `simctl launch` forwards via its
@@ -662,16 +675,29 @@ tier for the non-background scenarios remains future scope.
 - **Given** the notification site's page just painted
 - **When** the harness polls `dumpsys notification`
 - **Then** the foreground load itself must have posted a notification
-  (polyfill → local-notifications proven working), and that count is
-  the baseline the background assertion increments from
+  (polyfill → local-notifications proven working), and the identity
+  set it produced is the baseline the background assertion diffs
+  against
 
 #### Scenario: Forced periodic refresh posts a new notification while backgrounded
 
 - **Given** the app is backgrounded (HOME) with the process alive
 - **When** the harness forces the WorkManager job(s)
-- **Then** a new OS notification from the app appears within the
-  polling deadline, and on failure the harness saves the jobscheduler
-  dump, the notification dump, and a logcat tail as artifacts
+- **Then** a notification identity absent from the baseline appears
+  within the polling deadline, and on failure the harness saves the
+  jobscheduler dump, the notification dump, and a logcat tail as
+  artifacts
+
+#### Scenario: A failure names the leg that broke
+
+- **Given** the background assertion timed out
+- **When** the harness compares the host server's `/beacon` hit count
+  against the count taken when the app was backgrounded
+- **Then** a risen count reports the break as downstream (the site
+  reloaded, the polyfill → `NotificationService` →
+  `flutter_local_notifications` leg dropped it) and an unchanged count
+  reports it as upstream (worker → engine dispatch →
+  `onBackgroundRefresh` never reloaded the site)
 
 #### Scenario: The refreshed site still paints on return
 

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -80,12 +80,18 @@ page '#ffffff' > "$www/white.html"
 # background refresh reloads the page, so a new OS notification is the
 # outside-observable proof the whole NOTIF-005-A pipeline ran (worker ->
 # engine -> site reload -> polyfill -> flutter_local_notifications).
+# The beacon request is the second, independent signal: it says the page
+# was re-fetched even when no notification follows, which is what splits
+# "the worker never reached the engine" from "the reload ran but the
+# notification pipeline dropped it" in the failure message.
 cat > "$www/notif.html" <<'EOF'
 <!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1">
 <style>html,body{margin:0;height:100%;background:#123524;}</style></head><body><script>
 (function () {
+  var stamp = String(Date.now()) + '-' + Math.floor(Math.random() * 1e6);
+  try { fetch('/beacon?load=' + stamp, {cache: 'no-store'}); } catch (e) {}
   function fire() {
-    try { new Notification('ws-diag-bg', {body: String(Date.now())}); } catch (e) {}
+    try { new Notification('ws-diag-bg', {body: stamp}); } catch (e) {}
   }
   if (typeof Notification === 'undefined') return;
   if (Notification.permission === 'granted') { fire(); return; }
@@ -223,9 +229,28 @@ wait_for_pixels white-control 180 --expect-blank-white
 
 # ---- Background refresh (NOTIF-005-A / INTEG-012) ----
 
-notif_count() {
+# Notification *identities*, not a record count. A record count cannot see a
+# repost: Android collapses on the (tag, id) pair, so a second post with the
+# same pair updates the existing record and the count never moves — while the
+# same record does transiently appear in more than one dumpsys section
+# (enqueued + posted), which made a count-based assertion pass or fail on
+# whether the poll landed inside that window. `key` is `user|pkg|id|tag|uid`
+# (StatusBarNotification.getKey), stable across versions and printed in every
+# section, so a set difference over keys is the honest "a new notification was
+# posted" signal.
+notif_keys() {
+  adb shell dumpsys notification 2>/dev/null \
+    | grep -o "[0-9]*|$pkg|[^|]*|[^|]*|[0-9]*" | sort -u || true
+}
+
+notif_records() {
   adb shell dumpsys notification 2>/dev/null \
     | grep -c "NotificationRecord.*$pkg" || true
+}
+
+# Each notif.html load fires one /beacon request at the host server.
+beacon_hits() {
+  grep -c 'GET /beacon' "$server_log" || true
 }
 
 dump_bg_diagnostics() { # $1 = slug
@@ -249,16 +274,18 @@ wait_for_pixels notif-cold-start 180 --expect-dominant "$dark"
 # land a beat after the pixels settle).
 deadline=$(( $(date +%s) + 60 ))
 while :; do
-  baseline="$(notif_count)"
-  [ "$baseline" -ge 1 ] && break
+  baseline_keys="$(notif_keys)"
+  [ -n "$baseline_keys" ] && break
   if [ "$(date +%s)" -ge "$deadline" ]; then
     echo "FAIL: foreground load posted no notification within 60s" >&2
+    echo "  notification records for $pkg: $(notif_records) (0 keys parsed)" >&2
     dump_bg_diagnostics notif-foreground-post
     exit 1
   fi
   sleep 2
 done
-echo "  notifications posted after foreground load: $baseline"
+echo "  notification identities after foreground load: $(printf '%s\n' "$baseline_keys" | wc -l | tr -d ' ')"
+baseline_beacons="$(beacon_hits)"
 adb shell input keyevent 3
 sleep 3
 
@@ -280,14 +307,22 @@ done
 
 deadline=$(( $(date +%s) + 90 ))
 while :; do
-  count="$(notif_count)"
-  if [ "$count" -gt "$baseline" ]; then
-    echo "  background refresh posted a notification ($baseline -> $count)"
+  fresh="$(comm -13 <(printf '%s\n' "$baseline_keys") <(notif_keys))"
+  if [ -n "$fresh" ]; then
+    echo "  background refresh posted a notification: $(printf '%s\n' "$fresh" | head -1)"
     break
   fi
   if [ "$(date +%s)" -ge "$deadline" ]; then
+    now_beacons="$(beacon_hits)"
     echo "FAIL: no new notification within 90s of forcing the refresh job" >&2
-    echo "  count stayed at $count (baseline $baseline)" >&2
+    echo "  notification identities unchanged (page loads: $baseline_beacons -> $now_beacons)" >&2
+    if [ "$now_beacons" -gt "$baseline_beacons" ]; then
+      echo "  the site DID reload in the background — the break is downstream," \
+           "in the polyfill -> NotificationService -> flutter_local_notifications leg" >&2
+    else
+      echo "  the site did NOT reload — the break is upstream," \
+           "in the worker -> engine dispatch -> onBackgroundRefresh leg" >&2
+    fi
     dump_bg_diagnostics notif-refresh
     exit 1
   fi

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -38,26 +38,66 @@ void main() {
       expect(decoded['siteId'], equals(siteId));
     });
 
-    test('notification id is deterministic from siteId and title', () {
-      const siteId = 'test-site';
-      const title = 'New message';
-      final id1 = siteId.hashCode ^ title.hashCode;
-      final id2 = siteId.hashCode ^ title.hashCode;
-      expect(id1, equals(id2));
-    });
-
-    test('different titles produce different ids', () {
-      const siteId = 'test-site';
-      final id1 = siteId.hashCode ^ 'Message A'.hashCode;
-      final id2 = siteId.hashCode ^ 'Message B'.hashCode;
-      expect(id1, isNot(equals(id2)));
-    });
-
     test('tap payload round-trips through JSON', () {
       final original = {'siteId': 'my-site-id'};
       final encoded = jsonEncode(original);
       final decoded = jsonDecode(encoded) as Map<String, dynamic>;
       expect(decoded['siteId'], equals('my-site-id'));
+    });
+  });
+
+  group('Notification identity (NOTIF-002)', () {
+    NotificationTarget target(String siteId, String? tag, int seq) =>
+        NotificationTarget.resolve(siteId: siteId, tag: tag, sequence: seq);
+
+    test('same page tag from the same site replaces the earlier post', () {
+      final a = target('site-a', 'chat-42', 1);
+      final b = target('site-a', 'chat-42', 2);
+      expect(b.tag, equals(a.tag));
+      expect(b.id, equals(a.id));
+    });
+
+    test('different page tags coexist', () {
+      final a = target('site-a', 'chat-42', 1);
+      final b = target('site-a', 'chat-43', 1);
+      expect(a.id, isNot(equals(b.id)));
+    });
+
+    test('the same page tag on two sites does not collide', () {
+      final a = target('site-a', 'chat-42', 1);
+      final b = target('site-b', 'chat-42', 1);
+      expect(a.id, isNot(equals(b.id)));
+    });
+
+    test('untagged posts never replace each other', () {
+      final ids = {
+        for (var seq = 1; seq <= 5; seq++) target('site-a', null, seq).id,
+      };
+      expect(ids.length, equals(5));
+    });
+
+    test('empty tag from the polyfill counts as untagged', () {
+      // The JS polyfill sends `String(options.tag || '')`, so an untagged
+      // page notification arrives as '' rather than null.
+      final a = target('site-a', '', 1);
+      final b = target('site-a', '', 2);
+      expect(a.id, isNot(equals(b.id)));
+    });
+
+    test('the OS tag stays the siteId so taps route back to the site', () {
+      expect(target('site-a', 'chat-42', 1).tag, equals('site-a'));
+      expect(target('site-a', null, 1).tag, equals('site-a'));
+    });
+
+    test('ids stay non-negative 31-bit', () {
+      for (final t in [
+        target('site-a', 'chat-42', 1),
+        target('site-a', null, DateTime.now().microsecondsSinceEpoch),
+        target('', null, -1),
+      ]) {
+        expect(t.id, greaterThanOrEqualTo(0));
+        expect(t.id, lessThanOrEqualTo(0x7fffffff));
+      }
     });
   });
 }


### PR DESCRIPTION
Fixes notification identity to follow Web Notifications spec: posts with a `tag` replace the site's earlier post with that tag; untagged posts always create new notifications. Android collapses on `(tag, id)` pairs, so deriving id from title silently swallows repeats.

Key changes:

- Add `NotificationTarget` class to compute OS-side notification identity. Untagged posts draw unique ids seeded from the clock; tagged posts hash the siteId and tag together. The OS tag stays the siteId so taps route back to the originating site.
- Seed `_sequence` from `DateTime.now().microsecondsSinceEpoch` so a fresh process cannot reuse an id still held by a notification the previous process posted.
- Replace title-based id derivation (`siteId.hashCode ^ title.hashCode`) with `NotificationTarget.resolve()`.
- Remove obsolete unit tests that validated the old (broken) id scheme.
- Add comprehensive test suite for `NotificationTarget` covering same-tag replacement, different-tag coexistence, cross-site isolation, untagged accumulation, empty-tag polyfill edge case, and id range constraints.

Integration test harness (`run_android_lifecycle_tests.sh`):

- Switch from notification record count to identity set diffing. A count cannot see a repost — the OS collapses on `(tag, id)`, so a second post with the same pair updates the existing record and the count stays put. The same record transiently appears in multiple `dumpsys` sections while enqueuing, making count-based assertions flaky.
- Add `/beacon` request on every page load so failures can name which leg broke: upstream (worker → engine dispatch → `onBackgroundRefresh` never reloaded) vs downstream (site reloaded but polyfill → `NotificationService` → `flutter_local_notifications` dropped it).
- Use `StatusBarNotification.getKey` (`user|pkg|id|tag|uid`) as the stable notification identity across all dumpsys sections and versions.

Spec updates document the new requirement (NOTIF-009) and observation contract for the integration test.

https://claude.ai/code/session_01SdPPHXD5XJ9hUcidqUCZwz