### PR TITLE
Add version 25 changelog for Android

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/25.txt
+++ b/fastlane/metadata/android/en-US/changelogs/25.txt
@@ -1,0 +1,9 @@
+✨ New Features:
+• Per-site camera and microphone access
+• Background audio playback
+• Permission badges in the site drawer
+
+🐛 Bug Fixes:
+• Page zoom and viewport reflow
+• Media controls on iOS
+• Separate notifications per site


### PR DESCRIPTION
Add fastlane metadata changelog documenting version 25 release notes for Android.

Changes:
- Per-site camera and microphone access
- Background audio playback
- Permission badges in the site drawer
- Page zoom and viewport reflow fixes
- Media controls on iOS
- Separate notifications per site

https://claude.ai/code/session_01TUZhs5c6WZTFoEeyqprapY