### PR TITLE
Commit the return to the webspace list before the site teardown

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -61,6 +61,7 @@ import 'package:webspace/services/container_native.dart';
 import 'package:webspace/services/container_cookie_manager.dart';
 import 'package:webspace/services/site_settings_qr_codec.dart';
 import 'package:webspace/services/site_activation_engine.dart';
+import 'package:webspace/services/site_teardown_engine.dart';
 import 'package:webspace/services/app_lifecycle_engine.dart';
 import 'package:webspace/services/back_gesture_engine.dart';
 import 'package:webspace/services/site_data_clear_engine.dart';
@@ -3601,30 +3602,27 @@ class _WebSpacePageState extends State<WebSpacePage>
     final version = ++_setCurrentIndexVersion;
 
     if (index == null || index < 0 || index >= _webViewModels.length) {
-      // Going home: opportunistically capture state for the
-      // previously-active site so a later cold start (or
-      // OS-killed-while-backgrounded scenario) can re-hydrate its
-      // back/forward stack and form data on re-activation. The
-      // webview stays loaded (pause-only, not disposed) so a
-      // near-immediate return to the same site keeps its in-memory
-      // tab. Bytes-only capture — `lifecycleState` stays `live`
-      // because the webview is not actually disposed.
-      if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
-        await _captureStateBytes(_webViewModels[_currentIndex!]);
-        if (version != _setCurrentIndexVersion) return;
-        // Before the pause: on iOS the per-instance pause blocks the page's
-        // JS thread, so the stop would sit queued behind it (CAM-012), and so
-        // would the media pause (BGAUDIO-009, no-op for background-audio
-        // sites).
-        await _webViewModels[_currentIndex!].stopRealCameraCapture();
-        if (version != _setCurrentIndexVersion) return;
-        await _webViewModels[_currentIndex!].pauseMediaPlayback();
-        if (version != _setCurrentIndexVersion) return;
-        await _webViewModels[_currentIndex!].pauseWebView();
-        if (version != _setCurrentIndexVersion) return;
-      }
+      final leaving = _currentIndex != null &&
+              _currentIndex! < _webViewModels.length &&
+              _loadedIndices.contains(_currentIndex)
+          ? _webViewModels[_currentIndex!]
+          : null;
+      // Going home is committed before the teardown below, never after it
+      // (NAV-010): every step there is a native round-trip that can throw,
+      // be superseded, or never answer at all, and each of those used to
+      // abandon the whole call with `_currentIndex` still on the site the
+      // user asked to leave — a "back to webspaces" that silently did
+      // nothing. Nothing in the teardown decides where we end up.
       _currentIndex = index;
       _exitFullscreen();
+      // Opportunistically capture state for the previously-active site so a
+      // later cold start (or OS-killed-while-backgrounded scenario) can
+      // re-hydrate its back/forward stack and form data on re-activation.
+      // The webview stays loaded (pause-only, not disposed) so a
+      // near-immediate return to the same site keeps its in-memory tab.
+      // Bytes-only capture — `lifecycleState` stays `live` because the
+      // webview is not actually disposed.
+      if (leaving != null) await _quiesceOutgoingSite(leaving, version);
       return;
     }
 
@@ -3801,14 +3799,8 @@ class _WebSpacePageState extends State<WebSpacePage>
 
     // Pause the previously active webview to save resources
     if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
-      // Before the pause: on iOS the per-instance pause blocks the page's JS
-      // thread, so the stop would sit queued behind it (CAM-012), and so would
-      // the media pause (BGAUDIO-009, no-op for background-audio sites).
-      await _webViewModels[_currentIndex!].stopRealCameraCapture();
-      if (version != _setCurrentIndexVersion) return;
-      await _webViewModels[_currentIndex!].pauseMediaPlayback();
-      if (version != _setCurrentIndexVersion) return;
-      await _webViewModels[_currentIndex!].pauseWebView();
+      await _quiesceOutgoingSite(_webViewModels[_currentIndex!], version,
+          captureState: false);
       if (version != _setCurrentIndexVersion) return;
     }
 
@@ -3859,13 +3851,10 @@ class _WebSpacePageState extends State<WebSpacePage>
     // it unpaused. pauseWebView() is idempotent.
     //
     // unawaited: subsequent activation logic (fullscreen, logging)
-    // doesn't depend on these completing. Race-wise this is safe in
-    // Dart's single-threaded model: the resumeWebView above has
-    // already been dispatched on the platform channel by the time
-    // this loop runs, and the channel preserves FIFO order — so the
-    // active site is never left paused by these. A subsequent
-    // _setCurrentIndex would also do its own resume after these
-    // pauses, so the latest target always ends up resumed.
+    // doesn't depend on these completing, and a page whose JS thread is
+    // frozen may never answer at all. Race-wise the version guard inside
+    // the teardown is what keeps a sweep still in flight from pausing the
+    // site a newer activation has since resumed.
     //
     // (Per-instance pause() doesn't stop JavaScript — see
     // openspec/specs/webview-pause-lifecycle/spec.md. This is a
@@ -3878,13 +3867,10 @@ class _WebSpacePageState extends State<WebSpacePage>
       // Camera stop is dispatched before the pause (CAM-012) and covers the
       // sites pauseWebView() exempts — a notification or background-audio
       // site keeps its JS running, which is exactly where a forgotten capture
-      // would survive. Bound to a local model: the pause runs a microtask
+      // would survive. Bound to a local model: the steps run a microtask
       // later, by which point _webViewModels may have been reindexed.
       final model = _webViewModels[i];
-      unawaited(model
-          .stopRealCameraCapture()
-          .then((_) => model.pauseMediaPlayback())
-          .then((_) => model.pauseWebView()));
+      unawaited(_quiesceOutgoingSite(model, version, captureState: false));
     }
 
     // Auto-enter fullscreen if the site has fullscreenMode enabled
@@ -3988,6 +3974,42 @@ class _WebSpacePageState extends State<WebSpacePage>
       sensitivity: LogSensitivity.sensitive,
     );
     return true;
+  }
+
+  /// Quiesce the site the user is leaving — a site switch, or a return to the
+  /// webspace list (which also captures nav state).
+  ///
+  /// Ordering is CAM-012 / BGAUDIO-009: on iOS the per-instance pause blocks
+  /// the page's JS thread, so the camera stop and the media pause have to be
+  /// dispatched before it or they sit queued behind it forever. That same
+  /// freeze is why the engine bounds the sequence — a page an earlier pause
+  /// left frozen never answers `evaluateJavascript` again, and the caller's
+  /// own state change must not hang on it (NAV-010).
+  Future<void> _quiesceOutgoingSite(
+    WebViewModel model,
+    int version, {
+    bool captureState = true,
+  }) async {
+    final result = await SiteTeardownEngine.quiesceOutgoing(
+      superseded: () => version != _setCurrentIndexVersion,
+      steps: [
+        if (captureState)
+          SiteTeardownStep('captureState', () => _captureStateBytes(model)),
+        SiteTeardownStep('stopRealCameraCapture', model.stopRealCameraCapture),
+        SiteTeardownStep('pauseMediaPlayback', model.pauseMediaPlayback),
+        SiteTeardownStep('pauseWebView', model.pauseWebView),
+      ],
+    );
+    if (result.isClean) return;
+    LogService.instance.log(
+      'WebView',
+      'Teardown of "${model.name}" ran ${result.ran}'
+          '${result.errors.isEmpty ? '' : ', failed ${result.errors}'}'
+          '${result.stalledOn == null ? '' : ', stalled on ${result.stalledOn}'}'
+          '${result.supersededBefore == null ? '' : ', superseded before ${result.supersededBefore}'}',
+      level: result.stalledOn == null ? LogLevel.info : LogLevel.warning,
+      sensitivity: LogSensitivity.sensitive,
+    );
   }
 
   /// Capture state and flip the lifecycle to [SiteLifecycleState.savedForRestore].

--- a/lib/services/site_teardown_engine.dart
+++ b/lib/services/site_teardown_engine.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+
+/// One named step of the outgoing-site teardown.
+class SiteTeardownStep {
+  const SiteTeardownStep(this.name, this.run);
+
+  final String name;
+  final Future<void> Function() run;
+}
+
+/// What a [SiteTeardownEngine.quiesceOutgoing] run actually managed to do.
+class SiteTeardownResult {
+  const SiteTeardownResult({
+    required this.ran,
+    required this.errors,
+    this.stalledOn,
+    this.supersededBefore,
+  });
+
+  /// Steps that ran to completion, in order.
+  final List<String> ran;
+
+  /// Steps that threw, by name. A throwing step never stops the sequence.
+  final Map<String, Object> errors;
+
+  /// The step still in flight when the budget expired, if any.
+  final String? stalledOn;
+
+  /// The step the sequence stopped short of because a newer activation
+  /// superseded this one, if any.
+  final String? supersededBefore;
+
+  bool get isClean =>
+      errors.isEmpty && stalledOn == null && supersededBefore == null;
+}
+
+/// Quiesces the site the user is leaving — the step sequence shared by a site
+/// switch and a return to the webspace list, extracted from
+/// `_WebSpacePageState._setCurrentIndex` so the "what may abandon this
+/// sequence, and what may it cost" rules can be exercised headlessly.
+///
+/// Every step is a native round-trip that can stall for as long as the page
+/// wants: on iOS the per-instance pause freezes the page's JS thread (the
+/// plugin's withheld-`alert()` hack), so a page some earlier pause left frozen
+/// never answers `evaluateJavascript` again. The sequence therefore:
+///
+///   * runs steps in the caller's order (camera stop and media pause before
+///     the pause — CAM-012 / BGAUDIO-009: anything dispatched after the freeze
+///     never runs);
+///   * treats a step that throws as best-effort and keeps going, so losing a
+///     state capture doesn't cost the pause behind it;
+///   * gives the whole sequence one budget and returns when it expires,
+///     because the caller's own state change must not hinge on a native call
+///     that may never answer.
+///
+/// A stalled step is abandoned, not cancelled — Dart cannot cancel a pending
+/// platform-channel reply. The sequence keeps running in the background and
+/// re-checks [superseded] before each remaining step, so a late-arriving reply
+/// can't pause a webview that a newer activation has since resumed.
+class SiteTeardownEngine {
+  /// Long enough that a healthy `saveState()` + AES write on a slow device
+  /// finishes inside it, short enough that a frozen page costs one stutter
+  /// rather than the switch itself.
+  static const Duration defaultBudget = Duration(seconds: 2);
+
+  static Future<SiteTeardownResult> quiesceOutgoing({
+    required List<SiteTeardownStep> steps,
+    required bool Function() superseded,
+    Duration budget = defaultBudget,
+  }) async {
+    final ran = <String>[];
+    final errors = <String, Object>{};
+    String? inFlight;
+    String? supersededBefore;
+
+    Future<void> runAll() async {
+      for (final step in steps) {
+        if (superseded()) {
+          supersededBefore ??= step.name;
+          return;
+        }
+        inFlight = step.name;
+        try {
+          await step.run();
+          ran.add(step.name);
+        } catch (e) {
+          errors[step.name] = e;
+        }
+        inFlight = null;
+      }
+    }
+
+    String? stalledOn;
+    try {
+      await runAll().timeout(budget);
+    } on TimeoutException {
+      stalledOn = inFlight;
+    }
+
+    return SiteTeardownResult(
+      ran: List.unmodifiable(ran),
+      errors: Map.unmodifiable(errors),
+      stalledOn: stalledOn,
+      supersededBefore: supersededBefore,
+    );
+  }
+}

--- a/lib/services/webview_state_secure_storage.dart
+++ b/lib/services/webview_state_secure_storage.dart
@@ -75,12 +75,27 @@ class SecureWebViewStateStorage implements WebViewStateStorage {
   }
 
   Future<void> _doInitialize() async {
-    _store = _overrideStore ?? defaultFileStore(_cacheDir);
-    await _initEncryption();
-    await _clearCacheOnUpgrade();
-    await _store!.ensure();
-    _initialized = true;
-    _initInFlight = null;
+    try {
+      _store = _overrideStore ?? defaultFileStore(_cacheDir);
+      await _initEncryption();
+      await _clearCacheOnUpgrade();
+      await _store!.ensure();
+      _initialized = true;
+    } catch (e) {
+      // Never let an init failure escape: callers `await initialize()` from
+      // inside save/load, which run on the go-home and site-switch paths —
+      // a throw there used to abandon the navigation the user asked for.
+      // Nothing is initialized, so save/load degrade to no-ops below.
+      LogService.instance.log(
+        'WebViewState',
+        'Error initializing state storage: $e',
+        level: LogLevel.error,
+      );
+    } finally {
+      // Cleared on failure too: a memoized rejected future would make every
+      // later call re-throw the one-time failure for the rest of the run.
+      _initInFlight = null;
+    }
   }
 
   Future<void> _initEncryption() async {

--- a/openspec/specs/navigation/spec.md
+++ b/openspec/specs/navigation/spec.md
@@ -339,6 +339,55 @@ The escalation to leaving the app is bound to the drawer the gesture itself open
 
 ---
 
+### Requirement: NAV-010 - Leaving A Site Is Committed Before Its Teardown
+
+Returning to the webspace list SHALL take effect on the user's tap, independently of the teardown of the site being left. `_setCurrentIndex(null)` SHALL assign `_currentIndex` and exit fullscreen **before** it captures nav state, stops a real camera capture, pauses media, or pauses the webview — nothing in that sequence decides where the user ends up.
+
+That teardown is best-effort and SHALL be funnelled through `SiteTeardownEngine.quiesceOutgoing` (also used by the site-switch path and the defensive sweep of background sites), which:
+
+- keeps the caller's step order (camera stop and media pause ahead of the pause — CAM-012 / BGAUDIO-009);
+- treats a step that throws as best-effort and runs the ones behind it anyway;
+- gives the whole sequence one budget (`SiteTeardownEngine.defaultBudget`) and returns when it expires, abandoning — not cancelling — the stalled step;
+- re-checks the `_setCurrentIndexVersion` guard before each remaining step, including after the budget expired, so an abandoned sequence whose native reply lands late cannot pause a webview a newer activation has since resumed (PAUSE-005).
+
+Storage on this path SHALL fail closed rather than throw: `SecureWebViewStateStorage` swallows an initialization failure, degrades save/load to no-ops, and clears its memoized in-flight init so a later call retries instead of replaying the failure for the rest of the run.
+
+**Rationale:** each teardown step is a native round-trip, and the commit used to sit behind all four. Any of them throwing (a state-storage init that failed once and then re-threw its memoized failure forever), being superseded (a version bump from a concurrent delete, archive close, or activation), or never answering at all left `_currentIndex` on the site the user asked to leave — "back to webspaces" did nothing, silently, with nothing to retry against. The never-answering case is reachable: on iOS the per-instance pause freezes the page's JS thread (the plugin's withheld-`alert()` hack), so a site left paused by a race-cancelled switch never answers the `evaluateJavascript` that the next teardown opens with.
+
+#### Scenario: A teardown step that never answers still returns the user home
+
+**Given** site A is active and its JS thread is frozen by an earlier pause
+**When** the user taps "Back to Webspaces"
+**And** the media-pause step never answers
+**Then** `_currentIndex` is already null and fullscreen is already exited
+**And** the sequence is abandoned once the budget expires
+**And** the webspace list is shown
+
+#### Scenario: A failing state capture does not cost the pause
+
+**Given** site A is active
+**And** the state storage fails to initialize
+**When** the user returns to the webspace list
+**Then** the capture step is recorded as failed
+**And** the camera stop, media pause and webview pause still run
+**And** the return to the list is unaffected
+
+#### Scenario: A newer activation still wins the teardown
+
+**Given** a return to the webspace list is mid-teardown of site A
+**When** the user taps site A again before the teardown finishes
+**Then** the remaining teardown steps are skipped
+**And** A is not left paused by the abandoned sequence
+
+#### Scenario: A concurrent delete no longer strands the return
+
+**Given** a return to the webspace list is mid-teardown
+**When** another path bumps `_setCurrentIndexVersion` (site delete, archive close)
+**Then** the teardown stops early
+**And** the user is still on the webspace list, because the commit already happened
+
+---
+
 ## Race Condition Guards
 
 ### Guard: RACE-002 - _isBackHandling Flag
@@ -517,6 +566,14 @@ Home button pressed
 1. Open any site so a webview is visible
 2. Swipe from the left edge — verify the drawer does NOT open
 3. Open the drawer via the AppBar menu button — verify it works
+
+### Manual Test: Back To Webspaces Always Leaves The Site
+
+1. Open a site, then tap "Back to Webspaces" (menu or drawer)
+2. Verify the webspace list appears every time, including:
+   - right after switching between two sites in quick succession
+   - right after deleting another site
+   - on a page that stopped responding
 
 ### Manual Test: Rapid Home Tap (Race Condition)
 

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -349,6 +349,8 @@ The system SHALL capture `controller.saveState()` bytes opportunistically — wi
 
 None of these paths mutate the model's `lifecycleState` — the field stays at `resident` because the webview is not actually disposed. Capture goes through `_captureStateBytes` (bytes-only) rather than `_captureStateForRestore` (bytes + flip-to-savedForRestore). All three gate on `WebViewModel.persistsNavState` (no capture for incognito or archive-tier sites).
 
+The go-home capture runs *after* the home state is committed, inside the bounded teardown of NAV-010 in [navigation](../navigation/spec.md): it is best-effort and never gates the return to the webspace list.
+
 #### Scenario: Go-home captures state for the previously-active site
 
 **Given** site A is the active site
@@ -904,7 +906,7 @@ This narrows PAUSE-001 and PAUSE-002 on Android only: the call sites and call or
 
 ### Requirement: PAUSE-005 — Site-Switch Pause Survives Race-Cancellation
 
-The site-switch pause SHALL respect the `_setCurrentIndexVersion` race guard so a rapid switch sequence does not invert pause/resume ordering.
+The site-switch pause SHALL respect the `_setCurrentIndexVersion` race guard so a rapid switch sequence does not invert pause/resume ordering. The guard is threaded into `SiteTeardownEngine.quiesceOutgoing` (NAV-010 in [navigation](../navigation/spec.md)), which re-checks it before every remaining step — including after its budget expired, so a step abandoned mid-flight cannot pause a site the newer switch has since resumed.
 
 #### Scenario: User taps two sites in quick succession
 

--- a/test/js/camera_capture_stop_funnel.test.js
+++ b/test/js/camera_capture_stop_funnel.test.js
@@ -14,25 +14,39 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
+const { blockAfter } = require('./helpers/dart_blocks');
 
 const repoRoot = path.resolve(__dirname, '..', '..');
 const MAIN = 'lib/main.dart';
 
-const lines = fs.readFileSync(path.join(repoRoot, MAIN), 'utf8').split('\n');
+const src = fs.readFileSync(path.join(repoRoot, MAIN), 'utf8');
+const lines = src.split('\n');
 
-// Deactivation sites: a pause issued against a site that is losing (or has
-// lost) active status. pauseForAppLifecycle is a different axis — the whole
-// app going to background — and is deliberately not covered here.
+// Every deactivation path (go-home, site switch, the sweep of the sites left
+// in the background) runs the same step list through one funnel, so the
+// ordering is asserted once, where it is decided. See NAV-010.
+test(`${MAIN}: the deactivation funnel stops capture before it pauses`, () => {
+  const funnel = blockAfter(
+    src, 'Future<void> _quiesceOutgoingSite(', ') async {', MAIN);
+  const stopIdx = funnel.indexOf('stopRealCameraCapture');
+  const pauseIdx = funnel.indexOf('pauseWebView');
+  assert.notEqual(stopIdx, -1,
+    'a site being backgrounded must have its device capture ended (CAM-012)');
+  assert.notEqual(pauseIdx, -1, 'the funnel must still pause the webview');
+  assert.ok(
+    stopIdx < pauseIdx,
+    'the stop must be posted before the pause, or iOS freezes the JS ' +
+      'thread with the capture still running',
+  );
+});
+
+// Deactivation sites outside the funnel: a pause issued directly against a
+// site that is losing (or has lost) active status. pauseForAppLifecycle is a
+// different axis — the whole app going to background — and is deliberately
+// not covered here.
 const pauseSites = lines
   .map((line, i) => ({ line, i }))
   .filter(({ line }) => /\.pauseWebView\(\)/.test(line));
-
-test(`${MAIN}: has deactivation pause sites to guard`, () => {
-  assert.ok(
-    pauseSites.length >= 3,
-    `expected the known pause call sites, found ${pauseSites.length}`,
-  );
-});
 
 for (const { line, i } of pauseSites) {
   test(`${MAIN}:${i + 1}: capture stop precedes the pause`, () => {

--- a/test/js/go_home_commit_funnel.test.js
+++ b/test/js/go_home_commit_funnel.test.js
@@ -1,0 +1,72 @@
+// Go-home commit funnel gate (NAV-010).
+//
+// `_setCurrentIndex(null)` is what "back to webspaces" and every other return
+// to the site list run through. Its teardown of the site being left is a chain
+// of native round-trips, and each of them can throw, be superseded by a newer
+// activation, or — on an iOS page whose JS thread an earlier pause froze —
+// never answer at all. While `_currentIndex = index` sat *after* that chain,
+// any of those outcomes returned early with the user still on the site: the
+// tap did nothing, with no error and nothing in the UI to retry against.
+//
+// So the home state is committed before the teardown, and the teardown itself
+// is funnelled through `_quiesceOutgoingSite` (bounded + non-fatal, see
+// `SiteTeardownEngine`). A future edit that reintroduces an await ahead of the
+// commit, or dispatches a pause straight from `_setCurrentIndex`, re-opens it.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { blockAfter } = require('./helpers/dart_blocks');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const rel = 'lib/main.dart';
+const src = fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+
+const setCurrentIndex = blockAfter(
+  src, 'Future<void> _setCurrentIndex(int? index) async {', null, rel);
+const goHome = blockAfter(
+  setCurrentIndex,
+  'if (index == null || index < 0 || index >= _webViewModels.length) {',
+  null,
+  rel);
+
+test('the go-home branch commits _currentIndex before it awaits anything', () => {
+  const commit = goHome.indexOf('_currentIndex = index;');
+  assert.notEqual(commit, -1, 'go-home must assign _currentIndex = index');
+  const firstAwait = goHome.indexOf('await ');
+  if (firstAwait !== -1) {
+    assert.ok(commit < firstAwait,
+      'an await ahead of the commit can abandon the branch with _currentIndex ' +
+      'still on the site the user asked to leave');
+  }
+});
+
+test('the go-home branch cannot return before the commit', () => {
+  const commit = goHome.indexOf('_currentIndex = index;');
+  const before = goHome.slice(0, commit);
+  assert.ok(!/\breturn\b/.test(before),
+    'nothing may bail out of go-home before the home state is committed');
+});
+
+test('outgoing-site teardown is funnelled through _quiesceOutgoingSite', () => {
+  for (const raw of [
+    /\.pauseWebView\(\)/,
+    /\.pauseMediaPlayback\(\)/,
+    /\.stopRealCameraCapture\(\)/,
+  ]) {
+    assert.ok(!raw.test(setCurrentIndex),
+      `_setCurrentIndex dispatches ${raw} directly; route it through ` +
+      '_quiesceOutgoingSite so the sequence stays bounded and non-fatal');
+  }
+  assert.match(setCurrentIndex, /_quiesceOutgoingSite\(/,
+    '_setCurrentIndex must quiesce the site being left');
+});
+
+test('the funnel delegates to the bounded engine', () => {
+  const funnel = blockAfter(src, 'Future<void> _quiesceOutgoingSite(', ') async {', rel);
+  assert.match(funnel, /SiteTeardownEngine\.quiesceOutgoing\(/,
+    '_quiesceOutgoingSite must run the steps through SiteTeardownEngine');
+  assert.match(funnel, /superseded: \(\) => version != _setCurrentIndexVersion/,
+    'the teardown must still bail out for a newer activation (PAUSE-005)');
+});

--- a/test/js/helpers/dart_blocks.js
+++ b/test/js/helpers/dart_blocks.js
@@ -1,0 +1,25 @@
+// Brace-matching over Dart source, for the structural gates that assert where
+// a statement sits inside a method rather than merely that it exists.
+
+const assert = require('node:assert/strict');
+
+/**
+ * Body of the brace-balanced block that opens at the first `{` at or after
+ * `marker` — or after `openAt`, searched from `marker`, when given: a Dart
+ * signature with named parameters has a `{` of its own before the body.
+ */
+function blockAfter(text, marker, openAt, what = 'source') {
+  const at = text.indexOf(marker);
+  assert.notEqual(at, -1, `${what} no longer contains ${marker}`);
+  const from = openAt ? text.indexOf(openAt, at) : at + marker.length - 1;
+  assert.notEqual(from, -1, `${what} no longer contains ${openAt}`);
+  const open = text.indexOf('{', from);
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    if (text[i] === '{') depth++;
+    else if (text[i] === '}' && --depth === 0) return text.slice(open + 1, i);
+  }
+  assert.fail(`unbalanced braces after ${marker} in ${what}`);
+}
+
+module.exports = { blockAfter };

--- a/test/site_teardown_engine_test.dart
+++ b/test/site_teardown_engine_test.dart
@@ -1,0 +1,99 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/site_teardown_engine.dart';
+
+/// Regression tests for NAV-010: the teardown of the site the user is leaving
+/// is best-effort and bounded, so nothing in it can strand the navigation that
+/// triggered it.
+void main() {
+  group('SiteTeardownEngine.quiesceOutgoing', () {
+    test('runs the steps in the caller order', () async {
+      final order = <String>[];
+      final result = await SiteTeardownEngine.quiesceOutgoing(
+        superseded: () => false,
+        steps: [
+          SiteTeardownStep('capture', () async => order.add('capture')),
+          SiteTeardownStep('camera', () async => order.add('camera')),
+          SiteTeardownStep('media', () async => order.add('media')),
+          SiteTeardownStep('pause', () async => order.add('pause')),
+        ],
+      );
+      expect(order, ['capture', 'camera', 'media', 'pause']);
+      expect(result.isClean, isTrue);
+      expect(result.ran, ['capture', 'camera', 'media', 'pause']);
+    });
+
+    test('a throwing step does not cost the steps behind it', () async {
+      final order = <String>[];
+      final result = await SiteTeardownEngine.quiesceOutgoing(
+        superseded: () => false,
+        steps: [
+          SiteTeardownStep('capture', () async => throw StateError('disk')),
+          SiteTeardownStep('pause', () async => order.add('pause')),
+        ],
+      );
+      expect(order, ['pause'],
+          reason: 'losing a state capture must not cost the pause');
+      expect(result.ran, ['pause']);
+      expect(result.errors.keys, ['capture']);
+      expect(result.isClean, isFalse);
+    });
+
+    test('a step that never answers returns within the budget', () async {
+      final never = Completer<void>();
+      final reached = <String>[];
+      final result = await SiteTeardownEngine.quiesceOutgoing(
+        budget: const Duration(milliseconds: 20),
+        superseded: () => false,
+        steps: [
+          SiteTeardownStep('media', () => never.future),
+          SiteTeardownStep('pause', () async => reached.add('pause')),
+        ],
+      ).timeout(const Duration(seconds: 5));
+      expect(result.stalledOn, 'media');
+      expect(reached, isEmpty);
+      expect(result.isClean, isFalse);
+    });
+
+    test('a superseding activation stops the remaining steps', () async {
+      final order = <String>[];
+      var version = 1;
+      final result = await SiteTeardownEngine.quiesceOutgoing(
+        superseded: () => version != 1,
+        steps: [
+          SiteTeardownStep('capture', () async {
+            order.add('capture');
+            version = 2; // a newer _setCurrentIndex landed mid-teardown
+          }),
+          SiteTeardownStep('pause', () async => order.add('pause')),
+        ],
+      );
+      expect(order, ['capture'],
+          reason: 'pausing here would freeze the site the newer switch resumed');
+      expect(result.supersededBefore, 'pause');
+    });
+
+    test('a stalled step that answers late still respects supersession',
+        () async {
+      final late = Completer<void>();
+      final order = <String>[];
+      var version = 1;
+      final result = await SiteTeardownEngine.quiesceOutgoing(
+        budget: const Duration(milliseconds: 20),
+        superseded: () => version != 1,
+        steps: [
+          SiteTeardownStep('media', () => late.future),
+          SiteTeardownStep('pause', () async => order.add('pause')),
+        ],
+      );
+      expect(result.stalledOn, 'media');
+      // The caller moved on and a newer activation resumed the site; the
+      // abandoned sequence must not pause it when the reply finally lands.
+      version = 2;
+      late.complete();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(order, isEmpty);
+    });
+  });
+}

--- a/test/webview_state_secure_storage_test.dart
+++ b/test/webview_state_secure_storage_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/file_store.dart';
 import 'package:webspace/services/file_store_io.dart';
 import 'package:webspace/services/webview_state_secure_storage.dart';
 
@@ -139,6 +140,53 @@ class _FakeSecureStorage implements FlutterSecureStorage {
 }
 
 typedef ValueChanged<T> = void Function(T);
+
+/// A [FileStore] whose directory creation fails the first [_failures] times,
+/// then behaves like the in-memory store. Models a transient disk failure
+/// during storage init.
+class _FlakyEnsureStore implements FileStore {
+  _FlakyEnsureStore(this._failures);
+
+  int _failures;
+  final MemoryFileStore _inner = MemoryFileStore();
+  int ensureCalls = 0;
+
+  @override
+  Future<void> ensure() async {
+    ensureCalls++;
+    if (_failures > 0) {
+      _failures--;
+      throw const FileSystemException('no space left on device');
+    }
+    await _inner.ensure();
+  }
+
+  @override
+  Future<bool> exists(String name) => _inner.exists(name);
+
+  @override
+  Future<String?> readText(String name) => _inner.readText(name);
+
+  @override
+  Future<void> writeText(String name, String contents) =>
+      _inner.writeText(name, contents);
+
+  @override
+  Future<Uint8List?> readBytes(String name) => _inner.readBytes(name);
+
+  @override
+  Future<void> writeBytes(String name, List<int> bytes) =>
+      _inner.writeBytes(name, bytes);
+
+  @override
+  Future<void> delete(String name) => _inner.delete(name);
+
+  @override
+  Future<List<String>> list() => _inner.list();
+
+  @override
+  Future<void> deleteAll() => _inner.deleteAll();
+}
 
 void main() {
   late Directory tempDir;
@@ -330,6 +378,38 @@ void main() {
       await storage.removeState('a');
       expect(await storage.loadState('a'), isNull);
       expect(await storage.loadState('b'), Uint8List.fromList([1, 2, 3]));
+    });
+  });
+
+  group('SecureWebViewStateStorage init failure (NAV-010)', () {
+    test('a failing init never escapes into the caller', () async {
+      final store = _FlakyEnsureStore(1);
+      final storage = SecureWebViewStateStorage(
+        secureStorage: fakeStorage,
+        store: store,
+        versionProvider: () => 'v1',
+      );
+      // The go-home / site-switch paths await these; a throw here strands
+      // the navigation that triggered the capture.
+      await expectLater(
+          storage.saveState('a', Uint8List.fromList([1, 2, 3])), completes);
+      await expectLater(storage.loadState('a'), completes);
+    });
+
+    test('a later call retries init instead of replaying the failure',
+        () async {
+      final store = _FlakyEnsureStore(1);
+      final storage = SecureWebViewStateStorage(
+        secureStorage: fakeStorage,
+        store: store,
+        versionProvider: () => 'v1',
+      );
+      final bytes = Uint8List.fromList([9, 8, 7]);
+      await storage.saveState('a', bytes); // init fails, nothing written
+      await storage.saveState('a', bytes); // init retried, write lands
+      expect(store.ensureCalls, 2,
+          reason: 'a memoized rejected init future would never be retried');
+      expect(await storage.loadState('a'), bytes);
     });
   });
 }


### PR DESCRIPTION
The teardown ran first, so a step that threw, was superseded, or never
answered (an iOS page whose JS thread an earlier pause froze) left the
user on the site they asked to leave. It now runs through
SiteTeardownEngine: ordered, non-fatal, budgeted, still version-guarded.

Claude-Session: https://claude.ai/code/session_01VBPPzSa7P2cFfBc8MDmp7L

Co-authored-by: Claude <noreply@anthropic.com>