### PR TITLE
Extract Firefox version tile to dedicated widget

### DIFF
--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -25,6 +25,7 @@ import 'package:webspace/settings/global_outbound_proxy.dart';
 import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/settings/user_script.dart';
 import 'package:webspace/screens/user_scripts.dart';
+import 'package:webspace/widgets/firefox_version_tile.dart';
 import 'package:webspace/widgets/hint_button.dart';
 
 // Accent color definitions for display
@@ -1065,11 +1066,13 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
             padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
             child: Row(
               children: [
-                Text(
-                  loc.appSettingsOutboundProxy,
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold,
-                      ),
+                Flexible(
+                  child: Text(
+                    loc.appSettingsOutboundProxy,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
                 ),
                 HintButton(
                   title: loc.appSettingsOutboundProxy,
@@ -1170,9 +1173,11 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
             padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
             child: Row(
               children: [
-                Text(
-                  loc.appSettingsLocationPicker,
-                  style: Theme.of(context).textTheme.labelLarge,
+                Flexible(
+                  child: Text(
+                    loc.appSettingsLocationPicker,
+                    style: Theme.of(context).textTheme.labelLarge,
+                  ),
                 ),
                 HintButton(
                   title: loc.appSettingsLocationPicker,
@@ -1207,7 +1212,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
             leading: const Icon(Icons.public),
             title: Row(
               children: [
-                Text(loc.appSettingsTimezonePolygons),
+                Flexible(child: Text(loc.appSettingsTimezonePolygons)),
                 HintButton(
                   title: loc.appSettingsTimezonePolygons,
                   description: loc.appSettingsTimezonePolygonsHint,
@@ -1374,7 +1379,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
               leading: const Icon(Icons.lock_outline),
               title: Row(
                 children: [
-                  Text(loc.appSettingsTrustedCertificates),
+                  Flexible(child: Text(loc.appSettingsTrustedCertificates)),
                   HintButton(
                     title: loc.appSettingsTrustedCertificates,
                     description: loc.appSettingsTrustedCertificatesHint,
@@ -1396,7 +1401,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
             leading: const Icon(Icons.cleaning_services),
             title: Row(
               children: [
-                Text(loc.appSettingsClearUrlsRules),
+                Flexible(child: Text(loc.appSettingsClearUrlsRules)),
                 HintButton(
                   title: loc.appSettingsClearUrlsRules,
                   description: loc.appSettingsClearUrlsHint,
@@ -1433,53 +1438,13 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
                   ),
           ),
 
-          ListTile(
-            leading: const Icon(Icons.travel_explore),
-            title: Row(
-              children: [
-                Text(loc.appSettingsFirefoxVersion),
-                HintButton(
-                  title: loc.appSettingsFirefoxVersion,
-                  description: loc.appSettingsFirefoxVersionHint,
-                ),
-              ],
-            ),
-            subtitle: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(loc.appSettingsFirefoxVersionCurrent(
-                    FirefoxUserAgentService.instance.majorVersion)),
-                if (FirefoxUserAgentService.instance.lastChecked != null)
-                  Text(
-                    loc.appSettingsFirefoxVersionChecked(
-                      FirefoxUserAgentService.instance.lastChecked!
-                          .toLocal()
-                          .toString()
-                          .split('.')[0],
-                    ),
-                    style: const TextStyle(fontSize: 12),
-                  ),
-              ],
-            ),
-            trailing: _isUpdatingFirefoxVersion
-                ? const SizedBox(
-                    width: 24,
-                    height: 24,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : IconButton(
-                    icon: const Icon(Icons.sync),
-                    tooltip: loc.appSettingsUpdateFirefoxVersion,
-                    onPressed: _updateFirefoxVersion,
-                  ),
-          ),
-          SwitchListTile(
-            title: Text(loc.appSettingsFirefoxAutoUpdate),
-            subtitle: Text(loc.appSettingsFirefoxAutoUpdateHint),
-            value: _firefoxAutoRefresh,
-            onChanged: (bool value) {
-              _setFirefoxAutoRefresh(value);
-            },
+          FirefoxVersionTile(
+            majorVersion: FirefoxUserAgentService.instance.majorVersion,
+            lastChecked: FirefoxUserAgentService.instance.lastChecked,
+            isUpdating: _isUpdatingFirefoxVersion,
+            autoUpdate: _firefoxAutoRefresh,
+            onUpdate: _updateFirefoxVersion,
+            onAutoUpdateChanged: _setFirefoxAutoRefresh,
           ),
 
           // DNS Blocklist
@@ -1487,7 +1452,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
             leading: const Icon(Icons.shield),
             title: Row(
               children: [
-                Text(loc.appSettingsDnsBlocklist),
+                Flexible(child: Text(loc.appSettingsDnsBlocklist)),
                 HintButton(
                   title: loc.appSettingsDnsBlocklist,
                   description: loc.appSettingsDnsBlocklistHint,
@@ -1580,7 +1545,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
               leading: const Icon(Icons.storage),
               title: Row(
                 children: [
-                  Text(loc.appSettingsLocalCdn),
+                  Flexible(child: Text(loc.appSettingsLocalCdn)),
                   HintButton(
                     title: loc.appSettingsLocalCdn,
                     description: loc.appSettingsLocalCdnHint,
@@ -1653,11 +1618,14 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
                 Expanded(
                   child: Row(
                     children: [
-                      Text(
-                        loc.appSettingsContentBlocker,
-                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                              fontWeight: FontWeight.bold,
-                            ),
+                      Flexible(
+                        child: Text(
+                          loc.appSettingsContentBlocker,
+                          style: Theme.of(context)
+                              .textTheme
+                              .titleMedium
+                              ?.copyWith(fontWeight: FontWeight.bold),
+                        ),
                       ),
                       HintButton(
                         title: loc.appSettingsContentBlocker,

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -1612,7 +1612,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           SwitchListTile(
             title: Row(
               children: [
-                Text(loc.siteSettingsClearUrls),
+                Flexible(child: Text(loc.siteSettingsClearUrls)),
                 HintButton(
                   title: loc.siteSettingsClearUrls,
                   description: loc.siteSettingsClearUrlsHint,
@@ -1636,7 +1636,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           SwitchListTile(
             title: Row(
               children: [
-                Text(loc.siteSettingsDnsBlocklist),
+                Flexible(child: Text(loc.siteSettingsDnsBlocklist)),
                 HintButton(
                   title: loc.siteSettingsDnsBlocklist,
                   description: loc.siteSettingsDnsBlocklistHint,
@@ -1710,7 +1710,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             SwitchListTile(
               title: Row(
                 children: [
-                  Text(loc.siteSettingsLocalCdn),
+                  Flexible(child: Text(loc.siteSettingsLocalCdn)),
                   HintButton(
                     title: loc.siteSettingsLocalCdn,
                     description: loc.siteSettingsLocalCdnHint,

--- a/lib/widgets/firefox_version_tile.dart
+++ b/lib/widgets/firefox_version_tile.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+import 'package:webspace/l10n/gen/app_localizations.dart';
+import 'package:webspace/widgets/hint_button.dart';
+
+/// App-settings row for the Firefox version generated User-Agents render at.
+/// Both refresh modes hang off the one entry: the button checks now, the
+/// sub-row switch arms the weekly check at startup. What each costs in network
+/// terms is in the hint dialog.
+class FirefoxVersionTile extends StatelessWidget {
+  final int majorVersion;
+  final DateTime? lastChecked;
+  final bool isUpdating;
+  final bool autoUpdate;
+  final VoidCallback onUpdate;
+  final ValueChanged<bool> onAutoUpdateChanged;
+
+  const FirefoxVersionTile({
+    super.key,
+    required this.majorVersion,
+    required this.lastChecked,
+    required this.isUpdating,
+    required this.autoUpdate,
+    required this.onUpdate,
+    required this.onAutoUpdateChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context);
+    final description = '${loc.appSettingsFirefoxVersionHint}\n\n'
+        '${loc.appSettingsFirefoxAutoUpdate}: '
+        '${loc.appSettingsFirefoxAutoUpdateHint}';
+    final checked = lastChecked?.toLocal().toString().split('.')[0];
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        ListTile(
+          leading: const Icon(Icons.travel_explore),
+          title: Row(
+            children: [
+              Flexible(child: Text(loc.appSettingsFirefoxVersion)),
+              HintButton(
+                title: loc.appSettingsFirefoxVersion,
+                description: description,
+              ),
+            ],
+          ),
+          subtitle: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(loc.appSettingsFirefoxVersionCurrent(majorVersion)),
+              if (checked != null)
+                Text(
+                  loc.appSettingsFirefoxVersionChecked(checked),
+                  style: const TextStyle(fontSize: 12),
+                ),
+            ],
+          ),
+          trailing: isUpdating
+              ? const SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : IconButton(
+                  icon: const Icon(Icons.sync),
+                  tooltip: loc.appSettingsUpdateFirefoxVersion,
+                  onPressed: onUpdate,
+                ),
+        ),
+        SwitchListTile(
+          // start: the title column. end: 24 puts the switch track flush
+          // with the refresh icon above it, which sits inset in its button.
+          contentPadding: const EdgeInsetsDirectional.only(start: 72, end: 24),
+          dense: true,
+          visualDensity: VisualDensity.compact,
+          title: Text(
+            loc.appSettingsFirefoxAutoUpdate,
+            style: const TextStyle(fontSize: 13),
+          ),
+          value: autoUpdate,
+          onChanged: onAutoUpdateChanged,
+        ),
+      ],
+    );
+  }
+}

--- a/test/firefox_version_tile_test.dart
+++ b/test/firefox_version_tile_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/l10n/gen/app_localizations.dart';
+import 'package:webspace/l10n/gen/app_localizations_en.dart';
+import 'package:webspace/widgets/firefox_version_tile.dart';
+
+final AppLocalizationsEn en = AppLocalizationsEn();
+
+Future<void> pumpTile(
+  WidgetTester tester, {
+  bool autoUpdate = false,
+  bool isUpdating = false,
+  VoidCallback? onUpdate,
+  ValueChanged<bool>? onAutoUpdateChanged,
+}) async {
+  await tester.pumpWidget(MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: FirefoxVersionTile(
+        majorVersion: 152,
+        lastChecked: DateTime(2026, 8, 20, 10, 44, 3),
+        isUpdating: isUpdating,
+        autoUpdate: autoUpdate,
+        onUpdate: onUpdate ?? () {},
+        onAutoUpdateChanged: onAutoUpdateChanged ?? (_) {},
+      ),
+    ),
+  ));
+  // A running check animates forever, so settling would time out.
+  isUpdating ? await tester.pump() : await tester.pumpAndSettle();
+}
+
+void main() {
+  group('FirefoxVersionTile (DM-004)', () {
+    testWidgets('shows the version and the last check', (tester) async {
+      await pumpTile(tester);
+      expect(find.text(en.appSettingsFirefoxVersionCurrent(152)),
+          findsOneWidget);
+      expect(
+        find.text(en.appSettingsFirefoxVersionChecked('2026-08-20 10:44:03')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('manual refresh and the auto switch are both reachable',
+        (tester) async {
+      var updates = 0;
+      bool? armed;
+      await pumpTile(
+        tester,
+        onUpdate: () => updates++,
+        onAutoUpdateChanged: (v) => armed = v,
+      );
+
+      await tester.tap(find.byIcon(Icons.sync));
+      expect(updates, 1);
+
+      await tester.tap(find.byType(Switch));
+      expect(armed, isTrue);
+    });
+
+    testWidgets('the switch reflects the stored setting', (tester) async {
+      await pumpTile(tester, autoUpdate: true);
+      expect(tester.widget<Switch>(find.byType(Switch)).value, isTrue);
+    });
+
+    testWidgets('a running check replaces the button with a spinner',
+        (tester) async {
+      await pumpTile(tester, isUpdating: true);
+      expect(find.byIcon(Icons.sync), findsNothing);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    // The hint dialog is the only place the auto-update explanation is
+    // reachable, so it has to carry both halves.
+    testWidgets('the hint explains manual and automatic updates',
+        (tester) async {
+      await pumpTile(tester);
+      await tester.tap(find.byIcon(Icons.info_outline));
+      await tester.pumpAndSettle();
+
+      final dialog = find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.byType(Text),
+      );
+      final texts =
+          tester.widgetList<Text>(dialog).map((t) => t.data ?? '').join('\n');
+      expect(texts, contains(en.appSettingsFirefoxVersionHint));
+      expect(texts, contains(en.appSettingsFirefoxAutoUpdate));
+      expect(texts, contains(en.appSettingsFirefoxAutoUpdateHint));
+    });
+
+    // The row carries a title, a hint button, a timestamp, a switch and a
+    // refresh button; narrow screens and large text scales are where a Row
+    // runs out of width.
+    testWidgets('lays out without overflow across widths and text scales',
+        (tester) async {
+      final complaints = <String>[];
+      final previousOnError = FlutterError.onError;
+      FlutterError.onError = (details) => complaints
+          .add('${details.exception}'.split('\n').first);
+      addTearDown(() => FlutterError.onError = previousOnError);
+
+      for (final width in <double>[200, 240, 280, 320, 360, 412, 480, 800]) {
+        for (final scale in <double>[1.0, 1.3, 1.6, 2.0, 2.5]) {
+          tester.view.devicePixelRatio = 1.0;
+          tester.view.physicalSize = Size(width, 800);
+          addTearDown(tester.view.reset);
+          await tester.pumpWidget(MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: MediaQuery(
+              data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+              child: Scaffold(
+                body: ListView(children: [
+                  FirefoxVersionTile(
+                    majorVersion: 152,
+                    lastChecked: DateTime(2026, 8, 20, 10, 44, 3),
+                    isUpdating: false,
+                    autoUpdate: true,
+                    onUpdate: () {},
+                    onAutoUpdateChanged: (_) {},
+                  ),
+                ]),
+              ),
+            ),
+          ));
+          await tester.pumpAndSettle();
+          expect(complaints, isEmpty,
+              reason: 'width $width, text scale $scale');
+        }
+      }
+    });
+  });
+}

--- a/test/js/l10n_no_hardcoded_text.test.js
+++ b/test/js/l10n_no_hardcoded_text.test.js
@@ -33,6 +33,7 @@ const migrated = new Set([
   'lib/widgets/download_button.dart',
   'lib/widgets/external_url_prompt.dart',
   'lib/widgets/find_toolbar.dart',
+  'lib/widgets/firefox_version_tile.dart',
   'lib/widgets/hint_button.dart',
   'lib/widgets/root_messenger.dart',
   'lib/widgets/site_permission_badges.dart',

--- a/test/js/settings_title_row_overflow.test.js
+++ b/test/js/settings_title_row_overflow.test.js
@@ -1,0 +1,62 @@
+// A ListTile title of `Row([Text, HintButton])` overflows on the right as soon
+// as the title text needs more room than the row has - narrow windows, long
+// translations, large text scales. The fix is always the same: let the label
+// flex so it wraps instead of overflowing. This gate keeps the pattern from
+// creeping back one tile at a time.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const scanRoots = ['lib/main.dart', 'lib/screens', 'lib/widgets'];
+
+// How far past `children: [` we still consider ourselves inside the same row.
+const ROW_WINDOW = 600;
+
+function discoverDartFiles(roots) {
+  const out = [];
+  const walk = (abs, rel) => {
+    for (const e of fs.readdirSync(abs, { withFileTypes: true })) {
+      const childAbs = path.join(abs, e.name);
+      const childRel = `${rel}/${e.name}`;
+      if (e.isDirectory()) walk(childAbs, childRel);
+      else if (e.isFile() && e.name.endsWith('.dart')) out.push(childRel);
+    }
+  };
+  for (const root of roots) {
+    const abs = path.join(repoRoot, root);
+    if (!fs.existsSync(abs)) continue;
+    if (fs.statSync(abs).isDirectory()) walk(abs, root);
+    else if (root.endsWith('.dart')) out.push(root);
+  }
+  return out;
+}
+
+function findRigidTitles(rel, source) {
+  const hits = [];
+  const opener = /children:\s*\[\s*\n\s*(\w+)\(/g;
+  for (const m of source.matchAll(opener)) {
+    if (m[1] !== 'Text' && m[1] !== 'SelectableText') continue;
+    const row = source.slice(m.index, m.index + ROW_WINDOW);
+    if (!row.includes('HintButton(')) continue;
+    const line = (source.slice(0, m.index).match(/\n/g) || []).length + 1;
+    hits.push(`  ${rel}:${line}: ${m[1]}( sits next to a HintButton unflexed`);
+  }
+  return hits;
+}
+
+test('a label sharing a row with a HintButton can flex', () => {
+  const violations = [];
+  for (const rel of discoverDartFiles(scanRoots)) {
+    const abs = path.join(repoRoot, rel);
+    violations.push(...findRigidTitles(rel, fs.readFileSync(abs, 'utf8')));
+  }
+  assert.deepEqual(
+    violations,
+    [],
+    'Wrap each label in Flexible(child: ...) so it wraps instead of '
+      + `overflowing the row:\n${violations.join('\n')}`,
+  );
+});


### PR DESCRIPTION
Refactor the Firefox version settings UI into a reusable `FirefoxVersionTile` widget and fix text overflow issues across the settings screens.

- Extract Firefox version, auto-update switch, and refresh button into `FirefoxVersionTile` widget that combines both manual and automatic update modes in one cohesive component
- Wrap text labels in `Flexible` throughout `AppSettingsScreen` and `SettingsScreen` to prevent overflow on narrow screens and large text scales
- Update hint dialog in the tile to explain both manual refresh and automatic update modes in a single description
- Add comprehensive test suite for `FirefoxVersionTile` covering version display, button/switch interaction, loading state, hint dialog content, and layout stability across widths (200–800px) and text scales (1.0–2.5x)
- Add JS test gate to prevent future regressions of text-next-to-HintButton overflow pattern

https://claude.ai/code/session_01AHv61vH6BYy7pDCdD18Vtx