### PR TITLE
PAUSE-030: swallow the pause hack's escaped alert

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3968,9 +3968,16 @@ class _WebSpacePageState extends State<WebSpacePage>
       }
     }
 
-    // Pause the previously active webview to save resources
-    if (_currentIndex != null && _currentIndex! < _webViewModels.length && _loadedIndices.contains(_currentIndex)) {
-      await _quiesceOutgoingSite(_webViewModels[_currentIndex!], version,
+    // Pause the previously active webview to save resources. Nothing to do
+    // when the user tapped the site they are already on — see the engine.
+    final outgoing = SiteActivationEngine.outgoingSiteToQuiesce(
+      currentIndex: _currentIndex,
+      targetIndex: index,
+      siteCount: _webViewModels.length,
+      loadedIndices: _loadedIndices,
+    );
+    if (outgoing != null) {
+      await _quiesceOutgoingSite(_webViewModels[outgoing], version,
           captureState: false);
       if (version != _setCurrentIndexVersion) return;
     }

--- a/lib/services/site_activation_engine.dart
+++ b/lib/services/site_activation_engine.dart
@@ -44,4 +44,24 @@ class SiteActivationEngine {
     }
     return null;
   }
+
+  /// The index whose webview must be quiesced when [targetIndex] becomes
+  /// active, or `null` if none is.
+  ///
+  /// A tap on the site already showing is not a switch. That site is resumed
+  /// moments later, so quiescing it would stop its media, end a camera
+  /// capture it is running, and — on iOS, where the per-instance pause is the
+  /// plugin's `alert()` hack — strand that alert for the resume to expose as
+  /// an empty system dialog (PAUSE-030).
+  static int? outgoingSiteToQuiesce({
+    required int? currentIndex,
+    required int targetIndex,
+    required int siteCount,
+    required Set<int> loadedIndices,
+  }) {
+    if (currentIndex == null || currentIndex == targetIndex) return null;
+    if (currentIndex < 0 || currentIndex >= siteCount) return null;
+    if (!loadedIndices.contains(currentIndex)) return null;
+    return currentIndex;
+  }
 }

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -1014,6 +1014,59 @@ PerInstanceLifecycleCall perInstanceLifecycleCallFor({
   return PerInstanceLifecycleCall.none;
 }
 
+/// Whether `pauseTimers()` on this platform is the plugin's messageless
+/// `alert()` hack rather than a real timer pause. Android has the real API
+/// (`WebView.pauseTimers()`); iOS and macOS both implement it by evaluating
+/// `alert()` and having the native `WKUIDelegate` withhold its dismissal
+/// callback, which is what blocks the page's JS thread.
+bool pauseTimersUsesAlertHack({
+  required bool isAndroid,
+  required bool isIOS,
+  required bool isMacOS,
+}) =>
+    !isAndroid && (isIOS || isMacOS);
+
+/// Per-webview record of whether the `alert()`-hack pause has ever run on it
+/// (PAUSE-030), so the hack's own alert can be told apart from a dialog the
+/// page asked for.
+class PauseTimersHackState {
+  bool _issued = false;
+
+  /// True once a `pauseTimers()` that uses the alert hack has been issued on
+  /// this webview. Sticky: the hack leaves an alert queued in the page's JS
+  /// event loop with no signal for when it was consumed, so there is no point
+  /// at which this can be cleared without re-opening the escape.
+  bool get pauseWasIssued => _issued;
+
+  void notePauseIssued() => _issued = true;
+}
+
+/// Whether a JS alert arriving in Dart is the escaped remains of the
+/// `alert()`-hack pause (PAUSE-030) rather than a dialog the page asked for.
+///
+/// `pauseTimers()` marks the webview paused and evaluates `alert()`; the
+/// native delegate swallows that alert for as long as the mark is set.
+/// `resumeTimers()` clears the mark on the next site switch, app resume or
+/// dispose whether or not the alert has been delivered — and
+/// `evaluateJavaScript` queues behind the page's own JS, so on a busy or
+/// still-loading page the alert can land after the mark is gone and fall
+/// through to the app as a real, messageless system dialog.
+///
+/// Only an escaped alert can reach this predicate: the native delegate
+/// consults Dart only after its own paused check, so while the pause is live
+/// the alert never gets here. Answering it therefore releases a JS thread
+/// whose pause is already over, rather than cutting one short.
+///
+/// A page's own main-frame `alert('')` on an already-paused webview is
+/// swallowed too. It is indistinguishable from the hack's, and it renders as
+/// an empty system dialog carrying no information either way.
+bool isEscapedPauseTimersAlert({
+  required bool pauseWasIssued,
+  required String? message,
+  required bool? isMainFrame,
+}) =>
+    pauseWasIssued && (message ?? '').isEmpty && (isMainFrame ?? true);
+
 /// Whether the root site webview must defer its initial load so the
 /// controller-created handler can apply `restoreState` to a pristine
 /// back/forward list. True only on Android: `WebView.restoreState` no-ops
@@ -1037,7 +1090,13 @@ bool deferInitialLoadForRestore({
 /// InAppWebView controller wrapper
 class _WebViewController implements WebViewController {
   final inapp.InAppWebViewController _c;
-  _WebViewController(this._c);
+
+  /// Shared with the `onJsAlert` handler of the same webview, which needs to
+  /// know that this controller issued an alert-hack pause (PAUSE-030).
+  final PauseTimersHackState _pauseHack;
+
+  _WebViewController(this._c, {required PauseTimersHackState pauseHack})
+      : _pauseHack = pauseHack;
 
   @override
   inapp.InAppWebViewController get nativeController => _c;
@@ -1218,6 +1277,7 @@ class _WebViewController implements WebViewController {
       case PerInstanceLifecycleCall.none:
         return;
       case PerInstanceLifecycleCall.timers:
+        _pauseHack.notePauseIssued();
         await _c.pauseTimers();
     }
   }
@@ -1235,7 +1295,16 @@ class _WebViewController implements WebViewController {
   }
 
   @override
-  Future<void> pauseAllJsTimers() => _c.pauseTimers();
+  Future<void> pauseAllJsTimers() {
+    // On iOS and macOS there is no process-global lever: this lands on the
+    // same per-instance alert hack as [pause] and leaves the same escapable
+    // alert behind (PAUSE-030).
+    if (pauseTimersUsesAlertHack(
+        isAndroid: hostIsAndroid, isIOS: hostIsIOS, isMacOS: hostIsMacOS)) {
+      _pauseHack.notePauseIssued();
+    }
+    return _c.pauseTimers();
+  }
 
   @override
   Future<void> resumeAllJsTimers() => _c.resumeTimers();
@@ -3556,6 +3625,10 @@ class WebViewFactory {
       settings.loadWithOverviewMode = false;
     }
 
+    // Shared between this webview's controller (which issues the pause) and
+    // its `onJsAlert` (which has to recognise the pause's own alert).
+    final pauseHack = PauseTimersHackState();
+
     final inapp.InAppWebView webViewWidget = inapp.InAppWebView(
       key: config.key,
       initialUrlRequest: (renderInitialData || suppressInitialLoad) ? null : inapp.URLRequest(
@@ -3687,8 +3760,30 @@ class WebViewFactory {
             allow: false,
             retain: false,
           ),
+      // A messageless alert on a webview that has been through the iOS/macOS
+      // per-instance pause is that pause's own `alert()`, arriving after
+      // `resumeTimers()` stopped withholding it — never something the page
+      // asked for (PAUSE-030). Answer it so WebKit drops it instead of
+      // presenting an empty system dialog over the app; everything else
+      // returns null and keeps the plugin's default dialog.
+      onJsAlert: (controller, request) async {
+        if (!isEscapedPauseTimersAlert(
+          pauseWasIssued: pauseHack.pauseWasIssued,
+          message: request.message,
+          isMainFrame: request.isMainFrame,
+        )) {
+          return null;
+        }
+        LogService.instance.log(
+          'WebView',
+          'Swallowed escaped pauseTimers() alert for siteId=${config.siteId}',
+          sensitivity: LogSensitivity.sensitive,
+        );
+        return inapp.JsAlertResponse(handledByClient: true);
+      },
       onWebViewCreated: (controller) async {
-        final wrappedController = _WebViewController(controller);
+        final wrappedController =
+            _WebViewController(controller, pauseHack: pauseHack);
         onControllerCreated(wrappedController);
         _registerPageHandlers(
           controller,
@@ -4236,7 +4331,7 @@ class WebViewFactory {
           final List<Cookie> cookies;
           if (config.containerCookieManager != null && config.cookieSiteId != null) {
             cookies = await config.containerCookieManager!.getCookies(
-              controller: _WebViewController(controller),
+              controller: _WebViewController(controller, pauseHack: pauseHack),
               siteId: config.cookieSiteId!,
               url: Uri.parse(urlStr),
             );

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -47,6 +47,8 @@ The only way to truly silence a site is `disposeWebView()` — which tears down 
 
 The system SHALL pause the previously active webview on site switch using the per-instance API only, with no process-global side effects. Exempt: notification sites (`notificationsEnabled`) and background-audio sites (`effectiveBackgroundAudioEnabled`, BGAUDIO-001 in [background-audio](../background-audio/spec.md)) — `pauseWebView()` early-returns for both, since the iOS per-instance pause freezes the page's JS thread.
 
+A tap on the site that is **already active** is not a switch and SHALL quiesce nothing: the outgoing and incoming site are the same webview, and the teardown would run against a site that is resumed a few statements later. `SiteActivationEngine.outgoingSiteToQuiesce` decides this — it names the outgoing index only when there is a *different*, in-bounds, loaded site to leave. Skipping matters beyond the wasted work: the teardown ends a camera capture the site is running (CAM-012) and pauses its media (BGAUDIO-009), and on iOS its `pauseWebView()` strands the alert-hack alert for the resume moments later to expose as an empty system dialog (PAUSE-030) — which made a self-tap raise an empty popup every time, on any site.
+
 #### Scenario: Site switch from A to B
 
 **Given** sites A and B are both loaded
@@ -56,6 +58,14 @@ The system SHALL pause the previously active webview on site switch using the pe
 **And** A's controller receives `pause()` (Android: **no-op**, see PAUSE-016; iOS: per-instance `pauseTimers()` alert hack)
 **And** A's controller does NOT receive `pauseAllJsTimers()`
 **And** B's JS timers are unaffected by A's pause
+
+#### Scenario: Tapping the site already on screen
+
+**Given** site A is the currently active site
+**When** the user taps A in the drawer or tab strip
+**Then** no site is quiesced — A is not paused, its media keeps playing and a camera capture it is running is not ended
+**And** A is still resumed and re-added to `_loadedIndices` as the activation completes
+**And** no empty system dialog appears on iOS
 
 #### Scenario: Sites loaded but never previously active also get paused
 
@@ -1195,7 +1205,7 @@ bool isEscapedPauseTimersAlert({
 [lib/main.dart](../../lib/main.dart):
 
 - `didChangeAppLifecycleState`: calls `pauseForAppLifecycle()` / `resumeFromAppLifecycle()`.
-- `_setCurrentIndex`: calls `pauseWebView()` / `resumeWebView()`.
+- `_setCurrentIndex`: calls `pauseWebView()` / `resumeWebView()`, with the outgoing site named by `SiteActivationEngine.outgoingSiteToQuiesce` (PAUSE-001).
 
 `WebViewFactory.createWebView` ([lib/services/webview.dart](../../lib/services/webview.dart)):
 
@@ -1214,6 +1224,10 @@ bool isEscapedPauseTimersAlert({
 - PAUSE-016: `perInstanceLifecycleCallFor` returns `none` for Android and
   desktop, `timers` for iOS — verifying the Android per-instance no-op without
   a native controller.
+- PAUSE-001: `test/site_activation_engine_test.dart` — `outgoingSiteToQuiesce`
+  names nothing for a self-tap, for a null or unloaded outgoing index, or for
+  one left out of bounds by a deletion, and the outgoing index for a real
+  switch.
 - PAUSE-030: `pauseTimersUsesAlertHack` names iOS and macOS but not Android;
   `isEscapedPauseTimersAlert` swallows only a messageless main-frame alert on a
   webview that has been paused, and leaves a page's own dialog, a subframe
@@ -1225,7 +1239,8 @@ bool isEscapedPauseTimersAlert({
 
 - `lib/services/webview.dart` — split the `WebViewController` interface; `_WebViewController.pause()` no longer calls `pauseTimers()`; `createWebView` wires the PAUSE-030 `onJsAlert` funnel.
 - `lib/web_view_model.dart` — added `pauseForAppLifecycle()` / `resumeFromAppLifecycle()`; updated docs on `pauseWebView()` / `resumeWebView()`.
-- `lib/main.dart` — `didChangeAppLifecycleState` and `_resumeAfterLifecyclePause` use the lifecycle-named methods.
+- `lib/main.dart` — `didChangeAppLifecycleState` and `_resumeAfterLifecyclePause` use the lifecycle-named methods; `_setCurrentIndex` asks the engine which site to quiesce.
+- `lib/services/site_activation_engine.dart` — `outgoingSiteToQuiesce`.
 
 ### Added
 

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -983,6 +983,51 @@ This narrows PAUSE-001 and PAUSE-002 on Android only: the call sites and call or
 
 ---
 
+### Requirement: PAUSE-030 — The Alert-Hack Pause Never Surfaces Its Own Dialog
+
+The iOS/macOS `pauseTimers()` is the plugin's `alert()` deadlock: it marks the webview paused and evaluates `alert()`, and the native `WKUIDelegate` blocks the page's JS thread by withholding that alert's dismissal callback for as long as the mark is set. `resumeTimers()` clears the mark on the next site switch, app resume or dispose — whether or not the alert has been delivered yet. But `evaluateJavaScript` queues behind the page's own JS, so on a busy or still-loading page the alert can land *after* the mark is gone, fall through to the app's `onJsAlert`, and be presented as a real system dialog. `alert()` is called with no argument, so what the user sees is an **empty system popup** with an OK button, over whichever site they just switched to.
+
+Every webview the app creates SHALL therefore answer that escaped alert itself instead of letting the plugin present it:
+
+- A webview records whether an alert-hack `pauseTimers()` has ever been issued on it. Both levers count: the per-instance `pause()` (PAUSE-001, iOS) and `pauseAllJsTimers()` (PAUSE-002), which on iOS and macOS lands on the same hack because neither has a process-global timer pause.
+- An `onJsAlert` carrying **no message**, from the **main frame**, on a webview with that record, MUST be answered `handledByClient` so WebKit drops it silently. Every other alert MUST return null and keep the plugin's default dialog, unchanged.
+- Answering it cannot cut a live pause short: the native delegate consults Dart only *after* its own paused check, so while the pause is live the alert never reaches Dart at all. Anything that gets there belongs to a pause that is already over, and answering releases the page's JS thread — which is what the resume asked for.
+- The record is sticky. The hack leaves an alert queued in the page's JS event loop with no signal for when it was consumed, so there is no point at which it could be cleared without re-opening the escape. A page's own messageless main-frame `alert('')` on an already-paused webview is swallowed as collateral: it is indistinguishable from the hack's, and it renders as an empty dialog carrying no information either way.
+
+This is a funnel: it belongs to webview construction (`WebViewFactory.createWebView`), so the site webview and the nested `InAppWebViewScreen` both inherit it rather than each wiring its own. Popup webviews (`createPopupWebView`) are outside it and need nothing — they are never handed a controller wrapper, so no pause is ever issued on them. The record is a **required** constructor parameter of the controller wrapper, so a future webview path that issues a pause cannot compile without one — the gate is the type, not a grep.
+
+#### Scenario: Switching away and straight back does not raise a popup
+
+**Given** iOS with site A loaded, whose page is still running its load scripts
+**When** the user switches to site B (A is per-instance paused, queueing the hack's `alert()` behind A's JS) and switches back to A before that alert runs
+**Then** `resumeTimers()` has already cleared the plugin's paused mark, so the alert reaches the app's `onJsAlert`
+**And** the app recognises it as the hack's own (no message, main frame, pause was issued) and answers `handledByClient`
+**And** no system dialog is presented
+**And** A's JS thread is released
+
+#### Scenario: A page's real alert still shows
+
+**Given** iOS with site A, which has been paused and resumed at least once
+**When** A's page calls `alert('Session expired')`
+**Then** `onJsAlert` returns null
+**And** the plugin presents its usual dialog with that message
+
+#### Scenario: An empty alert on a never-paused webview still shows
+
+**Given** a freshly created webview that has never been per-instance paused
+**When** its page calls `alert('')`
+**Then** the app returns null and the plugin's dialog is presented
+**And** nothing in the pause machinery is implicated
+
+#### Scenario: The app-lifecycle global pause is covered too
+
+**Given** iOS or macOS, where `pauseAllJsTimers()` maps to the same per-instance `alert()` hack
+**When** the app is backgrounded and foregrounded quickly enough that the alert lands after `resumeAllJsTimers()`
+**Then** the escaped alert is swallowed by the same funnel
+**And** the user sees no empty popup on returning to the app
+
+---
+
 ### Requirement: PAUSE-004 — Null-Safe Controller Access
 
 `pauseWebView()`, `resumeWebView()`, `pauseForAppLifecycle()`, and `resumeFromAppLifecycle()` SHALL be no-ops when the underlying controller has not yet been initialized or has been disposed.
@@ -1122,9 +1167,22 @@ class _WebViewController implements WebViewController {
   }
 
   @override
-  Future<void> pauseAllJsTimers() => _c.pauseTimers();
+  Future<void> pauseAllJsTimers() {
+    if (pauseTimersUsesAlertHack(...)) _pauseHack.notePauseIssued();  // PAUSE-030
+    return _c.pauseTimers();
+  }
   // ... resume mirrors pause ...
 }
+
+// PAUSE-030: telling the alert hack's own stranded alert apart from a dialog
+// the page asked for. Both pure; the record is per webview.
+bool pauseTimersUsesAlertHack({
+  required bool isAndroid, required bool isIOS, required bool isMacOS,
+});
+class PauseTimersHackState { bool get pauseWasIssued; void notePauseIssued(); }
+bool isEscapedPauseTimersAlert({
+  required bool pauseWasIssued, required String? message, required bool? isMainFrame,
+});
 ```
 
 ### Call Sites
@@ -1139,6 +1197,11 @@ class _WebViewController implements WebViewController {
 - `didChangeAppLifecycleState`: calls `pauseForAppLifecycle()` / `resumeFromAppLifecycle()`.
 - `_setCurrentIndex`: calls `pauseWebView()` / `resumeWebView()`.
 
+`WebViewFactory.createWebView` ([lib/services/webview.dart](../../lib/services/webview.dart)):
+
+- Builds one `PauseTimersHackState` per webview, hands it to that webview's
+  `_WebViewController`, and reads it from the widget's `onJsAlert` (PAUSE-030).
+
 ### Tests
 
 [test/webview_pause_lifecycle_test.dart](../../test/webview_pause_lifecycle_test.dart) uses a recording fake `WebViewController` and asserts:
@@ -1151,12 +1214,16 @@ class _WebViewController implements WebViewController {
 - PAUSE-016: `perInstanceLifecycleCallFor` returns `none` for Android and
   desktop, `timers` for iOS — verifying the Android per-instance no-op without
   a native controller.
+- PAUSE-030: `pauseTimersUsesAlertHack` names iOS and macOS but not Android;
+  `isEscapedPauseTimersAlert` swallows only a messageless main-frame alert on a
+  webview that has been paused, and leaves a page's own dialog, a subframe
+  alert and a never-paused webview alone; the record is sticky.
 
 ## Files
 
 ### Modified
 
-- `lib/services/webview.dart` — split the `WebViewController` interface; `_WebViewController.pause()` no longer calls `pauseTimers()`.
+- `lib/services/webview.dart` — split the `WebViewController` interface; `_WebViewController.pause()` no longer calls `pauseTimers()`; `createWebView` wires the PAUSE-030 `onJsAlert` funnel.
 - `lib/web_view_model.dart` — added `pauseForAppLifecycle()` / `resumeFromAppLifecycle()`; updated docs on `pauseWebView()` / `resumeWebView()`.
 - `lib/main.dart` — `didChangeAppLifecycleState` and `_resumeAfterLifecyclePause` use the lifecycle-named methods.
 

--- a/test/site_activation_engine_test.dart
+++ b/test/site_activation_engine_test.dart
@@ -148,4 +148,79 @@ void main() {
       expect(result, anyOf(1, 2));
     });
   });
+
+  group('SiteActivationEngine.outgoingSiteToQuiesce', () {
+    test('tapping the site already active quiesces nothing (PAUSE-030)', () {
+      expect(
+        SiteActivationEngine.outgoingSiteToQuiesce(
+          currentIndex: 2,
+          targetIndex: 2,
+          siteCount: 4,
+          loadedIndices: {0, 2},
+        ),
+        isNull,
+        reason: 'The site is resumed moments later; pausing it first strands '
+            "the iOS pause hack's alert and stops its media.",
+      );
+    });
+
+    test('a real switch quiesces the outgoing site', () {
+      expect(
+        SiteActivationEngine.outgoingSiteToQuiesce(
+          currentIndex: 2,
+          targetIndex: 3,
+          siteCount: 4,
+          loadedIndices: {0, 2, 3},
+        ),
+        2,
+      );
+    });
+
+    test('nothing to quiesce when no site is active', () {
+      expect(
+        SiteActivationEngine.outgoingSiteToQuiesce(
+          currentIndex: null,
+          targetIndex: 1,
+          siteCount: 4,
+          loadedIndices: {1},
+        ),
+        isNull,
+      );
+    });
+
+    test('an unloaded outgoing site has no webview to quiesce', () {
+      expect(
+        SiteActivationEngine.outgoingSiteToQuiesce(
+          currentIndex: 2,
+          targetIndex: 3,
+          siteCount: 4,
+          loadedIndices: {3},
+        ),
+        isNull,
+      );
+    });
+
+    test('an out-of-bounds outgoing index is ignored', () {
+      expect(
+        SiteActivationEngine.outgoingSiteToQuiesce(
+          currentIndex: 7,
+          targetIndex: 1,
+          siteCount: 4,
+          loadedIndices: {1, 7},
+        ),
+        isNull,
+        reason: 'Deletion can shift indices out from under an in-flight '
+            'activation.',
+      );
+      expect(
+        SiteActivationEngine.outgoingSiteToQuiesce(
+          currentIndex: -1,
+          targetIndex: 1,
+          siteCount: 4,
+          loadedIndices: {1, -1},
+        ),
+        isNull,
+      );
+    });
+  });
 }

--- a/test/webview_pause_lifecycle_test.dart
+++ b/test/webview_pause_lifecycle_test.dart
@@ -265,6 +265,83 @@ void main() {
     });
   });
 
+  group('PAUSE-030 escaped pauseTimers() alert', () {
+    test('the alert hack is what pauseTimers means on iOS and macOS', () {
+      expect(
+        pauseTimersUsesAlertHack(
+            isAndroid: false, isIOS: true, isMacOS: false),
+        isTrue,
+      );
+      expect(
+        pauseTimersUsesAlertHack(
+            isAndroid: false, isIOS: false, isMacOS: true),
+        isTrue,
+        reason: 'macOS has no process-global lever either, so the global '
+            'pause lands on the same hack and can strand the same alert.',
+      );
+      expect(
+        pauseTimersUsesAlertHack(
+            isAndroid: true, isIOS: false, isMacOS: false),
+        isFalse,
+        reason: 'Android pauseTimers() is the real global timer API — it '
+            'raises no alert to escape.',
+      );
+      expect(
+        pauseTimersUsesAlertHack(
+            isAndroid: false, isIOS: false, isMacOS: false),
+        isFalse,
+      );
+    });
+
+    test('a messageless alert after a pause is the hack, and is swallowed', () {
+      expect(
+        isEscapedPauseTimersAlert(
+            pauseWasIssued: true, message: '', isMainFrame: true),
+        isTrue,
+      );
+      expect(
+        isEscapedPauseTimersAlert(
+            pauseWasIssued: true, message: null, isMainFrame: true),
+        isTrue,
+        reason: 'alert() with no argument carries no message at all.',
+      );
+    });
+
+    test('a webview that was never paused keeps its own empty alert', () {
+      expect(
+        isEscapedPauseTimersAlert(
+            pauseWasIssued: false, message: '', isMainFrame: true),
+        isFalse,
+      );
+    });
+
+    test("a page's own dialog is never swallowed", () {
+      expect(
+        isEscapedPauseTimersAlert(
+            pauseWasIssued: true, message: 'Are you sure?', isMainFrame: true),
+        isFalse,
+      );
+      expect(
+        isEscapedPauseTimersAlert(
+            pauseWasIssued: true, message: '', isMainFrame: false),
+        isFalse,
+        reason: 'The hack evaluates alert() on the webview itself, so it is '
+            'always the main frame; a subframe empty alert is the page.',
+      );
+    });
+
+    test('pauseWasIssued is sticky once the hack has run', () {
+      final state = PauseTimersHackState();
+      expect(state.pauseWasIssued, isFalse);
+      state.notePauseIssued();
+      expect(state.pauseWasIssued, isTrue);
+      state.notePauseIssued();
+      expect(state.pauseWasIssued, isTrue,
+          reason: 'There is no signal for when the queued alert was '
+              'consumed, so the record cannot be cleared.');
+    });
+  });
+
   group('cold-start restore initial-load deferral', () {
     test('Android with pending restore defers the initial load', () {
       expect(


### PR DESCRIPTION
iOS/macOS pauseTimers() evaluates alert() and blocks the page by withholding
its dismissal, but resumeTimers() stops withholding whether or not the alert
has been delivered. evaluateJavaScript queues behind the page's own JS, so a
switch away and back lands the alert late and the plugin presents it — an
empty system popup, since alert() carries no message.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RntXWHhWvtjZiey95HjyDt