### PR TITLE
Badge granted capture permissions on drawer site tiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,7 @@ Specs live under `openspec/specs/<slug>/spec.md` (Given/When/Then). **Read the r
 | screenshots | integration-test driven |
 | settings-backup | JSON import/export |
 | site-editing | URL + custom name |
+| site-permission-badges | drawer badges for location/camera/mic/background-audio grants; real device access vs simulated |
 | tracking-protection | umbrella per-site ETP: forces ClearURLs/DNS/content blocker/LocalCDN + injects anti-fingerprinting shim (Canvas/WebGL/audio/fonts/screen/hardware/timing/clientrects) seeded by siteId |
 | user-agent-identity | engine-consistent navigator identity for the per-site UA (vendor/productSub/oscpu/buildID/platform/userAgentData); complements desktop-mode |
 | user-scripts | per-site JS injection w/ timing control |

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -107,6 +107,7 @@ import 'package:share_plus/share_plus.dart';
 import 'package:webspace/widgets/download_button.dart';
 import 'package:webspace/widgets/external_url_prompt.dart';
 import 'package:webspace/widgets/root_messenger.dart';
+import 'package:webspace/widgets/site_permission_badges.dart';
 import 'package:webspace/widgets/untrusted_cert_prompt.dart';
 
 // Accent color enum
@@ -7925,97 +7926,7 @@ class _WebSpacePageState extends State<WebSpacePage>
             setState(() {});
             await _saveCurrentIndex();
           },
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              final isWide = constraints.maxWidth > constraints.maxHeight * 1.5;
-              return Container(
-                decoration: isSelected
-                    ? BoxDecoration(
-                        borderRadius: BorderRadius.circular(12),
-                        color: theme.colorScheme.primaryContainer.withAlpha(80),
-                      )
-                    : null,
-                padding: isWide
-                    ? const EdgeInsets.symmetric(vertical: 4, horizontal: 12)
-                    : const EdgeInsets.symmetric(vertical: 6, horizontal: 2),
-                child: isWide
-                    ? Row(
-                        children: [
-                          Container(
-                            width: 36,
-                            height: 36,
-                            decoration: BoxDecoration(
-                              borderRadius: BorderRadius.circular(8),
-                              color: theme.colorScheme.surfaceContainerHighest,
-                            ),
-                            clipBehavior: Clip.antiAlias,
-                            child: Center(
-                              child: UnifiedFaviconImage(
-                                url: _webViewModels[index].initUrl,
-                                size: 28,
-                                proxy: _webViewModels[index].proxySettings,
-                                customIcon: _webViewModels[index].customIconPng,
-                              ),
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: Column(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  _webViewModels[index].getDisplayName(),
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: TextStyle(fontSize: 13),
-                                ),
-                                Text(
-                                  extractDomain(_webViewModels[index].initUrl),
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: TextStyle(fontSize: 11, color: Colors.grey),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
-                      )
-                    : Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Container(
-                            width: 48,
-                            height: 48,
-                            decoration: BoxDecoration(
-                              borderRadius: BorderRadius.circular(12),
-                              color: theme.colorScheme.surfaceContainerHighest,
-                            ),
-                            clipBehavior: Clip.antiAlias,
-                            child: Center(
-                              child: UnifiedFaviconImage(
-                                url: _webViewModels[index].initUrl,
-                                size: 36,
-                                proxy: _webViewModels[index].proxySettings,
-                                customIcon: _webViewModels[index].customIconPng,
-                              ),
-                            ),
-                          ),
-                          const SizedBox(height: 4),
-                          Flexible(
-                            child: Text(
-                              _webViewModels[index].getDisplayName(),
-                              maxLines: 2,
-                              overflow: TextOverflow.ellipsis,
-                              textAlign: TextAlign.center,
-                              style: TextStyle(fontSize: 11),
-                            ),
-                          ),
-                        ],
-                      ),
-              );
-            },
-          ),
+          child: _buildSiteGridTileContent(context, index, isSelected, theme),
         ),
     );
   }
@@ -8075,27 +7986,51 @@ class _WebSpacePageState extends State<WebSpacePage>
                         ],
                       ),
                     ),
+                    SitePermissionBadges(
+                      model: _webViewModels[index],
+                      iconSize: 12,
+                    ),
                   ],
                 )
               : Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Container(
-                      width: 48,
-                      height: 48,
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(12),
-                        color: theme.colorScheme.surfaceContainerHighest,
-                      ),
-                      clipBehavior: Clip.antiAlias,
-                      child: Center(
-                        child: UnifiedFaviconImage(
-                          url: _webViewModels[index].initUrl,
-                          size: 36,
-                          proxy: _webViewModels[index].proxySettings,
-                          customIcon: _webViewModels[index].customIconPng,
+                    Stack(
+                      // The badge strip is anchored to the favicon's bottom
+                      // edge and can be wider than it; the tile has no spare
+                      // vertical room to stack it below the name.
+                      clipBehavior: Clip.none,
+                      children: [
+                        Container(
+                          width: 48,
+                          height: 48,
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(12),
+                            color: theme.colorScheme.surfaceContainerHighest,
+                          ),
+                          clipBehavior: Clip.antiAlias,
+                          child: Center(
+                            child: UnifiedFaviconImage(
+                              url: _webViewModels[index].initUrl,
+                              size: 36,
+                              proxy: _webViewModels[index].proxySettings,
+                              customIcon: _webViewModels[index].customIconPng,
+                            ),
+                          ),
                         ),
-                      ),
+                        Positioned(
+                          left: 0,
+                          right: 0,
+                          bottom: -2,
+                          child: Center(
+                            child: SitePermissionBadges(
+                              model: _webViewModels[index],
+                              iconSize: 9,
+                              overlay: true,
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
                     const SizedBox(height: 4),
                     Flexible(

--- a/lib/widgets/site_permission_badges.dart
+++ b/lib/widgets/site_permission_badges.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+
+import 'package:webspace/l10n/gen/app_localizations.dart';
+import 'package:webspace/settings/camera.dart';
+import 'package:webspace/settings/location.dart';
+import 'package:webspace/settings/microphone.dart';
+import 'package:webspace/web_view_model.dart';
+
+/// A capture/background capability a site currently holds, surfaced as a
+/// badge on the drawer tile so the grant is visible without opening
+/// per-site settings.
+///
+/// Only settled grants appear: `ask` (undecided), `block` and
+/// [LocationMode.off] produce no badge. [SitePermissionBadge.spoofLocation]
+/// and [SitePermissionBadge.virtualCamera] /
+/// [SitePermissionBadge.virtualMicrophone] mark grants the app satisfies
+/// synthetically — the site is fed data but no device is opened — and render
+/// muted, so a glance separates "this site can see/hear the room" from "this
+/// site is being played a file".
+enum SitePermissionBadge {
+  /// [LocationMode.live]: the real device fix reaches the page (at the
+  /// site's [LocationGranularity]).
+  realLocation,
+
+  /// [LocationMode.spoof]: pages get user-picked coordinates.
+  spoofLocation,
+
+  /// [CameraAccessMode.real]: the device camera is handed to the page.
+  realCamera,
+
+  /// [CameraAccessMode.virtual]: a picked image/video is served instead.
+  virtualCamera,
+
+  /// [MicrophoneAccessMode.virtual]: a picked audio clip is looped to the
+  /// page. There is no real-microphone mode in the app, so this is the only
+  /// microphone grant that exists.
+  virtualMicrophone,
+
+  /// `backgroundAudioEnabled`: the site keeps playing while another site is
+  /// visible or the app is backgrounded.
+  backgroundAudio,
+}
+
+/// Badges held by [model], in a stable display order (capture first, then
+/// background playback). Reads the `effective*` getters, so an archive-tier
+/// site shows no capture badge even when the stored mode says otherwise
+/// (ARCH-006).
+List<SitePermissionBadge> sitePermissionBadges(WebViewModel model) {
+  return [
+    switch (model.locationMode) {
+      LocationMode.live => SitePermissionBadge.realLocation,
+      LocationMode.spoof => SitePermissionBadge.spoofLocation,
+      LocationMode.off => null,
+    },
+    switch (model.effectiveCameraMode) {
+      CameraAccessMode.real => SitePermissionBadge.realCamera,
+      CameraAccessMode.virtual => SitePermissionBadge.virtualCamera,
+      CameraAccessMode.ask || CameraAccessMode.block => null,
+    },
+    if (model.effectiveMicrophoneMode == MicrophoneAccessMode.virtual)
+      SitePermissionBadge.virtualMicrophone,
+    if (model.effectiveBackgroundAudioEnabled)
+      SitePermissionBadge.backgroundAudio,
+  ].nonNulls.toList();
+}
+
+/// True when the badge means a real device is opened for the site, as
+/// opposed to a synthetic stream or a background-playback exemption.
+bool _isRealDeviceAccess(SitePermissionBadge badge) =>
+    badge == SitePermissionBadge.realLocation ||
+    badge == SitePermissionBadge.realCamera;
+
+/// Filled glyph for a real device, outlined for a synthetic stream.
+IconData sitePermissionBadgeIcon(SitePermissionBadge badge) => switch (badge) {
+      SitePermissionBadge.realLocation => Icons.location_on,
+      SitePermissionBadge.spoofLocation => Icons.location_on_outlined,
+      SitePermissionBadge.realCamera => Icons.videocam,
+      SitePermissionBadge.virtualCamera => Icons.videocam_outlined,
+      SitePermissionBadge.virtualMicrophone => Icons.mic_none,
+      SitePermissionBadge.backgroundAudio => Icons.music_note,
+    };
+
+/// Localized "<setting>: <value>" label, e.g. "Camera access: Always allow".
+/// Composed from the per-site settings strings the badge mirrors rather than
+/// new copy, so the badge and the settings screen can never drift apart.
+String sitePermissionBadgeLabel(AppLocalizations loc, SitePermissionBadge badge) {
+  const separator = ': ';
+  return switch (badge) {
+    SitePermissionBadge.realLocation =>
+      '${loc.siteSettingsGeolocation}$separator${loc.siteSettingsLocationLive}',
+    SitePermissionBadge.spoofLocation =>
+      '${loc.siteSettingsGeolocation}$separator${loc.siteSettingsLocationStatic}',
+    SitePermissionBadge.realCamera =>
+      '${loc.siteSettingsCameraAccess}$separator${loc.siteSettingsCameraAccessAllow}',
+    SitePermissionBadge.virtualCamera =>
+      '${loc.siteSettingsCameraAccess}$separator${loc.siteSettingsCameraAccessVirtual}',
+    SitePermissionBadge.virtualMicrophone =>
+      '${loc.siteSettingsMicrophoneAccess}$separator${loc.siteSettingsMicrophoneAccessVirtual}',
+    SitePermissionBadge.backgroundAudio => loc.siteSettingsBackgroundAudio,
+  };
+}
+
+/// Row of permission badges for [model], or an empty box when the site holds
+/// none. Sized for the drawer's site tiles: [iconSize] defaults to the
+/// smallest legible glyph, and [overlay] paints a scrim so the strip stays
+/// readable on top of a favicon.
+class SitePermissionBadges extends StatelessWidget {
+  const SitePermissionBadges({
+    super.key,
+    required this.model,
+    this.iconSize = 10,
+    this.overlay = false,
+  });
+
+  final WebViewModel model;
+  final double iconSize;
+  final bool overlay;
+
+  @override
+  Widget build(BuildContext context) {
+    final badges = sitePermissionBadges(model);
+    if (badges.isEmpty) return const SizedBox.shrink();
+
+    final theme = Theme.of(context);
+    final loc = AppLocalizations.of(context);
+    final strip = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // No Tooltip: the strip sits inside the drawer tile's long-press
+        // gestures (context menu, drag-to-reorder) and must not compete for
+        // them. The label rides `semanticLabel` instead.
+        for (final badge in badges)
+          Padding(
+            padding: EdgeInsets.symmetric(horizontal: iconSize * 0.05),
+            child: Icon(
+              sitePermissionBadgeIcon(badge),
+              size: iconSize,
+              semanticLabel: sitePermissionBadgeLabel(loc, badge),
+              color: _isRealDeviceAccess(badge)
+                  ? theme.colorScheme.error
+                  : theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+      ],
+    );
+
+    if (!overlay) return strip;
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: iconSize * 0.2, vertical: 1),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface.withValues(alpha: 0.85),
+        borderRadius: BorderRadius.circular(iconSize),
+      ),
+      child: strip,
+    );
+  }
+}

--- a/openspec/specs/site-permission-badges/spec.md
+++ b/openspec/specs/site-permission-badges/spec.md
@@ -1,0 +1,133 @@
+# Site Permission Badges Specification
+
+## Purpose
+
+Make it visible, at a glance in the drawer, which sites currently hold a
+capture or background-playback grant. Those grants are per-site, settled
+once (from a popup or the settings screen) and then applied silently
+forever after — so without a surface that names them, a user who allowed
+their camera on one banking site months ago has no way to notice it short
+of opening every site's settings.
+
+The badges are a *read-only projection* of state other specs own:
+
+- [`per-site-location`](../per-site-location/spec.md) — `locationMode`
+- [`web-camera-access`](../web-camera-access/spec.md) — `cameraMode`
+- [`web-microphone-access`](../web-microphone-access/spec.md) — `microphoneMode`
+- [`background-audio`](../background-audio/spec.md) — `backgroundAudioEnabled`
+
+They add no state, no persistence and no decision of their own. Two kinds
+of grant are distinguished, because they differ in what the site can
+actually observe:
+
+- **Real device access** — the OS opens a sensor for the site (live
+  location fix, device camera). Rendered in the theme's error color.
+- **Simulated access** — the app satisfies the request with data the user
+  supplied (static coordinates, a picked image/video, a looped audio
+  clip); no device is opened. Rendered muted. There is no real-microphone
+  mode in the app (MIC-001), so every microphone badge is of this kind.
+
+## Status
+
+- **Status**: Completed
+
+---
+
+## Requirements
+
+### Requirement: PERMBADGE-001 — Badge Set Derives From Effective Per-Site State
+
+`sitePermissionBadges(WebViewModel)`
+([lib/widgets/site_permission_badges.dart](../../../lib/widgets/site_permission_badges.dart))
+SHALL return exactly the grants the site currently holds, in the fixed
+order location, camera, microphone, background audio:
+
+| Badge | Condition |
+|---|---|
+| `realLocation` | `locationMode == LocationMode.live` |
+| `spoofLocation` | `locationMode == LocationMode.spoof` |
+| `realCamera` | `effectiveCameraMode == CameraAccessMode.real` |
+| `virtualCamera` | `effectiveCameraMode == CameraAccessMode.virtual` |
+| `virtualMicrophone` | `effectiveMicrophoneMode == MicrophoneAccessMode.virtual` |
+| `backgroundAudio` | `effectiveBackgroundAudioEnabled` |
+
+Undecided (`ask`), denied (`block`) and `LocationMode.off` SHALL produce
+no badge: a badge means "this site has been granted something", never
+"this site once asked". The `effective*` getters are read, never the raw
+fields, so an archive-tier site (ARCH-006) shows no badge for a grant the
+archive fold disables while the stored intent survives underneath.
+
+#### Scenario: A site with no grants shows nothing
+
+**Given** a site with `locationMode == off`, `cameraMode == ask`, `microphoneMode == ask` and background audio off
+**When** its drawer tile renders
+**Then** no permission badge is drawn
+
+#### Scenario: Blocked is not a grant
+
+**Given** a site with `cameraMode == block` and `microphoneMode == block`
+**When** its drawer tile renders
+**Then** no permission badge is drawn
+
+#### Scenario: Every grant is surfaced in a stable order
+
+**Given** a site with `locationMode == live`, `cameraMode == real`, `microphoneMode == virtual` and background audio on
+**When** its drawer tile renders
+**Then** the badges read location, camera, microphone, background audio in that order
+
+#### Scenario: Archive-tier sites show no capture badge
+
+**Given** an archive-tier site whose stored `cameraMode == real`, `microphoneMode == virtual` and background audio on
+**When** its drawer tile renders
+**Then** no badge is drawn, because the effective modes are `block` / `block` / off
+**And** the stored modes are unchanged for when the site leaves the archive
+
+### Requirement: PERMBADGE-002 — Real Device Access Reads Differently From Simulated
+
+A badge for a grant that opens a real device (`realLocation`,
+`realCamera`) SHALL render with the filled glyph in
+`ColorScheme.error`; a badge for a grant the app satisfies synthetically
+(`spoofLocation`, `virtualCamera`, `virtualMicrophone`) and the
+background-audio badge SHALL render with an outlined glyph in
+`ColorScheme.onSurfaceVariant`. No two badges SHALL share a glyph.
+
+#### Scenario: A simulated camera does not look like an open camera
+
+**Given** one site with `cameraMode == real` and another with `cameraMode == virtual`
+**When** both drawer tiles render
+**Then** the first shows a filled camera glyph in the error color
+**And** the second shows an outlined camera glyph in the muted color
+
+### Requirement: PERMBADGE-003 — Badges Are Labelled From The Settings Strings
+
+Each badge SHALL carry a `semanticLabel` of the form
+`<setting name>: <selected value>` (background audio, which is a
+boolean, uses its setting name alone), composed from the same
+`AppLocalizations` keys the per-site settings screen renders. No badge
+introduces new user-facing copy, so a badge can never describe a grant
+differently from the screen that sets it. The strip SHALL NOT install a
+`Tooltip` or any other gesture recognizer: it sits inside the tile's
+long-press gestures (context menu, drag-to-reorder) and must not compete
+with them.
+
+#### Scenario: Screen-reader users get the grant named
+
+**Given** a site with `cameraMode == real`
+**When** its badge is read by a screen reader
+**Then** the label is `siteSettingsCameraAccess` + ": " + `siteSettingsCameraAccessAllow`
+
+### Requirement: PERMBADGE-004 — Both Drawer Tile Paths Show Badges
+
+The drawer renders site tiles through one shared content builder
+(`_buildSiteGridTileContent` in [lib/main.dart](../../../lib/main.dart)),
+used by both the reorderable (drag-enabled) and static tile paths, so a
+grant is equally visible whichever path is active and in either tile
+layout (narrow icon-over-name, wide icon-beside-name). In the narrow
+layout the badge strip is anchored to the favicon's bottom edge, which is
+the only place with room; the tile's height is unchanged by the badges.
+
+#### Scenario: Reordering does not hide grants
+
+**Given** a webspace whose sites can be reordered by drag
+**When** the drawer renders a site holding a camera grant
+**Then** its badge is drawn, exactly as in a non-reorderable webspace

--- a/test/js/l10n_no_hardcoded_text.test.js
+++ b/test/js/l10n_no_hardcoded_text.test.js
@@ -34,6 +34,7 @@ const migrated = new Set([
   'lib/widgets/find_toolbar.dart',
   'lib/widgets/hint_button.dart',
   'lib/widgets/root_messenger.dart',
+  'lib/widgets/site_permission_badges.dart',
   'lib/widgets/stats_banner.dart',
   'lib/widgets/tab_bar_corner_button.dart',
   'lib/widgets/untrusted_cert_prompt.dart',

--- a/test/site_permission_badges_test.dart
+++ b/test/site_permission_badges_test.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/l10n/gen/app_localizations.dart';
+import 'package:webspace/settings/camera.dart';
+import 'package:webspace/settings/location.dart';
+import 'package:webspace/settings/microphone.dart';
+import 'package:webspace/web_view_model.dart';
+import 'package:webspace/widgets/site_permission_badges.dart';
+
+WebViewModel site({
+  LocationMode locationMode = LocationMode.off,
+  CameraAccessMode cameraMode = CameraAccessMode.ask,
+  MicrophoneAccessMode microphoneMode = MicrophoneAccessMode.ask,
+  bool backgroundAudioEnabled = false,
+  bool isArchiveTier = false,
+}) =>
+    WebViewModel(
+      initUrl: 'https://example.com',
+      locationMode: locationMode,
+      cameraMode: cameraMode,
+      microphoneMode: microphoneMode,
+      backgroundAudioEnabled: backgroundAudioEnabled,
+      isArchiveTier: isArchiveTier,
+    );
+
+void main() {
+  group('sitePermissionBadges (PERMBADGE-001)', () {
+    test('a site with nothing granted has no badges', () {
+      expect(sitePermissionBadges(site()), isEmpty);
+    });
+
+    test('undecided and blocked grants stay invisible', () {
+      final model = site(
+        cameraMode: CameraAccessMode.block,
+        microphoneMode: MicrophoneAccessMode.block,
+      );
+      expect(sitePermissionBadges(model), isEmpty);
+      expect(
+        sitePermissionBadges(site(
+          cameraMode: CameraAccessMode.ask,
+          microphoneMode: MicrophoneAccessMode.ask,
+        )),
+        isEmpty,
+      );
+    });
+
+    test('each grant maps to its badge', () {
+      expect(sitePermissionBadges(site(locationMode: LocationMode.live)),
+          [SitePermissionBadge.realLocation]);
+      expect(sitePermissionBadges(site(locationMode: LocationMode.spoof)),
+          [SitePermissionBadge.spoofLocation]);
+      expect(sitePermissionBadges(site(cameraMode: CameraAccessMode.real)),
+          [SitePermissionBadge.realCamera]);
+      expect(sitePermissionBadges(site(cameraMode: CameraAccessMode.virtual)),
+          [SitePermissionBadge.virtualCamera]);
+      expect(
+          sitePermissionBadges(
+              site(microphoneMode: MicrophoneAccessMode.virtual)),
+          [SitePermissionBadge.virtualMicrophone]);
+      expect(sitePermissionBadges(site(backgroundAudioEnabled: true)),
+          [SitePermissionBadge.backgroundAudio]);
+    });
+
+    test('badges keep a stable order: capture first, playback last', () {
+      final model = site(
+        locationMode: LocationMode.live,
+        cameraMode: CameraAccessMode.real,
+        microphoneMode: MicrophoneAccessMode.virtual,
+        backgroundAudioEnabled: true,
+      );
+      expect(sitePermissionBadges(model), [
+        SitePermissionBadge.realLocation,
+        SitePermissionBadge.realCamera,
+        SitePermissionBadge.virtualMicrophone,
+        SitePermissionBadge.backgroundAudio,
+      ]);
+    });
+
+    test('archive-tier sites show no capture or playback badge (ARCH-006)', () {
+      final model = site(
+        cameraMode: CameraAccessMode.real,
+        microphoneMode: MicrophoneAccessMode.virtual,
+        backgroundAudioEnabled: true,
+        isArchiveTier: true,
+      );
+      expect(sitePermissionBadges(model), isEmpty);
+      // Stored intent survives for when the site leaves the archive.
+      expect(model.cameraMode, CameraAccessMode.real);
+      expect(model.microphoneMode, MicrophoneAccessMode.virtual);
+    });
+
+    test('no two badges share a glyph', () {
+      final icons =
+          SitePermissionBadge.values.map(sitePermissionBadgeIcon).toSet();
+      expect(icons, hasLength(SitePermissionBadge.values.length));
+    });
+  });
+
+  group('SitePermissionBadges widget (PERMBADGE-002)', () {
+    Widget harness(WebViewModel model) => MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: SitePermissionBadges(model: model)),
+        );
+
+    testWidgets('renders nothing for a site without grants', (tester) async {
+      await tester.pumpWidget(harness(site()));
+      expect(find.byType(Icon), findsNothing);
+    });
+
+    testWidgets('renders one icon per grant', (tester) async {
+      await tester.pumpWidget(harness(site(
+        locationMode: LocationMode.live,
+        cameraMode: CameraAccessMode.real,
+        microphoneMode: MicrophoneAccessMode.virtual,
+        backgroundAudioEnabled: true,
+      )));
+      expect(find.byType(Icon), findsNWidgets(4));
+      expect(
+          find.byIcon(sitePermissionBadgeIcon(SitePermissionBadge.realCamera)),
+          findsOneWidget);
+    });
+
+    testWidgets('real device access is tinted apart from simulated grants',
+        (tester) async {
+      await tester.pumpWidget(harness(site(
+        cameraMode: CameraAccessMode.real,
+        microphoneMode: MicrophoneAccessMode.virtual,
+      )));
+      final context = tester.element(find.byType(SitePermissionBadges));
+      final scheme = Theme.of(context).colorScheme;
+      final real = tester.widget<Icon>(find
+          .byIcon(sitePermissionBadgeIcon(SitePermissionBadge.realCamera)));
+      final simulated = tester.widget<Icon>(find.byIcon(
+          sitePermissionBadgeIcon(SitePermissionBadge.virtualMicrophone)));
+      expect(real.color, scheme.error);
+      expect(simulated.color, scheme.onSurfaceVariant);
+    });
+
+    testWidgets('each badge carries a localized label for screen readers',
+        (tester) async {
+      await tester.pumpWidget(harness(site(cameraMode: CameraAccessMode.real)));
+      final context = tester.element(find.byType(SitePermissionBadges));
+      final loc = AppLocalizations.of(context);
+      final icon = tester.widget<Icon>(find.byType(Icon));
+      expect(icon.semanticLabel,
+          '${loc.siteSettingsCameraAccess}: ${loc.siteSettingsCameraAccessAllow}');
+      expect(icon.semanticLabel,
+          sitePermissionBadgeLabel(loc, SitePermissionBadge.realCamera));
+    });
+  });
+}


### PR DESCRIPTION
Location, camera, microphone and background-audio grants were only visible
by opening each site's settings, so an allow given once was invisible
afterwards. Real device access (live location, real camera) reads apart
from grants the app satisfies synthetically.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UnDrfMWXaZfjgSEUz73Nc4