### PR TITLE
Fix iOS media controls for sites without background audio

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -781,6 +781,9 @@ jobs:
                 # BGAUDIO-006 media notification is an Android foreground
                 # service; the emulator job owns it.
                 [ "$(basename "$t")" = "background_audio_media_notification_test.dart" ] && continue
+                # BGAUDIO-009 needs a real media pipeline (WPE crash-loops on
+                # one here) and a real pauseTimers(); emulator job owns it.
+                [ "$(basename "$t")" = "background_audio_media_stop_test.dart" ] && continue
                 echo "::group::$t"
                 # Hard per-test wall-clock cap: a WebView mount can deadlock
                 # the platform thread below Dart timeout layer, which would
@@ -1049,6 +1052,8 @@ jobs:
             [ "$(basename "$t")" = "camera_test.dart" ] && continue
             # Android-only BGAUDIO-006 media foreground service; emulator job.
             [ "$(basename "$t")" = "background_audio_media_notification_test.dart" ] && continue
+            # Android-only BGAUDIO-009 media-stop tier; emulator job.
+            [ "$(basename "$t")" = "background_audio_media_stop_test.dart" ] && continue
             echo "::group::$t"
             if [ -n "$TIMEOUT" ]; then
               "$TIMEOUT" -k 30s 12m fvm flutter test "$t" -d macos --ci || status=$?

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MediaSessionPlugin.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MediaSessionPlugin.kt
@@ -11,8 +11,9 @@ import io.flutter.plugin.common.MethodChannel
  * other way as `onTransport` invocations (see [MediaTransportDispatcher]),
  * which the Dart side turns into JS `play()`/`pause()` on the owning webview.
  *
- * iOS has no analogue: there the `.playback` AVAudioSession + the system's
- * own Now Playing UI cover this, driven by the page's own MediaSession.
+ * iOS answers the same channel from `ios/Runner/MediaSessionPlugin.swift`,
+ * which maps start/update/stop onto MPNowPlayingInfoCenter + the remote
+ * command centre (BGAUDIO-010).
  */
 class MediaSessionPlugin(
     private val context: Context,

--- a/integration_test/background_audio_media_stop_test.dart
+++ b/integration_test/background_audio_media_stop_test.dart
@@ -1,0 +1,200 @@
+// Media-stop integration test (BGAUDIO-009).
+//
+// The bug this reproduces: a site with Background audio OFF kept sounding
+// after it lost the screen, because neither pause stops the media pipeline —
+// `pauseWebView()` and `pauseForAppLifecycle()` freeze JS timers, and decoding
+// runs independently of the JS thread. On iOS that also left the system Now
+// Playing controls up for a site the user never opted in for (the `audio`
+// UIBackgroundModes entry is app-wide), with a play button that reached a
+// frozen page.
+//
+// The observable is the fixture's own beacon: it carries the media element's
+// `paused` flag and `currentTime`, so "did the audio actually stop" is read
+// off the page rather than off a Dart-side flag.
+//
+// Android emulator tier only (scripts/run_android_background_audio_tests.sh):
+// it needs a real media pipeline, which WPE in the headless Linux container
+// crash-loops on, and it needs `pauseTimers()` to be genuinely implemented so
+// the JS-freeze half of the interleaving is real. Self-skips elsewhere; the
+// Linux/macOS integration loops exclude it by name.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webspace/main.dart' as app;
+import 'package:webspace/demo_data.dart';
+import 'package:webspace/services/log_service.dart';
+import 'package:webspace/services/media_session_service.dart';
+import 'package:webspace/web_view_model.dart';
+import 'package:webspace/webspace_model.dart';
+
+import 'fixtures/background_audio_fixture.dart';
+
+class _Beacon {
+  _Beacon(this.ticks, this.playState, this.currentTime, this.paused);
+  final int ticks;
+  final String playState;
+  final double currentTime;
+  final String paused;
+
+  bool get mediaLive => paused == 'false' && currentTime > 0;
+  bool get mediaStopped => paused == 'true';
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late HttpServer server;
+  late int port;
+  final beacons = <_Beacon>[];
+
+  void log(String m) {
+    // ignore: avoid_print
+    print('[bgaudio-stop] $m');
+  }
+
+  setUpAll(() async {
+    server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    port = server.port;
+    server.listen((req) {
+      if (req.uri.path == '/beacon') {
+        final q = req.uri.queryParameters;
+        beacons.add(_Beacon(
+          int.tryParse(q['ticks'] ?? '') ?? -1,
+          q['audio'] ?? '?',
+          double.tryParse(q['t'] ?? '') ?? 0,
+          q['paused'] ?? '?',
+        ));
+        req.response
+          ..statusCode = 204
+          ..close();
+        return;
+      }
+      final res = req.response..headers.contentType = ContentType.html;
+      res.write(backgroundAudioFixtureHtml);
+      res.close();
+    });
+
+    isDemoMode = true;
+    // Background audio deliberately OFF: this test is about what the toggle
+    // promises when it is not set. `?media=stream` is a muted <video> off a
+    // canvas captureStream — the same element surface and paused/currentTime
+    // predicate as real audio, with no audio device (the emulator boots
+    // -noaudio).
+    final plainSite = WebViewModel(
+      siteId: 'bg-media-stop',
+      initUrl: 'http://127.0.0.1:$port/?media=stream',
+      name: 'Plain Media Site',
+    );
+    SharedPreferences.setMockInitialValues({
+      'webViewModels': [jsonEncode(plainSite.toJson())],
+    });
+  });
+
+  tearDownAll(() async {
+    await server.close(force: true);
+  });
+
+  testWidgets('a site without the toggle stops playing when the app backgrounds',
+      (tester) async {
+    if (!Platform.isAndroid) {
+      log('skipped: needs a real media pipeline + pauseTimers() '
+          '(platform=${Platform.operatingSystem})');
+      return;
+    }
+
+    app.main();
+    await tester.pumpAndSettle(const Duration(seconds: 30));
+
+    // Wall-clock wait that keeps pumping frames: a live WebView wedges
+    // pumpAndSettle, and beacon arrival needs no frames but UI transitions do.
+    Future<void> pumpUntil(
+      bool Function() predicate, {
+      Duration timeout = const Duration(seconds: 60),
+      Duration step = const Duration(milliseconds: 250),
+      required String description,
+    }) async {
+      final deadline = DateTime.now().add(timeout);
+      while (DateTime.now().isBefore(deadline)) {
+        await tester.pump(step);
+        await tester.runAsync(
+            () => Future<void>.delayed(const Duration(milliseconds: 50)));
+        if (predicate()) return;
+      }
+      throw StateError(
+          'Timed out after ${timeout.inSeconds}s waiting for: $description');
+    }
+
+    await tester.tap(find.byKey(const ValueKey(kAllWebspaceId)));
+    await tester.pumpAndSettle(const Duration(seconds: 5));
+    final tile = find.text('Plain Media Site');
+    expect(tile, findsOneWidget, reason: 'site should appear in the drawer');
+    await tester.tap(tile);
+
+    await pumpUntil(
+      () => beacons.any((b) => b.mediaLive),
+      description: 'the fixture media to report itself playing '
+          '(last beacon: ${beacons.isEmpty ? "none" : beacons.last.playState})',
+    );
+    final playingAt = beacons.lastWhere((b) => b.mediaLive).currentTime;
+    log('media live at t=$playingAt');
+
+    // The toggle is off, so nothing should have armed the media bridge — the
+    // BGAUDIO-007 line that tells "toggle off" from "bridge broken".
+    final mediaLines = LogService.instance.allEntriesMerged
+        .where((e) => e.tag == 'MediaSession')
+        .map((e) => e.message)
+        .toList();
+    expect(mediaLines.any((m) => m.contains('Bridge armed')), isFalse,
+        reason: 'the media-session shim is only injected for sites with the '
+            'Background audio toggle on');
+
+    beacons.clear();
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.runAsync(
+        () => Future<void>.delayed(const Duration(seconds: 3)));
+
+    // BGAUDIO-002's negative control already owns "the JS froze"; what matters
+    // here is that the media stop was dispatched BEFORE that freeze, so the
+    // page comes back with its player stopped rather than still running.
+    expect(
+      LogService.instance.allEntriesMerged.any((e) =>
+          e.tag == 'Lifecycle' &&
+          e.message.contains('jsPause=true') &&
+          e.message.contains('bgAudio=0')),
+      isTrue,
+      reason: 'a site without the toggle takes the ordinary background path',
+    );
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+    beacons.clear();
+
+    await pumpUntil(
+      () => beacons.isNotEmpty,
+      description: 'beacons to resume after foregrounding',
+    );
+    final after = beacons.first;
+    log('after resume: paused=${after.paused} t=${after.currentTime}');
+    expect(after.mediaStopped, isTrue,
+        reason: 'the media of a site with Background audio OFF must be paused '
+            'when the app goes to background (BGAUDIO-009). A `paused=false` '
+            'here is the reported bug: the audio kept playing, and on iOS the '
+            'system transport controls stayed up with it.');
+    expect(after.currentTime, lessThanOrEqualTo(playingAt + 1.0),
+        reason: 'a paused element does not advance its currentTime');
+
+    // The other half of the report: no media surface for a site that never
+    // opted in. Android raises the notification only from a shim report, and
+    // no shim was injected — this asserts the end of that chain.
+    final posted = await tester
+        .runAsync(() => MediaSessionService.instance.notificationPosted());
+    expect(posted, isFalse,
+        reason: 'no media notification may exist for a site with the toggle '
+            'off');
+  });
+}

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7AC100012ED2DC5600515811 /* LocationPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC100002ED2DC5600515811 /* LocationPlugin.swift */; };
 		7AC100032ED2DC5600515813 /* BackgroundTaskPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC100022ED2DC5600515813 /* BackgroundTaskPlugin.swift */; };
+		7AC300012ED2DC5600515830 /* MediaSessionPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC300002ED2DC5600515830 /* MediaSessionPlugin.swift */; };
 		7AC200012ED2DC5600515820 /* ShortcutsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC200002ED2DC5600515820 /* ShortcutsPlugin.swift */; };
 		7AC200032ED2DC5600515821 /* WebSpaceAppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC200022ED2DC5600515821 /* WebSpaceAppIntents.swift */; };
 		897CA73A1B12E395D36631E0 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEB686F40D1F327FFB98EB57 /* Pods_Runner.framework */; };
@@ -76,6 +77,7 @@
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AC100002ED2DC5600515811 /* LocationPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationPlugin.swift; sourceTree = "<group>"; };
 		7AC100022ED2DC5600515813 /* BackgroundTaskPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundTaskPlugin.swift; sourceTree = "<group>"; };
+		7AC300002ED2DC5600515830 /* MediaSessionPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaSessionPlugin.swift; sourceTree = "<group>"; };
 		7AC200002ED2DC5600515820 /* ShortcutsPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShortcutsPlugin.swift; sourceTree = "<group>"; };
 		7AC200022ED2DC5600515821 /* WebSpaceAppIntents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebSpaceAppIntents.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -204,6 +206,7 @@
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				7AC100002ED2DC5600515811 /* LocationPlugin.swift */,
 				7AC100022ED2DC5600515813 /* BackgroundTaskPlugin.swift */,
+				7AC300002ED2DC5600515830 /* MediaSessionPlugin.swift */,
 				7AC200002ED2DC5600515820 /* ShortcutsPlugin.swift */,
 				7AC200022ED2DC5600515821 /* WebSpaceAppIntents.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
@@ -468,6 +471,7 @@
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				7AC100012ED2DC5600515811 /* LocationPlugin.swift in Sources */,
 				7AC100032ED2DC5600515813 /* BackgroundTaskPlugin.swift in Sources */,
+				7AC300012ED2DC5600515830 /* MediaSessionPlugin.swift in Sources */,
 				7AC200012ED2DC5600515820 /* ShortcutsPlugin.swift in Sources */,
 				7AC200032ED2DC5600515821 /* WebSpaceAppIntents.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -8,6 +8,7 @@ import UserNotifications
   private var locationPlugin: LocationPlugin?
   private var backgroundTaskPlugin: BackgroundTaskPlugin?
   private var shortcutsPlugin: ShortcutsPlugin?
+  private var mediaSessionPlugin: MediaSessionPlugin?
   private var pendingShareUrl: String?
 
   private let shareChannelName = "org.codeberg.theoden8.webspace/share_intent"
@@ -37,6 +38,7 @@ import UserNotifications
       locationPlugin = LocationPlugin(messenger: controller.binaryMessenger)
       backgroundTaskPlugin = BackgroundTaskPlugin(messenger: controller.binaryMessenger)
       shortcutsPlugin = ShortcutsPlugin(messenger: controller.binaryMessenger)
+      mediaSessionPlugin = MediaSessionPlugin(messenger: controller.binaryMessenger)
       if let registrar = self.registrar(forPlugin: "WebSpaceShortcutsLink") {
         registrar.register(
           ShortcutsLinkViewFactory(messenger: controller.binaryMessenger),

--- a/ios/Runner/MediaSessionPlugin.swift
+++ b/ios/Runner/MediaSessionPlugin.swift
@@ -27,6 +27,11 @@ class MediaSessionPlugin: NSObject {
   /// second `start` cannot stack a duplicate handler per command.
   private var commandTargets: [(MPRemoteCommand, Any)] = []
 
+  /// Whether we currently publish Now Playing info for a background-audio
+  /// site. Gates the interruption recovery: an interruption that ends while
+  /// the app owns nothing must not activate a session or ask a page to play.
+  private var publishing = false
+
   init(messenger: FlutterBinaryMessenger) {
     self.channel = FlutterMethodChannel(
       name: "org.codeberg.theoden8.webspace/media_session",
@@ -35,6 +40,68 @@ class MediaSessionPlugin: NSObject {
     super.init()
     self.channel.setMethodCallHandler { [weak self] call, result in
       self?.handle(call: call, result: result)
+    }
+    // An interruption (a call, Siri, another app taking the session) leaves
+    // OUR session deactivated. Nothing re-activates it on its own, so without
+    // this the audio never comes back and the transport controls keep reaching
+    // a page whose engine has no session to play into — "I hit play and
+    // nothing happens" (BGAUDIO-011).
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(handleInterruption(_:)),
+      name: AVAudioSession.interruptionNotification,
+      object: nil
+    )
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(handleMediaServicesReset(_:)),
+      name: AVAudioSession.mediaServicesWereResetNotification,
+      object: nil
+    )
+  }
+
+  deinit {
+    NotificationCenter.default.removeObserver(self)
+  }
+
+  /// AVAudioSession posts on an arbitrary queue; everything this plugin owns
+  /// lives on main (BUG-007), so hop before reading or writing any of it.
+  @objc private func handleInterruption(_ note: Notification) {
+    guard let info = note.userInfo,
+          let raw = info[AVAudioSessionInterruptionTypeKey] as? UInt,
+          let type = AVAudioSession.InterruptionType(rawValue: raw) else { return }
+    let options = AVAudioSession.InterruptionOptions(
+      rawValue: info[AVAudioSessionInterruptionOptionKey] as? UInt ?? 0)
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self else { return }
+      switch type {
+      case .began:
+        self.reportSessionState("audio session interrupted")
+      case .ended:
+        guard self.publishing else {
+          self.reportSessionState("interruption ended, nothing of ours playing")
+          return
+        }
+        self.activateSession()
+        self.reportSessionState("interruption ended, session re-activated")
+        // `shouldResume` is the system saying the user expects playback back.
+        if options.contains(.shouldResume) {
+          self.channel.invokeMethod("onTransport", arguments: ["action": "play"])
+        }
+      @unknown default:
+        break
+      }
+    }
+  }
+
+  /// The media server can die and restart; every session and Now Playing entry
+  /// dies with it. Re-establish ours rather than looking alive with nothing
+  /// behind it.
+  @objc private func handleMediaServicesReset(_ note: Notification) {
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self, self.publishing else { return }
+      self.activateSession()
+      self.reportSessionState("media services reset, session re-established")
     }
   }
 
@@ -87,11 +154,13 @@ class MediaSessionPlugin: NSObject {
     let center = MPNowPlayingInfoCenter.default()
     center.nowPlayingInfo = info
     center.playbackState = playing ? .playing : .paused
+    publishing = true
 
     registerCommands()
   }
 
   private func stop() {
+    publishing = false
     unregisterCommands()
     let center = MPNowPlayingInfoCenter.default()
     center.nowPlayingInfo = nil
@@ -116,8 +185,22 @@ class MediaSessionPlugin: NSObject {
       try session.setCategory(.playback, mode: .default)
       try session.setActive(true)
     } catch {
-      NSLog("MediaSessionPlugin: audio session activation failed: \(error)")
+      reportSessionState("activation failed", error: error)
     }
+  }
+
+  /// Send one non-sensitive line (no site name, URL or track metadata) into the
+  /// app's own log. Whether the session is `.playback` and active at the moment
+  /// audio dies is the fact that separates every candidate cause here, and it
+  /// is invisible in a device console the user cannot easily export.
+  private func reportSessionState(_ what: String, error: Error? = nil) {
+    let session = AVAudioSession.sharedInstance()
+    var message = "\(what) [category=\(session.category.rawValue) "
+      + "otherAudio=\(session.isOtherAudioPlaying)]"
+    if let error = error {
+      message += " error=\(error.localizedDescription)"
+    }
+    channel.invokeMethod("onSessionState", arguments: ["message": message])
   }
 
   /// Play / pause / stop only, mirroring the Android notification's controls:

--- a/ios/Runner/MediaSessionPlugin.swift
+++ b/ios/Runner/MediaSessionPlugin.swift
@@ -1,0 +1,149 @@
+import AVFoundation
+import Flutter
+import MediaPlayer
+import UIKit
+
+/// BGAUDIO-010 iOS bridge for
+/// [`MediaSessionService`](../../lib/services/media_session_service.dart), the
+/// counterpart of `MediaSessionPlugin.kt`. Dart calls `start`/`update` with the
+/// playing site's metadata and `stop` to tear the session down; transport taps
+/// travel back as `onTransport`, which Dart applies to the owning webview's
+/// primary media element.
+///
+/// iOS previously left this to WebKit: it publishes its own Now Playing info
+/// for whatever a page is playing. That is invisible to the app — nothing knew
+/// the controls were up, nothing could clear them, and a play tap had no route
+/// back into the page. Owning the Now Playing info and the remote commands
+/// makes the surface ours for the sites the user opted in for.
+///
+/// All state is confined to the main queue: the channel handler already runs
+/// there, and the remote-command targets — whose queue is not documented — hop
+/// onto it before touching anything (BUG-007 — partially synchronized native
+/// state is the recurring failure).
+class MediaSessionPlugin: NSObject {
+  private let channel: FlutterMethodChannel
+
+  /// Handles for the targets we added, so teardown removes exactly ours and a
+  /// second `start` cannot stack a duplicate handler per command.
+  private var commandTargets: [(MPRemoteCommand, Any)] = []
+
+  init(messenger: FlutterBinaryMessenger) {
+    self.channel = FlutterMethodChannel(
+      name: "org.codeberg.theoden8.webspace/media_session",
+      binaryMessenger: messenger
+    )
+    super.init()
+    self.channel.setMethodCallHandler { [weak self] call, result in
+      self?.handle(call: call, result: result)
+    }
+  }
+
+  private func handle(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "start", "update":
+      let args = call.arguments as? [String: Any] ?? [:]
+      startOrUpdate(
+        title: args["title"] as? String ?? "",
+        artist: args["artist"] as? String ?? "",
+        album: args["album"] as? String ?? "",
+        playing: args["playing"] as? Bool ?? false,
+        artwork: (args["artwork"] as? FlutterStandardTypedData)?.data
+      )
+      result(nil)
+    case "stop":
+      stop()
+      result(nil)
+    case "isNotificationActive":
+      // Read back from the OS rather than from a local flag: the point of
+      // BGAUDIO-007's probe is to tell "we asked" from "it is on screen".
+      result(MPNowPlayingInfoCenter.default().nowPlayingInfo != nil)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func startOrUpdate(
+    title: String,
+    artist: String,
+    album: String,
+    playing: Bool,
+    artwork: Data?
+  ) {
+    // Only reached for a site whose page is (or just was) playing, so WebKit
+    // has already taken audio focus — activating here does not interrupt
+    // anyone who was not going to be interrupted anyway. It is what makes the
+    // system attribute the Now Playing controls to us.
+    let session = AVAudioSession.sharedInstance()
+    do {
+      try session.setCategory(.playback, mode: .default)
+      try session.setActive(true)
+    } catch {
+      NSLog("MediaSessionPlugin: audio session activation failed: \(error)")
+    }
+
+    var info: [String: Any] = [
+      MPMediaItemPropertyTitle: title,
+      MPMediaItemPropertyArtist: artist,
+      MPNowPlayingInfoPropertyPlaybackRate: playing ? 1.0 : 0.0,
+    ]
+    if !album.isEmpty {
+      info[MPMediaItemPropertyAlbumTitle] = album
+    }
+    if let bytes = artwork, let image = UIImage(data: bytes) {
+      info[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(boundsSize: image.size) { _ in
+        image
+      }
+    }
+    let center = MPNowPlayingInfoCenter.default()
+    center.nowPlayingInfo = info
+    center.playbackState = playing ? .playing : .paused
+
+    registerCommands()
+  }
+
+  private func stop() {
+    unregisterCommands()
+    let center = MPNowPlayingInfoCenter.default()
+    center.nowPlayingInfo = nil
+    center.playbackState = .stopped
+    // The session is deliberately NOT deactivated here: another loaded site
+    // may still be sounding in the foreground, and `setActive(false)` would
+    // cut it. `BackgroundTaskService.setBackgroundAudioActive(false)` puts the
+    // category back to `.ambient` (BGAUDIO-003), which is the posture that
+    // matters once no background-audio site is loaded.
+  }
+
+  /// Play / pause / stop only, mirroring the Android notification's controls:
+  /// next/previous have no universal web mechanism. `togglePlayPause` is
+  /// deliberately left to WebKit — it registers its own targets for the media
+  /// it plays, and a toggle handled twice cancels itself out, while a play or
+  /// a pause handled twice is idempotent.
+  private func registerCommands() {
+    guard commandTargets.isEmpty else { return }
+    let center = MPRemoteCommandCenter.shared()
+    let commands: [(MPRemoteCommand, String)] = [
+      (center.playCommand, "play"),
+      (center.pauseCommand, "pause"),
+      (center.stopCommand, "stop"),
+    ]
+    for (command, action) in commands {
+      command.isEnabled = true
+      let target = command.addTarget { [weak self] _ in
+        // The command centre does not promise a queue, and a Flutter channel
+        // must be spoken to from the platform (main) thread.
+        DispatchQueue.main.async {
+          self?.channel.invokeMethod("onTransport", arguments: ["action": action])
+        }
+        return .success
+      }
+      commandTargets.append((command, target))
+    }
+  }
+
+  private func unregisterCommands() {
+    for (command, target) in commandTargets {
+      command.removeTarget(target)
+    }
+    commandTargets.removeAll()
+  }
+}

--- a/ios/Runner/MediaSessionPlugin.swift
+++ b/ios/Runner/MediaSessionPlugin.swift
@@ -69,17 +69,7 @@ class MediaSessionPlugin: NSObject {
     playing: Bool,
     artwork: Data?
   ) {
-    // Only reached for a site whose page is (or just was) playing, so WebKit
-    // has already taken audio focus — activating here does not interrupt
-    // anyone who was not going to be interrupted anyway. It is what makes the
-    // system attribute the Now Playing controls to us.
-    let session = AVAudioSession.sharedInstance()
-    do {
-      try session.setCategory(.playback, mode: .default)
-      try session.setActive(true)
-    } catch {
-      NSLog("MediaSessionPlugin: audio session activation failed: \(error)")
-    }
+    activateSession()
 
     var info: [String: Any] = [
       MPMediaItemPropertyTitle: title,
@@ -113,6 +103,23 @@ class MediaSessionPlugin: NSObject {
     // matters once no background-audio site is loaded.
   }
 
+  /// An ACTIVE `.playback` session is what keeps iOS from suspending the
+  /// process once the app leaves the foreground, and what lets playback begin
+  /// again from the background. Setting only the category (BGAUDIO-003) is not
+  /// enough for either: the page stops when the app is suspended, and a play
+  /// tap then resumes nothing. Called when the page reports playback, and
+  /// before a play command is handed to the page — at that moment the session
+  /// may have been torn down by the very suspension we are recovering from.
+  private func activateSession() {
+    let session = AVAudioSession.sharedInstance()
+    do {
+      try session.setCategory(.playback, mode: .default)
+      try session.setActive(true)
+    } catch {
+      NSLog("MediaSessionPlugin: audio session activation failed: \(error)")
+    }
+  }
+
   /// Play / pause / stop only, mirroring the Android notification's controls:
   /// next/previous have no universal web mechanism. `togglePlayPause` is
   /// deliberately left to WebKit — it registers its own targets for the media
@@ -132,7 +139,14 @@ class MediaSessionPlugin: NSObject {
         // The command centre does not promise a queue, and a Flutter channel
         // must be spoken to from the platform (main) thread.
         DispatchQueue.main.async {
-          self?.channel.invokeMethod("onTransport", arguments: ["action": action])
+          guard let self = self else { return }
+          // Before the page is asked to play, not after: WebKit cannot start
+          // playback against an inactive session, and the tap that gets here
+          // is usually the one meant to bring the app back from suspension.
+          if action == "play" {
+            self.activateSession()
+          }
+          self.channel.invokeMethod("onTransport", arguments: ["action": action])
         }
         return .success
       }

--- a/ios/Runner/MediaSessionPlugin.swift
+++ b/ios/Runner/MediaSessionPlugin.swift
@@ -118,7 +118,8 @@ class MediaSessionPlugin: NSObject {
       )
       result(nil)
     case "stop":
-      stop()
+      let args = call.arguments as? [String: Any] ?? [:]
+      stop(deactivate: args["deactivate"] as? Bool ?? false)
       result(nil)
     case "isNotificationActive":
       // Read back from the OS rather than from a local flag: the point of
@@ -159,17 +160,27 @@ class MediaSessionPlugin: NSObject {
     registerCommands()
   }
 
-  private func stop() {
+  /// [deactivate] is passed when no background-audio site is loaded at all and
+  /// the pages that were sounding have just been paused (BGAUDIO-009). Only
+  /// then is giving the session up safe — and only then does it work: clearing
+  /// the metadata alone leaves an entry WebKit repopulates for whatever it was
+  /// playing, which is the transport control with a dead play button. Ordinary
+  /// teardown keeps the session, since another loaded site may still be
+  /// sounding in the foreground.
+  private func stop(deactivate: Bool = false) {
     publishing = false
     unregisterCommands()
     let center = MPNowPlayingInfoCenter.default()
     center.nowPlayingInfo = nil
     center.playbackState = .stopped
-    // The session is deliberately NOT deactivated here: another loaded site
-    // may still be sounding in the foreground, and `setActive(false)` would
-    // cut it. `BackgroundTaskService.setBackgroundAudioActive(false)` puts the
-    // category back to `.ambient` (BGAUDIO-003), which is the posture that
-    // matters once no background-audio site is loaded.
+    guard deactivate else { return }
+    let session = AVAudioSession.sharedInstance()
+    do {
+      try session.setActive(false, options: .notifyOthersOnDeactivation)
+    } catch {
+      // Busy means something is still playing — leave it be, and say so.
+      reportSessionState("session release declined", error: error)
+    }
   }
 
   /// An ACTIVE `.playback` session is what keeps iOS from suspending the

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1633,6 +1633,14 @@ class _WebSpacePageState extends State<WebSpacePage>
       if (pausePlan.flushCookies) {
         unawaited(_cookieManager.flush());
       }
+      // BGAUDIO-012: a site that stops itself when the page reports hidden
+      // (YouTube and every other player built for a tab) needs to be told the
+      // app is backgrounded before the OS tells the page it is hidden.
+      for (final i in _loadedIndices) {
+        if (i < 0 || i >= _webViewModels.length) continue;
+        if (!_webViewModels[i].effectiveBackgroundAudioEnabled) continue;
+        unawaited(_webViewModels[i].setBackgroundPlayback(true));
+      }
       // BGAUDIO-009: a site the user never opted in for must not keep sounding
       // through a backgrounded app (and keep the system transport controls up
       // with it). Dispatched before the JS pause below — on iOS that pause
@@ -1677,6 +1685,13 @@ class _WebSpacePageState extends State<WebSpacePage>
     } else if (state == AppLifecycleState.resumed) {
       if (_maskBackground) {
         setState(() => _maskBackground = false);
+      }
+      // BGAUDIO-012: hand the page's own visibility back. On screen again, a
+      // player that pauses when hidden should behave exactly as it always has.
+      for (final i in _loadedIndices) {
+        if (i < 0 || i >= _webViewModels.length) continue;
+        if (!_webViewModels[i].effectiveBackgroundAudioEnabled) continue;
+        unawaited(_webViewModels[i].setBackgroundPlayback(false));
       }
       // Open the warm-start repaint window before the async resume sequence, so
       // a late SurfaceView re-attach (which surfaces as a metrics change) is

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4892,11 +4892,13 @@ class _WebSpacePageState extends State<WebSpacePage>
       break;
     }
     await BackgroundTaskService.instance.setBackgroundAudioActive(any);
-    // BGAUDIO-006: with no background-audio site loaded there is nothing to
-    // drive the Android media notification — tear it down. While one is
-    // loaded the notification is raised/updated by its page-JS reports.
+    // With no background-audio site loaded there is nothing to drive the media
+    // surface — tear it down. On iOS that also removes the Now Playing entry
+    // WebKit publishes for any page that plays, which otherwise outlives the
+    // audio as a control that reaches nothing (BGAUDIO-009/010). While a site
+    // is loaded the surface is raised/updated by its page-JS reports.
     if (!any) {
-      await MediaSessionService.instance.stopAll();
+      await MediaSessionService.instance.clearOsMediaSurface();
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1650,6 +1650,7 @@ class _WebSpacePageState extends State<WebSpacePage>
         if (i < 0 || i >= _webViewModels.length) continue;
         mediaStops[i] = _webViewModels[i].pauseMediaPlayback();
       }
+      final allMediaStopped = Future.wait(mediaStops.values);
       if (pausePlan.jsPauseIndex != null) {
         final idx = pausePlan.jsPauseIndex!;
         final stopped = mediaStops.remove(idx) ?? Future<void>.value();
@@ -1680,8 +1681,11 @@ class _WebSpacePageState extends State<WebSpacePage>
       // before the process gets backgrounded.
       unawaited(_updateBackgroundRefreshSchedule());
       // iOS: make sure the `.playback` audio session is live before the
-      // process is backgrounded, or active webview audio gets cut.
-      unawaited(_updateBackgroundAudioSession());
+      // process is backgrounded, or active webview audio gets cut. Sequenced
+      // after the media stops above: WebKit republishes its Now Playing entry
+      // when it processes a pause, so clearing before that lands leaves the
+      // controls on screen (BGAUDIO-009).
+      unawaited(allMediaStopped.then((_) => _updateBackgroundAudioSession()));
     } else if (state == AppLifecycleState.resumed) {
       if (_maskBackground) {
         setState(() => _maskBackground = false);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1633,9 +1633,23 @@ class _WebSpacePageState extends State<WebSpacePage>
       if (pausePlan.flushCookies) {
         unawaited(_cookieManager.flush());
       }
+      // BGAUDIO-009: a site the user never opted in for must not keep sounding
+      // through a backgrounded app (and keep the system transport controls up
+      // with it). Dispatched before the JS pause below — on iOS that pause
+      // blocks the page's JS thread, so this would sit queued behind it.
+      final mediaStops = <int, Future<void>>{};
+      for (final i in pausePlan.mediaPauseIndices) {
+        if (i < 0 || i >= _webViewModels.length) continue;
+        mediaStops[i] = _webViewModels[i].pauseMediaPlayback();
+      }
       if (pausePlan.jsPauseIndex != null) {
-        _lifecyclePauseFuture =
-            _webViewModels[pausePlan.jsPauseIndex!].pauseForAppLifecycle();
+        final idx = pausePlan.jsPauseIndex!;
+        final stopped = mediaStops.remove(idx) ?? Future<void>.value();
+        _lifecyclePauseFuture = stopped
+            .then((_) => _webViewModels[idx].pauseForAppLifecycle());
+      }
+      for (final stop in mediaStops.values) {
+        unawaited(stop);
       }
       if (pausePlan.captureStateIndex != null) {
         final model = _webViewModels[pausePlan.captureStateIndex!];
@@ -3568,8 +3582,12 @@ class _WebSpacePageState extends State<WebSpacePage>
         await _captureStateBytes(_webViewModels[_currentIndex!]);
         if (version != _setCurrentIndexVersion) return;
         // Before the pause: on iOS the per-instance pause blocks the page's
-        // JS thread, so the stop would sit queued behind it (CAM-012).
+        // JS thread, so the stop would sit queued behind it (CAM-012), and so
+        // would the media pause (BGAUDIO-009, no-op for background-audio
+        // sites).
         await _webViewModels[_currentIndex!].stopRealCameraCapture();
+        if (version != _setCurrentIndexVersion) return;
+        await _webViewModels[_currentIndex!].pauseMediaPlayback();
         if (version != _setCurrentIndexVersion) return;
         await _webViewModels[_currentIndex!].pauseWebView();
         if (version != _setCurrentIndexVersion) return;
@@ -3753,8 +3771,11 @@ class _WebSpacePageState extends State<WebSpacePage>
     // Pause the previously active webview to save resources
     if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
       // Before the pause: on iOS the per-instance pause blocks the page's JS
-      // thread, so the stop would sit queued behind it (CAM-012).
+      // thread, so the stop would sit queued behind it (CAM-012), and so would
+      // the media pause (BGAUDIO-009, no-op for background-audio sites).
       await _webViewModels[_currentIndex!].stopRealCameraCapture();
+      if (version != _setCurrentIndexVersion) return;
+      await _webViewModels[_currentIndex!].pauseMediaPlayback();
       if (version != _setCurrentIndexVersion) return;
       await _webViewModels[_currentIndex!].pauseWebView();
       if (version != _setCurrentIndexVersion) return;
@@ -3829,8 +3850,10 @@ class _WebSpacePageState extends State<WebSpacePage>
       // would survive. Bound to a local model: the pause runs a microtask
       // later, by which point _webViewModels may have been reindexed.
       final model = _webViewModels[i];
-      unawaited(
-          model.stopRealCameraCapture().then((_) => model.pauseWebView()));
+      unawaited(model
+          .stopRealCameraCapture()
+          .then((_) => model.pauseMediaPlayback())
+          .then((_) => model.pauseWebView()));
     }
 
     // Auto-enter fullscreen if the site has fullscreenMode enabled

--- a/lib/services/app_lifecycle_engine.dart
+++ b/lib/services/app_lifecycle_engine.dart
@@ -24,6 +24,14 @@ class LifecycleBackgroundPlan {
   /// site is captured.
   final int? captureStateIndex;
 
+  /// Loaded sites whose page media must be paused before the app leaves the
+  /// foreground (BGAUDIO-009), ascending. Every loaded site WITHOUT
+  /// `effectiveBackgroundAudioEnabled` is listed: the JS pause freezes timers
+  /// but never the media pipeline, so without this a site the user never
+  /// opted in for keeps sounding through a backgrounded app and holds the
+  /// system transport controls up.
+  final List<int> mediaPauseIndices;
+
   /// Commit pending cookie writes to disk before the OS can kill the process.
   /// Chromium's cookie store commits lazily, so a session cookie set moments
   /// before backgrounding is otherwise lost on a swipe-kill and the user
@@ -34,6 +42,7 @@ class LifecycleBackgroundPlan {
     required this.jsPauseIndex,
     required this.captureStateIndex,
     required this.flushCookies,
+    this.mediaPauseIndices = const [],
   });
 }
 
@@ -71,10 +80,30 @@ class AppLifecycleEngine {
     return false;
   }
 
+  /// Loaded, in-bounds sites without background audio, ascending
+  /// (BGAUDIO-009). The exemption is per-site, unlike the JS-pause veto: one
+  /// opted-in site keeps its own audio, it does not license every other
+  /// loaded site to keep playing too.
+  static List<int> mediaPauseIndices({
+    required int siteCount,
+    required Set<int> loadedIndices,
+    required bool Function(int index) backgroundAudioEnabled,
+  }) {
+    final out = <int>[];
+    for (final i in loadedIndices) {
+      if (i < 0 || i >= siteCount) continue;
+      if (backgroundAudioEnabled(i)) continue;
+      out.add(i);
+    }
+    out.sort();
+    return out;
+  }
+
   /// Plan for `AppLifecycleState.paused`. The active site's JS timers pause
   /// only when it is loaded, NOT a notification site, and no loaded site has
   /// background audio enabled; restore-state is captured for any loaded
-  /// active site.
+  /// active site. Every loaded site without background audio has its media
+  /// paused (BGAUDIO-009), the active one included.
   ///
   /// [cookieFlushSupported] is the caller's platform answer for
   /// `CookieManager.flush` (Android only — everywhere else the platform
@@ -90,6 +119,11 @@ class AppLifecycleEngine {
     required bool cookieFlushSupported,
   }) {
     final flushCookies = cookieFlushSupported && loadedIndices.isNotEmpty;
+    final mediaPause = mediaPauseIndices(
+      siteCount: siteCount,
+      loadedIndices: loadedIndices,
+      backgroundAudioEnabled: backgroundAudioEnabled,
+    );
     final active = activeLoadedIndex(
       currentIndex: currentIndex,
       siteCount: siteCount,
@@ -100,6 +134,7 @@ class AppLifecycleEngine {
         jsPauseIndex: null,
         captureStateIndex: null,
         flushCookies: flushCookies,
+        mediaPauseIndices: mediaPause,
       );
     }
     final skipJsPause = notificationsEnabled(active) ||
@@ -112,6 +147,7 @@ class AppLifecycleEngine {
       jsPauseIndex: skipJsPause ? null : active,
       captureStateIndex: active,
       flushCookies: flushCookies,
+      mediaPauseIndices: mediaPause,
     );
   }
 

--- a/lib/services/media_session_service.dart
+++ b/lib/services/media_session_service.dart
@@ -192,11 +192,28 @@ class MediaSessionService {
   Future<void> clearOsMediaSurface() async {
     if (!_enabled) return;
     if (_active) {
-      await _stop();
-      return;
+      _active = false;
+      _ownerSiteId = null;
+      _ownerRunJs = null;
+      _ownerFrame = null;
+      _visibilityChecked = false;
+      LogService.instance.log('MediaSession', 'Notification torn down');
     }
-    await _invoke('stop', null);
+    // `deactivate`: with nothing of ours left playing, giving the audio
+    // session up is what actually drops the app out of the OS media surface —
+    // clearing the metadata alone leaves an entry the engine can repopulate.
+    // Ignored by the Android side, which owns its notification outright.
+    await _invoke('stop', {'deactivate': true});
+    // WebKit republishes its own Now Playing info when it finishes processing
+    // the pause that preceded this, which can land after the first clear.
+    await Future<void>.delayed(debugSurfaceReclearDelay);
+    await _invoke('stop', {'deactivate': true});
   }
+
+  /// How long to wait before the second clear. Short enough to run inside the
+  /// window a backgrounding app still gets.
+  @visibleForTesting
+  static Duration debugSurfaceReclearDelay = const Duration(milliseconds: 400);
 
   /// Tear the notification down when [siteId] owns it. Called when the site is
   /// unloaded/disposed or its background-audio toggle goes off.

--- a/lib/services/media_session_service.dart
+++ b/lib/services/media_session_service.dart
@@ -7,15 +7,18 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:webspace/services/log_service.dart';
 
-/// BGAUDIO-006 Dart bridge to the Android foreground media service
-/// (`MediaSessionPlugin.kt` / `MediaPlaybackService.kt`). A background-audio
+/// BGAUDIO-006 Dart bridge to the native media session. A background-audio
 /// site's page-JS reports its playback state here (via the `wsMediaSession`
 /// handler wired in `webview.dart`); this service raises/refreshes/tears down
-/// the media notification and routes transport controls back to the owning
+/// the OS media surface and routes transport controls back to the owning
 /// webview's JS.
 ///
-/// Android-only. iOS relies on its `.playback` AVAudioSession + the system
-/// Now Playing UI, which the page's own MediaSession populates.
+/// Two native implementations behind one channel: Android's `mediaPlayback`
+/// foreground service + `MediaStyle` notification (`MediaSessionPlugin.kt` /
+/// `MediaPlaybackService.kt`), and iOS's Now Playing info + remote command
+/// centre (`MediaSessionPlugin.swift`, BGAUDIO-010). Leaving iOS to WebKit's
+/// own Now Playing handling meant nothing in the app knew the controls were
+/// up, and a transport tap had no route back into the page.
 class MediaSessionService {
   static final MediaSessionService instance = MediaSessionService._();
   MediaSessionService._();
@@ -46,7 +49,13 @@ class MediaSessionService {
   @visibleForTesting
   static bool? debugEnabledOverride;
 
-  bool get _enabled => debugEnabledOverride ?? Platform.isAndroid;
+  bool get _enabled =>
+      debugEnabledOverride ?? (Platform.isAndroid || Platform.isIOS);
+
+  /// Whether this platform has a native media session behind the channel.
+  /// Read by `webview.dart` to gate the shim + handler injection, so the
+  /// bridge is armed exactly where something consumes its reports.
+  bool get isSupported => _enabled;
 
   /// Whether the notification is currently raised as far as Dart knows.
   /// [notificationPosted] is the authority on whether the OS actually shows it.

--- a/lib/services/media_session_service.dart
+++ b/lib/services/media_session_service.dart
@@ -84,6 +84,19 @@ class MediaSessionService {
     _initialized = true;
     if (!_enabled) return;
     _channel.setMethodCallHandler((call) async {
+      if (call.method == 'onSessionState') {
+        // Non-sensitive audio-session state from the native side (BGAUDIO-011).
+        // "The audio stopped in the background" has several candidate causes
+        // that look identical from Dart; the session's category and active
+        // state at that moment separate them, and this puts them in the App
+        // Logs export the user can actually send.
+        final args = call.arguments;
+        final message = (args is Map ? args['message'] : null) as String? ?? '';
+        if (message.isNotEmpty) {
+          LogService.instance.log('MediaSession', 'Audio session: $message');
+        }
+        return null;
+      }
       if (call.method == 'onTransport') {
         final args = call.arguments;
         final action = (args is Map ? args['action'] : null) as String? ?? '';

--- a/lib/services/media_session_service.dart
+++ b/lib/services/media_session_service.dart
@@ -152,6 +152,39 @@ class MediaSessionService {
     }
   }
 
+  /// A transport control the page could not act on (BGAUDIO-007). Reported by
+  /// the shim only on failure, and logged non-sensitively (no site name, URL or
+  /// track metadata): "I hit play and nothing happened" is otherwise silent at
+  /// every layer, and the engine's own reason — a rejected `play()` promise, or
+  /// no element left to drive — is the one fact that separates a dead bridge
+  /// from a refusal.
+  Future<void> reportControlFailure({
+    required String action,
+    required String error,
+  }) async {
+    if (!_enabled) return;
+    LogService.instance.log(
+      'MediaSession',
+      'Transport "$action" did not reach playback: $error',
+      level: LogLevel.warning,
+    );
+  }
+
+  /// Clear whatever media surface the OS shows for this app, including one we
+  /// never raised. On iOS WebKit publishes its own Now Playing info for any
+  /// page that plays audio, so a site WITHOUT the background-audio toggle can
+  /// leave transport controls behind after its media is stopped — controls
+  /// whose buttons reach a site the app is no longer keeping alive. Called
+  /// when no background-audio site is loaded (BGAUDIO-009/010).
+  Future<void> clearOsMediaSurface() async {
+    if (!_enabled) return;
+    if (_active) {
+      await _stop();
+      return;
+    }
+    await _invoke('stop', null);
+  }
+
   /// Tear the notification down when [siteId] owns it. Called when the site is
   /// unloaded/disposed or its background-audio toggle goes off.
   Future<void> stopForSite(String siteId) async {

--- a/lib/services/media_session_shim.dart
+++ b/lib/services/media_session_shim.dart
@@ -1,6 +1,9 @@
-/// Media-session bridge shim (BGAUDIO-006, Android only).
+/// Media-session bridge shim (BGAUDIO-006).
 ///
-/// Injected at DOCUMENT_START (all frames) on sites with `backgroundAudioEnabled`.
+/// Injected at DOCUMENT_START (all frames) on sites with
+/// `backgroundAudioEnabled`, on every platform with a native media session
+/// behind the channel (Android's foreground service, iOS's Now Playing info —
+/// see `MediaSessionService.isSupported`).
 /// It watches every `<audio>`/`<video>` element plus `navigator.mediaSession`
 /// metadata and reports `{frame, playing, title, artist, album, artwork}` to
 /// Dart via the `wsMediaSession` handler, coalesced on a short debounce. Dart
@@ -158,3 +161,39 @@ String buildMediaSessionShim() => r'''
   setInterval(schedule, 3000);
 })();
 ''';
+
+/// BGAUDIO-009: pause every playing media element in a page.
+///
+/// Evaluated on a site WITHOUT the background-audio toggle when it loses the
+/// screen. Neither pause stops the media pipeline (it runs independently of
+/// the JS thread), so without this the site keeps sounding — and keeps the OS
+/// transport surface up — after the user moved on.
+///
+/// Same-origin iframes are walked too: a player in one is common and
+/// `evaluateJavascript` reaches only the main frame. Cross-origin frames and
+/// elements that never entered the DOM (`new Audio(src).play()`) are out of
+/// reach without a shim injected on every site; that gap is documented in the
+/// background-audio spec.
+String buildMediaPauseJs() => r"""
+(function() {
+  var docs = [document];
+  try {
+    for (var f = 0; f < window.frames.length; f++) {
+      try {
+        var d = window.frames[f].document;
+        if (d) docs.push(d);
+      } catch (e) {}
+    }
+  } catch (e) {}
+  for (var i = 0; i < docs.length; i++) {
+    try {
+      var els = docs[i].querySelectorAll('audio,video');
+      for (var j = 0; j < els.length; j++) {
+        try {
+          if (!els[j].paused) els[j].pause();
+        } catch (e) {}
+      }
+    } catch (e) {}
+  }
+})();
+""";

--- a/lib/services/media_session_shim.dart
+++ b/lib/services/media_session_shim.dart
@@ -144,15 +144,42 @@ String buildMediaSessionShim() => r'''
   }
   scan();
 
+  // A transport control that reaches nothing is silent otherwise: the page
+  // looks idle, the OS controls stay up, and no log says whether the element
+  // was missing or the engine refused to start playback (WebKit rejects
+  // play() with NotAllowedError in cases the user experiences as "I hit play
+  // and nothing happened"). Reported only on failure, so the ordinary
+  // playing/paused report sequence is unchanged.
+  function reportControl(action, error) {
+    try {
+      window.flutter_inappwebview.callHandler('wsMediaSession', {
+        frame: frameId, control: action, error: error,
+      });
+    } catch (e) {}
+  }
+
   // Dart -> page. Driving the media element directly fires the same
   // play/pause the site listens to, so its own MediaSession stays in sync.
   window.__wsMediaControl = function(action) {
     try {
       var el = primaryMedia();
-      if (!el) return;
-      if (action === 'play') el.play();
-      else if (action === 'pause' || action === 'stop') el.pause();
-    } catch (e) {}
+      if (!el) {
+        reportControl(action, 'no-media-element');
+        return;
+      }
+      if (action === 'play') {
+        var p = el.play();
+        if (p && p.catch) {
+          p.catch(function(e) {
+            reportControl('play', (e && e.name) || 'unknown');
+          });
+        }
+      } else if (action === 'pause' || action === 'stop') {
+        el.pause();
+      }
+    } catch (e) {
+      reportControl(action, (e && e.name) || 'unknown');
+    }
     schedule();
   };
 

--- a/lib/services/media_session_shim.dart
+++ b/lib/services/media_session_shim.dart
@@ -116,6 +116,10 @@ String buildMediaSessionShim() => r'''
     el.__wsMediaAttached = true;
     ['play', 'playing', 'pause', 'ended', 'loadedmetadata', 'emptied']
       .forEach(function(ev) { el.addEventListener(ev, schedule, true); });
+    // Remembered so the background watchdog can tell "the page stopped this
+    // while we were not looking" from "this never played".
+    el.addEventListener('playing', function() { el.__wsWasPlaying = true; }, true);
+    el.addEventListener('ended', function() { el.__wsWasPlaying = false; }, true);
   }
   function scan() { mediaEls().forEach(attach); }
 
@@ -175,6 +179,9 @@ String buildMediaSessionShim() => r'''
           });
         }
       } else if (action === 'pause' || action === 'stop') {
+        // The user asked for silence: the watchdog must not fight it.
+        var all = mediaEls();
+        for (var i = 0; i < all.length; i++) all[i].__wsWasPlaying = false;
         el.pause();
       }
     } catch (e) {
@@ -182,6 +189,113 @@ String buildMediaSessionShim() => r'''
     }
     schedule();
   };
+
+  // BGAUDIO-012: keeping the app alive is not enough for a site that stops
+  // itself. A backgrounded app's page is told it is hidden, and players built
+  // for a tab (YouTube among them) pause on `visibilitychange` / `pagehide` by
+  // their own choice. While the app is backgrounded with this site's toggle on,
+  // report the page as visible, swallow those events before the page's own
+  // handlers see them, and re-issue play() if something paused anyway.
+  var bgActive = false;
+  var resumeTries = 0;
+  var watchTimer = null;
+
+  function realGetter(name) {
+    var d = Object.getOwnPropertyDescriptor(Document.prototype, name);
+    return d && d.get ? d.get : null;
+  }
+  function maskVisibility() {
+    ['hidden', 'webkitHidden'].forEach(function(name) {
+      var real = realGetter(name);
+      try {
+        Object.defineProperty(document, name, {
+          configurable: true,
+          get: function() {
+            if (bgActive) return false;
+            return real ? real.call(document) : false;
+          },
+        });
+      } catch (e) {}
+    });
+    ['visibilityState', 'webkitVisibilityState'].forEach(function(name) {
+      var real = realGetter(name);
+      try {
+        Object.defineProperty(document, name, {
+          configurable: true,
+          get: function() {
+            if (bgActive) return 'visible';
+            return real ? real.call(document) : 'visible';
+          },
+        });
+      } catch (e) {}
+    });
+  }
+  maskVisibility();
+
+  // Capture phase on window runs before anything the page registers on
+  // document or window, so its own pause-on-hide handler never runs.
+  ['visibilitychange', 'webkitvisibilitychange', 'pagehide', 'freeze', 'blur']
+    .forEach(function(type) {
+      var swallow = function(e) {
+        if (!bgActive) return;
+        e.stopImmediatePropagation();
+      };
+      try { window.addEventListener(type, swallow, true); } catch (e) {}
+      try { document.addEventListener(type, swallow, true); } catch (e) {}
+    });
+
+  function watchdog() {
+    if (!bgActive) return;
+    var els = mediaEls();
+    for (var i = 0; i < els.length; i++) {
+      var el = els[i];
+      if (!el.__wsWasPlaying || !el.paused || el.ended) continue;
+      if (resumeTries >= 8) continue;
+      resumeTries++;
+      try {
+        var p = el.play();
+        if (p && p.catch) {
+          p.catch(function(e) {
+            reportControl('background-resume', (e && e.name) || 'unknown');
+          });
+        }
+      } catch (e) {
+        reportControl('background-resume', (e && e.name) || 'unknown');
+      }
+    }
+  }
+
+  function setBackground(on) {
+    on = !!on;
+    if (on === bgActive) { relayBackground(on); return; }
+    bgActive = on;
+    resumeTries = 0;
+    if (watchTimer) { clearInterval(watchTimer); watchTimer = null; }
+    if (on) watchTimer = setInterval(watchdog, 1000);
+    relayBackground(on);
+    schedule();
+  }
+
+  // `evaluateJavascript` reaches the main frame only, so the state has to be
+  // handed down. A frame that fakes this message can only make its own page
+  // report itself visible, on a site the user opted into background audio for.
+  function relayBackground(on) {
+    try {
+      for (var i = 0; i < window.frames.length; i++) {
+        try {
+          window.frames[i].postMessage({ __wsMediaBackground: !!on }, '*');
+        } catch (e) {}
+      }
+    } catch (e) {}
+  }
+  window.addEventListener('message', function(ev) {
+    var d = ev && ev.data;
+    if (d && typeof d === 'object' && '__wsMediaBackground' in d) {
+      setBackground(d.__wsMediaBackground);
+    }
+  }, true);
+
+  window.__wsMediaBackground = setBackground;
 
   // Reconcile periodically: covers `ended` via currentTime, SPA route swaps,
   // and metadata set after the first report.

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -3313,6 +3313,14 @@ class WebViewFactory {
             callback: (args) async {
               if (args.isEmpty || args[0] is! Map) return null;
               final data = Map<String, dynamic>.from(args[0] as Map);
+              final control = data['control'] as String?;
+              if (control != null) {
+                await MediaSessionService.instance.reportControlFailure(
+                  action: control,
+                  error: data['error'] as String? ?? 'unknown',
+                );
+                return null;
+              }
               await MediaSessionService.instance.report(
                 siteId: config.siteId!,
                 frame: data['frame'] as String? ?? '',

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -2052,7 +2052,9 @@ class WebViewFactory {
     }
 
     // BGAUDIO-006: media-session bridge shim on background-audio sites only.
-    if (config.siteId != null && config.backgroundAudioEnabled && Platform.isAndroid) {
+    if (config.siteId != null &&
+        config.backgroundAudioEnabled &&
+        MediaSessionService.instance.isSupported) {
       userScripts.add(inapp.UserScript(
         groupName: 'media_session_shim',
         source: '${buildMediaSessionShim()}\n;null;',
@@ -3305,7 +3307,7 @@ class WebViewFactory {
         }
         if (config.siteId != null &&
             config.backgroundAudioEnabled &&
-            Platform.isAndroid) {
+            MediaSessionService.instance.isSupported) {
           controller.addJavaScriptHandler(
             handlerName: 'wsMediaSession',
             callback: (args) async {

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -1715,6 +1715,26 @@ class WebViewModel {
     }
   }
 
+  /// Tell a background-audio site's page whether the app is backgrounded
+  /// (BGAUDIO-012), so its media-session shim can mask the page-visibility
+  /// APIs and re-issue `play()` if the page stopped itself anyway.
+  ///
+  /// A no-op for every other site: masking visibility for a page the user did
+  /// not opt in for would keep timers and players running that should stop.
+  /// Main frame only — the shim relays the state to its own subframes.
+  Future<void> setBackgroundPlayback(bool active) async {
+    if (!effectiveBackgroundAudioEnabled) return;
+    final c = controller;
+    if (c == null) return;
+    try {
+      await c.evaluateJavascript(
+        'if(window.__wsMediaBackground)window.__wsMediaBackground($active);',
+      );
+    } catch (_) {
+      // Controller may have been disposed
+    }
+  }
+
   /// Pause every playing media element in the page's main frame (BGAUDIO-009).
   ///
   /// A no-op for sites with [effectiveBackgroundAudioEnabled] — that toggle

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -15,6 +15,8 @@ import 'package:webspace/services/external_url_engine.dart';
 import 'package:webspace/services/html_cache_service.dart';
 import 'package:webspace/services/link_routing_service.dart' show LinkRoutingService;
 import 'package:webspace/services/log_service.dart';
+import 'package:webspace/services/media_session_service.dart';
+import 'package:webspace/services/media_session_shim.dart';
 import 'package:webspace/services/navigation_decision_engine.dart';
 import 'package:webspace/services/camera_decision_engine.dart';
 import 'package:webspace/services/microphone_decision_engine.dart';
@@ -1713,6 +1715,32 @@ class WebViewModel {
     }
   }
 
+  /// Pause every playing media element in the page's main frame (BGAUDIO-009).
+  ///
+  /// A no-op for sites with [effectiveBackgroundAudioEnabled] — that toggle
+  /// exists precisely to keep them sounding. For every other site this is what
+  /// makes "Background audio: off" mean anything: neither [pauseWebView] nor
+  /// [pauseForAppLifecycle] stops the media pipeline (they freeze JS timers,
+  /// see the pause spec), so without it a site the user never opted in for
+  /// keeps playing after it loses the screen and holds the OS transport
+  /// controls up with it.
+  ///
+  /// Same ordering constraint as [stopRealCameraCapture]: it must be
+  /// dispatched BEFORE the pause, since the iOS per-instance pause blocks the
+  /// page's JS thread and this would sit queued behind it. Main frame only
+  /// (`evaluateJavascript` targets it) — a player inside a cross-origin
+  /// subframe is accepted degradation, as in BGAUDIO-008.
+  Future<void> pauseMediaPlayback() async {
+    if (effectiveBackgroundAudioEnabled) return;
+    final c = controller;
+    if (c == null) return;
+    try {
+      await c.evaluateJavascript(buildMediaPauseJs());
+    } catch (_) {
+      // Controller may have been disposed
+    }
+  }
+
   /// Resume a previously paused webview when it becomes active again.
   Future<void> resumeWebView() async {
     if (controller == null) return;
@@ -1785,6 +1813,10 @@ class WebViewModel {
     webview = null;
     controller = null;
     resumeReload.reset();
+    // The player this site's media session was speaking for is gone with the
+    // webview. Without this the OS transport controls outlive it and their
+    // buttons reach nothing — a no-op unless this site owns them.
+    unawaited(MediaSessionService.instance.stopForSite(siteId));
   }
 
   /// Drop the in-memory cache (decoded image cache + HTTP response

--- a/openspec/specs/background-audio/spec.md
+++ b/openspec/specs/background-audio/spec.md
@@ -576,6 +576,54 @@ targets
 registered, because `MediaSessionService.isSupported` is true
 (regression test: `test/media_session_service_test.dart`)
 
+---
+
+### Requirement: BGAUDIO-011 — Interruptions Are Recovered, and the Session State Is in the Log
+
+An interruption (an incoming call, Siri, another app taking the session)
+deactivates the app's AVAudioSession. iOS does not restore it: audio stays
+dead, and every later transport tap reaches a page whose engine has no session
+to play into. `MediaSessionPlugin` SHALL therefore observe
+`AVAudioSession.interruptionNotification` and, while it publishes Now Playing
+info for a background-audio site, re-activate the session when an interruption
+ends — issuing a `play` transport when the system's `shouldResume` option says
+the user expects playback back. It SHALL also re-establish the session on
+`mediaServicesWereResetNotification`, since a media-server restart takes every
+session and Now Playing entry with it. Recovery SHALL NOT run when the app
+publishes nothing: activating a session (or asking a page to play) on behalf of
+a site that is not playing steals audio focus from whatever interrupted us.
+
+The plugin SHALL report its audio-session state to Dart (`onSessionState`),
+which logs one non-sensitive line per event (no site name, URL or track
+metadata) carrying the session's category and whether other audio is playing.
+Every candidate cause of "the audio stopped in the background" looks identical
+from Dart; the session's category and active state at that moment is what
+separates them, and a device console the user cannot export does not.
+
+All notification handling hops onto the main queue before touching plugin
+state, which is confined there (BUG-007).
+
+#### Scenario: Playback returns after a phone call
+
+**Given** a background-audio site is playing and the app publishes Now Playing
+**When** an interruption ends with `shouldResume`
+**Then** the session is re-activated and a `play` transport reaches the page
+**And** the App Logs carry the interruption and the re-activation
+
+#### Scenario: An interruption while nothing of ours plays changes nothing
+
+**Given** the app publishes no Now Playing info
+**When** an interruption ends
+**Then** no session is activated and no page is asked to play
+(regression test: `test/js/native_media_session_targets.test.js`)
+
+#### Scenario: The session state reaches an App Logs export
+
+**Given** the native side reports its session state
+**When** `MediaSessionService` receives `onSessionState`
+**Then** one `MediaSession` line carries the category and other-audio flag
+(regression test: `test/media_session_service_test.dart`)
+
 ## Limitations (documented, accepted)
 
 - **iOS without playback**: the audio session keeps the app alive only
@@ -629,7 +677,8 @@ registered, because `MediaSessionService.isSupported` is true
 
 - `openspec/specs/background-audio/spec.md` — this document.
 - `ios/Runner/MediaSessionPlugin.swift` — BGAUDIO-010 Now Playing info +
-  remote command centre behind the `media_session` channel.
+  remote command centre behind the `media_session` channel; BGAUDIO-011
+  interruption recovery and session-state reporting.
 - `integration_test/background_audio_lifecycle_test.dart` (exempt direction),
   `integration_test/background_audio_freeze_test.dart` (negative control),
   `integration_test/background_audio_media_notification_test.dart` (BGAUDIO-007

--- a/openspec/specs/background-audio/spec.md
+++ b/openspec/specs/background-audio/spec.md
@@ -392,13 +392,160 @@ notification is up
 **Then** the subframe becomes the owner and its later `playing: false` is
 honored
 
+---
+
+### Requirement: BGAUDIO-009 — A Site Without the Toggle Stops Sounding When It Loses the Screen
+
+Neither pause stops media: `pauseWebView()` and `pauseForAppLifecycle()` freeze
+JS timers, while the media pipeline runs independently of the JS thread (see
+"Pause Is Not a Security Boundary" in the pause spec). Left alone, a site the
+user never opted in for keeps playing after it loses the screen — and holds the
+OS transport surface up with it, which on iOS is the app-wide Now Playing
+control that the `audio` `UIBackgroundModes` entry (BGAUDIO-003) keeps alive
+for every site, not just the opted-in one. That is the toggle promising the
+opposite of what it does.
+
+`WebViewModel.pauseMediaPlayback()` SHALL pause every playing media element in
+the page's main frame, and SHALL early-return for a site whose
+`effectiveBackgroundAudioEnabled` is true. It SHALL be dispatched wherever a
+site loses the screen, always BEFORE the pause (the iOS per-instance pause
+blocks the page's JS thread, so it would otherwise sit queued behind it —
+the ordering constraint CAM-012 already carries):
+
+- the previously-active site on a site switch, and on going home;
+- the defensive sweep over other loaded sites at the tail of a switch;
+- every index in `LifecycleBackgroundPlan.mediaPauseIndices` on app background.
+
+`AppLifecycleEngine.backgroundPlan` SHALL populate `mediaPauseIndices` with
+every loaded, in-bounds site WITHOUT background audio, ascending. Unlike the
+JS-pause veto (BGAUDIO-002), the exemption here is per-site: one opted-in site
+keeps its own audio, it does not license every other loaded site to keep
+playing. Nothing is resumed on foreground — restarting audio the user did not
+ask for is worse than leaving it paused where they can hit play.
+
+The snippet ([`buildMediaPauseJs`](../../../lib/services/media_session_shim.dart))
+walks same-origin subframes itself, since `evaluateJavascript` reaches only
+the main frame. Out of reach, and accepted: cross-origin subframes (the same
+degradation as BGAUDIO-008's transport controls), and elements that never
+entered the DOM (`new Audio(src).play()`) — the detached registry that catches
+those lives in the media-session shim, which is injected only on sites that
+have the toggle ON. It SHALL NOT re-pause an element that is already paused:
+the page's own player listens for `pause` events.
+
+#### Scenario: Ordinary site stops when the app goes to background
+
+**Given** a site with Background audio OFF is playing audio
+**When** the app goes to background
+**Then** its index is in `mediaPauseIndices` and its media elements are paused
+**And** no Now Playing / media notification survives it
+
+#### Scenario: The opted-in site is untouched, its neighbours are not
+
+**Given** audio site B (`backgroundAudioEnabled`) and plain site A are both loaded
+**When** the app goes to background
+**Then** `mediaPauseIndices` names A only
+**And** B keeps playing (regression test: `test/app_lifecycle_engine_test.dart`)
+
+#### Scenario: The stop works against a real media pipeline
+
+**Given** an `<audio>` element playing in headless Chromium, plus one in a
+same-origin iframe
+**When** the dumped snippet is evaluated in the top frame
+**Then** both report `paused === true` and their `currentTime` stops advancing
+**And** evaluating it again fires no further `pause` events
+(regression test: `test/browser/media_pause_real_engine.test.js`)
+
+#### Scenario: A site without the toggle goes quiet across an app background
+
+**Given** the fixture site with Background audio OFF is playing `?media=stream`
+on the Android emulator
+**When** the test injects `AppLifecycleState.paused`, waits, then `resumed`
+**Then** the beacons that follow the resume report `paused=true` with an
+unchanged `currentTime`
+**And** `notificationPosted()` is false — no media surface for a site that
+never opted in
+(regression test: `integration_test/background_audio_media_stop_test.dart`)
+
+#### Scenario: Switching away from an ordinary site stops its audio
+
+**Given** plain site A is playing and the user switches to site B
+**Then** `pauseMediaPlayback()` runs on A before `pauseWebView()`
+**And** for a background-audio site the same call is a no-op
+(regression test: `test/webview_pause_lifecycle_test.dart`)
+
+---
+
+### Requirement: BGAUDIO-010 — iOS Owns Its Now Playing Info and Transport Controls
+
+On iOS the app SHALL answer the `media_session` channel from
+[`MediaSessionPlugin.swift`](../../../ios/Runner/MediaSessionPlugin.swift),
+mapping `start`/`update` onto `MPNowPlayingInfoCenter` (title/artist/album,
+artwork, `playbackState`) and `stop` onto clearing it, and SHALL route the
+`MPRemoteCommandCenter` play/pause/stop commands back as `onTransport` —
+the same path the Android notification's buttons take, ending in
+`window.__wsMediaControl(action)` on the owning webview.
+
+`MediaSessionService` SHALL therefore be enabled on iOS as well as Android,
+and `webview.dart` SHALL gate the shim injection and the `wsMediaSession`
+handler on `MediaSessionService.isSupported` rather than on Android
+specifically, so the bridge is armed exactly where something consumes its
+reports.
+
+Leaving this to WebKit — which publishes its own Now Playing info for
+whatever a page plays — left the app blind to a surface it could not clear
+and gave a transport tap no route into the page. Consequences of owning it:
+
+- `start`/`update` set the `.playback` category and activate the session.
+  Only a page that is already playing reaches them, so no audio focus is
+  taken that WebKit had not taken already.
+- `stop` does NOT deactivate the session: another loaded site may still be
+  sounding in the foreground, and `setActive(false)` would cut it. Reverting
+  the category is BGAUDIO-003's job.
+- Play / pause / stop only, as on Android. `togglePlayPause` is deliberately
+  left to WebKit's own targets: a toggle handled twice cancels itself out,
+  while a play or a pause handled twice is idempotent.
+- All plugin state is confined to the main queue — the channel handler and
+  the remote-command targets both run there (BUG-007).
+- `isNotificationActive` is answered from `MPNowPlayingInfoCenter.default()
+  .nowPlayingInfo != nil` (an OS read, not a local flag), keeping
+  BGAUDIO-007's `notificationPosted()` meaningful on iOS.
+- `disposeWebView()` SHALL call `stopForSite`: the player the session spoke
+  for is gone with the webview, and stale controls whose buttons reach
+  nothing are exactly the symptom this requirement exists to remove.
+
+#### Scenario: Lock-screen play resumes the page
+
+**Given** a background-audio site is paused with the iOS Now Playing controls up
+**When** the user taps play there
+**Then** `onTransport('play')` runs `window.__wsMediaControl('play')` on the
+owning webview, which plays its primary media element
+**And** the page's next report flips `playbackState` back to `.playing`
+
+#### Scenario: Unloading the owning site clears the controls
+
+**Given** the Now Playing controls are up for a background-audio site
+**When** that site's webview is disposed
+**Then** `stopForSite` clears `nowPlayingInfo` and removes the remote command
+targets
+
+#### Scenario: The bridge is armed on iOS
+
+**Given** a site with Background audio enabled on iOS
+**When** its webview is built
+**Then** the media-session shim is injected and the `wsMediaSession` handler is
+registered, because `MediaSessionService.isSupported` is true
+(regression test: `test/media_session_service_test.dart`)
+
 ## Limitations (documented, accepted)
 
 - **iOS without playback**: the audio session keeps the app alive only
   while audio is actually playing; a paused player suspends with the app
-  as usual. iOS surfaces its own Now Playing controls from the page's
-  MediaSession — the Android media service (BGAUDIO-006) is not mirrored
-  there.
+  as usual. The Now Playing controls stay up in that state (resumable, as
+  the Android notification does), and the tap that resumes them wakes the
+  app to deliver it.
+- **Subframe players**: the shim reports from any frame (BGAUDIO-008), but
+  the transport controls and BGAUDIO-009's media stop both run through
+  `evaluateJavascript`, which targets the main frame only.
 - The exemption trades battery for playback: an enabled site's JS runs
   whenever it is loaded. The toggle is per-site and off by default.
 
@@ -407,22 +554,29 @@ honored
 ### Modified
 
 - `lib/web_view_model.dart` — `backgroundAudioEnabled` field (+`effective*`
-  getter, toJson/fromJson), `pauseWebView()` early-return.
+  getter, toJson/fromJson), `pauseWebView()` early-return; BGAUDIO-009
+  `pauseMediaPlayback()`, BGAUDIO-010 `stopForSite` on dispose.
 - `lib/services/app_lifecycle_engine.dart` — `anyLoadedBackgroundAudio`,
-  plan/resume gating.
+  plan/resume gating; BGAUDIO-009 `mediaPauseIndices`.
 - `lib/main.dart` — engine callbacks, decision log line, retention tier,
-  `_updateBackgroundAudioSession` sync points.
+  `_updateBackgroundAudioSession` sync points; BGAUDIO-009 media stop at the
+  site-switch, going-home, sweep and app-background call sites.
 - `lib/services/background_task_service.dart` — `setBackgroundAudioActive`.
 - `ios/Runner/BackgroundTaskPlugin.swift`, `ios/Runner/Info.plist` —
   AVAudioSession category switch, `audio` background mode.
+- `ios/Runner/AppDelegate.swift`, `ios/Runner.xcodeproj/project.pbxproj` —
+  BGAUDIO-010 plugin registration.
 - `lib/screens/settings.dart` — per-site toggle (+ POST_NOTIFICATIONS request).
 - `lib/services/site_settings_qr_codec.dart` — QR-shareable key.
 - `lib/services/webview.dart` — `WebViewConfig.backgroundAudioEnabled`, media
   shim injection (+ the BGAUDIO-007 armed line), `wsMediaSession` handler.
+- `lib/services/media_session_shim.dart` — BGAUDIO-009 `buildMediaPauseJs`
+  (dumped to `test/js_fixtures/media_session/pause_media.js`).
 - `lib/services/media_session_shim.dart`, `lib/services/media_session_service.dart`
   — BGAUDIO-006 page-JS bridge + Dart channel bridge; BGAUDIO-007 detached-
   element registry, raise/teardown logging and the visibility check;
-  BGAUDIO-008 per-frame token and media-less-frame silence.
+  BGAUDIO-008 per-frame token and media-less-frame silence; BGAUDIO-010
+  `isSupported` (iOS enablement).
 - `android/app/src/main/kotlin/.../MediaPlaybackService.kt`,
   `.../MediaSessionPlugin.kt`, `MainActivity.kt`, `AndroidManifest.xml` —
   BGAUDIO-006 foreground media service + permissions; BGAUDIO-007
@@ -434,6 +588,8 @@ honored
 ### Added
 
 - `openspec/specs/background-audio/spec.md` — this document.
+- `ios/Runner/MediaSessionPlugin.swift` — BGAUDIO-010 Now Playing info +
+  remote command centre behind the `media_session` channel.
 - `integration_test/background_audio_lifecycle_test.dart` (exempt direction),
   `integration_test/background_audio_freeze_test.dart` (negative control),
   `integration_test/background_audio_media_notification_test.dart` (BGAUDIO-007
@@ -446,6 +602,9 @@ honored
   test as well as each subtest, and a case that plays real media costs seconds.
 - `scripts/run_android_background_audio_tests.sh` + the Android emulator CI
   wiring in `.github/workflows/build-and-test.yml`.
+- `integration_test/background_audio_media_stop_test.dart` (BGAUDIO-009
+  emulator tier) and `test/browser/media_pause_real_engine.test.js` (the same
+  snippet under real Chromium).
 
 ## Related Specs
 

--- a/openspec/specs/background-audio/spec.md
+++ b/openspec/specs/background-audio/spec.md
@@ -106,12 +106,13 @@ background-audio sites were loaded.
 On iOS the app SHALL declare the `audio` `UIBackgroundModes` entry, and
 SHALL hold the shared `AVAudioSession` in the `.playback` category while
 any loaded site has `effectiveBackgroundAudioEnabled` (reverting to
-`.ambient` when none does). `.playback` plus the background mode is what
-lets WKWebView media keep running after the app leaves the foreground;
-`.ambient` restores the respect-the-silent-switch default so ordinary
-sites don't sound through a muted phone. Only the category is set — the
-session is not force-activated, so the app never steals audio focus while
-nothing is playing.
+`.ambient` when none does). `.ambient` restores the respect-the-silent-switch default so ordinary
+sites don't sound through a muted phone. The category is not force-activated
+here, so the app never steals audio focus while nothing is playing — but the
+category alone does NOT keep playback alive: iOS suspends the process unless
+the app holds an ACTIVE `.playback` session, and a suspended process is one
+whose audio has stopped and whose transport controls reach nothing. Activation
+is driven by actual playback, in BGAUDIO-010.
 
 Sync points (all idempotent, routed through
 `BackgroundTaskService.setBackgroundAudioActive`): per-site settings save,
@@ -305,6 +306,9 @@ that is the failure mode this requirement exists to make visible.
   `MediaSessionService.notificationPosted()` SHALL surface it.
 - On raising the notification the service SHALL check visibility once and log a
   warning when the OS did not post it.
+- A transport control the page could not act on SHALL be logged as a warning
+  carrying the engine's own reason (`reportControlFailure`). Without it, "the
+  play button does nothing" is silent at every layer above the page.
 - Coverage SHALL exist at three tiers, because no single one spans the chain:
   the shim's behaviour under a real engine
   (`test/browser/media_session_real_engine.test.js`, Puppeteer + headless
@@ -423,6 +427,14 @@ keeps its own audio, it does not license every other loaded site to keep
 playing. Nothing is resumed on foreground — restarting audio the user did not
 ask for is worse than leaving it paused where they can hit play.
 
+Pausing the media is not enough on iOS: WebKit publishes its own Now Playing
+info for any page that plays, and that entry outlives the audio as a control
+whose play button reaches a site the app is no longer keeping alive. When no
+loaded site has the toggle, `_updateBackgroundAudioSession` SHALL therefore
+call `MediaSessionService.clearOsMediaSurface()`, which clears the surface
+even when the app never raised it (`stopAll` alone cannot: it early-returns
+because nothing of ours is active).
+
 The snippet ([`buildMediaPauseJs`](../../../lib/services/media_session_shim.dart))
 walks same-origin subframes itself, since `evaluateJavascript` reaches only
 the main frame. Out of reach, and accepted: cross-origin subframes (the same
@@ -437,7 +449,9 @@ the page's own player listens for `pause` events.
 **Given** a site with Background audio OFF is playing audio
 **When** the app goes to background
 **Then** its index is in `mediaPauseIndices` and its media elements are paused
-**And** no Now Playing / media notification survives it
+**And** `clearOsMediaSurface()` removes the Now Playing entry WebKit published,
+so no transport control with a dead play button survives it
+(regression test: `test/media_session_service_test.dart`)
 
 #### Scenario: The opted-in site is untouched, its neighbours are not
 
@@ -495,9 +509,15 @@ Leaving this to WebKit — which publishes its own Now Playing info for
 whatever a page plays — left the app blind to a surface it could not clear
 and gave a transport tap no route into the page. Consequences of owning it:
 
-- `start`/`update` set the `.playback` category and activate the session.
+- `start`/`update` set the `.playback` category and **activate** the session.
   Only a page that is already playing reaches them, so no audio focus is
-  taken that WebKit had not taken already.
+  taken that WebKit had not taken already. This is what keeps iOS from
+  suspending the process when the app leaves the foreground.
+- A `play` remote command SHALL activate the session BEFORE the command is
+  handed to the page. The tap that arrives there is typically the one meant to
+  bring the app back from suspension, and WebKit cannot start playback against
+  an inactive session — activating after the fact resumes nothing, which is
+  the "I hit play and nothing plays" report.
 - `stop` does NOT deactivate the session: another loaded site may still be
   sounding in the foreground, and `setActive(false)` would cut it. Reverting
   the category is BGAUDIO-003's job.
@@ -513,6 +533,14 @@ and gave a transport tap no route into the page. Consequences of owning it:
   for is gone with the webview, and stale controls whose buttons reach
   nothing are exactly the symptom this requirement exists to remove.
 
+#### Scenario: Playback survives the app leaving the foreground
+
+**Given** a background-audio site is playing on iOS
+**When** the app goes to background
+**Then** the session the page's playback report activated keeps the process
+alive and the audio continues
+**And** the Now Playing controls are the app's own, not a leftover WebKit entry
+
 #### Scenario: Lock-screen play resumes the page
 
 **Given** a background-audio site is paused with the iOS Now Playing controls up
@@ -520,6 +548,18 @@ and gave a transport tap no route into the page. Consequences of owning it:
 **Then** `onTransport('play')` runs `window.__wsMediaControl('play')` on the
 owning webview, which plays its primary media element
 **And** the page's next report flips `playbackState` back to `.playing`
+
+#### Scenario: A transport that reaches nothing says so
+
+**Given** the page's primary media element is gone, or WebKit refuses the
+`play()` (a rejected promise, e.g. `NotAllowedError`)
+**When** the transport control runs `window.__wsMediaControl('play')`
+**Then** the shim reports `{control, error}` and `MediaSessionService` logs one
+non-sensitive warning naming the engine's own reason
+**And** the ordinary playing/paused report sequence is unchanged — only
+failures are reported
+(regression test: `test/browser/media_session_real_engine.test.js`,
+`test/media_session_service_test.dart`)
 
 #### Scenario: Unloading the owning site clears the controls
 

--- a/openspec/specs/background-audio/spec.md
+++ b/openspec/specs/background-audio/spec.md
@@ -624,6 +624,70 @@ state, which is confined there (BUG-007).
 **Then** one `MediaSession` line carries the category and other-audio flag
 (regression test: `test/media_session_service_test.dart`)
 
+---
+
+### Requirement: BGAUDIO-012 — A Site That Stops Itself When Hidden Keeps Playing
+
+Keeping the process alive (BGAUDIO-003/010/011) only settles what the OS does.
+A player built for a browser tab stops on its own: when the app is
+backgrounded the page is told it is hidden, and YouTube and its like pause on
+`visibilitychange` / `pagehide` by their own choice. The audio then dies with
+every OS-level lever correctly set, and the lockscreen play button starts a
+playback the page pauses again a frame later.
+
+While the app is backgrounded and the site's toggle is on, the media-session
+shim SHALL:
+
+- report the page as visible — `document.hidden` false and
+  `document.visibilityState` `'visible'` (plus the `webkit`-prefixed pair) —
+  deferring to the real values at every other time;
+- swallow `visibilitychange`, `pagehide`, `freeze` and `blur` in the capture
+  phase on `window` and `document`, so the page's own pause-on-hide handler
+  never runs (the shim is injected at DOCUMENT_START, so its capture listener
+  is registered before the page's);
+- re-issue `play()` on any element that was playing and is now paused, at most
+  8 times per background window, reporting a refusal through the same
+  `{control, error}` path as BGAUDIO-010;
+- stop fighting a pause the user asked for: a `pause`/`stop` transport clears
+  the watchdog's intent for every element.
+
+The state is handed to the page by `WebViewModel.setBackgroundPlayback`, called
+for every loaded background-audio site on the lifecycle `paused` and `resumed`
+branches, and is a no-op for every other site — masking visibility for a page
+the user did not opt in for would keep players and timers running that should
+stop. `evaluateJavascript` reaches the main frame only, so the shim relays the
+state to its subframes by `postMessage`; a frame that fakes that message can
+only make its own page report itself visible, on a site already opted in.
+
+#### Scenario: A pause-on-hide player survives the background window
+
+**Given** a background-audio site whose page pauses its player on
+`visibilitychange`
+**When** the app goes to background and the page receives the event
+**Then** the page's handler never runs, `document.hidden` reads false, and the
+element is still playing
+(regression test: `test/browser/media_background_playback.test.js`)
+
+#### Scenario: A player that stops itself anyway is resumed
+
+**Given** the app is backgrounded with the mask in place
+**When** the element pauses for its own reasons
+**Then** the watchdog re-issues `play()` within a second, and a refusal is
+reported as `{control: 'background-resume', error}`
+
+#### Scenario: The user's own pause is respected
+
+**Given** the app is backgrounded and playing
+**When** the user taps pause on the lockscreen controls
+**Then** the element stays paused — the watchdog does not resume it
+
+#### Scenario: Foregrounding restores the page's own visibility
+
+**Given** the app comes back to the foreground
+**When** `setBackgroundPlayback(false)` runs
+**Then** `document.hidden` / `visibilityState` report the real values again and
+the events reach the page as they always have
+
 ## Limitations (documented, accepted)
 
 - **iOS without playback**: the audio session keeps the app alive only
@@ -659,7 +723,8 @@ state, which is confined there (BUG-007).
 - `lib/services/webview.dart` — `WebViewConfig.backgroundAudioEnabled`, media
   shim injection (+ the BGAUDIO-007 armed line), `wsMediaSession` handler.
 - `lib/services/media_session_shim.dart` — BGAUDIO-009 `buildMediaPauseJs`
-  (dumped to `test/js_fixtures/media_session/pause_media.js`).
+  (dumped to `test/js_fixtures/media_session/pause_media.js`); BGAUDIO-012
+  visibility mask, background watchdog and `__wsMediaBackground`.
 - `lib/services/media_session_shim.dart`, `lib/services/media_session_service.dart`
   — BGAUDIO-006 page-JS bridge + Dart channel bridge; BGAUDIO-007 detached-
   element registry, raise/teardown logging and the visibility check;
@@ -694,6 +759,10 @@ state, which is confined there (BUG-007).
 - `integration_test/background_audio_media_stop_test.dart` (BGAUDIO-009
   emulator tier) and `test/browser/media_pause_real_engine.test.js` (the same
   snippet under real Chromium).
+- `test/browser/media_background_playback.test.js` — BGAUDIO-012 against a
+  page that pauses itself on hide.
+- `test/js/native_media_session_targets.test.js` — BGAUDIO-010/011 structural
+  gate on the iOS plugin.
 
 ## Related Specs
 

--- a/openspec/specs/background-audio/spec.md
+++ b/openspec/specs/background-audio/spec.md
@@ -433,7 +433,18 @@ whose play button reaches a site the app is no longer keeping alive. When no
 loaded site has the toggle, `_updateBackgroundAudioSession` SHALL therefore
 call `MediaSessionService.clearOsMediaSurface()`, which clears the surface
 even when the app never raised it (`stopAll` alone cannot: it early-returns
-because nothing of ours is active).
+because nothing of ours is active). Three things that clearing needs to
+survive contact with WebKit:
+
+- it SHALL run AFTER the media pauses complete, since WebKit republishes its
+  entry while processing a pause;
+- it SHALL clear twice, a short delay apart, for the republish that lands
+  after the first clear anyway;
+- it SHALL release the audio session (`setActive(false,
+  .notifyOthersOnDeactivation)`). Clearing the metadata alone leaves an entry
+  the engine repopulates; the app drops out of the OS media surface only when
+  it stops holding the session. This is the ONE place that releases it — every
+  other teardown keeps it, because another loaded site may still be sounding.
 
 The snippet ([`buildMediaPauseJs`](../../../lib/services/media_session_shim.dart))
 walks same-origin subframes itself, since `evaluateJavascript` reaches only

--- a/scripts/run_android_background_audio_tests.sh
+++ b/scripts/run_android_background_audio_tests.sh
@@ -8,7 +8,9 @@
 #   - the negative control (a plain site's JS timers genuinely freeze), and
 #   - BGAUDIO-006, the media notification: the foreground service and its
 #     MediaStyle notification only exist on Android, so this is the only tier
-#     that can assert the user-visible half of the feature.
+#     that can assert the user-visible half of the feature,
+#   - BGAUDIO-009, the media stop: a site WITHOUT the toggle must go quiet when
+#     it loses the screen, which needs a real media pipeline to observe.
 #
 # Single flat invocations, one per file: reactivecircus/android-emulator-runner
 # runs each CI `script:` line as a separate `sh -c`, and this script keeps the
@@ -45,7 +47,8 @@ status=0
 for t in \
   integration_test/background_audio_lifecycle_test.dart \
   integration_test/background_audio_freeze_test.dart \
-  integration_test/background_audio_media_notification_test.dart; do
+  integration_test/background_audio_media_notification_test.dart \
+  integration_test/background_audio_media_stop_test.dart; do
   echo "::group::$t"
   # Hard per-test wall-clock cap: a webview mount can deadlock below the Dart
   # timeout layer (same rationale as the white-screen tier).

--- a/test/app_lifecycle_engine_test.dart
+++ b/test/app_lifecycle_engine_test.dart
@@ -280,6 +280,86 @@ void main() {
     });
   });
 
+  group('BGAUDIO-009 media pause for sites without the toggle', () {
+    test('every loaded site without background audio is listed, ascending', () {
+      final plan = AppLifecycleEngine.backgroundPlan(
+        currentIndex: 0,
+        siteCount: 4,
+        loadedIndices: {2, 0, 3},
+        notificationsEnabled: (_) => false,
+        backgroundAudioEnabled: (_) => false,
+        cookieFlushSupported: false,
+      );
+      expect(plan.mediaPauseIndices, [0, 2, 3]);
+    });
+
+    test('the opted-in site keeps its audio, the others do not', () {
+      // The exemption is per-site, unlike the JS-pause veto: one background
+      // audio site must not license every other loaded site to keep sounding
+      // through a backgrounded app.
+      final plan = AppLifecycleEngine.backgroundPlan(
+        currentIndex: 0,
+        siteCount: 3,
+        loadedIndices: {0, 1, 2},
+        notificationsEnabled: (_) => false,
+        backgroundAudioEnabled: (i) => i == 1,
+        cookieFlushSupported: false,
+      );
+      expect(plan.mediaPauseIndices, [0, 2]);
+      expect(plan.jsPauseIndex, isNull);
+    });
+
+    test('the active site is included — it is the one usually playing', () {
+      final plan = AppLifecycleEngine.backgroundPlan(
+        currentIndex: 1,
+        siteCount: 2,
+        loadedIndices: {1},
+        notificationsEnabled: (_) => false,
+        backgroundAudioEnabled: (_) => false,
+        cookieFlushSupported: false,
+      );
+      expect(plan.mediaPauseIndices, [1]);
+      expect(plan.jsPauseIndex, 1);
+    });
+
+    test('a notification site is not exempt — only background audio is', () {
+      final plan = AppLifecycleEngine.backgroundPlan(
+        currentIndex: 0,
+        siteCount: 2,
+        loadedIndices: {0, 1},
+        notificationsEnabled: (i) => i == 0,
+        backgroundAudioEnabled: (_) => false,
+        cookieFlushSupported: false,
+      );
+      expect(plan.mediaPauseIndices, [0, 1]);
+      expect(plan.jsPauseIndex, isNull);
+    });
+
+    test('out-of-bounds loaded indices are dropped', () {
+      final plan = AppLifecycleEngine.backgroundPlan(
+        currentIndex: null,
+        siteCount: 2,
+        loadedIndices: {-1, 0, 7},
+        notificationsEnabled: (_) => false,
+        backgroundAudioEnabled: (_) => false,
+        cookieFlushSupported: false,
+      );
+      expect(plan.mediaPauseIndices, [0]);
+    });
+
+    test('nothing loaded, nothing to pause', () {
+      final plan = AppLifecycleEngine.backgroundPlan(
+        currentIndex: null,
+        siteCount: 2,
+        loadedIndices: const {},
+        notificationsEnabled: (_) => false,
+        backgroundAudioEnabled: (_) => false,
+        cookieFlushSupported: true,
+      );
+      expect(plan.mediaPauseIndices, isEmpty);
+    });
+  });
+
   group('BGAUDIO-002 background-audio pause exemption', () {
     test('active background-audio site: capture but do NOT pause', () {
       final plan = AppLifecycleEngine.backgroundPlan(

--- a/test/browser/media_background_playback.test.js
+++ b/test/browser/media_background_playback.test.js
@@ -1,0 +1,216 @@
+// Real-Chromium proof for background playback masking (BGAUDIO-012,
+// lib/services/media_session_shim.dart, dumped to
+// test/js_fixtures/media_session/shim.js).
+//
+// Keeping the app alive is not enough for a site that stops itself: a
+// backgrounded app's page is told it is hidden, and players built for a tab
+// (YouTube among them) pause on `visibilitychange` by their own choice. The
+// page under test does exactly that, so "did the audio survive" is asserted
+// against a player that actively wants to stop.
+//
+// jsdom cannot stand in: it has no media pipeline, so `paused` never moves,
+// and the capture-phase ordering that keeps the page's handler from running is
+// the whole mechanism.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { setupBrowser, requireBrowser } = require('./helpers/launch');
+const { LAUNCH_ARGS, newShimPage, reports } = require('./helpers/media_session_page');
+
+const browser = setupBrowser(LAUNCH_ARGS);
+const newPage = () => newShimPage(browser);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/// A page that pauses its own player the moment it is told it is hidden.
+async function playPauseOnHidePlayer(page) {
+  await page.evaluate(async () => {
+    const a = document.createElement('audio');
+    a.loop = true;
+    a.src = wsMakeSilentWav(6);
+    document.body.appendChild(a);
+    window.__el = a;
+    window.__pauseOnHideRan = 0;
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        window.__pauseOnHideRan++;
+        a.pause();
+      }
+    });
+    await a.play();
+  });
+  await sleep(500);
+}
+
+/// Chromium fires visibilitychange on a real tab switch only, so drive the
+/// event the way the OS does: the page sees the event, not our call.
+const dispatchHidden = (page) =>
+  page.evaluate(() => {
+    document.dispatchEvent(new Event('visibilitychange'));
+    window.dispatchEvent(new Event('pagehide'));
+  });
+
+test('a pause-on-hide player keeps playing while the app is backgrounded', async (t) => {
+  if (!requireBrowser(browser, t)) return;
+  const page = await newPage();
+  try {
+    await playPauseOnHidePlayer(page);
+    assert.equal(await page.evaluate(() => window.__el.paused), false);
+
+    await page.evaluate(() => window.__wsMediaBackground(true));
+    await dispatchHidden(page);
+    await sleep(300);
+
+    assert.equal(
+      await page.evaluate(() => window.__pauseOnHideRan),
+      0,
+      "the page's own pause-on-hide handler must never run",
+    );
+    assert.equal(await page.evaluate(() => window.__el.paused), false);
+    assert.equal(await page.evaluate(() => document.hidden), false);
+    assert.equal(await page.evaluate(() => document.visibilityState), 'visible');
+  } finally {
+    await page.close();
+  }
+});
+
+test('the watchdog re-issues play() when the page pauses anyway', async (t) => {
+  if (!requireBrowser(browser, t)) return;
+  const page = await newPage();
+  try {
+    await playPauseOnHidePlayer(page);
+    await page.evaluate(() => window.__wsMediaBackground(true));
+
+    // A player that pauses for its own reasons (buffer stall, an internal
+    // timer) rather than through the visibility event the mask swallows.
+    await page.evaluate(() => window.__el.pause());
+    await sleep(1600);
+
+    assert.equal(
+      await page.evaluate(() => window.__el.paused),
+      false,
+      'the background watchdog must resume a player that stopped itself',
+    );
+  } finally {
+    await page.close();
+  }
+});
+
+test('a lockscreen pause is not fought by the watchdog', async (t) => {
+  if (!requireBrowser(browser, t)) return;
+  const page = await newPage();
+  try {
+    await playPauseOnHidePlayer(page);
+    await page.evaluate(() => window.__wsMediaBackground(true));
+
+    // The user's own pause, arriving the way MediaSessionService sends it.
+    await page.evaluate(() => window.__wsMediaControl('pause'));
+    await sleep(1600);
+
+    assert.equal(
+      await page.evaluate(() => window.__el.paused),
+      true,
+      'silence the user asked for must stay',
+    );
+  } finally {
+    await page.close();
+  }
+});
+
+test('foregrounding hands the page its own visibility back', async (t) => {
+  if (!requireBrowser(browser, t)) return;
+  const page = await newPage();
+  try {
+    await playPauseOnHidePlayer(page);
+    await page.evaluate(() => window.__wsMediaBackground(true));
+    await dispatchHidden(page);
+    await page.evaluate(() => window.__wsMediaBackground(false));
+    await sleep(200);
+
+    // Back on screen the page behaves exactly as it always has.
+    await dispatchHidden(page);
+    await sleep(200);
+    assert.equal(
+      await page.evaluate(() => document.visibilityState),
+      'visible',
+      'the real value in a foreground tab',
+    );
+    assert.equal(
+      await page.evaluate(() => window.__el.paused),
+      false,
+      'headless Chromium reports the page visible, so nothing paused it',
+    );
+  } finally {
+    await page.close();
+  }
+});
+
+test('the background state reaches a same-origin subframe', async (t) => {
+  if (!requireBrowser(browser, t)) return;
+  const page = await newPage();
+  try {
+    // evaluateJavascript reaches the main frame only; the shim relays.
+    await page.evaluate(async () => {
+      const f = document.createElement('iframe');
+      f.srcdoc = '<html><body></body></html>';
+      document.body.appendChild(f);
+      window.__frame = f;
+      await new Promise((r) => f.addEventListener('load', r, { once: true }));
+    });
+    // The frame runs its own copy of the shim in the app; here inject it the
+    // same way the platform does, then drive the parent only.
+    const frameHasHook = await page.evaluate(
+      () => typeof window.__frame.contentWindow.__wsMediaBackground,
+    );
+    if (frameHasHook !== 'function') {
+      // srcdoc frames in this harness do not receive evaluateOnNewDocument;
+      // assert the relay itself instead, which is what the app depends on.
+      const relayed = await page.evaluate(async () => {
+        let got = null;
+        window.__frame.contentWindow.addEventListener('message', (ev) => {
+          if (ev.data && '__wsMediaBackground' in ev.data) got = ev.data;
+        });
+        window.__wsMediaBackground(true);
+        await new Promise((r) => setTimeout(r, 200));
+        return got;
+      });
+      assert.deepEqual(relayed, { __wsMediaBackground: true });
+      return;
+    }
+    await page.evaluate(() => window.__wsMediaBackground(true));
+    await sleep(200);
+    assert.equal(
+      await page.evaluate(
+        () => window.__frame.contentDocument.visibilityState,
+      ),
+      'visible',
+    );
+  } finally {
+    await page.close();
+  }
+});
+
+test('a failed background resume is reported, not swallowed', async (t) => {
+  if (!requireBrowser(browser, t)) return;
+  const page = await newPage();
+  try {
+    await playPauseOnHidePlayer(page);
+    await page.evaluate(() => {
+      window.__el.play = () =>
+        Promise.reject(Object.assign(new Error('blocked'), {
+          name: 'NotAllowedError',
+        }));
+      window.__wsMediaBackground(true);
+      window.__el.pause();
+    });
+    await sleep(1600);
+
+    const got = await reports(page);
+    const failure = got
+      .filter((r) => r.payload.control === 'background-resume')
+      .pop();
+    assert.ok(failure, 'a refused background resume must reach Dart');
+    assert.equal(failure.payload.error, 'NotAllowedError');
+  } finally {
+    await page.close();
+  }
+});

--- a/test/browser/media_pause_real_engine.test.js
+++ b/test/browser/media_pause_real_engine.test.js
@@ -1,0 +1,189 @@
+// Real-Chromium proof for the media stop (BGAUDIO-009,
+// lib/services/media_session_shim.dart `buildMediaPauseJs`, dumped to
+// test/js_fixtures/media_session/pause_media.js).
+//
+// This is the snippet the app evaluates on a site WITHOUT the background-audio
+// toggle when it loses the screen. jsdom cannot prove anything about it:
+// `paused` and `currentTime` never move there, so a page that never stopped
+// playing looks identical to one that did. Here real audio plays in headless
+// Chromium and the assertion is the element's own state.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { setupBrowser, requireBrowser, readFixture } = require('./helpers/launch');
+const { LAUNCH_ARGS, newShimPage } = require('./helpers/media_session_page');
+
+const PAUSE_JS = readFixture('media_session/pause_media.js');
+
+const browser = setupBrowser(LAUNCH_ARGS);
+
+// The page harness is shared with the BGAUDIO-006 tiers: it installs the
+// bridge stub and `wsMakeSilentWav`. The media-session shim it also installs
+// is inert here — it only reports, it never pauses anything.
+const newPage = () => newShimPage(browser);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+test('a playing element is paused and stops advancing', async (t) => {
+  if (!requireBrowser(browser, t)) return;
+  const page = await newPage();
+  try {
+    const played = await page.evaluate(async () => {
+      const a = document.createElement('audio');
+      a.loop = true;
+      a.src = wsMakeSilentWav(4);
+      document.body.appendChild(a);
+      window.__el = a;
+      try {
+        await a.play();
+        return true;
+      } catch (e) {
+        return e.name;
+      }
+    });
+    assert.equal(played, true, 'autoplay must be allowed in this tier');
+    await sleep(600);
+
+    const before = await page.evaluate(() => ({
+      paused: window.__el.paused,
+      t: window.__el.currentTime,
+    }));
+    assert.equal(before.paused, false, 'precondition: audio is playing');
+    assert.ok(before.t > 0, 'precondition: playback advanced');
+
+    await page.evaluate(PAUSE_JS);
+
+    const after = await page.evaluate(() => ({
+      paused: window.__el.paused,
+      t: window.__el.currentTime,
+    }));
+    assert.equal(after.paused, true, 'the element must be paused');
+
+    // The reported bug in one assertion: the audio kept going after the site
+    // lost the screen.
+    await sleep(700);
+    const later = await page.evaluate(() => window.__el.currentTime);
+    assert.equal(
+      later,
+      after.t,
+      `currentTime advanced from ${after.t} to ${later} — still playing`,
+    );
+  } finally {
+    await page.close();
+  }
+});
+
+test('every playing element is caught, video included', async (t) => {
+  if (!requireBrowser(browser, t)) return;
+  const page = await newPage();
+  try {
+    await page.evaluate(async () => {
+      window.__els = [];
+      for (let i = 0; i < 2; i++) {
+        const a = document.createElement('audio');
+        a.loop = true;
+        a.src = wsMakeSilentWav(4);
+        document.body.appendChild(a);
+        window.__els.push(a);
+      }
+      const canvas = document.createElement('canvas');
+      canvas.width = 32;
+      canvas.height = 32;
+      canvas.getContext('2d').fillRect(0, 0, 32, 32);
+      const v = document.createElement('video');
+      v.muted = true;
+      v.playsInline = true;
+      v.srcObject = canvas.captureStream(10);
+      document.body.appendChild(v);
+      window.__els.push(v);
+      await Promise.all(window.__els.map((e) => e.play().catch(() => {})));
+    });
+    await sleep(600);
+    assert.deepEqual(
+      await page.evaluate(() => window.__els.map((e) => e.paused)),
+      [false, false, false],
+      'precondition: all three playing',
+    );
+
+    await page.evaluate(PAUSE_JS);
+
+    assert.deepEqual(
+      await page.evaluate(() => window.__els.map((e) => e.paused)),
+      [true, true, true],
+    );
+  } finally {
+    await page.close();
+  }
+});
+
+test('a player in a same-origin iframe is caught too', async (t) => {
+  if (!requireBrowser(browser, t)) return;
+  const page = await newPage();
+  try {
+    // evaluateJavascript reaches the main frame only, so the snippet walks
+    // same-origin frames itself.
+    await page.evaluate(async () => {
+      const f = document.createElement('iframe');
+      document.body.appendChild(f);
+      window.__frame = f;
+      const d = f.contentDocument;
+      const a = d.createElement('audio');
+      a.loop = true;
+      a.src = wsMakeSilentWav(4);
+      d.body.appendChild(a);
+      await a.play().catch(() => {});
+    });
+    await sleep(600);
+    const paused = () =>
+      page.evaluate(
+        () => window.__frame.contentDocument.querySelector('audio').paused,
+      );
+    assert.equal(await paused(), false, 'precondition: iframe audio playing');
+
+    await page.evaluate(PAUSE_JS);
+    assert.equal(await paused(), true);
+  } finally {
+    await page.close();
+  }
+});
+
+test('an already-paused element is left alone and no media is fine', async (t) => {
+  if (!requireBrowser(browser, t)) return;
+  const page = await newPage();
+  try {
+    // No media at all: the snippet must not throw, or every later injected
+    // script in the same evaluation would be skipped.
+    assert.equal(await page.evaluate(`${PAUSE_JS}; 'ok';`), 'ok');
+
+    await page.evaluate(async () => {
+      const a = document.createElement('audio');
+      a.src = wsMakeSilentWav(4);
+      document.body.appendChild(a);
+      window.__el = a;
+      await a.play().catch(() => {});
+      a.pause();
+      a.currentTime = 0;
+      window.__pauseEvents = 0;
+      a.addEventListener('pause', () => {
+        window.__pauseEvents++;
+      });
+    });
+
+    // Let the `pause` event from the setup above land before counting.
+    await sleep(300);
+    await page.evaluate(() => {
+      window.__pauseEvents = 0;
+    });
+
+    await page.evaluate(PAUSE_JS);
+    await page.evaluate(PAUSE_JS);
+    await sleep(300);
+
+    // Re-pausing would fire spurious `pause` events at the site's own player,
+    // which listens to them (the media-session shim reports off them).
+    assert.equal(await page.evaluate(() => window.__pauseEvents), 0);
+    assert.equal(await page.evaluate(() => window.__el.paused), true);
+  } finally {
+    await page.close();
+  }
+});

--- a/test/browser/media_session_real_engine.test.js
+++ b/test/browser/media_session_real_engine.test.js
@@ -170,6 +170,45 @@ test('transport control round-trip drives the element and re-reports', async (t)
   }
 });
 
+test('a transport that reaches nothing is reported, not swallowed', async (t) => {
+  if (!requireBrowser(browser, t)) return;
+  const page = await newPage();
+  try {
+    // "I hit play and nothing happened" is silent at every layer above the
+    // page: no element, or an engine that refuses to start playback, look
+    // identical to a dead bridge. Only the failure is reported, so the
+    // ordinary playing/paused sequence above is unaffected.
+    await page.evaluate(() => window.__wsMediaControl('play'));
+    await settle();
+    let got = await reports(page);
+    assert.equal(got.length, 1, 'a control with no media must say so');
+    assert.equal(got[0].payload.control, 'play');
+    assert.equal(got[0].payload.error, 'no-media-element');
+
+    const refused = await page.evaluate(async () => {
+      const a = document.createElement('audio');
+      a.src = wsMakeSilentWav(2);
+      document.body.appendChild(a);
+      // Reject the way a suspended/blocked engine does, which is the state
+      // the iOS lockscreen play lands in.
+      a.play = () =>
+        Promise.reject(Object.assign(new Error('blocked'), {
+          name: 'NotAllowedError',
+        }));
+      window.__wsMediaControl('play');
+      await new Promise((r) => setTimeout(r, 200));
+      return true;
+    });
+    assert.equal(refused, true);
+    await settle();
+    got = await reports(page);
+    const failure = got.filter((r) => r.payload.control === 'play').pop();
+    assert.equal(failure.payload.error, 'NotAllowedError');
+  } finally {
+    await page.close();
+  }
+});
+
 test('does not re-report unchanged state', async (t) => {
   if (!requireBrowser(browser, t)) return;
   const page = await newPage();

--- a/test/js/native_media_session_targets.test.js
+++ b/test/js/native_media_session_targets.test.js
@@ -1,0 +1,73 @@
+// iOS media-session target gate (BGAUDIO-010, native concurrency).
+//
+// `MPRemoteCommandCenter` is a process-wide singleton and its targets outlive
+// nothing on their own: a handler added twice fires twice, and one never
+// removed keeps a dead plugin on the hook. The plugin therefore keeps every
+// target it added in `commandTargets`, adds only when that list is empty, and
+// removes exactly those on teardown. The handler body also hops onto the main
+// queue — the command centre documents no queue, and a Flutter channel must be
+// spoken to from the platform thread.
+//
+// No iOS SDK/Xcode in this repo's Dart+JS tiers, so this is a structural guard
+// (same shape as native_bgtask_completion_funnel).
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const rel = 'ios/Runner/MediaSessionPlugin.swift';
+const src = fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+// Comments explain why the forbidden shapes are forbidden, so match on code.
+const code = src
+  .split('\n')
+  .filter((l) => !l.trim().startsWith('//') && !l.trim().startsWith('///'))
+  .join('\n');
+
+test('every added target is retained for removal', () => {
+  assert.match(src, /private var commandTargets: \[\(MPRemoteCommand, Any\)\] = \[\]/,
+    `${rel} must keep the handles addTarget returns`);
+  assert.match(src, /commandTargets\.append\(\(command, target\)\)/,
+    'each addTarget result must be appended to commandTargets');
+  assert.match(src, /command\.removeTarget\(target\)/,
+    'teardown must remove the retained handles, not guess at them');
+});
+
+test('registration is idempotent', () => {
+  // Reports arrive on every play/pause; without this a long listening session
+  // stacks one handler per report and a single tap fires all of them.
+  assert.match(src, /guard commandTargets\.isEmpty else \{ return \}/,
+    'registerCommands must no-op while targets are already registered');
+});
+
+test('the transport callback hops onto the main queue', () => {
+  const addTarget = src.slice(src.indexOf('command.addTarget'));
+  const body = addTarget.slice(0, addTarget.indexOf('commandTargets.append'));
+  assert.match(body, /DispatchQueue\.main\.async/,
+    'the remote-command handler must hop to main before invoking the channel');
+  assert.ok(
+    body.indexOf('DispatchQueue.main.async') < body.indexOf('invokeMethod'),
+    'the channel call must be inside the main-queue hop, not before it',
+  );
+});
+
+test('only play / pause / stop are registered', () => {
+  // Dead buttons are worse than absent ones: next/previous have no universal
+  // web mechanism, and togglePlayPause handled twice (ours + WebKit's own
+  // targets) cancels itself out.
+  const registered = [...src.matchAll(/\(center\.(\w+Command), "(\w+)"\)/g)]
+    .map((m) => m[1]);
+  assert.deepEqual(registered, ['playCommand', 'pauseCommand', 'stopCommand']);
+  assert.ok(!/togglePlayPauseCommand/.test(code),
+    'togglePlayPause is deliberately left to WebKit');
+});
+
+test('teardown clears the now-playing info, not just the targets', () => {
+  const stop = src.slice(src.indexOf('private func stop()'));
+  assert.match(stop, /unregisterCommands\(\)/);
+  assert.match(stop, /center\.nowPlayingInfo = nil/,
+    'stale Now Playing controls whose buttons reach nothing are the bug');
+  assert.ok(!/setActive\(false/.test(code),
+    'deactivating the shared session would cut another site still sounding');
+});

--- a/test/js/native_media_session_targets.test.js
+++ b/test/js/native_media_session_targets.test.js
@@ -78,6 +78,24 @@ test('only play / pause / stop are registered', () => {
     'togglePlayPause is deliberately left to WebKit');
 });
 
+test('an interruption is observed and recovered from (BGAUDIO-011)', () => {
+  // Nothing re-activates a session iOS deactivated for a call / Siri / another
+  // app. Without this the audio never returns and every later transport tap
+  // reaches an engine with no session to play into.
+  assert.match(code, /AVAudioSession\.interruptionNotification/,
+    'the plugin must observe interruptions');
+  assert.match(code, /AVAudioSession\.mediaServicesWereResetNotification/,
+    'a media-server restart takes the session and the Now Playing entry with it');
+  const handler = code.slice(code.indexOf('func handleInterruption'));
+  const body = handler.slice(0, handler.indexOf('func handleMediaServicesReset'));
+  assert.match(body, /DispatchQueue\.main\.async/,
+    'AVAudioSession posts on an arbitrary queue; plugin state lives on main');
+  assert.match(body, /guard self\.publishing else/,
+    'recovery must not activate a session or ask a page to play when we own nothing');
+  assert.match(body, /options\.contains\(\.shouldResume\)/,
+    'resume only when the system says the user expects playback back');
+});
+
 test('teardown clears the now-playing info, not just the targets', () => {
   const stop = src.slice(src.indexOf('private func stop()'));
   assert.match(stop, /unregisterCommands\(\)/);

--- a/test/js/native_media_session_targets.test.js
+++ b/test/js/native_media_session_targets.test.js
@@ -97,10 +97,17 @@ test('an interruption is observed and recovered from (BGAUDIO-011)', () => {
 });
 
 test('teardown clears the now-playing info, not just the targets', () => {
-  const stop = src.slice(src.indexOf('private func stop()'));
+  const stop = src.slice(src.indexOf('private func stop(deactivate'));
   assert.match(stop, /unregisterCommands\(\)/);
   assert.match(stop, /center\.nowPlayingInfo = nil/,
     'stale Now Playing controls whose buttons reach nothing are the bug');
-  assert.ok(!/setActive\(false/.test(code),
-    'deactivating the shared session would cut another site still sounding');
+  // Ordinary teardown keeps the session: another loaded site may still be
+  // sounding in the foreground. Giving it up is reserved for the explicit
+  // `deactivate` call, which only arrives once every page has been paused.
+  assert.match(stop, /guard deactivate else \{ return \}/,
+    'the session release must sit behind the deactivate flag');
+  const releases = (code.match(/setActive\(false/g) || []).length;
+  assert.equal(releases, 1, 'exactly one place may release the session');
+  assert.match(stop, /options: \.notifyOthersOnDeactivation/,
+    'let whatever we interrupted resume');
 });

--- a/test/js/native_media_session_targets.test.js
+++ b/test/js/native_media_session_targets.test.js
@@ -52,6 +52,21 @@ test('the transport callback hops onto the main queue', () => {
   );
 });
 
+test('the play command activates the session before the page is asked', () => {
+  // WebKit cannot start playback against an inactive session, and the tap that
+  // gets here is usually the one meant to bring the app back from suspension.
+  const hop = code.slice(code.indexOf('DispatchQueue.main.async'));
+  const body = hop.slice(0, hop.indexOf('return .success'));
+  assert.match(body, /if action == "play" \{\s*self\.activateSession\(\)/,
+    'a play command must activate the audio session');
+  assert.ok(
+    body.indexOf('activateSession()') < body.indexOf('invokeMethod'),
+    'activation must precede handing the command to the page',
+  );
+  assert.match(code, /try session\.setActive\(true\)/,
+    'setting only the category leaves the process suspendable');
+});
+
 test('only play / pause / stop are registered', () => {
   // Dead buttons are worse than absent ones: next/previous have no universal
   // web mechanism, and togglePlayPause handled twice (ours + WebKit's own

--- a/test/js_fixtures/media_session/pause_media.js
+++ b/test/js_fixtures/media_session/pause_media.js
@@ -1,0 +1,21 @@
+(function() {
+  var docs = [document];
+  try {
+    for (var f = 0; f < window.frames.length; f++) {
+      try {
+        var d = window.frames[f].document;
+        if (d) docs.push(d);
+      } catch (e) {}
+    }
+  } catch (e) {}
+  for (var i = 0; i < docs.length; i++) {
+    try {
+      var els = docs[i].querySelectorAll('audio,video');
+      for (var j = 0; j < els.length; j++) {
+        try {
+          if (!els[j].paused) els[j].pause();
+        } catch (e) {}
+      }
+    } catch (e) {}
+  }
+})();

--- a/test/js_fixtures/media_session/shim.js
+++ b/test/js_fixtures/media_session/shim.js
@@ -122,15 +122,42 @@
   }
   scan();
 
+  // A transport control that reaches nothing is silent otherwise: the page
+  // looks idle, the OS controls stay up, and no log says whether the element
+  // was missing or the engine refused to start playback (WebKit rejects
+  // play() with NotAllowedError in cases the user experiences as "I hit play
+  // and nothing happened"). Reported only on failure, so the ordinary
+  // playing/paused report sequence is unchanged.
+  function reportControl(action, error) {
+    try {
+      window.flutter_inappwebview.callHandler('wsMediaSession', {
+        frame: frameId, control: action, error: error,
+      });
+    } catch (e) {}
+  }
+
   // Dart -> page. Driving the media element directly fires the same
   // play/pause the site listens to, so its own MediaSession stays in sync.
   window.__wsMediaControl = function(action) {
     try {
       var el = primaryMedia();
-      if (!el) return;
-      if (action === 'play') el.play();
-      else if (action === 'pause' || action === 'stop') el.pause();
-    } catch (e) {}
+      if (!el) {
+        reportControl(action, 'no-media-element');
+        return;
+      }
+      if (action === 'play') {
+        var p = el.play();
+        if (p && p.catch) {
+          p.catch(function(e) {
+            reportControl('play', (e && e.name) || 'unknown');
+          });
+        }
+      } else if (action === 'pause' || action === 'stop') {
+        el.pause();
+      }
+    } catch (e) {
+      reportControl(action, (e && e.name) || 'unknown');
+    }
     schedule();
   };
 

--- a/test/js_fixtures/media_session/shim.js
+++ b/test/js_fixtures/media_session/shim.js
@@ -94,6 +94,10 @@
     el.__wsMediaAttached = true;
     ['play', 'playing', 'pause', 'ended', 'loadedmetadata', 'emptied']
       .forEach(function(ev) { el.addEventListener(ev, schedule, true); });
+    // Remembered so the background watchdog can tell "the page stopped this
+    // while we were not looking" from "this never played".
+    el.addEventListener('playing', function() { el.__wsWasPlaying = true; }, true);
+    el.addEventListener('ended', function() { el.__wsWasPlaying = false; }, true);
   }
   function scan() { mediaEls().forEach(attach); }
 
@@ -153,6 +157,9 @@
           });
         }
       } else if (action === 'pause' || action === 'stop') {
+        // The user asked for silence: the watchdog must not fight it.
+        var all = mediaEls();
+        for (var i = 0; i < all.length; i++) all[i].__wsWasPlaying = false;
         el.pause();
       }
     } catch (e) {
@@ -160,6 +167,113 @@
     }
     schedule();
   };
+
+  // BGAUDIO-012: keeping the app alive is not enough for a site that stops
+  // itself. A backgrounded app's page is told it is hidden, and players built
+  // for a tab (YouTube among them) pause on `visibilitychange` / `pagehide` by
+  // their own choice. While the app is backgrounded with this site's toggle on,
+  // report the page as visible, swallow those events before the page's own
+  // handlers see them, and re-issue play() if something paused anyway.
+  var bgActive = false;
+  var resumeTries = 0;
+  var watchTimer = null;
+
+  function realGetter(name) {
+    var d = Object.getOwnPropertyDescriptor(Document.prototype, name);
+    return d && d.get ? d.get : null;
+  }
+  function maskVisibility() {
+    ['hidden', 'webkitHidden'].forEach(function(name) {
+      var real = realGetter(name);
+      try {
+        Object.defineProperty(document, name, {
+          configurable: true,
+          get: function() {
+            if (bgActive) return false;
+            return real ? real.call(document) : false;
+          },
+        });
+      } catch (e) {}
+    });
+    ['visibilityState', 'webkitVisibilityState'].forEach(function(name) {
+      var real = realGetter(name);
+      try {
+        Object.defineProperty(document, name, {
+          configurable: true,
+          get: function() {
+            if (bgActive) return 'visible';
+            return real ? real.call(document) : 'visible';
+          },
+        });
+      } catch (e) {}
+    });
+  }
+  maskVisibility();
+
+  // Capture phase on window runs before anything the page registers on
+  // document or window, so its own pause-on-hide handler never runs.
+  ['visibilitychange', 'webkitvisibilitychange', 'pagehide', 'freeze', 'blur']
+    .forEach(function(type) {
+      var swallow = function(e) {
+        if (!bgActive) return;
+        e.stopImmediatePropagation();
+      };
+      try { window.addEventListener(type, swallow, true); } catch (e) {}
+      try { document.addEventListener(type, swallow, true); } catch (e) {}
+    });
+
+  function watchdog() {
+    if (!bgActive) return;
+    var els = mediaEls();
+    for (var i = 0; i < els.length; i++) {
+      var el = els[i];
+      if (!el.__wsWasPlaying || !el.paused || el.ended) continue;
+      if (resumeTries >= 8) continue;
+      resumeTries++;
+      try {
+        var p = el.play();
+        if (p && p.catch) {
+          p.catch(function(e) {
+            reportControl('background-resume', (e && e.name) || 'unknown');
+          });
+        }
+      } catch (e) {
+        reportControl('background-resume', (e && e.name) || 'unknown');
+      }
+    }
+  }
+
+  function setBackground(on) {
+    on = !!on;
+    if (on === bgActive) { relayBackground(on); return; }
+    bgActive = on;
+    resumeTries = 0;
+    if (watchTimer) { clearInterval(watchTimer); watchTimer = null; }
+    if (on) watchTimer = setInterval(watchdog, 1000);
+    relayBackground(on);
+    schedule();
+  }
+
+  // `evaluateJavascript` reaches the main frame only, so the state has to be
+  // handed down. A frame that fakes this message can only make its own page
+  // report itself visible, on a site the user opted into background audio for.
+  function relayBackground(on) {
+    try {
+      for (var i = 0; i < window.frames.length; i++) {
+        try {
+          window.frames[i].postMessage({ __wsMediaBackground: !!on }, '*');
+        } catch (e) {}
+      }
+    } catch (e) {}
+  }
+  window.addEventListener('message', function(ev) {
+    var d = ev && ev.data;
+    if (d && typeof d === 'object' && '__wsMediaBackground' in d) {
+      setBackground(d.__wsMediaBackground);
+    }
+  }, true);
+
+  window.__wsMediaBackground = setBackground;
 
   // Reconcile periodically: covers `ended` via currentTime, SPA route swaps,
   // and metadata set after the first report.

--- a/test/media_session_service_test.dart
+++ b/test/media_session_service_test.dart
@@ -58,6 +58,7 @@ void main() {
     LogService.instance.clear();
     MediaSessionService.debugEnabledOverride = true;
     MediaSessionService.debugVisibilityCheckDelay = Duration.zero;
+    MediaSessionService.debugSurfaceReclearDelay = Duration.zero;
     service.debugReset();
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (call) async {
@@ -332,14 +333,22 @@ void main() {
       // so `isActive` is false and `stopAll` would do nothing.
       expect(service.isActive, isFalse);
       await service.clearOsMediaSurface();
-      expect(controlCalls().map((c) => c.method), ['stop']);
+      // Twice: WebKit republishes its Now Playing entry when it finishes
+      // processing the pause that preceded this.
+      expect(controlCalls().map((c) => c.method), ['stop', 'stop']);
+      expect(
+          controlCalls().every((c) =>
+              (c.arguments as Map)['deactivate'] == true),
+          isTrue,
+          reason: 'clearing the metadata alone leaves an entry the engine '
+              'repopulates; the session has to go with it');
     });
 
     test('tears our own surface down when we do own it', () async {
       await reportPlaying('a');
       calls.clear();
       await service.clearOsMediaSurface();
-      expect(controlCalls().map((c) => c.method), ['stop']);
+      expect(controlCalls().map((c) => c.method), ['stop', 'stop']);
       expect(service.isActive, isFalse);
     });
 

--- a/test/media_session_service_test.dart
+++ b/test/media_session_service_test.dart
@@ -259,6 +259,40 @@ void main() {
     ]);
   });
 
+  test('native audio-session state lands in the app log (BGAUDIO-011)',
+      () async {
+    service.initialize();
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+      channel.name,
+      codec.encodeMethodCall(const MethodCall('onSessionState', {
+        'message': 'interruption ended, session re-activated '
+            '[category=AVAudioSessionCategoryPlayback otherAudio=false]',
+      })),
+      (_) {},
+    );
+    final lines = LogService.instance.allEntriesMerged
+        .where((e) => e.tag == 'MediaSession')
+        .map((e) => e.message)
+        .toList();
+    expect(lines.any((m) => m.contains('interruption ended')), isTrue);
+    expect(lines.any((m) => m.contains('Playback')), isTrue);
+  });
+
+  test('an empty session-state message is ignored', () async {
+    service.initialize();
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+      channel.name,
+      codec.encodeMethodCall(
+          const MethodCall('onSessionState', {'message': ''})),
+      (_) {},
+    );
+    expect(LogService.instance.allEntriesMerged.where((e) =>
+        e.tag == 'MediaSession' && e.message.startsWith('Audio session')),
+        isEmpty);
+  });
+
   test('an empty transport action is ignored', () async {
     service.initialize();
     final js = <String>[];

--- a/test/media_session_service_test.dart
+++ b/test/media_session_service_test.dart
@@ -280,7 +280,8 @@ void main() {
     await expectLater(reportPlaying('a'), completes);
   });
 
-  test('everything is inert off Android', () async {
+  test('everything is inert on a platform with no native media session',
+      () async {
     MediaSessionService.debugEnabledOverride = false;
     service.debugReset();
 
@@ -288,5 +289,13 @@ void main() {
     await service.stopAll();
     expect(calls, isEmpty);
     expect(await service.notificationPosted(), isFalse);
+    // The same answer gates the shim + handler injection in webview.dart, so
+    // no report can arrive on a platform that would drop it.
+    expect(service.isSupported, isFalse);
+  });
+
+  test('isSupported is what arms the bridge', () async {
+    MediaSessionService.debugEnabledOverride = true;
+    expect(service.isSupported, isTrue);
   });
 }

--- a/test/media_session_service_test.dart
+++ b/test/media_session_service_test.dart
@@ -274,6 +274,49 @@ void main() {
     expect(js, isEmpty);
   });
 
+  group('control failures are diagnosable (BGAUDIO-007)', () {
+    test('a refused transport is logged as a warning, no metadata', () async {
+      await service.reportControlFailure(
+          action: 'play', error: 'NotAllowedError');
+      final warnings = LogService.instance.allEntriesMerged
+          .where((e) => e.tag == 'MediaSession' && e.level == LogLevel.warning)
+          .map((e) => e.message)
+          .toList();
+      expect(warnings.single, contains('play'));
+      expect(warnings.single, contains('NotAllowedError'));
+    });
+
+    test('the failure path invokes nothing on the channel', () async {
+      await service.reportControlFailure(action: 'play', error: 'unknown');
+      expect(calls, isEmpty);
+    });
+  });
+
+  group('clearOsMediaSurface (BGAUDIO-009/010)', () {
+    test('clears even when we never raised anything', () async {
+      // The iOS case this exists for: the Now Playing entry belongs to WebKit,
+      // so `isActive` is false and `stopAll` would do nothing.
+      expect(service.isActive, isFalse);
+      await service.clearOsMediaSurface();
+      expect(controlCalls().map((c) => c.method), ['stop']);
+    });
+
+    test('tears our own surface down when we do own it', () async {
+      await reportPlaying('a');
+      calls.clear();
+      await service.clearOsMediaSurface();
+      expect(controlCalls().map((c) => c.method), ['stop']);
+      expect(service.isActive, isFalse);
+    });
+
+    test('is inert where there is no native media session', () async {
+      MediaSessionService.debugEnabledOverride = false;
+      service.debugReset();
+      await service.clearOsMediaSurface();
+      expect(calls, isEmpty);
+    });
+  });
+
   test('a missing native side does not throw', () async {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, null);

--- a/test/media_session_shim_test.dart
+++ b/test/media_session_shim_test.dart
@@ -33,6 +33,10 @@ void main() {
 
   test('exposes the Dart->page transport entry point', () {
     expect(shim, contains('window.__wsMediaControl'));
+    // BGAUDIO-012: the app-background signal and the visibility mask it drives.
+    expect(shim, contains('window.__wsMediaBackground'));
+    expect(shim, contains('visibilitychange'));
+    expect(shim, contains('stopImmediatePropagation'));
     expect(shim, contains(".play()"));
     expect(shim, contains(".pause()"));
   });

--- a/test/webview_pause_lifecycle_test.dart
+++ b/test/webview_pause_lifecycle_test.dart
@@ -10,6 +10,7 @@ import 'package:webspace/web_view_model.dart';
 /// touches only the pause-related controller methods, nothing else".
 class _RecordingController extends Fake implements WebViewController {
   final List<String> calls = [];
+  final List<String> js = [];
 
   @override
   Future<void> pause() async {
@@ -29,6 +30,12 @@ class _RecordingController extends Fake implements WebViewController {
   @override
   Future<void> resumeAllJsTimers() async {
     calls.add('resumeAllJsTimers');
+  }
+
+  @override
+  Future<void> evaluateJavascript(String source) async {
+    calls.add('evaluateJavascript');
+    js.add(source);
   }
 }
 
@@ -123,6 +130,46 @@ void main() {
       final c = _RecordingController();
       await _modelWith(c, notificationsEnabled: true).resumeWebView();
       expect(c.calls, ['resume']);
+    });
+  });
+
+  group('BGAUDIO-009 media pause when a site loses the screen', () {
+    test('pauseMediaPlayback() pauses the page media of an ordinary site',
+        () async {
+      final c = _RecordingController();
+      await _modelWith(c).pauseMediaPlayback();
+      expect(c.calls, ['evaluateJavascript']);
+      expect(c.js.single, contains("querySelectorAll('audio,video')"));
+      expect(c.js.single, contains('.pause()'));
+    });
+
+    test('pauseMediaPlayback() with backgroundAudioEnabled is a no-op',
+        () async {
+      final c = _RecordingController();
+      await _modelWith(c, backgroundAudioEnabled: true).pauseMediaPlayback();
+      expect(c.calls, isEmpty,
+          reason: 'That toggle exists to keep this site sounding after it '
+              'loses the screen.');
+    });
+
+    test('an archive-tier site is not exempt', () async {
+      // ARCH-006: the effective getter folds archive tier to false, so the
+      // media stop applies as it does to any ordinary site.
+      final c = _RecordingController();
+      await _modelWith(c, backgroundAudioEnabled: true, isArchiveTier: true)
+          .pauseMediaPlayback();
+      expect(c.calls, ['evaluateJavascript']);
+    });
+
+    test('pauseMediaPlayback() does not touch the pause API', () async {
+      final c = _RecordingController();
+      await _modelWith(c).pauseMediaPlayback();
+      expect(c.calls, isNot(contains('pause')));
+      expect(c.calls, isNot(contains('pauseAllJsTimers')));
+    });
+
+    test('no controller, no call', () async {
+      await expectLater(_modelWith(null).pauseMediaPlayback(), completes);
     });
   });
 

--- a/test/webview_pause_lifecycle_test.dart
+++ b/test/webview_pause_lifecycle_test.dart
@@ -133,6 +133,45 @@ void main() {
     });
   });
 
+  group('BGAUDIO-012 background playback signal', () {
+    test('a background-audio site is told the app went to background',
+        () async {
+      final c = _RecordingController();
+      await _modelWith(c, backgroundAudioEnabled: true)
+          .setBackgroundPlayback(true);
+      expect(c.js.single, contains('__wsMediaBackground(true)'));
+    });
+
+    test('and told when it comes back', () async {
+      final c = _RecordingController();
+      await _modelWith(c, backgroundAudioEnabled: true)
+          .setBackgroundPlayback(false);
+      expect(c.js.single, contains('__wsMediaBackground(false)'));
+    });
+
+    test('a site without the toggle is never told', () async {
+      final c = _RecordingController();
+      await _modelWith(c).setBackgroundPlayback(true);
+      expect(c.calls, isEmpty,
+          reason: 'masking page visibility for a site the user did not opt in '
+              'for would keep players running that should stop');
+    });
+
+    test('an archive-tier site is never told', () async {
+      final c = _RecordingController();
+      await _modelWith(c, backgroundAudioEnabled: true, isArchiveTier: true)
+          .setBackgroundPlayback(true);
+      expect(c.calls, isEmpty);
+    });
+
+    test('the call is guarded against a missing hook', () async {
+      final c = _RecordingController();
+      await _modelWith(c, backgroundAudioEnabled: true)
+          .setBackgroundPlayback(true);
+      expect(c.js.single, startsWith('if(window.__wsMediaBackground)'));
+    });
+  });
+
   group('BGAUDIO-009 media pause when a site loses the screen', () {
     test('pauseMediaPlayback() pauses the page media of an ordinary site',
         () async {

--- a/tool/dump_shim_js.dart
+++ b/tool/dump_shim_js.dart
@@ -181,6 +181,7 @@ Map<String, String> buildAllFixtures() {
   fixtures['microphone_stream/shim.js'] = buildMicrophoneStreamShim();
 
   fixtures['media_session/shim.js'] = buildMediaSessionShim();
+  fixtures['media_session/pause_media.js'] = buildMediaPauseJs();
 
   // Engine-consistent navigator identity, one fixture per engine × form
   // factor: Gecko mobile (Firefox-Android — vendor "", oscpu/buildID set,


### PR DESCRIPTION
Neither pause stops the media pipeline, so a site with the toggle off kept
playing after it lost the screen and held the iOS Now Playing controls up,
with a play button that reached a frozen page. Sites that do opt in now get
an app-owned Now Playing session whose transport controls drive the page.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0181VBKDddBhbYZFragXTC75