### PR TITLE
NAV-009: Add opt-in back gesture menu opening at history start

### DIFF
--- a/lib/design_gallery/main.dart
+++ b/lib/design_gallery/main.dart
@@ -472,6 +472,8 @@ class _AppSettingsCard extends StatelessWidget {
         onTabStripInFullscreenChanged: (_) {},
         fullscreenOnShortcut: false,
         onFullscreenOnShortcutChanged: (_) {},
+        backOpensMenu: false,
+        onBackOpensMenuChanged: (_) {},
         tabBarButton: true,
         onTabBarButtonChanged: (_) {},
         tabMaxWidth: 180,

--- a/lib/l10n/app_af.arb
+++ b/lib/l10n/app_af.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Beperk hoe wyd elke oortjie kan word sodat lang name kompak bly",
   "appSettingsFullscreenOnShortcut": "Volskerm by kortpad-loods",
   "appSettingsFullscreenOnShortcutSubtitle": "Open in volskerm wanneer dit vanaf 'n tuisskerm-kortpad geloods word",
+  "appSettingsBackOpensMenu": "Terug-gebaar open die kieslys",
+  "appSettingsBackOpensMenuSubtitle": "Wanneer 'n webwerf niks meer het om na toe terug te gaan nie, open die terug-gebaar die sykieslys in plaas daarvan om niks te doen nie. Op Android sluit nog 'n terugdruk die program af.",
   "appSettingsFullscreenTabStrip": "In volskerm, oortjiebalk",
   "appSettingsFullscreenTabStripHidden": "Versteek",
   "appSettingsFullscreenTabStripAlways": "Altyd sigbaar",

--- a/lib/l10n/app_am.arb
+++ b/lib/l10n/app_am.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "ረጅም ስሞች ጥቅጥቅ ብለው እንዲቆዩ እያንዳንዱ ትር ምን ያህል ሊሰፋ እንደሚችል ይገድቡ",
   "appSettingsFullscreenOnShortcut": "በአቋራጭ ሲጀመር ሙሉ ማያ",
   "appSettingsFullscreenOnShortcutSubtitle": "ከመነሻ ማያ አቋራጭ ሲጀመር በሙሉ ማያ ይክፈቱ",
+  "appSettingsBackOpensMenu": "የመመለሻ ምልክት ምናሌውን ይከፍታል",
+  "appSettingsBackOpensMenuSubtitle": "አንድ ጣቢያ የሚመለስበት ገጽ ሲያጣ፣ የመመለሻ ምልክቱ ምንም ከማድረግ ይልቅ የጎን ምናሌውን ይከፍታል። በAndroid ላይ መመለሻን እንደገና መጫን መተግበሪያውን ይዘጋል።",
   "appSettingsFullscreenTabStrip": "በሙሉ ማያ ገጽ፣ የትር አሞሌ",
   "appSettingsFullscreenTabStripHidden": "ተደብቋል",
   "appSettingsFullscreenTabStripAlways": "ሁልጊዜ የሚታይ",

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "حدّد مدى اتساع كل تبويب لإبقاء الأسماء الطويلة مضغوطة",
   "appSettingsFullscreenOnShortcut": "ملء الشاشة عند التشغيل من اختصار",
   "appSettingsFullscreenOnShortcutSubtitle": "افتح بملء الشاشة عند التشغيل من اختصار على الشاشة الرئيسية",
+  "appSettingsBackOpensMenu": "إيماءة الرجوع تفتح القائمة",
+  "appSettingsBackOpensMenuSubtitle": "عندما لا يتبقى في الموقع ما يمكن الرجوع إليه، تفتح إيماءة الرجوع القائمة الجانبية بدلاً من ألا تفعل شيئًا. على Android، يؤدي الضغط على الرجوع مرة أخرى إلى الخروج من التطبيق.",
   "appSettingsFullscreenTabStrip": "في وضع ملء الشاشة، شريط التبويبات",
   "appSettingsFullscreenTabStripHidden": "مخفي",
   "appSettingsFullscreenTabStripAlways": "ظاهر دائمًا",

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Ограничете колко широк може да стане всеки раздел, за да останат дългите имена компактни",
   "appSettingsFullscreenOnShortcut": "Цял екран при стартиране от пряк път",
   "appSettingsFullscreenOnShortcutSubtitle": "Отваряне на цял екран при стартиране от пряк път на началния екран",
+  "appSettingsBackOpensMenu": "Жестът за връщане отваря менюто",
+  "appSettingsBackOpensMenuSubtitle": "Когато в даден сайт няма към какво повече да се върнете, жестът за връщане отваря страничното меню, вместо да не прави нищо. В Android повторното натискане на връщане затваря приложението.",
   "appSettingsFullscreenTabStrip": "На цял екран, лента с раздели",
   "appSettingsFullscreenTabStripHidden": "Скрита",
   "appSettingsFullscreenTabStripAlways": "Винаги видима",

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "দীর্ঘ নাম যাতে সংক্ষিপ্ত থাকে সেজন্য প্রতিটি ট্যাব কতটা চওড়া হতে পারে তা সীমিত করুন",
   "appSettingsFullscreenOnShortcut": "শর্টকাট থেকে চালু হলে পূর্ণ স্ক্রিন",
   "appSettingsFullscreenOnShortcutSubtitle": "হোম-স্ক্রিন শর্টকাট থেকে চালু হলে পূর্ণ স্ক্রিনে খুলুন",
+  "appSettingsBackOpensMenu": "ব্যাক জেসচার মেনু খোলে",
+  "appSettingsBackOpensMenuSubtitle": "কোনও সাইটে ফিরে যাওয়ার মতো কিছু না থাকলে, ব্যাক জেসচার কিছু না করে পাশের মেনু খোলে। Android-এ আবার ব্যাক চাপলে অ্যাপটি বন্ধ হয়ে যায়।",
   "appSettingsFullscreenTabStrip": "ফুলস্ক্রিনে, ট্যাব বার",
   "appSettingsFullscreenTabStripHidden": "লুকানো",
   "appSettingsFullscreenTabStripAlways": "সর্বদা দৃশ্যমান",

--- a/lib/l10n/app_bs.arb
+++ b/lib/l10n/app_bs.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Ograničite koliko svaka kartica može biti široka kako bi duga imena ostala kompaktna",
   "appSettingsFullscreenOnShortcut": "Cijeli ekran pri pokretanju iz prečice",
   "appSettingsFullscreenOnShortcutSubtitle": "Otvori u punom ekranu kada se pokrene iz prečice na početnom ekranu",
+  "appSettingsBackOpensMenu": "Gesta nazad otvara meni",
+  "appSettingsBackOpensMenuSubtitle": "Kada se na stranici nema više čemu vratiti, gesta nazad otvara bočni meni umjesto da ne uradi ništa. Na Androidu ponovni pritisak na nazad zatvara aplikaciju.",
   "appSettingsFullscreenTabStrip": "U punom ekranu, traka kartica",
   "appSettingsFullscreenTabStripHidden": "Skriveno",
   "appSettingsFullscreenTabStripAlways": "Uvijek vidljivo",

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Limita l'amplada de cada pestanya perquè els noms llargs es mantinguin compactes",
   "appSettingsFullscreenOnShortcut": "Pantalla completa en obrir des d'una drecera",
   "appSettingsFullscreenOnShortcutSubtitle": "Obre en pantalla completa quan s'inicia des d'una drecera de la pantalla d'inici",
+  "appSettingsBackOpensMenu": "El gest enrere obre el menú",
+  "appSettingsBackOpensMenuSubtitle": "Quan en un lloc no queda res on tornar enrere, el gest enrere obre el menú lateral en lloc de no fer res. A Android, tornar a prémer enrere tanca l'aplicació.",
   "appSettingsFullscreenTabStrip": "En pantalla completa, barra de pestanyes",
   "appSettingsFullscreenTabStripHidden": "Amagada",
   "appSettingsFullscreenTabStripAlways": "Sempre visible",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Omezte, jak široká může být každá karta, aby dlouhé názvy zůstaly kompaktní",
   "appSettingsFullscreenOnShortcut": "Celá obrazovka při spuštění ze zástupce",
   "appSettingsFullscreenOnShortcutSubtitle": "Otevřít na celou obrazovku při spuštění ze zástupce na ploše",
+  "appSettingsBackOpensMenu": "Gesto zpět otevře nabídku",
+  "appSettingsBackOpensMenuSubtitle": "Když se na webu není kam vrátit, gesto zpět otevře boční nabídku místo toho, aby neudělalo nic. V Androidu další stisknutí zpět ukončí aplikaci.",
   "appSettingsFullscreenTabStrip": "Na celé obrazovce, panel karet",
   "appSettingsFullscreenTabStripHidden": "Skrytý",
   "appSettingsFullscreenTabStripAlways": "Vždy viditelný",

--- a/lib/l10n/app_cy.arb
+++ b/lib/l10n/app_cy.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Cyfyngu pa mor llydan y gall pob tab dyfu fel bod enwau hir yn aros yn gryno",
   "appSettingsFullscreenOnShortcut": "Sgrin lawn wrth lansio o lwybr byr",
   "appSettingsFullscreenOnShortcutSubtitle": "Agor yn sgrin lawn pan gaiff ei lansio o lwybr byr ar y sgrin gartref",
+  "appSettingsBackOpensMenu": "Mae'r ystum yn ôl yn agor y ddewislen",
+  "appSettingsBackOpensMenuSubtitle": "Pan nad oes gan safle ddim byd ar ôl i fynd yn ôl ato, mae'r ystum yn ôl yn agor y ddewislen ochr yn lle gwneud dim. Ar Android, mae gwasgu yn ôl eto yn cau'r rhaglen.",
   "appSettingsFullscreenTabStrip": "Yn y sgrin lawn, bar tabiau",
   "appSettingsFullscreenTabStripHidden": "Cuddiedig",
   "appSettingsFullscreenTabStripAlways": "Gweladwy bob amser",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Begræns hvor bred hver fane kan blive, så lange navne forbliver kompakte",
   "appSettingsFullscreenOnShortcut": "Fuld skærm ved start fra genvej",
   "appSettingsFullscreenOnShortcutSubtitle": "Åbn i fuld skærm, når der startes fra en genvej på startskærmen",
+  "appSettingsBackOpensMenu": "Tilbage-bevægelsen åbner menuen",
+  "appSettingsBackOpensMenuSubtitle": "Når et websted ikke har mere at gå tilbage til, åbner tilbage-bevægelsen sidemenuen i stedet for ikke at gøre noget. På Android lukker endnu et tryk på tilbage appen.",
   "appSettingsFullscreenTabStrip": "I fuld skærm, fanebjælke",
   "appSettingsFullscreenTabStripHidden": "Skjult",
   "appSettingsFullscreenTabStripAlways": "Altid synlig",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Begrenzen, wie breit jeder Tab werden kann, damit lange Namen kompakt bleiben",
   "appSettingsFullscreenOnShortcut": "Vollbild beim Start über Verknüpfung",
   "appSettingsFullscreenOnShortcutSubtitle": "Im Vollbild öffnen, wenn über eine Startbildschirm-Verknüpfung gestartet",
+  "appSettingsBackOpensMenu": "Zurück-Geste öffnet das Menü",
+  "appSettingsBackOpensMenuSubtitle": "Wenn es auf einer Website nichts mehr gibt, wohin zurückgegangen werden kann, öffnet die Zurück-Geste das Seitenmenü, statt nichts zu tun. Unter Android beendet ein weiteres Zurück die App.",
   "appSettingsFullscreenTabStrip": "Im Vollbild, Tableiste",
   "appSettingsFullscreenTabStripHidden": "Ausgeblendet",
   "appSettingsFullscreenTabStripAlways": "Immer sichtbar",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Περιορίστε πόσο φαρδιά μπορεί να γίνει κάθε καρτέλα ώστε τα μεγάλα ονόματα να παραμένουν συμπαγή",
   "appSettingsFullscreenOnShortcut": "Πλήρης οθόνη κατά την εκκίνηση από συντόμευση",
   "appSettingsFullscreenOnShortcutSubtitle": "Άνοιγμα σε πλήρη οθόνη κατά την εκκίνηση από συντόμευση αρχικής οθόνης",
+  "appSettingsBackOpensMenu": "Η χειρονομία επιστροφής ανοίγει το μενού",
+  "appSettingsBackOpensMenuSubtitle": "Όταν σε έναν ιστότοπο δεν υπάρχει τίποτα άλλο για επιστροφή, η χειρονομία επιστροφής ανοίγει το πλαϊνό μενού αντί να μην κάνει τίποτα. Στο Android, μια ακόμη πίεση επιστροφής κλείνει την εφαρμογή.",
   "appSettingsFullscreenTabStrip": "Σε πλήρη οθόνη, γραμμή καρτελών",
   "appSettingsFullscreenTabStripHidden": "Κρυφή",
   "appSettingsFullscreenTabStripAlways": "Πάντα ορατή",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -855,6 +855,14 @@
   "@appSettingsFullscreenOnShortcutSubtitle": {
     "description": "Subtitle for the toggle that enters full screen when a site is opened from a pinned home-screen shortcut"
   },
+  "appSettingsBackOpensMenu": "Back gesture opens the menu",
+  "@appSettingsBackOpensMenu": {
+    "description": "Toggle title in app settings: the system back gesture opens the side menu once the site has no page left to go back to"
+  },
+  "appSettingsBackOpensMenuSubtitle": "Where a site has nothing left to go back to, the back gesture opens the side menu instead of doing nothing. On Android, pressing back again leaves the app.",
+  "@appSettingsBackOpensMenuSubtitle": {
+    "description": "Subtitle for that toggle: at the start of a site's browsing history the back gesture opens the navigation drawer, and a second back press quits the app on Android"
+  },
   "appSettingsFullscreenTabStrip": "In full screen, tab strip",
   "@appSettingsFullscreenTabStrip": {
     "description": "Group label for the choice of how the tab strip behaves in full screen (followed by the Hidden / Always visible options)"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Limita cuánto puede crecer cada pestaña para que los nombres largos se mantengan compactos",
   "appSettingsFullscreenOnShortcut": "Pantalla completa al abrir desde un acceso directo",
   "appSettingsFullscreenOnShortcutSubtitle": "Abrir en pantalla completa cuando se inicia desde un acceso directo de la pantalla de inicio",
+  "appSettingsBackOpensMenu": "El gesto atrás abre el menú",
+  "appSettingsBackOpensMenuSubtitle": "Cuando en un sitio no queda nada a lo que volver, el gesto atrás abre el menú lateral en lugar de no hacer nada. En Android, pulsar atrás otra vez cierra la aplicación.",
   "appSettingsFullscreenTabStrip": "En pantalla completa, barra de pestañas",
   "appSettingsFullscreenTabStripHidden": "Oculta",
   "appSettingsFullscreenTabStripAlways": "Siempre visible",

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Piira, kui laiaks iga vahekaart võib kasvada, et pikad nimed jääksid kompaktseks",
   "appSettingsFullscreenOnShortcut": "Täisekraan otsetee kaudu avamisel",
   "appSettingsFullscreenOnShortcutSubtitle": "Ava täisekraanil, kui käivitatakse avakuva otseteest",
+  "appSettingsBackOpensMenu": "Tagasi-žest avab menüü",
+  "appSettingsBackOpensMenuSubtitle": "Kui saidil pole enam midagi, kuhu tagasi minna, avab tagasi-žest külgmenüü selle asemel, et mitte midagi teha. Androidis sulgeb järgmine tagasivajutus rakenduse.",
   "appSettingsFullscreenTabStrip": "Täisekraanil, vahekaartide riba",
   "appSettingsFullscreenTabStripHidden": "Peidetud",
   "appSettingsFullscreenTabStripAlways": "Alati nähtav",

--- a/lib/l10n/app_eu.arb
+++ b/lib/l10n/app_eu.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Mugatu fitxa bakoitza zenbat zabaldu daitekeen, izen luzeak trinko mantentzeko",
   "appSettingsFullscreenOnShortcut": "Pantaila osoa lasterbidetik abiaraztean",
   "appSettingsFullscreenOnShortcutSubtitle": "Ireki pantaila osoan hasierako pantailako lasterbide batetik abiarazten denean",
+  "appSettingsBackOpensMenu": "Atzera keinuak menua irekitzen du",
+  "appSettingsBackOpensMenuSubtitle": "Gune batean atzera egiteko ezer geratzen ez denean, atzera keinuak alboko menua irekitzen du ezer egin ez ordez. Android-en, atzera berriro sakatzeak aplikazioa ixten du.",
   "appSettingsFullscreenTabStrip": "Pantaila osoan, fitxa-barra",
   "appSettingsFullscreenTabStripHidden": "Ezkutatuta",
   "appSettingsFullscreenTabStripAlways": "Beti ikusgai",

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "محدود کنید هر زبانه چقدر می‌تواند پهن شود تا نام‌های طولانی فشرده بمانند",
   "appSettingsFullscreenOnShortcut": "تمام‌صفحه هنگام اجرا از میان‌بر",
   "appSettingsFullscreenOnShortcutSubtitle": "هنگام اجرا از میان‌بر صفحه اصلی، در حالت تمام‌صفحه باز شود",
+  "appSettingsBackOpensMenu": "حرکت بازگشت منو را باز می‌کند",
+  "appSettingsBackOpensMenuSubtitle": "وقتی در یک سایت چیزی برای بازگشت باقی نمانده باشد، حرکت بازگشت به‌جای اینکه کاری نکند، منوی کناری را باز می‌کند. در Android، فشردن دوبارهٔ بازگشت برنامه را می‌بندد.",
   "appSettingsFullscreenTabStrip": "در تمام‌صفحه، نوار زبانه‌ها",
   "appSettingsFullscreenTabStripHidden": "پنهان",
   "appSettingsFullscreenTabStripAlways": "همیشه نمایان",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Rajoita, kuinka leveäksi kukin välilehti voi kasvaa, jotta pitkät nimet pysyvät tiiviinä",
   "appSettingsFullscreenOnShortcut": "Koko näyttö pikakuvakkeesta käynnistettäessä",
   "appSettingsFullscreenOnShortcutSubtitle": "Avaa koko näytöllä, kun käynnistetään aloitusnäytön pikakuvakkeesta",
+  "appSettingsBackOpensMenu": "Takaisin-ele avaa valikon",
+  "appSettingsBackOpensMenuSubtitle": "Kun sivustolla ei ole enää mitään, mihin palata, takaisin-ele avaa sivuvalikon sen sijaan, että se ei tekisi mitään. Androidissa uusi takaisin-painallus sulkee sovelluksen.",
   "appSettingsFullscreenTabStrip": "Koko näytössä, välilehtipalkki",
   "appSettingsFullscreenTabStripHidden": "Piilotettu",
   "appSettingsFullscreenTabStripAlways": "Aina näkyvissä",

--- a/lib/l10n/app_fil.arb
+++ b/lib/l10n/app_fil.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Limitahan kung gaano kalapad ang bawat tab para manatiling compact ang mahahabang pangalan",
   "appSettingsFullscreenOnShortcut": "Full screen kapag binuksan mula sa shortcut",
   "appSettingsFullscreenOnShortcutSubtitle": "Buksan sa full screen kapag inilunsad mula sa shortcut sa home screen",
+  "appSettingsBackOpensMenu": "Binubuksan ng galaw pabalik ang menu",
+  "appSettingsBackOpensMenuSubtitle": "Kapag wala nang mababalikan sa isang site, binubuksan ng galaw pabalik ang gilid na menu sa halip na walang gawin. Sa Android, isinasara ng susunod na pagpindot pabalik ang app.",
   "appSettingsFullscreenTabStrip": "Sa full screen, tab bar",
   "appSettingsFullscreenTabStripHidden": "Nakatago",
   "appSettingsFullscreenTabStripAlways": "Palaging nakikita",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Limiter la largeur de chaque onglet pour que les noms longs restent compacts",
   "appSettingsFullscreenOnShortcut": "Plein écran au lancement depuis un raccourci",
   "appSettingsFullscreenOnShortcutSubtitle": "Ouvrir en plein écran au lancement depuis un raccourci de l'écran d'accueil",
+  "appSettingsBackOpensMenu": "Le geste retour ouvre le menu",
+  "appSettingsBackOpensMenuSubtitle": "Lorsqu'un site n'a plus rien vers quoi revenir, le geste retour ouvre le menu latéral au lieu de ne rien faire. Sous Android, appuyer de nouveau sur retour quitte l'application.",
   "appSettingsFullscreenTabStrip": "En plein écran, barre d'onglets",
   "appSettingsFullscreenTabStripHidden": "Masquée",
   "appSettingsFullscreenTabStripAlways": "Toujours visible",

--- a/lib/l10n/app_ga.arb
+++ b/lib/l10n/app_ga.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Cuir teorainn le leithead gach cluaisín ionas go bhfanfaidh ainmneacha fada dlúth",
   "appSettingsFullscreenOnShortcut": "Lánscáileán nuair a sheoltar ó aicearra",
   "appSettingsFullscreenOnShortcutSubtitle": "Oscail i lánscáileán nuair a sheoltar ó aicearra ar an scáileán baile",
+  "appSettingsBackOpensMenu": "Osclaíonn an gotha ar ais an roghchlár",
+  "appSettingsBackOpensMenuSubtitle": "Nuair nach bhfuil aon rud fágtha ar shuíomh le filleadh air, osclaíonn an gotha ar ais an roghchlár taoibh in ionad gan aon rud a dhéanamh. Ar Android, dúnann brú eile ar ais an feidhmchlár.",
   "appSettingsFullscreenTabStrip": "Sa scáileán iomlán, barra cluaisíní",
   "appSettingsFullscreenTabStripHidden": "Folaithe",
   "appSettingsFullscreenTabStripAlways": "Le feiceáil i gcónaí",

--- a/lib/l10n/app_gl.arb
+++ b/lib/l10n/app_gl.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Limita canto pode medrar cada lapela para que os nomes longos se manteñan compactos",
   "appSettingsFullscreenOnShortcut": "Pantalla completa ao iniciar desde un atallo",
   "appSettingsFullscreenOnShortcutSubtitle": "Abrir en pantalla completa cando se inicia desde un atallo da pantalla de inicio",
+  "appSettingsBackOpensMenu": "O xesto atrás abre o menú",
+  "appSettingsBackOpensMenuSubtitle": "Cando nun sitio non queda nada ao que volver, o xesto atrás abre o menú lateral no canto de non facer nada. En Android, premer atrás outra vez pecha a aplicación.",
   "appSettingsFullscreenTabStrip": "En pantalla completa, barra de lapelas",
   "appSettingsFullscreenTabStripHidden": "Agochada",
   "appSettingsFullscreenTabStripAlways": "Sempre visible",

--- a/lib/l10n/app_gu.arb
+++ b/lib/l10n/app_gu.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "દરેક ટૅબ કેટલી પહોળી થઈ શકે તે મર્યાદિત કરો જેથી લાંબા નામ સંકુચિત રહે",
   "appSettingsFullscreenOnShortcut": "શૉર્ટકટથી શરૂ થાય ત્યારે પૂર્ણ સ્ક્રીન",
   "appSettingsFullscreenOnShortcutSubtitle": "હોમ-સ્ક્રીન શૉર્ટકટથી શરૂ થાય ત્યારે પૂર્ણ સ્ક્રીનમાં ખોલો",
+  "appSettingsBackOpensMenu": "પાછળ જવાનો સંકેત મેનૂ ખોલે છે",
+  "appSettingsBackOpensMenuSubtitle": "જ્યારે સાઇટ પર પાછા જવા માટે કંઈ બાકી ન હોય, ત્યારે પાછળનો સંકેત કંઈ ન કરવાને બદલે બાજુનું મેનૂ ખોલે છે. Android પર ફરીથી પાછળ દબાવવાથી ઍપ બંધ થાય છે.",
   "appSettingsFullscreenTabStrip": "પૂર્ણ સ્ક્રીનમાં, ટૅબ બાર",
   "appSettingsFullscreenTabStripHidden": "છુપાયેલ",
   "appSettingsFullscreenTabStripAlways": "હંમેશા દૃશ્યમાન",

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "הגבל את רוחב כל כרטיסייה כדי ששמות ארוכים יישארו קומפקטיים",
   "appSettingsFullscreenOnShortcut": "מסך מלא בהפעלה מקיצור דרך",
   "appSettingsFullscreenOnShortcutSubtitle": "פתח במסך מלא בעת הפעלה מקיצור דרך במסך הבית",
+  "appSettingsBackOpensMenu": "מחוות החזרה פותחת את התפריט",
+  "appSettingsBackOpensMenuSubtitle": "כשבאתר לא נותר לאן לחזור, מחוות החזרה פותחת את התפריט הצדי במקום לא לעשות דבר. ב-Android, לחיצה נוספת על חזרה סוגרת את האפליקציה.",
   "appSettingsFullscreenTabStrip": "במסך מלא, סרגל כרטיסיות",
   "appSettingsFullscreenTabStripHidden": "מוסתר",
   "appSettingsFullscreenTabStripAlways": "תמיד גלוי",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "सीमित करें कि प्रत्येक टैब कितना चौड़ा हो सकता है ताकि लंबे नाम संक्षिप्त रहें",
   "appSettingsFullscreenOnShortcut": "शॉर्टकट से खोलने पर फ़ुल स्क्रीन",
   "appSettingsFullscreenOnShortcutSubtitle": "होम-स्क्रीन शॉर्टकट से लॉन्च होने पर फ़ुल स्क्रीन में खोलें",
+  "appSettingsBackOpensMenu": "बैक जेस्चर मेन्यू खोलता है",
+  "appSettingsBackOpensMenuSubtitle": "जब किसी साइट पर वापस जाने के लिए कुछ नहीं बचता, तो बैक जेस्चर कुछ न करने के बजाय साइड मेन्यू खोलता है। Android पर फिर से बैक दबाने पर ऐप बंद हो जाता है।",
   "appSettingsFullscreenTabStrip": "फ़ुल स्क्रीन में, टैब बार",
   "appSettingsFullscreenTabStripHidden": "छिपा हुआ",
   "appSettingsFullscreenTabStripAlways": "हमेशा दृश्यमान",

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Ograničite koliko svaka kartica može biti široka kako bi dugačka imena ostala kompaktna",
   "appSettingsFullscreenOnShortcut": "Cijeli zaslon pri pokretanju iz prečaca",
   "appSettingsFullscreenOnShortcutSubtitle": "Otvori u punom zaslonu kada se pokrene iz prečaca na početnom zaslonu",
+  "appSettingsBackOpensMenu": "Gesta natrag otvara izbornik",
+  "appSettingsBackOpensMenuSubtitle": "Kada se na stranici nema više čemu vratiti, gesta natrag otvara bočni izbornik umjesto da ne učini ništa. Na Androidu sljedeći pritisak natrag zatvara aplikaciju.",
   "appSettingsFullscreenTabStrip": "U punom zaslonu, traka kartica",
   "appSettingsFullscreenTabStripHidden": "Skriveno",
   "appSettingsFullscreenTabStripAlways": "Uvijek vidljivo",

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Korlátozza, milyen széles lehet az egyes lapok, hogy a hosszú nevek tömörek maradjanak",
   "appSettingsFullscreenOnShortcut": "Teljes képernyő parancsikonból indításkor",
   "appSettingsFullscreenOnShortcutSubtitle": "Megnyitás teljes képernyőn, ha a kezdőképernyő parancsikonjából indul",
+  "appSettingsBackOpensMenu": "A vissza mozdulat megnyitja a menüt",
+  "appSettingsBackOpensMenuSubtitle": "Ha egy oldalon már nincs hová visszalépni, a vissza mozdulat az oldalsó menüt nyitja meg ahelyett, hogy nem tenne semmit. Androidon az újabb vissza megnyomása bezárja az alkalmazást.",
   "appSettingsFullscreenTabStrip": "Teljes képernyőn, lapsáv",
   "appSettingsFullscreenTabStripHidden": "Rejtett",
   "appSettingsFullscreenTabStripAlways": "Mindig látható",

--- a/lib/l10n/app_hy.arb
+++ b/lib/l10n/app_hy.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Սահմանափակեք, թե որքան լայն կարող է լինել յուրաքանչյուր ներդիր, որպեսզի երկար անունները մնան կոմպակտ",
   "appSettingsFullscreenOnShortcut": "Լրիվ էկրան դյուրանցումից բացելիս",
   "appSettingsFullscreenOnShortcutSubtitle": "Բացել լրիվ էկրանով, երբ գործարկվում է հիմնական էկրանի դյուրանցումից",
+  "appSettingsBackOpensMenu": "Հետ ժեստը բացում է ընտրացանկը",
+  "appSettingsBackOpensMenuSubtitle": "Երբ կայքում այլևս ոչինչ չկա, ուր վերադառնալ, հետ ժեստը ոչինչ չանելու փոխարեն բացում է կողային ընտրացանկը։ Android-ում հետ կրկին սեղմելը փակում է հավելվածը։",
   "appSettingsFullscreenTabStrip": "Ամբողջ էկրանին, ներդիրների գոտի",
   "appSettingsFullscreenTabStripHidden": "Թաքնված",
   "appSettingsFullscreenTabStripAlways": "Միշտ տեսանելի",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Batasi seberapa lebar setiap tab agar nama yang panjang tetap ringkas",
   "appSettingsFullscreenOnShortcut": "Layar penuh saat dibuka dari pintasan",
   "appSettingsFullscreenOnShortcutSubtitle": "Buka dalam layar penuh saat diluncurkan dari pintasan layar beranda",
+  "appSettingsBackOpensMenu": "Gestur kembali membuka menu",
+  "appSettingsBackOpensMenuSubtitle": "Saat tidak ada lagi tujuan untuk kembali di sebuah situs, gestur kembali membuka menu samping alih-alih tidak melakukan apa pun. Di Android, menekan kembali sekali lagi menutup aplikasi.",
   "appSettingsFullscreenTabStrip": "Di layar penuh, bilah tab",
   "appSettingsFullscreenTabStripHidden": "Tersembunyi",
   "appSettingsFullscreenTabStripAlways": "Selalu terlihat",

--- a/lib/l10n/app_is.arb
+++ b/lib/l10n/app_is.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Takmarkaðu hversu breiður hver flipi getur orðið svo löng nöfn haldist samanþjöppuð",
   "appSettingsFullscreenOnShortcut": "Allur skjárinn þegar ræst er úr flýtileið",
   "appSettingsFullscreenOnShortcutSubtitle": "Opna á öllum skjánum þegar ræst er úr flýtileið á heimaskjá",
+  "appSettingsBackOpensMenu": "Til baka-bendingin opnar valmyndina",
+  "appSettingsBackOpensMenuSubtitle": "Þegar ekkert er eftir til að fara til baka í á vefsvæði opnar til baka-bendingin hliðarvalmyndina í stað þess að gera ekkert. Í Android lokar annar til baka-smellur forritinu.",
   "appSettingsFullscreenTabStrip": "Í fullum skjá, flipastika",
   "appSettingsFullscreenTabStripHidden": "Falin",
   "appSettingsFullscreenTabStripAlways": "Alltaf sýnileg",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Limita quanto può diventare larga ogni scheda in modo che i nomi lunghi restino compatti",
   "appSettingsFullscreenOnShortcut": "Schermo intero all'avvio da scorciatoia",
   "appSettingsFullscreenOnShortcutSubtitle": "Apri a schermo intero quando avviato da una scorciatoia della schermata Home",
+  "appSettingsBackOpensMenu": "Il gesto Indietro apre il menu",
+  "appSettingsBackOpensMenuSubtitle": "Quando in un sito non c'è più nulla a cui tornare, il gesto Indietro apre il menu laterale invece di non fare nulla. Su Android, premere di nuovo Indietro chiude l'app.",
   "appSettingsFullscreenTabStrip": "A schermo intero, barra delle schede",
   "appSettingsFullscreenTabStripHidden": "Nascosta",
   "appSettingsFullscreenTabStripAlways": "Sempre visibile",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "長い名前がコンパクトに収まるよう、各タブの幅を制限します",
   "appSettingsFullscreenOnShortcut": "ショートカットからの起動時に全画面",
   "appSettingsFullscreenOnShortcutSubtitle": "ホーム画面のショートカットから起動したときに全画面で開く",
+  "appSettingsBackOpensMenu": "戻る操作でメニューを開く",
+  "appSettingsBackOpensMenuSubtitle": "サイト内に戻る先が残っていないとき、戻る操作は何もしない代わりにサイドメニューを開きます。Android では、もう一度戻る操作を行うとアプリを終了します。",
   "appSettingsFullscreenTabStrip": "全画面でのタブバー",
   "appSettingsFullscreenTabStripHidden": "非表示",
   "appSettingsFullscreenTabStripAlways": "常に表示",

--- a/lib/l10n/app_ka.arb
+++ b/lib/l10n/app_ka.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "შეზღუდე, რამდენად განიერი შეიძლება იყოს თითოეული ჩანართი, რომ გრძელი სახელები კომპაქტური დარჩეს",
   "appSettingsFullscreenOnShortcut": "სრული ეკრანი მალსახმობიდან გაშვებისას",
   "appSettingsFullscreenOnShortcutSubtitle": "გახსენით სრულ ეკრანზე, როცა მთავარი ეკრანის მალსახმობიდან ეშვება",
+  "appSettingsBackOpensMenu": "უკან ჟესტი ხსნის მენიუს",
+  "appSettingsBackOpensMenuSubtitle": "როცა საიტზე დასაბრუნებელი აღარაფერია, უკან ჟესტი არაფრის კეთების ნაცვლად ხსნის გვერდით მენიუს. Android-ზე უკან ხელახლა დაჭერა ხურავს აპლიკაციას.",
   "appSettingsFullscreenTabStrip": "სრულ ეკრანზე, ჩანართების ზოლი",
   "appSettingsFullscreenTabStripHidden": "დამალული",
   "appSettingsFullscreenTabStripAlways": "ყოველთვის ხილული",

--- a/lib/l10n/app_km.arb
+++ b/lib/l10n/app_km.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "កំណត់ទទឹងអតិបរមានៃផ្ទាំងនីមួយៗ ដើម្បីឱ្យឈ្មោះវែងនៅតែបង្រួម",
   "appSettingsFullscreenOnShortcut": "ពេញអេក្រង់ពេលបើកពីផ្លូវកាត់",
   "appSettingsFullscreenOnShortcutSubtitle": "បើកក្នុងពេញអេក្រង់ពេលបើកដំណើរការពីផ្លូវកាត់អេក្រង់ដើម",
+  "appSettingsBackOpensMenu": "កាយវិការត្រឡប់ក្រោយបើកម៉ឺនុយ",
+  "appSettingsBackOpensMenuSubtitle": "នៅពេលគេហទំព័រគ្មានអ្វីត្រឡប់ក្រោយទៀត កាយវិការត្រឡប់ក្រោយនឹងបើកម៉ឺនុយចំហៀង ជំនួសឱ្យការមិនធ្វើអ្វីទាំងអស់។ នៅលើ Android ការចុចត្រឡប់ក្រោយម្ដងទៀតនឹងបិទកម្មវិធី។",
   "appSettingsFullscreenTabStrip": "ក្នុងអេក្រង់ពេញ របារផ្ទាំង",
   "appSettingsFullscreenTabStripHidden": "លាក់",
   "appSettingsFullscreenTabStripAlways": "បង្ហាញជានិច្ច",

--- a/lib/l10n/app_kn.arb
+++ b/lib/l10n/app_kn.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "ಉದ್ದದ ಹೆಸರುಗಳು ಸಾಂದ್ರವಾಗಿರಲು ಪ್ರತಿ ಟ್ಯಾಬ್ ಎಷ್ಟು ಅಗಲವಾಗಬಹುದು ಎಂಬುದನ್ನು ಮಿತಿಗೊಳಿಸಿ",
   "appSettingsFullscreenOnShortcut": "ಶಾರ್ಟ್‌ಕಟ್‌ನಿಂದ ತೆರೆದಾಗ ಪೂರ್ಣ ಪರದೆ",
   "appSettingsFullscreenOnShortcutSubtitle": "ಮುಖಪುಟ ಪರದೆಯ ಶಾರ್ಟ್‌ಕಟ್‌ನಿಂದ ಪ್ರಾರಂಭಿಸಿದಾಗ ಪೂರ್ಣ ಪರದೆಯಲ್ಲಿ ತೆರೆಯಿರಿ",
+  "appSettingsBackOpensMenu": "ಹಿಂದಿನ ಸನ್ನೆ ಮೆನುವನ್ನು ತೆರೆಯುತ್ತದೆ",
+  "appSettingsBackOpensMenuSubtitle": "ಸೈಟ್‌ನಲ್ಲಿ ಹಿಂದಕ್ಕೆ ಹೋಗಲು ಏನೂ ಉಳಿದಿಲ್ಲದಿದ್ದಾಗ, ಹಿಂದಿನ ಸನ್ನೆ ಏನೂ ಮಾಡದಿರುವ ಬದಲು ಪಕ್ಕದ ಮೆನುವನ್ನು ತೆರೆಯುತ್ತದೆ. Android ನಲ್ಲಿ ಮತ್ತೆ ಹಿಂದೆ ಒತ್ತಿದರೆ ಆ್ಯಪ್ ಮುಚ್ಚುತ್ತದೆ.",
   "appSettingsFullscreenTabStrip": "ಪೂರ್ಣ ಪರದೆಯಲ್ಲಿ, ಟ್ಯಾಬ್ ಬಾರ್",
   "appSettingsFullscreenTabStripHidden": "ಮರೆಮಾಡಲಾಗಿದೆ",
   "appSettingsFullscreenTabStripAlways": "ಯಾವಾಗಲೂ ಗೋಚರ",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "긴 이름이 간결하게 유지되도록 각 탭이 넓어질 수 있는 정도를 제한합니다",
   "appSettingsFullscreenOnShortcut": "바로가기로 실행 시 전체 화면",
   "appSettingsFullscreenOnShortcutSubtitle": "홈 화면 바로가기로 실행할 때 전체 화면으로 열기",
+  "appSettingsBackOpensMenu": "뒤로 제스처로 메뉴 열기",
+  "appSettingsBackOpensMenuSubtitle": "사이트에서 더 이상 뒤로 갈 곳이 없을 때, 뒤로 제스처가 아무것도 하지 않는 대신 사이드 메뉴를 엽니다. Android에서는 뒤로를 한 번 더 누르면 앱이 종료됩니다.",
   "appSettingsFullscreenTabStrip": "전체 화면에서 탭 바",
   "appSettingsFullscreenTabStripHidden": "숨김",
   "appSettingsFullscreenTabStripAlways": "항상 표시",

--- a/lib/l10n/app_la.arb
+++ b/lib/l10n/app_la.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Limita quantum quaeque tabula latescere possit ut nomina longa compacta maneant",
   "appSettingsFullscreenOnShortcut": "Plena pictura cum e compendio aperitur",
   "appSettingsFullscreenOnShortcutSubtitle": "In plena pictura aperi cum e compendio paginae principalis initur",
+  "appSettingsBackOpensMenu": "Gestus retro menu aperit",
+  "appSettingsBackOpensMenuSubtitle": "Cum in loco nihil superest quo redeatur, gestus retro menu laterale aperit potius quam nihil agat. In Android, iterum retro premere applicationem claudit.",
   "appSettingsFullscreenTabStrip": "In pleno schemate, series tabularum",
   "appSettingsFullscreenTabStripHidden": "Occultata",
   "appSettingsFullscreenTabStripAlways": "Semper visibilis",

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Apribokite, kokio pločio gali būti kiekviena kortelė, kad ilgi pavadinimai liktų kompaktiški",
   "appSettingsFullscreenOnShortcut": "Visas ekranas paleidžiant iš nuorodos",
   "appSettingsFullscreenOnShortcutSubtitle": "Atidaryti per visą ekraną, kai paleidžiama iš pradžios ekrano nuorodos",
+  "appSettingsBackOpensMenu": "Grįžimo gestas atveria meniu",
+  "appSettingsBackOpensMenuSubtitle": "Kai svetainėje nebėra kur grįžti, grįžimo gestas atveria šoninį meniu, užuot nieko nedaręs. „Android“ sistemoje dar kartą paspaudus grįžimą programa užveriama.",
   "appSettingsFullscreenTabStrip": "Viso ekrano režime, kortelių juosta",
   "appSettingsFullscreenTabStripHidden": "Paslėpta",
   "appSettingsFullscreenTabStripAlways": "Visada matoma",

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Ierobežojiet, cik plata var kļūt katra cilne, lai gari nosaukumi paliktu kompakti",
   "appSettingsFullscreenOnShortcut": "Pilnekrāns, palaižot no saīsnes",
   "appSettingsFullscreenOnShortcutSubtitle": "Atvērt pilnekrānā, kad palaiž no sākuma ekrāna saīsnes",
+  "appSettingsBackOpensMenu": "Atpakaļ žests atver izvēlni",
+  "appSettingsBackOpensMenuSubtitle": "Kad vietnē vairs nav, uz kurieni atgriezties, atpakaļ žests atver sānu izvēlni, nevis nedara neko. Android ierīcēs atkārtota atpakaļ nospiešana aizver lietotni.",
   "appSettingsFullscreenTabStrip": "Pilnekrānā, ciļņu josla",
   "appSettingsFullscreenTabStripHidden": "Slēpta",
   "appSettingsFullscreenTabStripAlways": "Vienmēr redzama",

--- a/lib/l10n/app_mk.arb
+++ b/lib/l10n/app_mk.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Ограничете колку широко може да стане секое јазиче за да останат долгите имиња компактни",
   "appSettingsFullscreenOnShortcut": "Цел екран при отворање од кратенка",
   "appSettingsFullscreenOnShortcutSubtitle": "Отвори на цел екран кога се стартува од кратенка на почетниот екран",
+  "appSettingsBackOpensMenu": "Гестот назад го отвора менито",
+  "appSettingsBackOpensMenuSubtitle": "Кога на страницата нема повеќе каде да се вратите, гестот назад го отвора страничното мени наместо да не прави ништо. На Android, повторното притискање назад ја затвора апликацијата.",
   "appSettingsFullscreenTabStrip": "На цел екран, лента со јазичиња",
   "appSettingsFullscreenTabStripHidden": "Скриено",
   "appSettingsFullscreenTabStripAlways": "Секогаш видливо",

--- a/lib/l10n/app_ml.arb
+++ b/lib/l10n/app_ml.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "നീണ്ട പേരുകൾ ഒതുക്കമായി നിലനിൽക്കാൻ ഓരോ ടാബും എത്രമാത്രം വീതിയാകാം എന്നത് പരിമിതപ്പെടുത്തുക",
   "appSettingsFullscreenOnShortcut": "കുറുക്കുവഴിയിൽ നിന്ന് തുറക്കുമ്പോൾ പൂർണ്ണ സ്ക്രീൻ",
   "appSettingsFullscreenOnShortcutSubtitle": "ഹോം-സ്ക്രീൻ കുറുക്കുവഴിയിൽ നിന്ന് സമാരംഭിക്കുമ്പോൾ പൂർണ്ണ സ്ക്രീനിൽ തുറക്കുക",
+  "appSettingsBackOpensMenu": "പിന്നോട്ട് ആംഗ്യം മെനു തുറക്കുന്നു",
+  "appSettingsBackOpensMenuSubtitle": "ഒരു സൈറ്റിൽ പിന്നോട്ട് പോകാൻ ഒന്നും ബാക്കിയില്ലാത്തപ്പോൾ, പിന്നോട്ട് ആംഗ്യം ഒന്നും ചെയ്യാതിരിക്കുന്നതിനു പകരം സൈഡ് മെനു തുറക്കുന്നു. Android-ൽ വീണ്ടും പിന്നോട്ട് അമർത്തിയാൽ ആപ്പ് അടയ്ക്കും.",
   "appSettingsFullscreenTabStrip": "പൂർണ്ണ സ്ക്രീനിൽ, ടാബ് ബാർ",
   "appSettingsFullscreenTabStripHidden": "മറച്ചിരിക്കുന്നു",
   "appSettingsFullscreenTabStripAlways": "എപ്പോഴും ദൃശ്യം",

--- a/lib/l10n/app_mn.arb
+++ b/lib/l10n/app_mn.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Урт нэрс нягт байхын тулд таб бүр хэр өргөн болохыг хязгаарлана",
   "appSettingsFullscreenOnShortcut": "Товчлолоор нээхэд бүтэн дэлгэц",
   "appSettingsFullscreenOnShortcutSubtitle": "Үндсэн дэлгэцийн товчлолоор эхлүүлэхэд бүтэн дэлгэцээр нээх",
+  "appSettingsBackOpensMenu": "Буцах зангаа цэсийг нээнэ",
+  "appSettingsBackOpensMenuSubtitle": "Сайт дээр буцах зүйл үлдээгүй үед буцах зангаа юу ч хийхгүй байхын оронд хажуугийн цэсийг нээнэ. Android дээр дахин буцахыг дарвал програм хаагдана.",
   "appSettingsFullscreenTabStrip": "Бүтэн дэлгэцэд, таб самбар",
   "appSettingsFullscreenTabStripHidden": "Нуусан",
   "appSettingsFullscreenTabStripAlways": "Үргэлж харагдана",

--- a/lib/l10n/app_mr.arb
+++ b/lib/l10n/app_mr.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "लांब नावे संक्षिप्त राहावीत म्हणून प्रत्येक टॅब किती रुंद होऊ शकतो ते मर्यादित करा",
   "appSettingsFullscreenOnShortcut": "शॉर्टकटवरून उघडल्यावर पूर्ण स्क्रीन",
   "appSettingsFullscreenOnShortcutSubtitle": "होम-स्क्रीन शॉर्टकटवरून सुरू केल्यावर पूर्ण स्क्रीनमध्ये उघडा",
+  "appSettingsBackOpensMenu": "मागे जाण्याचा हावभाव मेनू उघडतो",
+  "appSettingsBackOpensMenuSubtitle": "साइटवर मागे जाण्यासाठी काहीही शिल्लक नसताना, मागे जाण्याचा हावभाव काहीच न करण्याऐवजी बाजूचा मेनू उघडतो. Android वर पुन्हा मागे दाबल्यास अ‍ॅप बंद होते.",
   "appSettingsFullscreenTabStrip": "पूर्ण स्क्रीनमध्ये, टॅब बार",
   "appSettingsFullscreenTabStripHidden": "लपवलेले",
   "appSettingsFullscreenTabStripAlways": "नेहमी दृश्यमान",

--- a/lib/l10n/app_ms.arb
+++ b/lib/l10n/app_ms.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Hadkan sejauh mana setiap tab boleh melebar supaya nama panjang kekal padat",
   "appSettingsFullscreenOnShortcut": "Skrin penuh apabila dilancarkan dari pintasan",
   "appSettingsFullscreenOnShortcutSubtitle": "Buka dalam skrin penuh apabila dilancarkan dari pintasan skrin utama",
+  "appSettingsBackOpensMenu": "Gerak isyarat kembali membuka menu",
+  "appSettingsBackOpensMenuSubtitle": "Apabila tiada lagi tempat untuk kembali di sesebuah tapak, gerak isyarat kembali membuka menu sisi dan bukannya tidak melakukan apa-apa. Pada Android, menekan kembali sekali lagi menutup aplikasi.",
   "appSettingsFullscreenTabStrip": "Dalam skrin penuh, bar tab",
   "appSettingsFullscreenTabStripHidden": "Tersembunyi",
   "appSettingsFullscreenTabStripAlways": "Sentiasa kelihatan",

--- a/lib/l10n/app_mt.arb
+++ b/lib/l10n/app_mt.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Illimita kemm jista' jikber wiesa' kull tab biex ismijiet twal jibqgħu kompatti",
   "appSettingsFullscreenOnShortcut": "Skrin sħiħ meta jitnieda minn shortcut",
   "appSettingsFullscreenOnShortcutSubtitle": "Iftaħ fi skrin sħiħ meta jitnieda minn shortcut tal-iskrin tad-dar",
+  "appSettingsBackOpensMenu": "Il-ġest lura jiftaħ il-menu",
+  "appSettingsBackOpensMenuSubtitle": "Meta f'sit ma jibqa' xejn fejn tmur lura, il-ġest lura jiftaħ il-menu tal-ġenb minflok ma jagħmel xejn. Fuq Android, għafas lura darb'oħra biex toħroġ mill-app.",
   "appSettingsFullscreenTabStrip": "Fl-iskrin sħiħ, bar tat-tabs",
   "appSettingsFullscreenTabStripHidden": "Moħbi",
   "appSettingsFullscreenTabStripAlways": "Dejjem viżibbli",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Begrens hvor bred hver fane kan bli, slik at lange navn forblir kompakte",
   "appSettingsFullscreenOnShortcut": "Fullskjerm ved oppstart fra snarvei",
   "appSettingsFullscreenOnShortcutSubtitle": "Åpne i fullskjerm når den startes fra en snarvei på startskjermen",
+  "appSettingsBackOpensMenu": "Tilbake-bevegelsen åpner menyen",
+  "appSettingsBackOpensMenuSubtitle": "Når et nettsted ikke har mer å gå tilbake til, åpner tilbake-bevegelsen sidemenyen i stedet for å ikke gjøre noe. På Android lukker nok et tilbake-trykk appen.",
   "appSettingsFullscreenTabStrip": "I fullskjerm, fanelinje",
   "appSettingsFullscreenTabStripHidden": "Skjult",
   "appSettingsFullscreenTabStripAlways": "Alltid synlig",

--- a/lib/l10n/app_ne.arb
+++ b/lib/l10n/app_ne.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "लामो नामहरू सङ्कुचित रहून् भनेर प्रत्येक ट्याब कति चौडा हुन सक्छ भनेर सीमित गर्नुहोस्",
   "appSettingsFullscreenOnShortcut": "सर्टकटबाट सुरु गर्दा फुल स्क्रिन",
   "appSettingsFullscreenOnShortcutSubtitle": "होम-स्क्रिन सर्टकटबाट सुरु हुँदा फुल स्क्रिनमा खोल्नुहोस्",
+  "appSettingsBackOpensMenu": "पछाडि जाने इसाराले मेनु खोल्छ",
+  "appSettingsBackOpensMenuSubtitle": "साइटमा पछाडि जान केही बाँकी नभएको बेला, पछाडि जाने इसाराले केही नगर्नुको सट्टा छेउको मेनु खोल्छ। Android मा फेरि पछाडि थिच्दा एप बन्द हुन्छ।",
   "appSettingsFullscreenTabStrip": "पूर्ण स्क्रिनमा, ट्याब बार",
   "appSettingsFullscreenTabStripHidden": "लुकाइएको",
   "appSettingsFullscreenTabStripAlways": "सधैं देखिने",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Beperk hoe breed elke tab kan worden zodat lange namen compact blijven",
   "appSettingsFullscreenOnShortcut": "Volledig scherm bij starten via snelkoppeling",
   "appSettingsFullscreenOnShortcutSubtitle": "Open in volledig scherm bij starten vanaf een snelkoppeling op het startscherm",
+  "appSettingsBackOpensMenu": "Terug-gebaar opent het menu",
+  "appSettingsBackOpensMenuSubtitle": "Wanneer er op een site niets meer is om naar terug te gaan, opent het terug-gebaar het zijmenu in plaats van niets te doen. Op Android sluit nogmaals op terug drukken de app.",
   "appSettingsFullscreenTabStrip": "In volledig scherm, tabbalk",
   "appSettingsFullscreenTabStripHidden": "Verborgen",
   "appSettingsFullscreenTabStripAlways": "Altijd zichtbaar",

--- a/lib/l10n/app_pa.arb
+++ b/lib/l10n/app_pa.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "ਸੀਮਤ ਕਰੋ ਕਿ ਹਰ ਟੈਬ ਕਿੰਨਾ ਚੌੜਾ ਹੋ ਸਕਦਾ ਹੈ ਤਾਂ ਜੋ ਲੰਬੇ ਨਾਮ ਸੰਖੇਪ ਰਹਿਣ",
   "appSettingsFullscreenOnShortcut": "ਸ਼ਾਰਟਕੱਟ ਤੋਂ ਖੋਲ੍ਹਣ 'ਤੇ ਪੂਰੀ ਸਕਰੀਨ",
   "appSettingsFullscreenOnShortcutSubtitle": "ਹੋਮ-ਸਕਰੀਨ ਸ਼ਾਰਟਕੱਟ ਤੋਂ ਲਾਂਚ ਹੋਣ 'ਤੇ ਪੂਰੀ ਸਕਰੀਨ ਵਿੱਚ ਖੋਲ੍ਹੋ",
+  "appSettingsBackOpensMenu": "ਪਿੱਛੇ ਦਾ ਇਸ਼ਾਰਾ ਮੀਨੂ ਖੋਲ੍ਹਦਾ ਹੈ",
+  "appSettingsBackOpensMenuSubtitle": "ਜਦੋਂ ਸਾਈਟ 'ਤੇ ਪਿੱਛੇ ਜਾਣ ਲਈ ਕੁਝ ਨਹੀਂ ਬਚਦਾ, ਤਾਂ ਪਿੱਛੇ ਦਾ ਇਸ਼ਾਰਾ ਕੁਝ ਨਾ ਕਰਨ ਦੀ ਥਾਂ ਪਾਸੇ ਵਾਲਾ ਮੀਨੂ ਖੋਲ੍ਹਦਾ ਹੈ। Android 'ਤੇ ਦੁਬਾਰਾ ਪਿੱਛੇ ਦਬਾਉਣ ਨਾਲ ਐਪ ਬੰਦ ਹੋ ਜਾਂਦੀ ਹੈ।",
   "appSettingsFullscreenTabStrip": "ਪੂਰੀ ਸਕ੍ਰੀਨ ਵਿੱਚ, ਟੈਬ ਬਾਰ",
   "appSettingsFullscreenTabStripHidden": "ਲੁਕਿਆ",
   "appSettingsFullscreenTabStripAlways": "ਹਮੇਸ਼ਾ ਦਿਖਾਈ ਦਿੰਦਾ",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Ogranicz szerokość każdej karty, aby długie nazwy pozostały zwarte",
   "appSettingsFullscreenOnShortcut": "Pełny ekran przy uruchomieniu ze skrótu",
   "appSettingsFullscreenOnShortcutSubtitle": "Otwieraj na pełnym ekranie po uruchomieniu ze skrótu na ekranie głównym",
+  "appSettingsBackOpensMenu": "Gest wstecz otwiera menu",
+  "appSettingsBackOpensMenuSubtitle": "Gdy w witrynie nie ma już dokąd wracać, gest wstecz otwiera menu boczne, zamiast nie robić nic. W Androidzie kolejne naciśnięcie wstecz zamyka aplikację.",
   "appSettingsFullscreenTabStrip": "Na pełnym ekranie, pasek kart",
   "appSettingsFullscreenTabStripHidden": "Ukryty",
   "appSettingsFullscreenTabStripAlways": "Zawsze widoczny",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Limite a largura de cada separador para que os nomes longos se mantenham compactos",
   "appSettingsFullscreenOnShortcut": "Ecrã inteiro ao abrir a partir de um atalho",
   "appSettingsFullscreenOnShortcutSubtitle": "Abrir em ecrã inteiro quando iniciado a partir de um atalho do ecrã inicial",
+  "appSettingsBackOpensMenu": "O gesto para trás abre o menu",
+  "appSettingsBackOpensMenuSubtitle": "Quando num site já não há nada para onde voltar, o gesto para trás abre o menu lateral em vez de não fazer nada. No Android, premir novamente para trás fecha a aplicação.",
   "appSettingsFullscreenTabStrip": "Em ecrã inteiro, barra de separadores",
   "appSettingsFullscreenTabStripHidden": "Oculta",
   "appSettingsFullscreenTabStripAlways": "Sempre visível",

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Limite a largura de cada aba para que os nomes longos fiquem compactos",
   "appSettingsFullscreenOnShortcut": "Tela cheia ao abrir por atalho",
   "appSettingsFullscreenOnShortcutSubtitle": "Abrir em tela cheia quando iniciado por um atalho da tela inicial",
+  "appSettingsBackOpensMenu": "O gesto de voltar abre o menu",
+  "appSettingsBackOpensMenuSubtitle": "Quando não há mais para onde voltar em um site, o gesto de voltar abre o menu lateral em vez de não fazer nada. No Android, pressionar voltar de novo fecha o aplicativo.",
   "appSettingsFullscreenTabStrip": "Em tela cheia, barra de abas",
   "appSettingsFullscreenTabStripHidden": "Oculta",
   "appSettingsFullscreenTabStripAlways": "Sempre visível",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Limitează cât de lată poate deveni fiecare filă, astfel încât numele lungi să rămână compacte",
   "appSettingsFullscreenOnShortcut": "Ecran complet la lansarea din comandă rapidă",
   "appSettingsFullscreenOnShortcutSubtitle": "Deschide pe ecran complet când este lansat dintr-o comandă rapidă de pe ecranul de pornire",
+  "appSettingsBackOpensMenu": "Gestul înapoi deschide meniul",
+  "appSettingsBackOpensMenuSubtitle": "Când pe un site nu mai există unde să te întorci, gestul înapoi deschide meniul lateral în loc să nu facă nimic. Pe Android, o nouă apăsare pe înapoi închide aplicația.",
   "appSettingsFullscreenTabStrip": "Pe ecran complet, bara de file",
   "appSettingsFullscreenTabStripHidden": "Ascunsă",
   "appSettingsFullscreenTabStripAlways": "Întotdeauna vizibilă",

--- a/lib/l10n/app_si.arb
+++ b/lib/l10n/app_si.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "දිගු නම් සංයුක්තව තබා ගැනීමට එක් එක් ටැබය කොතරම් පළල් විය හැකිද යන්න සීමා කරන්න",
   "appSettingsFullscreenOnShortcut": "කෙටිමඟකින් විවෘත කළ විට පූර්ණ තිරය",
   "appSettingsFullscreenOnShortcutSubtitle": "මුල් තිර කෙටිමඟකින් දියත් කළ විට පූර්ණ තිරයේ විවෘත කරන්න",
+  "appSettingsBackOpensMenu": "ආපසු අභිනය මෙනුව විවෘත කරයි",
+  "appSettingsBackOpensMenuSubtitle": "අඩවියක ආපසු යාමට කිසිවක් ඉතිරි නොවූ විට, ආපසු අභිනය කිසිවක් නොකර සිටීම වෙනුවට පැති මෙනුව විවෘත කරයි. Android හි නැවත ආපසු ඔබන විට යෙදුම වැසෙයි.",
   "appSettingsFullscreenTabStrip": "සම්පූර්ණ තිරයේ, ටැබ් තීරුව",
   "appSettingsFullscreenTabStripHidden": "සැඟවී ඇත",
   "appSettingsFullscreenTabStripAlways": "සැමවිටම දෘශ්‍යමාන",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Obmedzte, aká široká môže byť každá karta, aby dlhé názvy zostali kompaktné",
   "appSettingsFullscreenOnShortcut": "Celá obrazovka pri spustení zo skratky",
   "appSettingsFullscreenOnShortcutSubtitle": "Otvoriť na celej obrazovke pri spustení zo skratky na ploche",
+  "appSettingsBackOpensMenu": "Gesto späť otvorí ponuku",
+  "appSettingsBackOpensMenuSubtitle": "Keď sa na stránke nie je kam vrátiť, gesto späť otvorí bočnú ponuku namiesto toho, aby neurobilo nič. V Androide ďalšie stlačenie späť ukončí aplikáciu.",
   "appSettingsFullscreenTabStrip": "Na celej obrazovke, panel kariet",
   "appSettingsFullscreenTabStripHidden": "Skrytý",
   "appSettingsFullscreenTabStripAlways": "Vždy viditeľný",

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Omejite, kako širok je lahko vsak zavihek, da dolga imena ostanejo zgoščena",
   "appSettingsFullscreenOnShortcut": "Celozaslonski način pri zagonu iz bližnjice",
   "appSettingsFullscreenOnShortcutSubtitle": "Odpri v celozaslonskem načinu, ko se zažene iz bližnjice na začetnem zaslonu",
+  "appSettingsBackOpensMenu": "Poteza nazaj odpre meni",
+  "appSettingsBackOpensMenuSubtitle": "Ko se na spletnem mestu ni več kam vrniti, poteza nazaj odpre stranski meni, namesto da ne stori nič. V Androidu naslednji pritisk nazaj zapre aplikacijo.",
   "appSettingsFullscreenTabStrip": "V celozaslonskem načinu, vrstica zavihkov",
   "appSettingsFullscreenTabStripHidden": "Skrito",
   "appSettingsFullscreenTabStripAlways": "Vedno vidno",

--- a/lib/l10n/app_sq.arb
+++ b/lib/l10n/app_sq.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Kufizo sa e gjerë mund të bëhet çdo skedë që emrat e gjatë të mbeten kompaktë",
   "appSettingsFullscreenOnShortcut": "Ekran i plotë kur nisitet nga shkurtorja",
   "appSettingsFullscreenOnShortcutSubtitle": "Hape në ekran të plotë kur nisitet nga një shkurtore e ekranit bazë",
+  "appSettingsBackOpensMenu": "Gjesti prapa hap menynë",
+  "appSettingsBackOpensMenuSubtitle": "Kur në një sajt nuk ka më ku të kthehesh, gjesti prapa hap menynë anësore në vend që të mos bëjë asgjë. Në Android, shtypja sërish e prapa e mbyll aplikacionin.",
   "appSettingsFullscreenTabStrip": "Në ekran të plotë, shiriti i skedave",
   "appSettingsFullscreenTabStripHidden": "I fshehur",
   "appSettingsFullscreenTabStripAlways": "Gjithmonë i dukshëm",

--- a/lib/l10n/app_sr.arb
+++ b/lib/l10n/app_sr.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Ограничите колико свака картица може бити широка да би дугачка имена остала компактна",
   "appSettingsFullscreenOnShortcut": "Цео екран при покретању из пречице",
   "appSettingsFullscreenOnShortcutSubtitle": "Отвори преко целог екрана када се покрене из пречице на почетном екрану",
+  "appSettingsBackOpensMenu": "Покрет назад отвара мени",
+  "appSettingsBackOpensMenuSubtitle": "Када на сајту више нема чему да се вратите, покрет назад отвара бочни мени уместо да не уради ништа. На Android-у, поновни притисак назад затвара апликацију.",
   "appSettingsFullscreenTabStrip": "На пуном екрану, трака картица",
   "appSettingsFullscreenTabStripHidden": "Скривено",
   "appSettingsFullscreenTabStripAlways": "Увек видљиво",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Begränsa hur bred varje flik kan bli så att långa namn förblir kompakta",
   "appSettingsFullscreenOnShortcut": "Helskärm vid start från genväg",
   "appSettingsFullscreenOnShortcutSubtitle": "Öppna i helskärm när appen startas från en genväg på startskärmen",
+  "appSettingsBackOpensMenu": "Bakåtgesten öppnar menyn",
+  "appSettingsBackOpensMenuSubtitle": "När en webbplats inte har något mer att gå tillbaka till öppnar bakåtgesten sidomenyn i stället för att inte göra något. På Android stänger ytterligare en bakåttryckning appen.",
   "appSettingsFullscreenTabStrip": "I helskärm, flikfält",
   "appSettingsFullscreenTabStripHidden": "Dold",
   "appSettingsFullscreenTabStripAlways": "Alltid synlig",

--- a/lib/l10n/app_sw.arb
+++ b/lib/l10n/app_sw.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Punguza jinsi kila kichupo kinavyoweza kupanuka ili majina marefu yabaki yamebana",
   "appSettingsFullscreenOnShortcut": "Skrini nzima inapozinduliwa kutoka njia ya mkato",
   "appSettingsFullscreenOnShortcutSubtitle": "Fungua katika skrini nzima inapozinduliwa kutoka njia ya mkato ya skrini ya nyumbani",
+  "appSettingsBackOpensMenu": "Ishara ya kurudi hufungua menyu",
+  "appSettingsBackOpensMenuSubtitle": "Tovuti isipokuwa na mahali pengine pa kurudi, ishara ya kurudi hufungua menyu ya pembeni badala ya kutofanya chochote. Kwenye Android, kubonyeza kurudi tena hufunga programu.",
   "appSettingsFullscreenTabStrip": "Katika skrini nzima, upau wa vichupo",
   "appSettingsFullscreenTabStripHidden": "Imefichwa",
   "appSettingsFullscreenTabStripAlways": "Inaonekana kila wakati",

--- a/lib/l10n/app_ta.arb
+++ b/lib/l10n/app_ta.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "நீண்ட பெயர்கள் சுருக்கமாக இருக்க ஒவ்வொரு தாவலும் எவ்வளவு அகலமாக இருக்கலாம் என்பதை வரம்பிடவும்",
   "appSettingsFullscreenOnShortcut": "குறுக்குவழியில் இருந்து திறக்கும்போது முழுத்திரை",
   "appSettingsFullscreenOnShortcutSubtitle": "முகப்புத் திரை குறுக்குவழியில் இருந்து தொடங்கும்போது முழுத்திரையில் திறக்கவும்",
+  "appSettingsBackOpensMenu": "பின் சைகை மெனுவைத் திறக்கும்",
+  "appSettingsBackOpensMenuSubtitle": "ஒரு தளத்தில் பின்செல்ல எதுவும் இல்லாதபோது, பின் சைகை எதுவும் செய்யாமல் இருப்பதற்குப் பதிலாக பக்க மெனுவைத் திறக்கும். Android இல் மீண்டும் பின்னைத் தட்டினால் செயலி மூடப்படும்.",
   "appSettingsFullscreenTabStrip": "முழுத்திரையில், தாவல் பட்டி",
   "appSettingsFullscreenTabStripHidden": "மறைக்கப்பட்டது",
   "appSettingsFullscreenTabStripAlways": "எப்போதும் தெரியும்",

--- a/lib/l10n/app_te.arb
+++ b/lib/l10n/app_te.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "పొడవైన పేర్లు కుదించబడి ఉండేలా ప్రతి ట్యాబ్ ఎంత వెడల్పు కావచ్చో పరిమితం చేయండి",
   "appSettingsFullscreenOnShortcut": "షార్ట్‌కట్ నుండి తెరిచినప్పుడు పూర్తి స్క్రీన్",
   "appSettingsFullscreenOnShortcutSubtitle": "హోమ్-స్క్రీన్ షార్ట్‌కట్ నుండి ప్రారంభించినప్పుడు పూర్తి స్క్రీన్‌లో తెరవండి",
+  "appSettingsBackOpensMenu": "వెనుకకు సంజ్ఞ మెనూను తెరుస్తుంది",
+  "appSettingsBackOpensMenuSubtitle": "సైట్‌లో వెనుకకు వెళ్లడానికి ఏమీ మిగలనప్పుడు, వెనుకకు సంజ్ఞ ఏమీ చేయకుండా ఉండటానికి బదులుగా ప్రక్క మెనూను తెరుస్తుంది. Androidలో మళ్లీ వెనుకకు నొక్కితే యాప్ మూసివేయబడుతుంది.",
   "appSettingsFullscreenTabStrip": "పూర్తి స్క్రీన్‌లో, ట్యాబ్ బార్",
   "appSettingsFullscreenTabStripHidden": "దాచబడింది",
   "appSettingsFullscreenTabStripAlways": "ఎల్లప్పుడూ కనిపిస్తుంది",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "จำกัดความกว้างของแต่ละแท็บเพื่อให้ชื่อยาว ๆ ยังคงกระชับ",
   "appSettingsFullscreenOnShortcut": "เต็มหน้าจอเมื่อเปิดจากทางลัด",
   "appSettingsFullscreenOnShortcutSubtitle": "เปิดแบบเต็มหน้าจอเมื่อเปิดใช้จากทางลัดบนหน้าจอหลัก",
+  "appSettingsBackOpensMenu": "ท่าทางย้อนกลับเปิดเมนู",
+  "appSettingsBackOpensMenuSubtitle": "เมื่อไม่มีหน้าให้ย้อนกลับในเว็บไซต์แล้ว ท่าทางย้อนกลับจะเปิดเมนูด้านข้างแทนที่จะไม่ทำอะไร บน Android การกดย้อนกลับอีกครั้งจะปิดแอป",
   "appSettingsFullscreenTabStrip": "ในโหมดเต็มจอ แถบแท็บ",
   "appSettingsFullscreenTabStripHidden": "ซ่อน",
   "appSettingsFullscreenTabStripAlways": "แสดงตลอดเวลา",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Uzun adların derli toplu kalması için her sekmenin ne kadar genişleyebileceğini sınırlayın",
   "appSettingsFullscreenOnShortcut": "Kısayoldan açılışta tam ekran",
   "appSettingsFullscreenOnShortcutSubtitle": "Ana ekran kısayolundan başlatıldığında tam ekranda aç",
+  "appSettingsBackOpensMenu": "Geri hareketi menüyü açar",
+  "appSettingsBackOpensMenuSubtitle": "Bir sitede geri dönülecek bir şey kalmadığında, geri hareketi hiçbir şey yapmamak yerine yan menüyü açar. Android'de geriye yeniden basmak uygulamadan çıkar.",
   "appSettingsFullscreenTabStrip": "Tam ekranda, sekme çubuğu",
   "appSettingsFullscreenTabStripHidden": "Gizli",
   "appSettingsFullscreenTabStripAlways": "Her zaman görünür",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "Обмежте, наскільки широкою може стати кожна вкладка, щоб довгі назви залишалися компактними",
   "appSettingsFullscreenOnShortcut": "Повний екран під час запуску з ярлика",
   "appSettingsFullscreenOnShortcutSubtitle": "Відкривати на весь екран під час запуску з ярлика головного екрана",
+  "appSettingsBackOpensMenu": "Жест назад відкриває меню",
+  "appSettingsBackOpensMenuSubtitle": "Коли на сайті вже немає куди повертатися, жест назад відкриває бічне меню замість того, щоб нічого не робити. В Android наступне натискання назад закриває застосунок.",
   "appSettingsFullscreenTabStrip": "На весь екран, панель вкладок",
   "appSettingsFullscreenTabStripHidden": "Прихована",
   "appSettingsFullscreenTabStripAlways": "Завжди видима",

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "محدود کریں کہ ہر ٹیب کتنا چوڑا ہو سکتا ہے تاکہ لمبے نام مختصر رہیں",
   "appSettingsFullscreenOnShortcut": "شارٹ کٹ سے کھولنے پر فل اسکرین",
   "appSettingsFullscreenOnShortcutSubtitle": "ہوم اسکرین شارٹ کٹ سے کھلنے پر فل اسکرین میں کھولیں",
+  "appSettingsBackOpensMenu": "واپسی اشارہ مینو کھولتا ہے",
+  "appSettingsBackOpensMenuSubtitle": "جب کسی سائٹ پر واپس جانے کے لیے کچھ باقی نہ رہے تو واپسی کا اشارہ کچھ نہ کرنے کے بجائے سائیڈ مینو کھولتا ہے۔ Android پر دوبارہ واپس دبانے سے ایپ بند ہو جاتی ہے۔",
   "appSettingsFullscreenTabStrip": "فل اسکرین میں، ٹیب بار",
   "appSettingsFullscreenTabStripHidden": "پوشیدہ",
   "appSettingsFullscreenTabStripAlways": "ہمیشہ نظر آنے والا",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "限制每个标签的最大宽度，使较长的名称保持紧凑",
   "appSettingsFullscreenOnShortcut": "通过快捷方式启动时全屏",
   "appSettingsFullscreenOnShortcutSubtitle": "从主屏幕快捷方式启动时以全屏打开",
+  "appSettingsBackOpensMenu": "返回手势打开菜单",
+  "appSettingsBackOpensMenuSubtitle": "当站点中已没有可返回的页面时，返回手势会打开侧边菜单，而不是什么都不做。在 Android 上，再次按返回将退出应用。",
   "appSettingsFullscreenTabStrip": "全屏时，标签栏",
   "appSettingsFullscreenTabStripHidden": "隐藏",
   "appSettingsFullscreenTabStripAlways": "始终显示",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -695,6 +695,8 @@
   "appSettingsTabMaxWidthSubtitle": "限制每個分頁的最大寬度，讓較長的名稱保持精簡",
   "appSettingsFullscreenOnShortcut": "透過捷徑啟動時全螢幕",
   "appSettingsFullscreenOnShortcutSubtitle": "從主畫面捷徑啟動時以全螢幕開啟",
+  "appSettingsBackOpensMenu": "返回手勢開啟選單",
+  "appSettingsBackOpensMenuSubtitle": "當網站已沒有可返回的頁面時，返回手勢會開啟側邊選單，而不是什麼都不做。在 Android 上，再次按返回會結束應用程式。",
   "appSettingsFullscreenTabStrip": "全螢幕時，分頁列",
   "appSettingsFullscreenTabStripHidden": "隱藏",
   "appSettingsFullscreenTabStripAlways": "永遠顯示",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -62,6 +62,7 @@ import 'package:webspace/services/container_cookie_manager.dart';
 import 'package:webspace/services/site_settings_qr_codec.dart';
 import 'package:webspace/services/site_activation_engine.dart';
 import 'package:webspace/services/app_lifecycle_engine.dart';
+import 'package:webspace/services/back_gesture_engine.dart';
 import 'package:webspace/services/site_data_clear_engine.dart';
 import 'package:webspace/services/site_lifecycle_engine.dart';
 import 'package:webspace/services/site_lifecycle_promotion_engine.dart';
@@ -1000,6 +1001,13 @@ class _WebSpacePageState extends State<WebSpacePage>
   // pref mirror of the `fullscreenOnShortcut` SharedPreferences key. On by
   // default. Independent of per-site `WebViewModel.fullscreenMode`.
   bool _fullscreenOnShortcut = true;
+  // NAV-009: what the back gesture does at the start of a site's history.
+  // Off by default — the gesture only walks webview history (issue #369);
+  // turning it on opens the drawer there, and again to leave the app (#431).
+  BackAtHistoryStart _backAtHistoryStart = BackAtHistoryStart.ignore;
+  // True while the drawer showing is the one the back gesture itself opened.
+  // Only that drawer escalates to leaving the app on the next gesture.
+  bool _drawerOpenedByBackGesture = false;
   int _tabMaxWidth = 140;
   // Runtime-only: whether the tab-bar button has revealed the tab strip.
   // Reset on exiting fullscreen and on site switch; never persisted.
@@ -3281,6 +3289,15 @@ class _WebSpacePageState extends State<WebSpacePage>
     await prefs.setBool('fullscreenOnShortcut', _fullscreenOnShortcut);
   }
 
+  Future<void> _saveBackAtHistoryStart() async {
+    if (isDemoMode) return;
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(
+      kBackOpensMenuKey,
+      _backAtHistoryStart == BackAtHistoryStart.openMenu,
+    );
+  }
+
   Future<void> _saveTabBarButton() async {
     if (isDemoMode) return;
     SharedPreferences prefs = await SharedPreferences.getInstance();
@@ -4335,6 +4352,9 @@ class _WebSpacePageState extends State<WebSpacePage>
           prefs.getBool('tabBarButton') ?? prefs.getBool('tabBarButtonInFullscreen') ?? false;
       _tabBarButtonOnRight = prefs.getBool('tabBarButtonOnRight') ?? true;
       _fullscreenOnShortcut = prefs.getBool('fullscreenOnShortcut') ?? true;
+      _backAtHistoryStart = (prefs.getBool(kBackOpensMenuKey) ?? false)
+          ? BackAtHistoryStart.openMenu
+          : BackAtHistoryStart.ignore;
       _tabMaxWidth = prefs.getInt('tabMaxWidth') ?? 140;
       _showStatsBanner = prefs.getBool('showStatsBanner') ?? true;
       WebViewFactory.backForwardCacheEnabled =
@@ -5808,6 +5828,12 @@ class _WebSpacePageState extends State<WebSpacePage>
           backup.globalPrefs['tabBarButtonOnRight'] as bool? ?? _tabBarButtonOnRight;
       _fullscreenOnShortcut =
           backup.globalPrefs['fullscreenOnShortcut'] as bool? ?? _fullscreenOnShortcut;
+      final backOpensMenu = backup.globalPrefs[kBackOpensMenuKey] as bool?;
+      if (backOpensMenu != null) {
+        _backAtHistoryStart = backOpensMenu
+            ? BackAtHistoryStart.openMenu
+            : BackAtHistoryStart.ignore;
+      }
       _tabMaxWidth =
           backup.globalPrefs['tabMaxWidth'] as int? ?? _tabMaxWidth;
       _showStatsBanner =
@@ -6010,6 +6036,12 @@ class _WebSpacePageState extends State<WebSpacePage>
       return null;
     }
     return _webViewModels[_currentIndex!].getController(launchUrl, _cookieManager, _containerCookieManager, _saveWebViewModels, globalUserScripts: _globalUserScripts);
+  }
+
+  void _openDrawerFromBackGesture(ScaffoldState? scaffoldState) {
+    if (scaffoldState == null) return;
+    _drawerOpenedByBackGesture = true;
+    scaffoldState.openDrawer();
   }
 
   /// Navigate the visible webview back one history entry, then recomposite the
@@ -6310,6 +6342,16 @@ class _WebSpacePageState extends State<WebSpacePage>
                         _fullscreenOnShortcut = value;
                       });
                       _saveFullscreenOnShortcut();
+                    },
+                    backOpensMenu:
+                        _backAtHistoryStart == BackAtHistoryStart.openMenu,
+                    onBackOpensMenuChanged: (value) {
+                      setState(() {
+                        _backAtHistoryStart = value
+                            ? BackAtHistoryStart.openMenu
+                            : BackAtHistoryStart.ignore;
+                      });
+                      _saveBackAtHistoryStart();
                     },
                     tabBarButton: _tabBarButton,
                     onTabBarButtonChanged: (value) {
@@ -8534,54 +8576,80 @@ class _WebSpacePageState extends State<WebSpacePage>
         _isBackHandling = true;
         try {
           final scaffoldState = _scaffoldKey.currentState;
-          // If the drawer is open, just close it.
-          if (scaffoldState != null && scaffoldState.isDrawerOpen) {
-            LogService.instance.log('Navigation', 'Back gesture: closing open drawer');
-            Navigator.pop(context);
-            return;
-          }
-          // The back gesture only navigates webview history. It never opens
-          // the drawer and never exits the app; if there is nothing to go
-          // back to, it is a no-op.
+          final drawerOpen = scaffoldState?.isDrawerOpen ?? false;
           final controller = getController();
-          if (controller == null) {
-            LogService.instance.log('Navigation', 'Back gesture: no controller, ignoring');
-            return;
-          }
           // Android's canGoBack() is reliable (including for pushState/SPA
           // entries on Chromium). Trust it directly: URL-comparison can
           // false-positive when goBack() succeeds but the navigation
-          // hasn't propagated within the timeout.
-          if (hostIsAndroid) {
-            if (await controller.canGoBack()) {
-              await _goBackAndRepaint(controller);
-              LogService.instance.log('Navigation', 'Back gesture: navigated back (canGoBack)');
-            } else {
-              LogService.instance.log('Navigation', 'Back gesture: no history, ignoring');
-            }
-            return;
-          }
-          // iOS/macOS: canGoBack() can return false for pushState entries,
-          // so attempt goBack() unconditionally and use URL comparison as
-          // the authoritative check.
-          final urlBefore = (await controller.getUrl())?.toString();
-          await controller.goBack();
-          // Give the native webview time to process the navigation
-          await Future.delayed(const Duration(milliseconds: 150));
+          // hasn't propagated within the timeout. iOS/macOS decide from the
+          // URL diff instead, so they don't sample it at all.
+          final canGoBack = !drawerOpen && controller != null && hostIsAndroid
+              ? await controller.canGoBack()
+              : false;
           if (!mounted) return;
-          final urlAfter = (await controller.getUrl())?.toString();
-          if (urlBefore == urlAfter) {
-            LogService.instance.log(
-              'Navigation',
-              'Back gesture: URL unchanged ($urlAfter), ignoring',
-              sensitivity: LogSensitivity.sensitive,
-            );
-          } else {
-            LogService.instance.log(
-              'Navigation',
-              'Back gesture: navigated back from $urlBefore to $urlAfter',
-              sensitivity: LogSensitivity.sensitive,
-            );
+          final action = decideBackGesture(
+            drawerOpen: drawerOpen,
+            drawerOpenedByGesture: _drawerOpenedByBackGesture,
+            drawerAvailable: !_kioskLocked,
+            hasWebView: controller != null,
+            trustsCanGoBack: hostIsAndroid,
+            canGoBack: canGoBack,
+            atHistoryStart: _backAtHistoryStart,
+            canExitApp: hostIsAndroid,
+          );
+          switch (action) {
+            case BackGestureAction.ignore:
+              LogService.instance.log('Navigation', 'Back gesture: nothing to do, ignoring');
+              break;
+            case BackGestureAction.closeDrawer:
+              LogService.instance.log('Navigation', 'Back gesture: closing open drawer');
+              _scaffoldKey.currentState?.closeDrawer();
+              break;
+            case BackGestureAction.closeDrawerAndExit:
+              LogService.instance.log('Navigation', 'Back gesture: closing drawer and leaving app');
+              _scaffoldKey.currentState?.closeDrawer();
+              await SystemNavigator.pop();
+              break;
+            case BackGestureAction.openDrawer:
+              LogService.instance.log('Navigation', 'Back gesture: no history, opening drawer');
+              _openDrawerFromBackGesture(scaffoldState);
+              break;
+            case BackGestureAction.exitApp:
+              LogService.instance.log('Navigation', 'Back gesture: no site shown, leaving app');
+              await SystemNavigator.pop();
+              break;
+            case BackGestureAction.goBack:
+              await _goBackAndRepaint(controller!);
+              LogService.instance.log('Navigation', 'Back gesture: navigated back (canGoBack)');
+              break;
+            case BackGestureAction.attemptGoBack:
+              // iOS/macOS: canGoBack() can return false for pushState
+              // entries, so attempt goBack() unconditionally and use URL
+              // comparison as the authoritative check.
+              final urlBefore = (await controller!.getUrl())?.toString();
+              await controller.goBack();
+              // Give the native webview time to process the navigation
+              await Future.delayed(const Duration(milliseconds: 150));
+              if (!mounted) return;
+              final urlAfter = (await controller.getUrl())?.toString();
+              final urlChanged = urlBefore != urlAfter;
+              LogService.instance.log(
+                'Navigation',
+                urlChanged
+                    ? 'Back gesture: navigated back from $urlBefore to $urlAfter'
+                    : 'Back gesture: URL unchanged ($urlAfter)',
+                sensitivity: LogSensitivity.sensitive,
+              );
+              final next = decideAfterAttemptedGoBack(
+                urlChanged: urlChanged,
+                drawerAvailable: !_kioskLocked,
+                atHistoryStart: _backAtHistoryStart,
+              );
+              if (next == BackGestureAction.openDrawer) {
+                LogService.instance.log('Navigation', 'Back gesture: no history, opening drawer');
+                _openDrawerFromBackGesture(_scaffoldKey.currentState);
+              }
+              break;
           }
         } finally {
           _isBackHandling = false;
@@ -8589,6 +8657,11 @@ class _WebSpacePageState extends State<WebSpacePage>
       },
       child: Scaffold(
       key: _scaffoldKey,
+      // Clearing on close covers every way the drawer goes away; a drawer
+      // opened by any other affordance therefore starts with the flag down.
+      onDrawerChanged: (isOpen) {
+        if (!isOpen) _drawerOpenedByBackGesture = false;
+      },
       // Disable the drawer edge-swipe whenever a webview is active so the back
       // gesture never opens the drawer. The drawer is reached via the AppBar
       // menu button instead.

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -61,6 +61,10 @@ class AppSettingsScreen extends StatefulWidget {
   final ValueChanged<bool> onTabStripInFullscreenChanged;
   final bool fullscreenOnShortcut;
   final ValueChanged<bool> onFullscreenOnShortcutChanged;
+  /// NAV-009: back gesture opens the drawer where a site has no page left to
+  /// go back to (and leaves the app on the press after that). Off by default.
+  final bool backOpensMenu;
+  final ValueChanged<bool> onBackOpensMenuChanged;
   final bool tabBarButton;
   final ValueChanged<bool> onTabBarButtonChanged;
   final int tabMaxWidth;
@@ -104,6 +108,8 @@ class AppSettingsScreen extends StatefulWidget {
     required this.onTabStripInFullscreenChanged,
     required this.fullscreenOnShortcut,
     required this.onFullscreenOnShortcutChanged,
+    required this.backOpensMenu,
+    required this.onBackOpensMenuChanged,
     required this.tabBarButton,
     required this.onTabBarButtonChanged,
     required this.tabMaxWidth,
@@ -130,6 +136,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
   late bool _showTabStrip;
   late bool _tabStripInFullscreen;
   late bool _fullscreenOnShortcut;
+  late bool _backOpensMenu;
   late bool _tabBarButton;
   late double _tabMaxWidth;
   late bool _showStatsBanner;
@@ -190,6 +197,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
     _showTabStrip = widget.showTabStrip;
     _tabStripInFullscreen = widget.tabStripInFullscreen;
     _fullscreenOnShortcut = widget.fullscreenOnShortcut;
+    _backOpensMenu = widget.backOpensMenu;
     _tabBarButton = widget.tabBarButton;
     _tabMaxWidth = widget.tabMaxWidth.toDouble();
     _showStatsBanner = widget.showStatsBanner;
@@ -1019,6 +1027,17 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
                   ],
                 ),
               );
+            },
+          ),
+          SwitchListTile(
+            title: Text(loc.appSettingsBackOpensMenu),
+            subtitle: Text(loc.appSettingsBackOpensMenuSubtitle),
+            value: _backOpensMenu,
+            onChanged: (value) {
+              setState(() {
+                _backOpensMenu = value;
+              });
+              widget.onBackOpensMenuChanged(value);
             },
           ),
           SwitchListTile(

--- a/lib/services/back_gesture_engine.dart
+++ b/lib/services/back_gesture_engine.dart
@@ -1,0 +1,85 @@
+/// Decision policy for the system back gesture on the main page.
+///
+/// Pure logic: the call site in `_WebSpacePageState` owns the Navigator, the
+/// ScaffoldState and `SystemNavigator`. Spec:
+/// `openspec/specs/navigation/spec.md` (NAV-001, NAV-002, NAV-009).
+library;
+
+enum BackGestureAction {
+  /// Swallow the gesture: no navigation, no drawer, no exit.
+  ignore,
+
+  /// Navigate back in webview history (history is known to exist).
+  goBack,
+
+  /// Attempt `goBack()` and decide from the before/after URL diff, because
+  /// `canGoBack()` under-reports `pushState` entries (NAV-002, iOS/macOS).
+  attemptGoBack,
+
+  /// Close the open drawer.
+  closeDrawer,
+
+  /// Close the open drawer and leave the app (NAV-009).
+  closeDrawerAndExit,
+
+  /// Open the navigation drawer (NAV-009).
+  openDrawer,
+
+  /// Leave the app (NAV-009).
+  exitApp,
+}
+
+/// What the back gesture does once there is no page left to go back to.
+///
+/// [BackAtHistoryStart.ignore] is the default (issue #369): the gesture only
+/// ever walks webview history. [BackAtHistoryStart.openMenu] restores the
+/// pre-#371 behaviour (issue #431): the drawer opens, and a second gesture on
+/// that drawer leaves the app.
+enum BackAtHistoryStart { ignore, openMenu }
+
+/// Decides what a back gesture means before any webview navigation is
+/// attempted.
+///
+/// [drawerOpenedByGesture] distinguishes a drawer this policy opened from one
+/// the user opened via the AppBar menu button: only the former escalates to
+/// leaving the app, so back never quits from a deliberately opened menu.
+/// [drawerAvailable] is false while the kiosk shell is locked (KIOSK-002),
+/// which pins the gesture to the default behaviour.
+BackGestureAction decideBackGesture({
+  required bool drawerOpen,
+  required bool drawerOpenedByGesture,
+  required bool drawerAvailable,
+  required bool hasWebView,
+  required bool trustsCanGoBack,
+  required bool canGoBack,
+  required BackAtHistoryStart atHistoryStart,
+  required bool canExitApp,
+}) {
+  final openMenu = atHistoryStart == BackAtHistoryStart.openMenu && drawerAvailable;
+  if (drawerOpen) {
+    return openMenu && drawerOpenedByGesture && canExitApp
+        ? BackGestureAction.closeDrawerAndExit
+        : BackGestureAction.closeDrawer;
+  }
+  if (!hasWebView) {
+    // The site list is on screen; opening the drawer over it would show the
+    // same sites twice, so the gesture either leaves the app or does nothing.
+    return openMenu && canExitApp ? BackGestureAction.exitApp : BackGestureAction.ignore;
+  }
+  if (!trustsCanGoBack) return BackGestureAction.attemptGoBack;
+  if (canGoBack) return BackGestureAction.goBack;
+  return openMenu ? BackGestureAction.openDrawer : BackGestureAction.ignore;
+}
+
+/// Decides what remains to be done after [BackGestureAction.attemptGoBack]
+/// ran. [urlChanged] is the authoritative "back succeeded" signal (NAV-002).
+BackGestureAction decideAfterAttemptedGoBack({
+  required bool urlChanged,
+  required bool drawerAvailable,
+  required BackAtHistoryStart atHistoryStart,
+}) {
+  if (urlChanged) return BackGestureAction.ignore;
+  return atHistoryStart == BackAtHistoryStart.openMenu && drawerAvailable
+      ? BackGestureAction.openDrawer
+      : BackGestureAction.ignore;
+}

--- a/lib/settings/app_prefs.dart
+++ b/lib/settings/app_prefs.dart
@@ -95,9 +95,15 @@ final Map<String, Object> kExportedAppPrefs = <String, Object>{
   // on back/forward navigation. Mirrored into WebViewFactory and applied to
   // every WebView; no-ops where the feature is unsupported.
   kBackForwardCacheEnabledKey: true,
+  // NAV-009: what the system back gesture does once a site has no page left
+  // to go back to. Off (default) keeps the gesture on webview history only;
+  // on, it opens the drawer there and leaves the app on the next press.
+  kBackOpensMenuKey: false,
 };
 
 const String kBackForwardCacheEnabledKey = 'backForwardCacheEnabled';
+
+const String kBackOpensMenuKey = 'backOpensMenu';
 
 const String kFirefoxUaAutoRefreshKey = 'firefoxUaAutoRefresh';
 

--- a/openspec/specs/kiosk-mode/spec.md
+++ b/openspec/specs/kiosk-mode/spec.md
@@ -84,7 +84,7 @@ site's own webview fully presented. Specifically the shell SHALL NOT
 present: the navigation drawer (and its edge-swipe and auto app-bar
 hamburger), the bottom tab strip, the app-bar actions (download, theme
 toggle, settings), or the per-site context menu (edit, delete, move,
-archive). The webview and in-page back navigation remain available.
+archive). The webview and in-page back navigation remain available; the opt-in back-at-history-start behaviour (NAV-009) is inert while locked, since it would otherwise reach the suppressed drawer or leave the app.
 
 #### Scenario: Locked shell renders only the site
 

--- a/openspec/specs/navigation/spec.md
+++ b/openspec/specs/navigation/spec.md
@@ -38,7 +38,7 @@ WebSpace embeds webviews in a Scaffold with a drawer. Navigation gestures compet
 
 ### Requirement: NAV-001 - System Back Gesture
 
-The system back gesture (Android back button, iOS/macOS left-edge swipe) SHALL navigate back in webview history when possible. On the root site webview, iOS/macOS use WKWebView's native back/forward swipe (`allowsBackForwardNavigationGestures`); Android, and all nested routes, use the PopScope handler. It SHALL NOT open the drawer and SHALL NOT exit the app; when there is no back history it is a no-op.
+The system back gesture (Android back button, iOS/macOS left-edge swipe) SHALL navigate back in webview history when possible. On the root site webview, iOS/macOS use WKWebView's native back/forward swipe (`allowsBackForwardNavigationGestures`); Android, and all nested routes, use the PopScope handler. It SHALL NOT open the drawer and SHALL NOT exit the app; when there is no back history it is a no-op. What happens at that history start is the one thing the user can change, via the opt-in setting in NAV-009 — off by default, which is this requirement.
 
 **Rationale:** Users navigating content-heavy sites (especially SPA news sites) expect the back gesture to mean "go back in the page," not "open the menu" or "leave the app." Folding drawer-opening and app-exit into the back gesture made the gesture ambiguous and, combined with the iOS `canGoBack()` heuristic (NAV-002), occasionally misfired mid-navigation. The drawer is reached via the AppBar menu button; the app is left via the OS home/recents gesture.
 
@@ -60,6 +60,7 @@ The system back gesture (Android back button, iOS/macOS left-edge swipe) SHALL n
 **Given** a webview is visible with no navigation history
 **When** the user triggers the system back gesture
 **Then** nothing happens (no drawer, no exit)
+**And** the setting in NAV-009 is off
 
 #### Scenario: Drawer is already open
 
@@ -264,6 +265,80 @@ The **AppBar back button** on a nested `InAppWebViewScreen` SHALL always close t
 
 ---
 
+### Requirement: NAV-009 - Back At Start Of History (opt-in)
+
+The app SHALL expose exactly one global setting for what the system back gesture does once the webview has no page left to go back to. It SHALL default to off, which is NAV-001's no-op.
+
+When the setting is on, the back gesture at the start of a site's history SHALL open the drawer, and a further back gesture on a drawer *that gesture opened* SHALL close it and leave the app. A drawer the user opened any other way (AppBar menu button, webspace tap) SHALL only close, never leave the app — and leaving the app SHALL happen on Android only, where finishing the activity is the platform's own back-at-root behaviour.
+
+The setting SHALL be persisted as the `backOpensMenu` app pref and ride settings export/import. It SHALL have no effect while the kiosk shell is locked (KIOSK-002), which owns the drawer's absence.
+
+**Rationale:** Issue #369 and issue #431 ask for opposite gestures from the same swipe: one user's news-site navigation is broken by the drawer appearing mid-article, the other lost the "menu, then exit" sequence they navigated by. Neither is wrong, and no heuristic separates them, so the choice belongs to the user. Off stays the default because it is the gesture that cannot misfire: it never takes the user somewhere they did not ask to go.
+
+The escalation to leaving the app is bound to the drawer the gesture itself opened, because otherwise back-to-dismiss on a deliberately opened menu would quit the app — the exact ambiguity NAV-001 removed.
+
+#### Scenario: Setting off — start of history stays a no-op
+
+**Given** the setting is off
+**And** a webview is visible with no back history
+**When** the user triggers the system back gesture
+**Then** nothing happens (no drawer, no exit)
+
+#### Scenario: Setting on — start of history opens the drawer
+
+**Given** the setting is on
+**And** a webview is visible with no back history
+**When** the user triggers the system back gesture
+**Then** the drawer opens
+
+#### Scenario: Setting on — second gesture leaves the app
+
+**Given** the setting is on
+**And** the drawer was opened by the back gesture on Android
+**When** the user triggers the system back gesture again
+**Then** the drawer closes
+**And** the app is left via `SystemNavigator.pop()`
+
+#### Scenario: Setting on — back never quits from a deliberately opened menu
+
+**Given** the setting is on
+**And** the user opened the drawer with the AppBar menu button
+**When** the user triggers the system back gesture
+**Then** the drawer closes
+**And** the app is NOT left
+
+#### Scenario: Setting on — history still wins
+
+**Given** the setting is on
+**And** a webview is visible with back history
+**When** the user triggers the system back gesture
+**Then** the webview navigates back in history
+**And** the drawer does not open
+
+#### Scenario: Setting on — no site shown (Android)
+
+**Given** the setting is on
+**And** the webspace list screen is visible on Android
+**When** the user triggers the system back gesture
+**Then** the app is left (the drawer would only repeat the list already on screen)
+
+#### Scenario: Setting on — iOS/macOS URL-comparison path
+
+**Given** the setting is on on iOS or macOS
+**And** `goBack()` was attempted and the URL did not change (NAV-002)
+**When** the handler resolves the gesture
+**Then** the drawer opens
+**And** the app is NOT left
+
+#### Scenario: Locked kiosk shell ignores the setting
+
+**Given** the setting is on
+**And** the kiosk shell is locked (KIOSK-002, no drawer)
+**When** the user triggers the system back gesture at the start of history
+**Then** nothing happens (no drawer, no exit)
+
+---
+
 ## Race Condition Guards
 
 ### Guard: RACE-002 - _isBackHandling Flag
@@ -297,19 +372,27 @@ Double-tap is harmless: second call disposes an already-null webview. `deleteCac
 
 ### Decision Flow: System Back Gesture
 
+The call site gathers state (drawer, controller, `canGoBack()` where it is
+trusted) and `decideBackGesture` in
+[lib/services/back_gesture_engine.dart](../../../lib/services/back_gesture_engine.dart)
+returns the action; `openMenu` below is the NAV-009 setting, and is forced off
+while the kiosk shell is locked.
+
 ```
 System back gesture received
   │
   ├─ didPop? ──────────────────── return (system handled it)
   ├─ _isBackHandling? ─────────── return (drop concurrent)
   │
-  ├─ Drawer open? ─────────────── close drawer (never exit)
+  ├─ Drawer open?
+  │   ├─ openMenu && opened by this gesture && Android ─── close drawer + exit app
+  │   └─ else ──────────────────────────────────────────── close drawer
   │
-  ├─ No controller? ───────────── no-op (no drawer, no exit)
+  ├─ No controller? ───────────── openMenu && Android ? exit app : no-op
   │
   ├─ Android && has controller:
   │   ├─ canGoBack()? ─────────── goBack()
-  │   └─ else ─────────────────── no-op
+  │   └─ else ─────────────────── openMenu ? open drawer : no-op
   │
   └─ iOS/macOS && has controller:
       ├─ urlBefore = getUrl()
@@ -318,7 +401,7 @@ System back gesture received
       ├─ urlAfter = getUrl()
       │
       ├─ URL changed? ─────────── back succeeded
-      └─ URL same? ────────────── no-op
+      └─ URL same? ────────────── openMenu ? open drawer : no-op
 ```
 
 ### Decision Flow: Drawer Edge Drag Width
@@ -350,8 +433,17 @@ Home button pressed
 
 ### Files
 
+#### `lib/services/back_gesture_engine.dart`
+- `decideBackGesture` / `decideAfterAttemptedGoBack` — the whole policy above as
+  pure functions returning a `BackGestureAction`; `BackAtHistoryStart` is the
+  NAV-009 setting. Tests: [test/back_gesture_engine_test.dart](../../../test/back_gesture_engine_test.dart)
+
 #### `lib/main.dart`
 - `_isBackHandling` — boolean guard for PopScope handler
+- `_backAtHistoryStart` — NAV-009 setting, mirrored from the `backOpensMenu` pref
+- `_drawerOpenedByBackGesture` — set when the handler opens the drawer, cleared by
+  `Scaffold.onDrawerChanged` on every close, so only a gesture-opened drawer escalates
+- `_openDrawerFromBackGesture()` — the one place that opens the drawer for NAV-009
 - `_goHome()` — synchronous: dispose webview, reset URL, trigger rebuild
 - `PopScope` widget — wraps Scaffold; `canPop: false` always on Android (so back never exits the app), `!webviewIsVisible` on other platforms; handles system back gesture with URL comparison, navigating webview history only
 - `drawerEdgeDragWidth` — `0` whenever a webview is visible (drawer edge swipe disabled on all platforms); `null` otherwise
@@ -393,6 +485,14 @@ Home button pressed
 3. Press system back (Android) or trigger PopScope (iOS)
 4. Verify each press navigates back one page
 5. When at the initial URL, verify back does nothing (no drawer, no exit)
+
+### Manual Test: Back At Start Of History (NAV-009)
+
+1. App settings → turn on "Back gesture opens the menu"
+2. Open a site, press system back at its initial URL — the drawer opens
+3. Press system back again — the drawer closes and the app is left (Android)
+4. Open the drawer with the AppBar menu button, press system back — it only closes
+5. Turn the setting off again and repeat step 2 — back does nothing
 
 ### Manual Test: Android Back Never Exits (Webview)
 

--- a/test/back_gesture_engine_test.dart
+++ b/test/back_gesture_engine_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/back_gesture_engine.dart';
+
+BackGestureAction decide({
+  bool drawerOpen = false,
+  bool drawerOpenedByGesture = false,
+  bool drawerAvailable = true,
+  bool hasWebView = true,
+  bool trustsCanGoBack = true,
+  bool canGoBack = false,
+  BackAtHistoryStart atHistoryStart = BackAtHistoryStart.ignore,
+  bool canExitApp = true,
+}) =>
+    decideBackGesture(
+      drawerOpen: drawerOpen,
+      drawerOpenedByGesture: drawerOpenedByGesture,
+      drawerAvailable: drawerAvailable,
+      hasWebView: hasWebView,
+      trustsCanGoBack: trustsCanGoBack,
+      canGoBack: canGoBack,
+      atHistoryStart: atHistoryStart,
+      canExitApp: canExitApp,
+    );
+
+void main() {
+  group('default: back walks history only (NAV-001, issue #369)', () {
+    test('open drawer closes, never exits', () {
+      expect(
+        decide(drawerOpen: true, drawerOpenedByGesture: true),
+        BackGestureAction.closeDrawer,
+      );
+    });
+
+    test('history present navigates back', () {
+      expect(decide(canGoBack: true), BackGestureAction.goBack);
+    });
+
+    test('start of history is a no-op', () {
+      expect(decide(canGoBack: false), BackGestureAction.ignore);
+    });
+
+    test('no site shown is a no-op', () {
+      expect(decide(hasWebView: false), BackGestureAction.ignore);
+    });
+
+    test('canGoBack is not consulted where it under-reports (NAV-002)', () {
+      expect(
+        decide(trustsCanGoBack: false, canGoBack: false),
+        BackGestureAction.attemptGoBack,
+      );
+    });
+
+    test('a failed attempt stays a no-op', () {
+      expect(
+        decideAfterAttemptedGoBack(
+          urlChanged: false,
+          drawerAvailable: true,
+          atHistoryStart: BackAtHistoryStart.ignore,
+        ),
+        BackGestureAction.ignore,
+      );
+    });
+  });
+
+  group('opt-in: back opens the menu (NAV-009, issue #431)', () {
+    const opt = BackAtHistoryStart.openMenu;
+
+    test('start of history opens the drawer', () {
+      expect(
+        decide(canGoBack: false, atHistoryStart: opt),
+        BackGestureAction.openDrawer,
+      );
+    });
+
+    test('history still wins over the drawer', () {
+      expect(
+        decide(canGoBack: true, atHistoryStart: opt),
+        BackGestureAction.goBack,
+      );
+    });
+
+    test('a second gesture on that drawer leaves the app', () {
+      expect(
+        decide(drawerOpen: true, drawerOpenedByGesture: true, atHistoryStart: opt),
+        BackGestureAction.closeDrawerAndExit,
+      );
+    });
+
+    test('a drawer opened from the menu button only closes', () {
+      expect(
+        decide(drawerOpen: true, drawerOpenedByGesture: false, atHistoryStart: opt),
+        BackGestureAction.closeDrawer,
+      );
+    });
+
+    test('platforms that must not quit only close the drawer', () {
+      expect(
+        decide(
+          drawerOpen: true,
+          drawerOpenedByGesture: true,
+          atHistoryStart: opt,
+          canExitApp: false,
+        ),
+        BackGestureAction.closeDrawer,
+      );
+    });
+
+    test('no site shown leaves the app instead of opening the drawer', () {
+      expect(
+        decide(hasWebView: false, atHistoryStart: opt),
+        BackGestureAction.exitApp,
+      );
+      expect(
+        decide(hasWebView: false, atHistoryStart: opt, canExitApp: false),
+        BackGestureAction.ignore,
+      );
+    });
+
+    test('a failed attempt opens the drawer (NAV-002 path)', () {
+      expect(
+        decideAfterAttemptedGoBack(
+          urlChanged: false,
+          drawerAvailable: true,
+          atHistoryStart: opt,
+        ),
+        BackGestureAction.openDrawer,
+      );
+      expect(
+        decideAfterAttemptedGoBack(
+          urlChanged: true,
+          drawerAvailable: true,
+          atHistoryStart: opt,
+        ),
+        BackGestureAction.ignore,
+      );
+    });
+
+    test('a locked kiosk shell keeps the default behaviour (KIOSK-002)', () {
+      expect(
+        decide(canGoBack: false, atHistoryStart: opt, drawerAvailable: false),
+        BackGestureAction.ignore,
+      );
+      expect(
+        decide(
+          drawerOpen: true,
+          drawerOpenedByGesture: true,
+          atHistoryStart: opt,
+          drawerAvailable: false,
+        ),
+        BackGestureAction.closeDrawer,
+      );
+      expect(
+        decide(hasWebView: false, atHistoryStart: opt, drawerAvailable: false),
+        BackGestureAction.ignore,
+      );
+      expect(
+        decideAfterAttemptedGoBack(
+          urlChanged: false,
+          drawerAvailable: false,
+          atHistoryStart: opt,
+        ),
+        BackGestureAction.ignore,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Implements NAV-009 requirement: users can now opt into having the system back gesture open the navigation drawer when at the start of a site's history, with a second gesture on that drawer leaving the app. The setting defaults to off (NAV-001 behavior: back only walks history, never opens drawer or exits).

Key changes:
- New `BackGestureAction` enum and decision logic in `lib/services/back_gesture_engine.dart` with pure functions `decideBackGesture()` and `decideAfterAttemptedGoBack()` that handle all gesture scenarios (history navigation, drawer open/close, app exit, menu opening).
- Added `BackAtHistoryStart` enum to distinguish the two modes: `ignore` (default, NAV-001) and `openMenu` (NAV-009).
- Refactored back gesture handler in `_WebSpacePageState` to call the decision engine instead of inline logic, reducing complexity and enabling testability.
- New `_drawerOpenedByBackGesture` flag to track whether the drawer was opened by the gesture itself (escalates to app exit on next gesture) vs. opened by the user (only closes, never exits).
- Added `backOpensMenu` toggle to app settings with persistence as `kBackOpensMenuKey` pref, included in settings export/import.
- Setting has no effect while kiosk shell is locked (KIOSK-002), which owns the drawer's absence.
- Comprehensive test suite in `test/back_gesture_engine_test.dart` covering all scenarios: default behavior, opt-in behavior, history precedence, URL-comparison path (NAV-002), and kiosk lock interaction.
- Updated navigation spec with NAV-009 requirement, decision flow diagram, and all scenario details.
- Localization strings added across all language files.

The implementation preserves NAV-001's safe default (back never misfires mid-navigation) while giving users who want the menu-then-exit sequence the option to enable it.

https://claude.ai/code/session_01WStjTDcXwWTCt1X854oncY