### PR TITLE
Persist the protection report on a shorter, bounded debounce

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1584,6 +1584,15 @@ class _WebSpacePageState extends State<WebSpacePage>
         setState(() => _maskBackground = true);
       }
     }
+    // Persist the protection-report counters on every step away from the
+    // foreground, not only on `paused` (STATS-002): desktop never delivers
+    // `paused` at all, and a foreground kill delivers nothing, so whatever
+    // sits inside the debounce window is what a restart loses. The write is
+    // gated on a dirty flag, so a transient `inactive` — a native <select>,
+    // a permission prompt — with nothing new recorded costs nothing.
+    if (state != AppLifecycleState.resumed) {
+      unawaited(BlockStatsService.instance.flush());
+    }
     // Only treat `paused` as a real backgrounding event. `inactive` fires for
     // any transient focus loss — native <select> popup dialog, app-switcher
     // peek, system permission prompt, incoming call on iOS — where pausing
@@ -1592,10 +1601,6 @@ class _WebSpacePageState extends State<WebSpacePage>
     if (state == AppLifecycleState.paused) {
       _foregroundPollTimer?.cancel();
       _foregroundPollTimer = null;
-      // Persist the protection-report counters before the OS can reclaim
-      // the process: the in-memory debounce would otherwise lose up to
-      // BlockStatsService.flushDelay of counts on a kill.
-      unawaited(BlockStatsService.instance.flush());
       // URL-ephemeral sites (alwaysOpenHome / incognito) revert to their
       // initUrl only on a genuine app restart (fromJson strips currentUrl on
       // cold start, AOH-002) and on home-shortcut tap (AOH-004) — never on a

--- a/lib/services/block_stats_detail.dart
+++ b/lib/services/block_stats_detail.dart
@@ -56,13 +56,24 @@ class BlockStatsDetail {
   final Map<BlockCategory, Map<String, BlockDetailItem>> _items = {};
   final Map<BlockCategory, Map<String, BlockDetailItem>> _sites = {};
   bool _dirty = false;
+  int _revision = 0;
 
   bool get isEmpty => _items.isEmpty && _sites.isEmpty;
 
   /// True when a mutation has not been persisted yet.
   bool get isDirty => _dirty;
 
+  /// Bumped by every mutation. Read it before encoding a payload and hand it
+  /// back to [markCleanAt] once that payload is on disk.
+  int get revision => _revision;
+
   void markClean() => _dirty = false;
+
+  /// Clear the dirty flag only if nothing has been recorded since [revision]
+  /// was read, so rows folded in while a write was in flight stay pending.
+  void markCleanAt(int revision) {
+    if (revision == _revision) _dirty = false;
+  }
 
   /// Fold [count] events of [category] attributed to [siteId] into the
   /// detail. A null or empty [label] still moves the per-site counter: a
@@ -79,13 +90,13 @@ class BlockStatsDetail {
     if (siteId.isNotEmpty) {
       _fold(_sites.putIfAbsent(category, () => <String, BlockDetailItem>{}),
           siteId, count, at, maxSitesPerCategory);
-      _dirty = true;
+      _markDirty();
     }
     final key = label?.trim().toLowerCase();
     if (key == null || key.isEmpty) return;
     _fold(_items.putIfAbsent(category, () => <String, BlockDetailItem>{}), key,
         count, at, maxItemsPerCategory);
-    _dirty = true;
+    _markDirty();
   }
 
   /// Items of [category], most frequent first, ties broken by recency.
@@ -116,7 +127,7 @@ class BlockStatsDetail {
     final cutoff = DateTime(at.year, at.month, at.day - retentionDays);
     final dropped =
         _pruneTables(_items, cutoff) + _pruneTables(_sites, cutoff);
-    if (dropped > 0) _dirty = true;
+    if (dropped > 0) _markDirty();
     return dropped;
   }
 
@@ -134,14 +145,19 @@ class BlockStatsDetail {
       dropped += stale.length;
     }
     _sites.removeWhere((_, table) => table.isEmpty);
-    if (dropped > 0) _dirty = true;
+    if (dropped > 0) _markDirty();
     return dropped;
   }
 
   void clear() {
     _items.clear();
     _sites.clear();
+    _markDirty();
+  }
+
+  void _markDirty() {
     _dirty = true;
+    _revision++;
   }
 
   Map<String, dynamic> toJson() => {

--- a/lib/services/block_stats_detail_storage.dart
+++ b/lib/services/block_stats_detail_storage.dart
@@ -13,7 +13,10 @@ abstract class BlockStatsDetailStore {
   /// The stored payload, or null when there is none (or it cannot be read).
   Future<String?> read();
 
-  Future<void> write(String payload);
+  /// True when [payload] reached the store. False means nothing was written
+  /// (no key, no file, an I/O error), and the caller must keep the payload
+  /// pending rather than treat it as persisted.
+  Future<bool> write(String payload);
 
   /// Forget everything stored. Must leave nothing behind for the next load
   /// to merge: a reset the user confirmed cannot come back on relaunch.
@@ -97,16 +100,18 @@ class SecureBlockStatsDetailStore implements BlockStatsDetailStore {
   }
 
   @override
-  Future<void> write(String payload) async {
+  Future<bool> write(String payload) async {
     await _initialize();
     final store = _store;
     final encrypter = _encrypter;
-    if (store == null || encrypter == null) return;
+    if (store == null || encrypter == null) return false;
     try {
       await store.writeText(_fileName, encrypter.encrypt(payload, iv: _iv).base64);
+      return true;
     } catch (e) {
       LogService.instance.log('BlockStats', 'Detail write failed: $e',
           level: LogLevel.warning);
+      return false;
     }
   }
 

--- a/lib/services/block_stats_engine.dart
+++ b/lib/services/block_stats_engine.dart
@@ -56,6 +56,7 @@ class BlockStatsEngine {
 
   DateTime _since;
   bool _dirty = false;
+  int _revision = 0;
 
   BlockStatsEngine({
     DateTime? since,
@@ -71,7 +72,18 @@ class BlockStatsEngine {
   /// True when a mutation has not been persisted yet.
   bool get isDirty => _dirty;
 
+  /// Bumped by every mutation. Read it before encoding a payload and hand it
+  /// back to [markCleanAt] once that payload is on disk.
+  int get revision => _revision;
+
   void markClean() => _dirty = false;
+
+  /// Clear the dirty flag only if nothing has been recorded since [revision]
+  /// was read. A write that lands after a concurrent [record] must not mark
+  /// those newer counts persisted, or they are dropped on the next kill.
+  void markCleanAt(int revision) {
+    if (revision == _revision) _dirty = false;
+  }
 
   static int dayKey(DateTime d) => d.year * 10000 + d.month * 100 + d.day;
 
@@ -81,7 +93,7 @@ class BlockStatsEngine {
     final bucket = _days.putIfAbsent(dayKey(at), () => <BlockCategory, int>{});
     bucket[category] = (bucket[category] ?? 0) + count;
     _allTime[category] = (_allTime[category] ?? 0) + count;
-    _dirty = true;
+    _markDirty();
   }
 
   /// Per-category totals over the [days] calendar days ending today
@@ -132,7 +144,7 @@ class BlockStatsEngine {
     for (final k in stale) {
       _days.remove(k);
     }
-    if (stale.isNotEmpty) _dirty = true;
+    if (stale.isNotEmpty) _markDirty();
     return stale.length;
   }
 
@@ -141,7 +153,12 @@ class BlockStatsEngine {
     _days.clear();
     _allTime.clear();
     _since = now ?? DateTime.now();
+    _markDirty();
+  }
+
+  void _markDirty() {
     _dirty = true;
+    _revision++;
   }
 
   Map<String, dynamic> toJson() => {

--- a/lib/services/block_stats_service.dart
+++ b/lib/services/block_stats_service.dart
@@ -26,9 +26,17 @@ import 'package:webspace/services/log_service.dart';
 class BlockStatsService {
   static const String prefsKey = 'blockStatsV1';
 
-  /// How long a mutation may sit unpersisted. Block events arrive in bursts
-  /// of hundreds per page load; coalescing keeps that to one write.
-  static const Duration flushDelay = Duration(seconds: 10);
+  /// How long a burst must go quiet before it is persisted. Block events
+  /// arrive in bursts of hundreds per page load; the timer restarts on each
+  /// one, so the burst costs a single write and lands shortly after the page
+  /// settles rather than at the far end of a fixed window.
+  static const Duration flushDelay = Duration(seconds: 2);
+
+  /// Ceiling on how long a recorded count may sit unpersisted, measured from
+  /// the first unflushed record. A page that keeps firing blocked requests
+  /// (an infinite feed, a long-poll) would otherwise hold the idle debounce
+  /// open for as long as the user keeps browsing.
+  static const Duration maxFlushDelay = Duration(seconds: 10);
 
   static BlockStatsService? _instance;
   static BlockStatsService get instance => _instance ??= BlockStatsService._();
@@ -37,14 +45,19 @@ class BlockStatsService {
 
   /// Test seam: drop the singleton so each test starts from a clean engine.
   @visibleForTesting
-  static void resetInstanceForTest() => _instance = null;
+  static void resetInstanceForTest() {
+    _instance?._cancelFlushTimers();
+    _instance = null;
+  }
 
   BlockStatsEngine _engine = BlockStatsEngine();
   final BlockStatsDetail _detail = BlockStatsDetail();
   BlockStatsDetailStore? _detailStore;
   final Set<String> _contributingSiteIds = <String>{};
   final Set<VoidCallback> _listeners = <VoidCallback>{};
-  Timer? _flushTimer;
+  Timer? _idleFlushTimer;
+  Timer? _maxFlushTimer;
+  Future<void> _flushChain = Future<void>.value();
   Future<void>? _initFuture;
   bool _notifyScheduled = false;
   bool _initialized = false;
@@ -156,22 +169,31 @@ class BlockStatsService {
     notifyListeners();
   }
 
-  /// Persist now. Called on the debounce timer, on app pause, and after a
-  /// reset.
-  Future<void> flush() async {
-    _flushTimer?.cancel();
-    _flushTimer = null;
-    await _flushCounters();
-    await _flushDetail();
+  /// Persist now. Called on the debounce timer, on every step away from the
+  /// foreground, and after a reset.
+  Future<void> flush() {
+    _cancelFlushTimers();
+    // Serialised rather than concurrent: two flushes encoding the same
+    // counters can land the older payload last, which drops the difference
+    // until something else marks the engine dirty again.
+    final next =
+        _flushChain.then((_) => _flushCounters()).then((_) => _flushDetail());
+    _flushChain = next.catchError((_) {});
+    return next;
   }
 
   Future<void> _flushCounters() async {
-    if (!_engine.isDirty) return;
-    final payload = jsonEncode(_engine.toJson());
-    _engine.markClean();
+    final engine = _engine;
+    if (!engine.isDirty) return;
+    final revision = engine.revision;
+    final payload = jsonEncode(engine.toJson());
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(prefsKey, payload);
+      // Clean only what this payload carried. Marking clean before the write
+      // hands the counters to a write that may never land, and anything
+      // recorded while it was in flight is not in the payload at all.
+      engine.markCleanAt(revision);
     } catch (e) {
       LogService.instance.log('BlockStats', 'Failed to persist stats: $e',
           level: LogLevel.warning);
@@ -181,16 +203,25 @@ class BlockStatsService {
   Future<void> _flushDetail() async {
     final store = _detailStore;
     if (store == null || !_detail.isDirty) return;
+    final revision = _detail.revision;
     final payload = jsonEncode(_detail.toJson());
-    _detail.markClean();
-    await store.write(payload);
+    if (await store.write(payload)) _detail.markCleanAt(revision);
   }
 
   void _scheduleFlush() {
-    _flushTimer ??= Timer(flushDelay, () {
-      _flushTimer = null;
-      unawaited(flush());
-    });
+    _idleFlushTimer?.cancel();
+    _idleFlushTimer = Timer(flushDelay, () => unawaited(flush()));
+    // Armed once per pending batch and never restarted: the idle timer above
+    // restarts on every event, so a page that keeps blocking requests would
+    // otherwise hold the batch in memory for as long as it browses.
+    _maxFlushTimer ??= Timer(maxFlushDelay, () => unawaited(flush()));
+  }
+
+  void _cancelFlushTimers() {
+    _idleFlushTimer?.cancel();
+    _idleFlushTimer = null;
+    _maxFlushTimer?.cancel();
+    _maxFlushTimer = null;
   }
 
   void addListener(VoidCallback listener) => _listeners.add(listener);

--- a/openspec/specs/block-statistics/spec.md
+++ b/openspec/specs/block-statistics/spec.md
@@ -79,8 +79,20 @@ The system SHALL accumulate block events into per-category buckets keyed by the
 ### Requirement: STATS-002 - Persistence Across Restarts
 
 Counters SHALL survive process death. Writes SHALL be debounced so a page load
-recording hundreds of blocks does not cause hundreds of SharedPreferences writes,
-and SHALL be flushed when the app is backgrounded.
+recording hundreds of blocks does not cause hundreds of SharedPreferences writes.
+
+The debounce is what a restart loses, so it SHALL be bounded from both ends: the
+timer restarts on each event and fires once the events stop (a quiet window of at
+most 3 seconds), and a ceiling of at most 10 seconds, measured from the batch's
+first event, SHALL persist a page that never goes quiet.
+
+Counters SHALL also be flushed on every step away from the foreground, not only on
+`AppLifecycleState.paused`: desktop never delivers `paused`, and a foreground kill
+delivers nothing at all.
+
+A batch SHALL be treated as persisted only once its write has landed. A write that
+fails, and any event recorded while a write was in flight, SHALL stay pending for
+the next flush.
 
 #### Scenario: Counters survive a restart
 
@@ -93,6 +105,26 @@ and SHALL be flushed when the app is backgrounded.
 **Given** a page load records many blocks within the debounce window
 **When** the events are recorded
 **Then** at most one SharedPreferences write is issued for the batch
+**And** it is issued once the page goes quiet, not at the far end of the ceiling
+
+#### Scenario: A page that never goes quiet is still persisted
+
+**Given** a page recording a block a second, so the debounce never expires
+**When** the ceiling is reached
+**Then** the batch is written without waiting for the page to stop
+
+#### Scenario: Leaving the foreground persists immediately
+
+**Given** blocks recorded since the last write
+**When** the app reports any lifecycle state other than `resumed`
+**Then** the counters are flushed without waiting for the debounce
+
+#### Scenario: A write that does not land is retried
+
+**Given** the store cannot accept the payload
+**When** the flush completes
+**Then** the batch stays pending
+**And** the next flush writes it
 
 #### Scenario: Corrupt stored payload
 
@@ -366,4 +398,11 @@ load is still in flight
   `test/block_stats_service_test.dart`, `test/block_stats_detail_test.dart`,
   `test/block_stats_detail_storage_test.dart`, `test/block_stats_screen_test.dart`.
   Structural gate for STATS-007: `test/js/nested_webview_posture_parity.test.js`
-  (`contributesBlockStats` is POSTURE).
+  (`contributesBlockStats` is POSTURE); for the STATS-002 lifecycle flush:
+  `test/js/block_stats_flush_lifecycle.test.js`.
+- **Why the flush is not on `paused` alone.** `paused` is the Android/iOS
+  backgrounding signal; desktop delivers `inactive`/`hidden`/`detached` instead, and
+  a kill from the foreground delivers nothing. Gating the write on a dirty flag makes
+  the wider trigger free: a transient `inactive` with nothing new recorded does no
+  I/O. Same class of gap as the capture-side kill paths in
+  [docs/bugs/003-cold-start-history-loss.md](../../../docs/bugs/003-cold-start-history-loss.md).

--- a/test/block_stats_engine_test.dart
+++ b/test/block_stats_engine_test.dart
@@ -128,6 +128,21 @@ void main() {
       expect(engine.isDirty, isTrue);
     });
 
+    test('markCleanAt clears only what the written payload carried', () {
+      final engine = BlockStatsEngine();
+      engine.record(BlockCategory.filterList);
+      final written = engine.revision;
+
+      // A block recorded while the write was in flight: it is not in the
+      // payload, so the engine must stay dirty for the next flush.
+      engine.record(BlockCategory.dnsBlocklist);
+      engine.markCleanAt(written);
+      expect(engine.isDirty, isTrue);
+
+      engine.markCleanAt(engine.revision);
+      expect(engine.isDirty, isFalse);
+    });
+
     test('corrupt payloads degrade instead of throwing', () {
       final restored = BlockStatsEngine.fromJson(<String, dynamic>{
         'since': 'not-a-date',

--- a/test/block_stats_service_test.dart
+++ b/test/block_stats_service_test.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
 import 'dart:convert';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:webspace/services/block_stats_engine.dart';
@@ -8,6 +10,22 @@ import 'package:webspace/services/settings_backup.dart';
 import 'package:webspace/settings/app_prefs.dart';
 
 import 'helpers/memory_block_stats_store.dart';
+
+/// Smallest slice the fake clock is advanced by, to straddle a timer.
+const Duration _tick = Duration(milliseconds: 1);
+
+/// Boot the service from inside a fake zone. Every future it awaits has to be
+/// created there too — a `Future` born in the real zone schedules its
+/// continuations on the real microtask queue, which the fake clock never
+/// drains, so the flush would appear never to finish.
+BlockStatsService _bootInFakeZone(
+    FakeAsync async, MemoryBlockStatsDetailStore detailStore) {
+  SharedPreferences.setMockInitialValues({});
+  final service = BlockStatsService.instance;
+  unawaited(service.initialize(detailStore: detailStore));
+  async.flushMicrotasks();
+  return service;
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -308,6 +326,109 @@ void main() {
       await service.flush();
 
       expect(detailStore.writes, 1);
+    });
+  });
+
+  group('flush cadence (STATS-002)', () {
+    test('the quiet window is short, and well inside the ceiling', () {
+      // The window is what a restart loses. A page load's burst has to be on
+      // disk seconds after it settles, not at the far end of the ceiling.
+      expect(BlockStatsService.flushDelay,
+          lessThanOrEqualTo(const Duration(seconds: 3)));
+      expect(BlockStatsService.maxFlushDelay,
+          lessThanOrEqualTo(const Duration(seconds: 10)));
+      expect(BlockStatsService.flushDelay,
+          lessThan(BlockStatsService.maxFlushDelay));
+    });
+
+    test('a burst costs one write, shortly after the page goes quiet', () {
+      fakeAsync((async) {
+        final service = _bootInFakeZone(async, detailStore);
+        service.setSiteContributes('site', true);
+
+        for (var i = 0; i < 200; i++) {
+          service.record('site', BlockCategory.filterList,
+              label: 'ads-$i.example');
+        }
+
+        async.elapse(BlockStatsService.flushDelay - _tick);
+        expect(detailStore.writes, 0, reason: 'still coalescing the burst');
+
+        async.elapse(_tick);
+        async.flushMicrotasks();
+
+        expect(detailStore.writes, 1);
+        expect(service.engine.isDirty, isFalse,
+            reason: 'the counters reached SharedPreferences on their own');
+      });
+    });
+
+    test('a page that never goes quiet is persisted at the ceiling', () {
+      fakeAsync((async) {
+        final service = _bootInFakeZone(async, detailStore);
+        service.setSiteContributes('site', true);
+
+        // One block a second: the idle debounce is restarted before it can
+        // expire, so only the ceiling can get this batch onto disk.
+        const step = Duration(seconds: 1);
+        for (var elapsed = Duration.zero;
+            elapsed < BlockStatsService.maxFlushDelay;
+            elapsed += step) {
+          service.record('site', BlockCategory.filterList,
+              label: 'ads.example');
+          expect(detailStore.writes, 0,
+              reason: 'ceiling not reached at $elapsed');
+          async.elapse(step);
+        }
+        async.flushMicrotasks();
+
+        expect(detailStore.writes, 1);
+        expect(service.engine.isDirty, isFalse);
+      });
+    });
+  });
+
+  group('durable flush (STATS-002/STATS-009)', () {
+    test('a detail write that cannot land leaves the rows pending', () async {
+      final service = BlockStatsService.instance;
+      await service.initialize(detailStore: detailStore);
+      service.setSiteContributes('site', true);
+      service.record('site', BlockCategory.filterList, label: 'ads.example');
+
+      detailStore.writable = false;
+      await service.flush();
+
+      expect(detailStore.payload, isNull);
+      expect(service.detail.isDirty, isTrue,
+          reason: 'a write that never landed must not count as persisted');
+
+      detailStore.writable = true;
+      await service.flush();
+
+      expect(detailStore.payload, contains('ads.example'));
+    });
+
+    test('rows recorded while a write is in flight are not marked persisted',
+        () async {
+      final service = BlockStatsService.instance;
+      await service.initialize(detailStore: detailStore);
+      service.setSiteContributes('site', true);
+      service.record('site', BlockCategory.filterList, label: 'first.example');
+
+      final gate = Completer<void>();
+      detailStore.writeGate = gate;
+      final flushing = service.flush();
+      await Future<void>.delayed(Duration.zero);
+      service.record('site', BlockCategory.filterList, label: 'second.example');
+      detailStore.writeGate = null;
+      gate.complete();
+      await flushing;
+
+      expect(service.detail.isDirty, isTrue);
+      expect(detailStore.payload, isNot(contains('second.example')));
+
+      await service.flush();
+      expect(detailStore.payload, contains('second.example'));
     });
   });
 }

--- a/test/helpers/memory_block_stats_store.dart
+++ b/test/helpers/memory_block_stats_store.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:webspace/services/block_stats_detail_storage.dart';
 
 /// In-memory [BlockStatsDetailStore]. Models the contract the encrypted store
@@ -7,13 +9,23 @@ class MemoryBlockStatsDetailStore implements BlockStatsDetailStore {
   String? payload;
   int writes = 0;
 
+  /// Models a store that cannot write (no keychain, read-only disk): the
+  /// service must keep the payload pending instead of dropping it.
+  bool writable = true;
+
+  /// Gate a write mid-flight, so a test can record while one is in progress.
+  Completer<void>? writeGate;
+
   @override
   Future<String?> read() async => payload;
 
   @override
-  Future<void> write(String value) async {
+  Future<bool> write(String value) async {
+    await writeGate?.future;
+    if (!writable) return false;
     payload = value;
     writes++;
+    return true;
   }
 
   @override

--- a/test/js/block_stats_flush_lifecycle.test.js
+++ b/test/js/block_stats_flush_lifecycle.test.js
@@ -1,0 +1,32 @@
+// Protection-report flush funnel gate (STATS-002).
+//
+// The counters live in memory behind a debounce, so the only thing standing
+// between a recorded block and a restart that still shows it is a flush on
+// the way out of the foreground. Flushing on `paused` alone is not that:
+// desktop never delivers `paused`, and a foreground kill (OOM, force-stop)
+// delivers nothing at all. A future edit that narrows the flush back to one
+// lifecycle state re-opens "the stats went back to what they were before".
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const rel = 'lib/main.dart';
+const src = fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+
+test('the flush is gated on leaving the foreground, not on one state', () => {
+  assert.match(
+    src,
+    /if \(state != AppLifecycleState\.resumed\) \{\s*unawaited\(BlockStatsService\.instance\.flush\(\)\);\s*\}/,
+    `${rel} must flush block stats on every non-resumed lifecycle state`);
+});
+
+test('there is a single lifecycle flush call', () => {
+  // A second call inside a state-specific branch would drift from the funnel
+  // above and read as coverage that is not there.
+  const calls = src.match(/BlockStatsService\.instance\.flush\(\)/g) ?? [];
+  assert.equal(calls.length, 1,
+    `${rel} must funnel the lifecycle flush through one call, found ${calls.length}`);
+});


### PR DESCRIPTION
A restart lost whatever was inside the 10s debounce: the report showed the
value from before the last page load. The window is now a 2s quiet period
that restarts on each event, with the 10s ceiling kept for pages that never
go quiet, and the flush fires on every step out of the foreground rather
than on `paused` alone, which desktop never delivers and a foreground kill
skips entirely. Counters are marked persisted only once their write lands.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CqWqHcG9KEeyDf2NvUdPNV