### PR TITLE
Add protection report (block statistics) screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,7 @@ Specs live under `openspec/specs/<slug>/spec.md` (Given/When/Then). **Read the r
 | web-push-notifications | per-site `notificationsEnabled` toggle: JS Notification polyfill → flutter_local_notifications, auto-loads + skips per-instance pause for notif sites, iOS `beginBackgroundTask` grace + `BGAppRefreshTask` reload, Android mirrors via `WorkManager` periodic refresh (no foreground service) |
 | archive | passphrase-gated archived webspaces in a fixed slot pool; active state stays byte-identical when no archive is open |
 | background-audio | per-site toggle: skips per-instance pause + app-background global JS pause (any-loaded veto), iOS `.playback` AVAudioSession + `audio` background mode; Android `mediaPlayback` foreground service + MediaStyle notification (BGAUDIO-006) driven by a page-JS media-session bridge; CI-tested via lifecycle injection + beaconing HTML fixture, plus a 3-tier notification gate (BGAUDIO-007: real-Chromium shim, channel contract, emulator assert on `getActiveNotifications()`) |
+| block-statistics | persistent app-wide protection report: per-category daily buckets, 7/30-day ranges, all-time total; archive-tier sites excluded |
 | webspaces | named site collections |
 | webview-hints | color-scheme, matchMedia, theme prelude cache |
 | webview-pause-lifecycle | per-instance vs process-global pause; "paused != frozen" |

--- a/lib/l10n/app_af.arb
+++ b/lib/l10n/app_af.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Stuur toetskennisgewing",
   "devToolsTestNotificationSent": "Toetskennisgewing gestuur (sien logboeke)",
   "devToolsTestNotificationTitle": "WebSpace-toetskennisgewing",
-  "devToolsTestNotificationBody": "As jy dit kan sien, werk die bedryfstelsel se kennisgewingaflewering."
+  "devToolsTestNotificationBody": "As jy dit kan sien, werk die bedryfstelsel se kennisgewingaflewering.",
+  "blockStatsTitle": "Beskermingsverslag",
+  "blockStatsSubtitleWeek": "Volgers hierdie week geblokkeer",
+  "blockStatsSubtitleMonth": "Volgers in die afgelope 30 dae geblokkeer",
+  "blockStatsRange7": "7 dae",
+  "blockStatsRange30": "30 dae",
+  "blockStatsCategoryFilterList": "Advertensie- en volgerversoeke",
+  "blockStatsCategoryDns": "Bekende volgerdomeine",
+  "blockStatsCategoryParam": "Volgparameters verwyder",
+  "blockStatsCategoryCdn": "CDN-versoeke plaaslik bedien",
+  "blockStatsSince": "{count} geblokkeer sedert {date}",
+  "blockStatsEmpty": "Nog niks geblokkeer nie",
+  "blockStatsEmptyHint": "Skakel volgbeskerming vir 'n webwerf aan en die versoeke wat dit blokkeer verskyn hier.",
+  "blockStatsReset": "Statistieke terugstel",
+  "blockStatsResetConfirm": "Elke teller keer terug na nul en die telling begin vandag oor.",
+  "appSettingsProtectionReportSubtitle": "Wat die blokkeerders gekeer het, oor tyd"
 }

--- a/lib/l10n/app_am.arb
+++ b/lib/l10n/app_am.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "የሙከራ ማስታወቂያ ላክ",
   "devToolsTestNotificationSent": "የሙከራ ማስታወቂያ ተልኳል (ምዝግቦችን ይመልከቱ)",
   "devToolsTestNotificationTitle": "የWebSpace የሙከራ ማስታወቂያ",
-  "devToolsTestNotificationBody": "ይህን ማየት ከቻሉ የስርዓተ ክወና ማስታወቂያ ማድረስ ይሰራል።"
+  "devToolsTestNotificationBody": "ይህን ማየት ከቻሉ የስርዓተ ክወና ማስታወቂያ ማድረስ ይሰራል።",
+  "blockStatsTitle": "የጥበቃ ሪፖርት",
+  "blockStatsSubtitleWeek": "በዚህ ሳምንት የታገዱ ተከታታዮች",
+  "blockStatsSubtitleMonth": "ባለፉት 30 ቀናት የታገዱ ተከታታዮች",
+  "blockStatsRange7": "7 ቀናት",
+  "blockStatsRange30": "30 ቀናት",
+  "blockStatsCategoryFilterList": "የማስታወቂያና የመከታተያ ጥያቄዎች",
+  "blockStatsCategoryDns": "የሚታወቁ የመከታተያ ጎራዎች",
+  "blockStatsCategoryParam": "የመከታተያ መለኪያዎች ተወግደዋል",
+  "blockStatsCategoryCdn": "የCDN ጥያቄዎች በአካባቢው ቀርበዋል",
+  "blockStatsSince": "ከ{date} ጀምሮ {count} ታግደዋል",
+  "blockStatsEmpty": "እስካሁን ምንም አልታገደም",
+  "blockStatsEmptyHint": "ለአንድ ድረ-ገጽ የመከታተያ ጥበቃን ያብሩ፤ የሚያግዳቸው ጥያቄዎች እዚህ ይታያሉ።",
+  "blockStatsReset": "ስታቲስቲክስን ዳግም አስጀምር",
+  "blockStatsResetConfirm": "እያንዳንዱ ቆጣሪ ወደ ዜሮ ይመለሳል፤ ቆጠራውም ከዛሬ ጀምሮ እንደገና ይጀምራል።",
+  "appSettingsProtectionReportSubtitle": "አጋጆቹ ያገዱት፣ በጊዜ ሂደት"
 }

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "إرسال إشعار اختباري",
   "devToolsTestNotificationSent": "تم إرسال الإشعار الاختباري (راجع السجلات)",
   "devToolsTestNotificationTitle": "إشعار اختباري من WebSpace",
-  "devToolsTestNotificationBody": "إذا كنت ترى هذا، فإن تسليم إشعارات نظام التشغيل يعمل."
+  "devToolsTestNotificationBody": "إذا كنت ترى هذا، فإن تسليم إشعارات نظام التشغيل يعمل.",
+  "blockStatsTitle": "تقرير الحماية",
+  "blockStatsSubtitleWeek": "متعقبات محظورة هذا الأسبوع",
+  "blockStatsSubtitleMonth": "متعقبات محظورة خلال آخر 30 يومًا",
+  "blockStatsRange7": "7 أيام",
+  "blockStatsRange30": "30 يومًا",
+  "blockStatsCategoryFilterList": "طلبات الإعلانات والمتعقبات",
+  "blockStatsCategoryDns": "نطاقات تعقب معروفة",
+  "blockStatsCategoryParam": "معاملات التتبع المُزالة",
+  "blockStatsCategoryCdn": "طلبات CDN مُقدَّمة محليًا",
+  "blockStatsSince": "{count} محظورة منذ {date}",
+  "blockStatsEmpty": "لم يُحظر أي شيء بعد",
+  "blockStatsEmptyHint": "فعّل الحماية من التتبع لموقع ما وستظهر هنا الطلبات التي يحظرها.",
+  "blockStatsReset": "إعادة تعيين الإحصائيات",
+  "blockStatsResetConfirm": "يعود كل عدّاد إلى الصفر ويبدأ العد من جديد اليوم.",
+  "appSettingsProtectionReportSubtitle": "ما أوقفته أدوات الحظر، عبر الزمن"
 }

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Изпращане на тестово известие",
   "devToolsTestNotificationSent": "Тестовото известие е изпратено (вижте дневниците)",
   "devToolsTestNotificationTitle": "Тестово известие на WebSpace",
-  "devToolsTestNotificationBody": "Ако виждате това, доставянето на известия от операционната система работи."
+  "devToolsTestNotificationBody": "Ако виждате това, доставянето на известия от операционната система работи.",
+  "blockStatsTitle": "Отчет за защитата",
+  "blockStatsSubtitleWeek": "Блокирани тракери тази седмица",
+  "blockStatsSubtitleMonth": "Блокирани тракери през последните 30 дни",
+  "blockStatsRange7": "7 дни",
+  "blockStatsRange30": "30 дни",
+  "blockStatsCategoryFilterList": "Заявки към реклами и тракери",
+  "blockStatsCategoryDns": "Известни домейни на тракери",
+  "blockStatsCategoryParam": "Премахнати проследяващи параметри",
+  "blockStatsCategoryCdn": "Заявки към CDN, обслужени локално",
+  "blockStatsSince": "{count} блокирани от {date}",
+  "blockStatsEmpty": "Още нищо не е блокирано",
+  "blockStatsEmptyHint": "Включете защитата от проследяване за даден сайт и блокираните заявки ще се появят тук.",
+  "blockStatsReset": "Нулиране на статистиката",
+  "blockStatsResetConfirm": "Всеки брояч се връща на нула и броенето започва отново от днес.",
+  "appSettingsProtectionReportSubtitle": "Какво са спрели блокиращите модули с течение на времето"
 }

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "পরীক্ষামূলক বিজ্ঞপ্তি পাঠান",
   "devToolsTestNotificationSent": "পরীক্ষামূলক বিজ্ঞপ্তি পাঠানো হয়েছে (লগ দেখুন)",
   "devToolsTestNotificationTitle": "WebSpace পরীক্ষামূলক বিজ্ঞপ্তি",
-  "devToolsTestNotificationBody": "আপনি যদি এটি দেখতে পান, তাহলে অপারেটিং সিস্টেমের বিজ্ঞপ্তি প্রদান কাজ করছে।"
+  "devToolsTestNotificationBody": "আপনি যদি এটি দেখতে পান, তাহলে অপারেটিং সিস্টেমের বিজ্ঞপ্তি প্রদান কাজ করছে।",
+  "blockStatsTitle": "সুরক্ষা প্রতিবেদন",
+  "blockStatsSubtitleWeek": "এই সপ্তাহে অবরুদ্ধ ট্র্যাকার",
+  "blockStatsSubtitleMonth": "গত ৩০ দিনে অবরুদ্ধ ট্র্যাকার",
+  "blockStatsRange7": "৭ দিন",
+  "blockStatsRange30": "৩০ দিন",
+  "blockStatsCategoryFilterList": "বিজ্ঞাপন ও ট্র্যাকারের অনুরোধ",
+  "blockStatsCategoryDns": "পরিচিত ট্র্যাকার ডোমেইন",
+  "blockStatsCategoryParam": "ট্র্যাকিং প্যারামিটার সরানো হয়েছে",
+  "blockStatsCategoryCdn": "স্থানীয়ভাবে পরিবেশিত CDN অনুরোধ",
+  "blockStatsSince": "{date} থেকে {count}টি অবরুদ্ধ",
+  "blockStatsEmpty": "এখনও কিছু অবরুদ্ধ হয়নি",
+  "blockStatsEmptyHint": "কোনো সাইটের জন্য ট্র্যাকিং সুরক্ষা চালু করুন, তাহলে অবরুদ্ধ অনুরোধগুলো এখানে দেখা যাবে।",
+  "blockStatsReset": "পরিসংখ্যান রিসেট করুন",
+  "blockStatsResetConfirm": "প্রতিটি গণনা শূন্যে ফিরে যাবে এবং আজ থেকে নতুন করে গণনা শুরু হবে।",
+  "appSettingsProtectionReportSubtitle": "ব্লকারগুলো সময়ের সাথে যা আটকেছে"
 }

--- a/lib/l10n/app_bs.arb
+++ b/lib/l10n/app_bs.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Pošalji probnu obavijest",
   "devToolsTestNotificationSent": "Probna obavijest je poslana (pogledajte zapise)",
   "devToolsTestNotificationTitle": "WebSpace probna obavijest",
-  "devToolsTestNotificationBody": "Ako vidite ovo, isporuka obavijesti operativnog sistema radi."
+  "devToolsTestNotificationBody": "Ako vidite ovo, isporuka obavijesti operativnog sistema radi.",
+  "blockStatsTitle": "Izvještaj o zaštiti",
+  "blockStatsSubtitleWeek": "Blokirani pratioci ove sedmice",
+  "blockStatsSubtitleMonth": "Blokirani pratioci u posljednjih 30 dana",
+  "blockStatsRange7": "7 dana",
+  "blockStatsRange30": "30 dana",
+  "blockStatsCategoryFilterList": "Zahtjevi reklama i pratilaca",
+  "blockStatsCategoryDns": "Poznati domeni pratilaca",
+  "blockStatsCategoryParam": "Uklonjeni parametri praćenja",
+  "blockStatsCategoryCdn": "CDN zahtjevi posluženi lokalno",
+  "blockStatsSince": "{count} blokirano od {date}",
+  "blockStatsEmpty": "Još ništa nije blokirano",
+  "blockStatsEmptyHint": "Uključite zaštitu od praćenja za neku stranicu i zahtjevi koje blokira pojavit će se ovdje.",
+  "blockStatsReset": "Poništi statistiku",
+  "blockStatsResetConfirm": "Svaki brojač se vraća na nulu i brojanje počinje ponovo od danas.",
+  "appSettingsProtectionReportSubtitle": "Šta su blokatori zaustavili tokom vremena"
 }

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Envia una notificació de prova",
   "devToolsTestNotificationSent": "Notificació de prova enviada (vegeu els registres)",
   "devToolsTestNotificationTitle": "Notificació de prova de WebSpace",
-  "devToolsTestNotificationBody": "Si pots veure això, el lliurament de notificacions del sistema operatiu funciona."
+  "devToolsTestNotificationBody": "Si pots veure això, el lliurament de notificacions del sistema operatiu funciona.",
+  "blockStatsTitle": "Informe de protecció",
+  "blockStatsSubtitleWeek": "Rastrejadors bloquejats aquesta setmana",
+  "blockStatsSubtitleMonth": "Rastrejadors bloquejats els últims 30 dies",
+  "blockStatsRange7": "7 dies",
+  "blockStatsRange30": "30 dies",
+  "blockStatsCategoryFilterList": "Sol·licituds d'anuncis i rastrejadors",
+  "blockStatsCategoryDns": "Dominis de rastreig coneguts",
+  "blockStatsCategoryParam": "Paràmetres de seguiment eliminats",
+  "blockStatsCategoryCdn": "Sol·licituds de CDN servides localment",
+  "blockStatsSince": "{count} bloquejades des del {date}",
+  "blockStatsEmpty": "Encara no s'ha bloquejat res",
+  "blockStatsEmptyHint": "Activa la protecció contra el rastreig d'un lloc i les sol·licituds que bloquegi apareixeran aquí.",
+  "blockStatsReset": "Restableix les estadístiques",
+  "blockStatsResetConfirm": "Tots els comptadors tornen a zero i el recompte es reinicia avui.",
+  "appSettingsProtectionReportSubtitle": "Què han aturat els bloquejadors al llarg del temps"
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Odeslat testovací oznámení",
   "devToolsTestNotificationSent": "Testovací oznámení odesláno (viz protokoly)",
   "devToolsTestNotificationTitle": "Testovací oznámení WebSpace",
-  "devToolsTestNotificationBody": "Pokud toto vidíte, doručování oznámení operačního systému funguje."
+  "devToolsTestNotificationBody": "Pokud toto vidíte, doručování oznámení operačního systému funguje.",
+  "blockStatsTitle": "Zpráva o ochraně",
+  "blockStatsSubtitleWeek": "Sledovací prvky blokované tento týden",
+  "blockStatsSubtitleMonth": "Sledovací prvky blokované za posledních 30 dní",
+  "blockStatsRange7": "7 dní",
+  "blockStatsRange30": "30 dní",
+  "blockStatsCategoryFilterList": "Požadavky reklam a sledovačů",
+  "blockStatsCategoryDns": "Známé sledovací domény",
+  "blockStatsCategoryParam": "Odstraněné sledovací parametry",
+  "blockStatsCategoryCdn": "Požadavky na CDN obsloužené místně",
+  "blockStatsSince": "{count} blokováno od {date}",
+  "blockStatsEmpty": "Zatím nic nebylo blokováno",
+  "blockStatsEmptyHint": "Zapněte u webu ochranu proti sledování a blokované požadavky se objeví zde.",
+  "blockStatsReset": "Vynulovat statistiky",
+  "blockStatsResetConfirm": "Každé počítadlo se vrátí na nulu a počítání začne znovu od dneška.",
+  "appSettingsProtectionReportSubtitle": "Co blokátory zastavily v průběhu času"
 }

--- a/lib/l10n/app_cy.arb
+++ b/lib/l10n/app_cy.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Anfon hysbysiad prawf",
   "devToolsTestNotificationSent": "Anfonwyd hysbysiad prawf (gweler y cofnodion)",
   "devToolsTestNotificationTitle": "Hysbysiad prawf WebSpace",
-  "devToolsTestNotificationBody": "Os gallwch weld hyn, mae danfon hysbysiadau'r system weithredu yn gweithio."
+  "devToolsTestNotificationBody": "Os gallwch weld hyn, mae danfon hysbysiadau'r system weithredu yn gweithio.",
+  "blockStatsTitle": "Adroddiad diogelwch",
+  "blockStatsSubtitleWeek": "Traciwyr wedi'u rhwystro yr wythnos hon",
+  "blockStatsSubtitleMonth": "Traciwyr wedi'u rhwystro yn y 30 diwrnod diwethaf",
+  "blockStatsRange7": "7 diwrnod",
+  "blockStatsRange30": "30 diwrnod",
+  "blockStatsCategoryFilterList": "Ceisiadau hysbysebion a thraciwyr",
+  "blockStatsCategoryDns": "Parthau tracio hysbys",
+  "blockStatsCategoryParam": "Paramedrau tracio wedi'u tynnu",
+  "blockStatsCategoryCdn": "Ceisiadau CDN wedi'u gweini'n lleol",
+  "blockStatsSince": "{count} wedi'u rhwystro ers {date}",
+  "blockStatsEmpty": "Dim byd wedi'i rwystro eto",
+  "blockStatsEmptyHint": "Trowch amddiffyniad rhag tracio ymlaen ar gyfer gwefan a bydd y ceisiadau mae'n eu rhwystro yn ymddangos yma.",
+  "blockStatsReset": "Ailosod yr ystadegau",
+  "blockStatsResetConfirm": "Mae pob cyfrifydd yn dychwelyd i sero ac mae'r cyfrif yn ailddechrau heddiw.",
+  "appSettingsProtectionReportSubtitle": "Yr hyn mae'r rhwystrwyr wedi'i atal, dros amser"
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Send testnotifikation",
   "devToolsTestNotificationSent": "Testnotifikation sendt (se logfiler)",
   "devToolsTestNotificationTitle": "WebSpace-testnotifikation",
-  "devToolsTestNotificationBody": "Hvis du kan se dette, fungerer operativsystemets notifikationslevering."
+  "devToolsTestNotificationBody": "Hvis du kan se dette, fungerer operativsystemets notifikationslevering.",
+  "blockStatsTitle": "Beskyttelsesrapport",
+  "blockStatsSubtitleWeek": "Sporere blokeret i denne uge",
+  "blockStatsSubtitleMonth": "Sporere blokeret de seneste 30 dage",
+  "blockStatsRange7": "7 dage",
+  "blockStatsRange30": "30 dage",
+  "blockStatsCategoryFilterList": "Anmodninger fra reklamer og sporere",
+  "blockStatsCategoryDns": "Kendte sporingsdomæner",
+  "blockStatsCategoryParam": "Fjernede sporingsparametre",
+  "blockStatsCategoryCdn": "CDN-anmodninger leveret lokalt",
+  "blockStatsSince": "{count} blokeret siden {date}",
+  "blockStatsEmpty": "Intet blokeret endnu",
+  "blockStatsEmptyHint": "Slå sporingsbeskyttelse til for et websted, så vises de anmodninger, det blokerer, her.",
+  "blockStatsReset": "Nulstil statistik",
+  "blockStatsResetConfirm": "Alle tællere sættes til nul, og optællingen starter forfra i dag.",
+  "appSettingsProtectionReportSubtitle": "Hvad blokeringerne har stoppet over tid"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Testbenachrichtigung senden",
   "devToolsTestNotificationSent": "Testbenachrichtigung gesendet (siehe Protokolle)",
   "devToolsTestNotificationTitle": "WebSpace-Testbenachrichtigung",
-  "devToolsTestNotificationBody": "Wenn Sie dies sehen können, funktioniert die Benachrichtigungszustellung des Betriebssystems."
+  "devToolsTestNotificationBody": "Wenn Sie dies sehen können, funktioniert die Benachrichtigungszustellung des Betriebssystems.",
+  "blockStatsTitle": "Schutzbericht",
+  "blockStatsSubtitleWeek": "Diese Woche blockierte Tracker",
+  "blockStatsSubtitleMonth": "In den letzten 30 Tagen blockierte Tracker",
+  "blockStatsRange7": "7 Tage",
+  "blockStatsRange30": "30 Tage",
+  "blockStatsCategoryFilterList": "Werbe- und Tracker-Anfragen",
+  "blockStatsCategoryDns": "Bekannte Tracker-Domains",
+  "blockStatsCategoryParam": "Entfernte Tracking-Parameter",
+  "blockStatsCategoryCdn": "Lokal ausgelieferte CDN-Anfragen",
+  "blockStatsSince": "{count} blockiert seit {date}",
+  "blockStatsEmpty": "Bisher nichts blockiert",
+  "blockStatsEmptyHint": "Aktiviere den Tracking-Schutz für eine Website, dann erscheinen die blockierten Anfragen hier.",
+  "blockStatsReset": "Statistik zurücksetzen",
+  "blockStatsResetConfirm": "Alle Zähler werden auf null gesetzt und die Zählung beginnt heute von vorn.",
+  "appSettingsProtectionReportSubtitle": "Was die Blocker im Lauf der Zeit gestoppt haben"
 }

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Αποστολή δοκιμαστικής ειδοποίησης",
   "devToolsTestNotificationSent": "Η δοκιμαστική ειδοποίηση στάλθηκε (δείτε τα αρχεία καταγραφής)",
   "devToolsTestNotificationTitle": "Δοκιμαστική ειδοποίηση WebSpace",
-  "devToolsTestNotificationBody": "Αν μπορείτε να το δείτε αυτό, η παράδοση ειδοποιήσεων του λειτουργικού συστήματος λειτουργεί."
+  "devToolsTestNotificationBody": "Αν μπορείτε να το δείτε αυτό, η παράδοση ειδοποιήσεων του λειτουργικού συστήματος λειτουργεί.",
+  "blockStatsTitle": "Αναφορά προστασίας",
+  "blockStatsSubtitleWeek": "Ιχνηλάτες που αποκλείστηκαν αυτή την εβδομάδα",
+  "blockStatsSubtitleMonth": "Ιχνηλάτες που αποκλείστηκαν τις τελευταίες 30 ημέρες",
+  "blockStatsRange7": "7 ημέρες",
+  "blockStatsRange30": "30 ημέρες",
+  "blockStatsCategoryFilterList": "Αιτήματα διαφημίσεων και ιχνηλατών",
+  "blockStatsCategoryDns": "Γνωστοί τομείς ιχνηλάτησης",
+  "blockStatsCategoryParam": "Παράμετροι παρακολούθησης που αφαιρέθηκαν",
+  "blockStatsCategoryCdn": "Αιτήματα CDN που εξυπηρετήθηκαν τοπικά",
+  "blockStatsSince": "{count} αποκλείστηκαν από τις {date}",
+  "blockStatsEmpty": "Δεν έχει αποκλειστεί τίποτα ακόμη",
+  "blockStatsEmptyHint": "Ενεργοποιήστε την προστασία από ιχνηλάτηση σε έναν ιστότοπο και τα αιτήματα που αποκλείει θα εμφανιστούν εδώ.",
+  "blockStatsReset": "Επαναφορά στατιστικών",
+  "blockStatsResetConfirm": "Κάθε μετρητής μηδενίζεται και η καταμέτρηση ξεκινά ξανά από σήμερα.",
+  "appSettingsProtectionReportSubtitle": "Τι σταμάτησαν οι αποκλειστές με την πάροδο του χρόνου"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3414,5 +3414,69 @@
   "appSettingsContentBlockerHint": "Blocks ads, trackers, and unwanted page elements using filter lists like EasyList. Supports domain-level blocking, CSS cosmetic filters to hide page elements, and text-based hiding rules. Enable or disable individual filter lists below, and toggle content blocking per-site in each site's settings.",
   "@appSettingsContentBlockerHint": {
     "description": "Info dialog explaining the content blocker: it blocks ads, trackers, and unwanted page elements using filter lists like EasyList, supports domain, CSS cosmetic, and text-hiding rules, and is toggled on per-site."
+  },
+  "blockStatsTitle": "Protection report",
+  "@blockStatsTitle": {
+    "description": "Title of the screen (and of the App Settings entry that opens it) summarising how many tracking requests the app's blockers stopped over time."
+  },
+  "blockStatsSubtitleWeek": "Trackers blocked this week",
+  "@blockStatsSubtitleWeek": {
+    "description": "Caption under the large headline number on the protection report when the 7-day range is selected. The number itself is rendered separately above this text."
+  },
+  "blockStatsSubtitleMonth": "Trackers blocked in the last 30 days",
+  "@blockStatsSubtitleMonth": {
+    "description": "Caption under the large headline number on the protection report when the 30-day range is selected. The number itself is rendered separately above this text."
+  },
+  "blockStatsRange7": "7 days",
+  "@blockStatsRange7": {
+    "description": "Label of the button that switches the protection report to the last 7 days. Keep it short: it sits in a two-segment toggle."
+  },
+  "blockStatsRange30": "30 days",
+  "@blockStatsRange30": {
+    "description": "Label of the button that switches the protection report to the last 30 days. Keep it short: it sits in a two-segment toggle."
+  },
+  "blockStatsCategoryFilterList": "Ad and tracker requests",
+  "@blockStatsCategoryFilterList": {
+    "description": "Protection report row for requests blocked by an ABP filter list (EasyList, EasyPrivacy, Fanboy's). Preceded on screen by the count of such requests."
+  },
+  "blockStatsCategoryDns": "Known tracker domains",
+  "@blockStatsCategoryDns": {
+    "description": "Protection report row for requests blocked because the domain is on the downloaded DNS blocklist. Preceded on screen by the count of such requests."
+  },
+  "blockStatsCategoryParam": "Tracking parameters removed",
+  "@blockStatsCategoryParam": {
+    "description": "Protection report row counting URLs whose tracking query parameters (utm_source and similar) were stripped before the page loaded. Preceded on screen by the count."
+  },
+  "blockStatsCategoryCdn": "CDN requests served locally",
+  "@blockStatsCategoryCdn": {
+    "description": "Protection report row counting third-party CDN resources (JavaScript libraries, fonts) that were served from the local cache instead of being fetched from the CDN. Preceded on screen by the count."
+  },
+  "blockStatsSince": "{count} blocked since {date}",
+  "@blockStatsSince": {
+    "description": "Footer line of the protection report giving the all-time total and the day counting started, e.g. \"115 blocked since 22 June 2026\".",
+    "placeholders": {
+      "count": { "type": "int" },
+      "date": { "type": "String" }
+    }
+  },
+  "blockStatsEmpty": "Nothing blocked yet",
+  "@blockStatsEmpty": {
+    "description": "Headline of the protection report's empty state, shown when no request has been blocked since counting started."
+  },
+  "blockStatsEmptyHint": "Turn on tracking protection for a site and the requests it blocks show up here.",
+  "@blockStatsEmptyHint": {
+    "description": "Explanation under the protection report's empty state, telling the user that per-site tracking protection has to be switched on before anything is counted."
+  },
+  "blockStatsReset": "Reset statistics",
+  "@blockStatsReset": {
+    "description": "Action that clears every counter on the protection report. Used as the AppBar button tooltip, the confirmation dialog title, and its confirm button."
+  },
+  "blockStatsResetConfirm": "Every counter returns to zero and counting restarts from today.",
+  "@blockStatsResetConfirm": {
+    "description": "Body of the confirmation dialog shown before clearing the protection report counters."
+  },
+  "appSettingsProtectionReportSubtitle": "What the blockers stopped, over time",
+  "@appSettingsProtectionReportSubtitle": {
+    "description": "Subtitle of the App Settings row that opens the protection report screen."
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Enviar notificación de prueba",
   "devToolsTestNotificationSent": "Notificación de prueba enviada (consulta los registros)",
   "devToolsTestNotificationTitle": "Notificación de prueba de WebSpace",
-  "devToolsTestNotificationBody": "Si puedes ver esto, la entrega de notificaciones del sistema operativo funciona."
+  "devToolsTestNotificationBody": "Si puedes ver esto, la entrega de notificaciones del sistema operativo funciona.",
+  "blockStatsTitle": "Informe de protección",
+  "blockStatsSubtitleWeek": "Rastreadores bloqueados esta semana",
+  "blockStatsSubtitleMonth": "Rastreadores bloqueados en los últimos 30 días",
+  "blockStatsRange7": "7 días",
+  "blockStatsRange30": "30 días",
+  "blockStatsCategoryFilterList": "Solicitudes de anuncios y rastreadores",
+  "blockStatsCategoryDns": "Dominios de rastreo conocidos",
+  "blockStatsCategoryParam": "Parámetros de seguimiento eliminados",
+  "blockStatsCategoryCdn": "Solicitudes de CDN servidas localmente",
+  "blockStatsSince": "{count} bloqueadas desde el {date}",
+  "blockStatsEmpty": "Todavía no se ha bloqueado nada",
+  "blockStatsEmptyHint": "Activa la protección contra el rastreo de un sitio y las solicitudes que bloquee aparecerán aquí.",
+  "blockStatsReset": "Restablecer estadísticas",
+  "blockStatsResetConfirm": "Todos los contadores vuelven a cero y el recuento se reinicia hoy.",
+  "appSettingsProtectionReportSubtitle": "Lo que han detenido los bloqueadores a lo largo del tiempo"
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Saada testteavitus",
   "devToolsTestNotificationSent": "Testteavitus saadetud (vaata logisid)",
   "devToolsTestNotificationTitle": "WebSpace'i testteavitus",
-  "devToolsTestNotificationBody": "Kui näete seda, siis operatsioonisüsteemi teavituste edastamine töötab."
+  "devToolsTestNotificationBody": "Kui näete seda, siis operatsioonisüsteemi teavituste edastamine töötab.",
+  "blockStatsTitle": "Kaitsearuanne",
+  "blockStatsSubtitleWeek": "Sel nädalal blokeeritud jälgijad",
+  "blockStatsSubtitleMonth": "Viimase 30 päeva jooksul blokeeritud jälgijad",
+  "blockStatsRange7": "7 päeva",
+  "blockStatsRange30": "30 päeva",
+  "blockStatsCategoryFilterList": "Reklaami- ja jälgijapäringud",
+  "blockStatsCategoryDns": "Teadaolevad jälgimisdomeenid",
+  "blockStatsCategoryParam": "Eemaldatud jälgimisparameetrid",
+  "blockStatsCategoryCdn": "Kohapeal teenindatud CDN-päringud",
+  "blockStatsSince": "{count} blokeeritud alates {date}",
+  "blockStatsEmpty": "Veel pole midagi blokeeritud",
+  "blockStatsEmptyHint": "Lülita saidil jälgimiskaitse sisse ja siin ilmuvad päringud, mille see blokeerib.",
+  "blockStatsReset": "Lähtesta statistika",
+  "blockStatsResetConfirm": "Iga loendur läheb nulli ja lugemine algab tänasest uuesti.",
+  "appSettingsProtectionReportSubtitle": "Mida blokeerijad on aja jooksul peatanud"
 }

--- a/lib/l10n/app_eu.arb
+++ b/lib/l10n/app_eu.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Bidali probako jakinarazpena",
   "devToolsTestNotificationSent": "Probako jakinarazpena bidali da (ikus erregistroak)",
   "devToolsTestNotificationTitle": "WebSpace probako jakinarazpena",
-  "devToolsTestNotificationBody": "Hau ikus badezakezu, sistema eragilearen jakinarazpenen entrega ondo dabil."
+  "devToolsTestNotificationBody": "Hau ikus badezakezu, sistema eragilearen jakinarazpenen entrega ondo dabil.",
+  "blockStatsTitle": "Babes-txostena",
+  "blockStatsSubtitleWeek": "Aste honetan blokeatutako jarraitzaileak",
+  "blockStatsSubtitleMonth": "Azken 30 egunetan blokeatutako jarraitzaileak",
+  "blockStatsRange7": "7 egun",
+  "blockStatsRange30": "30 egun",
+  "blockStatsCategoryFilterList": "Iragarkien eta jarraitzaileen eskaerak",
+  "blockStatsCategoryDns": "Jarraipen-domeinu ezagunak",
+  "blockStatsCategoryParam": "Kendutako jarraipen-parametroak",
+  "blockStatsCategoryCdn": "Bertan zerbitzatutako CDN eskaerak",
+  "blockStatsSince": "{count} blokeatuta {date} geroztik",
+  "blockStatsEmpty": "Oraindik ez da ezer blokeatu",
+  "blockStatsEmptyHint": "Aktibatu gune baten jarraipenaren aurkako babesa eta blokeatzen dituen eskaerak hemen agertuko dira.",
+  "blockStatsReset": "Berrezarri estatistikak",
+  "blockStatsResetConfirm": "Kontagailu guztiak zerora itzuliko dira eta zenbaketa gaur hasiko da berriro.",
+  "appSettingsProtectionReportSubtitle": "Blokeatzaileek denboran zehar geldiarazi dutena"
 }

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "ارسال اعلان آزمایشی",
   "devToolsTestNotificationSent": "اعلان آزمایشی ارسال شد (گزارش‌ها را ببینید)",
   "devToolsTestNotificationTitle": "اعلان آزمایشی WebSpace",
-  "devToolsTestNotificationBody": "اگر این را می‌بینید، تحویل اعلان‌های سیستم‌عامل کار می‌کند."
+  "devToolsTestNotificationBody": "اگر این را می‌بینید، تحویل اعلان‌های سیستم‌عامل کار می‌کند.",
+  "blockStatsTitle": "گزارش محافظت",
+  "blockStatsSubtitleWeek": "ردیاب‌های مسدودشده در این هفته",
+  "blockStatsSubtitleMonth": "ردیاب‌های مسدودشده در ۳۰ روز گذشته",
+  "blockStatsRange7": "۷ روز",
+  "blockStatsRange30": "۳۰ روز",
+  "blockStatsCategoryFilterList": "درخواست‌های تبلیغات و ردیاب‌ها",
+  "blockStatsCategoryDns": "دامنه‌های ردیابی شناخته‌شده",
+  "blockStatsCategoryParam": "پارامترهای ردیابی حذف‌شده",
+  "blockStatsCategoryCdn": "درخواست‌های CDN که به‌صورت محلی پاسخ داده شدند",
+  "blockStatsSince": "{count} مسدودشده از {date}",
+  "blockStatsEmpty": "هنوز چیزی مسدود نشده است",
+  "blockStatsEmptyHint": "محافظت در برابر ردیابی را برای یک وب‌گاه روشن کنید تا درخواست‌هایی که مسدود می‌کند اینجا نمایش داده شود.",
+  "blockStatsReset": "بازنشانی آمار",
+  "blockStatsResetConfirm": "هر شمارنده به صفر بازمی‌گردد و شمارش از امروز دوباره آغاز می‌شود.",
+  "appSettingsProtectionReportSubtitle": "آنچه مسدودکننده‌ها در طول زمان متوقف کرده‌اند"
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Lähetä testi-ilmoitus",
   "devToolsTestNotificationSent": "Testi-ilmoitus lähetetty (katso lokit)",
   "devToolsTestNotificationTitle": "WebSpace-testi-ilmoitus",
-  "devToolsTestNotificationBody": "Jos näet tämän, käyttöjärjestelmän ilmoitusten toimitus toimii."
+  "devToolsTestNotificationBody": "Jos näet tämän, käyttöjärjestelmän ilmoitusten toimitus toimii.",
+  "blockStatsTitle": "Suojausraportti",
+  "blockStatsSubtitleWeek": "Tällä viikolla estetyt seuraimet",
+  "blockStatsSubtitleMonth": "Viimeisten 30 päivän aikana estetyt seuraimet",
+  "blockStatsRange7": "7 päivää",
+  "blockStatsRange30": "30 päivää",
+  "blockStatsCategoryFilterList": "Mainosten ja seuraimien pyynnöt",
+  "blockStatsCategoryDns": "Tunnetut seurantaverkkotunnukset",
+  "blockStatsCategoryParam": "Poistetut seurantaparametrit",
+  "blockStatsCategoryCdn": "Paikallisesti palvellut CDN-pyynnöt",
+  "blockStatsSince": "{count} estetty {date} alkaen",
+  "blockStatsEmpty": "Mitään ei ole vielä estetty",
+  "blockStatsEmptyHint": "Ota sivustolle seurannan esto käyttöön, niin sen estämät pyynnöt näkyvät täällä.",
+  "blockStatsReset": "Nollaa tilastot",
+  "blockStatsResetConfirm": "Jokainen laskuri palautuu nollaan ja laskenta alkaa uudelleen tästä päivästä.",
+  "appSettingsProtectionReportSubtitle": "Mitä estot ovat pysäyttäneet ajan mittaan"
 }

--- a/lib/l10n/app_fil.arb
+++ b/lib/l10n/app_fil.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Magpadala ng test notification",
   "devToolsTestNotificationSent": "Naipadala ang test notification (tingnan ang mga log)",
   "devToolsTestNotificationTitle": "Test notification ng WebSpace",
-  "devToolsTestNotificationBody": "Kung makikita mo ito, gumagana ang paghahatid ng notification ng operating system."
+  "devToolsTestNotificationBody": "Kung makikita mo ito, gumagana ang paghahatid ng notification ng operating system.",
+  "blockStatsTitle": "Ulat ng proteksiyon",
+  "blockStatsSubtitleWeek": "Mga tracker na hinarang ngayong linggo",
+  "blockStatsSubtitleMonth": "Mga tracker na hinarang sa nakalipas na 30 araw",
+  "blockStatsRange7": "7 araw",
+  "blockStatsRange30": "30 araw",
+  "blockStatsCategoryFilterList": "Mga kahilingan ng ad at tracker",
+  "blockStatsCategoryDns": "Mga kilalang domain ng pagsubaybay",
+  "blockStatsCategoryParam": "Mga inalis na parameter ng pagsubaybay",
+  "blockStatsCategoryCdn": "Mga kahilingan sa CDN na inihain nang lokal",
+  "blockStatsSince": "{count} ang hinarang mula {date}",
+  "blockStatsEmpty": "Wala pang hinaharang",
+  "blockStatsEmptyHint": "Buksan ang proteksiyon laban sa pagsubaybay para sa isang site at lilitaw dito ang mga kahilingang hinaharang nito.",
+  "blockStatsReset": "I-reset ang estadistika",
+  "blockStatsResetConfirm": "Babalik sa zero ang bawat counter at magsisimula muli ang pagbibilang ngayong araw.",
+  "appSettingsProtectionReportSubtitle": "Kung ano ang napigilan ng mga blocker sa paglipas ng panahon"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Envoyer une notification de test",
   "devToolsTestNotificationSent": "Notification de test envoyée (voir les journaux)",
   "devToolsTestNotificationTitle": "Notification de test WebSpace",
-  "devToolsTestNotificationBody": "Si vous voyez ceci, la diffusion des notifications du système d'exploitation fonctionne."
+  "devToolsTestNotificationBody": "Si vous voyez ceci, la diffusion des notifications du système d'exploitation fonctionne.",
+  "blockStatsTitle": "Rapport de protection",
+  "blockStatsSubtitleWeek": "Traqueurs bloqués cette semaine",
+  "blockStatsSubtitleMonth": "Traqueurs bloqués ces 30 derniers jours",
+  "blockStatsRange7": "7 jours",
+  "blockStatsRange30": "30 jours",
+  "blockStatsCategoryFilterList": "Requêtes de publicités et de traqueurs",
+  "blockStatsCategoryDns": "Domaines de pistage connus",
+  "blockStatsCategoryParam": "Paramètres de suivi supprimés",
+  "blockStatsCategoryCdn": "Requêtes CDN servies localement",
+  "blockStatsSince": "{count} bloqués depuis le {date}",
+  "blockStatsEmpty": "Rien n'a encore été bloqué",
+  "blockStatsEmptyHint": "Activez la protection contre le pistage pour un site et les requêtes qu'il bloque apparaîtront ici.",
+  "blockStatsReset": "Réinitialiser les statistiques",
+  "blockStatsResetConfirm": "Tous les compteurs reviennent à zéro et le décompte reprend aujourd'hui.",
+  "appSettingsProtectionReportSubtitle": "Ce que les bloqueurs ont arrêté, au fil du temps"
 }

--- a/lib/l10n/app_ga.arb
+++ b/lib/l10n/app_ga.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Seol fógra tástála",
   "devToolsTestNotificationSent": "Seoladh fógra tástála (féach na logaí)",
   "devToolsTestNotificationTitle": "Fógra tástála WebSpace",
-  "devToolsTestNotificationBody": "Más féidir leat é seo a fheiceáil, tá seachadadh fógraí an chórais oibriúcháin ag obair."
+  "devToolsTestNotificationBody": "Más féidir leat é seo a fheiceáil, tá seachadadh fógraí an chórais oibriúcháin ag obair.",
+  "blockStatsTitle": "Tuairisc chosanta",
+  "blockStatsSubtitleWeek": "Rianaitheoirí ar cuireadh bac orthu an tseachtain seo",
+  "blockStatsSubtitleMonth": "Rianaitheoirí ar cuireadh bac orthu le 30 lá anuas",
+  "blockStatsRange7": "7 lá",
+  "blockStatsRange30": "30 lá",
+  "blockStatsCategoryFilterList": "Iarratais fógraí agus rianaitheoirí",
+  "blockStatsCategoryDns": "Fearainn rianaithe aitheanta",
+  "blockStatsCategoryParam": "Paraiméadair rianaithe a baineadh",
+  "blockStatsCategoryCdn": "Iarratais CDN a freastalaíodh go háitiúil",
+  "blockStatsSince": "{count} bactha ó {date}",
+  "blockStatsEmpty": "Níor cuireadh bac ar aon rud fós",
+  "blockStatsEmptyHint": "Cuir cosaint ar rianú ar siúl do shuíomh agus taispeánfar anseo na hiarratais a chuireann sé bac orthu.",
+  "blockStatsReset": "Athshocraigh na staitisticí",
+  "blockStatsResetConfirm": "Fillfidh gach áiritheoir ar nialas agus tosóidh an comhaireamh as an nua inniu.",
+  "appSettingsProtectionReportSubtitle": "Ar stop na bacóirí, thar am"
 }

--- a/lib/l10n/app_gl.arb
+++ b/lib/l10n/app_gl.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Enviar notificación de proba",
   "devToolsTestNotificationSent": "Notificación de proba enviada (consulta os rexistros)",
   "devToolsTestNotificationTitle": "Notificación de proba de WebSpace",
-  "devToolsTestNotificationBody": "Se podes ver isto, a entrega de notificacións do sistema operativo funciona."
+  "devToolsTestNotificationBody": "Se podes ver isto, a entrega de notificacións do sistema operativo funciona.",
+  "blockStatsTitle": "Informe de protección",
+  "blockStatsSubtitleWeek": "Rastreadores bloqueados esta semana",
+  "blockStatsSubtitleMonth": "Rastreadores bloqueados nos últimos 30 días",
+  "blockStatsRange7": "7 días",
+  "blockStatsRange30": "30 días",
+  "blockStatsCategoryFilterList": "Solicitudes de anuncios e rastreadores",
+  "blockStatsCategoryDns": "Dominios de rastrexo coñecidos",
+  "blockStatsCategoryParam": "Parámetros de seguimento eliminados",
+  "blockStatsCategoryCdn": "Solicitudes de CDN servidas localmente",
+  "blockStatsSince": "{count} bloqueadas desde o {date}",
+  "blockStatsEmpty": "Aínda non se bloqueou nada",
+  "blockStatsEmptyHint": "Activa a protección contra o rastrexo dun sitio e as solicitudes que bloquee aparecerán aquí.",
+  "blockStatsReset": "Restablecer as estatísticas",
+  "blockStatsResetConfirm": "Todos os contadores volven a cero e a conta reiníciase hoxe.",
+  "appSettingsProtectionReportSubtitle": "O que detiveron os bloqueadores ao longo do tempo"
 }

--- a/lib/l10n/app_gu.arb
+++ b/lib/l10n/app_gu.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "પરીક્ષણ સૂચના મોકલો",
   "devToolsTestNotificationSent": "પરીક્ષણ સૂચના મોકલાઈ (લોગ જુઓ)",
   "devToolsTestNotificationTitle": "WebSpace પરીક્ષણ સૂચના",
-  "devToolsTestNotificationBody": "જો તમે આ જોઈ શકતા હો, તો ઓપરેટિંગ સિસ્ટમની સૂચના વિતરણ કાર્ય કરે છે."
+  "devToolsTestNotificationBody": "જો તમે આ જોઈ શકતા હો, તો ઓપરેટિંગ સિસ્ટમની સૂચના વિતરણ કાર્ય કરે છે.",
+  "blockStatsTitle": "સુરક્ષા અહેવાલ",
+  "blockStatsSubtitleWeek": "આ અઠવાડિયે અવરોધિત ટ્રેકર",
+  "blockStatsSubtitleMonth": "છેલ્લા 30 દિવસમાં અવરોધિત ટ્રેકર",
+  "blockStatsRange7": "7 દિવસ",
+  "blockStatsRange30": "30 દિવસ",
+  "blockStatsCategoryFilterList": "જાહેરાત અને ટ્રેકરની વિનંતીઓ",
+  "blockStatsCategoryDns": "જાણીતા ટ્રેકિંગ ડોમેન",
+  "blockStatsCategoryParam": "દૂર કરેલા ટ્રેકિંગ પરિમાણો",
+  "blockStatsCategoryCdn": "સ્થાનિક રીતે પીરસાયેલી CDN વિનંતીઓ",
+  "blockStatsSince": "{date} થી {count} અવરોધિત",
+  "blockStatsEmpty": "હજી સુધી કશું અવરોધિત થયું નથી",
+  "blockStatsEmptyHint": "કોઈ સાઇટ માટે ટ્રેકિંગ સુરક્ષા ચાલુ કરો, પછી તે અવરોધે તે વિનંતીઓ અહીં દેખાશે.",
+  "blockStatsReset": "આંકડા રીસેટ કરો",
+  "blockStatsResetConfirm": "દરેક કાઉન્ટર શૂન્ય પર પાછું આવે છે અને ગણતરી આજથી ફરી શરૂ થાય છે.",
+  "appSettingsProtectionReportSubtitle": "સમય જતાં અવરોધકોએ શું રોક્યું"
 }

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "שלח התראת בדיקה",
   "devToolsTestNotificationSent": "התראת הבדיקה נשלחה (ראה יומנים)",
   "devToolsTestNotificationTitle": "התראת בדיקה של WebSpace",
-  "devToolsTestNotificationBody": "אם אתה רואה זאת, מסירת ההתראות של מערכת ההפעלה פועלת."
+  "devToolsTestNotificationBody": "אם אתה רואה זאת, מסירת ההתראות של מערכת ההפעלה פועלת.",
+  "blockStatsTitle": "דוח הגנה",
+  "blockStatsSubtitleWeek": "עוקבים שנחסמו השבוע",
+  "blockStatsSubtitleMonth": "עוקבים שנחסמו ב-30 הימים האחרונים",
+  "blockStatsRange7": "7 ימים",
+  "blockStatsRange30": "30 יום",
+  "blockStatsCategoryFilterList": "בקשות של פרסומות ועוקבים",
+  "blockStatsCategoryDns": "דומיינים ידועים של מעקב",
+  "blockStatsCategoryParam": "פרמטרי מעקב שהוסרו",
+  "blockStatsCategoryCdn": "בקשות CDN שסופקו מקומית",
+  "blockStatsSince": "{count} נחסמו מאז {date}",
+  "blockStatsEmpty": "עדיין לא נחסם דבר",
+  "blockStatsEmptyHint": "הפעילו הגנה מפני מעקב עבור אתר, והבקשות שהוא חוסם יופיעו כאן.",
+  "blockStatsReset": "איפוס הסטטיסטיקה",
+  "blockStatsResetConfirm": "כל מונה חוזר לאפס והספירה מתחילה מחדש מהיום.",
+  "appSettingsProtectionReportSubtitle": "מה החוסמים עצרו, לאורך זמן"
 }

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "परीक्षण सूचना भेजें",
   "devToolsTestNotificationSent": "परीक्षण सूचना भेजी गई (लॉग देखें)",
   "devToolsTestNotificationTitle": "WebSpace परीक्षण सूचना",
-  "devToolsTestNotificationBody": "यदि आप इसे देख सकते हैं, तो ऑपरेटिंग सिस्टम की सूचना वितरण कार्य कर रहा है।"
+  "devToolsTestNotificationBody": "यदि आप इसे देख सकते हैं, तो ऑपरेटिंग सिस्टम की सूचना वितरण कार्य कर रहा है।",
+  "blockStatsTitle": "सुरक्षा रिपोर्ट",
+  "blockStatsSubtitleWeek": "इस सप्ताह अवरोधित ट्रैकर",
+  "blockStatsSubtitleMonth": "पिछले 30 दिनों में अवरोधित ट्रैकर",
+  "blockStatsRange7": "7 दिन",
+  "blockStatsRange30": "30 दिन",
+  "blockStatsCategoryFilterList": "विज्ञापन और ट्रैकर अनुरोध",
+  "blockStatsCategoryDns": "ज्ञात ट्रैकिंग डोमेन",
+  "blockStatsCategoryParam": "हटाए गए ट्रैकिंग पैरामीटर",
+  "blockStatsCategoryCdn": "स्थानीय रूप से पूरे किए गए CDN अनुरोध",
+  "blockStatsSince": "{date} से {count} अवरोधित",
+  "blockStatsEmpty": "अभी तक कुछ भी अवरोधित नहीं हुआ",
+  "blockStatsEmptyHint": "किसी साइट के लिए ट्रैकिंग सुरक्षा चालू करें, फिर वह जिन अनुरोधों को रोकेगी वे यहाँ दिखेंगे।",
+  "blockStatsReset": "आँकड़े रीसेट करें",
+  "blockStatsResetConfirm": "हर काउंटर शून्य पर लौट आता है और गिनती आज से फिर शुरू होती है।",
+  "appSettingsProtectionReportSubtitle": "समय के साथ अवरोधकों ने क्या रोका"
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Pošalji probnu obavijest",
   "devToolsTestNotificationSent": "Probna obavijest poslana (pogledajte zapisnike)",
   "devToolsTestNotificationTitle": "WebSpace probna obavijest",
-  "devToolsTestNotificationBody": "Ako ovo vidite, isporuka obavijesti operativnog sustava radi."
+  "devToolsTestNotificationBody": "Ako ovo vidite, isporuka obavijesti operativnog sustava radi.",
+  "blockStatsTitle": "Izvješće o zaštiti",
+  "blockStatsSubtitleWeek": "Blokirani pratitelji ovaj tjedan",
+  "blockStatsSubtitleMonth": "Blokirani pratitelji u posljednjih 30 dana",
+  "blockStatsRange7": "7 dana",
+  "blockStatsRange30": "30 dana",
+  "blockStatsCategoryFilterList": "Zahtjevi oglasa i pratitelja",
+  "blockStatsCategoryDns": "Poznate domene za praćenje",
+  "blockStatsCategoryParam": "Uklonjeni parametri praćenja",
+  "blockStatsCategoryCdn": "CDN zahtjevi posluženi lokalno",
+  "blockStatsSince": "{count} blokirano od {date}",
+  "blockStatsEmpty": "Još ništa nije blokirano",
+  "blockStatsEmptyHint": "Uključite zaštitu od praćenja za web-mjesto i ovdje će se pojaviti zahtjevi koje blokira.",
+  "blockStatsReset": "Poništi statistiku",
+  "blockStatsResetConfirm": "Svaki brojač vraća se na nulu, a brojanje počinje ponovno od danas.",
+  "appSettingsProtectionReportSubtitle": "Što su blokatori zaustavili tijekom vremena"
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Tesztértesítés küldése",
   "devToolsTestNotificationSent": "Tesztértesítés elküldve (lásd a naplókat)",
   "devToolsTestNotificationTitle": "WebSpace tesztértesítés",
-  "devToolsTestNotificationBody": "Ha ezt látja, az operációs rendszer értesítéskézbesítése működik."
+  "devToolsTestNotificationBody": "Ha ezt látja, az operációs rendszer értesítéskézbesítése működik.",
+  "blockStatsTitle": "Védelmi jelentés",
+  "blockStatsSubtitleWeek": "A héten blokkolt nyomkövetők",
+  "blockStatsSubtitleMonth": "Az elmúlt 30 napban blokkolt nyomkövetők",
+  "blockStatsRange7": "7 nap",
+  "blockStatsRange30": "30 nap",
+  "blockStatsCategoryFilterList": "Hirdetés- és nyomkövetőkérések",
+  "blockStatsCategoryDns": "Ismert nyomkövető tartományok",
+  "blockStatsCategoryParam": "Eltávolított követési paraméterek",
+  "blockStatsCategoryCdn": "Helyileg kiszolgált CDN-kérések",
+  "blockStatsSince": "{count} blokkolva {date} óta",
+  "blockStatsEmpty": "Még semmi sem lett blokkolva",
+  "blockStatsEmptyHint": "Kapcsold be egy webhelynél a nyomkövetés elleni védelmet, és az általa blokkolt kérések itt jelennek meg.",
+  "blockStatsReset": "Statisztika visszaállítása",
+  "blockStatsResetConfirm": "Minden számláló nullázódik, és a számlálás a mai naptól újraindul.",
+  "appSettingsProtectionReportSubtitle": "Mit állítottak meg a blokkolók az idő során"
 }

--- a/lib/l10n/app_hy.arb
+++ b/lib/l10n/app_hy.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Ուղարկել փորձնական ծանուցում",
   "devToolsTestNotificationSent": "Փորձնական ծանուցումն ուղարկվել է (տես մատյանները)",
   "devToolsTestNotificationTitle": "WebSpace փորձնական ծանուցում",
-  "devToolsTestNotificationBody": "Եթե տեսնում եք սա, օպերացիոն համակարգի ծանուցումների առաքումն աշխատում է:"
+  "devToolsTestNotificationBody": "Եթե տեսնում եք սա, օպերացիոն համակարգի ծանուցումների առաքումն աշխատում է:",
+  "blockStatsTitle": "Պաշտպանության հաշվետվություն",
+  "blockStatsSubtitleWeek": "Այս շաբաթ արգելափակված հետագծիչներ",
+  "blockStatsSubtitleMonth": "Վերջին 30 օրում արգելափակված հետագծիչներ",
+  "blockStatsRange7": "7 օր",
+  "blockStatsRange30": "30 օր",
+  "blockStatsCategoryFilterList": "Գովազդի և հետագծիչների հարցումներ",
+  "blockStatsCategoryDns": "Հայտնի հետագծման տիրույթներ",
+  "blockStatsCategoryParam": "Հեռացված հետագծման պարամետրեր",
+  "blockStatsCategoryCdn": "Տեղում սպասարկված CDN հարցումներ",
+  "blockStatsSince": "{count} արգելափակված՝ {date}-ից",
+  "blockStatsEmpty": "Դեռ ոչինչ չի արգելափակվել",
+  "blockStatsEmptyHint": "Միացրեք կայքի հետագծման պաշտպանությունը, և նրա արգելափակած հարցումները կհայտնվեն այստեղ։",
+  "blockStatsReset": "Զրոյացնել վիճակագրությունը",
+  "blockStatsResetConfirm": "Բոլոր հաշվիչները զրոյանում են, և հաշվարկը սկսվում է այսօրվանից։",
+  "appSettingsProtectionReportSubtitle": "Ինչ են կանգնեցրել արգելափակիչները ժամանակի ընթացքում"
 }

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Kirim notifikasi uji",
   "devToolsTestNotificationSent": "Notifikasi uji terkirim (lihat log)",
   "devToolsTestNotificationTitle": "Notifikasi uji WebSpace",
-  "devToolsTestNotificationBody": "Jika Anda dapat melihat ini, pengiriman notifikasi sistem operasi berfungsi."
+  "devToolsTestNotificationBody": "Jika Anda dapat melihat ini, pengiriman notifikasi sistem operasi berfungsi.",
+  "blockStatsTitle": "Laporan perlindungan",
+  "blockStatsSubtitleWeek": "Pelacak yang diblokir minggu ini",
+  "blockStatsSubtitleMonth": "Pelacak yang diblokir dalam 30 hari terakhir",
+  "blockStatsRange7": "7 hari",
+  "blockStatsRange30": "30 hari",
+  "blockStatsCategoryFilterList": "Permintaan iklan dan pelacak",
+  "blockStatsCategoryDns": "Domain pelacak yang dikenal",
+  "blockStatsCategoryParam": "Parameter pelacakan yang dihapus",
+  "blockStatsCategoryCdn": "Permintaan CDN yang dilayani secara lokal",
+  "blockStatsSince": "{count} diblokir sejak {date}",
+  "blockStatsEmpty": "Belum ada yang diblokir",
+  "blockStatsEmptyHint": "Aktifkan perlindungan pelacakan untuk sebuah situs, lalu permintaan yang diblokirnya akan muncul di sini.",
+  "blockStatsReset": "Setel ulang statistik",
+  "blockStatsResetConfirm": "Setiap penghitung kembali ke nol dan penghitungan dimulai lagi hari ini.",
+  "appSettingsProtectionReportSubtitle": "Apa yang dihentikan pemblokir, dari waktu ke waktu"
 }

--- a/lib/l10n/app_is.arb
+++ b/lib/l10n/app_is.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Senda prufutilkynningu",
   "devToolsTestNotificationSent": "Prufutilkynning send (sjá annála)",
   "devToolsTestNotificationTitle": "WebSpace prufutilkynning",
-  "devToolsTestNotificationBody": "Ef þú sérð þetta virkar afhending tilkynninga stýrikerfisins."
+  "devToolsTestNotificationBody": "Ef þú sérð þetta virkar afhending tilkynninga stýrikerfisins.",
+  "blockStatsTitle": "Verndarskýrsla",
+  "blockStatsSubtitleWeek": "Rekjarar sem lokað var á í þessari viku",
+  "blockStatsSubtitleMonth": "Rekjarar sem lokað var á síðustu 30 daga",
+  "blockStatsRange7": "7 dagar",
+  "blockStatsRange30": "30 dagar",
+  "blockStatsCategoryFilterList": "Beiðnir auglýsinga og rekjara",
+  "blockStatsCategoryDns": "Þekkt rakningarlén",
+  "blockStatsCategoryParam": "Fjarlægðar rakningarfæribreytur",
+  "blockStatsCategoryCdn": "CDN-beiðnir afgreiddar staðbundið",
+  "blockStatsSince": "{count} lokað frá {date}",
+  "blockStatsEmpty": "Engu hefur verið lokað enn",
+  "blockStatsEmptyHint": "Kveiktu á rakningarvörn fyrir vefsvæði og beiðnirnar sem hún stöðvar birtast hér.",
+  "blockStatsReset": "Núllstilla tölfræði",
+  "blockStatsResetConfirm": "Allir teljarar fara í núll og talning hefst að nýju í dag.",
+  "appSettingsProtectionReportSubtitle": "Hverju vörnin hefur stöðvað með tímanum"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Invia notifica di prova",
   "devToolsTestNotificationSent": "Notifica di prova inviata (vedi i registri)",
   "devToolsTestNotificationTitle": "Notifica di prova WebSpace",
-  "devToolsTestNotificationBody": "Se riesci a vedere questo, la consegna delle notifiche del sistema operativo funziona."
+  "devToolsTestNotificationBody": "Se riesci a vedere questo, la consegna delle notifiche del sistema operativo funziona.",
+  "blockStatsTitle": "Rapporto sulla protezione",
+  "blockStatsSubtitleWeek": "Tracciatori bloccati questa settimana",
+  "blockStatsSubtitleMonth": "Tracciatori bloccati negli ultimi 30 giorni",
+  "blockStatsRange7": "7 giorni",
+  "blockStatsRange30": "30 giorni",
+  "blockStatsCategoryFilterList": "Richieste di pubblicità e tracciatori",
+  "blockStatsCategoryDns": "Domini di tracciamento noti",
+  "blockStatsCategoryParam": "Parametri di tracciamento rimossi",
+  "blockStatsCategoryCdn": "Richieste CDN servite localmente",
+  "blockStatsSince": "{count} bloccate dal {date}",
+  "blockStatsEmpty": "Non è stato ancora bloccato nulla",
+  "blockStatsEmptyHint": "Attiva la protezione dal tracciamento per un sito e le richieste che blocca compariranno qui.",
+  "blockStatsReset": "Azzera le statistiche",
+  "blockStatsResetConfirm": "Ogni contatore torna a zero e il conteggio riparte da oggi.",
+  "appSettingsProtectionReportSubtitle": "Che cosa hanno fermato i blocchi, nel tempo"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "テスト通知を送信",
   "devToolsTestNotificationSent": "テスト通知を送信しました（ログを参照）",
   "devToolsTestNotificationTitle": "WebSpace テスト通知",
-  "devToolsTestNotificationBody": "これが表示されている場合、OSの通知配信は正常に機能しています。"
+  "devToolsTestNotificationBody": "これが表示されている場合、OSの通知配信は正常に機能しています。",
+  "blockStatsTitle": "保護レポート",
+  "blockStatsSubtitleWeek": "今週ブロックしたトラッカー",
+  "blockStatsSubtitleMonth": "過去30日間にブロックしたトラッカー",
+  "blockStatsRange7": "7日間",
+  "blockStatsRange30": "30日間",
+  "blockStatsCategoryFilterList": "広告とトラッカーのリクエスト",
+  "blockStatsCategoryDns": "既知のトラッキングドメイン",
+  "blockStatsCategoryParam": "削除したトラッキングパラメーター",
+  "blockStatsCategoryCdn": "ローカルで提供したCDNリクエスト",
+  "blockStatsSince": "{date}以降に{count}件をブロック",
+  "blockStatsEmpty": "まだ何もブロックしていません",
+  "blockStatsEmptyHint": "サイトのトラッキング保護を有効にすると、ブロックされたリクエストがここに表示されます。",
+  "blockStatsReset": "統計をリセット",
+  "blockStatsResetConfirm": "すべてのカウンターがゼロに戻り、本日から集計をやり直します。",
+  "appSettingsProtectionReportSubtitle": "ブロック機能がこれまでに止めたもの"
 }

--- a/lib/l10n/app_ka.arb
+++ b/lib/l10n/app_ka.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "სატესტო შეტყობინების გაგზავნა",
   "devToolsTestNotificationSent": "სატესტო შეტყობინება გაიგზავნა (იხილეთ ჟურნალები)",
   "devToolsTestNotificationTitle": "WebSpace-ის სატესტო შეტყობინება",
-  "devToolsTestNotificationBody": "თუ ამას ხედავთ, ოპერაციული სისტემის შეტყობინებების მიწოდება მუშაობს."
+  "devToolsTestNotificationBody": "თუ ამას ხედავთ, ოპერაციული სისტემის შეტყობინებების მიწოდება მუშაობს.",
+  "blockStatsTitle": "დაცვის ანგარიში",
+  "blockStatsSubtitleWeek": "ამ კვირაში დაბლოკილი მეთვალყურეები",
+  "blockStatsSubtitleMonth": "ბოლო 30 დღეში დაბლოკილი მეთვალყურეები",
+  "blockStatsRange7": "7 დღე",
+  "blockStatsRange30": "30 დღე",
+  "blockStatsCategoryFilterList": "რეკლამებისა და მეთვალყურეების მოთხოვნები",
+  "blockStatsCategoryDns": "ცნობილი თვალთვალის დომენები",
+  "blockStatsCategoryParam": "წაშლილი თვალთვალის პარამეტრები",
+  "blockStatsCategoryCdn": "ლოკალურად მოწოდებული CDN მოთხოვნები",
+  "blockStatsSince": "{count} დაბლოკილია {date}-დან",
+  "blockStatsEmpty": "ჯერ არაფერია დაბლოკილი",
+  "blockStatsEmptyHint": "ჩართეთ საიტისთვის თვალთვალისგან დაცვა და მის მიერ დაბლოკილი მოთხოვნები აქ გამოჩნდება.",
+  "blockStatsReset": "სტატისტიკის განულება",
+  "blockStatsResetConfirm": "ყველა მრიცხველი ნულდება და დათვლა დღიდან იწყება თავიდან.",
+  "appSettingsProtectionReportSubtitle": "რა შეაჩერეს ბლოკერებმა დროთა განმავლობაში"
 }

--- a/lib/l10n/app_km.arb
+++ b/lib/l10n/app_km.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "ផ្ញើការជូនដំណឹងសាកល្បង",
   "devToolsTestNotificationSent": "បានផ្ញើការជូនដំណឹងសាកល្បង (មើលកំណត់ហេតុ)",
   "devToolsTestNotificationTitle": "ការជូនដំណឹងសាកល្បង WebSpace",
-  "devToolsTestNotificationBody": "ប្រសិនបើអ្នកអាចមើលឃើញវា ការផ្ញើការជូនដំណឹងរបស់ប្រព័ន្ធប្រតិបត្តិការដំណើរការ។"
+  "devToolsTestNotificationBody": "ប្រសិនបើអ្នកអាចមើលឃើញវា ការផ្ញើការជូនដំណឹងរបស់ប្រព័ន្ធប្រតិបត្តិការដំណើរការ។",
+  "blockStatsTitle": "របាយការណ៍ការពារ",
+  "blockStatsSubtitleWeek": "កម្មវិធីតាមដានដែលបានទប់ស្កាត់សប្តាហ៍នេះ",
+  "blockStatsSubtitleMonth": "កម្មវិធីតាមដានដែលបានទប់ស្កាត់ក្នុងរយៈពេល 30 ថ្ងៃចុងក្រោយ",
+  "blockStatsRange7": "7 ថ្ងៃ",
+  "blockStatsRange30": "30 ថ្ងៃ",
+  "blockStatsCategoryFilterList": "សំណើពាណិជ្ជកម្ម និងកម្មវិធីតាមដាន",
+  "blockStatsCategoryDns": "ដែនតាមដានដែលស្គាល់",
+  "blockStatsCategoryParam": "ប៉ារ៉ាម៉ែត្រតាមដានដែលបានលុប",
+  "blockStatsCategoryCdn": "សំណើ CDN ដែលបានផ្តល់ជូនក្នុងមូលដ្ឋាន",
+  "blockStatsSince": "{count} ត្រូវបានទប់ស្កាត់តាំងពី {date}",
+  "blockStatsEmpty": "មិនទាន់មានអ្វីត្រូវបានទប់ស្កាត់ទេ",
+  "blockStatsEmptyHint": "បើកការការពារពីការតាមដានសម្រាប់គេហទំព័រណាមួយ រួចសំណើដែលវាទប់ស្កាត់នឹងបង្ហាញនៅទីនេះ។",
+  "blockStatsReset": "កំណត់ស្ថិតិឡើងវិញ",
+  "blockStatsResetConfirm": "ការរាប់នីមួយៗត្រឡប់ទៅសូន្យវិញ ហើយការរាប់ចាប់ផ្តើមឡើងវិញពីថ្ងៃនេះ។",
+  "appSettingsProtectionReportSubtitle": "អ្វីដែលកម្មវិធីទប់ស្កាត់បានបញ្ឈប់ តាមពេលវេលា"
 }

--- a/lib/l10n/app_kn.arb
+++ b/lib/l10n/app_kn.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "ಪರೀಕ್ಷಾ ಅಧಿಸೂಚನೆ ಕಳುಹಿಸಿ",
   "devToolsTestNotificationSent": "ಪರೀಕ್ಷಾ ಅಧಿಸೂಚನೆ ಕಳುಹಿಸಲಾಗಿದೆ (ಲಾಗ್‌ಗಳನ್ನು ನೋಡಿ)",
   "devToolsTestNotificationTitle": "WebSpace ಪರೀಕ್ಷಾ ಅಧಿಸೂಚನೆ",
-  "devToolsTestNotificationBody": "ಇದು ನಿಮಗೆ ಕಾಣಿಸಿದರೆ, ಆಪರೇಟಿಂಗ್ ಸಿಸ್ಟಂನ ಅಧಿಸೂಚನೆ ವಿತರಣೆ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತಿದೆ."
+  "devToolsTestNotificationBody": "ಇದು ನಿಮಗೆ ಕಾಣಿಸಿದರೆ, ಆಪರೇಟಿಂಗ್ ಸಿಸ್ಟಂನ ಅಧಿಸೂಚನೆ ವಿತರಣೆ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತಿದೆ.",
+  "blockStatsTitle": "ರಕ್ಷಣಾ ವರದಿ",
+  "blockStatsSubtitleWeek": "ಈ ವಾರ ನಿರ್ಬಂಧಿಸಿದ ಟ್ರ್ಯಾಕರ್‌ಗಳು",
+  "blockStatsSubtitleMonth": "ಕಳೆದ 30 ದಿನಗಳಲ್ಲಿ ನಿರ್ಬಂಧಿಸಿದ ಟ್ರ್ಯಾಕರ್‌ಗಳು",
+  "blockStatsRange7": "7 ದಿನಗಳು",
+  "blockStatsRange30": "30 ದಿನಗಳು",
+  "blockStatsCategoryFilterList": "ಜಾಹೀರಾತು ಮತ್ತು ಟ್ರ್ಯಾಕರ್ ವಿನಂತಿಗಳು",
+  "blockStatsCategoryDns": "ತಿಳಿದಿರುವ ಟ್ರ್ಯಾಕಿಂಗ್ ಡೊಮೇನ್‌ಗಳು",
+  "blockStatsCategoryParam": "ತೆಗೆದುಹಾಕಿದ ಟ್ರ್ಯಾಕಿಂಗ್ ನಿಯತಾಂಕಗಳು",
+  "blockStatsCategoryCdn": "ಸ್ಥಳೀಯವಾಗಿ ಪೂರೈಸಿದ CDN ವಿನಂತಿಗಳು",
+  "blockStatsSince": "{date} ರಿಂದ {count} ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ",
+  "blockStatsEmpty": "ಇನ್ನೂ ಏನನ್ನೂ ನಿರ್ಬಂಧಿಸಿಲ್ಲ",
+  "blockStatsEmptyHint": "ಯಾವುದೇ ಸೈಟ್‌ಗೆ ಟ್ರ್ಯಾಕಿಂಗ್ ರಕ್ಷಣೆಯನ್ನು ಆನ್ ಮಾಡಿ, ಅದು ನಿರ್ಬಂಧಿಸುವ ವಿನಂತಿಗಳು ಇಲ್ಲಿ ಕಾಣಿಸುತ್ತವೆ.",
+  "blockStatsReset": "ಅಂಕಿಅಂಶಗಳನ್ನು ಮರುಹೊಂದಿಸಿ",
+  "blockStatsResetConfirm": "ಪ್ರತಿ ಎಣಿಕೆ ಶೂನ್ಯಕ್ಕೆ ಮರಳುತ್ತದೆ ಮತ್ತು ಎಣಿಕೆ ಇಂದಿನಿಂದ ಮತ್ತೆ ಆರಂಭವಾಗುತ್ತದೆ.",
+  "appSettingsProtectionReportSubtitle": "ಕಾಲಾನಂತರದಲ್ಲಿ ನಿರ್ಬಂಧಕಗಳು ತಡೆದದ್ದು"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "테스트 알림 보내기",
   "devToolsTestNotificationSent": "테스트 알림을 보냈습니다 (로그 참조)",
   "devToolsTestNotificationTitle": "WebSpace 테스트 알림",
-  "devToolsTestNotificationBody": "이것이 보이면 운영 체제의 알림 전송이 작동합니다."
+  "devToolsTestNotificationBody": "이것이 보이면 운영 체제의 알림 전송이 작동합니다.",
+  "blockStatsTitle": "보호 보고서",
+  "blockStatsSubtitleWeek": "이번 주에 차단한 추적기",
+  "blockStatsSubtitleMonth": "지난 30일 동안 차단한 추적기",
+  "blockStatsRange7": "7일",
+  "blockStatsRange30": "30일",
+  "blockStatsCategoryFilterList": "광고 및 추적기 요청",
+  "blockStatsCategoryDns": "알려진 추적 도메인",
+  "blockStatsCategoryParam": "제거된 추적 매개변수",
+  "blockStatsCategoryCdn": "로컬에서 제공한 CDN 요청",
+  "blockStatsSince": "{date} 이후 {count}건 차단",
+  "blockStatsEmpty": "아직 차단된 항목이 없습니다",
+  "blockStatsEmptyHint": "사이트의 추적 보호를 켜면 차단된 요청이 여기에 표시됩니다.",
+  "blockStatsReset": "통계 초기화",
+  "blockStatsResetConfirm": "모든 카운터가 0으로 돌아가고 오늘부터 다시 집계합니다.",
+  "appSettingsProtectionReportSubtitle": "차단 기능이 그동안 막아낸 것"
 }

--- a/lib/l10n/app_la.arb
+++ b/lib/l10n/app_la.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Nuntiationem probatoriam mittere",
   "devToolsTestNotificationSent": "Nuntiatio probatoria missa est (vide acta)",
   "devToolsTestNotificationTitle": "Nuntiatio probatoria WebSpace",
-  "devToolsTestNotificationBody": "Si hoc videre potes, traditio nuntiationum systematis operandi operatur."
+  "devToolsTestNotificationBody": "Si hoc videre potes, traditio nuntiationum systematis operandi operatur.",
+  "blockStatsTitle": "Relatio tutelae",
+  "blockStatsSubtitleWeek": "Vestigatores hac hebdomade impediti",
+  "blockStatsSubtitleMonth": "Vestigatores per ultimos 30 dies impediti",
+  "blockStatsRange7": "7 dies",
+  "blockStatsRange30": "30 dies",
+  "blockStatsCategoryFilterList": "Petitiones nuntiorum et vestigatorum",
+  "blockStatsCategoryDns": "Dominia vestigationis nota",
+  "blockStatsCategoryParam": "Parametri vestigationis remoti",
+  "blockStatsCategoryCdn": "Petitiones CDN localiter ministratae",
+  "blockStatsSince": "{count} impediti ab {date}",
+  "blockStatsEmpty": "Nihil adhuc impeditum est",
+  "blockStatsEmptyHint": "Tutelam contra vestigationem pro sede accende, et petitiones quas impedit hic apparebunt.",
+  "blockStatsReset": "Statisticam restituere",
+  "blockStatsResetConfirm": "Omnis numerator ad nihilum redit et numeratio hodie iterum incipit.",
+  "appSettingsProtectionReportSubtitle": "Quid impeditores per tempus prohibuerint"
 }

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Siųsti bandomąjį pranešimą",
   "devToolsTestNotificationSent": "Bandomasis pranešimas išsiųstas (žr. žurnalus)",
   "devToolsTestNotificationTitle": "WebSpace bandomasis pranešimas",
-  "devToolsTestNotificationBody": "Jei tai matote, operacinės sistemos pranešimų pristatymas veikia."
+  "devToolsTestNotificationBody": "Jei tai matote, operacinės sistemos pranešimų pristatymas veikia.",
+  "blockStatsTitle": "Apsaugos ataskaita",
+  "blockStatsSubtitleWeek": "Šią savaitę užblokuoti sekliai",
+  "blockStatsSubtitleMonth": "Per pastarąsias 30 dienų užblokuoti sekliai",
+  "blockStatsRange7": "7 dienos",
+  "blockStatsRange30": "30 dienų",
+  "blockStatsCategoryFilterList": "Reklamų ir seklių užklausos",
+  "blockStatsCategoryDns": "Žinomi sekimo domenai",
+  "blockStatsCategoryParam": "Pašalinti sekimo parametrai",
+  "blockStatsCategoryCdn": "Vietoje aptarnautos CDN užklausos",
+  "blockStatsSince": "{count} užblokuota nuo {date}",
+  "blockStatsEmpty": "Kol kas nieko neužblokuota",
+  "blockStatsEmptyHint": "Įjunkite svetainės apsaugą nuo sekimo ir čia matysite jos blokuojamas užklausas.",
+  "blockStatsReset": "Atstatyti statistiką",
+  "blockStatsResetConfirm": "Visi skaitikliai grąžinami į nulį, o skaičiavimas pradedamas iš naujo nuo šiandien.",
+  "appSettingsProtectionReportSubtitle": "Ką blokavimo priemonės sustabdė laikui bėgant"
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Sūtīt testa paziņojumu",
   "devToolsTestNotificationSent": "Testa paziņojums nosūtīts (skatiet žurnālus)",
   "devToolsTestNotificationTitle": "WebSpace testa paziņojums",
-  "devToolsTestNotificationBody": "Ja redzat šo, operētājsistēmas paziņojumu piegāde darbojas."
+  "devToolsTestNotificationBody": "Ja redzat šo, operētājsistēmas paziņojumu piegāde darbojas.",
+  "blockStatsTitle": "Aizsardzības pārskats",
+  "blockStatsSubtitleWeek": "Šonedēļ bloķētie izsekotāji",
+  "blockStatsSubtitleMonth": "Pēdējās 30 dienās bloķētie izsekotāji",
+  "blockStatsRange7": "7 dienas",
+  "blockStatsRange30": "30 dienas",
+  "blockStatsCategoryFilterList": "Reklāmu un izsekotāju pieprasījumi",
+  "blockStatsCategoryDns": "Zināmi izsekošanas domēni",
+  "blockStatsCategoryParam": "Noņemtie izsekošanas parametri",
+  "blockStatsCategoryCdn": "Lokāli apkalpotie CDN pieprasījumi",
+  "blockStatsSince": "{count} bloķēti kopš {date}",
+  "blockStatsEmpty": "Vēl nekas nav bloķēts",
+  "blockStatsEmptyHint": "Ieslēdziet vietnei aizsardzību pret izsekošanu, un tās bloķētie pieprasījumi parādīsies šeit.",
+  "blockStatsReset": "Atiestatīt statistiku",
+  "blockStatsResetConfirm": "Katrs skaitītājs atgriežas nullē, un skaitīšana no šodienas sākas no jauna.",
+  "appSettingsProtectionReportSubtitle": "Ko bloķētāji laika gaitā ir apturējuši"
 }

--- a/lib/l10n/app_mk.arb
+++ b/lib/l10n/app_mk.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Испрати тестно известување",
   "devToolsTestNotificationSent": "Тестното известување е испратено (видете ги дневниците)",
   "devToolsTestNotificationTitle": "WebSpace тестно известување",
-  "devToolsTestNotificationBody": "Ако го гледате ова, испораката на известувања на оперативниот систем работи."
+  "devToolsTestNotificationBody": "Ако го гледате ова, испораката на известувања на оперативниот систем работи.",
+  "blockStatsTitle": "Извештај за заштита",
+  "blockStatsSubtitleWeek": "Следачи блокирани оваа недела",
+  "blockStatsSubtitleMonth": "Следачи блокирани во последните 30 дена",
+  "blockStatsRange7": "7 дена",
+  "blockStatsRange30": "30 дена",
+  "blockStatsCategoryFilterList": "Барања од реклами и следачи",
+  "blockStatsCategoryDns": "Познати домени за следење",
+  "blockStatsCategoryParam": "Отстранети параметри за следење",
+  "blockStatsCategoryCdn": "CDN-барања услужени локално",
+  "blockStatsSince": "{count} блокирани од {date}",
+  "blockStatsEmpty": "Сè уште ништо не е блокирано",
+  "blockStatsEmptyHint": "Вклучете заштита од следење за некој сајт и барањата што ги блокира ќе се појават овде.",
+  "blockStatsReset": "Ресетирај ја статистиката",
+  "blockStatsResetConfirm": "Секој бројач се враќа на нула и броењето почнува одново од денес.",
+  "appSettingsProtectionReportSubtitle": "Што запреле блокаторите со текот на времето"
 }

--- a/lib/l10n/app_ml.arb
+++ b/lib/l10n/app_ml.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "ടെസ്റ്റ് അറിയിപ്പ് അയയ്ക്കുക",
   "devToolsTestNotificationSent": "ടെസ്റ്റ് അറിയിപ്പ് അയച്ചു (ലോഗുകൾ കാണുക)",
   "devToolsTestNotificationTitle": "WebSpace ടെസ്റ്റ് അറിയിപ്പ്",
-  "devToolsTestNotificationBody": "ഇത് നിങ്ങൾക്ക് കാണാൻ കഴിയുമെങ്കിൽ, ഓപ്പറേറ്റിംഗ് സിസ്റ്റത്തിന്റെ അറിയിപ്പ് വിതരണം പ്രവർത്തിക്കുന്നു."
+  "devToolsTestNotificationBody": "ഇത് നിങ്ങൾക്ക് കാണാൻ കഴിയുമെങ്കിൽ, ഓപ്പറേറ്റിംഗ് സിസ്റ്റത്തിന്റെ അറിയിപ്പ് വിതരണം പ്രവർത്തിക്കുന്നു.",
+  "blockStatsTitle": "സുരക്ഷാ റിപ്പോർട്ട്",
+  "blockStatsSubtitleWeek": "ഈ ആഴ്ച തടഞ്ഞ ട്രാക്കറുകൾ",
+  "blockStatsSubtitleMonth": "കഴിഞ്ഞ 30 ദിവസത്തിൽ തടഞ്ഞ ട്രാക്കറുകൾ",
+  "blockStatsRange7": "7 ദിവസം",
+  "blockStatsRange30": "30 ദിവസം",
+  "blockStatsCategoryFilterList": "പരസ്യ, ട്രാക്കർ അഭ്യർത്ഥനകൾ",
+  "blockStatsCategoryDns": "അറിയപ്പെടുന്ന ട്രാക്കിംഗ് ഡൊമെയ്‌നുകൾ",
+  "blockStatsCategoryParam": "നീക്കം ചെയ്ത ട്രാക്കിംഗ് പാരാമീറ്ററുകൾ",
+  "blockStatsCategoryCdn": "പ്രാദേശികമായി നൽകിയ CDN അഭ്യർത്ഥനകൾ",
+  "blockStatsSince": "{date} മുതൽ {count} എണ്ണം തടഞ്ഞു",
+  "blockStatsEmpty": "ഇതുവരെ ഒന്നും തടഞ്ഞിട്ടില്ല",
+  "blockStatsEmptyHint": "ഒരു സൈറ്റിനായി ട്രാക്കിംഗ് സംരക്ഷണം ഓണാക്കുക, അത് തടയുന്ന അഭ്യർത്ഥനകൾ ഇവിടെ കാണാം.",
+  "blockStatsReset": "സ്ഥിതിവിവരം പുനഃസജ്ജമാക്കുക",
+  "blockStatsResetConfirm": "ഓരോ കൗണ്ടറും പൂജ്യത്തിലേക്ക് മടങ്ങുകയും എണ്ണം ഇന്ന് മുതൽ വീണ്ടും തുടങ്ങുകയും ചെയ്യും.",
+  "appSettingsProtectionReportSubtitle": "കാലക്രമേണ ബ്ലോക്കറുകൾ തടഞ്ഞത്"
 }

--- a/lib/l10n/app_mn.arb
+++ b/lib/l10n/app_mn.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Туршилтын мэдэгдэл илгээх",
   "devToolsTestNotificationSent": "Туршилтын мэдэгдэл илгээгдсэн (бүртгэлийг харна уу)",
   "devToolsTestNotificationTitle": "WebSpace туршилтын мэдэгдэл",
-  "devToolsTestNotificationBody": "Хэрэв та үүнийг харж байгаа бол үйлдлийн системийн мэдэгдэл хүргэлт ажиллаж байна."
+  "devToolsTestNotificationBody": "Хэрэв та үүнийг харж байгаа бол үйлдлийн системийн мэдэгдэл хүргэлт ажиллаж байна.",
+  "blockStatsTitle": "Хамгаалалтын тайлан",
+  "blockStatsSubtitleWeek": "Энэ долоо хоногт хаасан хянагчид",
+  "blockStatsSubtitleMonth": "Сүүлийн 30 хоногт хаасан хянагчид",
+  "blockStatsRange7": "7 хоног",
+  "blockStatsRange30": "30 хоног",
+  "blockStatsCategoryFilterList": "Сурталчилгаа болон хянагчийн хүсэлтүүд",
+  "blockStatsCategoryDns": "Мэдэгдэж буй хянах домэйнууд",
+  "blockStatsCategoryParam": "Устгасан хянах параметрүүд",
+  "blockStatsCategoryCdn": "Дотооддоо үйлчилсэн CDN хүсэлтүүд",
+  "blockStatsSince": "{date}-аас хойш {count} хаагдсан",
+  "blockStatsEmpty": "Одоогоор юу ч хаагдаагүй байна",
+  "blockStatsEmptyHint": "Сайтын хянахаас хамгаалахыг асаавал түүний хаасан хүсэлтүүд энд харагдана.",
+  "blockStatsReset": "Статистикийг шинэчлэх",
+  "blockStatsResetConfirm": "Тоолуур бүр тэг рүү буцаж, тооллого өнөөдрөөс дахин эхэлнэ.",
+  "appSettingsProtectionReportSubtitle": "Хаагчид цаг хугацааны туршид юуг зогсоосон нь"
 }

--- a/lib/l10n/app_mr.arb
+++ b/lib/l10n/app_mr.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "चाचणी सूचना पाठवा",
   "devToolsTestNotificationSent": "चाचणी सूचना पाठवली (लॉग पाहा)",
   "devToolsTestNotificationTitle": "WebSpace चाचणी सूचना",
-  "devToolsTestNotificationBody": "तुम्हाला हे दिसत असल्यास, ऑपरेटिंग सिस्टमचे सूचना वितरण कार्य करत आहे."
+  "devToolsTestNotificationBody": "तुम्हाला हे दिसत असल्यास, ऑपरेटिंग सिस्टमचे सूचना वितरण कार्य करत आहे.",
+  "blockStatsTitle": "संरक्षण अहवाल",
+  "blockStatsSubtitleWeek": "या आठवड्यात अवरोधित ट्रॅकर",
+  "blockStatsSubtitleMonth": "गेल्या 30 दिवसांत अवरोधित ट्रॅकर",
+  "blockStatsRange7": "7 दिवस",
+  "blockStatsRange30": "30 दिवस",
+  "blockStatsCategoryFilterList": "जाहिरात आणि ट्रॅकर विनंत्या",
+  "blockStatsCategoryDns": "ज्ञात ट्रॅकिंग डोमेन",
+  "blockStatsCategoryParam": "काढून टाकलेले ट्रॅकिंग घटक",
+  "blockStatsCategoryCdn": "स्थानिक पातळीवर पुरवलेल्या CDN विनंत्या",
+  "blockStatsSince": "{date} पासून {count} अवरोधित",
+  "blockStatsEmpty": "अद्याप काहीही अवरोधित झालेले नाही",
+  "blockStatsEmptyHint": "एखाद्या साइटसाठी ट्रॅकिंग संरक्षण चालू करा, मग ती अवरोधित करत असलेल्या विनंत्या इथे दिसतील.",
+  "blockStatsReset": "आकडेवारी रीसेट करा",
+  "blockStatsResetConfirm": "प्रत्येक मोजणी शून्यावर येते आणि मोजणी आजपासून पुन्हा सुरू होते.",
+  "appSettingsProtectionReportSubtitle": "काळानुसार अवरोधकांनी काय थांबवले"
 }

--- a/lib/l10n/app_ms.arb
+++ b/lib/l10n/app_ms.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Hantar pemberitahuan ujian",
   "devToolsTestNotificationSent": "Pemberitahuan ujian dihantar (lihat log)",
   "devToolsTestNotificationTitle": "Pemberitahuan ujian WebSpace",
-  "devToolsTestNotificationBody": "Jika anda dapat melihat ini, penghantaran pemberitahuan sistem pengendalian berfungsi."
+  "devToolsTestNotificationBody": "Jika anda dapat melihat ini, penghantaran pemberitahuan sistem pengendalian berfungsi.",
+  "blockStatsTitle": "Laporan perlindungan",
+  "blockStatsSubtitleWeek": "Penjejak disekat minggu ini",
+  "blockStatsSubtitleMonth": "Penjejak disekat dalam 30 hari lepas",
+  "blockStatsRange7": "7 hari",
+  "blockStatsRange30": "30 hari",
+  "blockStatsCategoryFilterList": "Permintaan iklan dan penjejak",
+  "blockStatsCategoryDns": "Domain penjejakan yang diketahui",
+  "blockStatsCategoryParam": "Parameter penjejakan dibuang",
+  "blockStatsCategoryCdn": "Permintaan CDN disajikan secara setempat",
+  "blockStatsSince": "{count} disekat sejak {date}",
+  "blockStatsEmpty": "Belum ada apa-apa disekat",
+  "blockStatsEmptyHint": "Hidupkan perlindungan penjejakan bagi sesuatu tapak dan permintaan yang disekatnya akan muncul di sini.",
+  "blockStatsReset": "Tetapkan semula statistik",
+  "blockStatsResetConfirm": "Setiap pembilang kembali kepada sifar dan pengiraan bermula semula hari ini.",
+  "appSettingsProtectionReportSubtitle": "Apa yang dihalang oleh penyekat, dari masa ke masa"
 }

--- a/lib/l10n/app_mt.arb
+++ b/lib/l10n/app_mt.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Ibgħat notifika ta' prova",
   "devToolsTestNotificationSent": "In-notifika ta' prova ntbagħtet (ara r-reġistri)",
   "devToolsTestNotificationTitle": "Notifika ta' prova WebSpace",
-  "devToolsTestNotificationBody": "Jekk tista' tara dan, il-konsenja tan-notifiki tas-sistema operattiva taħdem."
+  "devToolsTestNotificationBody": "Jekk tista' tara dan, il-konsenja tan-notifiki tas-sistema operattiva taħdem.",
+  "blockStatsTitle": "Rapport ta' protezzjoni",
+  "blockStatsSubtitleWeek": "Tracers imblukkati din il-ġimgħa",
+  "blockStatsSubtitleMonth": "Tracers imblukkati fl-aħħar 30 jum",
+  "blockStatsRange7": "7 ijiem",
+  "blockStatsRange30": "30 jum",
+  "blockStatsCategoryFilterList": "Talbiet ta' reklami u tracers",
+  "blockStatsCategoryDns": "Dominji ta' traċċar magħrufa",
+  "blockStatsCategoryParam": "Parametri ta' traċċar imneħħija",
+  "blockStatsCategoryCdn": "Talbiet CDN moqdija lokalment",
+  "blockStatsSince": "{count} imblukkati mill-{date}",
+  "blockStatsEmpty": "Xejn għadu ma ġie mblukkat",
+  "blockStatsEmptyHint": "Ixgħel il-protezzjoni mit-traċċar għal sit u t-talbiet li jimblokka jidhru hawn.",
+  "blockStatsReset": "Irrisettja l-istatistika",
+  "blockStatsResetConfirm": "Kull kontatur jerġa' lura għal żero u l-għadd jerġa' jibda mil-lum.",
+  "appSettingsProtectionReportSubtitle": "X'waqqfu l-imblukkaturi, maż-żmien"
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Send testvarsel",
   "devToolsTestNotificationSent": "Testvarsel sendt (se loggene)",
   "devToolsTestNotificationTitle": "WebSpace-testvarsel",
-  "devToolsTestNotificationBody": "Hvis du kan se dette, fungerer operativsystemets varsellevering."
+  "devToolsTestNotificationBody": "Hvis du kan se dette, fungerer operativsystemets varsellevering.",
+  "blockStatsTitle": "Beskyttelsesrapport",
+  "blockStatsSubtitleWeek": "Sporere blokkert denne uken",
+  "blockStatsSubtitleMonth": "Sporere blokkert de siste 30 dagene",
+  "blockStatsRange7": "7 dager",
+  "blockStatsRange30": "30 dager",
+  "blockStatsCategoryFilterList": "Forespørsler fra reklame og sporere",
+  "blockStatsCategoryDns": "Kjente sporingsdomener",
+  "blockStatsCategoryParam": "Fjernede sporingsparametere",
+  "blockStatsCategoryCdn": "CDN-forespørsler levert lokalt",
+  "blockStatsSince": "{count} blokkert siden {date}",
+  "blockStatsEmpty": "Ingenting er blokkert ennå",
+  "blockStatsEmptyHint": "Slå på sporingsbeskyttelse for et nettsted, så vises forespørslene det blokkerer her.",
+  "blockStatsReset": "Nullstill statistikk",
+  "blockStatsResetConfirm": "Alle tellere settes til null, og tellingen starter på nytt i dag.",
+  "appSettingsProtectionReportSubtitle": "Hva blokkererne har stoppet over tid"
 }

--- a/lib/l10n/app_ne.arb
+++ b/lib/l10n/app_ne.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "परीक्षण सूचना पठाउनुहोस्",
   "devToolsTestNotificationSent": "परीक्षण सूचना पठाइयो (लगहरू हेर्नुहोस्)",
   "devToolsTestNotificationTitle": "WebSpace परीक्षण सूचना",
-  "devToolsTestNotificationBody": "यदि तपाईं यो देख्न सक्नुहुन्छ भने, अपरेटिङ सिस्टमको सूचना वितरण काम गरिरहेको छ।"
+  "devToolsTestNotificationBody": "यदि तपाईं यो देख्न सक्नुहुन्छ भने, अपरेटिङ सिस्टमको सूचना वितरण काम गरिरहेको छ।",
+  "blockStatsTitle": "सुरक्षा प्रतिवेदन",
+  "blockStatsSubtitleWeek": "यो हप्ता रोकिएका ट्र्याकरहरू",
+  "blockStatsSubtitleMonth": "पछिल्ला 30 दिनमा रोकिएका ट्र्याकरहरू",
+  "blockStatsRange7": "7 दिन",
+  "blockStatsRange30": "30 दिन",
+  "blockStatsCategoryFilterList": "विज्ञापन र ट्र्याकर अनुरोधहरू",
+  "blockStatsCategoryDns": "ज्ञात ट्र्याकिङ डोमेनहरू",
+  "blockStatsCategoryParam": "हटाइएका ट्र्याकिङ प्यारामिटरहरू",
+  "blockStatsCategoryCdn": "स्थानीय रूपमा उपलब्ध गराइएका CDN अनुरोधहरू",
+  "blockStatsSince": "{date} देखि {count} रोकिए",
+  "blockStatsEmpty": "अहिलेसम्म केही पनि रोकिएको छैन",
+  "blockStatsEmptyHint": "कुनै साइटका लागि ट्र्याकिङ सुरक्षा सक्रिय गर्नुहोस्, त्यसपछि यसले रोकेका अनुरोधहरू यहाँ देखिनेछन्।",
+  "blockStatsReset": "तथ्याङ्क रिसेट गर्नुहोस्",
+  "blockStatsResetConfirm": "हरेक गणक शून्यमा फर्कन्छ र गणना आजैबाट फेरि सुरु हुन्छ।",
+  "appSettingsProtectionReportSubtitle": "समयसँगै अवरोधकहरूले के रोके"
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Testmelding verzenden",
   "devToolsTestNotificationSent": "Testmelding verzonden (zie logboeken)",
   "devToolsTestNotificationTitle": "WebSpace-testmelding",
-  "devToolsTestNotificationBody": "Als je dit kunt zien, werkt de meldingslevering van het besturingssysteem."
+  "devToolsTestNotificationBody": "Als je dit kunt zien, werkt de meldingslevering van het besturingssysteem.",
+  "blockStatsTitle": "Beschermingsrapport",
+  "blockStatsSubtitleWeek": "Deze week geblokkeerde trackers",
+  "blockStatsSubtitleMonth": "Geblokkeerde trackers in de afgelopen 30 dagen",
+  "blockStatsRange7": "7 dagen",
+  "blockStatsRange30": "30 dagen",
+  "blockStatsCategoryFilterList": "Verzoeken van advertenties en trackers",
+  "blockStatsCategoryDns": "Bekende trackingdomeinen",
+  "blockStatsCategoryParam": "Verwijderde trackingparameters",
+  "blockStatsCategoryCdn": "Lokaal geleverde CDN-verzoeken",
+  "blockStatsSince": "{count} geblokkeerd sinds {date}",
+  "blockStatsEmpty": "Nog niets geblokkeerd",
+  "blockStatsEmptyHint": "Zet trackingbescherming aan voor een site en de verzoeken die worden geblokkeerd verschijnen hier.",
+  "blockStatsReset": "Statistieken wissen",
+  "blockStatsResetConfirm": "Elke teller gaat terug naar nul en het tellen begint vandaag opnieuw.",
+  "appSettingsProtectionReportSubtitle": "Wat de blokkers in de loop van de tijd hebben tegengehouden"
 }

--- a/lib/l10n/app_pa.arb
+++ b/lib/l10n/app_pa.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "ਟੈਸਟ ਸੂਚਨਾ ਭੇਜੋ",
   "devToolsTestNotificationSent": "ਟੈਸਟ ਸੂਚਨਾ ਭੇਜੀ ਗਈ (ਲੌਗ ਵੇਖੋ)",
   "devToolsTestNotificationTitle": "WebSpace ਟੈਸਟ ਸੂਚਨਾ",
-  "devToolsTestNotificationBody": "ਜੇ ਤੁਸੀਂ ਇਹ ਵੇਖ ਸਕਦੇ ਹੋ, ਤਾਂ ਓਪਰੇਟਿੰਗ ਸਿਸਟਮ ਦੀ ਸੂਚਨਾ ਡਿਲਿਵਰੀ ਕੰਮ ਕਰ ਰਹੀ ਹੈ।"
+  "devToolsTestNotificationBody": "ਜੇ ਤੁਸੀਂ ਇਹ ਵੇਖ ਸਕਦੇ ਹੋ, ਤਾਂ ਓਪਰੇਟਿੰਗ ਸਿਸਟਮ ਦੀ ਸੂਚਨਾ ਡਿਲਿਵਰੀ ਕੰਮ ਕਰ ਰਹੀ ਹੈ।",
+  "blockStatsTitle": "ਸੁਰੱਖਿਆ ਰਿਪੋਰਟ",
+  "blockStatsSubtitleWeek": "ਇਸ ਹਫ਼ਤੇ ਰੋਕੇ ਗਏ ਟ੍ਰੈਕਰ",
+  "blockStatsSubtitleMonth": "ਪਿਛਲੇ 30 ਦਿਨਾਂ ਵਿੱਚ ਰੋਕੇ ਗਏ ਟ੍ਰੈਕਰ",
+  "blockStatsRange7": "7 ਦਿਨ",
+  "blockStatsRange30": "30 ਦਿਨ",
+  "blockStatsCategoryFilterList": "ਇਸ਼ਤਿਹਾਰ ਅਤੇ ਟ੍ਰੈਕਰ ਬੇਨਤੀਆਂ",
+  "blockStatsCategoryDns": "ਜਾਣੇ-ਪਛਾਣੇ ਟ੍ਰੈਕਿੰਗ ਡੋਮੇਨ",
+  "blockStatsCategoryParam": "ਹਟਾਏ ਗਏ ਟ੍ਰੈਕਿੰਗ ਪੈਰਾਮੀਟਰ",
+  "blockStatsCategoryCdn": "ਸਥਾਨਕ ਤੌਰ 'ਤੇ ਦਿੱਤੀਆਂ CDN ਬੇਨਤੀਆਂ",
+  "blockStatsSince": "{date} ਤੋਂ {count} ਰੋਕੀਆਂ ਗਈਆਂ",
+  "blockStatsEmpty": "ਹਾਲੇ ਤੱਕ ਕੁਝ ਵੀ ਨਹੀਂ ਰੋਕਿਆ ਗਿਆ",
+  "blockStatsEmptyHint": "ਕਿਸੇ ਸਾਈਟ ਲਈ ਟ੍ਰੈਕਿੰਗ ਸੁਰੱਖਿਆ ਚਾਲੂ ਕਰੋ, ਫਿਰ ਇਸ ਵੱਲੋਂ ਰੋਕੀਆਂ ਬੇਨਤੀਆਂ ਇੱਥੇ ਦਿਖਣਗੀਆਂ।",
+  "blockStatsReset": "ਅੰਕੜੇ ਰੀਸੈੱਟ ਕਰੋ",
+  "blockStatsResetConfirm": "ਹਰ ਗਿਣਤੀ ਸਿਫ਼ਰ 'ਤੇ ਆ ਜਾਂਦੀ ਹੈ ਅਤੇ ਗਿਣਤੀ ਅੱਜ ਤੋਂ ਮੁੜ ਸ਼ੁਰੂ ਹੁੰਦੀ ਹੈ।",
+  "appSettingsProtectionReportSubtitle": "ਸਮੇਂ ਦੇ ਨਾਲ ਬਲਾਕਰਾਂ ਨੇ ਕੀ ਰੋਕਿਆ"
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Wyślij powiadomienie testowe",
   "devToolsTestNotificationSent": "Wysłano powiadomienie testowe (zobacz logi)",
   "devToolsTestNotificationTitle": "Powiadomienie testowe WebSpace",
-  "devToolsTestNotificationBody": "Jeśli to widzisz, dostarczanie powiadomień systemu operacyjnego działa."
+  "devToolsTestNotificationBody": "Jeśli to widzisz, dostarczanie powiadomień systemu operacyjnego działa.",
+  "blockStatsTitle": "Raport ochrony",
+  "blockStatsSubtitleWeek": "Trackery zablokowane w tym tygodniu",
+  "blockStatsSubtitleMonth": "Trackery zablokowane w ciągu ostatnich 30 dni",
+  "blockStatsRange7": "7 dni",
+  "blockStatsRange30": "30 dni",
+  "blockStatsCategoryFilterList": "Żądania reklam i trackerów",
+  "blockStatsCategoryDns": "Znane domeny śledzące",
+  "blockStatsCategoryParam": "Usunięte parametry śledzące",
+  "blockStatsCategoryCdn": "Żądania CDN obsłużone lokalnie",
+  "blockStatsSince": "{count} zablokowanych od {date}",
+  "blockStatsEmpty": "Nic jeszcze nie zostało zablokowane",
+  "blockStatsEmptyHint": "Włącz ochronę przed śledzeniem dla witryny, a blokowane żądania pojawią się tutaj.",
+  "blockStatsReset": "Wyzeruj statystyki",
+  "blockStatsResetConfirm": "Każdy licznik wraca do zera, a liczenie zaczyna się od dzisiaj.",
+  "appSettingsProtectionReportSubtitle": "Co blokery zatrzymały na przestrzeni czasu"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Enviar notificação de teste",
   "devToolsTestNotificationSent": "Notificação de teste enviada (consulte os registos)",
   "devToolsTestNotificationTitle": "Notificação de teste WebSpace",
-  "devToolsTestNotificationBody": "Se conseguir ver isto, a entrega de notificações do sistema operativo funciona."
+  "devToolsTestNotificationBody": "Se conseguir ver isto, a entrega de notificações do sistema operativo funciona.",
+  "blockStatsTitle": "Relatório de proteção",
+  "blockStatsSubtitleWeek": "Rastreadores bloqueados esta semana",
+  "blockStatsSubtitleMonth": "Rastreadores bloqueados nos últimos 30 dias",
+  "blockStatsRange7": "7 dias",
+  "blockStatsRange30": "30 dias",
+  "blockStatsCategoryFilterList": "Pedidos de anúncios e rastreadores",
+  "blockStatsCategoryDns": "Domínios de rastreio conhecidos",
+  "blockStatsCategoryParam": "Parâmetros de rastreio removidos",
+  "blockStatsCategoryCdn": "Pedidos CDN servidos localmente",
+  "blockStatsSince": "{count} bloqueados desde {date}",
+  "blockStatsEmpty": "Ainda não foi bloqueado nada",
+  "blockStatsEmptyHint": "Ative a proteção contra rastreio de um site e os pedidos que este bloquear aparecem aqui.",
+  "blockStatsReset": "Repor as estatísticas",
+  "blockStatsResetConfirm": "Todos os contadores voltam a zero e a contagem recomeça hoje.",
+  "appSettingsProtectionReportSubtitle": "O que os bloqueadores travaram, ao longo do tempo"
 }

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Enviar notificação de teste",
   "devToolsTestNotificationSent": "Notificação de teste enviada (consulte os logs)",
   "devToolsTestNotificationTitle": "Notificação de teste do WebSpace",
-  "devToolsTestNotificationBody": "Se você consegue ver isto, a entrega de notificações do sistema operacional funciona."
+  "devToolsTestNotificationBody": "Se você consegue ver isto, a entrega de notificações do sistema operacional funciona.",
+  "blockStatsTitle": "Relatório de proteção",
+  "blockStatsSubtitleWeek": "Rastreadores bloqueados esta semana",
+  "blockStatsSubtitleMonth": "Rastreadores bloqueados nos últimos 30 dias",
+  "blockStatsRange7": "7 dias",
+  "blockStatsRange30": "30 dias",
+  "blockStatsCategoryFilterList": "Solicitações de anúncios e rastreadores",
+  "blockStatsCategoryDns": "Domínios de rastreamento conhecidos",
+  "blockStatsCategoryParam": "Parâmetros de rastreamento removidos",
+  "blockStatsCategoryCdn": "Solicitações de CDN atendidas localmente",
+  "blockStatsSince": "{count} bloqueados desde {date}",
+  "blockStatsEmpty": "Nada foi bloqueado ainda",
+  "blockStatsEmptyHint": "Ative a proteção contra rastreamento de um site e as solicitações bloqueadas aparecerão aqui.",
+  "blockStatsReset": "Redefinir estatísticas",
+  "blockStatsResetConfirm": "Todos os contadores voltam a zero e a contagem recomeça hoje.",
+  "appSettingsProtectionReportSubtitle": "O que os bloqueadores impediram, ao longo do tempo"
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Trimite o notificare de test",
   "devToolsTestNotificationSent": "Notificarea de test a fost trimisă (vezi jurnalele)",
   "devToolsTestNotificationTitle": "Notificare de test WebSpace",
-  "devToolsTestNotificationBody": "Dacă vezi acest mesaj, livrarea notificărilor sistemului de operare funcționează."
+  "devToolsTestNotificationBody": "Dacă vezi acest mesaj, livrarea notificărilor sistemului de operare funcționează.",
+  "blockStatsTitle": "Raport de protecție",
+  "blockStatsSubtitleWeek": "Urmăritori blocați săptămâna aceasta",
+  "blockStatsSubtitleMonth": "Urmăritori blocați în ultimele 30 de zile",
+  "blockStatsRange7": "7 zile",
+  "blockStatsRange30": "30 de zile",
+  "blockStatsCategoryFilterList": "Cereri de reclame și urmăritori",
+  "blockStatsCategoryDns": "Domenii de urmărire cunoscute",
+  "blockStatsCategoryParam": "Parametri de urmărire eliminați",
+  "blockStatsCategoryCdn": "Cereri CDN servite local",
+  "blockStatsSince": "{count} blocate din {date}",
+  "blockStatsEmpty": "Nu a fost blocat nimic încă",
+  "blockStatsEmptyHint": "Activează protecția împotriva urmăririi pentru un site, iar cererile blocate vor apărea aici.",
+  "blockStatsReset": "Resetează statisticile",
+  "blockStatsResetConfirm": "Fiecare contor revine la zero, iar numărătoarea începe din nou de astăzi.",
+  "appSettingsProtectionReportSubtitle": "Ce au oprit blocantele, de-a lungul timpului"
 }

--- a/lib/l10n/app_si.arb
+++ b/lib/l10n/app_si.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "පරීක්ෂණ දැනුම්දීමක් යවන්න",
   "devToolsTestNotificationSent": "පරීක්ෂණ දැනුම්දීම යවන ලදී (ලඝු-සටහන් බලන්න)",
   "devToolsTestNotificationTitle": "WebSpace පරීක්ෂණ දැනුම්දීම",
-  "devToolsTestNotificationBody": "ඔබට මෙය දැකිය හැකි නම්, මෙහෙයුම් පද්ධතියේ දැනුම්දීම් බෙදා හැරීම ක්‍රියා කරයි."
+  "devToolsTestNotificationBody": "ඔබට මෙය දැකිය හැකි නම්, මෙහෙයුම් පද්ධතියේ දැනුම්දීම් බෙදා හැරීම ක්‍රියා කරයි.",
+  "blockStatsTitle": "ආරක්ෂණ වාර්තාව",
+  "blockStatsSubtitleWeek": "මෙම සතියේ අවහිර කළ ලුහුබැඳීම්",
+  "blockStatsSubtitleMonth": "පසුගිය දින 30 තුළ අවහිර කළ ලුහුබැඳීම්",
+  "blockStatsRange7": "දින 7",
+  "blockStatsRange30": "දින 30",
+  "blockStatsCategoryFilterList": "වෙළඳ දැන්වීම් සහ ලුහුබැඳීම් ඉල්ලීම්",
+  "blockStatsCategoryDns": "දන්නා ලුහුබැඳීම් වසම්",
+  "blockStatsCategoryParam": "ඉවත් කළ ලුහුබැඳීම් පරාමිති",
+  "blockStatsCategoryCdn": "ස්ථානීයව සපයන ලද CDN ඉල්ලීම්",
+  "blockStatsSince": "{date} සිට {count}ක් අවහිර කර ඇත",
+  "blockStatsEmpty": "තවම කිසිවක් අවහිර කර නැත",
+  "blockStatsEmptyHint": "අඩවියක් සඳහා ලුහුබැඳීම් ආරක්ෂණය සක්‍රීය කරන්න, එවිට එය අවහිර කරන ඉල්ලීම් මෙහි පෙනෙනු ඇත.",
+  "blockStatsReset": "සංඛ්‍යාලේඛන යළි සකසන්න",
+  "blockStatsResetConfirm": "සෑම ගණකයක්ම බිංදුවට පැමිණේ, ගණන් කිරීම අදින් නැවත ආරම්භ වේ.",
+  "appSettingsProtectionReportSubtitle": "කාලයාගේ ඇවෑමෙන් අවහිර කරන්නන් නැවැත්වූ දේ"
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Odoslať testovacie upozornenie",
   "devToolsTestNotificationSent": "Testovacie upozornenie odoslané (pozri protokoly)",
   "devToolsTestNotificationTitle": "Testovacie upozornenie WebSpace",
-  "devToolsTestNotificationBody": "Ak toto vidíte, doručovanie upozornení operačného systému funguje."
+  "devToolsTestNotificationBody": "Ak toto vidíte, doručovanie upozornení operačného systému funguje.",
+  "blockStatsTitle": "Správa o ochrane",
+  "blockStatsSubtitleWeek": "Sledovače zablokované tento týždeň",
+  "blockStatsSubtitleMonth": "Sledovače zablokované za posledných 30 dní",
+  "blockStatsRange7": "7 dní",
+  "blockStatsRange30": "30 dní",
+  "blockStatsCategoryFilterList": "Požiadavky reklám a sledovačov",
+  "blockStatsCategoryDns": "Známe sledovacie domény",
+  "blockStatsCategoryParam": "Odstránené sledovacie parametre",
+  "blockStatsCategoryCdn": "Požiadavky na CDN obslúžené lokálne",
+  "blockStatsSince": "{count} zablokovaných od {date}",
+  "blockStatsEmpty": "Zatiaľ nebolo nič zablokované",
+  "blockStatsEmptyHint": "Zapnite pre stránku ochranu pred sledovaním a blokované požiadavky sa zobrazia tu.",
+  "blockStatsReset": "Vynulovať štatistiky",
+  "blockStatsResetConfirm": "Každé počítadlo sa vráti na nulu a počítanie sa začne odznova od dnes.",
+  "appSettingsProtectionReportSubtitle": "Čo blokovače časom zastavili"
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Pošlji preizkusno obvestilo",
   "devToolsTestNotificationSent": "Preizkusno obvestilo poslano (glejte dnevnike)",
   "devToolsTestNotificationTitle": "Preizkusno obvestilo WebSpace",
-  "devToolsTestNotificationBody": "Če to vidite, dostava obvestil operacijskega sistema deluje."
+  "devToolsTestNotificationBody": "Če to vidite, dostava obvestil operacijskega sistema deluje.",
+  "blockStatsTitle": "Poročilo o zaščiti",
+  "blockStatsSubtitleWeek": "Ta teden blokirani sledilniki",
+  "blockStatsSubtitleMonth": "Blokirani sledilniki v zadnjih 30 dneh",
+  "blockStatsRange7": "7 dni",
+  "blockStatsRange30": "30 dni",
+  "blockStatsCategoryFilterList": "Zahteve oglasov in sledilnikov",
+  "blockStatsCategoryDns": "Znane domene za sledenje",
+  "blockStatsCategoryParam": "Odstranjeni parametri sledenja",
+  "blockStatsCategoryCdn": "Lokalno postrežene zahteve CDN",
+  "blockStatsSince": "{count} blokiranih od {date}",
+  "blockStatsEmpty": "Nič še ni blokirano",
+  "blockStatsEmptyHint": "Vklopite zaščito pred sledenjem za spletno mesto in tu se bodo prikazale zahteve, ki jih blokira.",
+  "blockStatsReset": "Ponastavi statistiko",
+  "blockStatsResetConfirm": "Vsak števec se vrne na nič in štetje se začne znova od danes.",
+  "appSettingsProtectionReportSubtitle": "Kaj so blokirniki ustavili skozi čas"
 }

--- a/lib/l10n/app_sq.arb
+++ b/lib/l10n/app_sq.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Dërgo njoftim provë",
   "devToolsTestNotificationSent": "Njoftimi provë u dërgua (shih regjistrat)",
   "devToolsTestNotificationTitle": "Njoftim provë i WebSpace",
-  "devToolsTestNotificationBody": "Nëse mund ta shihni këtë, dorëzimi i njoftimeve të sistemit operativ funksionon."
+  "devToolsTestNotificationBody": "Nëse mund ta shihni këtë, dorëzimi i njoftimeve të sistemit operativ funksionon.",
+  "blockStatsTitle": "Raport mbrojtjeje",
+  "blockStatsSubtitleWeek": "Gjurmues të bllokuar këtë javë",
+  "blockStatsSubtitleMonth": "Gjurmues të bllokuar në 30 ditët e fundit",
+  "blockStatsRange7": "7 ditë",
+  "blockStatsRange30": "30 ditë",
+  "blockStatsCategoryFilterList": "Kërkesa reklamash dhe gjurmuesish",
+  "blockStatsCategoryDns": "Domene gjurmimi të njohura",
+  "blockStatsCategoryParam": "Parametra gjurmimi të hequr",
+  "blockStatsCategoryCdn": "Kërkesa CDN të shërbyera lokalisht",
+  "blockStatsSince": "{count} të bllokuara që nga {date}",
+  "blockStatsEmpty": "Ende s'është bllokuar asgjë",
+  "blockStatsEmptyHint": "Aktivizo mbrojtjen nga gjurmimi për një sajt dhe kërkesat që bllokon do të shfaqen këtu.",
+  "blockStatsReset": "Rivendos statistikat",
+  "blockStatsResetConfirm": "Çdo numërues kthehet në zero dhe numërimi rinis që sot.",
+  "appSettingsProtectionReportSubtitle": "Çfarë kanë ndalur bllokuesit, me kalimin e kohës"
 }

--- a/lib/l10n/app_sr.arb
+++ b/lib/l10n/app_sr.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Пошаљи пробно обавештење",
   "devToolsTestNotificationSent": "Пробно обавештење послато (погледајте записе)",
   "devToolsTestNotificationTitle": "WebSpace пробно обавештење",
-  "devToolsTestNotificationBody": "Ако ово видите, испорука обавештења оперативног система ради."
+  "devToolsTestNotificationBody": "Ако ово видите, испорука обавештења оперативног система ради.",
+  "blockStatsTitle": "Извештај о заштити",
+  "blockStatsSubtitleWeek": "Пратиоци блокирани ове недеље",
+  "blockStatsSubtitleMonth": "Пратиоци блокирани у последњих 30 дана",
+  "blockStatsRange7": "7 дана",
+  "blockStatsRange30": "30 дана",
+  "blockStatsCategoryFilterList": "Захтеви реклама и пратилаца",
+  "blockStatsCategoryDns": "Познати домени за праћење",
+  "blockStatsCategoryParam": "Уклоњени параметри праћења",
+  "blockStatsCategoryCdn": "CDN захтеви услужени локално",
+  "blockStatsSince": "{count} блокирано од {date}",
+  "blockStatsEmpty": "Ништа још није блокирано",
+  "blockStatsEmptyHint": "Укључите заштиту од праћења за неки сајт и захтеви које блокира појавиће се овде.",
+  "blockStatsReset": "Поништи статистику",
+  "blockStatsResetConfirm": "Сваки бројач се враћа на нулу и бројање почиње изнова од данас.",
+  "appSettingsProtectionReportSubtitle": "Шта су блокатори зауставили током времена"
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Skicka testavisering",
   "devToolsTestNotificationSent": "Testavisering skickad (se loggarna)",
   "devToolsTestNotificationTitle": "WebSpace-testavisering",
-  "devToolsTestNotificationBody": "Om du kan se detta fungerar operativsystemets aviseringsleverans."
+  "devToolsTestNotificationBody": "Om du kan se detta fungerar operativsystemets aviseringsleverans.",
+  "blockStatsTitle": "Skyddsrapport",
+  "blockStatsSubtitleWeek": "Spårare blockerade den här veckan",
+  "blockStatsSubtitleMonth": "Spårare blockerade de senaste 30 dagarna",
+  "blockStatsRange7": "7 dagar",
+  "blockStatsRange30": "30 dagar",
+  "blockStatsCategoryFilterList": "Förfrågningar från annonser och spårare",
+  "blockStatsCategoryDns": "Kända spårningsdomäner",
+  "blockStatsCategoryParam": "Borttagna spårningsparametrar",
+  "blockStatsCategoryCdn": "CDN-förfrågningar som levererats lokalt",
+  "blockStatsSince": "{count} blockerade sedan {date}",
+  "blockStatsEmpty": "Inget har blockerats ännu",
+  "blockStatsEmptyHint": "Slå på spårningsskydd för en webbplats, så visas förfrågningarna den blockerar här.",
+  "blockStatsReset": "Nollställ statistiken",
+  "blockStatsResetConfirm": "Alla räknare återgår till noll och räkningen börjar om i dag.",
+  "appSettingsProtectionReportSubtitle": "Vad blockerarna har stoppat över tid"
 }

--- a/lib/l10n/app_sw.arb
+++ b/lib/l10n/app_sw.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Tuma arifa ya majaribio",
   "devToolsTestNotificationSent": "Arifa ya majaribio imetumwa (angalia kumbukumbu)",
   "devToolsTestNotificationTitle": "Arifa ya majaribio ya WebSpace",
-  "devToolsTestNotificationBody": "Ikiwa unaweza kuona hili, uwasilishaji wa arifa za mfumo wa uendeshaji unafanya kazi."
+  "devToolsTestNotificationBody": "Ikiwa unaweza kuona hili, uwasilishaji wa arifa za mfumo wa uendeshaji unafanya kazi.",
+  "blockStatsTitle": "Ripoti ya ulinzi",
+  "blockStatsSubtitleWeek": "Vifuatiliaji vilivyozuiwa wiki hii",
+  "blockStatsSubtitleMonth": "Vifuatiliaji vilivyozuiwa katika siku 30 zilizopita",
+  "blockStatsRange7": "Siku 7",
+  "blockStatsRange30": "Siku 30",
+  "blockStatsCategoryFilterList": "Maombi ya matangazo na vifuatiliaji",
+  "blockStatsCategoryDns": "Vikoa vya ufuatiliaji vinavyojulikana",
+  "blockStatsCategoryParam": "Vigezo vya ufuatiliaji vilivyoondolewa",
+  "blockStatsCategoryCdn": "Maombi ya CDN yaliyohudumiwa ndani ya kifaa",
+  "blockStatsSince": "{count} vimezuiwa tangu {date}",
+  "blockStatsEmpty": "Bado hakuna kilichozuiwa",
+  "blockStatsEmptyHint": "Washa ulinzi dhidi ya ufuatiliaji kwa tovuti fulani, kisha maombi inayozuia yataonekana hapa.",
+  "blockStatsReset": "Weka upya takwimu",
+  "blockStatsResetConfirm": "Kila kihesabu kinarudi sifuri na kuhesabu kunaanza upya leo.",
+  "appSettingsProtectionReportSubtitle": "Kile vizuizi vimezuia, kadri muda unavyopita"
 }

--- a/lib/l10n/app_ta.arb
+++ b/lib/l10n/app_ta.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "சோதனை அறிவிப்பை அனுப்பு",
   "devToolsTestNotificationSent": "சோதனை அறிவிப்பு அனுப்பப்பட்டது (பதிவுகளைப் பார்க்கவும்)",
   "devToolsTestNotificationTitle": "WebSpace சோதனை அறிவிப்பு",
-  "devToolsTestNotificationBody": "இதை நீங்கள் பார்க்க முடிந்தால், இயக்க முறைமையின் அறிவிப்பு வழங்கல் வேலை செய்கிறது."
+  "devToolsTestNotificationBody": "இதை நீங்கள் பார்க்க முடிந்தால், இயக்க முறைமையின் அறிவிப்பு வழங்கல் வேலை செய்கிறது.",
+  "blockStatsTitle": "பாதுகாப்பு அறிக்கை",
+  "blockStatsSubtitleWeek": "இந்த வாரம் தடுக்கப்பட்ட கண்காணிப்பிகள்",
+  "blockStatsSubtitleMonth": "கடந்த 30 நாட்களில் தடுக்கப்பட்ட கண்காணிப்பிகள்",
+  "blockStatsRange7": "7 நாட்கள்",
+  "blockStatsRange30": "30 நாட்கள்",
+  "blockStatsCategoryFilterList": "விளம்பர மற்றும் கண்காணிப்பி கோரிக்கைகள்",
+  "blockStatsCategoryDns": "அறியப்பட்ட கண்காணிப்பு களங்கள்",
+  "blockStatsCategoryParam": "நீக்கப்பட்ட கண்காணிப்பு அளபுருக்கள்",
+  "blockStatsCategoryCdn": "உள்ளூரில் வழங்கப்பட்ட CDN கோரிக்கைகள்",
+  "blockStatsSince": "{date} முதல் {count} தடுக்கப்பட்டன",
+  "blockStatsEmpty": "இதுவரை எதுவும் தடுக்கப்படவில்லை",
+  "blockStatsEmptyHint": "ஒரு தளத்திற்கு கண்காணிப்புப் பாதுகாப்பை இயக்கினால், அது தடுக்கும் கோரிக்கைகள் இங்கே காட்டப்படும்.",
+  "blockStatsReset": "புள்ளிவிவரங்களை மீட்டமை",
+  "blockStatsResetConfirm": "ஒவ்வொரு எண்ணிக்கையும் பூஜ்ஜியத்திற்குத் திரும்பும், எண்ணிக்கை இன்று முதல் மீண்டும் தொடங்கும்.",
+  "appSettingsProtectionReportSubtitle": "காலப்போக்கில் தடுப்பான்கள் நிறுத்தியவை"
 }

--- a/lib/l10n/app_te.arb
+++ b/lib/l10n/app_te.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "పరీక్ష నోటిఫికేషన్ పంపండి",
   "devToolsTestNotificationSent": "పరీక్ష నోటిఫికేషన్ పంపబడింది (లాగ్‌లను చూడండి)",
   "devToolsTestNotificationTitle": "WebSpace పరీక్ష నోటిఫికేషన్",
-  "devToolsTestNotificationBody": "ఇది మీకు కనిపిస్తే, ఆపరేటింగ్ సిస్టమ్ నోటిఫికేషన్ డెలివరీ పని చేస్తోంది."
+  "devToolsTestNotificationBody": "ఇది మీకు కనిపిస్తే, ఆపరేటింగ్ సిస్టమ్ నోటిఫికేషన్ డెలివరీ పని చేస్తోంది.",
+  "blockStatsTitle": "రక్షణ నివేదిక",
+  "blockStatsSubtitleWeek": "ఈ వారం నిరోధించిన ట్రాకర్లు",
+  "blockStatsSubtitleMonth": "గత 30 రోజుల్లో నిరోధించిన ట్రాకర్లు",
+  "blockStatsRange7": "7 రోజులు",
+  "blockStatsRange30": "30 రోజులు",
+  "blockStatsCategoryFilterList": "ప్రకటన మరియు ట్రాకర్ అభ్యర్థనలు",
+  "blockStatsCategoryDns": "తెలిసిన ట్రాకింగ్ డొమైన్‌లు",
+  "blockStatsCategoryParam": "తొలగించిన ట్రాకింగ్ పారామితులు",
+  "blockStatsCategoryCdn": "స్థానికంగా అందించిన CDN అభ్యర్థనలు",
+  "blockStatsSince": "{date} నుండి {count} నిరోధించబడ్డాయి",
+  "blockStatsEmpty": "ఇంకా ఏదీ నిరోధించబడలేదు",
+  "blockStatsEmptyHint": "ఒక సైట్‌కు ట్రాకింగ్ రక్షణను ఆన్ చేయండి, అది నిరోధించే అభ్యర్థనలు ఇక్కడ కనిపిస్తాయి.",
+  "blockStatsReset": "గణాంకాలను రీసెట్ చేయండి",
+  "blockStatsResetConfirm": "ప్రతి కౌంటర్ సున్నాకు తిరిగి వస్తుంది, లెక్కింపు ఈరోజు నుండి మళ్లీ మొదలవుతుంది.",
+  "appSettingsProtectionReportSubtitle": "కాలక్రమేణా బ్లాకర్లు ఆపినవి"
 }

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "ส่งการแจ้งเตือนทดสอบ",
   "devToolsTestNotificationSent": "ส่งการแจ้งเตือนทดสอบแล้ว (ดูบันทึก)",
   "devToolsTestNotificationTitle": "การแจ้งเตือนทดสอบ WebSpace",
-  "devToolsTestNotificationBody": "หากคุณเห็นข้อความนี้ แสดงว่าการส่งการแจ้งเตือนของระบบปฏิบัติการทำงานได้"
+  "devToolsTestNotificationBody": "หากคุณเห็นข้อความนี้ แสดงว่าการส่งการแจ้งเตือนของระบบปฏิบัติการทำงานได้",
+  "blockStatsTitle": "รายงานการป้องกัน",
+  "blockStatsSubtitleWeek": "ตัวติดตามที่ถูกบล็อกสัปดาห์นี้",
+  "blockStatsSubtitleMonth": "ตัวติดตามที่ถูกบล็อกใน 30 วันที่ผ่านมา",
+  "blockStatsRange7": "7 วัน",
+  "blockStatsRange30": "30 วัน",
+  "blockStatsCategoryFilterList": "คำขอจากโฆษณาและตัวติดตาม",
+  "blockStatsCategoryDns": "โดเมนติดตามที่รู้จัก",
+  "blockStatsCategoryParam": "พารามิเตอร์ติดตามที่ถูกลบ",
+  "blockStatsCategoryCdn": "คำขอ CDN ที่ให้บริการภายในเครื่อง",
+  "blockStatsSince": "บล็อกไปแล้ว {count} รายการตั้งแต่ {date}",
+  "blockStatsEmpty": "ยังไม่มีอะไรถูกบล็อก",
+  "blockStatsEmptyHint": "เปิดการป้องกันการติดตามให้กับเว็บไซต์ แล้วคำขอที่ถูกบล็อกจะแสดงที่นี่",
+  "blockStatsReset": "ล้างสถิติ",
+  "blockStatsResetConfirm": "ตัวนับทุกตัวจะกลับเป็นศูนย์และเริ่มนับใหม่ตั้งแต่วันนี้",
+  "appSettingsProtectionReportSubtitle": "สิ่งที่ตัวบล็อกหยุดไว้ ตลอดช่วงเวลา"
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Test bildirimi gönder",
   "devToolsTestNotificationSent": "Test bildirimi gönderildi (günlüklere bakın)",
   "devToolsTestNotificationTitle": "WebSpace test bildirimi",
-  "devToolsTestNotificationBody": "Bunu görebiliyorsanız, işletim sisteminin bildirim teslimatı çalışıyor."
+  "devToolsTestNotificationBody": "Bunu görebiliyorsanız, işletim sisteminin bildirim teslimatı çalışıyor.",
+  "blockStatsTitle": "Koruma raporu",
+  "blockStatsSubtitleWeek": "Bu hafta engellenen izleyiciler",
+  "blockStatsSubtitleMonth": "Son 30 günde engellenen izleyiciler",
+  "blockStatsRange7": "7 gün",
+  "blockStatsRange30": "30 gün",
+  "blockStatsCategoryFilterList": "Reklam ve izleyici istekleri",
+  "blockStatsCategoryDns": "Bilinen izleme alan adları",
+  "blockStatsCategoryParam": "Kaldırılan izleme parametreleri",
+  "blockStatsCategoryCdn": "Yerel olarak sunulan CDN istekleri",
+  "blockStatsSince": "{date} tarihinden bu yana {count} engellendi",
+  "blockStatsEmpty": "Henüz hiçbir şey engellenmedi",
+  "blockStatsEmptyHint": "Bir site için izleme korumasını açın; engellediği istekler burada görünür.",
+  "blockStatsReset": "İstatistikleri sıfırla",
+  "blockStatsResetConfirm": "Her sayaç sıfıra döner ve sayım bugünden yeniden başlar.",
+  "appSettingsProtectionReportSubtitle": "Engelleyicilerin zaman içinde durdurdukları"
 }

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "Надіслати тестове сповіщення",
   "devToolsTestNotificationSent": "Тестове сповіщення надіслано (див. журнали)",
   "devToolsTestNotificationTitle": "Тестове сповіщення WebSpace",
-  "devToolsTestNotificationBody": "Якщо ви це бачите, доставлення сповіщень операційної системи працює."
+  "devToolsTestNotificationBody": "Якщо ви це бачите, доставлення сповіщень операційної системи працює.",
+  "blockStatsTitle": "Звіт про захист",
+  "blockStatsSubtitleWeek": "Заблоковані стежники цього тижня",
+  "blockStatsSubtitleMonth": "Заблоковані стежники за останні 30 днів",
+  "blockStatsRange7": "7 днів",
+  "blockStatsRange30": "30 днів",
+  "blockStatsCategoryFilterList": "Запити реклами та стежників",
+  "blockStatsCategoryDns": "Відомі домени стеження",
+  "blockStatsCategoryParam": "Вилучені параметри стеження",
+  "blockStatsCategoryCdn": "Запити CDN, обслужені локально",
+  "blockStatsSince": "{count} заблоковано з {date}",
+  "blockStatsEmpty": "Ще нічого не заблоковано",
+  "blockStatsEmptyHint": "Увімкніть захист від стеження для сайту, і заблоковані запити з'являться тут.",
+  "blockStatsReset": "Скинути статистику",
+  "blockStatsResetConfirm": "Кожен лічильник повертається до нуля, а підрахунок починається знову від сьогодні.",
+  "appSettingsProtectionReportSubtitle": "Що блокувальники зупинили з часом"
 }

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "ٹیسٹ اطلاع بھیجیں",
   "devToolsTestNotificationSent": "ٹیسٹ اطلاع بھیج دی گئی (لاگز دیکھیں)",
   "devToolsTestNotificationTitle": "WebSpace ٹیسٹ اطلاع",
-  "devToolsTestNotificationBody": "اگر آپ یہ دیکھ سکتے ہیں، تو آپریٹنگ سسٹم کی اطلاع کی ترسیل کام کر رہی ہے۔"
+  "devToolsTestNotificationBody": "اگر آپ یہ دیکھ سکتے ہیں، تو آپریٹنگ سسٹم کی اطلاع کی ترسیل کام کر رہی ہے۔",
+  "blockStatsTitle": "تحفظ کی رپورٹ",
+  "blockStatsSubtitleWeek": "اس ہفتے مسدود کیے گئے ٹریکرز",
+  "blockStatsSubtitleMonth": "پچھلے 30 دنوں میں مسدود کیے گئے ٹریکرز",
+  "blockStatsRange7": "7 دن",
+  "blockStatsRange30": "30 دن",
+  "blockStatsCategoryFilterList": "اشتہارات اور ٹریکرز کی درخواستیں",
+  "blockStatsCategoryDns": "معروف ٹریکنگ ڈومینز",
+  "blockStatsCategoryParam": "ہٹائے گئے ٹریکنگ پیرامیٹرز",
+  "blockStatsCategoryCdn": "مقامی طور پر فراہم کردہ CDN درخواستیں",
+  "blockStatsSince": "{date} سے {count} مسدود",
+  "blockStatsEmpty": "ابھی تک کچھ مسدود نہیں ہوا",
+  "blockStatsEmptyHint": "کسی سائٹ کے لیے ٹریکنگ تحفظ آن کریں، پھر جو درخواستیں یہ روکے گی وہ یہاں دکھائی دیں گی۔",
+  "blockStatsReset": "اعدادوشمار دوبارہ ترتیب دیں",
+  "blockStatsResetConfirm": "ہر شمار کنندہ صفر پر واپس آ جاتا ہے اور گنتی آج سے دوبارہ شروع ہوتی ہے۔",
+  "appSettingsProtectionReportSubtitle": "بلاک کرنے والوں نے وقت کے ساتھ کیا روکا"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "发送测试通知",
   "devToolsTestNotificationSent": "已发送测试通知（查看日志）",
   "devToolsTestNotificationTitle": "WebSpace 测试通知",
-  "devToolsTestNotificationBody": "如果您能看到这条消息，说明操作系统的通知投递功能正常。"
+  "devToolsTestNotificationBody": "如果您能看到这条消息，说明操作系统的通知投递功能正常。",
+  "blockStatsTitle": "防护报告",
+  "blockStatsSubtitleWeek": "本周拦截的跟踪器",
+  "blockStatsSubtitleMonth": "过去 30 天拦截的跟踪器",
+  "blockStatsRange7": "7 天",
+  "blockStatsRange30": "30 天",
+  "blockStatsCategoryFilterList": "广告与跟踪器请求",
+  "blockStatsCategoryDns": "已知跟踪域名",
+  "blockStatsCategoryParam": "已移除的跟踪参数",
+  "blockStatsCategoryCdn": "本地提供的 CDN 请求",
+  "blockStatsSince": "自 {date} 起已拦截 {count} 个",
+  "blockStatsEmpty": "尚未拦截任何内容",
+  "blockStatsEmptyHint": "为某个站点开启跟踪保护后，它拦截的请求会显示在这里。",
+  "blockStatsReset": "重置统计",
+  "blockStatsResetConfirm": "所有计数器归零，并从今天重新开始统计。",
+  "appSettingsProtectionReportSubtitle": "拦截器长期以来阻止的内容"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -706,5 +706,20 @@
   "devToolsTestNotification": "傳送測試通知",
   "devToolsTestNotificationSent": "已傳送測試通知（查看記錄）",
   "devToolsTestNotificationTitle": "WebSpace 測試通知",
-  "devToolsTestNotificationBody": "如果您能看到這則訊息，表示作業系統的通知傳遞功能正常。"
+  "devToolsTestNotificationBody": "如果您能看到這則訊息，表示作業系統的通知傳遞功能正常。",
+  "blockStatsTitle": "防護報告",
+  "blockStatsSubtitleWeek": "本週攔截的追蹤器",
+  "blockStatsSubtitleMonth": "過去 30 天攔截的追蹤器",
+  "blockStatsRange7": "7 天",
+  "blockStatsRange30": "30 天",
+  "blockStatsCategoryFilterList": "廣告與追蹤器要求",
+  "blockStatsCategoryDns": "已知追蹤網域",
+  "blockStatsCategoryParam": "已移除的追蹤參數",
+  "blockStatsCategoryCdn": "本機提供的 CDN 要求",
+  "blockStatsSince": "自 {date} 起已攔截 {count} 個",
+  "blockStatsEmpty": "尚未攔截任何內容",
+  "blockStatsEmptyHint": "為某個網站開啟追蹤保護後，它攔截的要求會顯示在這裡。",
+  "blockStatsReset": "重設統計",
+  "blockStatsResetConfirm": "所有計數器歸零，並從今天重新開始統計。",
+  "appSettingsProtectionReportSubtitle": "攔截器長期以來阻擋的內容"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -73,6 +73,7 @@ import 'package:webspace/services/webspace_selection_engine.dart';
 import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/adblock_engine.dart';
 import 'package:webspace/services/content_blocker_service.dart';
+import 'package:webspace/services/block_stats_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/services/firefox_user_agent_service.dart';
 import 'package:webspace/services/timezone_location_service.dart';
@@ -661,6 +662,7 @@ void main() async {
       () => _runTimed('firefoxUa', FirefoxUserAgentService.instance.initialize),
       () => _runTimed('adblock', ContentBlockerService.instance.initialize),
       () => _runTimed('localCdn', LocalCdnService.instance.initialize),
+      () => _runTimed('blockStats', BlockStatsService.instance.initialize),
       if (Platform.isAndroid)
         () => _runTimed('swBlock', blockServiceWorkerNetwork),
     ],
@@ -1593,6 +1595,10 @@ class _WebSpacePageState extends State<WebSpacePage>
     if (state == AppLifecycleState.paused) {
       _foregroundPollTimer?.cancel();
       _foregroundPollTimer = null;
+      // Persist the protection-report counters before the OS can reclaim
+      // the process: the in-memory debounce would otherwise lose up to
+      // BlockStatsService.flushDelay of counts on a kill.
+      unawaited(BlockStatsService.instance.flush());
       // URL-ephemeral sites (alwaysOpenHome / incognito) revert to their
       // initUrl only on a genuine app restart (fromJson strips currentUrl on
       // cold start, AOH-002) and on home-shortcut tap (AOH-004) — never on a
@@ -2535,6 +2541,7 @@ class _WebSpacePageState extends State<WebSpacePage>
       dnsBlockEnabled: model.dnsBlockEnabled,
       contentBlockEnabled: model.contentBlockEnabled,
       localCdnEnabled: model.effectiveLocalCdnEnabled,
+      contributesBlockStats: model.contributesBlockStats,
       trackingProtectionEnabled: model.trackingProtectionEnabled,
       letterboxEnabled: model.letterboxEnabled,
       spoofWindowWidth: model.spoofWindowWidth,
@@ -5019,6 +5026,7 @@ class _WebSpacePageState extends State<WebSpacePage>
     required bool dnsBlockEnabled,
     required bool contentBlockEnabled,
     required bool localCdnEnabled,
+    required bool contributesBlockStats,
     required bool trackingProtectionEnabled,
     bool letterboxEnabled = false,
     int? spoofWindowWidth,
@@ -5054,6 +5062,7 @@ class _WebSpacePageState extends State<WebSpacePage>
           dnsBlockEnabled: dnsBlockEnabled,
           contentBlockEnabled: contentBlockEnabled,
           localCdnEnabled: localCdnEnabled,
+          contributesBlockStats: contributesBlockStats,
           trackingProtectionEnabled: trackingProtectionEnabled,
           letterboxEnabled: letterboxEnabled,
           spoofWindowWidth: spoofWindowWidth,
@@ -6833,6 +6842,7 @@ class _WebSpacePageState extends State<WebSpacePage>
                   dnsBlockEnabled: model.dnsBlockEnabled,
                   contentBlockEnabled: model.contentBlockEnabled,
                   localCdnEnabled: model.localCdnEnabled,
+                  contributesBlockStats: model.contributesBlockStats,
                   trackingProtectionEnabled: model.trackingProtectionEnabled,
                   letterboxEnabled: model.letterboxEnabled,
                   spoofWindowWidth: model.spoofWindowWidth,

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:webspace/l10n/gen/app_localizations.dart';
 import 'package:webspace/settings/app_locale.dart';
 import 'package:webspace/main.dart' show AppThemeSettings, AccentColor;
+import 'package:webspace/screens/block_stats.dart';
 import 'package:webspace/screens/dev_tools.dart';
 import 'package:webspace/screens/trusted_certificates.dart';
 import 'package:webspace/services/clearurl_service.dart';
@@ -1029,6 +1030,16 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
               });
               widget.onShowStatsBannerChanged(value);
             },
+          ),
+          ListTile(
+            leading: const Icon(Icons.shield_outlined),
+            title: Text(loc.blockStatsTitle),
+            subtitle: Text(loc.appSettingsProtectionReportSubtitle),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => const BlockStatsScreen()),
+            ),
           ),
           ListTile(
             leading: const Icon(Icons.language),

--- a/lib/screens/block_stats.dart
+++ b/lib/screens/block_stats.dart
@@ -1,0 +1,308 @@
+import 'package:flutter/material.dart';
+
+import 'package:webspace/l10n/gen/app_localizations.dart';
+import 'package:webspace/services/block_stats_engine.dart';
+import 'package:webspace/services/block_stats_service.dart';
+
+/// App-wide protection report (STATS-003): what the blockers stopped over the
+/// last 7 / 30 days, split by the mechanism that stopped it, plus the
+/// all-time total since counting started.
+class BlockStatsScreen extends StatefulWidget {
+  const BlockStatsScreen({super.key});
+
+  @override
+  State<BlockStatsScreen> createState() => _BlockStatsScreenState();
+}
+
+class _BlockStatsScreenState extends State<BlockStatsScreen> {
+  static const List<int> _ranges = [7, 30];
+
+  int _rangeDays = 7;
+
+  BlockStatsService get _service => BlockStatsService.instance;
+
+  @override
+  void initState() {
+    super.initState();
+    _service.addListener(_onStatsChanged);
+  }
+
+  @override
+  void dispose() {
+    _service.removeListener(_onStatsChanged);
+    super.dispose();
+  }
+
+  void _onStatsChanged() {
+    if (!mounted) return;
+    setState(() {});
+  }
+
+  Future<void> _confirmReset() async {
+    final loc = AppLocalizations.of(context);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(loc.blockStatsReset),
+        content: Text(loc.blockStatsResetConfirm),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: Text(loc.commonCancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: Text(loc.blockStatsReset),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await _service.reset();
+    if (!mounted) return;
+    setState(() {});
+  }
+
+  String _categoryLabel(AppLocalizations loc, BlockCategory category) {
+    switch (category) {
+      case BlockCategory.filterList:
+        return loc.blockStatsCategoryFilterList;
+      case BlockCategory.dnsBlocklist:
+        return loc.blockStatsCategoryDns;
+      case BlockCategory.trackingParam:
+        return loc.blockStatsCategoryParam;
+      case BlockCategory.localCdn:
+        return loc.blockStatsCategoryCdn;
+    }
+  }
+
+  IconData _categoryIcon(BlockCategory category) {
+    switch (category) {
+      case BlockCategory.filterList:
+        return Icons.block;
+      case BlockCategory.dnsBlocklist:
+        return Icons.dns_outlined;
+      case BlockCategory.trackingParam:
+        return Icons.link_off;
+      case BlockCategory.localCdn:
+        return Icons.cloud_off_outlined;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final engine = _service.engine;
+    final totals = engine.totalsForLastDays(_rangeDays);
+    final rangeTotal = totals.values.fold<int>(0, (a, b) => a + b);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(loc.blockStatsTitle),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.restart_alt),
+            tooltip: loc.blockStatsReset,
+            onPressed: engine.allTimeTotal == 0 ? null : _confirmReset,
+          ),
+        ],
+      ),
+      body: engine.allTimeTotal == 0
+          ? _buildEmptyState(loc, theme)
+          : ListView(
+              padding: const EdgeInsets.only(bottom: 24),
+              children: [
+                _buildHero(loc, theme, rangeTotal),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                  child: Center(
+                    child: SegmentedButton<int>(
+                      segments: [
+                        for (final days in _ranges)
+                          ButtonSegment<int>(
+                            value: days,
+                            label: Text(days == 7
+                                ? loc.blockStatsRange7
+                                : loc.blockStatsRange30),
+                          ),
+                      ],
+                      selected: {_rangeDays},
+                      showSelectedIcon: false,
+                      onSelectionChanged: (selection) =>
+                          setState(() => _rangeDays = selection.first),
+                    ),
+                  ),
+                ),
+                _buildChart(theme, engine.dailyTotals(_rangeDays)),
+                const SizedBox(height: 20),
+                ..._buildCategoryRows(loc, theme, totals, rangeTotal),
+                const Divider(height: 32),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Text(
+                    loc.blockStatsSince(
+                      engine.allTimeTotal,
+                      MaterialLocalizations.of(context)
+                          .formatShortDate(engine.since),
+                    ),
+                    style: theme.textTheme.bodyMedium
+                        ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+
+  Widget _buildEmptyState(AppLocalizations loc, ThemeData theme) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.shield_outlined,
+                size: 72, color: theme.colorScheme.primary),
+            const SizedBox(height: 16),
+            Text(loc.blockStatsEmpty, style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Text(
+              loc.blockStatsEmptyHint,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHero(AppLocalizations loc, ThemeData theme, int total) {
+    // Pure-data display goes through a variable, never a literal inside
+    // Text(...) — LOC-002.
+    final totalLabel = '$total';
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 16),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            theme.colorScheme.primaryContainer,
+            theme.colorScheme.tertiaryContainer,
+          ],
+        ),
+      ),
+      child: Column(
+        children: [
+          Icon(Icons.shield,
+              size: 56, color: theme.colorScheme.onPrimaryContainer),
+          const SizedBox(height: 12),
+          Text(
+            totalLabel,
+            style: theme.textTheme.displayMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: theme.colorScheme.onPrimaryContainer,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            _rangeDays == 7
+                ? loc.blockStatsSubtitleWeek
+                : loc.blockStatsSubtitleMonth,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.titleMedium
+                ?.copyWith(color: theme.colorScheme.onPrimaryContainer),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Daily totals as a bare bar strip. Deliberately label-free: the axis
+  /// values would need a locale-formatted date per bar and the shape is the
+  /// point, not the readings.
+  Widget _buildChart(ThemeData theme, List<int> daily) {
+    final peak = daily.fold<int>(0, (a, b) => b > a ? b : a);
+    return SizedBox(
+      height: 72,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            for (final value in daily)
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 1),
+                  child: FractionallySizedBox(
+                    // A zero day draws nothing; any non-zero day gets a
+                    // visible stub so a quiet day is not mistaken for none.
+                    heightFactor: value == 0 ? 0.0 : (value / peak).clamp(0.04, 1.0),
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.primary,
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildCategoryRows(
+    AppLocalizations loc,
+    ThemeData theme,
+    Map<BlockCategory, int> totals,
+    int rangeTotal,
+  ) {
+    final ordered = BlockCategory.values.toList()
+      ..sort((a, b) => (totals[b] ?? 0).compareTo(totals[a] ?? 0));
+    final rowLabels = <BlockCategory, String>{
+      for (final category in ordered)
+        category: '${totals[category] ?? 0}  ${_categoryLabel(loc, category)}',
+    };
+    return [
+      for (final category in ordered)
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+          child: Row(
+            children: [
+              Icon(_categoryIcon(category),
+                  color: theme.colorScheme.onSurfaceVariant),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      rowLabels[category]!,
+                      style: theme.textTheme.titleSmall,
+                    ),
+                    const SizedBox(height: 6),
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(4),
+                      child: LinearProgressIndicator(
+                        value: rangeTotal == 0
+                            ? 0
+                            : (totals[category] ?? 0) / rangeTotal,
+                        minHeight: 6,
+                        backgroundColor: theme.colorScheme.surfaceContainerHighest,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+    ];
+  }
+}

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -39,6 +39,10 @@ class InAppWebViewScreen extends StatefulWidget {
   final bool dnsBlockEnabled;
   final bool contentBlockEnabled;
   final bool localCdnEnabled;
+  /// Mirrors the parent site's `contributesBlockStats` so a nested webview
+  /// for an archive-tier site never rolls its blocks into the app-wide
+  /// protection report (ARCH-006).
+  final bool contributesBlockStats;
   final bool trackingProtectionEnabled;
   final bool letterboxEnabled;
   final int? spoofWindowWidth;
@@ -112,6 +116,7 @@ class InAppWebViewScreen extends StatefulWidget {
     required this.dnsBlockEnabled,
     required this.contentBlockEnabled,
     required this.localCdnEnabled,
+    this.contributesBlockStats = true,
     required this.trackingProtectionEnabled,
     this.letterboxEnabled = false,
     this.spoofWindowWidth,
@@ -276,6 +281,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
         dnsBlockEnabled: widget.dnsBlockEnabled || widget.trackingProtectionEnabled,
         contentBlockEnabled: widget.contentBlockEnabled || widget.trackingProtectionEnabled,
         localCdnEnabled: widget.localCdnEnabled || widget.trackingProtectionEnabled,
+        contributesBlockStats: widget.contributesBlockStats,
         trackingProtectionEnabled: widget.trackingProtectionEnabled,
         letterboxEnabled: widget.letterboxEnabled,
         spoofWindowWidth: widget.spoofWindowWidth,

--- a/lib/services/block_stats_engine.dart
+++ b/lib/services/block_stats_engine.dart
@@ -1,0 +1,186 @@
+/// Pure aggregation engine behind the protection report (STATS-001).
+///
+/// Holds daily buckets of block events per category, an all-time total, and
+/// the timestamp counting started from. No Flutter, no I/O: the owning
+/// [BlockStatsService] handles persistence and gating.
+library;
+
+/// What blocked a request. Each value maps to a mechanism the app already
+/// runs, so a count is never inferred from a category the app cannot
+/// attribute.
+enum BlockCategory {
+  /// ABP filter list match (EasyList, EasyPrivacy, Fanboy's, custom).
+  filterList,
+
+  /// Hagezi DNS blocklist match.
+  dnsBlocklist,
+
+  /// ClearURLs stripped at least one tracking parameter from a URL.
+  trackingParam,
+
+  /// A third-party CDN request was served from the local LocalCDN cache
+  /// instead of reaching the CDN.
+  localCdn,
+}
+
+const Map<BlockCategory, String> _categoryKeys = {
+  BlockCategory.filterList: 'abp',
+  BlockCategory.dnsBlocklist: 'dns',
+  BlockCategory.trackingParam: 'param',
+  BlockCategory.localCdn: 'cdn',
+};
+
+BlockCategory? _categoryFromKey(String key) {
+  for (final entry in _categoryKeys.entries) {
+    if (entry.value == key) return entry.key;
+  }
+  return null;
+}
+
+class BlockStatsEngine {
+  /// Daily buckets older than this are dropped on the next [prune]. The
+  /// all-time totals are kept independently, so pruning never rewrites
+  /// the headline number.
+  static const int retentionDays = 90;
+
+  static const int schemaVersion = 1;
+
+  /// Buckets keyed by local calendar day as `yyyymmdd`. The encoding is
+  /// chronologically ordered as an int, so pruning is a less-than comparison.
+  final Map<int, Map<BlockCategory, int>> _days;
+  final Map<BlockCategory, int> _allTime;
+
+  DateTime _since;
+  bool _dirty = false;
+
+  BlockStatsEngine({
+    DateTime? since,
+    Map<int, Map<BlockCategory, int>>? days,
+    Map<BlockCategory, int>? allTime,
+  })  : _since = since ?? DateTime.now(),
+        _days = days ?? <int, Map<BlockCategory, int>>{},
+        _allTime = allTime ?? <BlockCategory, int>{};
+
+  /// When counting started. Rendered as the report's "N blocked since" date.
+  DateTime get since => _since;
+
+  /// True when a mutation has not been persisted yet.
+  bool get isDirty => _dirty;
+
+  void markClean() => _dirty = false;
+
+  static int dayKey(DateTime d) => d.year * 10000 + d.month * 100 + d.day;
+
+  void record(BlockCategory category, {int count = 1, DateTime? now}) {
+    if (count < 1) return;
+    final at = now ?? DateTime.now();
+    final bucket = _days.putIfAbsent(dayKey(at), () => <BlockCategory, int>{});
+    bucket[category] = (bucket[category] ?? 0) + count;
+    _allTime[category] = (_allTime[category] ?? 0) + count;
+    _dirty = true;
+  }
+
+  /// Per-category totals over the [days] calendar days ending today
+  /// (inclusive), so `days: 7` is "this week" in the user's own timezone.
+  Map<BlockCategory, int> totalsForLastDays(int days, {DateTime? now}) {
+    final at = now ?? DateTime.now();
+    final out = <BlockCategory, int>{};
+    for (var i = 0; i < days; i++) {
+      final key = dayKey(DateTime(at.year, at.month, at.day - i));
+      final bucket = _days[key];
+      if (bucket == null) continue;
+      for (final entry in bucket.entries) {
+        out[entry.key] = (out[entry.key] ?? 0) + entry.value;
+      }
+    }
+    return out;
+  }
+
+  int totalForLastDays(int days, {DateTime? now}) =>
+      totalsForLastDays(days, now: now).values.fold(0, (a, b) => a + b);
+
+  /// Daily totals oldest-first over the [days] window, for the bar chart.
+  List<int> dailyTotals(int days, {DateTime? now}) {
+    final at = now ?? DateTime.now();
+    return List<int>.generate(days, (i) {
+      final key = dayKey(DateTime(at.year, at.month, at.day - (days - 1 - i)));
+      final bucket = _days[key];
+      if (bucket == null) return 0;
+      return bucket.values.fold(0, (a, b) => a + b);
+    });
+  }
+
+  Map<BlockCategory, int> get allTimeTotals =>
+      Map<BlockCategory, int>.unmodifiable(_allTime);
+
+  int get allTimeTotal => _allTime.values.fold(0, (a, b) => a + b);
+
+  /// Drop buckets older than [retentionDays]. Returns the number dropped.
+  int prune({DateTime? now}) {
+    final at = now ?? DateTime.now();
+    final cutoff = dayKey(DateTime(at.year, at.month, at.day - retentionDays));
+    final stale = _days.keys.where((k) => k < cutoff).toList();
+    for (final k in stale) {
+      _days.remove(k);
+    }
+    if (stale.isNotEmpty) _dirty = true;
+    return stale.length;
+  }
+
+  /// Wipe every counter and restart the "since" clock.
+  void reset({DateTime? now}) {
+    _days.clear();
+    _allTime.clear();
+    _since = now ?? DateTime.now();
+    _dirty = true;
+  }
+
+  Map<String, dynamic> toJson() => {
+        'v': schemaVersion,
+        'since': _since.toIso8601String(),
+        'allTime': {
+          for (final entry in _allTime.entries)
+            _categoryKeys[entry.key]!: entry.value,
+        },
+        'days': {
+          for (final day in _days.entries)
+            day.key.toString(): {
+              for (final entry in day.value.entries)
+                _categoryKeys[entry.key]!: entry.value,
+            },
+        },
+      };
+
+  /// Tolerant of unknown categories and malformed buckets: a corrupt
+  /// stats blob degrades to a smaller count, never a startup crash.
+  factory BlockStatsEngine.fromJson(Map<String, dynamic> json) {
+    final days = <int, Map<BlockCategory, int>>{};
+    final rawDays = json['days'];
+    if (rawDays is Map) {
+      for (final entry in rawDays.entries) {
+        final key = int.tryParse(entry.key.toString());
+        final value = entry.value;
+        if (key == null || value is! Map) continue;
+        final bucket = _countsFromJson(value);
+        if (bucket.isNotEmpty) days[key] = bucket;
+      }
+    }
+    final rawAll = json['allTime'];
+    return BlockStatsEngine(
+      since: DateTime.tryParse(json['since']?.toString() ?? '') ?? DateTime.now(),
+      days: days,
+      allTime: rawAll is Map ? _countsFromJson(rawAll) : null,
+    );
+  }
+
+  static Map<BlockCategory, int> _countsFromJson(Map<dynamic, dynamic> raw) {
+    final out = <BlockCategory, int>{};
+    for (final entry in raw.entries) {
+      final category = _categoryFromKey(entry.key.toString());
+      final count = entry.value;
+      if (category == null || count is! int || count <= 0) continue;
+      out[category] = count;
+    }
+    return out;
+  }
+}

--- a/lib/services/block_stats_service.dart
+++ b/lib/services/block_stats_service.dart
@@ -1,0 +1,155 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:webspace/services/block_stats_engine.dart';
+import 'package:webspace/services/log_service.dart';
+
+/// Persistent, app-wide block statistics behind the protection report
+/// (STATS-001).
+///
+/// Per-site live counters stay in `DnsBlockService` (session-scoped, keyed by
+/// siteId). This service is the aggregate: no siteId is ever persisted, only
+/// per-category daily totals, so the report cannot be mined for which sites
+/// the user visits.
+///
+/// **Archive neutrality (ARCH-006).** A site only contributes once
+/// [setSiteContributes] has declared it app-tier. Unknown siteIds are
+/// ignored, so an archive-tier site whose scope was never declared can never
+/// move a counter that lands in plaintext SharedPreferences.
+class BlockStatsService {
+  static const String prefsKey = 'blockStatsV1';
+
+  /// How long a mutation may sit unpersisted. Block events arrive in bursts
+  /// of hundreds per page load; coalescing keeps that to one write.
+  static const Duration flushDelay = Duration(seconds: 10);
+
+  static BlockStatsService? _instance;
+  static BlockStatsService get instance => _instance ??= BlockStatsService._();
+
+  BlockStatsService._();
+
+  /// Test seam: drop the singleton so each test starts from a clean engine.
+  @visibleForTesting
+  static void resetInstanceForTest() => _instance = null;
+
+  BlockStatsEngine _engine = BlockStatsEngine();
+  final Set<String> _contributingSiteIds = <String>{};
+  final Set<VoidCallback> _listeners = <VoidCallback>{};
+  Timer? _flushTimer;
+  Future<void>? _initFuture;
+  bool _notifyScheduled = false;
+  bool _initialized = false;
+
+  BlockStatsEngine get engine => _engine;
+
+  bool get isInitialized => _initialized;
+
+  /// Load persisted counters. Safe to call more than once: concurrent callers
+  /// await the same load, and later calls are no-ops, so a re-entrant startup
+  /// path cannot replace an engine that has already taken counts.
+  Future<void> initialize() {
+    return _initFuture ??= _initialize();
+  }
+
+  Future<void> _initialize() async {
+    _initialized = true;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(prefsKey);
+      if (raw != null && raw.isNotEmpty) {
+        final decoded = jsonDecode(raw);
+        if (decoded is Map<String, dynamic>) {
+          _engine = BlockStatsEngine.fromJson(decoded);
+        }
+      }
+    } catch (e) {
+      LogService.instance.log('BlockStats', 'Failed to load stats: $e',
+          level: LogLevel.warning);
+      _engine = BlockStatsEngine();
+    }
+    if (_engine.prune() > 0) {
+      unawaited(flush());
+    }
+    notifyListeners();
+  }
+
+  /// Declare whether [siteId]'s block events roll into the app-wide report.
+  /// Called from the webview factory for every webview built, so the answer
+  /// always arrives before the first block event for that site.
+  void setSiteContributes(String siteId, bool contributes) {
+    if (siteId.isEmpty) return;
+    if (contributes) {
+      _contributingSiteIds.add(siteId);
+    } else {
+      _contributingSiteIds.remove(siteId);
+    }
+  }
+
+  @visibleForTesting
+  bool siteContributes(String siteId) => _contributingSiteIds.contains(siteId);
+
+  /// Record [count] block events of [category] attributed to [siteId].
+  /// Ignored for sites that have not been declared app-tier.
+  void record(String siteId, BlockCategory category, {int count = 1}) {
+    if (count < 1) return;
+    if (!_contributingSiteIds.contains(siteId)) return;
+    _engine.record(category, count: count);
+    _scheduleFlush();
+    _scheduleNotify();
+  }
+
+  Future<void> reset() async {
+    _engine.reset();
+    await flush();
+    notifyListeners();
+  }
+
+  /// Persist now. Called on the debounce timer, on app pause, and after a
+  /// reset.
+  Future<void> flush() async {
+    _flushTimer?.cancel();
+    _flushTimer = null;
+    if (!_engine.isDirty) return;
+    final payload = jsonEncode(_engine.toJson());
+    _engine.markClean();
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(prefsKey, payload);
+    } catch (e) {
+      LogService.instance.log('BlockStats', 'Failed to persist stats: $e',
+          level: LogLevel.warning);
+    }
+  }
+
+  void _scheduleFlush() {
+    _flushTimer ??= Timer(flushDelay, () {
+      _flushTimer = null;
+      unawaited(flush());
+    });
+  }
+
+  void addListener(VoidCallback listener) => _listeners.add(listener);
+
+  void removeListener(VoidCallback listener) => _listeners.remove(listener);
+
+  void notifyListeners() {
+    for (final listener in List<VoidCallback>.from(_listeners)) {
+      listener();
+    }
+  }
+
+  /// Coalesce listener notifications across a microtask: a page load records
+  /// hundreds of blocks in well under a frame, and the report only needs one
+  /// rebuild for the batch.
+  void _scheduleNotify() {
+    if (_listeners.isEmpty || _notifyScheduled) return;
+    _notifyScheduled = true;
+    scheduleMicrotask(() {
+      _notifyScheduled = false;
+      notifyListeners();
+    });
+  }
+}

--- a/lib/services/dns_block_service.dart
+++ b/lib/services/dns_block_service.dart
@@ -5,6 +5,8 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:webspace/services/outbound_http.dart';
 import 'package:webspace/settings/global_outbound_proxy.dart';
+import 'package:webspace/services/block_stats_engine.dart';
+import 'package:webspace/services/block_stats_service.dart';
 import 'package:webspace/services/bloom_filter.dart';
 import 'package:webspace/services/host_lookup.dart';
 import 'package:webspace/services/log_service.dart';
@@ -441,6 +443,18 @@ class DnsBlockService {
       {BlockSource? source, int count = 1}) {
     if (host.isEmpty) return;
     statsForSite(siteId).record(host, wasBlocked, source: source, count: count);
+    // Single funnel for the persisted app-wide report (STATS-002): every
+    // DNS/ABP block on every platform passes through here, so the aggregate
+    // cannot drift from the per-site counters.
+    if (wasBlocked && source != null) {
+      BlockStatsService.instance.record(
+        siteId,
+        source == BlockSource.dns
+            ? BlockCategory.dnsBlocklist
+            : BlockCategory.filterList,
+        count: count,
+      );
+    }
     recordDomainDecision(host, wasBlocked);
     _scheduleNotifyDnsLogListeners();
   }

--- a/lib/services/localcdn_service.dart
+++ b/lib/services/localcdn_service.dart
@@ -7,6 +7,8 @@ import 'package:webspace/services/outbound_http.dart';
 import 'package:webspace/settings/global_outbound_proxy.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webspace/services/block_stats_engine.dart';
+import 'package:webspace/services/block_stats_service.dart';
 import 'package:webspace/services/log_service.dart';
 
 /// CDN URL pattern with named capture groups for library, version, and file.
@@ -302,6 +304,7 @@ class LocalCdnService {
   /// Record that a CDN request was replaced with a local copy for [siteId].
   void recordReplacement(String siteId) {
     _replacementsPerSite[siteId] = (_replacementsPerSite[siteId] ?? 0) + 1;
+    BlockStatsService.instance.record(siteId, BlockCategory.localCdn);
   }
 
   /// Number of CDN requests replaced from cache for a given site.

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -30,6 +30,8 @@ import 'package:webspace/services/user_agent_classifier.dart';
 import 'package:webspace/services/user_agent_identity_shim.dart';
 import 'package:webspace/services/worker_shim.dart';
 import 'package:webspace/services/user_agent_metadata_builder.dart';
+import 'package:webspace/services/block_stats_engine.dart';
+import 'package:webspace/services/block_stats_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/services/trusted_hosts_service.dart';
 import 'package:webspace/services/download_engine.dart';
@@ -641,6 +643,13 @@ class WebViewConfig {
   final String? fingerprintResetNonce;
   /// Whether to serve CDN resources from local cache (Android only).
   final bool localCdnEnabled;
+  /// Whether this site's block events roll into the app-wide protection
+  /// report (STATS-001). False for archive-tier sites, whose activity must
+  /// not move a counter persisted in plaintext SharedPreferences
+  /// (ARCH-001/ARCH-006). Declared to `BlockStatsService` when the webview
+  /// is built, keyed by [siteId], so nested webviews for the same site
+  /// inherit the same answer.
+  final bool contributesBlockStats;
   /// Callback for JS console messages.
   final Function(String message, inapp.ConsoleMessageLevel level)? onConsoleMessage;
   /// Per-site user scripts to inject into the webview.
@@ -771,6 +780,7 @@ class WebViewConfig {
     this.deferInitialLoad = false,
     this.language,
     this.zoomPercent = 100,
+    this.contributesBlockStats = true,
     this.clearUrlEnabled = true,
     this.dnsBlockEnabled = true,
     this.contentBlockEnabled = true,
@@ -1758,6 +1768,14 @@ class WebViewFactory {
       'DNT': '1',
       'Sec-GPC': '1',
     };
+
+    // Declare this site's protection-report scope before any block event can
+    // be recorded for it. Keyed by siteId, so a nested webview built for the
+    // same site re-asserts the same answer rather than flipping it.
+    if (config.siteId != null) {
+      BlockStatsService.instance
+          .setSiteContributes(config.siteId!, config.contributesBlockStats);
+    }
     if (config.language != null) {
       headers['Accept-Language'] = '${config.language}, *;q=0.5';
     }
@@ -3071,7 +3089,13 @@ class WebViewFactory {
         if (config.clearUrlEnabled) {
           controller.addJavaScriptHandler(handlerName: 'clearUrl', callback: (args) {
             if (args.isNotEmpty && args[0] is String) {
-              return ClearUrlService.instance.cleanUrl(args[0] as String);
+              final original = args[0] as String;
+              final cleaned = ClearUrlService.instance.cleanUrl(original);
+              if (cleaned != original && config.siteId != null) {
+                BlockStatsService.instance
+                    .record(config.siteId!, BlockCategory.trackingParam);
+              }
+              return cleaned;
             }
             return args.isNotEmpty ? args[0] : '';
           });
@@ -3600,6 +3624,10 @@ class WebViewFactory {
           final cleanedUrl = ClearUrlService.instance.cleanUrl(url);
           if (cleanedUrl.isEmpty) return inapp.NavigationActionPolicy.CANCEL;
           if (cleanedUrl != url) {
+            if (config.siteId != null) {
+              BlockStatsService.instance
+                  .record(config.siteId!, BlockCategory.trackingParam);
+            }
             controller.loadUrl(urlRequest: inapp.URLRequest(url: inapp.WebUri(cleanedUrl)));
             return inapp.NavigationActionPolicy.CANCEL;
           }

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -588,6 +588,14 @@ class WebViewModel {
   bool get effectiveHtmlCachingEnabled =>
       isArchiveTier ? false : htmlCachingEnabled;
 
+  /// Whether this site's block events roll into the app-wide protection
+  /// report. Archive-tier sites never do: the report's counters live in
+  /// plaintext SharedPreferences, and a counter that only moves while an
+  /// archive is open leaks that the archive was used (ARCH-001/ARCH-006).
+  /// Per-site live counters (`DnsBlockService`) are unaffected — they are
+  /// in-memory and die with the session.
+  bool get contributesBlockStats => !isArchiveTier;
+
   /// Whether this site may persist/restore webview navigation state
   /// (`controller.saveState()` bytes) to the device-key on-disk store.
   /// Single source of truth for the capture, debounce, and cold-start
@@ -981,7 +989,7 @@ class WebViewModel {
   }
 
   Widget getWebView(
-    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required bool localCdnEnabled, required bool trackingProtectionEnabled, bool letterboxEnabled, int? spoofWindowWidth, int? spoofWindowHeight, String? fingerprintResetNonce, required String? language, required int zoomPercent, LocationMode locationMode, double? spoofLatitude, double? spoofLongitude, double spoofAccuracy, String? spoofTimezone, bool spoofTimezoneFromLocation, LocationGranularity liveLocationGranularity, WebRtcPolicy webRtcPolicy, String? userAgent, bool javascriptEnabled, required List<UserScriptConfig> userScripts, UserProxySettings? proxySettings, bool notificationsEnabled, bool externalLinksInBrowser}) launchUrlFunc,
+    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required bool localCdnEnabled, required bool contributesBlockStats, required bool trackingProtectionEnabled, bool letterboxEnabled, int? spoofWindowWidth, int? spoofWindowHeight, String? fingerprintResetNonce, required String? language, required int zoomPercent, LocationMode locationMode, double? spoofLatitude, double? spoofLongitude, double spoofAccuracy, String? spoofTimezone, bool spoofTimezoneFromLocation, LocationGranularity liveLocationGranularity, WebRtcPolicy webRtcPolicy, String? userAgent, bool javascriptEnabled, required List<UserScriptConfig> userScripts, UserProxySettings? proxySettings, bool notificationsEnabled, bool externalLinksInBrowser}) launchUrlFunc,
     CookieManager cookieManager,
     ContainerCookieManager? containerCookieManager,
     Function saveFunc, {
@@ -1091,6 +1099,7 @@ class WebViewModel {
           dnsBlockEnabled: dnsBlockEnabled || trackingProtectionEnabled,
           contentBlockEnabled: contentBlockEnabled || trackingProtectionEnabled,
           localCdnEnabled: localCdnEnabled || trackingProtectionEnabled,
+          contributesBlockStats: contributesBlockStats,
           trackingProtectionEnabled: trackingProtectionEnabled,
           letterboxEnabled: letterboxEnabled,
           spoofWindowWidth: spoofWindowWidth,
@@ -1216,7 +1225,7 @@ class WebViewModel {
                   '  -> CANCEL (opening nested webview)',
                   sensitivity: LogSensitivity.sensitive,
                 );
-                launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: effectiveIncognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, localCdnEnabled: localCdnEnabled, trackingProtectionEnabled: trackingProtectionEnabled, letterboxEnabled: letterboxEnabled, spoofWindowWidth: spoofWindowWidth, spoofWindowHeight: spoofWindowHeight, fingerprintResetNonce: fingerprintResetNonce, language: this.language, zoomPercent: zoomPercent, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, liveLocationGranularity: liveLocationGranularity, webRtcPolicy: webRtcPolicy, userAgent: effectiveUserAgentOrNull, javascriptEnabled: javascriptEnabled, userScripts: combineUserScripts(globalUserScripts), proxySettings: proxySettings, notificationsEnabled: notificationsEnabled, externalLinksInBrowser: effectiveExternalLinksInBrowser);
+                launchUrlFunc(url, homeTitle: name, siteId: siteId, incognito: effectiveIncognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, localCdnEnabled: localCdnEnabled, contributesBlockStats: contributesBlockStats, trackingProtectionEnabled: trackingProtectionEnabled, letterboxEnabled: letterboxEnabled, spoofWindowWidth: spoofWindowWidth, spoofWindowHeight: spoofWindowHeight, fingerprintResetNonce: fingerprintResetNonce, language: this.language, zoomPercent: zoomPercent, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, liveLocationGranularity: liveLocationGranularity, webRtcPolicy: webRtcPolicy, userAgent: effectiveUserAgentOrNull, javascriptEnabled: javascriptEnabled, userScripts: combineUserScripts(globalUserScripts), proxySettings: proxySettings, notificationsEnabled: notificationsEnabled, externalLinksInBrowser: effectiveExternalLinksInBrowser);
                 return false;
               case NavigationDecision.blockOpenExternal:
                 LogService.instance.log(
@@ -1323,7 +1332,7 @@ class WebViewModel {
                     sensitivity: LogSensitivity.sensitive,
                   );
                   if (handled.launchNestedUrl != null) {
-                    launchUrlFunc(handled.launchNestedUrl!, homeTitle: name, siteId: siteId, incognito: effectiveIncognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, localCdnEnabled: localCdnEnabled, trackingProtectionEnabled: trackingProtectionEnabled, letterboxEnabled: letterboxEnabled, spoofWindowWidth: spoofWindowWidth, spoofWindowHeight: spoofWindowHeight, fingerprintResetNonce: fingerprintResetNonce, language: this.language, zoomPercent: zoomPercent, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, liveLocationGranularity: liveLocationGranularity, webRtcPolicy: webRtcPolicy, userAgent: effectiveUserAgentOrNull, javascriptEnabled: javascriptEnabled, userScripts: combineUserScripts(globalUserScripts), proxySettings: proxySettings, notificationsEnabled: notificationsEnabled, externalLinksInBrowser: effectiveExternalLinksInBrowser);
+                    launchUrlFunc(handled.launchNestedUrl!, homeTitle: name, siteId: siteId, incognito: effectiveIncognito, thirdPartyCookiesEnabled: thirdPartyCookiesEnabled, clearUrlEnabled: clearUrlEnabled, dnsBlockEnabled: dnsBlockEnabled, contentBlockEnabled: contentBlockEnabled, localCdnEnabled: localCdnEnabled, contributesBlockStats: contributesBlockStats, trackingProtectionEnabled: trackingProtectionEnabled, letterboxEnabled: letterboxEnabled, spoofWindowWidth: spoofWindowWidth, spoofWindowHeight: spoofWindowHeight, fingerprintResetNonce: fingerprintResetNonce, language: this.language, zoomPercent: zoomPercent, locationMode: locationMode, spoofLatitude: spoofLatitude, spoofLongitude: spoofLongitude, spoofAccuracy: spoofAccuracy, spoofTimezone: spoofTimezone, spoofTimezoneFromLocation: spoofTimezoneFromLocation, liveLocationGranularity: liveLocationGranularity, webRtcPolicy: webRtcPolicy, userAgent: effectiveUserAgentOrNull, javascriptEnabled: javascriptEnabled, userScripts: combineUserScripts(globalUserScripts), proxySettings: proxySettings, notificationsEnabled: notificationsEnabled, externalLinksInBrowser: effectiveExternalLinksInBrowser);
                   }
                   return;
                 case NavigationDecision.blockOpenExternal:
@@ -1531,7 +1540,7 @@ class WebViewModel {
   }
 
   WebViewController? getController(
-    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required bool localCdnEnabled, required bool trackingProtectionEnabled, bool letterboxEnabled, int? spoofWindowWidth, int? spoofWindowHeight, String? fingerprintResetNonce, required String? language, required int zoomPercent, LocationMode locationMode, double? spoofLatitude, double? spoofLongitude, double spoofAccuracy, String? spoofTimezone, bool spoofTimezoneFromLocation, LocationGranularity liveLocationGranularity, WebRtcPolicy webRtcPolicy, String? userAgent, bool javascriptEnabled, required List<UserScriptConfig> userScripts, UserProxySettings? proxySettings, bool notificationsEnabled, bool externalLinksInBrowser}) launchUrlFunc,
+    Function(String url, {String? homeTitle, required String? siteId, required bool incognito, required bool thirdPartyCookiesEnabled, required bool clearUrlEnabled, required bool dnsBlockEnabled, required bool contentBlockEnabled, required bool localCdnEnabled, required bool contributesBlockStats, required bool trackingProtectionEnabled, bool letterboxEnabled, int? spoofWindowWidth, int? spoofWindowHeight, String? fingerprintResetNonce, required String? language, required int zoomPercent, LocationMode locationMode, double? spoofLatitude, double? spoofLongitude, double spoofAccuracy, String? spoofTimezone, bool spoofTimezoneFromLocation, LocationGranularity liveLocationGranularity, WebRtcPolicy webRtcPolicy, String? userAgent, bool javascriptEnabled, required List<UserScriptConfig> userScripts, UserProxySettings? proxySettings, bool notificationsEnabled, bool externalLinksInBrowser}) launchUrlFunc,
     CookieManager cookieManager,
     ContainerCookieManager? containerCookieManager,
     Function saveFunc, {

--- a/openspec/specs/block-statistics/spec.md
+++ b/openspec/specs/block-statistics/spec.md
@@ -1,0 +1,201 @@
+# Protection Report (Block Statistics)
+
+## Status
+**Implemented**
+
+## Purpose
+
+Give the user a persistent, app-wide account of what the blockers actually stopped —
+"N trackers blocked this week", a per-category breakdown, and an all-time total since
+counting started. Mainstream privacy browsers surface this; without it the app's
+blocking work is invisible and users cannot tell whether their posture is doing
+anything.
+
+## Problem Statement
+
+Block accounting before this feature was session-scoped and per-site: `DnsStats`
+(in `DnsBlockService`) counts allowed/blocked per `siteId` in memory and dies with
+the process, the `StatsBanner` shows the current site's live count, and DevTools
+shows engine counters. Nothing survived a restart, nothing aggregated across sites,
+and nothing answered "how much did this app block for me this month".
+
+## Solution
+
+A pure aggregation engine (`BlockStatsEngine`, `lib/services/block_stats_engine.dart`)
+holds per-category daily buckets, an all-time per-category total, and the timestamp
+counting started. `BlockStatsService` (`lib/services/block_stats_service.dart`) owns
+persistence (one JSON blob in SharedPreferences), debounced writes, archive gating,
+and change notification. `BlockStatsScreen` (`lib/screens/block_stats.dart`) renders
+the report, reachable from App Settings.
+
+Categories are limited to what the app can actually attribute at block time. The ABP
+engine returns a boolean, not the matched list, so there is no per-filter-list or
+per-tracker-taxonomy split; the four categories are the four distinct mechanisms:
+
+| Category | Source of the count |
+|---|---|
+| `filterList` | ABP filter-list match (`BlockSource.abp`) |
+| `dnsBlocklist` | DNS blocklist match (`BlockSource.dns`) |
+| `trackingParam` | ClearURLs stripped at least one parameter from a URL |
+| `localCdn` | A CDN resource was served from the LocalCDN cache instead of the CDN |
+
+---
+
+## Requirements
+
+### Requirement: STATS-001 - Time-Bucketed Category Counters
+
+The system SHALL accumulate block events into per-category buckets keyed by the
+**local** calendar day, so ranges match the user's own days rather than UTC.
+
+#### Scenario: Events land in the day they happened
+
+**Given** a block is recorded at 23:59 local time on day D
+**And** another block is recorded at 00:01 local time on day D+1
+**When** the report asks for the last 1 day on D+1
+**Then** only the second block is counted
+**And** asking for the last 2 days counts both
+
+#### Scenario: Range windows cross month and year boundaries
+
+**Given** blocks recorded on 30 December and 2 January
+**When** the report asks for the last 7 days on 3 January
+**Then** both are counted
+
+#### Scenario: A quiet day is distinguishable from no day
+
+**Given** a day in the window with zero recorded blocks
+**When** the daily chart is rendered
+**Then** that day draws no bar at all
+**And** a day with any non-zero count draws a visible bar
+
+### Requirement: STATS-002 - Persistence Across Restarts
+
+Counters SHALL survive process death. Writes SHALL be debounced so a page load
+recording hundreds of blocks does not cause hundreds of SharedPreferences writes,
+and SHALL be flushed when the app is backgrounded.
+
+#### Scenario: Counters survive a restart
+
+**Given** blocks were recorded and the app was backgrounded
+**When** the app is launched again
+**Then** the report shows the same all-time total and the same day buckets
+
+#### Scenario: Burst of block events costs one write
+
+**Given** a page load records many blocks within the debounce window
+**When** the events are recorded
+**Then** at most one SharedPreferences write is issued for the batch
+
+#### Scenario: Corrupt stored payload
+
+**Given** the persisted blob is not valid JSON, or carries unknown categories,
+negative counts, or malformed day keys
+**When** the service initializes
+**Then** it starts from the recoverable subset (empty in the unparseable case)
+**And** does not throw on the startup path
+
+### Requirement: STATS-003 - Report Surface
+
+The user SHALL be able to open a report from App Settings showing, for a selectable
+7- or 30-day range: the range total, a per-day bar chart, and each category's count
+with its share of the range; plus the all-time total and the date counting started.
+
+#### Scenario: Nothing blocked yet
+
+**Given** the all-time total is zero
+**When** the user opens the report
+**Then** an empty state explains that per-site tracking protection has to be on
+**And** the reset action is disabled
+
+#### Scenario: Reset
+
+**Given** the user confirms "Reset statistics"
+**When** the reset completes
+**Then** every counter is zero
+**And** the "since" date is today
+**And** the zeroed state is persisted immediately
+
+### Requirement: STATS-004 - Bounded Retention
+
+Daily buckets SHALL be pruned beyond a fixed retention window (90 days) so the
+persisted blob cannot grow without bound. All-time totals SHALL survive pruning.
+
+#### Scenario: Old buckets are dropped, all-time survives
+
+**Given** a bucket older than the retention window and a bucket from today
+**When** the service initializes and prunes
+**Then** only the recent bucket remains in the day buckets
+**And** the all-time total still includes the pruned bucket's events
+
+### Requirement: STATS-005 - Archive Neutrality
+
+Archive-tier sites SHALL NOT contribute to the report. The report's counters live in
+plaintext SharedPreferences; a counter that only advances while an archive is open
+would leak that the archive was used, violating ARCH-001 active-state byte-identity
+and the ARCH-006 per-site feature audit.
+
+A site contributes only after its scope has been declared, keyed by `siteId`, at
+webview construction (`WebViewConfig.contributesBlockStats`, sourced from
+`WebViewModel.contributesBlockStats`). An undeclared `siteId` is ignored, so a path
+that forgets to declare fails closed (undercount) rather than open (leak).
+
+#### Scenario: Archive-tier site leaves no trace
+
+**Given** a site whose scope was declared non-contributing
+**When** its requests are blocked and the service flushes
+**Then** the persisted key is unchanged
+**And** the all-time total is unchanged
+
+#### Scenario: Undeclared site is ignored
+
+**Given** a block recorded for a `siteId` whose scope was never declared
+**When** the record is attempted
+**Then** no counter moves
+
+#### Scenario: Moving a site into the archive stops its contributions
+
+**Given** a contributing site is moved into the archive
+**When** its scope is re-declared as non-contributing and blocks are recorded
+**Then** the counters keep the pre-move total and take no new events
+
+### Requirement: STATS-006 - Excluded from Settings Backup
+
+The report SHALL NOT be registered in `kExportedAppPrefs`. Backup files are emailed
+and synced; block volume over time is browsing-activity history, not a user setting,
+and restoring one device's activity onto another would be wrong regardless.
+
+#### Scenario: Export omits the counters
+
+**Given** counters with a non-zero all-time total
+**When** the user exports settings
+**Then** the export contains no block-statistics payload
+
+### Requirement: STATS-007 - Nested Webviews Inherit the Scope
+
+A cross-domain navigation opening a nested `InAppWebViewScreen` SHALL carry the
+parent site's contribution scope, so an outbound link from an archive-tier site
+cannot start feeding the app-wide report.
+
+#### Scenario: Nested webview of an archive site
+
+**Given** an archive-tier site opens a cross-domain link in a nested webview
+**When** that webview blocks requests
+**Then** no app-wide counter moves
+
+---
+
+## Implementation Notes
+
+- **Single funnel.** DNS/ABP block accounting on every platform already passes through
+  `DnsBlockService.recordHostRequest` (the Android native interceptor drains into it,
+  the iOS/macOS JS bridge calls it per URL, navigation checks call it). The report
+  hooks that one place, so the aggregate cannot drift from the per-site counters.
+- **No siteId is persisted.** Only per-category daily totals reach disk, so the blob
+  cannot be mined for which sites the user visits.
+- **Per-site live counters are unchanged.** `DnsStats` and the `StatsBanner` stay
+  in-memory and session-scoped; this feature is additive.
+- Files: `lib/services/block_stats_engine.dart`, `lib/services/block_stats_service.dart`,
+  `lib/screens/block_stats.dart`. Tests: `test/block_stats_engine_test.dart`,
+  `test/block_stats_service_test.dart`. Structural gate for STATS-007:
+  `test/js/nested_webview_posture_parity.test.js` (`contributesBlockStats` is POSTURE).

--- a/test/block_stats_engine_test.dart
+++ b/test/block_stats_engine_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/block_stats_engine.dart';
+
+void main() {
+  group('day bucketing (STATS-001)', () {
+    test('records land in the local calendar day they happened on', () {
+      final engine = BlockStatsEngine(since: DateTime(2026, 8, 1));
+      engine.record(BlockCategory.filterList,
+          count: 3, now: DateTime(2026, 8, 19, 23, 59));
+      engine.record(BlockCategory.filterList,
+          count: 2, now: DateTime(2026, 8, 20, 0, 1));
+
+      expect(engine.totalForLastDays(1, now: DateTime(2026, 8, 20, 12)), 2);
+      expect(engine.totalForLastDays(2, now: DateTime(2026, 8, 20, 12)), 5);
+    });
+
+    test('a day with no events contributes nothing', () {
+      final engine = BlockStatsEngine();
+      engine.record(BlockCategory.dnsBlocklist, now: DateTime(2026, 8, 10));
+      expect(engine.totalForLastDays(7, now: DateTime(2026, 8, 20)), 0);
+      expect(engine.totalForLastDays(30, now: DateTime(2026, 8, 20)), 1);
+    });
+
+    test('window arithmetic crosses month and year boundaries', () {
+      final engine = BlockStatsEngine();
+      engine.record(BlockCategory.filterList, now: DateTime(2025, 12, 30));
+      engine.record(BlockCategory.filterList, now: DateTime(2026, 1, 2));
+      expect(engine.totalForLastDays(7, now: DateTime(2026, 1, 3)), 2);
+    });
+
+    test('count below 1 is ignored', () {
+      final engine = BlockStatsEngine();
+      engine.record(BlockCategory.filterList, count: 0);
+      engine.record(BlockCategory.filterList, count: -5);
+      expect(engine.allTimeTotal, 0);
+    });
+  });
+
+  group('category totals', () {
+    test('totals split by category and sum to the range total', () {
+      final now = DateTime(2026, 8, 19, 10);
+      final engine = BlockStatsEngine();
+      engine.record(BlockCategory.filterList, count: 10, now: now);
+      engine.record(BlockCategory.dnsBlocklist, count: 4, now: now);
+      engine.record(BlockCategory.trackingParam, count: 1, now: now);
+      engine.record(BlockCategory.localCdn, count: 2, now: now);
+
+      final totals = engine.totalsForLastDays(7, now: now);
+      expect(totals[BlockCategory.filterList], 10);
+      expect(totals[BlockCategory.dnsBlocklist], 4);
+      expect(totals[BlockCategory.trackingParam], 1);
+      expect(totals[BlockCategory.localCdn], 2);
+      expect(engine.totalForLastDays(7, now: now), 17);
+    });
+
+    test('dailyTotals is oldest-first and aligned to the window', () {
+      final now = DateTime(2026, 8, 19);
+      final engine = BlockStatsEngine();
+      engine.record(BlockCategory.filterList, count: 5, now: now);
+      engine.record(BlockCategory.dnsBlocklist,
+          count: 2, now: DateTime(2026, 8, 17));
+
+      expect(engine.dailyTotals(7, now: now), [0, 0, 0, 0, 2, 0, 5]);
+    });
+  });
+
+  group('retention (STATS-004)', () {
+    test('prune drops buckets past the retention window, keeps all-time', () {
+      final now = DateTime(2026, 8, 19);
+      final engine = BlockStatsEngine();
+      engine.record(BlockCategory.filterList,
+          count: 7, now: DateTime(2026, 1, 1));
+      engine.record(BlockCategory.filterList, count: 3, now: now);
+
+      expect(engine.prune(now: now), 1);
+      expect(engine.totalForLastDays(BlockStatsEngine.retentionDays, now: now), 3);
+      expect(engine.allTimeTotal, 10);
+    });
+
+    test('prune keeps a bucket exactly on the cutoff', () {
+      final now = DateTime(2026, 8, 19);
+      final edge = DateTime(2026, 8, 19 - BlockStatsEngine.retentionDays);
+      final engine = BlockStatsEngine();
+      engine.record(BlockCategory.filterList, now: edge);
+      expect(engine.prune(now: now), 0);
+      expect(engine.allTimeTotal, 1);
+    });
+  });
+
+  group('reset', () {
+    test('clears every counter and restarts the since clock', () {
+      final engine = BlockStatsEngine(since: DateTime(2026, 1, 1));
+      engine.record(BlockCategory.filterList, count: 5);
+      engine.reset(now: DateTime(2026, 8, 19));
+
+      expect(engine.allTimeTotal, 0);
+      expect(engine.totalForLastDays(30, now: DateTime(2026, 8, 19)), 0);
+      expect(engine.since, DateTime(2026, 8, 19));
+    });
+  });
+
+  group('persistence round-trip (STATS-002)', () {
+    test('toJson/fromJson preserves buckets, all-time totals and since', () {
+      final now = DateTime(2026, 8, 19, 8);
+      final engine = BlockStatsEngine(since: DateTime(2026, 6, 22));
+      engine.record(BlockCategory.filterList, count: 9, now: now);
+      engine.record(BlockCategory.trackingParam,
+          count: 4, now: DateTime(2026, 8, 15));
+
+      final restored = BlockStatsEngine.fromJson(engine.toJson());
+
+      expect(restored.since, DateTime(2026, 6, 22));
+      expect(restored.allTimeTotal, 13);
+      expect(restored.totalsForLastDays(7, now: now)[BlockCategory.filterList], 9);
+      expect(
+        restored.totalsForLastDays(7, now: now)[BlockCategory.trackingParam],
+        4,
+      );
+    });
+
+    test('a restored engine is clean until it is mutated again', () {
+      final engine = BlockStatsEngine();
+      engine.record(BlockCategory.filterList);
+      expect(engine.isDirty, isTrue);
+      engine.markClean();
+      expect(engine.isDirty, isFalse);
+      engine.record(BlockCategory.filterList);
+      expect(engine.isDirty, isTrue);
+    });
+
+    test('corrupt payloads degrade instead of throwing', () {
+      final restored = BlockStatsEngine.fromJson(<String, dynamic>{
+        'since': 'not-a-date',
+        'allTime': {'abp': 5, 'unknown-category': 3, 'dns': 'nope'},
+        'days': {
+          'not-a-day': {'abp': 1},
+          '20260819': 'not-a-bucket',
+          '20260818': {'abp': -4},
+        },
+      });
+
+      expect(restored.allTimeTotals[BlockCategory.filterList], 5);
+      expect(restored.allTimeTotals[BlockCategory.dnsBlocklist], isNull);
+      expect(restored.totalForLastDays(30, now: DateTime(2026, 8, 19)), 0);
+    });
+  });
+}

--- a/test/block_stats_service_test.dart
+++ b/test/block_stats_service_test.dart
@@ -1,0 +1,143 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webspace/services/block_stats_engine.dart';
+import 'package:webspace/services/block_stats_service.dart';
+import 'package:webspace/services/settings_backup.dart';
+import 'package:webspace/settings/app_prefs.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    BlockStatsService.resetInstanceForTest();
+  });
+
+  group('site scope gating (ARCH-006)', () {
+    test('a site that never declared its scope contributes nothing', () async {
+      final service = BlockStatsService.instance;
+      await service.initialize();
+
+      service.record('undeclared-site', BlockCategory.filterList, count: 5);
+
+      expect(service.engine.allTimeTotal, 0);
+    });
+
+    test('an app-tier site contributes once declared', () async {
+      final service = BlockStatsService.instance;
+      await service.initialize();
+      service.setSiteContributes('app-site', true);
+
+      service.record('app-site', BlockCategory.filterList, count: 5);
+
+      expect(service.engine.allTimeTotal, 5);
+    });
+
+    test('an archive-tier site is ignored and leaves no persisted trace',
+        () async {
+      final service = BlockStatsService.instance;
+      await service.initialize();
+      service.setSiteContributes('archive-site', false);
+
+      service.record('archive-site', BlockCategory.filterList, count: 12);
+      service.record('archive-site', BlockCategory.dnsBlocklist, count: 3);
+      await service.flush();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(service.engine.allTimeTotal, 0);
+      expect(prefs.getString(BlockStatsService.prefsKey), isNull);
+    });
+
+    test('moving a site into the archive stops its contributions', () async {
+      final service = BlockStatsService.instance;
+      await service.initialize();
+      service.setSiteContributes('moving-site', true);
+      service.record('moving-site', BlockCategory.filterList, count: 2);
+
+      service.setSiteContributes('moving-site', false);
+      service.record('moving-site', BlockCategory.filterList, count: 40);
+
+      expect(service.engine.allTimeTotal, 2);
+      expect(service.siteContributes('moving-site'), isFalse);
+    });
+  });
+
+  group('persistence (STATS-002)', () {
+    test('counters survive a restart', () async {
+      final first = BlockStatsService.instance;
+      await first.initialize();
+      first.setSiteContributes('site', true);
+      first.record('site', BlockCategory.filterList, count: 8);
+      first.record('site', BlockCategory.trackingParam, count: 2);
+      await first.flush();
+
+      BlockStatsService.resetInstanceForTest();
+      final second = BlockStatsService.instance;
+      await second.initialize();
+
+      expect(second.engine.allTimeTotal, 10);
+      expect(second.engine.allTimeTotals[BlockCategory.trackingParam], 2);
+    });
+
+    test('a corrupt stored blob starts from empty instead of crashing',
+        () async {
+      SharedPreferences.setMockInitialValues({
+        BlockStatsService.prefsKey: 'not json at all',
+      });
+
+      final service = BlockStatsService.instance;
+      await service.initialize();
+
+      expect(service.engine.allTimeTotal, 0);
+    });
+
+    test('reset zeroes the persisted payload', () async {
+      final service = BlockStatsService.instance;
+      await service.initialize();
+      service.setSiteContributes('site', true);
+      service.record('site', BlockCategory.filterList, count: 4);
+      await service.flush();
+
+      await service.reset();
+
+      final prefs = await SharedPreferences.getInstance();
+      final stored = jsonDecode(prefs.getString(BlockStatsService.prefsKey)!);
+      expect(stored['allTime'], isEmpty);
+      expect(stored['days'], isEmpty);
+    });
+
+    test('the counters never reach a settings export (STATS-006)', () async {
+      final service = BlockStatsService.instance;
+      await service.initialize();
+      service.setSiteContributes('site', true);
+      service.record('site', BlockCategory.filterList, count: 4242);
+      await service.flush();
+
+      final prefs = await SharedPreferences.getInstance();
+      final backup = SettingsBackupService.createBackup(
+        webViewModels: const [],
+        webspaces: const [],
+        themeMode: 0,
+        globalPrefs: readExportedAppPrefs(prefs),
+      );
+      final exported = SettingsBackupService.exportToJson(backup);
+
+      expect(kExportedAppPrefs.containsKey(BlockStatsService.prefsKey), isFalse);
+      expect(exported, isNot(contains(BlockStatsService.prefsKey)));
+      expect(exported, isNot(contains('4242')));
+    });
+
+    test('initialize is idempotent and does not discard live counts', () async {
+      final service = BlockStatsService.instance;
+      await service.initialize();
+      service.setSiteContributes('site', true);
+      service.record('site', BlockCategory.dnsBlocklist, count: 3);
+
+      await service.initialize();
+
+      expect(service.engine.allTimeTotal, 3);
+    });
+  });
+}

--- a/test/js/l10n_no_hardcoded_text.test.js
+++ b/test/js/l10n_no_hardcoded_text.test.js
@@ -18,6 +18,7 @@ const migrated = new Set([
   'lib/main.dart',
   'lib/screens/add_site.dart',
   'lib/screens/app_settings.dart',
+  'lib/screens/block_stats.dart',
   'lib/screens/dev_tools.dart',
   'lib/screens/inappbrowser.dart',
   'lib/screens/link_handling_settings.dart',

--- a/test/js/nested_webview_posture_parity.test.js
+++ b/test/js/nested_webview_posture_parity.test.js
@@ -138,7 +138,7 @@ const POSTURE = new Set([
   'localCdnEnabled', 'userScripts', 'locationMode', 'spoofLatitude',
   'spoofLongitude', 'spoofAccuracy', 'spoofTimezone', 'spoofTimezoneFromLocation',
   'liveLocationGranularity', 'webRtcPolicy', 'proxySettings',
-  'notificationsEnabled',
+  'notificationsEnabled', 'contributesBlockStats',
 ]);
 
 const PLUMBING = new Set([


### PR DESCRIPTION
Implements STATS-001 … STATS-007 (`openspec/specs/block-statistics/spec.md`): a persistent, app-wide protection report showing what the blockers stopped over the last 7/30 days and all-time, split by blocking mechanism.

**BlockStatsEngine** (`lib/services/block_stats_engine.dart`) — pure aggregation engine holding per-category daily buckets keyed by local calendar day, all-time totals per category, and the timestamp counting started. No Flutter, no I/O. 90-day retention on the daily buckets; all-time totals survive pruning.

**BlockStatsService** (`lib/services/block_stats_service.dart`) — owns persistence (one JSON blob in SharedPreferences, no `siteId` ever written), debounced writes (10s window to coalesce burst block events, plus a flush on app pause), archive-tier gating, and change notification. Concurrent initialization is safe; later calls await the same load.

**BlockStatsScreen** (`lib/screens/block_stats.dart`) — hero number, 7/30-day range toggle, daily bar chart, per-category breakdown with each category's share, and the all-time total since counting started. Reachable from App Settings. Reset clears all counters behind a confirmation.

**Four block categories** — limited to what the app can attribute at block time. adblock-rust returns a boolean, not the matched rule or list, so there is deliberately no per-filter-list or Firefox-style tracker-taxonomy split:

- `filterList`: ABP filter-list match (`BlockSource.abp`)
- `dnsBlocklist`: DNS blocklist match (`BlockSource.dns`)
- `trackingParam`: ClearURLs stripped at least one parameter
- `localCdn`: a CDN resource was served from the LocalCDN cache

**Integration points:**

- `DnsBlockService.recordHostRequest` is the single funnel for DNS/ABP block accounting on every platform (Android native interceptor drain, iOS/macOS JS bridge, navigation checks), so the aggregate cannot drift from the per-site counters. It forwards blocked events to `BlockStatsService.record`.
- The two ClearURLs paths in `webview.dart` (navigation strip, `clearUrl` JS handler) and `LocalCdnService.recordReplacement` feed the other two categories.
- `WebViewFactory.createWebView` calls `BlockStatsService.setSiteContributes(siteId, config.contributesBlockStats)` before any block event can be recorded for that site.
- `WebViewModel.contributesBlockStats` (`!isArchiveTier`) sources that flag; it is threaded through `launchUrl` and the nested `InAppWebViewScreen` so an outbound link from an archive site cannot start feeding the report (STATS-007, enforced structurally by `test/js/nested_webview_posture_parity.test.js`).
- `main.dart` initializes the service in the parallel startup group and flushes it on `AppLifecycleState.paused`.

**Archive neutrality (ARCH-001 / ARCH-006)** — archive-tier sites never contribute: the counters live in plaintext SharedPreferences, and one that only advances while an archive is open would leak that the archive was used. An undeclared `siteId` is ignored, so a path that forgets to declare fails closed (undercount) rather than open (leak).

**Not in settings backup (STATS-006)** — block volume over time is browsing-activity history, not a user setting, so the key is deliberately absent from `kExportedAppPrefs`, with a regression test asserting it never appears in an export.

**Localization** — 15 new keys in `app_en.arb`, translated into all 67 locale ARBs.

**Tests** — `test/block_stats_engine_test.dart` and `test/block_stats_service_test.dart` cover day bucketing, range windows crossing month/year boundaries, retention pruning, reset, corrupt-payload tolerance, persistence across restart, archive-tier gating, and backup exclusion.

https://claude.ai/code/session_01RnRPqhcsJV9pk2ixmoMqVG