### PR TITLE
Cover block-stats accounting end to end; add report shield

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,7 @@ import 'package:webspace/services/webview.dart';
 import 'package:webspace/screens/add_site.dart' show AddSiteScreen, UnifiedFaviconImage, FaviconUrlCache, SiteSuggestion;
 import 'package:webspace/screens/settings.dart';
 import 'package:webspace/screens/app_settings.dart';
+import 'package:webspace/screens/block_stats.dart';
 import 'package:webspace/services/icon_service.dart';
 import 'package:webspace/services/icon_png_export.dart';
 import 'package:webspace/services/custom_icon.dart';
@@ -6254,6 +6255,11 @@ class _WebSpacePageState extends State<WebSpacePage>
             }
           },
         ),
+        // Protection report shield, badged with the week's block count.
+        // Same visibility rule as the settings gear: the webspaces list is
+        // the app's "home", which is where a protection summary belongs.
+        if (_currentIndex == null || _currentIndex! >= _webViewModels.length)
+          _buildProtectionShield(context, loc),
         // Settings icon button (only visible on webspaces list screen)
         if (_currentIndex == null || _currentIndex! >= _webViewModels.length)
           IconButton(
@@ -7842,6 +7848,30 @@ class _WebSpacePageState extends State<WebSpacePage>
             child: Text(loc.commonCancel),
           ),
         ],
+      ),
+    );
+  }
+
+  /// Shield + week's block count in the app bar of the webspaces list,
+  /// opening the protection report. Reads the counters at build time rather
+  /// than subscribing: this bar only renders on the list screen, where no
+  /// page is loading, and returning from a site rebuilds it anyway.
+  Widget _buildProtectionShield(BuildContext context, AppLocalizations loc) {
+    final weekTotal = BlockStatsService.instance.engine.totalForLastDays(7);
+    return Badge.count(
+      count: weekTotal,
+      isLabelVisible: weekTotal > 0,
+      child: IconButton(
+        icon: const Icon(Icons.shield_outlined),
+        tooltip: loc.blockStatsTitle,
+        onPressed: () async {
+          await Navigator.push(
+            context,
+            MaterialPageRoute(builder: (context) => const BlockStatsScreen()),
+          );
+          if (!mounted) return;
+          setState(() {});
+        },
       ),
     );
   }

--- a/lib/services/web_intercept_native.dart
+++ b/lib/services/web_intercept_native.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/dns_block_service.dart';
@@ -57,36 +58,47 @@ class WebInterceptNative {
       final list =
           await _channel.invokeMethod('fetchBlockEvents', {'siteId': siteId});
       if (list is! List) return;
-      for (final entry in list) {
-        if (entry is Map) {
-          final host = entry['host'] as String?;
-          final blocked = entry['blocked'] as bool?;
-          if (host == null || blocked == null) continue;
-          final sourceStr = entry['source'] as String?;
-          final source = switch (sourceStr) {
-            'dns' => BlockSource.dns,
-            'abp' => BlockSource.abp,
-            _ => null,
-          };
-          // Native dedupes by host across the drain window. `count` is
-          // the number of repeat requests since the last drain; default
-          // 1 if absent (older codec / no dedup). Pass it straight to
-          // the host-level recorder so the per-site Total/Allowed/
-          // Blocked counts stay accurate while the log keeps a single
-          // entry per host.
-          final count = (entry['count'] as int?) ?? 1;
-          DnsBlockService.instance
-              .recordHostRequest(siteId, host, blocked, source: source, count: count);
-          // Engine blocks decided natively never pass through
-          // ContentBlockerService.isBlocked, so fold them into the
-          // DevTools ABP counters here or the ABP tab undercounts.
-          if (blocked && source == BlockSource.abp) {
-            ContentBlockerService.instance
-                .recordNativeEngineBlock(host, count: count);
-          }
+      applyBlockEvents(siteId, list);
+    } catch (_) {}
+  }
+
+  /// Decode one drained batch and apply it to the stats funnels.
+  ///
+  /// Split out of [_drainBlockEvents] so the payload contract with
+  /// `WebInterceptPlugin.drainBlockEvents` (`{host, blocked, source, count}`,
+  /// with `source` absent for allowed requests) is testable without an
+  /// Android device: the fetch is platform-gated, the accounting is not.
+  @visibleForTesting
+  static void applyBlockEvents(String siteId, List<dynamic> list) {
+    for (final entry in list) {
+      if (entry is Map) {
+        final host = entry['host'] as String?;
+        final blocked = entry['blocked'] as bool?;
+        if (host == null || blocked == null) continue;
+        final sourceStr = entry['source'] as String?;
+        final source = switch (sourceStr) {
+          'dns' => BlockSource.dns,
+          'abp' => BlockSource.abp,
+          _ => null,
+        };
+        // Native dedupes by host across the drain window. `count` is
+        // the number of repeat requests since the last drain; default
+        // 1 if absent (older codec / no dedup). Pass it straight to
+        // the host-level recorder so the per-site Total/Allowed/
+        // Blocked counts stay accurate while the log keeps a single
+        // entry per host.
+        final count = (entry['count'] as int?) ?? 1;
+        DnsBlockService.instance
+            .recordHostRequest(siteId, host, blocked, source: source, count: count);
+        // Engine blocks decided natively never pass through
+        // ContentBlockerService.isBlocked, so fold them into the
+        // DevTools ABP counters here or the ABP tab undercounts.
+        if (blocked && source == BlockSource.abp) {
+          ContentBlockerService.instance
+              .recordNativeEngineBlock(host, count: count);
         }
       }
-    } catch (_) {}
+    }
   }
 
   static Future<void> _drainCdnEvents(String? siteId) async {

--- a/test/block_stats_integration_test.dart
+++ b/test/block_stats_integration_test.dart
@@ -1,0 +1,133 @@
+// End-to-end accounting: a block decision made anywhere in the app must
+// arrive at the protection report. The unit tests cover the engine and the
+// service in isolation; this covers the seam between them and the real
+// recording funnels, which is where a silent zero hides.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webspace/services/block_stats_engine.dart';
+import 'package:webspace/services/block_stats_service.dart';
+import 'package:webspace/services/dns_block_service.dart';
+import 'package:webspace/services/localcdn_service.dart';
+import 'package:webspace/services/web_intercept_native.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late BlockStatsService stats;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    BlockStatsService.resetInstanceForTest();
+    stats = BlockStatsService.instance;
+    await stats.initialize();
+    stats.setSiteContributes('site-1', true);
+    DnsBlockService.instance.clearStatsForSite('site-1');
+  });
+
+  group('DnsBlockService funnel feeds the report', () {
+    test('a DNS-attributed block increments the DNS category', () {
+      DnsBlockService.instance.recordHostRequest(
+          'site-1', 'tracker.example', true,
+          source: BlockSource.dns, count: 3);
+
+      expect(stats.engine.allTimeTotals[BlockCategory.dnsBlocklist], 3);
+      expect(stats.engine.allTimeTotal, 3);
+    });
+
+    test('an ABP-attributed block increments the filter-list category', () {
+      DnsBlockService.instance.recordHostRequest('site-1', 'ads.example', true,
+          source: BlockSource.abp, count: 5);
+
+      expect(stats.engine.allTimeTotals[BlockCategory.filterList], 5);
+    });
+
+    test('the URL-shaped funnel lands the same way', () {
+      DnsBlockService.instance.recordRequest(
+          'site-1', 'https://ads.example/pixel.gif', true,
+          source: BlockSource.abp);
+
+      expect(stats.engine.allTimeTotals[BlockCategory.filterList], 1);
+    });
+
+    test('allowed requests move no report counter', () {
+      DnsBlockService.instance
+          .recordHostRequest('site-1', 'cdn.example', false, count: 9);
+
+      expect(stats.engine.allTimeTotal, 0);
+    });
+
+    test('the report never disagrees with the per-site counters', () {
+      DnsBlockService.instance.recordHostRequest('site-1', 'a.example', true,
+          source: BlockSource.dns, count: 2);
+      DnsBlockService.instance.recordHostRequest('site-1', 'b.example', true,
+          source: BlockSource.abp, count: 7);
+      DnsBlockService.instance
+          .recordHostRequest('site-1', 'c.example', false, count: 4);
+
+      final perSite = DnsBlockService.instance.statsForSite('site-1');
+      expect(stats.engine.allTimeTotal, perSite.blocked);
+      expect(stats.engine.allTimeTotals[BlockCategory.dnsBlocklist],
+          perSite.blockedByDns);
+      expect(stats.engine.allTimeTotals[BlockCategory.filterList],
+          perSite.blockedByAbp);
+    });
+  });
+
+  group('Android native drain feeds the report', () {
+    /// Drive the decode step with the payload shape
+    /// `WebInterceptPlugin.drainBlockEvents` actually emits:
+    /// `{host, blocked, source, count}`, with `source` absent when allowed.
+    /// The fetch around it is `Platform.isAndroid`-gated, which is why the
+    /// accounting is exercised here rather than through the channel.
+    test('native block events reach the report with their attribution', () {
+      WebInterceptNative.applyBlockEvents('site-1', [
+        {'host': 'ads.example', 'blocked': true, 'source': 'abp', 'count': 12},
+        {'host': 'trk.example', 'blocked': true, 'source': 'dns', 'count': 4},
+        {'host': 'cdn.example', 'blocked': false, 'count': 30},
+      ]);
+
+      expect(stats.engine.allTimeTotals[BlockCategory.filterList], 12);
+      expect(stats.engine.allTimeTotals[BlockCategory.dnsBlocklist], 4);
+      expect(stats.engine.allTimeTotal, 16);
+    });
+
+    test('a source-less block is counted per-site but not categorised', () {
+      WebInterceptNative.applyBlockEvents('site-1', [
+        {'host': 'ads.example', 'blocked': true, 'count': 6},
+      ]);
+
+      expect(DnsBlockService.instance.statsForSite('site-1').blocked, 6);
+      expect(stats.engine.allTimeTotal, 0);
+    });
+
+    test('malformed entries are skipped without losing the good ones', () {
+      WebInterceptNative.applyBlockEvents('site-1', [
+        {'blocked': true, 'source': 'abp', 'count': 3},
+        {'host': 'ok.example', 'blocked': true, 'source': 'abp', 'count': 2},
+        'not-a-map',
+      ]);
+
+      expect(stats.engine.allTimeTotals[BlockCategory.filterList], 2);
+    });
+
+    test('an archive-tier site drains without moving the report', () {
+      stats.setSiteContributes('site-1', false);
+
+      WebInterceptNative.applyBlockEvents('site-1', [
+        {'host': 'ads.example', 'blocked': true, 'source': 'abp', 'count': 12},
+      ]);
+
+      expect(stats.engine.allTimeTotal, 0);
+      expect(DnsBlockService.instance.statsForSite('site-1').blocked, 12);
+    });
+  });
+
+  group('LocalCDN funnel feeds the report', () {
+    test('a cache substitution increments the CDN category', () {
+      LocalCdnService.instance.recordReplacement('site-1');
+      LocalCdnService.instance.recordReplacement('site-1');
+
+      expect(stats.engine.allTimeTotals[BlockCategory.localCdn], 2);
+    });
+  });
+}


### PR DESCRIPTION
Follow-up to #540. Two things: close the test gap that let a silent zero through, and add the protection-report entry point to the webspaces app bar.

## Why the tests missed it

`block_stats_engine_test.dart` and `block_stats_service_test.dart` exercise the engine and the service in isolation, and `nested_webview_posture_parity.test.js` gates the posture field structurally. Nothing covered the seam that actually matters: a real block event travelling from the recording funnel into the report. A block that never arrived would have passed CI.

The Android leg was not merely untested, it was **untestable**: the decode of the native drain payload was inlined inside `_drainBlockEvents`, whose fetch is `Platform.isAndroid`-gated, so under `flutter test` the channel handler is never even registered.

## Changes

**`WebInterceptNative.applyBlockEvents`** — the decode step is split out of `_drainBlockEvents` and marked `@visibleForTesting`. The fetch stays platform-gated; the accounting no longer is. No behaviour change: `_drainBlockEvents` calls it with exactly what it used to loop over.

**`test/block_stats_integration_test.dart`** — asserts the whole chain:

- `recordHostRequest` / `recordRequest` with a `dns` or `abp` source lands in the matching report category, with `count` respected
- allowed requests move no report counter
- the report never disagrees with the per-site `DnsStats` counters (total, `blockedByDns`, `blockedByAbp`)
- the native payload contract `{host, blocked, source, count}` from `WebInterceptPlugin.drainBlockEvents`, including `source` absent for allowed requests
- a source-less block is counted per-site but stays uncategorised in the report
- malformed entries are skipped without dropping the good ones in the same batch
- an archive-tier drain moves per-site counters but not the report

**Protection shield** — `_buildProtectionShield` in the webspaces app bar, next to the settings gear and under the same visibility rule, badged with the last 7 days' count and opening the report. Reads at build time rather than subscribing: that bar only renders on the list screen, where no page is loading.

## Verification

`flutter test`: 2158 passed, 0 failed. `npm run test:js`: 417/417. `flutter analyze`: no new issues.

## Note

The new tests pass, so the accounting chain is correct as written — this does not by itself explain a report reading zero on a device where the blockers are configured. Diagnosis continues separately.

https://claude.ai/code/session_01RnRPqhcsJV9pk2ixmoMqVG

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnRPqhcsJV9pk2ixmoMqVG)_