### PR TITLE
Fix media pause dispatch timing on app background

### DIFF
--- a/integration_test/background_audio_media_stop_test.dart
+++ b/integration_test/background_audio_media_stop_test.dart
@@ -140,8 +140,7 @@ void main() {
       description: 'the fixture media to report itself playing '
           '(last beacon: ${beacons.isEmpty ? "none" : beacons.last.playState})',
     );
-    final playingAt = beacons.lastWhere((b) => b.mediaLive).currentTime;
-    log('media live at t=$playingAt');
+    log('media live at t=${beacons.lastWhere((b) => b.mediaLive).currentTime}');
 
     // The toggle is off, so nothing should have armed the media bridge — the
     // BGAUDIO-007 line that tells "toggle off" from "bridge broken".
@@ -153,10 +152,25 @@ void main() {
         reason: 'the media-session shim is only injected for sites with the '
             'Background audio toggle on');
 
+    // Sample the media clock as late as possible. Everything between a beacon
+    // and the background dispatch is foreground time the element is entitled
+    // to advance through, and on a loaded emulator the assertions above cost
+    // more of it than a fixed budget can allow for.
+    beacons.clear();
+    await pumpUntil(
+      () => beacons.isNotEmpty,
+      description: 'a fresh beacon to sample the media clock from',
+    );
+    final before = beacons.last;
+    expect(before.mediaLive, isTrue,
+        reason: 'the media must still be playing when the app backgrounds');
+    log('before background: t=${before.currentTime}');
+
+    const backgroundHold = Duration(seconds: 3);
+    final leftForeground = DateTime.now();
     beacons.clear();
     tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
-    await tester.runAsync(
-        () => Future<void>.delayed(const Duration(seconds: 3)));
+    await tester.runAsync(() => Future<void>.delayed(backgroundHold));
 
     // BGAUDIO-002's negative control already owns "the JS froze"; what matters
     // here is that the media stop was dispatched BEFORE that freeze, so the
@@ -178,14 +192,37 @@ void main() {
       () => beacons.isNotEmpty,
       description: 'beacons to resume after foregrounding',
     );
+    final wallClock = DateTime.now().difference(leftForeground);
     final after = beacons.first;
-    log('after resume: paused=${after.paused} t=${after.currentTime}');
+    log('after resume: paused=${after.paused} t=${after.currentTime} '
+        'wall=${wallClock.inMilliseconds}ms');
     expect(after.mediaStopped, isTrue,
         reason: 'the media of a site with Background audio OFF must be paused '
             'when the app goes to background (BGAUDIO-009). A `paused=false` '
             'here is the reported bug: the audio kept playing, and on iOS the '
             'system transport controls stayed up with it.');
-    expect(after.currentTime, lessThanOrEqualTo(playingAt + 1.0),
+
+    // The element may legitimately advance over the two foreground slivers
+    // around the background window — the stop's dispatch latency going in, and
+    // the resume that precedes the first beacon coming out — but not through
+    // the window itself. So the budget is the wall clock actually spent, minus
+    // the hold it had to sit out, plus a second for those two dispatches. A
+    // site that kept sounding lands a whole hold above it, whatever the
+    // emulator's pace, which a fixed budget cannot say.
+    final advance = after.currentTime - before.currentTime;
+    final wallSeconds = wallClock.inMilliseconds / 1000.0;
+    final budget = wallSeconds - backgroundHold.inSeconds + 1.0;
+    expect(advance, lessThanOrEqualTo(budget),
+        reason: 'the media clock advanced ${advance}s across ${wallSeconds}s '
+            'of wall clock holding a ${backgroundHold.inSeconds}s background: '
+            'it kept playing while the app was away, and was only paused on '
+            'the way back');
+
+    await pumpUntil(
+      () => beacons.length >= 2,
+      description: 'a second beacon to confirm the media clock stands still',
+    );
+    expect(beacons[1].currentTime, closeTo(after.currentTime, 0.05),
         reason: 'a paused element does not advance its currentTime');
 
     // The other half of the report: no media surface for a site that never

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1679,12 +1679,6 @@ class _WebSpacePageState extends State<WebSpacePage>
             'capture=${pausePlan.captureStateIndex != null} '
             'bgAudio=$loadedBgAudio loaded',
       );
-      // Backgrounding is the last moment we control before the OS may kill
-      // the process, and Chromium commits cookies to disk lazily. Unawaited:
-      // durability is best-effort and nothing downstream depends on it.
-      if (pausePlan.flushCookies) {
-        unawaited(_cookieManager.flush());
-      }
       // BGAUDIO-012: a site that stops itself when the page reports hidden
       // (YouTube and every other player built for a tab) needs to be told the
       // app is backgrounded before the OS tells the page it is hidden.
@@ -1695,14 +1689,23 @@ class _WebSpacePageState extends State<WebSpacePage>
       }
       // BGAUDIO-009: a site the user never opted in for must not keep sounding
       // through a backgrounded app (and keep the system transport controls up
-      // with it). Dispatched before the JS pause below — on iOS that pause
-      // blocks the page's JS thread, so this would sit queued behind it.
+      // with it). Dispatched with the visibility hand-off above and ahead of
+      // everything else here: the JS pause below blocks the page's JS thread
+      // on iOS, and Android's CookieManager.flush() blocks the platform thread
+      // on disk I/O with every later channel message queued behind it. The
+      // element decodes on for as long as the stop is waiting its turn.
       final mediaStops = <int, Future<void>>{};
       for (final i in pausePlan.mediaPauseIndices) {
         if (i < 0 || i >= _webViewModels.length) continue;
         mediaStops[i] = _webViewModels[i].pauseMediaPlayback();
       }
       final allMediaStopped = Future.wait(mediaStops.values);
+      // Backgrounding is the last moment we control before the OS may kill
+      // the process, and Chromium commits cookies to disk lazily. Unawaited:
+      // durability is best-effort and nothing downstream depends on it.
+      if (pausePlan.flushCookies) {
+        unawaited(_cookieManager.flush());
+      }
       if (pausePlan.jsPauseIndex != null) {
         final idx = pausePlan.jsPauseIndex!;
         final stopped = mediaStops.remove(idx) ?? Future<void>.value();

--- a/openspec/specs/background-audio/spec.md
+++ b/openspec/specs/background-audio/spec.md
@@ -420,6 +420,11 @@ the ordering constraint CAM-012 already carries):
 - the defensive sweep over other loaded sites at the tail of a switch;
 - every index in `LifecycleBackgroundPlan.mediaPauseIndices` on app background.
 
+On app background it SHALL also precede the cookie flush, which is the other
+platform call the handler makes: Android's `CookieManager.flush()` blocks the
+platform thread on disk I/O, and channel messages behind it wait — the element
+decodes on for as long as the stop sits in a queue.
+
 `AppLifecycleEngine.backgroundPlan` SHALL populate `mediaPauseIndices` with
 every loaded, in-bounds site WITHOUT background audio, ascending. Unlike the
 JS-pause veto (BGAUDIO-002), the exemption here is per-site: one opted-in site
@@ -487,6 +492,9 @@ on the Android emulator
 **When** the test injects `AppLifecycleState.paused`, waits, then `resumed`
 **Then** the beacons that follow the resume report `paused=true` with an
 unchanged `currentTime`
+**And** the media clock advanced by less than the background window it sat out,
+measured against the wall clock the run actually took: a fixed budget reads a
+slow emulator's foreground as a site that kept playing
 **And** `notificationPosted()` is false — no media surface for a site that
 never opted in
 (regression test: `integration_test/background_audio_media_stop_test.dart`)


### PR DESCRIPTION
Reorder lifecycle handlers to dispatch media pause before cookie flush, which blocks the platform thread on Android and delays subsequent channel messages. This prevents audio from continuing to decode while the stop command waits in queue.

Key changes:
- Move `pauseMediaPlayback()` calls ahead of `CookieManager.flush()` in `_WebSpacePageState.handleAppLifecycleStateChanged()`. The flush blocks the platform thread on disk I/O; media elements keep decoding until the stop is actually processed.
- Refine the integration test to measure wall-clock time across the background window and validate that media advance stays within a computed budget (wall seconds minus background hold plus 1s for dispatch latency). This avoids false failures on slow emulators where a fixed time delta cannot distinguish a paused element from one that kept playing.
- Add a second beacon check to confirm the media clock stands still after pause.
- Update spec to document the ordering constraint: media pause must precede cookie flush.

https://claude.ai/code/session_01WV2YDUBpAwKjd5i85cLBeW