### PR TITLE
Don't fire pull-to-refresh on a two-finger pinch

### DIFF
--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 import 'package:webspace/platform/host_platform.dart';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp
-    show PullToRefreshController, PullToRefreshSettings, SslCertificate;
 import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -16,6 +14,7 @@ import 'package:webspace/services/microphone_decision_engine.dart';
 import 'package:webspace/services/screen_share_decision_engine.dart';
 import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/log_service.dart';
+import 'package:webspace/services/pull_to_refresh_gate.dart';
 import 'package:webspace/services/resume_reload_engine.dart';
 import 'package:webspace/services/surface_repaint_engine.dart';
 import 'package:webspace/services/surface_route_observer.dart';
@@ -221,7 +220,7 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
   WebViewController? _controller;
   String? title;
   late String _currentUrl;
-  late final inapp.PullToRefreshController? _pullToRefreshController;
+  late final PullToRefreshGate? _pullToRefreshGate;
 
   /// In-memory protected-content (Widevine/EME) decision for this nested
   /// screen. null = ask, true/false = remembered grant/deny. Nested screens
@@ -340,12 +339,8 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
       currentUrl: widget.url,
     );
     final bool isMobile = hostIsIOS || hostIsAndroid;
-    _pullToRefreshController = isMobile ? inapp.PullToRefreshController(
-      settings: inapp.PullToRefreshSettings(enabled: true),
-      onRefresh: () async {
-        await _reloadAndRepaint();
-      },
-    ) : null;
+    _pullToRefreshGate =
+        isMobile ? PullToRefreshGate.create(onRefresh: _reloadAndRepaint) : null;
     _webView = WebViewFactory.createWebView(
       config: WebViewConfig(
         siteId: widget.siteId,
@@ -516,7 +511,8 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
                   }
                 }
               },
-        pullToRefreshController: _pullToRefreshController,
+        pullToRefreshController: _pullToRefreshGate?.controller,
+        pullToRefreshGate: _pullToRefreshGate,
         onUrlChanged: (url) {
           _devToolsHost.currentUrl = url;
           if (mounted) {

--- a/lib/services/pull_to_refresh_gate.dart
+++ b/lib/services/pull_to_refresh_gate.dart
@@ -1,0 +1,130 @@
+import 'dart:async';
+
+import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp;
+
+/// The slice of [inapp.PullToRefreshController] the gate drives, kept as an
+/// interface so the state machine can be exercised without a platform channel.
+abstract class RefreshControl {
+  Future<void> setEnabled(bool enabled);
+  Future<void> endRefreshing();
+}
+
+class _ControllerRefreshControl implements RefreshControl {
+  _ControllerRefreshControl(this._controller);
+
+  final inapp.PullToRefreshController _controller;
+
+  @override
+  Future<void> setEnabled(bool enabled) => _controller.setEnabled(enabled);
+
+  @override
+  Future<void> endRefreshing() => _controller.endRefreshing();
+}
+
+/// Keeps a two-finger pinch from firing pull-to-refresh (NAV-006).
+///
+/// Neither platform's refresh control is multi-touch aware: Android's
+/// `SwipeRefreshLayout` follows a single pointer and never consults
+/// `getPointerCount()`, so a pinch that starts with the page at scroll top
+/// reads as a downward drag, and iOS's `UIRefreshControl` sees the same thing
+/// through the scroll view's simultaneous two-finger pan. Neither exposes a
+/// knob for it, so the gate watches Flutter's own pointer stream (which sees
+/// every touch over the platform view before the native view does) and:
+///
+///  1. disables the control the moment a second pointer lands, which lands
+///     ahead of the native drag passing its touch slop, and
+///  2. swallows an `onRefresh` that beat step 1, so losing that race costs a
+///     spinner rather than a page reload.
+class PullToRefreshGate {
+  PullToRefreshGate._(this._control, this.controller, this._now);
+
+  /// Builds the refresh controller together with the gate guarding it.
+  factory PullToRefreshGate.create({
+    required Future<void> Function() onRefresh,
+  }) {
+    late final PullToRefreshGate gate;
+    final controller = inapp.PullToRefreshController(
+      settings: inapp.PullToRefreshSettings(enabled: true),
+      onRefresh: () => gate.runRefresh(onRefresh),
+    );
+    gate = PullToRefreshGate._(
+      _ControllerRefreshControl(controller),
+      controller,
+      DateTime.now,
+    );
+    return gate;
+  }
+
+  /// Test seam: a gate over a fake control and clock, with no platform channel
+  /// and no controller of its own.
+  PullToRefreshGate.forControl(
+    RefreshControl control, {
+    DateTime Function() now = DateTime.now,
+  })  : _control = control,
+        controller = null,
+        _now = now;
+
+  /// A refresh arriving this soon after the last finger of a pinch lifted is
+  /// still that pinch: the native control fires on release and the event
+  /// crosses the platform channel after Flutter has seen the pointer up.
+  static const Duration _multiTouchGrace = Duration(milliseconds: 600);
+
+  final RefreshControl _control;
+  final DateTime Function() _now;
+
+  /// The controller to hand to `InAppWebView`, or null for a test gate.
+  final inapp.PullToRefreshController? controller;
+
+  final Set<int> _pointers = <int>{};
+  bool _multiTouch = false;
+  bool _enabled = true;
+  DateTime? _multiTouchEndedAt;
+
+  bool get isEnabled => _enabled;
+
+  /// True while a refresh would be attributable to a multi-touch gesture.
+  bool get suppressesRefresh {
+    if (_multiTouch) return true;
+    final endedAt = _multiTouchEndedAt;
+    return endedAt != null && _now().difference(endedAt) < _multiTouchGrace;
+  }
+
+  void onPointerDown(int pointer) {
+    _pointers.add(pointer);
+    if (_pointers.length < 2 || _multiTouch) return;
+    _multiTouch = true;
+    _setEnabled(false);
+  }
+
+  void onPointerUp(int pointer) {
+    if (!_pointers.remove(pointer)) return;
+    if (_pointers.isNotEmpty || !_multiTouch) return;
+    _multiTouch = false;
+    _multiTouchEndedAt = _now();
+    _setEnabled(true);
+  }
+
+  /// Runs [onRefresh] unless the gesture behind it was a pinch, in which
+  /// case the spinner is stopped and the page is left alone.
+  Future<void> runRefresh(Future<void> Function() onRefresh) async {
+    if (suppressesRefresh) {
+      await _swallow(_control.endRefreshing);
+      return;
+    }
+    await onRefresh();
+  }
+
+  void _setEnabled(bool enabled) {
+    if (_enabled == enabled) return;
+    _enabled = enabled;
+    unawaited(_swallow(() => _control.setEnabled(enabled)));
+  }
+
+  // The control is reachable only once the native view is attached; a pointer
+  // arriving before that (or after disposal) must not surface as an error.
+  Future<void> _swallow(Future<void> Function() op) async {
+    try {
+      await op();
+    } catch (_) {}
+  }
+}

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -16,6 +16,7 @@ import 'package:webspace/services/launch_nonce.dart';
 import 'package:webspace/services/letterbox.dart';
 import 'package:webspace/services/page_zoom_shim.dart';
 import 'package:webspace/services/proxy_relay.dart';
+import 'package:webspace/services/pull_to_refresh_gate.dart';
 import 'package:webspace/services/resume_reload_engine.dart';
 import 'package:webspace/services/target_blank_rewrite.dart';
 import 'package:webspace/services/theme_color_scheme_shim.dart';
@@ -679,6 +680,10 @@ class WebViewConfig {
   )? onUntrustedCertificate;
   /// Optional pull-to-refresh controller for enabling pull-to-refresh gesture.
   final inapp.PullToRefreshController? pullToRefreshController;
+  /// Guards [pullToRefreshController] against two-finger gestures. Owns the
+  /// pointer bookkeeping the platform refresh controls lack; the factory
+  /// feeds it from a [Listener] wrapped around the webview.
+  final PullToRefreshGate? pullToRefreshGate;
   /// Fires when the underlying renderer terminates unexpectedly. On Android
   /// this maps to `WebView.onRenderProcessGone` — the OS sometimes kills the
   /// renderer to reclaim memory after the app has been backgrounded for a
@@ -827,6 +832,7 @@ class WebViewConfig {
     this.onExternalSchemeUrl,
     this.onUntrustedCertificate,
     this.pullToRefreshController,
+    this.pullToRefreshGate,
     this.onRendererGone,
     this.locationMode = LocationMode.off,
     this.spoofLatitude,
@@ -4507,7 +4513,22 @@ class WebViewFactory {
         config.onRendererGone?.call(true);
       },
     );
-    return _applyLetterbox(config, webViewWidget);
+    return _applyLetterbox(config, _applyRefreshGate(config, webViewWidget));
+  }
+
+  /// Feeds the raw pointer stream to [WebViewConfig.pullToRefreshGate].
+  /// [Listener] never joins the gesture arena, so the webview keeps every
+  /// touch it would otherwise receive.
+  static Widget _applyRefreshGate(WebViewConfig config, Widget webView) {
+    final gate = config.pullToRefreshGate;
+    if (gate == null) return webView;
+    return Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerDown: (event) => gate.onPointerDown(event.pointer),
+      onPointerUp: (event) => gate.onPointerUp(event.pointer),
+      onPointerCancel: (event) => gate.onPointerUp(event.pointer),
+      child: webView,
+    );
   }
 
   /// Wrap [webView] in a centered, grid-snapped box with margin bars when the

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -7,7 +7,7 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' show ConsoleMessageLevel;
 import 'package:flutter_inappwebview/flutter_inappwebview.dart' as inapp
-    show CookieManager, PullToRefreshController, PullToRefreshSettings, SslCertificate, WebUri;
+    show CookieManager, SslCertificate, WebUri;
 import 'package:webspace/services/connectivity_service.dart';
 import 'package:webspace/services/container_cookie_manager.dart';
 import 'package:webspace/services/domain_claim.dart';
@@ -21,6 +21,7 @@ import 'package:webspace/services/navigation_decision_engine.dart';
 import 'package:webspace/services/camera_decision_engine.dart';
 import 'package:webspace/services/screen_share_decision_engine.dart';
 import 'package:webspace/services/microphone_decision_engine.dart';
+import 'package:webspace/services/pull_to_refresh_gate.dart';
 import 'package:webspace/services/resume_reload_engine.dart';
 import 'package:webspace/services/firefox_user_agent_service.dart';
 import 'package:webspace/services/site_lifecycle_promotion_engine.dart';
@@ -1179,12 +1180,8 @@ class WebViewModel {
         sensitivity: LogSensitivity.sensitive,
       );
       final bool isMobile = hostIsIOS || hostIsAndroid;
-      final pullToRefreshController = isMobile ? inapp.PullToRefreshController(
-        settings: inapp.PullToRefreshSettings(enabled: true),
-        onRefresh: () async {
-          await userDrivenReload();
-        },
-      ) : null;
+      final pullToRefreshGate =
+          isMobile ? PullToRefreshGate.create(onRefresh: userDrivenReload) : null;
       // Track last user gesture on same-domain navigation, so we can
       // propagate it to cross-domain redirects (e.g., search engine
       // redirect links like DuckDuckGo's /l/?uddg=... or Google's /url?q=...).
@@ -1324,7 +1321,8 @@ class WebViewModel {
                     isActive: isActive,
                     saveFunc: saveFunc,
                   ),
-          pullToRefreshController: pullToRefreshController,
+          pullToRefreshController: pullToRefreshGate?.controller,
+          pullToRefreshGate: pullToRefreshGate,
           onWindowRequested: onWindowRequested,
           shouldOverrideUrlLoading: (url, hasGesture) {
             LogService.instance.log(

--- a/openspec/specs/navigation/spec.md
+++ b/openspec/specs/navigation/spec.md
@@ -184,6 +184,21 @@ All webviews (main and nested) SHALL support pull-to-refresh to reload the curre
 **And** the pull-to-refresh indicator animates
 **And** the indicator stops when `onLoadStop` fires
 
+#### Scenario: Pinch to zoom does not refresh
+
+**Given** a webview is scrolled to the top
+**When** the user pinches with two fingers
+**Then** the page does not reload
+**And** the refresh control is disabled for the rest of that gesture
+**And** a refresh that the native control fired before the gate reached it is
+swallowed, stopping the indicator without reloading
+
+**Note:** Neither `SwipeRefreshLayout` (Android) nor `UIRefreshControl` (iOS)
+consults the pointer count, so a pinch reads as a downward drag. `PullToRefreshGate`
+([lib/services/pull_to_refresh_gate.dart](../../../lib/services/pull_to_refresh_gate.dart))
+watches Flutter's pointer stream through a `Listener` wrapped around the webview
+and both disables the control and guards `onRefresh`.
+
 ---
 
 ### Requirement: NAV-007 - URL Bar Sync
@@ -589,6 +604,9 @@ Home button pressed
 4. Open a cross-domain link (opens nested webview)
 5. Pull down in the nested webview
 6. Verify refresh works in nested webview too
+7. Scroll back to the top and pinch to zoom with two fingers
+8. Verify no refresh indicator appears and the page does not reload
+9. Verify a normal one-finger pull still refreshes right after
 
 ### Manual Test: URL Bar Sync on iOS Back Gesture
 

--- a/test/js/nested_webview_posture_parity.test.js
+++ b/test/js/nested_webview_posture_parity.test.js
@@ -154,6 +154,9 @@ const PLUMBING = new Set([
   'onProgressChanged', 'onReloadIssued', 'onMainFrameLoad',
   'onWindowRequested', 'onHtmlLoaded', 'shouldFetchHtml', 'onConsoleMessage',
   'onConfirmScriptFetch', 'onExternalSchemeUrl', 'pullToRefreshController',
+  // Pointer bookkeeping for the refresh control above it, created next to it
+  // on both surfaces; not a posture value to copy.
+  'pullToRefreshGate',
   'onRendererGone', 'onProtectedMediaRequest', 'onCameraDecision',
   // Accessor for the host's live camera mode (backs the non-prompting
   // webCameraMode handler), not a posture value to copy: the nested screen

--- a/test/js/pull_to_refresh_multitouch_gate.test.js
+++ b/test/js/pull_to_refresh_multitouch_gate.test.js
@@ -1,0 +1,77 @@
+// Pull-to-refresh multi-touch gate (NAV-006).
+//
+// Neither Android's SwipeRefreshLayout nor iOS's UIRefreshControl looks at the
+// pointer count, so a two-finger pinch at scroll top fires a refresh. The fix
+// lives in PullToRefreshGate, which both webview surfaces must go through: a
+// bare PullToRefreshController anywhere else reintroduces the bug on that
+// surface, and a controller handed to InAppWebView without its gate leaves the
+// pointer stream unwatched.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const GATE = 'lib/services/pull_to_refresh_gate.dart';
+// The surfaces that own a refresh controller: the main webview and the nested
+// cross-domain one.
+const SURFACES = ['lib/web_view_model.dart', 'lib/screens/inappbrowser.dart'];
+
+const read = (rel) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+
+test('the gate disables the control on a second pointer', () => {
+  const src = read(GATE);
+  assert.match(src, /_pointers\.length\s*<\s*2/,
+    'the gate must key off the pointer count');
+  assert.match(src, /_setEnabled\(false\)/,
+    'a second pointer must disable the refresh control');
+});
+
+test('the gate swallows a refresh that outran the disable', () => {
+  const src = read(GATE);
+  assert.match(src, /suppressesRefresh/,
+    'runRefresh must consult the multi-touch state');
+  assert.match(src, /endRefreshing/,
+    'a swallowed refresh must still stop the spinner');
+});
+
+for (const rel of SURFACES) {
+  const src = read(rel);
+
+  test(`${rel}: the refresh controller is built by the gate`, () => {
+    assert.match(src, /PullToRefreshGate\.create\(/,
+      'build the controller through PullToRefreshGate.create');
+  });
+
+  test(`${rel}: no bare PullToRefreshController (NAV-006 gate)`, () => {
+    const offenders = src
+      .split('\n')
+      .map((l, i) => [l, i + 1])
+      .filter(([l]) => /(?:inapp\.)?PullToRefreshController\(/.test(l))
+      .map(([, n]) => n);
+    assert.deepEqual(offenders, [],
+      `bare PullToRefreshController at line(s) ${offenders.join(', ')}. ` +
+        'Route it through PullToRefreshGate.create (NAV-006).');
+  });
+
+  test(`${rel}: the controller ships with its gate`, () => {
+    assert.match(src, /pullToRefreshController:\s*\S*[Gg]ate\?\.controller/,
+      'the config must take the controller off the gate');
+    assert.match(src, /pullToRefreshGate:\s*\S*[Gg]ate/,
+      'the config must carry the gate so the factory can feed it pointers');
+  });
+}
+
+test('the factory feeds the gate from a raw pointer Listener', () => {
+  const src = read('lib/services/webview.dart');
+  const idx = src.indexOf('_applyRefreshGate');
+  assert.ok(idx >= 0, 'WebViewFactory must wrap the webview in a refresh gate');
+  const body = src.slice(src.indexOf('static Widget _applyRefreshGate'));
+  const decl = body.slice(0, body.indexOf('\n  static Widget _applyLetterbox'));
+  assert.match(decl, /Listener\(/,
+    'a raw Listener (never a GestureDetector, which would join the arena)');
+  for (const cb of ['onPointerDown', 'onPointerUp', 'onPointerCancel']) {
+    assert.match(decl, new RegExp(`${cb}:`), `the Listener must handle ${cb}`);
+  }
+});

--- a/test/pull_to_refresh_gate_test.dart
+++ b/test/pull_to_refresh_gate_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/services/pull_to_refresh_gate.dart';
+
+class FakeRefreshControl implements RefreshControl {
+  final List<bool> enabledCalls = [];
+  int endRefreshingCalls = 0;
+
+  @override
+  Future<void> setEnabled(bool enabled) async => enabledCalls.add(enabled);
+
+  @override
+  Future<void> endRefreshing() async => endRefreshingCalls++;
+}
+
+void main() {
+  group('PullToRefreshGate (NAV-006 multi-touch)', () {
+    late FakeRefreshControl control;
+    late DateTime clock;
+    late PullToRefreshGate gate;
+
+    setUp(() {
+      control = FakeRefreshControl();
+      clock = DateTime(2026, 1, 1);
+      gate = PullToRefreshGate.forControl(control, now: () => clock);
+    });
+
+    // The same entry point `PullToRefreshGate.create` hands the controller.
+    Future<bool> refresh() async {
+      var ran = false;
+      await gate.runRefresh(() async => ran = true);
+      return ran;
+    }
+
+    test('a single-finger drag leaves the control alone', () async {
+      gate.onPointerDown(1);
+      expect(gate.isEnabled, isTrue);
+      expect(await refresh(), isTrue);
+      gate.onPointerUp(1);
+      expect(control.enabledCalls, isEmpty);
+    });
+
+    test('a second pointer disables the control', () async {
+      gate.onPointerDown(1);
+      gate.onPointerDown(2);
+      expect(control.enabledCalls, [false]);
+      expect(gate.isEnabled, isFalse);
+    });
+
+    test('a third pointer does not re-send the disable', () {
+      gate.onPointerDown(1);
+      gate.onPointerDown(2);
+      gate.onPointerDown(3);
+      expect(control.enabledCalls, [false]);
+    });
+
+    test('lifting one finger of a pinch keeps the control disabled', () {
+      gate.onPointerDown(1);
+      gate.onPointerDown(2);
+      gate.onPointerUp(2);
+      expect(control.enabledCalls, [false]);
+      expect(gate.isEnabled, isFalse);
+    });
+
+    test('the control comes back once every finger lifts', () {
+      gate.onPointerDown(1);
+      gate.onPointerDown(2);
+      gate.onPointerUp(1);
+      gate.onPointerUp(2);
+      expect(control.enabledCalls, [false, true]);
+      expect(gate.isEnabled, isTrue);
+    });
+
+    test('a cancelled pointer counts as lifted', () {
+      gate.onPointerDown(1);
+      gate.onPointerDown(2);
+      // The factory routes onPointerCancel to onPointerUp.
+      gate.onPointerUp(1);
+      gate.onPointerUp(2);
+      expect(gate.isEnabled, isTrue);
+    });
+
+    test('a refresh mid-pinch is swallowed', () async {
+      gate.onPointerDown(1);
+      gate.onPointerDown(2);
+      expect(await refresh(), isFalse);
+      expect(control.endRefreshingCalls, 1);
+    });
+
+    test('a refresh that beat the disable by a hair is swallowed', () async {
+      gate.onPointerDown(1);
+      gate.onPointerDown(2);
+      gate.onPointerUp(1);
+      gate.onPointerUp(2);
+      clock = clock.add(const Duration(milliseconds: 100));
+      expect(await refresh(), isFalse);
+      expect(control.endRefreshingCalls, 1);
+    });
+
+    test('a deliberate pull after the pinch still refreshes', () async {
+      gate.onPointerDown(1);
+      gate.onPointerDown(2);
+      gate.onPointerUp(1);
+      gate.onPointerUp(2);
+      clock = clock.add(const Duration(seconds: 1));
+      gate.onPointerDown(3);
+      expect(await refresh(), isTrue);
+      expect(control.endRefreshingCalls, 0);
+    });
+
+    test('an unmatched pointer up is ignored', () {
+      gate.onPointerDown(1);
+      gate.onPointerDown(2);
+      gate.onPointerUp(9);
+      expect(gate.isEnabled, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Neither SwipeRefreshLayout nor UIRefreshControl looks at the pointer
count, so a pinch at scroll top reads as a downward drag. PullToRefreshGate
watches Flutter's pointer stream, disables the control on the second
pointer, and swallows an onRefresh that beat it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BMeLAsj4wxc6UoGny9WxEQ