### PR TITLE
Copy only the filtered DNS entries, not the whole log

### DIFF
--- a/lib/l10n/app_af.arb
+++ b/lib/l10n/app_af.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Wys sensitiewe inskrywings (siteId, URL's, gasheername)",
   "devToolsExport": "Voer uit",
   "devToolsLogsCopied": "{count} loginskrywings gekopieer",
+  "devToolsLogsCopySensitiveTitle": "Sensitiewe inskrywings kopieer?",
+  "devToolsLogsCopySensitiveBody": "{count} van die inskrywings wat gewys word bevat werf-ID's, URL's en gasheername. Die knipbord kan van die toestel af sinkroniseer.",
   "devToolsExportLogsDialogTitle": "Voer logboeke uit",
   "devToolsLogsExported": "Logboeke uitgevoer",
   "siteSettingsTitle": "Instellings",

--- a/lib/l10n/app_am.arb
+++ b/lib/l10n/app_am.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "ስሱ ግቤቶችን አሳይ (siteId, URLs, የአስተናጋጅ ስሞች)",
   "devToolsExport": "ላክ",
   "devToolsLogsCopied": "{count} የምዝግብ ግቤቶች ተቀድተዋል",
+  "devToolsLogsCopySensitiveTitle": "ሚስጥራዊ ግቤቶች ይቅዱ?",
+  "devToolsLogsCopySensitiveBody": "ከሚታዩት ግቤቶች ውስጥ {count} የጣቢያ መለያዎችን፣ URLs እና የአስተናጋጅ ስሞችን ይዘዋል። ቅንጥብ ሰሌዳው ከመሣሪያው ውጭ ሊመሳሰል ይችላል።",
   "devToolsExportLogsDialogTitle": "ምዝግቦችን ላክ",
   "devToolsLogsExported": "ምዝግቦች ተልከዋል",
   "siteSettingsTitle": "ቅንብሮች",

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "إظهار الإدخالات الحسّاسة (siteId، عناوين URL، أسماء المضيفين)",
   "devToolsExport": "تصدير",
   "devToolsLogsCopied": "تم نسخ {count} إدخال سجل",
+  "devToolsLogsCopySensitiveTitle": "نسخ الإدخالات الحساسة؟",
+  "devToolsLogsCopySensitiveBody": "{count} من الإدخالات المعروضة تحتوي على معرّفات المواقع وعناوين URL وأسماء المضيفين. قد تتم مزامنة الحافظة خارج الجهاز.",
   "devToolsExportLogsDialogTitle": "تصدير السجلات",
   "devToolsLogsExported": "تم تصدير السجلات",
   "siteSettingsTitle": "الإعدادات",

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Показвай чувствителни записи (siteId, URL адреси, имена на хостове)",
   "devToolsExport": "Експортирай",
   "devToolsLogsCopied": "Копирани {count} записа от дневника",
+  "devToolsLogsCopySensitiveTitle": "Копиране на чувствителните записи?",
+  "devToolsLogsCopySensitiveBody": "{count} от показаните записи съдържат идентификатори на сайтове, URL адреси и имена на хостове. Клипбордът може да се синхронизира извън устройството.",
   "devToolsExportLogsDialogTitle": "Експортиране на дневници",
   "devToolsLogsExported": "Дневниците са експортирани",
   "siteSettingsTitle": "Настройки",

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "সংবেদনশীল এন্ট্রি দেখান (siteId, URL, হোস্টনেম)",
   "devToolsExport": "এক্সপোর্ট",
   "devToolsLogsCopied": "{count}টি লগ এন্ট্রি কপি হয়েছে",
+  "devToolsLogsCopySensitiveTitle": "সংবেদনশীল এন্ট্রি কপি করবেন?",
+  "devToolsLogsCopySensitiveBody": "প্রদর্শিত এন্ট্রিগুলির মধ্যে {count}টিতে সাইট আইডি, URL ও হোস্টনেম রয়েছে। ক্লিপবোর্ড ডিভাইসের বাইরে সিঙ্ক হতে পারে।",
   "devToolsExportLogsDialogTitle": "লগ এক্সপোর্ট করুন",
   "devToolsLogsExported": "লগ এক্সপোর্ট হয়েছে",
   "siteSettingsTitle": "সেটিংস",

--- a/lib/l10n/app_bs.arb
+++ b/lib/l10n/app_bs.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Prikaži osjetljive unose (siteId, URL-ovi, hostnameovi)",
   "devToolsExport": "Izvezi",
   "devToolsLogsCopied": "Kopirano {count} unosa zapisa",
+  "devToolsLogsCopySensitiveTitle": "Kopirati osjetljive unose?",
+  "devToolsLogsCopySensitiveBody": "{count} prikazanih unosa sadrži ID-ove stranica, URL-ove i imena hostova. Međuspremnik se može sinhronizirati izvan uređaja.",
   "devToolsExportLogsDialogTitle": "Izvezi zapise",
   "devToolsLogsExported": "Zapisi izvezeni",
   "siteSettingsTitle": "Postavke",

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Mostra les entrades sensibles (siteId, URL, noms d'amfitrió)",
   "devToolsExport": "Exporta",
   "devToolsLogsCopied": "S'han copiat {count} entrades de registre",
+  "devToolsLogsCopySensitiveTitle": "Voleu copiar les entrades sensibles?",
+  "devToolsLogsCopySensitiveBody": "{count} de les entrades mostrades contenen identificadors de lloc, URL i noms d'amfitrió. El porta-retalls es pot sincronitzar fora del dispositiu.",
   "devToolsExportLogsDialogTitle": "Exporta els registres",
   "devToolsLogsExported": "S'han exportat els registres",
   "siteSettingsTitle": "Configuració",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Zobrazit citlivé záznamy (siteId, URL, názvy hostitelů)",
   "devToolsExport": "Exportovat",
   "devToolsLogsCopied": "Zkopírováno {count} záznamů protokolu",
+  "devToolsLogsCopySensitiveTitle": "Zkopírovat citlivé záznamy?",
+  "devToolsLogsCopySensitiveBody": "{count} zobrazených záznamů obsahuje ID webů, adresy URL a názvy hostitelů. Schránka se může synchronizovat mimo zařízení.",
   "devToolsExportLogsDialogTitle": "Exportovat protokoly",
   "devToolsLogsExported": "Protokoly exportovány",
   "siteSettingsTitle": "Nastavení",

--- a/lib/l10n/app_cy.arb
+++ b/lib/l10n/app_cy.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Dangos cofnodion sensitif (siteId, URLau, enwau gwesteiwyr)",
   "devToolsExport": "Allforio",
   "devToolsLogsCopied": "Copïwyd {count} cofnod log",
+  "devToolsLogsCopySensitiveTitle": "Copïo cofnodion sensitif?",
+  "devToolsLogsCopySensitiveBody": "Mae {count} o'r cofnodion a ddangosir yn cynnwys IDau gwefan, URLau ac enwau gwesteiwr. Gall y clipfwrdd gydweddu oddi ar y ddyfais.",
   "devToolsExportLogsDialogTitle": "Allforio Logiau",
   "devToolsLogsExported": "Allforiwyd y logiau",
   "siteSettingsTitle": "Gosodiadau",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Vis følsomme poster (siteId, URL'er, værtsnavne)",
   "devToolsExport": "Eksportér",
   "devToolsLogsCopied": "Kopierede {count} logposter",
+  "devToolsLogsCopySensitiveTitle": "Kopiér følsomme poster?",
+  "devToolsLogsCopySensitiveBody": "{count} af de viste poster indeholder websteds-id'er, URL'er og værtsnavne. Udklipsholderen kan synkronisere uden for enheden.",
   "devToolsExportLogsDialogTitle": "Eksportér logfiler",
   "devToolsLogsExported": "Logfiler eksporteret",
   "siteSettingsTitle": "Indstillinger",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Sensible Einträge anzeigen (siteId, URLs, Hostnamen)",
   "devToolsExport": "Exportieren",
   "devToolsLogsCopied": "{count} Protokolleinträge kopiert",
+  "devToolsLogsCopySensitiveTitle": "Sensible Einträge kopieren?",
+  "devToolsLogsCopySensitiveBody": "{count} der angezeigten Einträge enthalten Website-IDs, URLs und Hostnamen. Die Zwischenablage kann außerhalb des Geräts synchronisiert werden.",
   "devToolsExportLogsDialogTitle": "Protokolle exportieren",
   "devToolsLogsExported": "Protokolle exportiert",
   "siteSettingsTitle": "Einstellungen",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Εμφάνιση ευαίσθητων καταχωρήσεων (siteId, URL, ονόματα κεντρικών υπολογιστών)",
   "devToolsExport": "Εξαγωγή",
   "devToolsLogsCopied": "Αντιγράφηκαν {count} καταχωρήσεις καταγραφής",
+  "devToolsLogsCopySensitiveTitle": "Αντιγραφή ευαίσθητων καταχωρήσεων;",
+  "devToolsLogsCopySensitiveBody": "{count} από τις εμφανιζόμενες καταχωρήσεις περιέχουν αναγνωριστικά ιστότοπων, διευθύνσεις URL και ονόματα κεντρικών υπολογιστών. Το πρόχειρο μπορεί να συγχρονιστεί εκτός της συσκευής.",
   "devToolsExportLogsDialogTitle": "Εξαγωγή αρχείων καταγραφής",
   "devToolsLogsExported": "Τα αρχεία καταγραφής εξήχθησαν",
   "siteSettingsTitle": "Ρυθμίσεις",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1671,6 +1671,19 @@
       }
     }
   },
+  "devToolsLogsCopySensitiveTitle": "Copy sensitive entries?",
+  "@devToolsLogsCopySensitiveTitle": {
+    "description": "Title of the dialog shown when the Copy button on the app-log screen would put sensitive log entries on the clipboard."
+  },
+  "devToolsLogsCopySensitiveBody": "{count} of the entries shown carry site IDs, URLs and hostnames. The clipboard can sync off the device.",
+  "@devToolsLogsCopySensitiveBody": {
+    "description": "Body of the dialog asking whether sensitive log entries may be copied to the clipboard. {count} is how many of the visible entries are sensitive.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "devToolsExportLogsDialogTitle": "Export Logs",
   "@devToolsExportLogsDialogTitle": {
     "description": "Title of the file-save dialog when exporting app logs."

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Mostrar entradas sensibles (siteId, URL, nombres de host)",
   "devToolsExport": "Exportar",
   "devToolsLogsCopied": "Se copiaron {count} entradas de registro",
+  "devToolsLogsCopySensitiveTitle": "¿Copiar las entradas sensibles?",
+  "devToolsLogsCopySensitiveBody": "{count} de las entradas mostradas contienen identificadores de sitio, URL y nombres de host. El portapapeles puede sincronizarse fuera del dispositivo.",
   "devToolsExportLogsDialogTitle": "Exportar registros",
   "devToolsLogsExported": "Registros exportados",
   "siteSettingsTitle": "Ajustes",

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Näita tundlikke kirjeid (siteId, URL-id, hostinimed)",
   "devToolsExport": "Ekspordi",
   "devToolsLogsCopied": "Kopeeritud {count} logikirjet",
+  "devToolsLogsCopySensitiveTitle": "Kas kopeerida tundlikud kirjed?",
+  "devToolsLogsCopySensitiveBody": "{count} kuvatud kirjet sisaldab saidi ID-sid, URL-e ja hostinimesid. Lõikelaud võib sünkroonida seadmest välja.",
   "devToolsExportLogsDialogTitle": "Ekspordi logid",
   "devToolsLogsExported": "Logid eksporditud",
   "siteSettingsTitle": "Seaded",

--- a/lib/l10n/app_eu.arb
+++ b/lib/l10n/app_eu.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Erakutsi sarrera sentikorrak (siteId, URLak, ostalari-izenak)",
   "devToolsExport": "Esportatu",
   "devToolsLogsCopied": "{count} erregistro-sarrera kopiatuta",
+  "devToolsLogsCopySensitiveTitle": "Sarrera sentikorrak kopiatu?",
+  "devToolsLogsCopySensitiveBody": "Erakutsitako sarreretatik {count} sarrerak gunearen IDak, URLak eta ostalari-izenak dituzte. Arbela gailutik kanpo sinkroniza daiteke.",
   "devToolsExportLogsDialogTitle": "Esportatu erregistroak",
   "devToolsLogsExported": "Erregistroak esportatuta",
   "siteSettingsTitle": "Ezarpenak",

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "نمایش مدخل‌های حساس (siteId، URLها، نام‌های میزبان)",
   "devToolsExport": "خروجی",
   "devToolsLogsCopied": "{count} مدخل گزارش کپی شد",
+  "devToolsLogsCopySensitiveTitle": "ورودی‌های حساس کپی شوند؟",
+  "devToolsLogsCopySensitiveBody": "{count} مورد از ورودی‌های نمایش‌داده‌شده شناسه سایت، نشانی اینترنتی و نام میزبان دارند. کلیپ‌بورد ممکن است خارج از دستگاه همگام‌سازی شود.",
   "devToolsExportLogsDialogTitle": "خروجی گرفتن از گزارش‌ها",
   "devToolsLogsExported": "گزارش‌ها خروجی گرفته شد",
   "siteSettingsTitle": "تنظیمات",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Näytä arkaluonteiset merkinnät (siteId, URL-osoitteet, isäntänimet)",
   "devToolsExport": "Vie",
   "devToolsLogsCopied": "Kopioitu {count} lokimerkintää",
+  "devToolsLogsCopySensitiveTitle": "Kopioidaanko arkaluontoiset merkinnät?",
+  "devToolsLogsCopySensitiveBody": "{count} näytetystä merkinnästä sisältää sivustotunnuksia, URL-osoitteita ja isäntänimiä. Leikepöytä voi synkronoitua laitteen ulkopuolelle.",
   "devToolsExportLogsDialogTitle": "Vie lokit",
   "devToolsLogsExported": "Lokit viety",
   "siteSettingsTitle": "Asetukset",

--- a/lib/l10n/app_fil.arb
+++ b/lib/l10n/app_fil.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Ipakita ang mga sensitibong entry (siteId, URL, hostname)",
   "devToolsExport": "I-export",
   "devToolsLogsCopied": "Nakopya ang {count} na log entry",
+  "devToolsLogsCopySensitiveTitle": "Kopyahin ang mga sensitibong entry?",
+  "devToolsLogsCopySensitiveBody": "{count} sa mga ipinapakitang entry ang naglalaman ng mga site ID, URL, at hostname. Maaaring mag-sync ang clipboard sa labas ng device.",
   "devToolsExportLogsDialogTitle": "I-export ang mga Log",
   "devToolsLogsExported": "Na-export ang mga log",
   "siteSettingsTitle": "Mga Setting",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Afficher les entrées sensibles (siteId, URL, noms d'hôte)",
   "devToolsExport": "Exporter",
   "devToolsLogsCopied": "{count} entrées de journal copiées",
+  "devToolsLogsCopySensitiveTitle": "Copier les entrées sensibles ?",
+  "devToolsLogsCopySensitiveBody": "{count} des entrées affichées contiennent des identifiants de site, des URL et des noms d'hôte. Le presse-papiers peut se synchroniser en dehors de l'appareil.",
   "devToolsExportLogsDialogTitle": "Exporter les journaux",
   "devToolsLogsExported": "Journaux exportés",
   "siteSettingsTitle": "Paramètres",

--- a/lib/l10n/app_ga.arb
+++ b/lib/l10n/app_ga.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Taispeáin iontrálacha íogaire (siteId, URLanna, óstainmneacha)",
   "devToolsExport": "Easpórtáil",
   "devToolsLogsCopied": "Cóipeáladh {count} iontráil loga",
+  "devToolsLogsCopySensitiveTitle": "Iontrálacha íogaire a chóipeáil?",
+  "devToolsLogsCopySensitiveBody": "Tá aitheantóirí suímh, URLanna agus óstainmneacha i {count} de na hiontrálacha atá ar taispeáint. Is féidir leis an ngearrthaisce sioncronú lasmuigh den ghléas.",
   "devToolsExportLogsDialogTitle": "Easpórtáil Logaí",
   "devToolsLogsExported": "Easpórtáladh na logaí",
   "siteSettingsTitle": "Socruithe",

--- a/lib/l10n/app_gl.arb
+++ b/lib/l10n/app_gl.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Mostrar entradas sensibles (siteId, URL, nomes de servidor)",
   "devToolsExport": "Exportar",
   "devToolsLogsCopied": "Copiáronse {count} entradas de rexistro",
+  "devToolsLogsCopySensitiveTitle": "Copiar as entradas sensibles?",
+  "devToolsLogsCopySensitiveBody": "{count} das entradas amosadas conteñen identificadores de sitio, URL e nomes de servidor. O portapapeis pode sincronizarse fóra do dispositivo.",
   "devToolsExportLogsDialogTitle": "Exportar rexistros",
   "devToolsLogsExported": "Rexistros exportados",
   "siteSettingsTitle": "Axustes",

--- a/lib/l10n/app_gu.arb
+++ b/lib/l10n/app_gu.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "સંવેદનશીલ એન્ટ્રીઓ બતાવો (siteId, URL, હોસ્ટનામ)",
   "devToolsExport": "નિકાસ કરો",
   "devToolsLogsCopied": "{count} લોગ એન્ટ્રીઓ કૉપિ થઈ",
+  "devToolsLogsCopySensitiveTitle": "સંવેદનશીલ એન્ટ્રીઓ કૉપિ કરવી?",
+  "devToolsLogsCopySensitiveBody": "બતાવેલી એન્ટ્રીઓમાંથી {count} એન્ટ્રીમાં સાઇટ ID, URL અને હોસ્ટનેમ છે. ક્લિપબોર્ડ ઉપકરણની બહાર સિંક થઈ શકે છે.",
   "devToolsExportLogsDialogTitle": "લોગ્સ નિકાસ કરો",
   "devToolsLogsExported": "લોગ્સ નિકાસ થયા",
   "siteSettingsTitle": "સેટિંગ્સ",

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "הצג רשומות רגישות (siteId, כתובות URL, שמות מארח)",
   "devToolsExport": "ייצא",
   "devToolsLogsCopied": "הועתקו {count} רשומות יומן",
+  "devToolsLogsCopySensitiveTitle": "להעתיק רשומות רגישות?",
+  "devToolsLogsCopySensitiveBody": "{count} מהרשומות המוצגות מכילות מזהי אתרים, כתובות URL ושמות מארח. הלוח עשוי להסתנכרן אל מחוץ למכשיר.",
   "devToolsExportLogsDialogTitle": "ייצא יומנים",
   "devToolsLogsExported": "היומנים יוצאו",
   "siteSettingsTitle": "הגדרות",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "संवेदनशील प्रविष्टियाँ दिखाएँ (siteId, URL, होस्टनाम)",
   "devToolsExport": "निर्यात करें",
   "devToolsLogsCopied": "{count} लॉग प्रविष्टियाँ कॉपी की गईं",
+  "devToolsLogsCopySensitiveTitle": "संवेदनशील प्रविष्टियाँ कॉपी करें?",
+  "devToolsLogsCopySensitiveBody": "दिखाई गई प्रविष्टियों में से {count} में साइट आईडी, URL और होस्टनाम हैं। क्लिपबोर्ड डिवाइस के बाहर सिंक हो सकता है।",
   "devToolsExportLogsDialogTitle": "लॉग निर्यात करें",
   "devToolsLogsExported": "लॉग निर्यात किए गए",
   "siteSettingsTitle": "सेटिंग",

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Prikaži osjetljive unose (siteId, URL-ovi, imena hostova)",
   "devToolsExport": "Izvezi",
   "devToolsLogsCopied": "Kopirano {count} unosa zapisnika",
+  "devToolsLogsCopySensitiveTitle": "Kopirati osjetljive unose?",
+  "devToolsLogsCopySensitiveBody": "{count} prikazanih unosa sadrži ID-ove stranica, URL-ove i nazive hostova. Međuspremnik se može sinkronizirati izvan uređaja.",
   "devToolsExportLogsDialogTitle": "Izvezi zapisnike",
   "devToolsLogsExported": "Zapisnici izvezeni",
   "siteSettingsTitle": "Postavke",

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Érzékeny bejegyzések megjelenítése (siteId, URL-ek, gazdagépnevek)",
   "devToolsExport": "Exportálás",
   "devToolsLogsCopied": "{count} naplóbejegyzés másolva",
+  "devToolsLogsCopySensitiveTitle": "Másolja az érzékeny bejegyzéseket?",
+  "devToolsLogsCopySensitiveBody": "A megjelenített bejegyzések közül {count} tartalmaz webhelyazonosítókat, URL-eket és gazdaneveket. A vágólap az eszközön kívülre is szinkronizálódhat.",
   "devToolsExportLogsDialogTitle": "Naplók exportálása",
   "devToolsLogsExported": "Naplók exportálva",
   "siteSettingsTitle": "Beállítások",

--- a/lib/l10n/app_hy.arb
+++ b/lib/l10n/app_hy.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Ցույց տալ զգայուն գրառումները (siteId, URL-ներ, հոսթանուններ)",
   "devToolsExport": "Արտահանել",
   "devToolsLogsCopied": "Պատճենվեց {count} մատյանի գրառում",
+  "devToolsLogsCopySensitiveTitle": "Պատճենե՞լ զգայուն գրառումները",
+  "devToolsLogsCopySensitiveBody": "Ցուցադրված գրառումներից {count}-ը պարունակում է կայքի նույնացուցիչներ, URL-ներ և հոսթի անուններ։ Սեղմատախտակը կարող է համաժամացվել սարքից դուրս։",
   "devToolsExportLogsDialogTitle": "Արտահանել մատյանները",
   "devToolsLogsExported": "Մատյանները արտահանվեցին",
   "siteSettingsTitle": "Կարգավորումներ",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Tampilkan entri sensitif (siteId, URL, nama host)",
   "devToolsExport": "Ekspor",
   "devToolsLogsCopied": "Menyalin {count} entri log",
+  "devToolsLogsCopySensitiveTitle": "Salin entri sensitif?",
+  "devToolsLogsCopySensitiveBody": "{count} dari entri yang ditampilkan memuat ID situs, URL, dan nama host. Papan klip dapat disinkronkan ke luar perangkat.",
   "devToolsExportLogsDialogTitle": "Ekspor Log",
   "devToolsLogsExported": "Log diekspor",
   "siteSettingsTitle": "Pengaturan",

--- a/lib/l10n/app_is.arb
+++ b/lib/l10n/app_is.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Sýna viðkvæmar færslur (siteId, URL, hýsilheiti)",
   "devToolsExport": "Flytja út",
   "devToolsLogsCopied": "Afritaði {count} annálafærslur",
+  "devToolsLogsCopySensitiveTitle": "Afrita viðkvæmar færslur?",
+  "devToolsLogsCopySensitiveBody": "{count} af sýndum færslum innihalda auðkenni vefsvæða, vefslóðir og hýsilnöfn. Klippiborðið getur samstillst út fyrir tækið.",
   "devToolsExportLogsDialogTitle": "Flytja út annála",
   "devToolsLogsExported": "Annálar fluttir út",
   "siteSettingsTitle": "Stillingar",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Mostra voci sensibili (siteId, URL, hostname)",
   "devToolsExport": "Esporta",
   "devToolsLogsCopied": "Copiate {count} voci di log",
+  "devToolsLogsCopySensitiveTitle": "Copiare le voci sensibili?",
+  "devToolsLogsCopySensitiveBody": "{count} delle voci mostrate contengono ID dei siti, URL e nomi host. Gli appunti possono sincronizzarsi fuori dal dispositivo.",
   "devToolsExportLogsDialogTitle": "Esporta log",
   "devToolsLogsExported": "Log esportati",
   "siteSettingsTitle": "Impostazioni",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "機密エントリ（siteId、URL、ホスト名）を表示",
   "devToolsExport": "エクスポート",
   "devToolsLogsCopied": "{count} 件のログエントリをコピーしました",
+  "devToolsLogsCopySensitiveTitle": "機密エントリをコピーしますか？",
+  "devToolsLogsCopySensitiveBody": "表示中のエントリのうち {count} 件にサイト ID、URL、ホスト名が含まれています。クリップボードは端末外に同期されることがあります。",
   "devToolsExportLogsDialogTitle": "ログをエクスポート",
   "devToolsLogsExported": "ログをエクスポートしました",
   "siteSettingsTitle": "設定",

--- a/lib/l10n/app_ka.arb
+++ b/lib/l10n/app_ka.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "სენსიტიური ჩანაწერების ჩვენება (siteId, URL-ები, ჰოსტსახელები)",
   "devToolsExport": "ექსპორტი",
   "devToolsLogsCopied": "დაკოპირდა {count} ჟურნალის ჩანაწერი",
+  "devToolsLogsCopySensitiveTitle": "დაკოპირდეს მგრძნობიარე ჩანაწერები?",
+  "devToolsLogsCopySensitiveBody": "ნაჩვენები ჩანაწერებიდან {count} შეიცავს საიტის იდენტიფიკატორებს, URL-ებსა და ჰოსტების სახელებს. ბუფერი შეიძლება მოწყობილობის გარეთ დასინქრონდეს.",
   "devToolsExportLogsDialogTitle": "ჟურნალების ექსპორტი",
   "devToolsLogsExported": "ჟურნალები დაექსპორტდა",
   "siteSettingsTitle": "პარამეტრები",

--- a/lib/l10n/app_km.arb
+++ b/lib/l10n/app_km.arb
@@ -331,6 +331,8 @@
   "devToolsSensitiveShow": "បង្ហាញ entries រសើប (siteId, URLs, hostnames)",
   "devToolsExport": "Export",
   "devToolsLogsCopied": "បានចម្លង {count} log entries",
+  "devToolsLogsCopySensitiveTitle": "ចម្លងធាតុរសើបឬ?",
+  "devToolsLogsCopySensitiveBody": "ធាតុដែលបង្ហាញចំនួន {count} មានលេខសម្គាល់គេហទំព័រ URL និងឈ្មោះម៉ាស៊ីន។ ក្ដារតម្បៀតខ្ទាស់អាចធ្វើសមកាលកម្មចេញក្រៅឧបករណ៍។",
   "devToolsExportLogsDialogTitle": "Export Logs",
   "devToolsLogsExported": "បាន export logs",
   "siteSettingsTitle": "ការកំណត់",

--- a/lib/l10n/app_kn.arb
+++ b/lib/l10n/app_kn.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "ಸೂಕ್ಷ್ಮ ನಮೂದುಗಳನ್ನು (siteId, URL‌ಗಳು, ಹೋಸ್ಟ್‌ನೇಮ್‌ಗಳು) ತೋರಿಸಿ",
   "devToolsExport": "ರಫ್ತು",
   "devToolsLogsCopied": "{count} ಲಾಗ್ ನಮೂದುಗಳನ್ನು ನಕಲಿಸಲಾಗಿದೆ",
+  "devToolsLogsCopySensitiveTitle": "ಸೂಕ್ಷ್ಮ ನಮೂದುಗಳನ್ನು ನಕಲಿಸಬೇಕೆ?",
+  "devToolsLogsCopySensitiveBody": "ತೋರಿಸಲಾದ ನಮೂದುಗಳಲ್ಲಿ {count} ನಮೂದುಗಳು ಸೈಟ್ ಐಡಿಗಳು, URL ಗಳು ಮತ್ತು ಹೋಸ್ಟ್‌ನೇಮ್‌ಗಳನ್ನು ಹೊಂದಿವೆ. ಕ್ಲಿಪ್‌ಬೋರ್ಡ್ ಸಾಧನದ ಹೊರಗೆ ಸಿಂಕ್ ಆಗಬಹುದು.",
   "devToolsExportLogsDialogTitle": "ಲಾಗ್‌ಗಳನ್ನು ರಫ್ತು ಮಾಡಿ",
   "devToolsLogsExported": "ಲಾಗ್‌ಗಳನ್ನು ರಫ್ತು ಮಾಡಲಾಗಿದೆ",
   "siteSettingsTitle": "ಸೆಟ್ಟಿಂಗ್ಸ್",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "민감한 항목(siteId, URL, 호스트 이름) 표시",
   "devToolsExport": "내보내기",
   "devToolsLogsCopied": "로그 항목 {count}개를 복사했습니다",
+  "devToolsLogsCopySensitiveTitle": "민감한 항목을 복사할까요?",
+  "devToolsLogsCopySensitiveBody": "표시된 항목 중 {count}개에 사이트 ID, URL, 호스트 이름이 포함되어 있습니다. 클립보드는 기기 외부로 동기화될 수 있습니다.",
   "devToolsExportLogsDialogTitle": "로그 내보내기",
   "devToolsLogsExported": "로그를 내보냈습니다",
   "siteSettingsTitle": "설정",

--- a/lib/l10n/app_la.arb
+++ b/lib/l10n/app_la.arb
@@ -331,6 +331,8 @@
   "devToolsSensitiveShow": "Inscriptiones sensibiles ostendere (siteId, URL, nomina hospitum)",
   "devToolsExport": "Exportare",
   "devToolsLogsCopied": "{count} inscriptiones actorum exscriptae",
+  "devToolsLogsCopySensitiveTitle": "Inscriptiones sensibiles exscribere?",
+  "devToolsLogsCopySensitiveBody": "{count} ex inscriptionibus ostensis identificatores locorum, URL et nomina hospitum continent. Tabula transcriptionis extra machinam synchronizari potest.",
   "devToolsExportLogsDialogTitle": "Acta exportare",
   "devToolsLogsExported": "Acta exportata",
   "siteSettingsTitle": "Institutiones",

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Rodyti jautrius įrašus (siteId, URL, pagrindinių kompiuterių vardus)",
   "devToolsExport": "Eksportuoti",
   "devToolsLogsCopied": "Nukopijuota žurnalo įrašų: {count}",
+  "devToolsLogsCopySensitiveTitle": "Kopijuoti jautrius įrašus?",
+  "devToolsLogsCopySensitiveBody": "{count} iš rodomų įrašų turi svetainių ID, URL adresus ir prieglobų vardus. Iškarpinė gali būti sinchronizuojama už įrenginio ribų.",
   "devToolsExportLogsDialogTitle": "Eksportuoti žurnalus",
   "devToolsLogsExported": "Žurnalai eksportuoti",
   "siteSettingsTitle": "Nustatymai",

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Rādīt sensitīvus ierakstus (siteId, URL, resursdatoru nosaukumi)",
   "devToolsExport": "Eksportēt",
   "devToolsLogsCopied": "Nokopēti {count} žurnāla ieraksti",
+  "devToolsLogsCopySensitiveTitle": "Kopēt sensitīvos ierakstus?",
+  "devToolsLogsCopySensitiveBody": "{count} no parādītajiem ierakstiem satur vietņu ID, URL adreses un resursdatoru nosaukumus. Starpliktuve var sinhronizēties ārpus ierīces.",
   "devToolsExportLogsDialogTitle": "Eksportēt žurnālus",
   "devToolsLogsExported": "Žurnāli eksportēti",
   "siteSettingsTitle": "Iestatījumi",

--- a/lib/l10n/app_mk.arb
+++ b/lib/l10n/app_mk.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Прикажи чувствителни записи (siteId, URL-и, имиња на хостови)",
   "devToolsExport": "Извези",
   "devToolsLogsCopied": "Копирани {count} записи од дневникот",
+  "devToolsLogsCopySensitiveTitle": "Да се копираат чувствителните записи?",
+  "devToolsLogsCopySensitiveBody": "{count} од прикажаните записи содржат идентификатори на сајтови, URL-адреси и имиња на хостови. Таблата со исечоци може да се синхронизира надвор од уредот.",
   "devToolsExportLogsDialogTitle": "Извези дневници",
   "devToolsLogsExported": "Дневниците се извезени",
   "siteSettingsTitle": "Поставки",

--- a/lib/l10n/app_ml.arb
+++ b/lib/l10n/app_ml.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "സെൻസിറ്റീവ് എൻട്രികൾ കാണിക്കുക (siteId, URL-കൾ, ഹോസ്റ്റ്നെയിമുകൾ)",
   "devToolsExport": "കയറ്റുമതി ചെയ്യുക",
   "devToolsLogsCopied": "{count} ലോഗ് എൻട്രികൾ പകർത്തി",
+  "devToolsLogsCopySensitiveTitle": "സെൻസിറ്റീവ് എൻട്രികൾ പകർത്തണോ?",
+  "devToolsLogsCopySensitiveBody": "കാണിച്ചിരിക്കുന്ന എൻട്രികളിൽ {count} എണ്ണത്തിൽ സൈറ്റ് ഐഡികളും URL-കളും ഹോസ്റ്റ്നാമങ്ങളും ഉണ്ട്. ക്ലിപ്പ്ബോർഡ് ഉപകരണത്തിന് പുറത്തേക്ക് സമന്വയിപ്പിക്കപ്പെട്ടേക്കാം.",
   "devToolsExportLogsDialogTitle": "ലോഗുകൾ കയറ്റുമതി ചെയ്യുക",
   "devToolsLogsExported": "ലോഗുകൾ കയറ്റുമതി ചെയ്തു",
   "siteSettingsTitle": "ക്രമീകരണങ്ങൾ",

--- a/lib/l10n/app_mn.arb
+++ b/lib/l10n/app_mn.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Эмзэг бичлэгүүдийг харуулах (siteId, URL, хостын нэр)",
   "devToolsExport": "Экспортлох",
   "devToolsLogsCopied": "{count} логийн бичлэг хуулагдлаа",
+  "devToolsLogsCopySensitiveTitle": "Нууцлалтай бичлэгүүдийг хуулах уу?",
+  "devToolsLogsCopySensitiveBody": "Харагдаж буй бичлэгүүдийн {count} нь сайтын ID, URL болон хостын нэр агуулна. Түр санах ой төхөөрөмжөөс гадагш синк хийгдэж болно.",
   "devToolsExportLogsDialogTitle": "Лог экспортлох",
   "devToolsLogsExported": "Лог экспортлогдлоо",
   "siteSettingsTitle": "Тохиргоо",

--- a/lib/l10n/app_mr.arb
+++ b/lib/l10n/app_mr.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "संवेदनशील नोंदी दाखवा (siteId, URL, होस्टनावे)",
   "devToolsExport": "निर्यात करा",
   "devToolsLogsCopied": "{count} लॉग नोंदी कॉपी केल्या",
+  "devToolsLogsCopySensitiveTitle": "संवेदनशील नोंदी कॉपी करायच्या?",
+  "devToolsLogsCopySensitiveBody": "दाखवलेल्या नोंदींपैकी {count} नोंदींमध्ये साइट आयडी, URL आणि होस्टनावे आहेत. क्लिपबोर्ड डिव्हाइसबाहेर सिंक होऊ शकतो.",
   "devToolsExportLogsDialogTitle": "लॉग निर्यात करा",
   "devToolsLogsExported": "लॉग निर्यात केले",
   "siteSettingsTitle": "सेटिंग्ज",

--- a/lib/l10n/app_ms.arb
+++ b/lib/l10n/app_ms.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Tunjukkan entri sensitif (siteId, URL, nama hos)",
   "devToolsExport": "Eksport",
   "devToolsLogsCopied": "{count} entri log disalin",
+  "devToolsLogsCopySensitiveTitle": "Salin entri sensitif?",
+  "devToolsLogsCopySensitiveBody": "{count} daripada entri yang dipaparkan mengandungi ID tapak, URL dan nama hos. Papan keratan boleh disegerakkan ke luar peranti.",
   "devToolsExportLogsDialogTitle": "Eksport Log",
   "devToolsLogsExported": "Log dieksport",
   "siteSettingsTitle": "Tetapan",

--- a/lib/l10n/app_mt.arb
+++ b/lib/l10n/app_mt.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Uri entrati sensittivi (siteId, URLs, hostnames)",
   "devToolsExport": "Esporta",
   "devToolsLogsCopied": "Ġew ikkupjati {count} entrati tal-log",
+  "devToolsLogsCopySensitiveTitle": "Tikkopja l-annotazzjonijiet sensittivi?",
+  "devToolsLogsCopySensitiveBody": "{count} mill-annotazzjonijiet murija fihom IDs ta' siti, URLs u ismijiet ta' hosts. Il-klipbord jista' jissinkronizza barra mill-apparat.",
   "devToolsExportLogsDialogTitle": "Esporta l-Logs",
   "devToolsLogsExported": "Il-logs ġew esportati",
   "siteSettingsTitle": "Settings",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Vis sensitive oppføringer (siteId, URL-er, vertsnavn)",
   "devToolsExport": "Eksporter",
   "devToolsLogsCopied": "Kopierte {count} loggoppføringer",
+  "devToolsLogsCopySensitiveTitle": "Kopiere sensitive oppføringer?",
+  "devToolsLogsCopySensitiveBody": "{count} av oppføringene som vises inneholder nettsteds-ID-er, URL-er og vertsnavn. Utklippstavlen kan synkroniseres utenfor enheten.",
   "devToolsExportLogsDialogTitle": "Eksporter logger",
   "devToolsLogsExported": "Logger eksportert",
   "siteSettingsTitle": "Innstillinger",

--- a/lib/l10n/app_ne.arb
+++ b/lib/l10n/app_ne.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "संवेदनशील प्रविष्टिहरू देखाउनुहोस् (siteId, URL, होस्टनाम)",
   "devToolsExport": "निर्यात गर्नुहोस्",
   "devToolsLogsCopied": "{count} लग प्रविष्टिहरू कपी गरियो",
+  "devToolsLogsCopySensitiveTitle": "संवेदनशील प्रविष्टिहरू प्रतिलिपि गर्ने?",
+  "devToolsLogsCopySensitiveBody": "देखाइएका प्रविष्टिहरूमध्ये {count} मा साइट आईडी, URL र होस्टनाम छन्। क्लिपबोर्ड यन्त्रबाहिर सिंक हुन सक्छ।",
   "devToolsExportLogsDialogTitle": "लगहरू निर्यात गर्नुहोस्",
   "devToolsLogsExported": "लगहरू निर्यात गरियो",
   "siteSettingsTitle": "सेटिङ",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Gevoelige vermeldingen tonen (siteId, URL's, hostnamen)",
   "devToolsExport": "Exporteren",
   "devToolsLogsCopied": "{count} logvermeldingen gekopieerd",
+  "devToolsLogsCopySensitiveTitle": "Gevoelige items kopiëren?",
+  "devToolsLogsCopySensitiveBody": "{count} van de getoonde items bevatten site-ID's, URL's en hostnamen. Het klembord kan buiten het apparaat synchroniseren.",
   "devToolsExportLogsDialogTitle": "Logboeken exporteren",
   "devToolsLogsExported": "Logboeken geëxporteerd",
   "siteSettingsTitle": "Instellingen",

--- a/lib/l10n/app_pa.arb
+++ b/lib/l10n/app_pa.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "ਸੰਵੇਦਨਸ਼ੀਲ ਐਂਟਰੀਆਂ ਵਿਖਾਓ (siteId, URL, ਹੋਸਟਨਾਮ)",
   "devToolsExport": "ਐਕਸਪੋਰਟ ਕਰੋ",
   "devToolsLogsCopied": "{count} ਲੌਗ ਐਂਟਰੀਆਂ ਕਾਪੀ ਹੋਈਆਂ",
+  "devToolsLogsCopySensitiveTitle": "ਸੰਵੇਦਨਸ਼ੀਲ ਐਂਟਰੀਆਂ ਕਾਪੀ ਕਰਨੀਆਂ ਹਨ?",
+  "devToolsLogsCopySensitiveBody": "ਦਿਖਾਈਆਂ ਗਈਆਂ ਐਂਟਰੀਆਂ ਵਿੱਚੋਂ {count} ਵਿੱਚ ਸਾਈਟ ID, URL ਅਤੇ ਹੋਸਟਨਾਮ ਹਨ। ਕਲਿੱਪਬੋਰਡ ਡੀਵਾਈਸ ਤੋਂ ਬਾਹਰ ਸਿੰਕ ਹੋ ਸਕਦਾ ਹੈ।",
   "devToolsExportLogsDialogTitle": "ਲੌਗ ਐਕਸਪੋਰਟ ਕਰੋ",
   "devToolsLogsExported": "ਲੌਗ ਐਕਸਪੋਰਟ ਹੋ ਗਏ",
   "siteSettingsTitle": "ਸੈਟਿੰਗਾਂ",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Pokaż wrażliwe wpisy (siteId, adresy URL, nazwy hostów)",
   "devToolsExport": "Eksportuj",
   "devToolsLogsCopied": "Skopiowano {count} wpisów dziennika",
+  "devToolsLogsCopySensitiveTitle": "Skopiować wrażliwe wpisy?",
+  "devToolsLogsCopySensitiveBody": "{count} z wyświetlonych wpisów zawiera identyfikatory witryn, adresy URL i nazwy hostów. Schowek może synchronizować się poza urządzeniem.",
   "devToolsExportLogsDialogTitle": "Eksportuj dzienniki",
   "devToolsLogsExported": "Wyeksportowano dzienniki",
   "siteSettingsTitle": "Ustawienia",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Mostrar entradas sensíveis (siteId, URLs, nomes de anfitrião)",
   "devToolsExport": "Exportar",
   "devToolsLogsCopied": "Copiadas {count} entradas de registo",
+  "devToolsLogsCopySensitiveTitle": "Copiar as entradas sensíveis?",
+  "devToolsLogsCopySensitiveBody": "{count} das entradas mostradas contêm identificadores de sites, URLs e nomes de anfitrião. A área de transferência pode sincronizar fora do dispositivo.",
   "devToolsExportLogsDialogTitle": "Exportar registos",
   "devToolsLogsExported": "Registos exportados",
   "siteSettingsTitle": "Definições",

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Mostrar entradas sensíveis (siteId, URLs, nomes de host)",
   "devToolsExport": "Exportar",
   "devToolsLogsCopied": "{count} entradas de log copiadas",
+  "devToolsLogsCopySensitiveTitle": "Copiar as entradas sensíveis?",
+  "devToolsLogsCopySensitiveBody": "{count} das entradas exibidas contêm identificadores de sites, URLs e nomes de host. A área de transferência pode sincronizar fora do dispositivo.",
   "devToolsExportLogsDialogTitle": "Exportar logs",
   "devToolsLogsExported": "Logs exportados",
   "siteSettingsTitle": "Configurações",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Afișează intrările sensibile (siteId, URL-uri, nume de host)",
   "devToolsExport": "Exportă",
   "devToolsLogsCopied": "S-au copiat {count} intrări de jurnal",
+  "devToolsLogsCopySensitiveTitle": "Copiezi intrările sensibile?",
+  "devToolsLogsCopySensitiveBody": "{count} dintre intrările afișate conțin ID-uri de site, adrese URL și nume de gazdă. Clipboardul se poate sincroniza în afara dispozitivului.",
   "devToolsExportLogsDialogTitle": "Exportă jurnalele",
   "devToolsLogsExported": "Jurnale exportate",
   "siteSettingsTitle": "Setări",

--- a/lib/l10n/app_si.arb
+++ b/lib/l10n/app_si.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "සංවේදී ඇතුළත් කිරීම් (siteId, URLs, සත්කාරක නාම) පෙන්වන්න",
   "devToolsExport": "නිර්යාත කරන්න",
   "devToolsLogsCopied": "ලොග් ඇතුළත් කිරීම් {count}ක් පිටපත් කෙරිණි",
+  "devToolsLogsCopySensitiveTitle": "සංවේදී ඇතුළත් කිරීම් පිටපත් කරන්නද?",
+  "devToolsLogsCopySensitiveBody": "පෙන්වා ඇති ඇතුළත් කිරීම් අතරින් {count}ක් අඩවි හැඳුනුම්, URL සහ ධාරක නාම දරයි. පසුරු පුවරුව උපාංගයෙන් පිටතට සමමුහුර්ත විය හැක.",
   "devToolsExportLogsDialogTitle": "ලොග් නිර්යාත කරන්න",
   "devToolsLogsExported": "ලොග් නිර්යාත කෙරිණි",
   "siteSettingsTitle": "සැකසුම්",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Zobraziť citlivé záznamy (siteId, URL, názvy hostiteľov)",
   "devToolsExport": "Exportovať",
   "devToolsLogsCopied": "Skopírovaných {count} záznamov protokolu",
+  "devToolsLogsCopySensitiveTitle": "Skopírovať citlivé záznamy?",
+  "devToolsLogsCopySensitiveBody": "{count} zobrazených záznamov obsahuje ID stránok, adresy URL a názvy hostiteľov. Schránka sa môže synchronizovať mimo zariadenia.",
   "devToolsExportLogsDialogTitle": "Exportovať protokoly",
   "devToolsLogsExported": "Protokoly exportované",
   "siteSettingsTitle": "Nastavenia",

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Pokaži občutljive vnose (siteId, URL-ji, imena gostiteljev)",
   "devToolsExport": "Izvozi",
   "devToolsLogsCopied": "Kopiranih {count} vnosov dnevnika",
+  "devToolsLogsCopySensitiveTitle": "Želite kopirati občutljive vnose?",
+  "devToolsLogsCopySensitiveBody": "{count} prikazanih vnosov vsebuje ID-je spletnih mest, naslove URL in imena gostiteljev. Odložišče se lahko sinhronizira zunaj naprave.",
   "devToolsExportLogsDialogTitle": "Izvozi dnevnike",
   "devToolsLogsExported": "Dnevniki izvoženi",
   "siteSettingsTitle": "Nastavitve",

--- a/lib/l10n/app_sq.arb
+++ b/lib/l10n/app_sq.arb
@@ -331,6 +331,8 @@
   "devToolsSensitiveShow": "Shfaq hyrje të ndjeshme (siteId, URL, emra hostesh)",
   "devToolsExport": "Eksporto",
   "devToolsLogsCopied": "U kopjuan {count} hyrje regjistri",
+  "devToolsLogsCopySensitiveTitle": "Të kopjohen hyrjet e ndjeshme?",
+  "devToolsLogsCopySensitiveBody": "{count} nga hyrjet e shfaqura përmbajnë ID sajtesh, URL dhe emra hostesh. Kujtesa e fragmenteve mund të sinkronizohet jashtë pajisjes.",
   "devToolsExportLogsDialogTitle": "Eksporto regjistrat",
   "devToolsLogsExported": "Regjistrat u eksportuan",
   "siteSettingsTitle": "Cilësimet",

--- a/lib/l10n/app_sr.arb
+++ b/lib/l10n/app_sr.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Прикажи осетљиве уносе (siteId, URL-ови, хостнејмови)",
   "devToolsExport": "Извези",
   "devToolsLogsCopied": "Копирано {count} уноса дневника",
+  "devToolsLogsCopySensitiveTitle": "Копирати осетљиве уносе?",
+  "devToolsLogsCopySensitiveBody": "{count} приказаних уноса садржи ИД-ове сајтова, URL адресе и имена хостова. Остава може да се синхронизује изван уређаја.",
   "devToolsExportLogsDialogTitle": "Извези дневнике",
   "devToolsLogsExported": "Дневници извезени",
   "siteSettingsTitle": "Подешавања",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Visa känsliga poster (siteId, URL:er, värdnamn)",
   "devToolsExport": "Exportera",
   "devToolsLogsCopied": "Kopierade {count} loggposter",
+  "devToolsLogsCopySensitiveTitle": "Kopiera känsliga poster?",
+  "devToolsLogsCopySensitiveBody": "{count} av posterna som visas innehåller webbplats-ID:n, URL:er och värdnamn. Urklipp kan synkroniseras utanför enheten.",
   "devToolsExportLogsDialogTitle": "Exportera loggar",
   "devToolsLogsExported": "Loggar exporterade",
   "siteSettingsTitle": "Inställningar",

--- a/lib/l10n/app_sw.arb
+++ b/lib/l10n/app_sw.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Onyesha maingizo nyeti (siteId, URL, majina ya mwenyeji)",
   "devToolsExport": "Hamisha",
   "devToolsLogsCopied": "Zimenakiliwa maingizo {count} ya kumbukumbu",
+  "devToolsLogsCopySensitiveTitle": "Nakili maingizo nyeti?",
+  "devToolsLogsCopySensitiveBody": "Maingizo {count} kati ya yanayoonyeshwa yana vitambulisho vya tovuti, URL na majina ya seva pangishi. Ubao wa kunakili unaweza kusawazishwa nje ya kifaa.",
   "devToolsExportLogsDialogTitle": "Hamisha Kumbukumbu",
   "devToolsLogsExported": "Kumbukumbu zimehamishwa",
   "siteSettingsTitle": "Mipangilio",

--- a/lib/l10n/app_ta.arb
+++ b/lib/l10n/app_ta.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "முக்கியமான உள்ளீடுகளைக் காட்டு (siteId, URL கள், ஹோஸ்ட்நேம்கள்)",
   "devToolsExport": "ஏற்றுமதி",
   "devToolsLogsCopied": "{count} பதிவு உள்ளீடுகள் நகலெடுக்கப்பட்டன",
+  "devToolsLogsCopySensitiveTitle": "முக்கியமான உள்ளீடுகளை நகலெடுக்கவா?",
+  "devToolsLogsCopySensitiveBody": "காட்டப்படும் உள்ளீடுகளில் {count} எண்ணிக்கையில் தள ஐடிகள், URL-கள் மற்றும் ஹோஸ்ட்பெயர்கள் உள்ளன. கிளிப்போர்டு சாதனத்திற்கு வெளியே ஒத்திசைக்கப்படலாம்.",
   "devToolsExportLogsDialogTitle": "பதிவுகளை ஏற்றுமதி செய்",
   "devToolsLogsExported": "பதிவுகள் ஏற்றுமதி செய்யப்பட்டன",
   "siteSettingsTitle": "அமைப்புகள்",

--- a/lib/l10n/app_te.arb
+++ b/lib/l10n/app_te.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "సున్నితమైన ఎంట్రీలను చూపించు (siteId, URLs, hostnames)",
   "devToolsExport": "ఎగుమతి చేయి",
   "devToolsLogsCopied": "{count} లాగ్ ఎంట్రీలు కాపీ చేయబడ్డాయి",
+  "devToolsLogsCopySensitiveTitle": "సున్నితమైన ఎంట్రీలను కాపీ చేయాలా?",
+  "devToolsLogsCopySensitiveBody": "చూపిన ఎంట్రీలలో {count} సైట్ IDలు, URLలు మరియు హోస్ట్‌నేమ్‌లను కలిగి ఉన్నాయి. క్లిప్‌బోర్డ్ పరికరం వెలుపలికి సింక్ కావచ్చు.",
   "devToolsExportLogsDialogTitle": "లాగ్‌లను ఎగుమతి చేయి",
   "devToolsLogsExported": "లాగ్‌లు ఎగుమతి చేయబడ్డాయి",
   "siteSettingsTitle": "సెట్టింగ్‌లు",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "แสดงรายการที่ละเอียดอ่อน (siteId, URL, ชื่อโฮสต์)",
   "devToolsExport": "ส่งออก",
   "devToolsLogsCopied": "คัดลอก {count} รายการบันทึกแล้ว",
+  "devToolsLogsCopySensitiveTitle": "คัดลอกรายการที่ละเอียดอ่อนหรือไม่",
+  "devToolsLogsCopySensitiveBody": "รายการที่แสดง {count} รายการมีรหัสไซต์ URL และชื่อโฮสต์ คลิปบอร์ดอาจซิงก์ออกนอกอุปกรณ์",
   "devToolsExportLogsDialogTitle": "ส่งออกบันทึก",
   "devToolsLogsExported": "ส่งออกบันทึกแล้ว",
   "siteSettingsTitle": "การตั้งค่า",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Hassas girişleri göster (siteId, URL'ler, ana makine adları)",
   "devToolsExport": "Dışa aktar",
   "devToolsLogsCopied": "{count} günlük girişi kopyalandı",
+  "devToolsLogsCopySensitiveTitle": "Hassas girdiler kopyalansın mı?",
+  "devToolsLogsCopySensitiveBody": "Gösterilen girdilerin {count} tanesi site kimlikleri, URL'ler ve ana bilgisayar adları içeriyor. Pano cihaz dışına eşitlenebilir.",
   "devToolsExportLogsDialogTitle": "Günlükleri Dışa Aktar",
   "devToolsLogsExported": "Günlükler dışa aktarıldı",
   "siteSettingsTitle": "Ayarlar",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "Показати конфіденційні записи (siteId, URL, імена хостів)",
   "devToolsExport": "Експорт",
   "devToolsLogsCopied": "Скопійовано записів журналу: {count}",
+  "devToolsLogsCopySensitiveTitle": "Скопіювати чутливі записи?",
+  "devToolsLogsCopySensitiveBody": "{count} із показаних записів містять ідентифікатори сайтів, URL-адреси та імена хостів. Буфер обміну може синхронізуватися поза пристроєм.",
   "devToolsExportLogsDialogTitle": "Експортувати журнали",
   "devToolsLogsExported": "Журнали експортовано",
   "siteSettingsTitle": "Налаштування",

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "حساس اندراجات دکھائیں (siteId، URLs، ہوسٹ نام)",
   "devToolsExport": "برآمد کریں",
   "devToolsLogsCopied": "{count} لاگ اندراجات کاپی ہو گئے",
+  "devToolsLogsCopySensitiveTitle": "حساس اندراجات کاپی کریں؟",
+  "devToolsLogsCopySensitiveBody": "دکھائے گئے اندراجات میں سے {count} میں سائٹ IDs، URLs اور ہوسٹ نام شامل ہیں۔ کلپ بورڈ ڈیوائس سے باہر مطابقت پذیر ہو سکتا ہے۔",
   "devToolsExportLogsDialogTitle": "لاگز برآمد کریں",
   "devToolsLogsExported": "لاگز برآمد ہو گئے",
   "siteSettingsTitle": "سیٹنگز",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "顯示敏感項目（siteId、網址、主機名稱）",
   "devToolsExport": "匯出",
   "devToolsLogsCopied": "已複製 {count} 條記錄項目",
+  "devToolsLogsCopySensitiveTitle": "复制敏感条目？",
+  "devToolsLogsCopySensitiveBody": "显示的条目中有 {count} 条包含站点 ID、网址和主机名。剪贴板可能会同步到设备之外。",
   "devToolsExportLogsDialogTitle": "匯出記錄",
   "devToolsLogsExported": "記錄已匯出",
   "siteSettingsTitle": "設定",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -329,6 +329,8 @@
   "devToolsSensitiveShow": "顯示敏感項目（siteId、網址、主機名稱）",
   "devToolsExport": "匯出",
   "devToolsLogsCopied": "已複製 {count} 條記錄項目",
+  "devToolsLogsCopySensitiveTitle": "複製敏感項目？",
+  "devToolsLogsCopySensitiveBody": "顯示的項目中有 {count} 項包含網站 ID、網址和主機名稱。剪貼簿可能會同步到裝置之外。",
   "devToolsExportLogsDialogTitle": "匯出記錄",
   "devToolsLogsExported": "記錄已匯出",
   "siteSettingsTitle": "設定",

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -203,6 +203,10 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
   final ScrollController _consoleScrollController = ScrollController();
   final ScrollController _logScrollController = ScrollController();
 
+  /// Guards `_copyLogs` against re-entry: a second tap while its confirmation
+  /// dialog is up would stack a second dialog (or pop the first).
+  bool _isCopyingLogs = false;
+
   bool _isSearchVisible = false;
   String _searchQuery = '';
   final TextEditingController _searchController = TextEditingController();
@@ -1736,6 +1740,54 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
     );
   }
 
+  /// Copies exactly what the Logs tab shows. Sensitive entries reach the
+  /// clipboard only through the confirmation below: the show-sensitive toggle
+  /// is consent to display them, not to hand them to clipboard history, a
+  /// cloud clipboard or a third-party keyboard. Files written by Export never
+  /// carry them at all.
+  Future<void> _copyLogs(List<LogEntry> filtered) async {
+    if (_isCopyingLogs) return;
+    final loc = AppLocalizations.of(context);
+    final messenger = ScaffoldMessenger.of(context);
+    final sensitive =
+        filtered.where((e) => e.sensitivity == LogSensitivity.sensitive).length;
+    var includeSensitive = false;
+    _isCopyingLogs = true;
+    try {
+      if (sensitive > 0) {
+        final confirmed = await showDialog<bool>(
+          context: context,
+          builder: (dialogContext) => AlertDialog(
+            title: Text(loc.devToolsLogsCopySensitiveTitle),
+            content: Text(loc.devToolsLogsCopySensitiveBody(sensitive)),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(dialogContext).pop(false),
+                child: Text(loc.commonCancel),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(dialogContext).pop(true),
+                child: Text(loc.devToolsCopy),
+              ),
+            ],
+          ),
+        );
+        if (confirmed != true || !mounted) return;
+        includeSensitive = true;
+      }
+      await Clipboard.setData(ClipboardData(
+        text: LogService.formatForClipboard(filtered,
+            includeSensitive: includeSensitive),
+      ));
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(content: Text(loc.devToolsLogsCopied(filtered.length))),
+      );
+    } finally {
+      _isCopyingLogs = false;
+    }
+  }
+
   Widget _buildLogActions(List<LogEntry> filtered) {
     final loc = AppLocalizations.of(context);
     return Padding(
@@ -1748,22 +1800,8 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
             label: Text(loc.devToolsExport),
           ),
           TextButton.icon(
-            onPressed: filtered.isEmpty
-                ? null
-                : () {
-                    // Strip sensitive entries from the clipboard even when the
-                    // tab shows them: the clipboard syncs off-device, same
-                    // contract as export(). See LogService.formatForClipboard.
-                    final text = LogService.formatForClipboard(filtered);
-                    final copied = filtered
-                        .where((e) =>
-                            e.sensitivity != LogSensitivity.sensitive)
-                        .length;
-                    Clipboard.setData(ClipboardData(text: text));
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text(loc.devToolsLogsCopied(copied))),
-                    );
-                  },
+            key: const Key('devtools-logs-copy'),
+            onPressed: filtered.isEmpty ? null : () => _copyLogs(filtered),
             icon: const Icon(Icons.copy, size: 18),
             label: Text(loc.devToolsCopy),
           ),

--- a/lib/screens/dev_tools.dart
+++ b/lib/screens/dev_tools.dart
@@ -1312,7 +1312,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
       children: [
         _buildDnsStats(stats),
         _buildDnsFilters(stats),
-        _buildDnsActions(stats),
+        _buildDnsActions(entries),
         Expanded(
           child: entries.isEmpty
               ? Center(child: Text(_searchQuery.isEmpty ? loc.devToolsDnsEmpty : loc.devToolsNoMatches))
@@ -1408,7 +1408,7 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
     );
   }
 
-  Widget _buildDnsActions(DnsStats stats) {
+  Widget _buildDnsActions(List<DnsLogEntry> entries) {
     final loc = AppLocalizations.of(context);
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
@@ -1422,10 +1422,11 @@ class _DevToolsScreenState extends State<DevToolsScreen> {
             label: Text(loc.devToolsClear),
           ),
           TextButton.icon(
-            onPressed: stats.log.isEmpty
+            key: const Key('devtools-dns-copy'),
+            onPressed: entries.isEmpty
                 ? null
                 : () {
-                    final text = stats.log
+                    final text = entries
                         .map((e) =>
                             '[${_formatTimeMs(e.timestamp)}] ${e.blocked ? 'BLOCKED' : 'ALLOWED'} ${e.domain}')
                         .join('\n');

--- a/lib/services/log_service.dart
+++ b/lib/services/log_service.dart
@@ -94,15 +94,20 @@ class LogService extends ChangeNotifier {
     return buffer.toString();
   }
 
-  /// Format an arbitrary set of entries for the clipboard, dropping sensitive
-  /// ones. The system clipboard syncs off-device (Android clipboard history,
-  /// cloud clipboard, third-party keyboards), so copying from the Logs tab
-  /// falls under the same "sensitive never leaves the device" contract as
-  /// [export] — even when the tab is currently showing sensitive entries.
-  static String formatForClipboard(Iterable<LogEntry> entries) {
+  /// Format an arbitrary set of entries for the clipboard. Sensitive entries
+  /// are dropped unless [includeSensitive] is set: the system clipboard syncs
+  /// off-device (Android clipboard history, cloud clipboard, third-party
+  /// keyboards), so the caller must have confirmed that with the user first.
+  /// Files written by [export] never carry them at all.
+  static String formatForClipboard(
+    Iterable<LogEntry> entries, {
+    bool includeSensitive = false,
+  }) {
     final buffer = StringBuffer();
     for (final entry in entries) {
-      if (entry.sensitivity == LogSensitivity.sensitive) continue;
+      if (!includeSensitive && entry.sensitivity == LogSensitivity.sensitive) {
+        continue;
+      }
       final time = '${entry.timestamp.hour.toString().padLeft(2, '0')}:'
           '${entry.timestamp.minute.toString().padLeft(2, '0')}:'
           '${entry.timestamp.second.toString().padLeft(2, '0')}';

--- a/openspec/specs/developer-tools/spec.md
+++ b/openspec/specs/developer-tools/spec.md
@@ -212,6 +212,22 @@ The app SHALL maintain a ring buffer of app-level log entries accessible from bo
 **Then** only the currently visible (filtered by level chips and search query) log entries are copied to clipboard
 **And** the snackbar shows the count of copied entries
 
+#### Scenario: Copying sensitive entries takes a second confirmation
+
+**Given** the show-sensitive toggle is on and the visible entries include sensitive ones
+**When** the user taps "Copy"
+**Then** a dialog names how many of them are sensitive and that the clipboard can sync off the device
+**When** the user confirms
+**Then** every visible entry, sensitive ones included, is copied
+**When** the user cancels
+**Then** nothing is written to the clipboard
+
+#### Scenario: Sensitive entries never reach a file
+
+**Given** the show-sensitive toggle is on
+**When** the user taps "Export"
+**Then** the written file carries only non-sensitive entries, whatever the toggle says
+
 #### Scenario: Access from App Settings
 
 **Given** no site is loaded
@@ -411,5 +427,6 @@ class ConsoleLogEntry {
 5a. **Save Icon as PNG** (AppBar image icon): tap and verify a save dialog with `{domain}_icon.png`; save and confirm the file opens as a PNG. Test on a site with an SVG favicon (e.g. codeberg) and one with an ICO favicon to confirm both rasterize/convert correctly
 6. **Scripts** (AppBar code icon): tap and verify bottom sheet shows user scripts (or "no scripts" message); expand a script and copy its source
 7. **App Logs tab**: verify app log entries appear; use filter chips; tap "Copy" and paste — verify only filtered entries are copied
-8. **Filtered copy**: on each tab, enter a search query, tap Copy, and verify clipboard contains only the matching entries (not all)
+8. **Filtered copy**: on each tab, enter a search query, tap Copy, and verify clipboard contains only the matching entries (not all). On the DNS tab also select the "Blocked" chip and confirm the allowed lookups stay off the clipboard
+8a. **Sensitive copy**: on the App Logs tab turn on "Show sensitive entries", tap Copy, cancel the dialog and verify the clipboard is untouched; tap Copy again, confirm, and verify the sensitive lines are in the paste. Then tap Export and verify the written file has none of them
 9. Go back, open App Settings -> App Logs: verify it works without a site loaded (share and scripts icons should not appear)

--- a/openspec/specs/dns-blocklist/spec.md
+++ b/openspec/specs/dns-blocklist/spec.md
@@ -551,7 +551,9 @@ Developer Tools SHALL include a DNS tab with a Pi-hole-style query log showing a
 
 **Given** DNS entries are recorded
 **When** the user taps "Copy"
-**Then** the full log is copied to the clipboard in `[timestamp] BLOCKED/ALLOWED domain` format
+**Then** only the entries the status chip and the search query leave visible are
+copied to the clipboard, in `[timestamp] BLOCKED/ALLOWED domain` format
+**And** the Copy button is disabled when those filters leave no entries
 
 ---
 

--- a/test/dev_tools_copy_test.dart
+++ b/test/dev_tools_copy_test.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/l10n/gen/app_localizations.dart';
+import 'package:webspace/screens/dev_tools.dart';
+import 'package:webspace/services/dns_block_service.dart';
+import 'package:webspace/services/log_service.dart';
+import 'package:webspace/services/webview.dart';
+import 'package:webspace/settings/proxy.dart';
+import 'package:webspace/settings/user_script.dart';
+import 'package:webspace/web_view_model.dart';
+
+/// The Copy button on each Developer Tools tab must copy exactly the entries
+/// the tab is showing (DEVTOOLS-003/004): the level chips, the search query
+/// and the DNS blocked/allowed chips all narrow what lands on the clipboard.
+/// Sensitive log entries are the one exception — they reach the clipboard
+/// only through the confirmation dialog.
+class _StubCookieManager implements CookieManager {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _StubHost implements DevToolsHost {
+  @override
+  final String? siteId;
+  _StubHost(this.siteId);
+
+  @override
+  String get name => 'stub';
+  @override
+  String get currentUrl => 'https://example.com/';
+  @override
+  String get iconUrl => 'https://example.com/';
+  @override
+  UserProxySettings? get proxy => null;
+  @override
+  WebViewController? get controller => null;
+  @override
+  List<ConsoleLogEntry> get consoleLogs => const [];
+  @override
+  set onConsoleLogChanged(VoidCallback? cb) {}
+  @override
+  List<Cookie> get cookies => const [];
+  @override
+  set cookies(List<Cookie> value) {}
+  @override
+  Set<BlockedCookie>? get blockedCookies => <BlockedCookie>{};
+  @override
+  List<UserScriptConfig>? get siteUserScripts => const [];
+  @override
+  Set<String> get enabledGlobalScriptIds => const {};
+  @override
+  void reload() {}
+}
+
+void main() {
+  late List<String> clipboard;
+
+  setUp(() {
+    clipboard = [];
+    LogService.instance.resetForTest();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == 'Clipboard.setData') {
+        clipboard.add((call.arguments as Map)['text'] as String);
+      }
+      return null;
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+    LogService.instance.resetForTest();
+    DnsBlockService.instance.loadDomainsFromString('');
+  });
+
+  Future<void> pumpDevTools(WidgetTester tester, {DevToolsHost? host}) async {
+    await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: DevToolsScreen(host: host, cookieManager: _StubCookieManager()),
+    ));
+    await tester.pumpAndSettle();
+  }
+
+  group('App Logs copy', () {
+    testWidgets('copies the visible entries with no dialog when none are sensitive',
+        (tester) async {
+      LogService.instance.log('Nav', 'app started');
+      LogService.instance.log('Theme', 'dark mode on');
+      await pumpDevTools(tester);
+
+      await tester.tap(find.byKey(const Key('devtools-logs-copy')));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsNothing);
+      expect(clipboard, hasLength(1));
+      expect(clipboard.single, contains('app started'));
+      expect(clipboard.single, contains('dark mode on'));
+    });
+
+    testWidgets('sensitive entries are hidden and uncopied while the toggle is off',
+        (tester) async {
+      LogService.instance.log('Nav', 'app started');
+      LogService.instance.log('Cookie', 'siteId=abc host=github.com',
+          sensitivity: LogSensitivity.sensitive);
+      await pumpDevTools(tester);
+
+      await tester.tap(find.byKey(const Key('devtools-logs-copy')));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsNothing);
+      expect(clipboard.single, contains('app started'));
+      expect(clipboard.single.contains('siteId=abc'), isFalse);
+    });
+
+    testWidgets('confirming the dialog copies the sensitive entries too',
+        (tester) async {
+      LogService.instance.log('Nav', 'app started');
+      LogService.instance.log('Cookie', 'siteId=abc host=github.com',
+          sensitivity: LogSensitivity.sensitive);
+      await pumpDevTools(tester);
+
+      await tester.tap(find.byType(Switch));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('devtools-logs-copy')));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsOneWidget);
+      await tester.tap(find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.widgetWithText(TextButton, 'Copy'),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(clipboard.single, contains('app started'));
+      expect(clipboard.single, contains('siteId=abc'));
+    });
+
+    testWidgets('cancelling the dialog copies nothing', (tester) async {
+      LogService.instance.log('Cookie', 'siteId=abc host=github.com',
+          sensitivity: LogSensitivity.sensitive);
+      await pumpDevTools(tester);
+
+      await tester.tap(find.byType(Switch));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('devtools-logs-copy')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.widgetWithText(TextButton, 'Cancel'),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(clipboard, isEmpty);
+    });
+
+    testWidgets('a level filter narrows what is copied', (tester) async {
+      LogService.instance.log('Nav', 'app started');
+      LogService.instance.log('Net', 'request failed', level: LogLevel.error);
+      await pumpDevTools(tester);
+
+      await tester.tap(find.widgetWithText(FilterChip, 'debug'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('devtools-logs-copy')));
+      await tester.pumpAndSettle();
+
+      expect(clipboard.single, contains('request failed'));
+      expect(clipboard.single.contains('app started'), isFalse);
+    });
+  });
+
+  group('DNS log copy', () {
+    testWidgets('copies only the entries the blocked/allowed filter leaves',
+        (tester) async {
+      DnsBlockService.instance.loadDomainsFromString('tracker.net');
+      DnsBlockService.instance.recordHostRequest('site-1', 'tracker.net', true);
+      DnsBlockService.instance.recordHostRequest('site-1', 'example.com', false);
+      addTearDown(() => DnsBlockService.instance.clearStatsForSite('site-1'));
+
+      await pumpDevTools(tester, host: _StubHost('site-1'));
+      await tester.tap(find.text('DNS'));
+      await tester.pumpAndSettle();
+
+      // Blocked-only chip: the allowed lookup must not reach the clipboard.
+      await tester.tap(find.widgetWithText(FilterChip, 'Blocked (1)'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('devtools-dns-copy')));
+      await tester.pumpAndSettle();
+
+      expect(clipboard.single, contains('tracker.net'));
+      expect(clipboard.single.contains('example.com'), isFalse);
+    });
+  });
+}

--- a/test/log_clipboard_strip_test.dart
+++ b/test/log_clipboard_strip_test.dart
@@ -1,10 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:webspace/services/log_service.dart';
 
-/// The Logs tab "Copy" button routes through [LogService.formatForClipboard],
-/// which must drop sensitive entries even when the tab is showing them: the
-/// system clipboard syncs off-device, so it falls under the same contract as
-/// [LogService.export] ("sensitive never leaves the device").
+/// [LogService.formatForClipboard] drops sensitive entries unless the caller
+/// asks for them: the Logs tab only passes `includeSensitive` after the user
+/// confirms the copy, and no other caller may opt in silently. Files written
+/// by [LogService.export] never carry sensitive entries at all.
 void main() {
   LogEntry entry(String tag, String message, LogSensitivity s) => LogEntry(
         timestamp: DateTime(2026, 1, 1, 12, 0, 0),
@@ -14,15 +14,15 @@ void main() {
         sensitivity: s,
       );
 
-  test('formatForClipboard omits sensitive entries but keeps normal ones', () {
-    final entries = [
-      entry('Nav', 'app started', LogSensitivity.normal),
-      entry('Cookie', 'siteId=abc host=github.com proxy=1.2.3.4:8080',
-          LogSensitivity.sensitive),
-      entry('Theme', 'dark mode on', LogSensitivity.normal),
-    ];
+  final mixed = [
+    entry('Nav', 'app started', LogSensitivity.normal),
+    entry('Cookie', 'siteId=abc host=github.com proxy=1.2.3.4:8080',
+        LogSensitivity.sensitive),
+    entry('Theme', 'dark mode on', LogSensitivity.normal),
+  ];
 
-    final out = LogService.formatForClipboard(entries);
+  test('formatForClipboard omits sensitive entries by default', () {
+    final out = LogService.formatForClipboard(mixed);
 
     expect(out, contains('app started'));
     expect(out, contains('dark mode on'));
@@ -38,5 +38,27 @@ void main() {
       entry('Proxy', 'host=10.0.0.1', LogSensitivity.sensitive),
     ];
     expect(LogService.formatForClipboard(entries).trim(), isEmpty);
+  });
+
+  test('formatForClipboard keeps every entry when includeSensitive is set', () {
+    final out = LogService.formatForClipboard(mixed, includeSensitive: true);
+
+    expect(out, contains('app started'));
+    expect(out, contains('siteId=abc'));
+    expect(out, contains('dark mode on'));
+    expect(out.trim().split('\n'), hasLength(3));
+  });
+
+  test('export never ships sensitive entries', () {
+    LogService.instance.resetForTest();
+    LogService.instance.log('Nav', 'app started');
+    LogService.instance.log('Cookie', 'siteId=abc',
+        sensitivity: LogSensitivity.sensitive);
+
+    final out = LogService.instance.export();
+
+    expect(out, contains('app started'));
+    expect(out.contains('siteId=abc'), isFalse);
+    LogService.instance.resetForTest();
   });
 }


### PR DESCRIPTION
The DNS tab's Copy button read stats.log directly, so the status chip and
the search query narrowed the list on screen but not the clipboard, and an
empty filter result still left the button enabled.

Co-authored-by: Claude <noreply@anthropic.com>