### PR TITLE
BUG-001 Attempt 10: route-return, first-commit, and nested-screen repaint gates

### DIFF
--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -214,12 +214,60 @@ recommit, which is what the fix rests on. The `trigger=reload -> nudge` /
 `trigger=reload-settled -> nudge` pair exists to close that; until such a trace exists the
 causal claim is unverified, exactly as in Attempt 8.
 
+### Attempt 10 — Route-return chokepoint, first-commit latch, nested-screen parity (`PAUSE-024`/`025`/`026`)
+**Date:** 2026-08-20 · **Files:** lib/services/surface_route_observer.dart (new),
+lib/services/surface_repaint_engine.dart, lib/main.dart, lib/screens/inappbrowser.dart,
+formal/kernel.tla (+ proofs), test/surface_repaint_engine_test.dart,
+test/js/surface_repaint_funnel.test.js, integration_test/white_screen_test.dart,
+openspec/specs/webview-pause-lifecycle/spec.md
+**What it did:** Three paths, one shape each.
+(a) **Route return** (`PAUSE-024`): both webview-hosting screens are now `RouteAware` on a
+shared `surfaceRouteObserver` registered on `MaterialApp.navigatorObservers`, and nudge from
+`didPopNext`. The observer is typed to `PageRoute`, so only an *opaque* route — the kind that
+stops the platform view being composited — triggers it; dialogs and other popup routes, which
+leave the webview composited under the barrier, do not.
+(b) **First commit** (`PAUSE-025`): the `reloadIssued` latch generalised to
+`noteCommitPending`, and armed by a fresh controller attach and by activating a site whose load
+is still in flight. `consumeLoadSettled` then repaints the committed document exactly as it
+does for a reload. Diagnostics: `trigger=controller-attach -> nudge` and
+`trigger=commit-settled -> nudge` (the latter subsumes `reload-settled`).
+(c) **Nested-screen parity** (`PAUSE-026`): `InAppWebViewScreen` gained the controller-attach
+nudge, the post-resume window + `didChangeMetrics` re-nudge, and the route-return nudge. It
+already had the back path and the reload funnel.
+**Why:** These are the *reachable* paths a user hits that no prior attempt covers, found by
+auditing every surface (re)attach against the nudge chokepoints rather than waiting for
+another report. (a) is the most common of them: every full-screen route in the app — site
+settings, app settings, developer tools, downloads, the nested browser — detaches the visible
+site's `SurfaceView` while it covers the screen, and popping back re-attaches it through no
+chokepoint at all (same site, same controller, no navigation, no lifecycle event). (b) is
+open gap #7 from the 2026-08-13 report, where a first load commits after both fresh-webview
+nudges drain — the Attempt 8/9 ordering, on a surface that has never painted; the latch
+already existed and simply was not armed on that path. (c) matters because the main page's
+nudge physically cannot repaint the nested screen: it toggles an inset around the
+`IndexedStack`, which sits *under* the nested route, so a warm start with the nested browser
+on top had no repaint at all.
+**Why partial:** Still per-path (gap #3), and (b) still keys on `onLoadingChanged(false)`, the
+same parse-time proxy for the commit that gap #6 describes. Every trigger here is *reasoned
+from the mechanism*, not confirmed from a device report: unlike Attempt 9's reload, no user
+has yet stated "I returned from settings and it was white", so the `trigger=route-return`
+diagnostic exists to establish that from a log. The route-return nudge also assumes the
+embedder actually detaches the platform view under an opaque route; if a Flutter version keeps
+it attached, the nudge is a harmless no-op rather than a fix.
+
 ## Known open gaps (candidates for the next recurrence)
 
 1. ~~Nested `InAppWebViewScreen`~~ — **closed by Attempt 6** (now funneled + gated).
 2. **Forward navigation** (`goForward`) into a bfcached entry is the symmetric case of
    Attempts 5–6 and is currently unnudged. (There is no `goForward` call site today,
    but adding one on Android would need the same funnel.)
+8. ~~Return from a pushed route~~ — **closed by Attempt 10** for both screens
+   (`PAUSE-024`), gated structurally and covered by pixel scenarios 8 and 9.
+9. **Every attach path is still enumerated by hand.** Attempt 10 found its three paths by
+   auditing the code against the chokepoint list, not from a report — which is an improvement
+   on waiting for users, but the audit is only as good as the reviewer, and it must be redone
+   whenever a new screen hosts a webview or a new lifecycle signal appears. That is gap #3
+   from the process side: a native attach callback would make the audit unnecessary rather
+   than merely up to date.
 3. **The class isn't closed.** Every fix is per-path. The durable fix is a **single
    chokepoint** that nudges on *every* surface (re)attach — ideally a native
    surface-changed/-redrawn callback from the fork driving the repaint — instead of
@@ -262,7 +310,11 @@ causal claim is unverified, exactly as in Attempt 8.
    new `SurfaceDiag` line `trigger=metrics-resume -> nudge` exists to confirm this from a
    device log; until such a trace exists, the causal claim (this fixes the reported warm-start
    white screen) is unverified.
-7. **First activation of a fresh site is diagnostically dark and has no commit-side nudge.**
+7. ~~**First activation of a fresh site is diagnostically dark and has no commit-side nudge.**~~
+   **Closed by Attempt 10** (`PAUSE-025`): the controller attach now arms the commit latch and
+   emits `trigger=controller-attach -> nudge`, so the settled load repaints the first document
+   and the path is no longer dark. It inherits gap #6 — load-stop is not the frame commit.
+   Original report, kept for the lineage:
    Reported 2026-08-13 (sanitized log export): user cold-started to the site picker, tapped a
    not-yet-loaded site three minutes later, webview created from scratch, main-frame load
    started, white screen. The log cannot classify it because this path emits *no* SurfaceDiag:
@@ -302,6 +354,11 @@ causal claim is unverified, exactly as in Attempt 8.
   `inappbrowser.dart` must sit inside a `reloadAndRepaint` funnel that latches the reload,
   `main.dart` must wire both host hooks to the engine, and each file must drive the repaint
   off the load-settled signal. A new raw reload fails CI.
+  Attempt 10 adds three more: both webview screens must be `RouteAware`, subscribe and
+  unsubscribe from `surfaceRouteObserver`, and nudge in `didPopNext` (with the observer
+  registered on `MaterialApp`); each controller-attach handler must arm the commit latch as
+  well as nudge; and the nested screen must carry the resume window + `didChangeMetrics`
+  re-nudge. Dropping any of that wiring — the way a refactor quietly would — fails CI.
 - **Window-pixel detector + scenario suite**
   ([android/.../SurfaceDiagPlugin.kt](../../android/app/src/main/kotlin/org/codeberg/theoden8/webspace/SurfaceDiagPlugin.kt),
   [lib/services/surface_diag_native.dart](../../lib/services/surface_diag_native.dart),
@@ -312,8 +369,15 @@ causal claim is unverified, exactly as in Attempt 8.
   can reach — and classifies uniform white/black over the webview rect. The integration
   suite (emulator step in the `build-android` CI job, every push/PR) drives the
   in-process-drivable entry paths (fresh first activation incl. gap #7, loaded-site
-  switch, reload funnel, memory pressure, fresh activation among live sites) and fails
-  on a blank window, with a white control page proving the detector is not vacuous.
+  switch, reload funnel, memory pressure, fresh activation among live sites, plus
+  Attempt 10's route return and nested screen) and fails on a blank window, with a white
+  control page proving the detector is not vacuous.
+  Until Attempt 10 it was nonetheless **blind to the ordering every recurrence since
+  Attempt 8 is about**: every page it served committed in a millisecond, so the repaint
+  always landed while the issue-time nudge loop was still running, and no scenario could
+  tell "the fix works" from "the fix was never needed here". Scenarios 7 and 9 now
+  withhold the first byte for 3s, which puts the commit outside the ~0.6s nudge budget and
+  leaves the settled-side re-nudge as the only thing that can paint it.
   Not yet wired into production
   diagnostics; doing so would give `SurfaceDiag` log lines a `window=` classification.
   First emulator run confirmed the sampler reads real webview pixels on SwiftShader and

--- a/formal/kernel.tla
+++ b/formal/kernel.tla
@@ -112,6 +112,15 @@ Forward ==
     /\ Attach
     /\ UNCHANGED << currentIndex, loaded, frozen, jarOwner >>
 
+\* An opaque route pushed over the webview screen pops: the platform view was
+\* not composited while covered, so the SurfaceView re-attaches blank. Same
+\* site, same controller, no navigation, no lifecycle event -- it passes
+\* through no other action here, which is why PAUSE-024 gives it its own
+\* chokepoint (didPopNext -> Nudge).
+RouteReturn ==
+    /\ Attach
+    /\ UNCHANGED << currentIndex, loaded, frozen, jarOwner >>
+
 (***************************************************************************)
 (* Module: lazy-webview-loading   (owns: loaded)                          *)
 (***************************************************************************)
@@ -182,6 +191,7 @@ GoodNext ==
     \/ ControllerAttach
     \/ Back
     \/ Forward
+    \/ RouteReturn
     \/ Nudge
     \/ \E s \in Sites : LoadSite(s)
     \/ \E s \in Sites : Evict(s)

--- a/formal/proofs/check_proofs.sh
+++ b/formal/proofs/check_proofs.sh
@@ -34,13 +34,13 @@ min_obligations() {
   case "$1" in
     archive_identity.tla)      echo 25 ;;
     containers_disjoint.tla)   echo 23 ;;
-    current_loaded.tla)        echo 51 ;;
-    jar_matches.tla)           echo 51 ;;
+    current_loaded.tla)        echo 52 ;;
+    jar_matches.tla)           echo 52 ;;
     jar_repopulated.tla)       echo 28 ;;
     no_lost_update.tla)        echo 23 ;;
     proxy_coherent.tla)        echo 29 ;;
     proxy_failclosed_safe.tla) echo 28 ;;
-    repaint_liveness.tla)      echo 71 ;;
+    repaint_liveness.tla)      echo 72 ;;
     retention_safety.tla)      echo 22 ;;
     switch_guarded.tla)        echo 34 ;;
     # A new proof module is unpinned until someone records its count above.

--- a/formal/proofs/current_loaded.tla
+++ b/formal/proofs/current_loaded.tla
@@ -57,12 +57,14 @@ LEMMA InductiveStep == IndInv /\ [GoodNext]_vars => IndInv'
       BY <2>5 DEF Back, Attach
     <2>6. CASE Forward
       BY <2>6 DEF Forward, Attach
+    <2>9. CASE RouteReturn
+      BY <2>9 DEF RouteReturn, Attach
     <2>7. CASE \E s \in Sites : LoadSite(s)
       BY <2>7 DEF LoadSite
     <2>8. CASE \E s \in Sites : Evict(s)
       BY <2>8 DEF Evict
     <2> QED
-      BY <1>1, <2>1, <2>2, <2>3, <2>4, <2>5, <2>6, <2>7, <2>8 DEF GoodNext
+      BY <1>1, <2>1, <2>2, <2>3, <2>4, <2>5, <2>6, <2>7, <2>8, <2>9 DEF GoodNext
   <1>2. CASE UNCHANGED vars
     BY <1>2 DEF vars
   <1> QED

--- a/formal/proofs/jar_matches.tla
+++ b/formal/proofs/jar_matches.tla
@@ -44,12 +44,14 @@ LEMMA InductiveStep == IndInv /\ [GoodNext]_vars => IndInv'
       BY <2>5 DEF Back, Attach
     <2>6. CASE Forward
       BY <2>6 DEF Forward, Attach
+    <2>9. CASE RouteReturn
+      BY <2>9 DEF RouteReturn, Attach
     <2>7. CASE \E s \in Sites : LoadSite(s)
       BY <2>7 DEF LoadSite
     <2>8. CASE \E s \in Sites : Evict(s)
       BY <2>8 DEF Evict
     <2> QED
-      BY <1>1, <2>1, <2>2, <2>3, <2>4, <2>5, <2>6, <2>7, <2>8 DEF GoodNext
+      BY <1>1, <2>1, <2>2, <2>3, <2>4, <2>5, <2>6, <2>7, <2>8, <2>9 DEF GoodNext
   <1>2. CASE UNCHANGED vars
     BY <1>2 DEF vars
   <1> QED

--- a/formal/proofs/repaint_liveness.tla
+++ b/formal/proofs/repaint_liveness.tla
@@ -57,12 +57,14 @@ LEMMA StepBackbone == Backbone /\ [GoodNext]_vars => Backbone'
       BY <2>5 DEF Back, Attach
     <2>6. CASE Forward
       BY <2>6 DEF Forward, Attach
+    <2>9. CASE RouteReturn
+      BY <2>9 DEF RouteReturn, Attach
     <2>7. CASE \E s \in Sites : LoadSite(s)
       BY <2>7 DEF LoadSite
     <2>8. CASE \E s \in Sites : Evict(s)
       BY <2>8 DEF Evict
     <2> QED
-      BY <1>1, <2>1, <2>2, <2>3, <2>4, <2>5, <2>6, <2>7, <2>8 DEF GoodNext
+      BY <1>1, <2>1, <2>2, <2>3, <2>4, <2>5, <2>6, <2>7, <2>8, <2>9 DEF GoodNext
   <1>2. CASE UNCHANGED vars
     BY <1>2 DEF vars
   <1> QED
@@ -106,7 +108,7 @@ THEOREM Liveness == GoodSpecWF => (surface = "blank" ~> surface = "painted")
   <1>2. (surface = "blank") /\ [GoodNext]_vars =>
           ((surface = "blank")' \/ (surface = "painted")')
     BY DEF GoodNext, Activate, Resume, ControllerAttach, Nudge, Back, Forward,
-           LoadSite, Evict, Attach, vars
+           RouteReturn, LoadSite, Evict, Attach, vars
   <1>3. (surface = "blank") /\ <<GoodNext /\ Nudge>>_vars => (surface = "painted")'
     BY DEF Nudge, vars
   <1>4. ASSUME Backbone, surface = "blank"

--- a/integration_test/white_screen_test.dart
+++ b/integration_test/white_screen_test.dart
@@ -19,6 +19,19 @@
 //   5. OS memory pressure against the visible site (Attempt 7).
 //   6. Fresh activation with other sites live (controller-attach nudge,
 //      Attempt 4).
+//   7. Fresh activation of a site whose document commits LATE (PAUSE-025).
+//   8. Return from a pushed opaque route (PAUSE-024).
+//   9. Nested InAppWebViewScreen: fresh surface on a late-committing
+//      document, then the return to the main page (PAUSE-024/025).
+//
+// Scenarios 1–6 all serve documents that commit in a millisecond, so every
+// repaint they exercise lands while the issue-time nudge loop is still
+// running. That makes them blind to the ordering every recurrence since
+// Attempt 8 has actually been about: a surface that attaches or commits
+// AFTER the ~0.6s nudge budget drains. Scenarios 7 and 9 hold the response
+// for _kSlowCommit before the first byte, which puts the commit outside that
+// budget and leaves the settled-side re-nudge as the only thing that can
+// paint it.
 //
 // Warm start, activity recreation, and back/forward-cache restores need
 // real activity lifecycle transitions that an in-process integration test
@@ -28,7 +41,10 @@
 // Pages are served from an in-process loopback HTTP server so a network
 // failure can never masquerade as a white screen. Each content page is a
 // solid color Flutter never draws, so a matching dominant color proves the
-// sampled pixels came from the webview, not the app chrome.
+// sampled pixels came from the webview, not the app chrome. The server binds
+// every IPv4 interface so the same pages are reachable as both 127.0.0.1 and
+// 127.0.0.2 — two hosts, one server: a cross-domain navigation (which opens
+// the nested screen) that still cannot fail on the network.
 
 import 'dart:convert';
 import 'dart:io';
@@ -40,6 +56,8 @@ import 'package:integration_test/integration_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:webspace/main.dart' as app;
 import 'package:webspace/demo_data.dart';
+import 'package:webspace/screens/inappbrowser.dart';
+import 'package:webspace/screens/settings.dart';
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/surface_diag_native.dart';
 import 'package:webspace/web_view_model.dart';
@@ -47,11 +65,19 @@ import 'package:webspace/webspace_model.dart';
 
 const int _kDarkColor = 0xFF123524;
 const int _kMagentaColor = 0xFF8C1D5A;
+const int _kBlueColor = 0xFF1D3F8C;
 
-String _solidPage(String cssColor) => '<!doctype html><html><head>'
+/// How long the slow pages withhold their first byte. Must exceed the nudge
+/// loop's budget (`SurfaceRepaintEngine.ticksPerRequest` × 100ms ≈ 0.6s) by
+/// enough that every issue-time nudge has drained before the document
+/// commits — that is the ordering BUG-001 Attempts 8/9/10 are about.
+const Duration _kSlowCommit = Duration(seconds: 3);
+
+String _solidPage(String cssColor, {String body = ''}) =>
+    '<!doctype html><html><head>'
     '<meta name="viewport" content="width=device-width, initial-scale=1">'
     '<style>html,body{margin:0;height:100%;background:$cssColor;}</style>'
-    '</head><body></body></html>';
+    '</head><body>$body</body></html>';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -61,20 +87,40 @@ void main() {
   setUpAll(() async {
     isDemoMode = true;
 
-    server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-    server!.listen((request) {
+    // anyIPv4, not loopbackIPv4: the nested-screen scenario needs a second
+    // host name for the same pages (127.0.0.2), because the nested screen
+    // opens on a *cross-domain* navigation and getBaseDomain compares IPs
+    // literally. Both addresses are loopback, so nothing leaves the device.
+    server = await HttpServer.bind(InternetAddress.anyIPv4, 0);
+    final port = server!.port;
+    final altBase = 'http://127.0.0.2:$port';
+    server!.listen((request) async {
       final page = switch (request.uri.path) {
         '/dark.html' => _solidPage('#123524'),
         '/white.html' => _solidPage('#ffffff'),
         '/magenta.html' => _solidPage('#8c1d5a'),
+        '/slow-blue.html' => _solidPage('#1d3f8c'),
+        // Cross-domain hop into the nested screen, script-initiated so the
+        // test never depends on a synthetic touch reaching the platform view.
+        // The site that serves it has blockAutoRedirects off, so the
+        // navigation decision engine resolves it to blockOpenNested.
+        '/opener.html' => _solidPage('#123524',
+            body: '<script>setTimeout(function(){'
+                "location.href='$altBase/slow-blue.html';"
+                '},500);</script>'),
         _ => '<!doctype html><html><body>404</body></html>',
       };
+      // Withhold the first byte so the document commits well after every
+      // issue-time nudge has drained (see _kSlowCommit).
+      if (request.uri.path.startsWith('/slow-')) {
+        await Future.delayed(_kSlowCommit);
+      }
       request.response
         ..headers.contentType = ContentType.html
         ..write(page);
       request.response.close();
     });
-    final base = 'http://127.0.0.1:${server!.port}';
+    final base = 'http://127.0.0.1:$port';
 
     final dark = WebViewModel(
       siteId: 'ws-dark',
@@ -91,11 +137,27 @@ void main() {
       initUrl: '$base/magenta.html',
       name: 'Magenta',
     );
+    final slow = WebViewModel(
+      siteId: 'ws-slow',
+      initUrl: '$base/slow-blue.html',
+      name: 'Slow',
+    );
+    final opener = WebViewModel(
+      siteId: 'ws-opener',
+      initUrl: '$base/opener.html',
+      name: 'Opener',
+      // The hop to 127.0.0.2 is script-initiated and therefore gestureless;
+      // the default (block) would classify it blockSilent and never open the
+      // nested screen.
+      blockAutoRedirects: false,
+    );
     SharedPreferences.setMockInitialValues({
       'webViewModels': [
         jsonEncode(dark.toJson()),
         jsonEncode(white.toJson()),
         jsonEncode(magenta.toJson()),
+        jsonEncode(slow.toJson()),
+        jsonEncode(opener.toJson()),
       ],
     });
   });
@@ -129,8 +191,8 @@ void main() {
     }
   }
 
-  Future<WindowRegionSample> sampleSite(WidgetTester tester, String siteId) {
-    final logical = tester.getRect(find.byKey(ValueKey(siteId)).first);
+  Future<WindowRegionSample> sampleSlot(WidgetTester tester, Finder slot) {
+    final logical = tester.getRect(slot.first);
     return SurfaceDiagNative.sampleWindowRegion(SurfaceDiagNative.physicalRect(
       logicalRect: logical,
       devicePixelRatio: tester.view.devicePixelRatio,
@@ -143,9 +205,9 @@ void main() {
   // until the sample is accepted or the deadline passes. On timeout the last
   // sample is the diagnostic: uniform white with an ok status IS a white
   // screen.
-  Future<WindowRegionSample> pollSite(
+  Future<WindowRegionSample> pollSlot(
     WidgetTester tester,
-    String siteId,
+    Finder slot,
     String description,
     bool Function(WindowRegionSample) accept, {
     Duration timeout = const Duration(seconds: 90),
@@ -154,8 +216,8 @@ void main() {
     WindowRegionSample? last;
     while (DateTime.now().isBefore(deadline)) {
       await tester.pump(const Duration(milliseconds: 250));
-      if (find.byKey(ValueKey(siteId)).evaluate().isEmpty) continue;
-      last = await sampleSite(tester, siteId);
+      if (slot.evaluate().isEmpty) continue;
+      last = await sampleSlot(tester, slot);
       if (accept(last)) {
         print('white_screen_test: $description -> $last');
         return last;
@@ -165,6 +227,16 @@ void main() {
     fail('Timed out after ${timeout.inSeconds}s waiting for: $description '
         '(last sample: $last)');
   }
+
+  Future<WindowRegionSample> pollSite(
+    WidgetTester tester,
+    String siteId,
+    String description,
+    bool Function(WindowRegionSample) accept, {
+    Duration timeout = const Duration(seconds: 90),
+  }) =>
+      pollSlot(tester, find.byKey(ValueKey(siteId)), description, accept,
+          timeout: timeout);
 
   Future<void> openSiteDrawer(WidgetTester tester) async {
     for (var attempt = 0; attempt < 3; attempt++) {
@@ -205,6 +277,46 @@ void main() {
     await tester.tap(tile.first);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 400));
+  }
+
+  // Tap an action in the AppBar's overflow popup menu. Menu contents are
+  // built at open time and some entries are conditional (Refresh swaps to
+  // Stop while a load is in flight), so an absent action means dismiss and
+  // reopen until it appears. The action's icon is unique to the open menu:
+  // the AppBar renders its own gear only on the webspaces list, where no
+  // site is active.
+  Future<void> openOverflowMenuAction(
+    WidgetTester tester,
+    IconData action,
+    String label, {
+    Duration timeout = const Duration(seconds: 45),
+  }) async {
+    final deadline = DateTime.now().add(timeout);
+    while (true) {
+      if (DateTime.now().isAfter(deadline)) {
+        dumpDiagnostics(tester, '$label: overflow menu action not reachable');
+        fail('$label: timed out opening the overflow menu / finding the action');
+      }
+      final item = find.byIcon(action);
+      if (item.evaluate().isNotEmpty) {
+        await tester.tap(item.first);
+        await tester.pump();
+        return;
+      }
+      if (find.byType(PopupMenuItem<String>).evaluate().isNotEmpty) {
+        // Menu is open without the action: dismiss and reopen next pass.
+        await tester.tapAt(const Offset(5, 5));
+      } else {
+        final menuButton = find.descendant(
+            of: find.byType(AppBar),
+            matching: find.byType(PopupMenuButton<String>));
+        if (menuButton.evaluate().isNotEmpty) {
+          await tester.tap(menuButton.first);
+        }
+      }
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+    }
   }
 
   testWidgets(
@@ -260,36 +372,7 @@ void main() {
       // open: open the menu, tap Refresh, then require the recommitted
       // document on the window. Menu contents are built at open time, so a
       // menu showing Stop is dismissed and reopened until the load settles.
-      final refreshDeadline = DateTime.now().add(const Duration(seconds: 45));
-      var refreshTapped = false;
-      while (!refreshTapped) {
-        if (DateTime.now().isAfter(refreshDeadline)) {
-          dumpDiagnostics(tester, 'scenario 4: Refresh menu action not reachable');
-          fail('Timed out opening the overflow menu / finding Refresh');
-        }
-        final refresh = find.byIcon(Icons.refresh);
-        if (refresh.evaluate().isNotEmpty) {
-          await tester.tap(refresh.first);
-          await tester.pump();
-          refreshTapped = true;
-          break;
-        }
-        final menuOpen =
-            find.byType(PopupMenuItem<String>).evaluate().isNotEmpty;
-        if (menuOpen) {
-          // Menu is open but shows Stop: dismiss and reopen next pass.
-          await tester.tapAt(const Offset(5, 5));
-        } else {
-          final menuButton = find.descendant(
-              of: find.byType(AppBar),
-              matching: find.byType(PopupMenuButton<String>));
-          if (menuButton.evaluate().isNotEmpty) {
-            await tester.tap(menuButton.first);
-          }
-        }
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
-      }
+      await openOverflowMenuAction(tester, Icons.refresh, 'scenario 4');
       await pollSite(tester, 'ws-dark',
           'scenario 4: reload recommits dark content', darkVisible);
 
@@ -320,8 +403,102 @@ void main() {
               s.ok &&
               colorNear(s.dominantColor, _kMagentaColor) &&
               (s.uniformFraction ?? 0) > 0.5);
+
+      bool blueVisible(WindowRegionSample s) =>
+          s.ok &&
+          colorNear(s.dominantColor, _kBlueColor) &&
+          (s.uniformFraction ?? 0) > 0.5;
+
+      // Scenario 7: fresh activation of a site whose document commits LATE
+      // (PAUSE-025, bug doc gap #7). Every scenario above serves instantly, so
+      // its commit lands inside the activation/controller-attach nudge loops
+      // and any of them would repaint it. Here the surface attaches, both
+      // nudges drain against a surface with nothing on it, and only then does
+      // the document commit — so the settled-side re-nudge is the only thing
+      // that can paint it. The deadline is deliberately tight: a blank that
+      // clears minutes later, on some unrelated relayout, is still the bug.
+      await openSiteDrawer(tester);
+      await tapSite(tester, 'Slow');
+      await pollSlot(
+          tester,
+          find.byKey(const ValueKey('ws-slow')),
+          'scenario 7: late-committing first document paints blue',
+          blueVisible,
+          timeout: const Duration(seconds: 45));
+
+      // Scenario 8: return from a pushed opaque route (PAUSE-024). While the
+      // settings page covers the webview its platform view is not composited,
+      // so Android detaches the SurfaceView and re-attaches it on the pop —
+      // through no other chokepoint: same site, same controller, no
+      // navigation, no lifecycle event.
+      await openOverflowMenuAction(tester, Icons.settings, 'scenario 8');
+      final settlesSettings = DateTime.now().add(const Duration(seconds: 20));
+      while (find.byType(SettingsScreen).evaluate().isEmpty &&
+          DateTime.now().isBefore(settlesSettings)) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      expect(find.byType(SettingsScreen), findsOneWidget,
+          reason: 'the site settings route should cover the webview');
+      // Nothing was edited, so PopScope lets the back button pop directly.
+      await tester.tap(find
+          .descendant(
+              of: find.byType(SettingsScreen), matching: find.byType(BackButton))
+          .first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+      await pollSlot(
+          tester,
+          find.byKey(const ValueKey('ws-slow')),
+          'scenario 8: returning from a pushed route repaints the surface',
+          blueVisible,
+          timeout: const Duration(seconds: 45));
+
+      // Scenario 9: the nested InAppWebViewScreen. Its cross-domain entry
+      // mounts a brand-new SurfaceView on a late-committing document — the
+      // PAUSE-017 + PAUSE-025 pair, neither of which the nested screen had
+      // before, and which the main page's nudge cannot reach (that one
+      // toggles an inset around an IndexedStack sitting under this route).
+      await openSiteDrawer(tester);
+      await tapSite(tester, 'Opener');
+      final nestedDeadline = DateTime.now().add(const Duration(seconds: 60));
+      while (find.byType(InAppWebViewScreen).evaluate().isEmpty &&
+          DateTime.now().isBefore(nestedDeadline)) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      if (find.byType(InAppWebViewScreen).evaluate().isEmpty) {
+        dumpDiagnostics(tester, 'scenario 9: nested screen never opened');
+      }
+      expect(find.byType(InAppWebViewScreen), findsOneWidget,
+          reason: 'the cross-domain hop should open the nested webview screen');
+      await pollSlot(
+          tester,
+          find.byKey(const ValueKey(kNestedWebViewSlotKey)),
+          'scenario 9: nested fresh surface paints its late document',
+          blueVisible,
+          timeout: const Duration(seconds: 45));
+
+      // ...and popping back to the main page re-attaches the opener's
+      // surface, the nested half of PAUSE-024. The nested AppBar's leading is
+      // a custom IconButton (it pops directly, bypassing PopScope), not a
+      // BackButton, so match its icon.
+      await tester.tap(find
+          .descendant(
+              of: find.byType(InAppWebViewScreen),
+              matching: find.byType(BackButtonIcon))
+          .first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+      await pollSlot(
+          tester,
+          find.byKey(const ValueKey('ws-opener')),
+          'scenario 9: returning from the nested screen repaints the site',
+          darkVisible,
+          timeout: const Duration(seconds: 45));
     },
     skip: !Platform.isAndroid,
+    // Stays under the wrapper script's 25m wall-clock cap, which also has to
+    // cover the debug build and install: a Dart-level timeout names the
+    // scenario that hung, a killed process does not.
     timeout: const Timeout(Duration(minutes: 15)),
   );
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,6 +49,7 @@ import 'package:webspace/services/settings_backup.dart';
 import 'package:webspace/services/cookie_isolation.dart';
 import 'package:webspace/services/resume_reload_engine.dart';
 import 'package:webspace/services/surface_repaint_engine.dart';
+import 'package:webspace/services/surface_route_observer.dart';
 import 'package:webspace/services/diag_seed.dart';
 import 'package:webspace/services/cookie_secure_storage.dart';
 import 'package:webspace/services/proxy_password_secure_storage.dart';
@@ -883,6 +884,9 @@ class _WebSpaceAppState extends State<WebSpaceApp> {
     final Color accentColor = _accentColorToColor(_themeSettings.accentColor);
     return MaterialApp(
       onGenerateTitle: (context) => AppLocalizations.of(context).appTitle,
+      // Lets every webview-hosting screen learn when an opaque route above it
+      // pops, which re-attaches its platform view blank (PAUSE-024/BUG-001).
+      navigatorObservers: [surfaceRouteObserver],
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       locale: _localeOverride,
@@ -939,7 +943,7 @@ class _ArchiveSlice {
 }
 
 class _WebSpacePageState extends State<WebSpacePage>
-    with WidgetsBindingObserver
+    with WidgetsBindingObserver, RouteAware
     implements DeferredStartupHost {
   int? _currentIndex;
   final List<WebViewModel> _webViewModels = [];
@@ -1435,11 +1439,34 @@ class _WebSpacePageState extends State<WebSpacePage>
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final route = ModalRoute.of(context);
+    if (route is PageRoute) surfaceRouteObserver.subscribe(this, route);
+  }
+
+  /// An opaque route pushed over this page has popped and the webview is
+  /// visible again. While it was covered the platform view was not composited,
+  /// so Android detached its SurfaceView and re-attaches it here — blank, and
+  /// through none of the other chokepoints: the site did not change
+  /// (`_setCurrentIndex`), the controller was not recreated
+  /// (`onControllerReady`), nothing navigated, and the app never left the
+  /// foreground. See PAUSE-024 / BUG-001.
+  @override
+  void didPopNext() {
+    if (Platform.isAndroid) {
+      LogService.instance.log('SurfaceDiag', 'trigger=route-return -> nudge');
+    }
+    _nudgeSurfaceRepaint();
+  }
+
+  @override
   void dispose() {
     _foregroundPollTimer?.cancel();
     _resumeRepaintWindowTimer?.cancel();
     _navStateDebouncer.dispose();
     _untrustSub?.cancel();
+    surfaceRouteObserver.unsubscribe(this);
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
@@ -3898,6 +3925,12 @@ class _WebSpacePageState extends State<WebSpacePage>
     // gesture is dead, so pull-to-refresh can't recover it — only this relayout
     // can. _probeRendererAndRecover above only relayouts web content, not the
     // surface (see its doc), so it does not cover this. No-op off Android.
+    //
+    // Activating a site whose document is still in flight has the PAUSE-021
+    // ordering on top of that: this nudge drains against a surface that has
+    // nothing to show yet, and the commit lands afterwards. Latch it so
+    // onLoadSettled repaints the committed document (PAUSE-025).
+    if (target.isLoading) _surfaceRepaint.noteCommitPending();
     _nudgeSurfaceRepaint();
     // _loadedIndices may have changed (LRU eviction, conflict unload,
     // first-load of target), so re-evaluate the background refresh
@@ -8212,7 +8245,19 @@ class _WebSpacePageState extends State<WebSpacePage>
                         // SurfaceView can come back blank-white. Reads
                         // _currentIndex live at fire time; no-op off Android.
                         webViewModel.onControllerReady = () {
-                          if (index == _currentIndex) _nudgeSurfaceRepaint();
+                          if (index != _currentIndex) return;
+                          // The nudge alone covers only a surface whose first
+                          // document has already committed. A fresh webview's
+                          // initial load commits an unbounded time after the
+                          // controller attaches — later than this loop's ~0.6s
+                          // budget on a slow page — so latch the commit too and
+                          // let onLoadSettled repaint it (PAUSE-025).
+                          _surfaceRepaint.noteCommitPending();
+                          if (Platform.isAndroid) {
+                            LogService.instance.log(
+                                'SurfaceDiag', 'trigger=controller-attach -> nudge');
+                          }
+                          _nudgeSurfaceRepaint();
                         };
 
                         // A reload of the visible site blanks the surface
@@ -8240,7 +8285,7 @@ class _WebSpacePageState extends State<WebSpacePage>
                           if (!_surfaceRepaint.consumeLoadSettled()) return;
                           if (Platform.isAndroid) {
                             LogService.instance.log(
-                                'SurfaceDiag', 'trigger=reload-settled -> nudge');
+                                'SurfaceDiag', 'trigger=commit-settled -> nudge');
                           }
                           _nudgeSurfaceRepaint();
                         };

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -15,6 +15,7 @@ import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/log_service.dart';
 import 'package:webspace/services/resume_reload_engine.dart';
 import 'package:webspace/services/surface_repaint_engine.dart';
+import 'package:webspace/services/surface_route_observer.dart';
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/settings/camera.dart';
 import 'package:webspace/settings/microphone.dart';
@@ -28,6 +29,11 @@ import 'package:webspace/widgets/external_url_prompt.dart';
 import 'package:webspace/widgets/find_toolbar.dart';
 import 'package:webspace/widgets/untrusted_cert_prompt.dart';
 import 'package:webspace/widgets/url_bar.dart';
+
+/// Identifies the nested webview's slot, the counterpart of the main page's
+/// per-site `ValueKey(siteId)` slot. The BUG-001 pixel suite samples the
+/// composited window over this rect (integration_test/white_screen_test.dart).
+const String kNestedWebViewSlotKey = 'nested-webview-slot';
 
 class InAppWebViewScreen extends StatefulWidget {
   final String url;
@@ -152,7 +158,7 @@ class InAppWebViewScreen extends StatefulWidget {
 }
 
 class _InAppWebViewScreenState extends State<InAppWebViewScreen>
-    with WidgetsBindingObserver {
+    with WidgetsBindingObserver, RouteAware {
   WebViewController? _controller;
   String? title;
   late String _currentUrl;
@@ -221,6 +227,8 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
   /// 1px-inset toggle rendered below; no-op off Android.
   final SurfaceRepaintEngine _surfaceRepaint = SurfaceRepaintEngine();
   bool _repaintNudge = false;
+  bool _resumeRepaintWindowOpen = false;
+  Timer? _resumeRepaintWindowTimer;
 
   /// Recovery state for a load the OS stranded while the app was backgrounded
   /// (PAUSE-022). The nested screen is as exposed as the main page: it is the
@@ -457,6 +465,13 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
       onControllerCreated: (controller) {
         _controller = controller;
         _devToolsHost.controller = controller;
+        // This screen always mounts a brand-new hybrid-composition
+        // SurfaceView, which shows its white default fill until something
+        // paints it — the main page's PAUSE-017 case, which the nested screen
+        // never had. Latch the first commit too: the entry URL is remote, so
+        // it routinely settles after this nudge drains (PAUSE-025).
+        _surfaceRepaint.noteCommitPending();
+        _nudgeSurfaceRepaint();
         // Remove all cookies on load
         controller.evaluateJavascript('''
           (function() {
@@ -473,7 +488,25 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final route = ModalRoute.of(context);
+    if (route is PageRoute) surfaceRouteObserver.subscribe(this, route);
+  }
+
+  /// An opaque route pushed over this screen (Developer Tools, site settings,
+  /// a further nested webview) has popped. The platform view was not
+  /// composited while it was covered, so it re-attaches blank here — the
+  /// nested counterpart of the main page's route return (PAUSE-024).
+  @override
+  void didPopNext() {
+    _nudgeSurfaceRepaint();
+  }
+
+  @override
   void dispose() {
+    _resumeRepaintWindowTimer?.cancel();
+    surfaceRouteObserver.unsubscribe(this);
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
@@ -606,8 +639,36 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
       _resumeReload.noteAppBackgrounded();
     } else if (state == AppLifecycleState.resumed) {
       _probeNestedRenderer();
+      // A warm start destroys and re-creates this screen's SurfaceView exactly
+      // as it does the main page's, and the main page's nudge cannot reach it:
+      // that one toggles the inset around an IndexedStack sitting under this
+      // route. Same two-part fix as PAUSE-020 — a tail nudge now, plus a
+      // re-nudge on the attach signal for a surface that comes back later.
+      _openResumeRepaintWindow();
+      _nudgeSurfaceRepaint();
       unawaited(_retryIncompleteLoadOnResume());
     }
+  }
+
+  @override
+  void didChangeMetrics() {
+    super.didChangeMetrics();
+    if (!_resumeRepaintWindowOpen) return;
+    _nudgeSurfaceRepaint();
+  }
+
+  /// Post-resume window during which a `didChangeMetrics` — the closest
+  /// Dart-side signal to the SurfaceView re-attaching — re-fires the nudge.
+  /// Bounded so steady-state metric changes (keyboard, rotation) don't nudge.
+  /// Mirrors `_WebSpacePageState._openResumeRepaintWindow` (PAUSE-020).
+  void _openResumeRepaintWindow() {
+    if (!Platform.isAndroid) return;
+    _resumeRepaintWindowOpen = true;
+    _resumeRepaintWindowTimer?.cancel();
+    _resumeRepaintWindowTimer = Timer(const Duration(seconds: 3), () {
+      _resumeRepaintWindowOpen = false;
+      _resumeRepaintWindowTimer = null;
+    });
   }
 
   Future<void> launchExternalUrl(String url) async {
@@ -912,6 +973,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
           // navigation (BUG-001 gap #1). Zero inset in steady state.
           Expanded(
             child: Padding(
+              key: const ValueKey(kNestedWebViewSlotKey),
               padding: EdgeInsets.only(bottom: _repaintNudge ? 1.0 : 0.0),
               // KeyedSubtree key bumped by _handleRendererGone remounts a fresh
               // InAppWebView after a renderer death (BUG-002 gap #1).

--- a/lib/services/surface_repaint_engine.dart
+++ b/lib/services/surface_repaint_engine.dart
@@ -19,6 +19,7 @@ enum SurfaceTransition {
   back, // bfcache restore reuses the controller (PAUSE-018)
   forward, // bfcache restore reuses the controller (PAUSE-018)
   reload, // reload discards the painted frame, recommits later (PAUSE-021)
+  routeReturn, // an opaque route above popped, re-attaching the view (PAUSE-024)
   goHome, // dispose + rebuild at initUrl (PAUSE-017)
   rendererRebuilt, // renderer-gone recovery rebuild (PAUSE-017)
   appBackground, // app going to background: no attach, no repaint owed
@@ -68,29 +69,38 @@ class SurfaceRepaintEngine {
   static bool mustRepaint(SurfaceTransition t) =>
       t != SurfaceTransition.appBackground;
 
-  bool _reloadPending = false;
+  bool _commitPending = false;
 
-  /// Whether a reload has been issued whose new document has not yet settled.
-  bool get reloadPending => _reloadPending;
+  /// Whether a document has been issued whose commit onto the visible surface
+  /// has not yet settled.
+  bool get commitPending => _commitPending;
 
-  /// A reload was issued on the visible webview (PAUSE-021). Unlike every
-  /// other transition here, the surface does not go blank when the *call* is
-  /// made: the reload discards the painted frame and the new document commits
-  /// onto the surface some unbounded time later, so the one-shot nudge fired
-  /// at issue time can drain before the recommit lands — the same ordering
-  /// `formal/warmstart.tla` model-checks for the warm-start resume. This latch
-  /// carries the debt across that gap; [consumeLoadSettled] pays it.
-  void reloadIssued() {
-    _reloadPending = true;
+  /// A document was issued for the visible webview whose commit will land an
+  /// unbounded time later. Unlike every other transition here, the surface
+  /// does not go blank when the *call* is made: the old frame is discarded now
+  /// and the replacement commits later (network, parse, script), so the
+  /// one-shot nudge fired at issue time can drain before the commit lands —
+  /// the same ordering `formal/warmstart.tla` model-checks for the warm-start
+  /// resume. This latch carries the debt across that gap; [consumeLoadSettled]
+  /// pays it.
+  ///
+  /// Two callers arm it: a reload ([reloadIssued], PAUSE-021) and a
+  /// freshly-attached surface whose *first* document has not committed yet
+  /// (PAUSE-025).
+  void noteCommitPending() {
+    _commitPending = true;
   }
 
+  /// A reload was issued on the visible webview (PAUSE-021).
+  void reloadIssued() => noteCommitPending();
+
   /// A main-frame load settled on the visible webview. Returns true iff it
-  /// completes a pending reload, in which case the host MUST nudge: the
-  /// recommit is the reload's real surface attach. Consumes the latch, so a
+  /// completes a pending commit, in which case the host MUST nudge: the
+  /// commit is the document's real surface attach. Consumes the latch, so a
   /// later unrelated navigation does not nudge.
   bool consumeLoadSettled() {
-    if (!_reloadPending) return false;
-    _reloadPending = false;
+    if (!_commitPending) return false;
+    _commitPending = false;
     attach();
     return true;
   }

--- a/lib/services/surface_route_observer.dart
+++ b/lib/services/surface_route_observer.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/widgets.dart';
+
+/// Route observer that every webview-hosting screen subscribes to, so that
+/// returning from a pushed page recomposites the Android surface
+/// (PAUSE-024 / BUG-001).
+///
+/// While an opaque route covers a screen, its hybrid-composition platform view
+/// is not composited, and Android detaches it from the view hierarchy; popping
+/// back re-attaches it, blank, through none of the existing nudge chokepoints.
+///
+/// Typed to [PageRoute] deliberately. `RouteObserver` only notifies a
+/// subscriber when both the popped route and the revealed one are of its type,
+/// so a dialog or any other [PopupRoute] — which leaves the webview composited
+/// underneath — cannot trigger a repaint.
+final RouteObserver<PageRoute<dynamic>> surfaceRouteObserver =
+    RouteObserver<PageRoute<dynamic>>();

--- a/openspec/specs/integration-tests/spec.md
+++ b/openspec/specs/integration-tests/spec.md
@@ -469,11 +469,45 @@ came from the webview.
 The suite SHALL cover at least: fresh first activation (BUG-001 gap
 #7), loaded-site switch (`_setCurrentIndex` reuse), the reload funnel
 (`PAUSE-021`), memory pressure against the visible site
-(`PAUSE-019`), and fresh activation with other sites live
-(`PAUSE-017`). Warm start, activity recreation, and bfcache back
-navigation need real activity lifecycle transitions an in-process
-test cannot produce; those belong to the adb-driven lifecycle tier
-(INTEG-011).
+(`PAUSE-019`), fresh activation with other sites live
+(`PAUSE-017`), the return from a pushed opaque route (`PAUSE-024`),
+and the nested `InAppWebViewScreen` — both its own fresh surface and
+the return to the main page behind it (`PAUSE-026`). Warm start,
+activity recreation, and bfcache back navigation need real activity
+lifecycle transitions an in-process test cannot produce; those belong
+to the adb-driven lifecycle tier (INTEG-011).
+
+At least one scenario per commit-side repaint (`PAUSE-021`,
+`PAUSE-025`) SHALL be driven by a page that **withholds its first byte
+longer than the nudge's tick budget** (~0.6s). A page that commits
+instantly is repainted by the issue-time nudge whether or not the
+settled-side re-nudge exists, so an all-instant suite cannot fail on
+the ordering defect that every BUG-001 recurrence since Attempt 8 has
+actually been — it asserts only that the app renders at all. The
+delay SHALL come from the in-process server holding the response, not
+from a slow network, so the scenario stays deterministic.
+
+The nested-screen scenario SHALL reach the nested route through a
+**script-initiated cross-domain navigation** from a seeded site with
+`blockAutoRedirects` off, and the cross-domain target SHALL be the
+same in-process server reached under a second loopback address
+(`127.0.0.2` alongside `127.0.0.1`, hence a server bound to
+`anyIPv4`). Two hosts on one server keep the navigation genuinely
+cross-domain — `getBaseDomain` compares IP literals — while keeping a
+network failure impossible, and a scripted navigation keeps the
+scenario off any synthetic touch reaching the platform view.
+
+#### Scenario: A late-committing document is repainted promptly
+
+- **Given** a seeded site whose page withholds its first byte for
+  longer than the repaint nudge's tick budget
+- **When** the suite activates it, so the surface attaches and every
+  issue-time nudge drains before the document commits
+- **Then** the composited webview region shows the page's color within
+  a bounded settle window, which only the settled-side re-nudge
+  (`PAUSE-025`) can produce
+- **And** the deadline is tight on purpose: a blank that clears much
+  later, on some unrelated relayout, is still the bug
 
 #### Scenario: White control page proves the detector is not vacuous
 

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -705,6 +705,90 @@ Both nudges SHALL emit a non-sensitive `SurfaceDiag` line (`trigger=reload -> nu
 
 ---
 
+### Requirement: PAUSE-024 — Surface Repaint On Return From A Pushed Route
+
+On Android, the system SHALL recomposite the surface when an opaque route pushed over a webview screen is popped and the webview becomes visible again. While an opaque `PageRoute` covers the screen its platform view is not composited, and the embedder detaches the hybrid-composition `SurfaceView` from the view hierarchy; the pop re-attaches it, blank, exactly as PAUSE-017's fresh controller does. The pop passes through **none** of the existing chokepoints: the site did not change (`_setCurrentIndex`, PAUSE-015), no controller was created (`onControllerReady`, PAUSE-017), nothing navigated (PAUSE-018/021), and the app never left the foreground (PAUSE-020). Every full-screen route in the app reaches this: site settings, app settings, developer tools, downloads, add-site, the QR scanner, and the nested webview screen.
+
+Each webview-hosting screen SHALL be `RouteAware`, subscribe its own `ModalRoute` to the shared `surfaceRouteObserver` in `didChangeDependencies`, unsubscribe in `dispose`, and fire `_nudgeSurfaceRepaint` from `didPopNext`. The observer SHALL be registered on the app's `MaterialApp.navigatorObservers` and SHALL be typed to `PageRoute`, so a dialog or any other `PopupRoute` — which leaves the webview composited underneath and therefore needs no repaint — cannot trigger a nudge. The main page SHALL emit the non-sensitive `SurfaceDiag` line `trigger=route-return -> nudge` (Android only, no site name or URL), the same diagnostic contract as PAUSE-019/020/021. The nudge is a no-op off Android.
+
+#### Scenario: Returning from site settings
+
+**Given** a site is visible on Android
+**When** the user opens site settings from the overflow menu and then pops back
+**Then** `didPopNext` fires `_nudgeSurfaceRepaint` against the re-attached surface
+**And** the page is visible again without the user rotating, locking, or switching tabs
+
+#### Scenario: Returning from the nested webview screen
+
+**Given** a cross-domain link opened the nested `InAppWebViewScreen` over the main page
+**When** the user pops it
+**Then** the main page repaints through its own `didPopNext`, and the nested screen — which is itself route-aware — would repaint the same way if a route were popped over *it*
+
+#### Scenario: A dialog does not nudge
+
+**Given** a site is visible on Android
+**When** a confirmation dialog or any other popup route opens and closes over it
+**Then** no repaint runs, because the observer is typed to `PageRoute` and the webview stayed composited under the barrier
+
+---
+
+### Requirement: PAUSE-025 — Repaint When The First Document Commits
+
+On Android, the system SHALL repaint the surface when a webview's **first** document commits, not only when a reload's does. PAUSE-021 established that a repaint fired at issue time drains against a surface the new document has not reached yet; the identical ordering applies to a webview that has never painted at all. A freshly created webview attaches a brand-new `SurfaceView` showing its white default fill, both the activation nudge (PAUSE-015) and the controller-attach nudge (PAUSE-017) run and drain within ~0.6s, and the initial load commits an unbounded time later — so on a slow first load nothing repaints after the commit. This is BUG-001 open gap #7, reported 2026-08-13: cold start to the site picker, tap a not-yet-loaded site, white screen.
+
+The commit latch SHALL therefore be armed by more than a reload. `SurfaceRepaintEngine.noteCommitPending` (which `reloadIssued` now delegates to) SHALL be called when a fresh controller attaches for the visible site, and when a site is activated while its main-frame load is still in flight; `consumeLoadSettled` then repaints once the document settles, exactly as it does for a reload. The latch stays one-shot, so an ordinary in-page navigation still does not nudge. The settled nudge SHALL emit the non-sensitive `SurfaceDiag` line `trigger=commit-settled -> nudge` (which subsumes the PAUSE-021 `reload-settled` line), and the attach SHALL emit `trigger=controller-attach -> nudge` — the path was previously diagnostically dark, because `_probeRendererAndRecover` early-returns without logging when a fresh model has no controller yet.
+
+This narrows, but does not close, BUG-001 gap #3: `onLoadingChanged(false)` remains a *proxy* for the commit (it maps to `onLoadStop`, i.e. document parse rather than the compositor's first frame), so a page that paints materially later than load-stop can still outrun it. The durable fix remains a native surface-changed callback.
+
+#### Scenario: First activation of a site whose page commits slowly
+
+**Given** a site that has never been loaded is activated on Android
+**And** its first document takes longer to commit than the nudge's tick budget
+**When** the controller attaches, the nudges drain, and the document finally commits
+**Then** the attach-armed latch is consumed by the settled load and `_nudgeSurfaceRepaint` runs against the committed document
+**And** the page paints instead of staying blank-white
+
+#### Scenario: Activating a site mid-load
+
+**Given** a site is loading in the background and the user switches to it
+**When** `_setCurrentIndex` nudges and its load settles afterwards
+**Then** the activation armed the latch, so the settled commit repaints
+
+#### Scenario: A background site's fresh controller does not repaint the visible one
+
+**Given** a webview is created off-screen while another site is visible
+**When** its controller attaches and its first load settles
+**Then** neither the latch nor the nudge fires, because both host hooks are gated on the model being the visible site
+
+---
+
+### Requirement: PAUSE-026 — The Nested Screen Mirrors The Repaint Lifecycle
+
+`InAppWebViewScreen` SHALL carry the same Android repaint coverage as the main page, because it owns a separate hybrid-composition `SurfaceView` that the main page's nudge cannot reach: that nudge toggles a 1px inset around the `IndexedStack`, which sits *under* the nested route. Whenever the nested screen is the visible webview, a repaint that only runs on the main page is a no-op the user sees as a white screen.
+
+Beyond the back path (PAUSE-018) and the reload funnel (PAUSE-021), which the nested screen already had, it SHALL:
+
+1. Nudge on **controller attach** and arm the commit latch (PAUSE-017 + PAUSE-025). Every mount of this screen is a fresh `SurfaceView` loading a remote entry URL, so it is the most exposed instance of both.
+2. On `AppLifecycleState.resumed`, open a bounded post-resume repaint window and nudge (PAUSE-020), and re-nudge from `didChangeMetrics` while that window is open — the warm-start attach signal. The window timer is cancelled in `dispose`.
+3. Be `RouteAware` and nudge on `didPopNext` (PAUSE-024), for routes pushed over it (developer tools, per-site settings, a further nested webview).
+
+Its webview slot SHALL carry `ValueKey(kNestedWebViewSlotKey)` so the pixel suite can sample the composited window over exactly that rect, the nested counterpart of the main page's `ValueKey(siteId)` slot.
+
+#### Scenario: Warm start with the nested screen on top
+
+**Given** the nested webview screen is the visible webview on Android
+**When** the user backgrounds the app and returns, and the nested `SurfaceView` re-attaches after the resume event
+**Then** the nested screen's own resume nudge and its `didChangeMetrics` re-nudge repaint it
+**And** it does not depend on the main page's nudge, which cannot reach a platform view under this route
+
+#### Scenario: A fresh nested webview on a slow page
+
+**Given** a cross-domain link opens the nested screen on Android
+**When** the entry document commits after the attach nudge has drained
+**Then** the latch armed at controller attach is consumed by the settled load and the surface repaints
+
+---
+
 ### Requirement: PAUSE-022 — Resume Re-Issues A Load Stranded By The Background
 
 The system SHALL re-issue, on `AppLifecycleState.resumed`, a main-frame load of the visible webview that never completed because the app was in the background.

--- a/test/js/surface_repaint_funnel.test.js
+++ b/test/js/surface_repaint_funnel.test.js
@@ -180,3 +180,101 @@ for (const rel of GUARDED) {
     assert.ok(refs >= 2, `expected window-open definition + >=1 call site, found ${refs}`);
   });
 }
+
+// Route-return repaint gate (PAUSE-024 / BUG-001 Attempt 10). An opaque route
+// pushed over a webview screen stops its platform view from being composited,
+// so Android detaches the SurfaceView and re-attaches it blank on the pop.
+// That pop passes through no other chokepoint — same site, same controller, no
+// navigation, no lifecycle event — so every webview-hosting screen must be
+// RouteAware and nudge in didPopNext.
+{
+  test('lib/main.dart: the app registers the surface route observer', () => {
+    const src = linesOf('lib/main.dart').join('\n');
+    assert.match(src, /navigatorObservers:\s*\[[^\]]*surfaceRouteObserver/,
+      'MaterialApp must register surfaceRouteObserver, or no screen is notified');
+  });
+
+  for (const rel of GUARDED) {
+    const lines = linesOf(rel);
+    const src = lines.join('\n');
+
+    test(`${rel}: the webview screen subscribes to the route observer`, () => {
+      assert.match(src, /with\s+[^{]*RouteAware/,
+        'the state class must mix in RouteAware');
+      assert.match(src, /surfaceRouteObserver\.subscribe\(this,\s*route\)/,
+        'didChangeDependencies must subscribe the screen to its PageRoute');
+      assert.match(src, /surfaceRouteObserver\.unsubscribe\(this\)/,
+        'dispose must unsubscribe, or the observer retains a dead State');
+    });
+
+    test(`${rel}: didPopNext repaints the re-attached surface (PAUSE-024)`, () => {
+      const defIdx = lines.findIndex((l) => /void\s+didPopNext\s*\(/.test(l));
+      assert.ok(defIdx >= 0, 'didPopNext override must exist');
+      const body = lines.slice(defIdx, defIdx + 8).join('\n');
+      assert.match(body, /_nudgeSurfaceRepaint\(\)/,
+        'returning from a pushed route must nudge the surface');
+    });
+  }
+}
+
+// First-commit repaint gate (PAUSE-025 / BUG-001 Attempt 10, bug doc gap #7).
+// A freshly-attached SurfaceView shows its white default fill until the first
+// document commits, which on a slow page lands after the attach nudge's ~0.6s
+// budget has drained. The attach must therefore arm the same latch a reload
+// does, so the load-settled signal repaints the committed document.
+{
+  const COMMIT_LATCH = [
+    // file, the attach handler that must arm the latch
+    { file: 'lib/main.dart', handler: /onControllerReady\s*=\s*\(\)\s*\{/ },
+    { file: 'lib/screens/inappbrowser.dart', handler: /onControllerCreated:\s*\(controller\)\s*\{/ },
+  ];
+
+  for (const { file, handler } of COMMIT_LATCH) {
+    test(`${file}: a fresh controller attach latches the first commit`, () => {
+      const lines = linesOf(file);
+      const defIdx = lines.findIndex((l) => handler.test(l));
+      assert.ok(defIdx >= 0, 'the controller-attach handler must exist');
+      const body = lines.slice(defIdx, defIdx + 20).join('\n');
+      assert.match(body, /_surfaceRepaint\.noteCommitPending\(\)/,
+        'the attach must arm the commit latch (PAUSE-025)');
+      assert.match(body, /_nudgeSurfaceRepaint\(\)/,
+        'the attach must also nudge now (PAUSE-017)');
+    });
+  }
+}
+
+// Nested-screen lifecycle parity (PAUSE-020 in InAppWebViewScreen, BUG-001
+// Attempt 10). A warm start re-attaches the nested SurfaceView exactly as it
+// does the main page's, and the main page's nudge cannot reach it: that one
+// toggles an inset around an IndexedStack sitting under this route.
+{
+  const lines = linesOf('lib/screens/inappbrowser.dart');
+  const src = lines.join('\n');
+
+  test('lib/screens/inappbrowser.dart: a resume repaints the nested surface', () => {
+    const defIdx = lines.findIndex((l) =>
+      /void\s+didChangeAppLifecycleState\s*\(/.test(l),
+    );
+    assert.ok(defIdx >= 0, 'the nested screen must observe app lifecycle');
+    const body = lines.slice(defIdx, defIdx + 24).join('\n');
+    assert.match(body, /_openResumeRepaintWindow\(\)/,
+      'a resume must open the post-resume repaint window');
+    assert.match(body, /_nudgeSurfaceRepaint\(\)/,
+      'a resume must nudge the nested surface');
+  });
+
+  test('lib/screens/inappbrowser.dart: didChangeMetrics re-nudges in the window', () => {
+    const defIdx = lines.findIndex((l) => /void\s+didChangeMetrics\s*\(/.test(l));
+    assert.ok(defIdx >= 0, 'didChangeMetrics override must exist');
+    const body = lines.slice(defIdx, defIdx + 12).join('\n');
+    assert.match(body, /_resumeRepaintWindowOpen/,
+      'the re-nudge must be bounded to the post-resume window');
+    assert.match(body, /_nudgeSurfaceRepaint\(\)/,
+      'the attach signal must nudge the nested surface');
+  });
+
+  test('lib/screens/inappbrowser.dart: the resume window timer is cancelled', () => {
+    assert.match(src, /_resumeRepaintWindowTimer\?\.cancel\(\)/,
+      'dispose must cancel the window timer');
+  });
+}

--- a/test/surface_repaint_engine_test.dart
+++ b/test/surface_repaint_engine_test.dart
@@ -242,7 +242,7 @@ void main() {
       final e = SurfaceRepaintEngine();
       e.reloadIssued();
       expect(e.consumeLoadSettled(), isTrue);
-      expect(e.reloadPending, isFalse);
+      expect(e.commitPending, isFalse);
       expect(e.consumeLoadSettled(), isFalse,
           reason: 'an ordinary navigation must not trigger a repaint');
     });
@@ -285,6 +285,78 @@ void main() {
                   : 'reproduction: slow reload left blank-white');
         });
       }
+    });
+  });
+
+  group('first-commit ordering (BUG-001 Attempt 10 / PAUSE-025)', () {
+    // The reload ordering above, reached on a surface that has never painted:
+    // a fresh controller attaches, the activation and controller-attach nudges
+    // drain, and the site's FIRST document commits after them. Before the
+    // latch was armed by the attach, no signal existed on this path at all —
+    // bug doc gap #7.
+
+    test('reproduce: a first commit after the attach nudges is left unpainted',
+        () {
+      fakeAsync((async) {
+        final e = SurfaceRepaintEngine();
+        void nudge() {
+          if (!e.request()) return;
+          void tick() {
+            final t = e.tick();
+            if (t.done) return;
+            Future.delayed(const Duration(milliseconds: 100), tick);
+          }
+
+          tick();
+        }
+
+        e.attach(); // fresh SurfaceView mounts, blank
+        nudge(); // controller-attach nudge, ~600ms of ticks
+        Future.delayed(const Duration(seconds: 3), () {
+          // The initial document commits here, onto a surface the drained
+          // loop never sees again.
+          e.attach();
+        });
+        async.elapse(const Duration(seconds: 6));
+
+        expect(e.owed, isTrue,
+            reason: 'BUG-001 gap #7: the committed document is never painted');
+      });
+    });
+
+    test('fix: the attach arms the latch, the settled commit repaints', () {
+      fakeAsync((async) {
+        final e = SurfaceRepaintEngine();
+        void nudge() {
+          if (!e.request()) return;
+          void tick() {
+            final t = e.tick();
+            if (t.done) return;
+            Future.delayed(const Duration(milliseconds: 100), tick);
+          }
+
+          tick();
+        }
+
+        e.noteCommitPending(); // controller attach, first load in flight
+        e.attach();
+        nudge();
+        Future.delayed(const Duration(seconds: 3), () {
+          if (e.consumeLoadSettled()) nudge();
+        });
+        async.elapse(const Duration(seconds: 6));
+
+        expect(e.owed, isFalse);
+      });
+    });
+
+    test('a reload latch and a first-commit latch are the same one-shot', () {
+      final e = SurfaceRepaintEngine();
+      e.noteCommitPending();
+      e.reloadIssued();
+      expect(e.consumeLoadSettled(), isTrue);
+      expect(e.consumeLoadSettled(), isFalse,
+          reason: 'one pending commit, one repaint');
     });
   });
 }


### PR DESCRIPTION
Closes three reachable surface-repaint paths that prior attempts missed, found by auditing every (re)attach against nudge chokepoints.

**Route return (PAUSE-024):** Both webview-hosting screens now subscribe to a shared `surfaceRouteObserver` registered on `MaterialApp.navigatorObservers`. When an opaque route pops, `didPopNext` fires `_nudgeSurfaceRepaint`. The observer is typed to `PageRoute` so only opaque routes trigger it; dialogs and popup routes, which leave the webview composited under the barrier, do not. Diagnostics: `trigger=route-return -> nudge` (Android only).

**First commit (PAUSE-025):** The reload-pending latch generalized to `noteCommitPending`, armed by both a fresh controller attach and by activating a site whose load is still in flight. `consumeLoadSettled` repaints the committed document exactly as it does for a reload. Diagnostics: `trigger=controller-attach -> nudge` and `trigger=commit-settled -> nudge` (subsumes `reload-settled`). This closes open gap #7: cold start to the site picker, tap a not-yet-loaded site, white screen until the document commits after both fresh-webview nudges drain.

**Nested-screen parity (PAUSE-026):** `InAppWebViewScreen` gained the controller-attach nudge, the post-resume window + `didChangeMetrics` re-nudge, and the route-return nudge. It already had the back path and the reload funnel. The main page's nudge cannot reach the nested screen because it toggles an inset around the `IndexedStack` sitting under the nested route.

Integration test scenarios 7–9 exercise these paths with a slow-committing page (3s delay) to verify the settled-side re-nudge is the only thing that can paint after the issue-time nudges drain. Scenario 9 uses a script-initiated cross-domain navigation to the nested screen via a second loopback address (`127.0.0.2`), keeping the navigation genuinely cross-domain while preventing network failure.

Formal model updated to include `RouteReturn` action; proofs regenerated.

https://claude.ai/code/session_01GemNT1BX4TuxMTcQZ8t5ku