### PR TITLE
Repaint when the renderer reports pixels; say what the tier cannot test

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -515,7 +515,7 @@ jobs:
             bash scripts/run_android_background_audio_tests.sh
             bash scripts/run_android_camera_tests.sh
             bash scripts/run_android_page_zoom_tests.sh
-            WS_RUN_NATIVE_REPAINT_PROBE=1 WS_RUN_BLANK_CONTROL=${{ inputs.blank_control && '1' || '0' }} WS_LIFECYCLE_BUILD_MODE=profile bash scripts/run_android_lifecycle_tests.sh
+            WS_RUN_NATIVE_REPAINT_PROBE=1 WS_RUN_BLANK_CONTROL=${{ inputs.blank_control && '1' || '0' }} WS_LIFECYCLE_BUILD_MODE=${{ inputs.lifecycle_build_mode || 'debug' }} bash scripts/run_android_lifecycle_tests.sh
 
       # always(), not failure(): the tier now dumps the platform view's
       # composition mode on every run, and that dump is only worth having on

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -505,7 +505,7 @@ jobs:
             bash scripts/run_android_background_audio_tests.sh
             bash scripts/run_android_camera_tests.sh
             bash scripts/run_android_page_zoom_tests.sh
-            WS_RUN_NATIVE_REPAINT_PROBE=1 WS_RUN_BLANK_CONTROL=1 bash scripts/run_android_lifecycle_tests.sh
+            WS_RUN_NATIVE_REPAINT_PROBE=1 bash scripts/run_android_lifecycle_tests.sh
 
       - name: Upload white-screen lifecycle diagnostics
         if: failure()

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -505,7 +505,7 @@ jobs:
             bash scripts/run_android_background_audio_tests.sh
             bash scripts/run_android_camera_tests.sh
             bash scripts/run_android_page_zoom_tests.sh
-            WS_RUN_NATIVE_REPAINT_PROBE=1 bash scripts/run_android_lifecycle_tests.sh
+            WS_RUN_NATIVE_REPAINT_PROBE=1 WS_RUN_BLANK_CONTROL=1 bash scripts/run_android_lifecycle_tests.sh
 
       - name: Upload white-screen lifecycle diagnostics
         if: failure()

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,11 @@ on:
       - '**'
   # Allow manual trigger for testing
   workflow_dispatch:
+    inputs:
+      blank_control:
+        description: 'BUG-001 blank control (lifecycle Scenario B3-A). Red by design on a device that reproduces the white screen; skipped on every push.'
+        type: boolean
+        default: false
 
 # Supersede in-progress runs for the same ref: a new push cancels the
 # previous run instead of letting both consume runners. A hung job (e.g. a
@@ -505,10 +510,14 @@ jobs:
             bash scripts/run_android_background_audio_tests.sh
             bash scripts/run_android_camera_tests.sh
             bash scripts/run_android_page_zoom_tests.sh
-            WS_RUN_NATIVE_REPAINT_PROBE=1 bash scripts/run_android_lifecycle_tests.sh
+            WS_RUN_NATIVE_REPAINT_PROBE=1 WS_RUN_BLANK_CONTROL=${{ inputs.blank_control && '1' || '0' }} bash scripts/run_android_lifecycle_tests.sh
 
+      # always(), not failure(): the tier now dumps the platform view's
+      # composition mode on every run, and that dump is only worth having on
+      # the green ones -- it says whether a green means the bug did not happen
+      # or that the emulator cannot host it.
       - name: Upload white-screen lifecycle diagnostics
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: white-screen-adb-diagnostics

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,6 +14,11 @@ on:
         description: 'BUG-001 blank control (lifecycle Scenario B3-A). Red by design on a device that reproduces the white screen; skipped on every push.'
         type: boolean
         default: false
+      lifecycle_build_mode:
+        description: 'Build the lifecycle tier drives. profile is AOT with isInspectable off, which is what ships; debug is neither.'
+        type: choice
+        options: [debug, profile]
+        default: debug
 
 # Supersede in-progress runs for the same ref: a new push cancels the
 # previous run instead of letting both consume runners. A hung job (e.g. a
@@ -510,7 +515,7 @@ jobs:
             bash scripts/run_android_background_audio_tests.sh
             bash scripts/run_android_camera_tests.sh
             bash scripts/run_android_page_zoom_tests.sh
-            WS_RUN_NATIVE_REPAINT_PROBE=1 WS_RUN_BLANK_CONTROL=${{ inputs.blank_control && '1' || '0' }} bash scripts/run_android_lifecycle_tests.sh
+            WS_RUN_NATIVE_REPAINT_PROBE=1 WS_RUN_BLANK_CONTROL=${{ inputs.blank_control && '1' || '0' }} WS_LIFECYCLE_BUILD_MODE=profile bash scripts/run_android_lifecycle_tests.sh
 
       # always(), not failure(): the tier now dumps the platform view's
       # composition mode on every run, and that dump is only worth having on

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -505,7 +505,7 @@ jobs:
             bash scripts/run_android_background_audio_tests.sh
             bash scripts/run_android_camera_tests.sh
             bash scripts/run_android_page_zoom_tests.sh
-            bash scripts/run_android_lifecycle_tests.sh
+            WS_RUN_NATIVE_REPAINT_PROBE=1 bash scripts/run_android_lifecycle_tests.sh
 
       - name: Upload white-screen lifecycle diagnostics
         if: failure()

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -452,13 +452,13 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-api34-x86_64-google_apis-pixel_5-v1
+          key: avd-api35-x86_64-google_apis-pixel_5-v1
 
       - name: Pre-warm AVD snapshot
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 34
+          api-level: 35
           target: google_apis
           arch: x86_64
           profile: pixel_5
@@ -487,7 +487,7 @@ jobs:
       - name: Run emulator integration scenarios
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 34
+          api-level: 35
           target: google_apis
           arch: x86_64
           profile: pixel_5
@@ -533,7 +533,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 34
+          api-level: 35
           target: google_apis
           arch: x86_64
           profile: pixel_5

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -452,14 +452,14 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-api35-x86_64-google_apis-pixel_5-v1
+          key: avd-api35-x86_64-aosp-pixel_5-v1
 
       - name: Pre-warm AVD snapshot
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 35
-          target: google_apis
+          target: default
           arch: x86_64
           profile: pixel_5
           disk-size: 4096M
@@ -468,6 +468,13 @@ jobs:
           disable-animations: true
           script: echo "Generated AVD snapshot for caching."
 
+      # `target: default` is the AOSP image, deliberately: this app ships
+      # GMS-free (the "Verify APK is free of Google Mobile Services" step above
+      # asserts it), so the test host must not be a google_apis image either.
+      # Its WebView is `com.android.webview`, and like every emulator image it
+      # is pinned at image build time with no Play Store to update it, so the
+      # API level is what moves it. The lifecycle tier records the version it
+      # got; see docs/bugs/001-white-screen.md gap #13.
       # Emulator scenarios, run on every push/PR:
       #   INTEG-010 white-screen pixels — drive the known blank-screen entry
       #     paths and assert on composited window pixels over the webview via
@@ -488,7 +495,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 35
-          target: google_apis
+          target: default
           arch: x86_64
           profile: pixel_5
           disk-size: 4096M
@@ -534,7 +541,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 35
-          target: google_apis
+          target: default
           arch: x86_64
           profile: pixel_5
           disk-size: 4096M

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/MainActivity.kt
@@ -163,6 +163,18 @@ class MainActivity: FlutterActivity() {
                         }
                     )
                 }
+                "getDiagReload" -> {
+                    // Adb white-screen tier (INTEG-011). The refresh funnel
+                    // is only reachable from the overflow menu, which adb
+                    // cannot drive; same debuggable gate as the seed. Drained
+                    // on read so a later resume does not reload again.
+                    val debuggable =
+                        (applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
+                    val spec =
+                        if (debuggable) intent?.getStringExtra("ws_diag_reload") else null
+                    intent?.removeExtra("ws_diag_reload")
+                    result.success(spec)
+                }
                 "getLaunchSiteId" -> {
                     val siteId = intent?.getStringExtra("siteId")
                     // Drain the extra after reading so it fires once per tap.

--- a/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/SurfaceDiagPlugin.kt
+++ b/android/app/src/main/kotlin/org/codeberg/theoden8/webspace/SurfaceDiagPlugin.kt
@@ -7,6 +7,9 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.view.PixelCopy
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebView
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 
@@ -48,8 +51,70 @@ class SurfaceDiagPlugin(private val activity: Activity, flutterEngine: FlutterEn
                         sampleWindowRegion(left, top, width, height, result)
                     }
                 }
+                "nativeRepaint" -> {
+                    val mode = call.argument<String>("mode")
+                    if (mode == null) {
+                        result.error("INVALID_ARGS", "mode required", null)
+                    } else {
+                        result.success(nativeRepaint(mode))
+                    }
+                }
                 else -> result.notImplemented()
             }
+        }
+    }
+
+    /**
+     * Ask the real Android views to redraw, rather than resizing them from
+     * Dart.
+     *
+     * A Dart-side nudge changes a widget's padding, which reaches the platform
+     * view as a resize through Flutter's own plumbing; BUG-001 gap #18 recorded
+     * six such nudges landing against a live renderer with the screen blank.
+     * These call the View API directly on every WebView in the window, which is
+     * what rotation and lock-unlock do and what a resize does not:
+     *
+     *  - "invalidate": schedule a redraw and a measure/layout pass.
+     *  - "visibility": GONE then VISIBLE, so the view detaches from and
+     *    re-attaches to the window without the WebView being destroyed.
+     *
+     * Main-looper only, like everything else here (BUG-007: none-shared).
+     */
+    private fun nativeRepaint(mode: String): Map<String, Any> {
+        val decor = activity.window?.decorView
+            ?: return mapOf("status" to "no-window", "views" to 0)
+        val views = ArrayList<WebView>()
+        collectWebViews(decor, views)
+        for (v in views) {
+            when (mode) {
+                "invalidate" -> {
+                    v.invalidate()
+                    v.requestLayout()
+                }
+                "visibility" -> {
+                    val previous = v.visibility
+                    v.visibility = View.GONE
+                    // Restore on the next main-looper turn: setting it back in
+                    // this one is coalesced into no change at all, since the
+                    // view never reaches a traversal in between.
+                    Handler(Looper.getMainLooper()).post {
+                        v.visibility = previous
+                        v.invalidate()
+                    }
+                }
+                else -> return mapOf("status" to "unknown-mode", "views" to 0)
+            }
+        }
+        return mapOf("status" to "ok", "views" to views.size)
+    }
+
+    private fun collectWebViews(view: View, out: MutableList<WebView>) {
+        if (view is WebView) {
+            out.add(view)
+            return
+        }
+        if (view is ViewGroup) {
+            for (i in 0 until view.childCount) collectWebViews(view.getChildAt(i), out)
         }
     }
 

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -448,6 +448,36 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
    ("a JS `offsetHeight` read does not [fix it]") and `_probeRendererAndRecover`'s
    ("the read alone fixes the blank surface") open. Deciding gap #5, and the fork
    pin with it, needs a device that actually goes white.
+
+   **The reload path answers the same way (2026-09-04, PR #576).** Gap #5's
+   warm start was one route; refresh is the other, and the one this bug was
+   reported on. It differs in the way that should matter: a warm start carries
+   a window visibility change and a reload does not, so nothing below Dart has
+   an obvious reason to repaint what a reload blanks. Scenario B3-A suppresses
+   all fourteen `_nudgeSurfaceRepaint` triggers, issues one reload of a page
+   that stalls 5s before its first byte, and samples *past* the commit -- blank
+   before it is a slow page, blank after it is the bug. The trace shows the
+   four suppressions and nothing else firing, and the surface came back
+   painted. So the emulator repaints reloads on its own too, and no route this
+   harness has can make it go white. B3-A is therefore opt-in
+   (`WS_RUN_BLANK_CONTROL=1`) and not run in CI: it is the right experiment for
+   hardware that reproduces, not for this one. Three of the attempts to get
+   there were instrument defects rather than evidence -- a suppression list
+   missing `_probeRendererAndRecover`, one missing `metrics-resume`, and a
+   dropped `os.chdir` that made every page 404 into a white error document that
+   looked exactly like the bug. Each is why the tier now prints the app pid,
+   the focused window, the page-server access log and the SurfaceDiag tail on
+   any pixel failure.
+
+   **The same run is the first direct evidence that PAUSE-027 works.**
+   Scenario B3-B drives five reloads 120ms apart against that 5s page, so four
+   commits abort before the fifth lands -- the shape that spent the old
+   one-shot latch on an aborted load. Every reload nudge coalesced into one
+   loop, and then `commit-settled` fired as a *fresh, uncoalesced* nudge when
+   the real document committed ~5s later, and the surface stayed painted. That
+   is the bounded commit window doing exactly what Attempt 11 built it for,
+   observed on a real surface rather than argued. B3-B runs unconditionally and
+   is now that fix's regression guard.
 12. **The trace is now honest but still opt-in.** `PAUSE-029` closed the coverage half
    of the diagnostic — every path reports, and a new one cannot be silent — but the
    developer-mode gate means a user who hits the bug has no trace *of the occurrence that

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -604,33 +604,49 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
     with no keep rules for the fork or androidx.webkit beyond their own consumer
     rules. That gap stays open.
 
-15. **A trigger with no user action behind it, shipped in v0.3.1 and untested.**
-    `_refreshNotificationSites` reloaded the *visible* site on every native
-    background-refresh tick. Android's WorkManager tick (NOTIF-005-A) fires
-    whenever the Flutter engine is reachable, the foreground included, and the
-    handler took no `excludeActive`: it was written when only iOS's
-    `BGAppRefreshTask` reached it, where the app is suspended by definition.
-    So on any device with a notification site, the page the user was reading
-    was reloaded out of nowhere on the worker's schedule, and a reload discards
-    the painted frame. That is BUG-001's reload path (PAUSE-021/027) reached
-    with no user action, at no reproducible moment, which is what "it happens
-    on many things" looks like from outside the app.
+15. **The release predates the fix the tests are testing.** `v0.3.1` is tagged
+    2026-08-27. Attempt 11 (`PAUSE-027`/`PAUSE-028`, the bounded commit window)
+    landed 2026-09-03 in `7453743`, six days later. `v0.3.1:lib/main.dart`
+    carries `PAUSE-009`…`PAUSE-025`; master carries those plus `PAUSE-027` and
+    `PAUSE-028`, and `commitWindow` appears zero times in `v0.3.1`'s
+    `surface_repaint_engine.dart` against three on master.
 
-    Fixed on master by `f02d4af` (2026-09-03), which lands **after** `v0.3.1`,
-    so the released build still has it. This does not subsume the class: the
-    reload path is nudged and latched, so a correct commit still repaints. What
-    it supplies is the missing *trigger* — an unattributable one — and it
-    explains why a user hits this without being able to say what they did.
+    So a device on `v0.3.1` has Attempt 9's one-shot reload latch with no
+    bounded window over it, which is precisely the state Attempt 11 was written
+    for: the report it answers is "if I hit refresh often it's still there ...
+    hitting refresh again helps", and a one-shot latch is exactly what makes
+    rapid refreshing fail while a single later refresh succeeds. Meanwhile
+    **Scenario B3-B, the tier's rapid-reload scenario, is the regression guard
+    for `PAUSE-027`** — it asserts behaviour the shipped build does not contain.
+    Before reaching for host or artifact differences, that is the first-order
+    answer to "why is CI green and the device not": CI is running the fix.
 
-    **Why no test caught it.** Scenario F fires the refresh receiver while the
-    app is BACKGROUNDED, which is the leg that was always correct; nothing
-    fired it in the foreground, which is the leg that broke. The real
-    15-minute WorkManager tick cannot be driven in CI at all (`cmd jobscheduler
-    run -f` will not execute a periodic `WorkSpec` before its next run time),
-    so the debug receiver is the only way in, and it was only ever used from
-    the background. Scenario F2 now fires the same receiver with the app
-    foregrounded and asserts the visible site neither re-fetches (its beacon
-    count is unchanged) nor goes blank.
+    Two more BUG-001-adjacent fixes are also post-tag: `7fd570a` (pull-to-refresh
+    firing on a two-finger pinch, 2026-09-02) and `f02d4af` (below).
+
+    **Correction, and the reasoning error behind it.** This entry first claimed
+    the discriminator was `f02d4af`: `_refreshNotificationSites` reloading the
+    *visible* site on a native background-refresh tick, since Android's
+    WorkManager tick fires in the foreground while the handler took no
+    `excludeActive`. Two checks kill that as *the* discriminator. The same
+    unconditional wiring is present in `v0.2.6`, `v0.2.7`, `v0.2.9` and `v0.3.0`,
+    so nothing about it changed at this release; and the reload it issues goes
+    through `reloadAndRepaint`, the funnelled path the `PAUSE-021`/`027` latch
+    already covers, so it is a *trigger* for a blank the machinery claims to
+    handle, not an unnudged path. It also needs a `notificationsEnabled` site
+    and fires at most every 15 minutes. What it genuinely contributes is a
+    trigger with no user action behind it, which is worth having on the list of
+    things a user cannot attribute; it is not why this release goes white and
+    the tests do not. The error was reading a commit that post-dates the tag as
+    a regression introduced by the tag, without checking the older tags.
+
+    **Why no test caught the foreground leg anyway.** Scenario F fires the
+    refresh receiver while the app is BACKGROUNDED, the leg that was always
+    correct; the real 15-minute WorkManager tick cannot be driven in CI at all
+    (`cmd jobscheduler run -f` will not execute a periodic `WorkSpec` before its
+    next run time), so the debug receiver is the only way in and it was only
+    ever used from the background. Scenario F2 now fires it foregrounded and
+    asserts the visible site neither re-fetches nor blanks.
 
     One correction rides along, because it changes where the next fix should
     look. The `SurfaceView`-does-not-self-invalidate rule was cited here as the

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -502,7 +502,16 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
     uploaded on green runs too) as the runtime witness — it does not decide the
     mode, and a first cut of it that tried to read the mode off the layer count
     got the reading backwards, which is why it now prints layer names and no
-    verdict.
+    verdict. What it prints on the emulator, with the webview on screen:
+    `SurfaceView[<pkg>/.MainActivity]#402`, its `(BLAST)#403` buffer-queue
+    child, `Background for` that same SurfaceView, and the activity's own
+    window layers. One SurfaceView, which is `FlutterSurfaceView`, and no layer
+    of any kind for the webview. That is consistent with HC as current Flutter
+    implements it: the SurfaceView base stays and `FlutterImageView` overlays
+    are added above the platform view, and an overlay is a View inside the
+    window layer, not a layer of its own. So a layer list cannot separate the
+    two modes in either direction, and the Dart-level determination above is
+    the only sound one. Do not re-derive a verdict from this dump.
 
     One correction rides along, because it changes where the next fix should
     look. The `SurfaceView`-does-not-self-invalidate rule was cited here as the

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -606,6 +606,30 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
     with no keep rules for the fork or androidx.webkit beyond their own consumer
     rules. That gap stays open.
 
+    **First profile run (2026-09-05, `79ada4e`): unresolved, not negative.** The
+    `app-fdebug-profile.apk` built (152 MB) and installed, `am start -W` reported
+    `Status: ok / LaunchState: COLD / TotalTime: 2849`, and then Scenario A never
+    reached its pixels in 180s. What the job log carries: dominant `ffffff` at
+    `uniform 0.7644`, the app process alive (`pid 9414`), `mCurrentFocus` on the
+    **launcher** rather than the app, and the page server showing only the host's
+    own startup curl — the emulator never fetched `dark.html`. That is consistent
+    with the app never reaching a seeded webview, and it is not enough to say
+    why: the seed's native gate is `FLAG_DEBUGGABLE`, which profile should
+    satisfy (`initWith(debug)`), so either that assumption is wrong on this AGP
+    version or the app failed earlier. The run also cold-booted its AVD (snapshot
+    cache miss), so it was the slowest configuration this tier has had.
+
+    The empty `last SurfaceDiag lines` in that dump is *not* evidence either way:
+    those lines only appear once a repaint is traced, so an empty list says
+    nothing about how far startup got. That the dump could not distinguish
+    "crashed", "never seeded" and "still starting" is a defect in the dump, now
+    fixed — a pixel failure prints the Dart side's own `flutter:V` tail and any
+    `AndroidRuntime`/`FATAL`/`ANR`/force-finish lines. The tier is back on
+    `debug` by default; the profile arm stays available through
+    `WS_LIFECYCLE_BUILD_MODE` and the `lifecycle_build_mode` dispatch input, and
+    the next run of it will say what happened in the job log rather than only in
+    an artifact.
+
 15. **The release predates the fix the tests are testing.** `v0.3.1` is tagged
     2026-08-27. Attempt 11 (`PAUSE-027`/`PAUSE-028`, the bounded commit window)
     landed 2026-09-03 in `7453743`, six days later. `v0.3.1:lib/main.dart`

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -478,6 +478,20 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
    is the bounded commit window doing exactly what Attempt 11 built it for,
    observed on a real surface rather than argued. B3-B runs unconditionally and
    is now that fix's regression guard.
+
+   **Forcing GPU composition was tried and could not be tried (2026-09-05).**
+   The one cheap hypothesis for why the emulator repaints unasked is hardware
+   overlays: an overlay-composed layer is re-scanned out every frame from
+   whatever its buffer last held. `service call SurfaceFlinger 1008 i32 1`, the
+   old "Disable HW overlays" developer-option call, was accepted and discarded
+   on API 34 both as shell and as root, with `dumpsys` still reporting four
+   layers at `composition type=DEVICE`. `1008` is a raw binder code from before
+   SurfaceFlinger moved to AIDL and no longer maps to that toggle. B3-A now
+   verifies that precondition and *skips* rather than failing, because a red
+   from an arm whose precondition never held is the same false evidence this
+   scenario exists to prevent. The overlay hypothesis is untested, not
+   disproved; testing it needs whatever the developer option calls on a modern
+   API level.
 12. **The trace is now honest but still opt-in.** `PAUSE-029` closed the coverage half
    of the diagnostic — every path reports, and a new one cannot be silent — but the
    developer-mode gate means a user who hits the bug has no trace *of the occurrence that

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -570,6 +570,40 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
     work on real hardware, which would invalidate the remedy rather than its
     coverage). Nothing in the repository currently distinguishes them.
 
+14. **No CI tier has ever run a non-debug build on a device.** Every Android
+    device-side script builds debug: the lifecycle tier does
+    `flutter build apk --debug --flavor fdebug`, and the four `flutter test`
+    tiers get a debug APK by default. The release job builds the shipped APK
+    and checks two static properties of it (GMS-free, JNI survived shrinking),
+    then never installs it. So the artifact that goes white has not been run by
+    any test.
+
+    Two differences follow, and both sit inside the component that goes blank:
+
+    - **`isInspectable: kDebugMode`** (`lib/services/webview.dart:1221`, `:1928`,
+      `:3621`) is the *only* build-mode-dependent WebView setting in the app.
+      Every webview CI drives has `setWebContentsDebuggingEnabled(true)`; every
+      webview that ships has it off. An audit of `kDebugMode` across `lib/`
+      turns up nothing else touching the webview: the rest is startup
+      stopwatches, log forwarding, and the diag hooks themselves.
+    - **JIT vs AOT.** Frame timing decides whether an attach lands before or
+      after a commit, and every ordering fix in this file (PAUSE-020/021/025/027)
+      is about exactly that ordering.
+
+    The tier can now drive `profile` (`WS_LIFECYCLE_BUILD_MODE=profile`, also a
+    `workflow_dispatch` input), which flips both: AOT, `isInspectable` false,
+    and still debuggable, because Flutter's profile build type is
+    `initWith(debug)` (`FlutterPlugin.kt:250`) so the native `FLAG_DEBUGGABLE`
+    gate the diag channels use still passes. Three gates moved from `kDebugMode`
+    to `!kReleaseMode` to let it through — `DiagSeed`, `RepaintSuppression`, and
+    `LogService`'s logcat forwarding — none of which changes release behaviour,
+    which is what those gates were protecting.
+
+    This does not reach the shipped artifact: profile does not run R8, and
+    `minifyEnabled true` with `proguard-android-optimize.txt` is release-only,
+    with no keep rules for the fork or androidx.webkit beyond their own consumer
+    rules. That gap stays open.
+
     One correction rides along, because it changes where the next fix should
     look. The `SurfaceView`-does-not-self-invalidate rule was cited here as the
     root mechanism, but under HC the platform view is an `android.webkit.WebView`

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -427,6 +427,27 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
    SurfaceView's own buffer callbacks, so they cover the warm-start and fresh-mount
    triggers and none of the commit-side class (Attempts 9/10/11) — they narrow gap
    #3, they do not close it.
+
+   **Run on 2026-09-04 (PR #576): the emulator cannot answer it.** With both
+   resume-time Dart repaint paths dropped and the `SurfaceDiag` trace showing
+   nothing else ran, the warm-started surface came back the page colour,
+   `uniform: 1.0`. On the CI emulator (API 34, x86_64, `swiftshader_indirect`)
+   the reattached SurfaceView repaints with no Dart help at all, so B2 is green
+   by nature there and can never be the red that justifies the fork pin. Two
+   readings of the instrument had to be fixed before that was even legible, and
+   both are worth knowing:
+   `RepaintSuppression` gated only `_nudgeSurfaceRepaint`, while
+   `_probeRendererAndRecover` repaints too — its `offsetHeight` read forces the
+   layout that schedules the missing paint — and both log under the same trigger
+   name, so suppressing "the resume nudge" left the other one doing the work;
+   and a passing run dumped no logcat, so a green proved nothing. Both are fixed
+   (the probe honours the suppression; B2 asserts both drops and prints the trace
+   on success). A corollary: because the native layer alone suffices on the
+   emulator, no CI run there can say whether the probe's read repaints anything —
+   which leaves the contradiction between `_nudgeSurfaceRepaint`'s doc comment
+   ("a JS `offsetHeight` read does not [fix it]") and `_probeRendererAndRecover`'s
+   ("the read alone fixes the blank surface") open. Deciding gap #5, and the fork
+   pin with it, needs a device that actually goes white.
 12. **The trace is now honest but still opt-in.** `PAUSE-029` closed the coverage half
    of the diagnostic — every path reports, and a new one cannot be silent — but the
    developer-mode gate means a user who hits the bug has no trace *of the occurrence that

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -450,8 +450,11 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
    pin with it, needs a device that actually goes white.
 
    **The reload path answers the same way (2026-09-04, PR #576).** Gap #5's
-   warm start was one route; refresh is the other, and the one this bug was
-   reported on. It differs in the way that should matter: a warm start carries
+   warm start was one route; refresh is another. Refresh is not *the* trigger --
+   the symptom is reported across warm start, tab switch, fullscreen exit and
+   back navigation as well, and any account that treats one entry path as the
+   bug's definition is describing a route, not the bug. Refresh is worth its own
+   arm because it differs in the way that should matter: a warm start carries
    a window visibility change and a reload does not, so nothing below Dart has
    an obvious reason to repaint what a reload blanks. Scenario B3-A suppresses
    all fourteen `_nudgeSurfaceRepaint` triggers, issues one reload of a page
@@ -468,6 +471,25 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
    looked exactly like the bug. Each is why the tier now prints the app pid,
    the focused window, the page-server access log and the SurfaceDiag tail on
    any pixel failure.
+
+12. **Nothing has established which composition mode the CI emulator runs.**
+    Flutter's platform-view docs state the rule this bug lives under: certain
+    Android views, `SurfaceView` and `SurfaceTexture` among them, do not
+    invalidate themselves when their content changes, so an embedder hosting
+    one must invalidate it manually after the swap chain flips. That is the
+    invariant behind all eleven attempts, and it only applies in the modes that
+    put the webview behind such a surface. If the emulator resolves the
+    platform view to the texture path instead, Flutter's own frame loop redraws
+    it and the gap cannot occur there **by construction** -- which would make
+    every negative result above (gap #5's warm start, gap #11's reload) a
+    statement about the emulator, not about the bug. This is disproved at the
+    *plugin* level: the fork defaults `useHybridComposition = true`. It is not
+    disproved at the *engine* level, which is where the mode is actually
+    chosen. The lifecycle tier now dumps `dumpsys SurfaceFlinger --list`, the
+    per-layer composition types and the platform-view logcat chatter on every
+    run (`build/white_screen_adb/composition-mode.txt`, uploaded on green runs
+    too) so the question stops being unanswered by default. Read that before
+    trusting any green from this tier.
 
    **The same run is the first direct evidence that PAUSE-027 works.**
    Scenario B3-B drives five reloads 120ms apart against that 5s page, so four

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -513,6 +513,63 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
     two modes in either direction, and the Dart-level determination above is
     the only sound one. Do not re-derive a verdict from this dump.
 
+13. **Why the device reproduces and this tier does not.** The tier's negatives
+    are real (gap #12), which makes this the live question, and it has one
+    settled part and several open ones.
+
+    Settled: **the emulator repaints the platform view with no Dart help.**
+    Scenario B2 (warm start) and Scenario B3-A (committed reload) each
+    suppressed every `_nudgeSurfaceRepaint` trigger *and* the second repaint
+    path in `_probeRendererAndRecover`, showed the drops in the trace, and the
+    surface came back painted anyway. So no arrangement of scenarios on this
+    host can go red on this class: the symptom needs a surface that stays stale
+    until something forces it, and this one does not stay stale. Adding
+    scenarios is not the missing piece.
+
+    Open: which host difference supplies that unprompted repaint. Ranked by how
+    directly each bears on it, with what CI can do about it:
+
+    1. **Software rasterisation.** The runner has no GPU, so the emulator runs
+       `-gpu swiftshader_indirect`. A software compositor recomposes the whole
+       frame every vsync; there is no damage-rect, buffer-age or partial-update
+       path for a stale buffer to survive in. This is the best candidate and it
+       is the one CI cannot change: GitHub-hosted runners have no GPU.
+    2. **Animations disabled.** The emulator step runs with
+       `disable-animations: true`, zeroing all three scales. BUG-001 lives in
+       activity and route transitions, and a transition with no animation has a
+       different surface-transaction ordering than a real one. Cheap to flip in
+       this tier; untried.
+    3. **Debug build.** The tier installs `app-fdebug-debug.apk`; users run
+       release. JIT vs AOT changes frame timing, and the timing is what decides
+       whether an attach lands before or after a commit. Flipping it costs the
+       diag hooks: `RepaintSuppression` is `kDebugMode`-gated, so B2/B3-A cannot
+       run against release, though the pixel scenarios could.
+    4. **One site, one trivial page.** The seed is a single site serving a
+       solid-colour static document from localhost. Users run many sites in the
+       `IndexedStack` with real pages: slow first paint, subframes, service
+       workers, and enough memory pressure to evict a renderer. Site count and
+       page weight are both raisable here.
+    5. **A different isolation engine.** `_useContainers` is resolved from
+       `WebViewFeature.MULTI_PROFILE` at startup, and it selects a different
+       webview creation path (`containerId` set, a Profile bound in the fork's
+       `prepare()`). If the emulator's bundled System WebView answers
+       differently from a Play-updated one on a phone, the two are not running
+       the same attach path at all. The tier now records the answer.
+
+    The tier records 1, 2, 4 and 5 per run (`host:` lines beside the
+    composition dump) so a future green states what it was green on.
+
+    **The measurement that would settle it is on the device, not here.**
+    `_traceRepaint` is gated on developer mode, not `kDebugMode`, so a release
+    build with developer mode on records the full SurfaceDiag trigger sequence
+    into `LogService` (2000-entry ring) and Dev Tools can export it. Capturing
+    that at the moment a real screen goes white separates the two hypotheses
+    every attempt so far has had to guess between: **no nudge fired** (another
+    unnudged path, which is gap #3 and what all eleven attempts assumed) versus
+    **a nudge fired and the surface stayed blank** (the nudge itself does not
+    work on real hardware, which would invalidate the remedy rather than its
+    coverage). Nothing in the repository currently distinguishes them.
+
     One correction rides along, because it changes where the next fix should
     look. The `SurfaceView`-does-not-self-invalidate rule was cited here as the
     root mechanism, but under HC the platform view is an `android.webkit.WebView`

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -689,6 +689,19 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
     returns nothing. A repaint driven by the commit the engine actually reports,
     rather than by a lifecycle event we hope implies one, needs no list.
 
+    **First step taken (2026-09-05): assert the request, not the paint.** Since
+    the pixels cannot fail here, the tier now also asserts, from the app's own
+    `SurfaceDiag` trace, that a repaint was *requested* on the path just driven:
+    `trigger=resume` after a warm start, `trigger=back` after a back gesture,
+    `trigger=activate` after a warm site switch (`assert_nudged` in
+    `scripts/run_android_lifecycle_tests.sh`). This is host-independent — it
+    reads the app, not the compositor — and it fails on the actual recurrence
+    mode, a path that reaches a surface without passing a chokepoint. It does
+    not make the tier representative: it still only covers paths someone
+    enumerated, and it still cannot tell whether a nudge that fires actually
+    saves the screen. Those two need the commit-driven chokepoint above and a
+    device trace respectively.
+
     One correction rides along, because it changes where the next fix should
     look. The `SurfaceView`-does-not-self-invalidate rule was cited here as the
     root mechanism, but under HC the platform view is an `android.webkit.WebView`
@@ -702,15 +715,21 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
     the doc quote names, and any fix aimed at "invalidate the platform view's
     SurfaceView" would be aimed at the wrong object.
 
-   **The same run is the first direct evidence that PAUSE-027 works.**
-   Scenario B3-B drives five reloads 120ms apart against that 5s page, so four
-   commits abort before the fifth lands -- the shape that spent the old
-   one-shot latch on an aborted load. Every reload nudge coalesced into one
-   loop, and then `commit-settled` fired as a *fresh, uncoalesced* nudge when
-   the real document committed ~5s later, and the surface stayed painted. That
-   is the bounded commit window doing exactly what Attempt 11 built it for,
-   observed on a real surface rather than argued. B3-B runs unconditionally and
-   is now that fix's regression guard.
+   **What Scenario B3-B does and does not show.** It drives five reloads 120ms
+   apart against that 5s page, so four commits abort before the fifth lands --
+   the shape that spent the old one-shot latch on an aborted load. Every reload
+   nudge coalesced into one loop, and then `commit-settled` fired as a *fresh,
+   uncoalesced* nudge when the real document committed ~5s later. That trace is
+   real evidence, and it is evidence about the **latch's timing**: the window
+   was still open at the commit, which is what Attempt 11 built it for.
+
+   It is not evidence that the repaint prevented a blank. An earlier revision of
+   this paragraph said the surface "stayed painted" and read that as the fix
+   working, which is the same vacuity gap #16 describes: on this host the
+   surface stays painted with every trigger suppressed, so "stayed painted"
+   distinguishes nothing. B3-B guards the latch's *ordering*, read from the
+   app's trace. Whether that ordering saves a real screen is untested here and
+   needs a device.
 
    **Forcing GPU composition was tried and could not be tried (2026-09-05).**
    The one cheap hypothesis for why the emulator repaints unasked is hardware

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -604,6 +604,34 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
     with no keep rules for the fork or androidx.webkit beyond their own consumer
     rules. That gap stays open.
 
+15. **A trigger with no user action behind it, shipped in v0.3.1 and untested.**
+    `_refreshNotificationSites` reloaded the *visible* site on every native
+    background-refresh tick. Android's WorkManager tick (NOTIF-005-A) fires
+    whenever the Flutter engine is reachable, the foreground included, and the
+    handler took no `excludeActive`: it was written when only iOS's
+    `BGAppRefreshTask` reached it, where the app is suspended by definition.
+    So on any device with a notification site, the page the user was reading
+    was reloaded out of nowhere on the worker's schedule, and a reload discards
+    the painted frame. That is BUG-001's reload path (PAUSE-021/027) reached
+    with no user action, at no reproducible moment, which is what "it happens
+    on many things" looks like from outside the app.
+
+    Fixed on master by `f02d4af` (2026-09-03), which lands **after** `v0.3.1`,
+    so the released build still has it. This does not subsume the class: the
+    reload path is nudged and latched, so a correct commit still repaints. What
+    it supplies is the missing *trigger* — an unattributable one — and it
+    explains why a user hits this without being able to say what they did.
+
+    **Why no test caught it.** Scenario F fires the refresh receiver while the
+    app is BACKGROUNDED, which is the leg that was always correct; nothing
+    fired it in the foreground, which is the leg that broke. The real
+    15-minute WorkManager tick cannot be driven in CI at all (`cmd jobscheduler
+    run -f` will not execute a periodic `WorkSpec` before its next run time),
+    so the debug receiver is the only way in, and it was only ever used from
+    the background. Scenario F2 now fires the same receiver with the app
+    foregrounded and asserts the visible site neither re-fetches (its beacon
+    count is unchanged) nor goes blank.
+
     One correction rides along, because it changes where the next fix should
     look. The `SurfaceView`-does-not-self-invalidate rule was cited here as the
     root mechanism, but under HC the platform view is an `android.webkit.WebView`

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -558,8 +558,40 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
        differently from a Play-updated one on a phone, the two are not running
        the same attach path at all. The tier now records the answer.
 
-    The tier records 1, 2, 4 and 5 per run (`host:` lines beside the
-    composition dump) so a future green states what it was green on.
+    **Measured 2026-09-05 (`f3afb5c`), and #5 is no longer a candidate.** The
+    `host:` lines from the first green run carrying them:
+
+    ```
+    isolation engine: Container API not supported - using CookieIsolationEngine
+                      + (legacy) CookieManager
+    system webview:   com.google.android.webview, 113.0.5672.136
+    animation scales: 0.0 0.0 0.0   (window / transition / animator)
+    app build mode:   debug
+    build:            Android 14, api 34, sdk_gphone64_x86_64
+    ```
+
+    So **CI never runs the container engine at all.** The emulator's bundled
+    WebView is 113, which does not advertise `MULTI_PROFILE`, so
+    `ContainerNative.isSupported()` returns false and every scenario in this
+    tier exercises `CookieIsolationEngine`. A phone with a Play-updated System
+    WebView takes the other branch, where `WebViewFactory.createWebView` sets
+    `containerId` and the fork binds an `androidx.webkit.Profile` inside
+    `InAppWebView.prepare()`. That is a different webview creation and attach
+    path, and the attach path is where this bug lives. Candidate #5 is
+    confirmed: the two are not running the same code.
+
+    Candidate #2 is confirmed too — all three animation scales are 0.0, against
+    1.0 on a normal device, so every activity and route transition this tier
+    drives completes without the animation a real one has.
+
+    The WebView version is worth its own line: 113.0.5672.136 shipped in May
+    2023. The compositor a phone runs is years of Chromium ahead of the one
+    every one of these scenarios has ever tested.
+
+    The renderer line came back empty: the logcat pattern was a guess at the
+    engine's banner wording and matched nothing, so Impeller-vs-Skia and
+    Vulkan-vs-GLES are still unmeasured. The probe now dumps the candidate
+    lines instead of matching a phrase it cannot verify.
 
     **The measurement that would settle it is on the device, not here.**
     `_traceRepaint` is gated on developer mode, not `kDebugMode`, so a release
@@ -674,6 +706,10 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
     ever used from the background. Scenario F2 now fires it foregrounded and
     asserts the visible site neither re-fetches nor blanks.
 
+    Verified green on `f3afb5c`: `visible site not reloaded (page loads
+    unchanged at 2)`, with the surface still painted. That confirms `f02d4af`
+    holds on a real foreground tick, and it is the leg no scenario drove before.
+
     **What gap #15 does NOT claim.** That `v0.3.1` lacks `PAUSE-027` is a fact
     about the tag. That `PAUSE-027` fixes this user's white screens is a
     separate claim, and the base rate is against it: eleven attempts precede it,
@@ -718,7 +754,9 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
     `SurfaceDiag` trace, that a repaint was *requested* on the path just driven:
     `trigger=resume` after a warm start, `trigger=back` after a back gesture,
     `trigger=activate` after a warm site switch (`assert_nudged` in
-    `scripts/run_android_lifecycle_tests.sh`). This is host-independent — it
+    `scripts/run_android_lifecycle_tests.sh`). All three passed first time on
+    `f3afb5c`, so they are guards rather than findings: the wiring is intact on
+    the paths the tier drives. This is host-independent — it
     reads the app, not the compositor — and it fails on the actual recurrence
     mode, a path that reaches a surface without passing a chokepoint. It does
     not make the tier representative: it still only covers paths someone

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -456,10 +456,12 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
    pin with it, needs a device that actually goes white.
 
    **The reload path answers the same way (2026-09-04, PR #576).** Gap #5's
-   warm start was one route; refresh is another. Refresh is not *the* trigger --
-   the symptom is reported across warm start, tab switch, fullscreen exit and
-   back navigation as well, and any account that treats one entry path as the
-   bug's definition is describing a route, not the bug. Refresh is worth its own
+   warm start was one route; refresh is another. Refresh is not *the* trigger:
+   the reporter's words are that it happens on "many things", without naming
+   them, and any account that treats one entry path as the bug's definition is
+   describing a route, not the bug. (An earlier revision of this paragraph
+   listed four specific paths as if the report named them. It did not; that
+   list was invented here and is removed.) Refresh is worth its own
    arm because it differs in the way that should matter: a warm start carries
    a window visibility change and a reload does not, so nothing below Dart has
    an obvious reason to repaint what a reload blanks. Scenario B3-A suppresses
@@ -647,6 +649,45 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
     next run time), so the debug receiver is the only way in and it was only
     ever used from the background. Scenario F2 now fires it foregrounded and
     asserts the visible site neither re-fetches nor blanks.
+
+    **What gap #15 does NOT claim.** That `v0.3.1` lacks `PAUSE-027` is a fact
+    about the tag. That `PAUSE-027` fixes this user's white screens is a
+    separate claim, and the base rate is against it: eleven attempts precede it,
+    every one landed believing it had the bug, and this file exists because each
+    was partial. Attempt 12 asserting otherwise would be the same error a
+    twelfth time.
+
+    Three things argue specifically against it. The reporter says the symptom
+    arrives on "many things", and `PAUSE-027` is a bounded window over the
+    *reload* latch: it does not touch warm start, activation, memory pressure or
+    route return. Those paths were already wired in the release —
+    `v0.3.1:lib/main.dart` has **14** `_nudgeSurfaceRepaint` call sites against
+    master's **15**, and already logs `commit-settled`, `controller-attach`,
+    `metrics-resume`, `reload` and `route-return`. So a device going white on
+    paths other than rapid refresh is a device on which Attempts 1–10 did not
+    hold, and one more call site plus a window will not change that. The honest
+    reading of the version skew is that it covers the *rapid-refresh subset* of
+    the report and nothing more.
+
+16. **The tier is built from the same enumeration as the fix, so it cannot
+    catch what the enumeration missed.** This is the structural answer to "why
+    is CI green", and unlike gap #15 it does not depend on which attempt is
+    latest. Every fix keys on a Dart-side proxy for "a surface attached"
+    (resumed, metrics changed, route popped, load settled), every scenario in
+    the adb tier drives one of those same known entry paths and checks pixels,
+    and the bug by construction lives in whatever path nobody enumerated. A
+    suite derived from the fix's own list of paths can only ever confirm the
+    list, never find what is missing from it. That is gap #3 and gap #9 stated
+    as a property of the tests rather than of the code, and it is why the count
+    of green scenarios has never predicted anything about the device.
+
+    The way out is the same one gap #3 names: stop enumerating. The fork
+    already surfaces the real signal — `onPageCommitVisible` is plumbed all the
+    way to Dart (`InAppWebViewClient.java:782`,
+    `InAppWebViewClientCompat.java:808`, `WebViewChannelDelegate.java:1183`,
+    `platform_webview.dart:1399`) and `grep -rn onPageCommitVisible lib/`
+    returns nothing. A repaint driven by the commit the engine actually reports,
+    rather than by a lifecycle event we hope implies one, needs no list.
 
     One correction rides along, because it changes where the next fix should
     look. The `SurfaceView`-does-not-self-invalidate rule was cited here as the

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -14,10 +14,16 @@ user just sees a dead-looking screen after some navigation or app-lifecycle even
 
 ## Root mechanism (the invariant behind every instance)
 
-On Android the webview is a **hybrid-composition `SurfaceView`**. That surface can
+On Android the webview runs under **hybrid composition** (confirmed: the fork
+defaults `useHybridComposition` to `true`, which routes to
+`PlatformViewsService.initExpensiveAndroidView`, "always creates a 'Hybrid
+Composition (HC)' view"). The surface backing the composited result can
 **re-attach (or newly attach) without receiving a paint**. The renderer is healthy,
 so nothing emits an error event; the compositor just never draws onto the new
-surface until something forces a relayout.
+surface until something forces a relayout. The `WebView` itself is an ordinary
+Android view in the hierarchy, not a `SurfaceView`; the surface that presents a
+stale frame is Flutter's own `FlutterImageView` overlay, which shows the last
+image it acquired and does not repaint on its own (see open gap #12).
 
 Two colors, two sub-causes:
 
@@ -472,24 +478,44 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
    the focused window, the page-server access log and the SurfaceDiag tail on
    any pixel failure.
 
-12. **Nothing has established which composition mode the CI emulator runs.**
-    Flutter's platform-view docs state the rule this bug lives under: certain
-    Android views, `SurfaceView` and `SurfaceTexture` among them, do not
-    invalidate themselves when their content changes, so an embedder hosting
-    one must invalidate it manually after the swap chain flips. That is the
-    invariant behind all eleven attempts, and it only applies in the modes that
-    put the webview behind such a surface. If the emulator resolves the
-    platform view to the texture path instead, Flutter's own frame loop redraws
-    it and the gap cannot occur there **by construction** -- which would make
-    every negative result above (gap #5's warm start, gap #11's reload) a
-    statement about the emulator, not about the bug. This is disproved at the
-    *plugin* level: the fork defaults `useHybridComposition = true`. It is not
-    disproved at the *engine* level, which is where the mode is actually
-    chosen. The lifecycle tier now dumps `dumpsys SurfaceFlinger --list`, the
-    per-layer composition types and the platform-view logcat chatter on every
-    run (`build/white_screen_adb/composition-mode.txt`, uploaded on green runs
-    too) so the question stops being unanswered by default. Read that before
-    trusting any green from this tier.
+12. ~~Which composition mode the CI emulator runs~~ — **answered 2026-09-05, and
+    it is the affected one.** The worry was real: Flutter's platform-view docs
+    warn that certain Android views (`SurfaceView`, `SurfaceTexture`) do not
+    invalidate themselves when their content changes, so the embedder must; if
+    the emulator instead composited the webview into Flutter's own frames,
+    Flutter's frame loop would redraw it and the gap could not occur there by
+    construction, making gap #5's and gap #11's negatives statements about the
+    emulator rather than about the bug. It does not. The mode is settled in
+    Dart, not at runtime: `InAppWebViewSettings.useHybridComposition` defaults
+    to `true` and this app never sets it, and the fork's
+    `_createAndroidViewController` routes `true` to
+    `PlatformViewsService.initExpensiveAndroidView`, whose contract in the
+    pinned SDK (`packages/flutter/lib/src/services/platform_views.dart`) is
+    "Always creates a 'Hybrid Composition (HC)' view" with "the Android view and
+    Flutter widgets ... composed at the Android view hierarchy level". No
+    TLHC-or-HC fallback is in play; that logic belongs to
+    `initSurfaceAndroidView`, which is the `false` branch. So the emulator runs
+    the same mode as the reporting devices, and this tier's negative results
+    stand as evidence. The lifecycle tier still dumps `dumpsys SurfaceFlinger
+    --list`, the per-layer composition types and the platform-view logcat
+    chatter on every run (`build/white_screen_adb/composition-mode.txt`,
+    uploaded on green runs too) as the runtime witness — it does not decide the
+    mode, and a first cut of it that tried to read the mode off the layer count
+    got the reading backwards, which is why it now prints layer names and no
+    verdict.
+
+    One correction rides along, because it changes where the next fix should
+    look. The `SurfaceView`-does-not-self-invalidate rule was cited here as the
+    root mechanism, but under HC the platform view is an `android.webkit.WebView`
+    in the Android view hierarchy, and a `WebView` is not a `SurfaceView` — it
+    draws through a functor into whatever surface contains it and never owns a
+    SurfaceFlinger layer. The surface that can present a stale frame in HC is
+    Flutter's own: `FlutterView.convertToImageView()` swaps the render surface
+    for `FlutterImageView`s, which present whatever image was last acquired and
+    do not repaint on their own. That is consistent with the symptom and with
+    why a 1px inset toggle clears it, but it is a different surface from the one
+    the doc quote names, and any fix aimed at "invalidate the platform view's
+    SurfaceView" would be aimed at the wrong object.
 
    **The same run is the first direct evidence that PAUSE-027 works.**
    Scenario B3-B drives five reloads 120ms apart against that 5s page, so four

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -662,6 +662,13 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
     `LogService`'s logcat forwarding — none of which changes release behaviour,
     which is what those gates were protecting.
 
+    The two modes install under **different applicationIds**. `#579` gave the
+    `debug` build type `applicationIdSuffix ".debug"`; `initWith(debug)` runs
+    while Flutter applies its plugin, which is before that block, so `profile`
+    copies `debuggable = true` but not the suffix. The tier derives `pkg` from
+    the mode for that reason — a hardcoded package name is right for exactly one
+    of them.
+
     This does not reach the shipped artifact: profile does not run R8, and
     `minifyEnabled true` with `proguard-android-optimize.txt` is release-only,
     with no keep rules for the fork or androidx.webkit beyond their own consumer

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -593,6 +593,31 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
     Vulkan-vs-GLES are still unmeasured. The probe now dumps the candidate
     lines instead of matching a phrase it cannot verify.
 
+    **Four of the five were our own choices (2026-09-06).** Only #1 is a
+    property of the runner. The others were configuration, and are now changed:
+
+    - **#5, the isolation engine.** `androidx.webkit` resolves to 1.14.0 (the
+      fork pins it; the app asks for 1.12.1), so the library supports
+      `MULTI_PROFILE`. What did not was the runtime WebView: `google_apis`
+      images ship a WebView pinned at image build time and have no Play Store
+      to update it, so API 34 sat on 113.0.5672.136 from May 2023 no matter how
+      current the image itself looked. The emulator is now API 35, which
+      carries a newer bundled WebView; the tier records the version, so the run
+      says whether that crossed the threshold. If it still reports unsupported,
+      the next step is API 36, not a sideloaded WebView APK: pulling a
+      third-party binary into CI to fix a test host is not a trade worth making.
+    - **#2, animations.** The tier now sets all three scales to 1.0 for its own
+      run and restores what it found. It runs last in the emulator session, so
+      no other tier sees them.
+    - **#3, build mode.** Already switchable (`WS_LIFECYCLE_BUILD_MODE`),
+      default `debug` until the profile arm's Scenario A failure is understood.
+
+    That leaves #1, software rasterisation, as the only difference CI cannot
+    close, and it is also the one Cuttlefish would not close: a GitHub-hosted
+    runner has no GPU, so `cvd` falls back to the same software compositor.
+    Reaching for a different emulator was the wrong instinct; the cheap
+    configuration changes above buy the differences that matter.
+
     **The measurement that would settle it is on the device, not here.**
     `_traceRepaint` is gated on developer mode, not `kDebugMode`, so a release
     build with developer mode on records the full SurfaceDiag trigger sequence

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -1020,6 +1020,58 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
     depends on that line: a third classification (no body -> reload, not
     nudge) if the document is blank, something else if it is not.
 
+18. **The nudge fires correctly and does not repaint (second device capture,
+    2026-09-06).** Same phone, same `fdebug` debug build, developer mode on so
+    `_traceRepaint` writes. A cold start, then one site opened for the first
+    time. It went white, and the trace is complete:
+
+    ```
+    22:32:19  trigger=activate          -> nudge
+    22:32:20  trigger=controller-attach -> nudge (coalesced)
+    22:32:21  trigger=reload            -> nudge (coalesced)
+    22:32:23  onLoadStart
+    22:32:24  onLoadStop
+    22:32:24  trigger=commit-settled    -> nudge
+    22:32:28  onLoadStart / onLoadStop
+    22:32:29  trigger=commit-settled    -> nudge
+    22:32:41  HtmlCache saved 376028 bytes for site hm1uscucyi-vy3
+    22:32:45  HtmlCache saved 376020 bytes
+    22:32:48  HtmlCache saved 376028 bytes  (x3)
+    ```
+
+    Six nudges. The two `commit-settled` ones are not coalesced, so each ran
+    its own six-tick loop, and they ran immediately after `onLoadStop` — the
+    exact moment PAUSE-027 exists to cover. The renderer answered `getHtml`
+    five times over the following seven seconds with a 376 KB document, after
+    the screen was already blank. Live renderer, complete document, correct
+    trigger, correct timing, blank surface.
+
+    **This closes gap #11 against the fix rather than for it.** The question
+    was whether a nudge that fires saves the screen. It does not. Every attempt
+    in this file from 3 onward adds or moves a *trigger*; the trigger set was
+    never the problem on this path. `_nudgeSurfaceRepaint` toggles a 1px body
+    inset over six frames to make the platform view recomposite
+    (`lib/main.dart`), as a stand-in for the rotation / lock-unlock / tab
+    switch that the reporter has always said does recover the screen. The
+    stand-in does not reproduce the effect. Until something is found that
+    does, no trigger work can help, `onPageCommitVisible` (gap #16) included:
+    it is a better-timed call to the same inert mechanism.
+
+    It also retires two working assumptions. The blank does not need a
+    backgrounded site or a warm start — this was a first load after a cold
+    start. And it is unrelated to gap #17's `-1`: the document here is 376 KB.
+
+    **The formal layer defined this away.** `Nudge` in `formal/kernel.tla`
+    carries `surface' = "painted"` inside the action, so "nudging repaints the
+    surface" is an axiom, and `formal/proofs/repaint_liveness.tla`
+    (`THEOREM Liveness == GoodSpecWF => (surface = "blank" ~> surface =
+    "painted")`) discharges liveness from it plus `WF_vars(Nudge)`. TLC and
+    TLAPS were both sound about a machine in which the failing proposition is
+    true by construction. A model of the repaint must make the effect of a
+    nudge a *possibility* rather than a definition, with a behavior where the
+    nudge fires and the surface stays blank — that behavior is the bug, and it
+    is currently unrepresentable.
+
 - Identify the **new entry path**: what navigation/lifecycle event preceded the blank?
   Does it pass through `_setCurrentIndex` (Attempt 3) or `onControllerReady`
   (Attempt 4)? If neither, that path needs `_nudgeSurfaceRepaint`.

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -598,14 +598,18 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
 
     - **#5, the isolation engine.** `androidx.webkit` resolves to 1.14.0 (the
       fork pins it; the app asks for 1.12.1), so the library supports
-      `MULTI_PROFILE`. What did not was the runtime WebView: `google_apis`
-      images ship a WebView pinned at image build time and have no Play Store
-      to update it, so API 34 sat on 113.0.5672.136 from May 2023 no matter how
-      current the image itself looked. The emulator is now API 35, which
-      carries a newer bundled WebView; the tier records the version, so the run
-      says whether that crossed the threshold. If it still reports unsupported,
-      the next step is API 36, not a sideloaded WebView APK: pulling a
-      third-party binary into CI to fix a test host is not a trade worth making.
+      `MULTI_PROFILE`. What did not was the runtime WebView. Every emulator
+      image pins its WebView at image build time and has no Play Store to
+      update it, so API 34 sat on Chromium 113 from May 2023 no matter how
+      current the image itself looked; the API level is the only thing that
+      moves it. The emulator is now API 35, and on the **AOSP** image
+      (`target: default`, WebView `com.android.webview`) rather than
+      `google_apis`: this app ships GMS-free and CI asserts that about the APK,
+      so the test host should not carry Google's stack either. The tier records
+      the version it got, so the run says whether it crossed the threshold. If
+      it still reports unsupported, the next step is API 36, not a sideloaded
+      WebView APK: pulling a third-party binary into CI to fix a test host is
+      not a trade worth making.
     - **#2, animations.** The tier now sets all three scales to 1.0 for its own
       run and restores what it found. It runs last in the emulator session, so
       no other tier sees them.

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -332,6 +332,38 @@ has to find is an admission the automatic coverage is still incomplete. The deve
 gate sharpens that trade-off rather than resolving it: the diagnostic now reaches only users
 who were told how to unlock it, so the falsifying report needs someone to ask for it.
 
+### Attempt 12 — Repaint when the renderer reports pixels (`PAUSE-031`)
+
+**Date:** 2026-09-06
+
+**What it did.** Wired Android's `onPageCommitVisible` through
+`WebViewConfig` to a nudge under the trigger `page-commit-visible`, on both the
+site webview (via `WebViewModel.onPageCommitVisible`, the same shape as
+`onLoadSettled`) and the nested `InAppWebViewScreen`. Deliberately not gated on
+the PAUSE-027 commit window.
+
+**Why.** The second device capture (gap #18) showed a load where all six nudges
+had drained and the 15-second window had closed twelve or more seconds before
+the renderer produced any content. Every trigger up to here is a lifecycle
+event *hoped* to imply a painted surface — a resume, a metrics change, a route
+pop, a load settling. `onLoadStop` is the closest, and it reports that a
+navigation finished, not that a frame exists; on a slow device the gap between
+them is seconds. `onPageCommitVisible` is the only signal in the stack that
+fires because the WebView committed a visible frame, so it is the one trigger
+that cannot land before there is something to paint. It was already plumbed to
+Dart in the fork and unused, which gap #16 had named as the way out of
+enumerating paths.
+
+**Why it is partial.** It is still a trigger, and gap #18 leaves open whether
+the mechanism it calls works at all on the reporting device — the two
+hypotheses in that gap are not yet separated, and this attempt only helps under
+one of them. It says nothing about the `-1` no-body case (gap #17). It is
+Android-only by construction. And a page whose first commit-visible frame is
+itself blank (a shell that paints later) gets one nudge at the wrong moment and
+nothing after, because there is no second commit for a same-document update.
+
+---
+
 ## Known open gaps (candidates for the next recurrence)
 
 1. ~~Nested `InAppWebViewScreen`~~ — **closed by Attempt 6** (now funneled + gated).
@@ -1041,21 +1073,40 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
 
     Six nudges. The two `commit-settled` ones are not coalesced, so each ran
     its own six-tick loop, and they ran immediately after `onLoadStop` — the
-    exact moment PAUSE-027 exists to cover. The renderer answered `getHtml`
-    five times over the following seven seconds with a 376 KB document, after
-    the screen was already blank. Live renderer, complete document, correct
-    trigger, correct timing, blank surface.
+    moment PAUSE-027 exists to cover. The renderer answered `getHtml` five
+    times over the following seven seconds with a 376 KB document, after the
+    screen was already blank. Live renderer, complete document, every
+    enumerated trigger fired, blank surface.
 
-    **This closes gap #11 against the fix rather than for it.** The question
-    was whether a nudge that fires saves the screen. It does not. Every attempt
-    in this file from 3 onward adds or moves a *trigger*; the trigger set was
-    never the problem on this path. `_nudgeSurfaceRepaint` toggles a 1px body
+    **Two hypotheses fit this, and they are not yet separated.**
+
+    *H1, the mechanism is inert.* `_nudgeSurfaceRepaint` toggles a 1px body
     inset over six frames to make the platform view recomposite
-    (`lib/main.dart`), as a stand-in for the rotation / lock-unlock / tab
-    switch that the reporter has always said does recover the screen. The
-    stand-in does not reproduce the effect. Until something is found that
-    does, no trigger work can help, `onPageCommitVisible` (gap #16) included:
-    it is a better-timed call to the same inert mechanism.
+    (`lib/main.dart`), standing in for the rotation / lock-unlock / tab switch
+    the reporter has always said does recover the screen. Those differ from a
+    1px resize in magnitude, in whether the view stops being painted, and in
+    whether the platform view is destroyed. If the stand-in reproduces none of
+    what matters, no trigger work can help.
+
+    *H2, every nudge ran too early.* The last nudge fired at 22:32:29 and its
+    six ticks drained by ~22:32:29.6. The commit window was armed by the reload
+    at 22:32:21 and closed 15 seconds later, ~22:32:36. No `onLoadStop`
+    followed 22:32:29, so no further `commit-settled` nudge. The renderer's DOM
+    serializations land at 22:32:41, :45 and :48 — 12 to 19 seconds after the
+    last nudge drained and after the window shut. If the first composited frame
+    arrived in that span, every trigger had already spent itself. This is the
+    shape of attempts 9, 10 and 11, one step further out in time, and it makes
+    `onPageCommitVisible` (gap #16) the fix rather than a better-timed call to
+    an inert mechanism.
+
+    **The discriminator is one tap.** The developer-mode "Repaint Screen" entry
+    now cycles through mechanisms on successive taps and logs which it ran:
+    `inset-1` (today's), `inset-16`, `unpaint` (held unpainted for a few frames,
+    which detaches and re-attaches the Android view without destroying the
+    WebView), `recreate`. On a blank screen, `inset-1` restoring it means H2 and
+    the mechanism is sound; `inset-1` doing nothing where `unpaint` or
+    `recreate` works means H1 and the mechanism has to change. Attempt 12 acts
+    on H2, which is the cheap half; H1 stays open until a device answers.
 
     It also retires two working assumptions. The blank does not need a
     backgrounded site or a warm start — this was a first load after a cold

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -963,6 +963,57 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
   does a rotate or tab-switch instantly fix it? If yes → surface, use the nudge. If a
   rotate doesn't fix it and JS is dead → renderer death, a different bug:
   [BUG-002](002-black-screen.md) (`PAUSE-013/014`).
+17. **The probe calls an empty document healthy (first device capture,
+    2026-09-06).** The first `SurfaceDiag` trace anyone has taken off an
+    affected phone, an `fdebug` debug build in ordinary use over seven minutes,
+    ends like this:
+
+    ```
+    22:23:49  Switching to site 2: "GitHub ..." (siteId: hm1uscucyi-vy3)
+    22:24:00  Teardown of "Google Maps" ran [], stalled on stopRealCameraCapture
+    22:24:02  trigger=site-switch probe=-1 -> renderer-alive (nudge)
+    22:24:08  trigger=resume      probe=-1 -> renderer-alive (nudge)
+    22:24:19  trigger=resume      probe=-1 -> renderer-alive (nudge)
+    22:24:33  trigger=resume      probe=-1 -> renderer-alive (nudge)
+    ```
+
+    with the reporter saying GitHub never appeared. `-1` is the else branch of
+    `document.body ? document.body.offsetHeight : -1`: the document has no
+    body. `rendererProbeIndicatesGone` is `probeResult == null`
+    (`lib/web_view_model.dart:452`), so `-1` classifies as alive and the app
+    nudges. **A surface nudge cannot repaint a document that has no body**, so
+    every trigger on that path is a no-op by construction, however many of them
+    fire — which is why the count of enumerated paths has never mattered.
+
+    The same site had a body earlier in the session (`onLoadStop` at 22:17:33,
+    a 376 KB HTML cache save at 22:17:56), then sat backgrounded and paused
+    from 22:17:38 to 22:23:49 while two other webviews loaded. A document does
+    not lose its body by being slow: a parsing document has one. It loses it by
+    being replaced, which is what an Android WebView does when its renderer is
+    reaped under memory pressure while backgrounded and comes back attached to
+    a fresh empty document. That reads as BUG-002, except the BUG-002 detector
+    cannot see it: the probe returns *successfully* from the new document, so
+    `probeResult == null` is false and `handleRendererGone` is never called.
+    The two recovery paths split on "did the call fail", and this case fails
+    neither.
+
+    This is also the concrete answer to gap #11 (whether a nudge that fires
+    saves the screen: no, on this path) and to why CI is green (gap #16): the
+    emulator has memory to spare and no scenario leaves a site backgrounded
+    behind two other loaded webviews for six minutes, so its renderers are
+    never reaped and `-1` never appears in a tier trace.
+
+    **Not yet closed, and deliberately not fixed on one capture.** The trace
+    shows the classification is wrong; it does not yet show *which* document
+    answered. `_probeRendererAndRecover` now emits a second line on the `-1`
+    path (`readyState`, whether `documentElement` exists, `protocol//host`),
+    which separates a renderer that came back on `about:blank` from a live
+    document that genuinely has no body. Developer mode was off for this
+    capture, so `_traceRepaint` wrote nothing and only the probe's four call
+    sites are visible — the next capture needs it on. What the fix will be
+    depends on that line: a third classification (no body -> reload, not
+    nudge) if the document is blank, something else if it is not.
+
 - Identify the **new entry path**: what navigation/lifecycle event preceded the blank?
   Does it pass through `_setCurrentIndex` (Attempt 3) or `onControllerReady`
   (Attempt 4)? If neither, that path needs `_nudgeSurfaceRepaint`.

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -987,21 +987,27 @@ who were told how to unlock it, so the falsifying report needs someone to ask fo
 
     The same site had a body earlier in the session (`onLoadStop` at 22:17:33,
     a 376 KB HTML cache save at 22:17:56), then sat backgrounded and paused
-    from 22:17:38 to 22:23:49 while two other webviews loaded. A document does
-    not lose its body by being slow: a parsing document has one. It loses it by
-    being replaced, which is what an Android WebView does when its renderer is
-    reaped under memory pressure while backgrounded and comes back attached to
-    a fresh empty document. That reads as BUG-002, except the BUG-002 detector
-    cannot see it: the probe returns *successfully* from the new document, so
-    `probeResult == null` is false and `handleRendererGone` is never called.
-    The two recovery paths split on "did the call fail", and this case fails
-    neither.
+    from 22:17:38 to 22:23:49 while two other webviews loaded, with no
+    `Creating webview` / `onControllerCreated` / `onLoadStart` for it in
+    between. Nothing was loading when the `-1`s were logged, and a parsing
+    document has a body from its first bytes, so "the page had not loaded yet"
+    does not account for four probes over 31 seconds.
 
-    This is also the concrete answer to gap #11 (whether a nudge that fires
-    saves the screen: no, on this path) and to why CI is green (gap #16): the
-    emulator has memory to spare and no scenario leaves a site backgrounded
-    behind two other loaded webviews for six minutes, so its renderers are
-    never reaped and `-1` never appears in a tier trace.
+    **Two things this trace cannot settle, both of them the trace's fault.**
+    The probe line carried no site identity, and the window holds two logged
+    switches to site 2 (22:23:49, 22:24:00), two concurrent `site-switch`
+    probes, and teardowns of two other sites: a `-1` off a torn-down Maps
+    controller is indistinguishable from one off GitHub. `site=<siteId>` is now
+    on both probe lines. And the obvious mechanism — an Android WebView whose
+    renderer was reaped while backgrounded, answering from a fresh empty
+    document — is contradicted here: `handleRendererGone` logs
+    `Renderer gone for "..."` unconditionally (`lib/web_view_model.dart:1779`)
+    and that line is absent, so `onRenderProcessGone` never fired. Whatever
+    emptied the document did not announce itself as a renderer death.
+
+    Whichever site the `-1`s belong to, no tier scenario has ever produced one:
+    none leaves a site backgrounded behind two other loaded webviews for six
+    minutes, so `-1` has never appeared in a tier trace (gap #16).
 
     **Not yet closed, and deliberately not fixed on one capture.** The trace
     shows the classification is wrong; it does not yet show *which* document

--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -1100,13 +1100,27 @@ nothing after, because there is no second commit for a same-document update.
     an inert mechanism.
 
     **The discriminator is one tap.** The developer-mode "Repaint Screen" entry
-    now cycles through mechanisms on successive taps and logs which it ran:
-    `inset-1` (today's), `inset-16`, `unpaint` (held unpainted for a few frames,
-    which detaches and re-attaches the Android view without destroying the
-    WebView), `recreate`. On a blank screen, `inset-1` restoring it means H2 and
-    the mechanism is sound; `inset-1` doing nothing where `unpaint` or
-    `recreate` works means H1 and the mechanism has to change. Attempt 12 acts
-    on H2, which is the cheap half; H1 stays open until a device answers.
+    cycles through mechanisms on successive taps and logs which it ran:
+
+    | tap | mechanism | what it does that the others do not |
+    |-----|-----------|-------------------------------------|
+    | 1 | `inset-1` | today's mechanism, unchanged |
+    | 2 | `inset-16` | same resize, sixteen times the magnitude |
+    | 3 | `unpaint` | Flutter stops painting the subtree for a few frames, so the Android view leaves and re-enters the hierarchy without the WebView being destroyed |
+    | 4 | `native-invalidate` | `View.invalidate()` + `requestLayout()` on every WebView in the window, called on the platform thread rather than resized from Dart |
+    | 5 | `native-visibility` | `GONE` then `VISIBLE` on the same views, which is what lock-unlock does |
+    | 6 | `recreate` | dispose and rebuild (reloads the page) |
+
+    Taps 1 and 2 separate "the mechanism works" from "the magnitude is too
+    small". Tap 3 separates a resize from a detach. Taps 4 and 5 separate
+    Flutter's platform-view plumbing from the Android views themselves —
+    `SurfaceDiagPlugin` already holds the Activity and runs on the main looper,
+    so neither needs a change in the fork. Tap 6 is the answer that always
+    works and costs the page.
+
+    Whichever tap restores the screen names the layer, and the mechanism the
+    automatic nudge should use becomes that one. Attempt 12 acts on H2, the
+    cheap half; H1 stays open until a device answers.
 
     It also retires two working assumptions. The blank does not need a
     backgrounded site or a warm start — this was a first load after a cold

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2024,7 +2024,12 @@ class _WebSpacePageState extends State<WebSpacePage>
     // Debug-only, diag tiers only: drop this trigger so a scenario can observe
     // what the native layer repaints on its own (BUG-001 gap #5).
     if (RepaintSuppression.suppresses(trigger)) {
-      _traceRepaint('$trigger-suppressed', coalesced: false);
+      // Logged directly, not through _traceRepaint: that is gated on developer
+      // mode, and the adb probe needs this line in logcat to prove the nudge it
+      // suppressed was actually reached. A green probe with no drop recorded
+      // means the suppression never armed, not that the surface came back on
+      // its own.
+      LogService.instance.log('SurfaceDiag', 'trigger=$trigger suppressed');
       return;
     }
     final started = _surfaceRepaint.request();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1851,6 +1851,7 @@ class _WebSpacePageState extends State<WebSpacePage>
       // was recreated and the platform-view surface came back blank. See
       // PAUSE-015.
       _nudgeSurfaceRepaint('resume');
+      unawaited(_handleDiagReload());
       // A repaint cannot recover a page that never loaded. Re-issue a load
       // the OS stranded while we were backgrounded, against the same
       // now-final visible site. Runs long (bounded retries with a backoff),
@@ -2118,6 +2119,31 @@ class _WebSpacePageState extends State<WebSpacePage>
       unawaited(_probeRendererAndRecover(_webViewModels[idx], trigger: 'manual'));
     }
     _nudgeSurfaceRepaint('manual');
+  }
+
+  /// Adb white-screen tier only (INTEG-011): issue the launch intent's
+  /// requested reloads through the production refresh funnel.
+  ///
+  /// The reload path is the one BUG-001 was reported on and the one no
+  /// scenario could reach, because refresh lives in the overflow menu. It also
+  /// differs from a warm start in the way that matters: a reload carries no
+  /// window visibility change, so nothing below Dart has a reason to repaint
+  /// the surface it blanks.
+  ///
+  /// Delayed so the resume nudge that necessarily precedes it has drained;
+  /// otherwise its tick loop repaints the surface the reload just blanked and
+  /// the scenario measures the resume instead of the reload.
+  Future<void> _handleDiagReload() async {
+    final count = await DiagSeed.takeReloadRequest();
+    if (count == null || count <= 0 || !mounted) return;
+    await Future.delayed(const Duration(seconds: 1));
+    for (var i = 0; i < count; i++) {
+      if (!mounted) return;
+      final idx = _currentIndex;
+      if (idx == null || idx < 0 || idx >= _webViewModels.length) return;
+      unawaited(_webViewModels[idx].reloadAndRepaint());
+      await Future.delayed(const Duration(milliseconds: 120));
+    }
   }
 
   Future<void> _handleShortcutIntent() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1973,6 +1973,14 @@ class _WebSpacePageState extends State<WebSpacePage>
       {String trigger = 'unspecified'}) async {
     final controller = model.controller;
     if (controller == null) return;
+    // Debug-only, diag tiers only. The offsetHeight read below is itself a
+    // repaint path, so a scenario isolating what the native layer does on its
+    // own has to drop this too: suppressing only the nudge funnel leaves this
+    // running under the same trigger name and the surface comes back anyway.
+    if (RepaintSuppression.suppresses(trigger)) {
+      LogService.instance.log('SurfaceDiag', 'trigger=$trigger probe suppressed');
+      return;
+    }
     final result = await controller
         .evaluateJavascriptReturning('document.body ? document.body.offsetHeight : -1');
     if (!mounted) return;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1035,6 +1035,14 @@ class _WebSpacePageState extends State<WebSpacePage>
   // forces Android hybrid-composition platform views to recomposite after
   // the activity is recreated (shortcut/resume). Always false in steady state.
   bool _repaintNudge = false;
+  // Magnitude of that inset, and whether the visible subtree is held unpainted
+  // for a frame. Both exist because the 1px inset provably does not repaint the
+  // surface on the reporting device (BUG-001 gap #18) while rotation,
+  // lock-unlock and a tab switch do; the menu repaint cycles through them so a
+  // device can say which property matters. Steady state is 1.0 / false.
+  double _repaintInsetPx = 1.0;
+  bool _repaintHidden = false;
+  int _manualRepaintPass = 0;
   // Coalescing tick machine for _nudgeSurfaceRepaint. Pure-Dart engine (no
   // Timer/setState); the host drives the clock and renders _repaintNudge from
   // its tick output. See lib/services/surface_repaint_engine.dart and
@@ -2125,12 +2133,48 @@ class _WebSpacePageState extends State<WebSpacePage>
   /// than nudged (the two blank classes are indistinguishable on screen), then
   /// recomposite. Off Android the nudge is a no-op, so the menu entry is
   /// Android-only.
+  ///
+  /// Successive taps try a *different* mechanism, because the default one is
+  /// known not to work: BUG-001 gap #18 caught six nudges firing against a
+  /// live renderer holding a 376 KB document with the screen blank, while
+  /// rotation, lock-unlock and a tab switch all recover it. Those differ from
+  /// a 1px resize in magnitude, in whether the view stops being painted, and
+  /// in whether the platform view is destroyed; one tap each says which
+  /// property the surface actually responds to. The chosen magnitude sticks
+  /// for later automatic nudges in the same session, which only matters while
+  /// a loop is running (steady state settles at a zero inset).
   void _repaintCurrentSurface() {
     final idx = _currentIndex;
     if (idx != null && idx < _webViewModels.length) {
       unawaited(_probeRendererAndRecover(_webViewModels[idx], trigger: 'manual'));
     }
-    _nudgeSurfaceRepaint('manual');
+    const mechanisms = <String>['inset-1', 'inset-16', 'unpaint', 'recreate'];
+    final mechanism = mechanisms[_manualRepaintPass % mechanisms.length];
+    _manualRepaintPass++;
+    LogService.instance.log('SurfaceDiag', 'manual mechanism=$mechanism');
+    if (mechanism == 'unpaint') {
+      _repaintInsetPx = 1.0;
+      unawaited(_holdUnpainted());
+    } else if (mechanism == 'recreate') {
+      _repaintInsetPx = 1.0;
+      _resetCurrentSiteWebView();
+    } else {
+      _repaintInsetPx = mechanism == 'inset-16' ? 16.0 : 1.0;
+      _nudgeSurfaceRepaint('manual');
+    }
+  }
+
+  /// Hold the visible subtree unpainted for a few frames, keeping it mounted
+  /// and laid out. Flutter drops the platform view's layer while nothing
+  /// paints it, so the Android view leaves and re-enters the native hierarchy
+  /// without the WebView being destroyed — what a tab switch does, and what a
+  /// resize does not.
+  Future<void> _holdUnpainted() async {
+    if (_repaintHidden) return;
+    setState(() => _repaintHidden = true);
+    await Future<void>.delayed(const Duration(milliseconds: 120));
+    if (!mounted) return;
+    setState(() => _repaintHidden = false);
   }
 
   /// Adb white-screen tier only (INTEG-011): issue the launch intent's
@@ -8983,8 +9027,14 @@ class _WebSpacePageState extends State<WebSpacePage>
                     // hybrid-composition webview SurfaceView to recomposite —
                     // otherwise it can come back black on Android. No-op
                     // (zero inset) in steady state.
-                    child: Padding(
-                      padding: EdgeInsets.only(bottom: _repaintNudge ? 1.0 : 0.0),
+                    child: Visibility(
+                      visible: !_repaintHidden,
+                      maintainState: true,
+                      maintainSize: true,
+                      maintainAnimation: true,
+                      child: Padding(
+                      padding: EdgeInsets.only(
+                          bottom: _repaintNudge ? _repaintInsetPx : 0.0),
                       child: IndexedStack(
                       index: _currentIndex ?? 0,
                       children: _webViewModels.asMap().entries.map<Widget>((entry) {
@@ -9033,6 +9083,15 @@ class _WebSpacePageState extends State<WebSpacePage>
                           if (index != _currentIndex) return;
                           if (!_surfaceRepaint.noteLoadSettled()) return;
                           _nudgeSurfaceRepaint('commit-settled');
+                        };
+                        // Deliberately not gated on the commit window the
+                        // trigger above uses. That window is 15s from the
+                        // issue, and gap #18 caught a load whose renderer
+                        // produced its first content well after it closed —
+                        // gating this on it would reproduce exactly that.
+                        webViewModel.onPageCommitVisible = () {
+                          if (index != _currentIndex) return;
+                          _nudgeSurfaceRepaint('page-commit-visible');
                         };
 
                         // Keep the on-disk back/forward stack tracking
@@ -9157,6 +9216,7 @@ class _WebSpacePageState extends State<WebSpacePage>
                         );
                       }).toList(),
                       ),
+                    ),
                     ),
                   ),
                 // NAV-009 on iOS: WKWebView owns the left-edge swipe on the

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1995,6 +1995,20 @@ class _WebSpacePageState extends State<WebSpacePage>
       'trigger=$trigger probe=${result ?? 'null'} → '
           '${gone ? 'renderer-gone (recreate)' : 'renderer-alive (nudge)'}',
     );
+    // -1 is `document.body` missing, which the classification above counts as
+    // alive: the call returned, so the renderer answered. A document with no
+    // body cannot be repainted by a surface nudge, so say which document
+    // answered — an Android WebView whose renderer was reaped while
+    // backgrounded comes back attached to a fresh empty one. See BUG-001
+    // gap #17.
+    if (!gone && result.toString() == '-1') {
+      final detail = await controller.evaluateJavascriptReturning(
+          "document.readyState + ' ' + (document.documentElement ? 'html' : "
+          "'no-html') + ' ' + location.protocol + '//' + location.host");
+      if (!mounted) return;
+      LogService.instance
+          .log('SurfaceDiag', 'trigger=$trigger no body: ${detail ?? 'null'}');
+    }
     // identical() guard: a concurrent recreate may have already swapped the
     // controller out from under us — don't null a fresh one.
     if (gone && identical(model.controller, controller)) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,6 +48,7 @@ import 'package:webspace/services/html_import_storage.dart';
 import 'package:webspace/services/settings_backup.dart';
 import 'package:webspace/services/cookie_isolation.dart';
 import 'package:webspace/services/resume_reload_engine.dart';
+import 'package:webspace/services/surface_diag_native.dart';
 import 'package:webspace/services/surface_repaint_engine.dart';
 import 'package:webspace/services/surface_route_observer.dart';
 import 'package:webspace/services/diag_seed.dart';
@@ -2148,13 +2149,26 @@ class _WebSpacePageState extends State<WebSpacePage>
     if (idx != null && idx < _webViewModels.length) {
       unawaited(_probeRendererAndRecover(_webViewModels[idx], trigger: 'manual'));
     }
-    const mechanisms = <String>['inset-1', 'inset-16', 'unpaint', 'recreate'];
+    const mechanisms = <String>[
+      'inset-1',
+      'inset-16',
+      'unpaint',
+      'native-invalidate',
+      'native-visibility',
+      'recreate',
+    ];
     final mechanism = mechanisms[_manualRepaintPass % mechanisms.length];
     _manualRepaintPass++;
     LogService.instance.log('SurfaceDiag', 'manual mechanism=$mechanism');
     if (mechanism == 'unpaint') {
       _repaintInsetPx = 1.0;
       unawaited(_holdUnpainted());
+    } else if (mechanism.startsWith('native-')) {
+      _repaintInsetPx = 1.0;
+      unawaited(SurfaceDiagNative.nativeRepaint(
+              mechanism.substring('native-'.length))
+          .then((views) => LogService.instance
+              .log('SurfaceDiag', 'manual $mechanism reached ${views ?? 0} view(s)')));
     } else if (mechanism == 'recreate') {
       _repaintInsetPx = 1.0;
       _resetCurrentSiteWebView();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1992,22 +1992,20 @@ class _WebSpacePageState extends State<WebSpacePage>
     // unpainted surface (a number → BUG-001, nudge). See PAUSE-019.
     LogService.instance.log(
       'SurfaceDiag',
-      'trigger=$trigger probe=${result ?? 'null'} → '
+      'trigger=$trigger site=${model.siteId} probe=${result ?? 'null'} → '
           '${gone ? 'renderer-gone (recreate)' : 'renderer-alive (nudge)'}',
     );
     // -1 is `document.body` missing, which the classification above counts as
     // alive: the call returned, so the renderer answered. A document with no
     // body cannot be repainted by a surface nudge, so say which document
-    // answered — an Android WebView whose renderer was reaped while
-    // backgrounded comes back attached to a fresh empty one. See BUG-001
-    // gap #17.
+    // answered. See BUG-001 gap #17.
     if (!gone && result.toString() == '-1') {
       final detail = await controller.evaluateJavascriptReturning(
           "document.readyState + ' ' + (document.documentElement ? 'html' : "
           "'no-html') + ' ' + location.protocol + '//' + location.host");
       if (!mounted) return;
-      LogService.instance
-          .log('SurfaceDiag', 'trigger=$trigger no body: ${detail ?? 'null'}');
+      LogService.instance.log('SurfaceDiag',
+          'trigger=$trigger site=${model.siteId} no body: ${detail ?? 'null'}');
     }
     // identical() guard: a concurrent recreate may have already swapped the
     // controller out from under us — don't null a fresh one.

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -362,6 +362,10 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
         // leaving a dead black surface. Destroy-and-rebuild on the event,
         // mirroring the main screen's handleRendererGone.
         onRendererGone: (didCrash) => _handleRendererGone(didCrash),
+        // Ungated, unlike the commit-settled trigger below: this fires when
+        // the WebView has pixels, and the 15s commit window can close before
+        // a slow renderer produces any (BUG-001 gap #18).
+        onPageCommitVisible: () => _nudgeSurfaceRepaint('page-commit-visible'),
         incognito: widget.incognito,
         javascriptEnabled: widget.javascriptEnabled,
         userAgent: widget.userAgent,

--- a/lib/services/diag_seed.dart
+++ b/lib/services/diag_seed.dart
@@ -60,6 +60,27 @@ class DiagSeed {
     return DiagSeedData(sites: sites);
   }
 
+  /// How many reloads the launch intent asked the harness to issue, drained
+  /// on read so a later resume does not repeat them.
+  ///
+  /// The refresh funnel is only reachable from the overflow menu, which adb
+  /// cannot drive, and the reload path is the one BUG-001 was reported on.
+  /// Debug builds only, like the seed.
+  static Future<int?> takeReloadRequest() async {
+    if (!kDebugMode) return null;
+    String? spec;
+    try {
+      spec = await _channel.invokeMethod<String>('getDiagReload');
+    } on MissingPluginException {
+      spec = null;
+    } on PlatformException {
+      spec = null;
+    }
+    spec ??= hostEnvironment['WS_DIAG_RELOAD'];
+    if (spec == null || spec.trim().isEmpty) return null;
+    return int.tryParse(spec.trim());
+  }
+
   /// Reads the seed from the `ws_diag_seed` launch-intent extra (Android)
   /// or the `WS_DIAG_SEED` process environment (iOS/macOS: `simctl launch`
   /// forwards `SIMCTL_CHILD_`-prefixed host variables, so a future simctl

--- a/lib/services/diag_seed.dart
+++ b/lib/services/diag_seed.dart
@@ -25,10 +25,13 @@ class DiagSeedData {
 /// base64 JSON site list (Android intent extra / `WS_DIAG_SEED` env)
 /// and the app seeds itself before the first prefs read.
 ///
-/// Debug builds only: the call is gated on [kDebugMode] and the Kotlin
-/// side refuses the extra on non-debuggable builds, so a release build
-/// never honors it. Seeding enables demo mode, so nothing from the run
-/// is persisted past the seeded values themselves.
+/// Never in a release build: the call is gated on [kReleaseMode] and the
+/// Kotlin side refuses the extra on non-debuggable builds, so a release build
+/// never honors it. Profile builds are in scope, and are how the tier drives
+/// an AOT, non-inspectable webview (Flutter's `profile` build type is
+/// `initWith(debug)`, so it stays debuggable and the native gate passes).
+/// Seeding enables demo mode, so nothing from the run is persisted past the
+/// seeded values themselves.
 class DiagSeed {
   static const _channel =
       MethodChannel('org.codeberg.theoden8.webspace/shortcuts');
@@ -64,10 +67,10 @@ class DiagSeed {
   /// on read so a later resume does not repeat them.
   ///
   /// The refresh funnel is only reachable from the overflow menu, which adb
-  /// cannot drive, and the reload path is the one BUG-001 was reported on.
-  /// Debug builds only, like the seed.
+  /// cannot drive, and refresh is one of the entry paths BUG-001 is reported
+  /// on. Non-release builds only, like the seed.
   static Future<int?> takeReloadRequest() async {
-    if (!kDebugMode) return null;
+    if (kReleaseMode) return null;
     String? spec;
     try {
       spec = await _channel.invokeMethod<String>('getDiagReload');
@@ -89,7 +92,7 @@ class DiagSeed {
   /// Returns whether a seed was applied. Must complete before the page
   /// state loads models from prefs.
   static Future<bool> applyFromLaunch() async {
-    if (!kDebugMode) return false;
+    if (kReleaseMode) return false;
     String? encoded;
     try {
       encoded = await _channel.invokeMethod<String>('getDiagSeed');

--- a/lib/services/log_service.dart
+++ b/lib/services/log_service.dart
@@ -63,7 +63,11 @@ class LogService extends ChangeNotifier {
       if (_entries.length > maxEntries) {
         _entries.removeAt(0);
       }
-      if (kDebugMode) {
+      // Not release: a shipped build keeps its log ring in memory for Dev
+      // Tools and puts nothing in logcat. Profile is in scope because the
+      // adb tiers read these lines out of logcat, and profile is the build
+      // mode that gets them an AOT, non-inspectable webview.
+      if (!kReleaseMode) {
         debugPrint('[${entry.tag}/${entry.level.name}] ${entry.message}');
       }
     }

--- a/lib/services/repaint_suppression.dart
+++ b/lib/services/repaint_suppression.dart
@@ -16,8 +16,10 @@ import 'package:flutter/foundation.dart';
 /// the instrument for deciding whether a native attach callback in the fork is
 /// worth adopting.
 ///
-/// Gated on [kDebugMode] and never set outside the diag tiers, so a release
-/// build cannot lose a repaint to it.
+/// Gated on [kReleaseMode] and never set outside the diag tiers, so a release
+/// build cannot lose a repaint to it. Profile builds are in scope on purpose:
+/// they are what the tier needs to drive an AOT, non-inspectable webview, the
+/// two things a shipped build has and a debug build does not.
 class RepaintSuppression {
   RepaintSuppression._();
 
@@ -26,9 +28,9 @@ class RepaintSuppression {
   /// Trigger labels currently dropped. Empty in every ordinary build.
   static Set<String> get triggers => _triggers;
 
-  /// Replace the suppressed set. No-op outside debug builds.
+  /// Replace the suppressed set. No-op in release builds.
   static void set(Iterable<String> triggers) {
-    if (!kDebugMode) return;
+    if (kReleaseMode) return;
     _triggers = Set<String>.unmodifiable(triggers.map((t) => t.trim()).where(
           (t) => t.isNotEmpty,
         ));
@@ -46,7 +48,7 @@ class RepaintSuppression {
 
   /// Whether [trigger] is currently dropped.
   static bool suppresses(String trigger) =>
-      kDebugMode && _triggers.contains(trigger);
+      !kReleaseMode && _triggers.contains(trigger);
 
   @visibleForTesting
   static void reset() => _triggers = const <String>{};

--- a/lib/services/surface_diag_native.dart
+++ b/lib/services/surface_diag_native.dart
@@ -79,6 +79,29 @@ class SurfaceDiagNative {
     }
   }
 
+  /// Ask the Android views themselves to redraw ([SurfaceDiagPlugin.kt]).
+  ///
+  /// A Dart nudge resizes the platform view through Flutter's plumbing; this
+  /// calls `invalidate()` + `requestLayout()` (`mode` `invalidate`) or cycles
+  /// visibility so the view leaves and re-enters the window (`visibility`) on
+  /// every WebView in it. Rotation and lock-unlock do the latter and recover
+  /// the screen; a resize does neither (BUG-001 gap #18). Returns how many
+  /// views it reached, or null off Android.
+  static Future<int?> nativeRepaint(String mode) async {
+    if (!hostIsAndroid) return null;
+    try {
+      final res = await _channel.invokeMapMethod<String, dynamic>(
+          'nativeRepaint', <String, String>{'mode': mode});
+      if (res == null) return null;
+      if (res['status'] != 'ok') return null;
+      return res['views'] as int?;
+    } on MissingPluginException {
+      return null;
+    } on PlatformException {
+      return null;
+    }
+  }
+
   /// Map a logical-coordinate region to the physical-pixel window rect the
   /// sampler needs. [insetLogical] shrinks the region on all sides so
   /// borders, scrollbar gutters, and the pull-to-refresh edge glow don't

--- a/lib/services/surface_repaint_engine.dart
+++ b/lib/services/surface_repaint_engine.dart
@@ -19,6 +19,7 @@ enum SurfaceTransition {
   back, // bfcache restore reuses the controller (PAUSE-018)
   forward, // bfcache restore reuses the controller (PAUSE-018)
   reload, // reload discards the painted frame, recommits later (PAUSE-021)
+  pageCommitVisible, // the renderer produced its first visible frame (PAUSE-031)
   routeReturn, // an opaque route above popped, re-attaching the view (PAUSE-024)
   goHome, // dispose + rebuild at initUrl (PAUSE-017)
   rendererRebuilt, // renderer-gone recovery rebuild (PAUSE-017)

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -721,6 +721,12 @@ class WebViewConfig {
   /// the controller and rebuild the widget. If unset, the WebView is left
   /// in its post-crash state (visible to the user as a black rectangle).
   final void Function(bool didCrash)? onRendererGone;
+  /// Android: the WebView has committed a frame that is visible for the first
+  /// time on this navigation. The only signal in the app that fires *because
+  /// pixels exist* — every other repaint trigger is a lifecycle event hoped to
+  /// imply one, and BUG-001 gap #18 caught a load whose nudges had all drained
+  /// twelve seconds before the renderer produced anything.
+  final VoidCallback? onPageCommitVisible;
   /// Per-site geolocation mode. [LocationMode.spoof] injects a shim that
   /// overrides `navigator.geolocation` with [spoofLatitude]/[spoofLongitude].
   final LocationMode locationMode;
@@ -865,6 +871,7 @@ class WebViewConfig {
     this.pullToRefreshController,
     this.pullToRefreshGate,
     this.onRendererGone,
+    this.onPageCommitVisible,
     this.locationMode = LocationMode.off,
     this.spoofLatitude,
     this.spoofLongitude,
@@ -4225,6 +4232,14 @@ class WebViewFactory {
         if (stillCurrent()) {
           await userScriptService.reinjectOnLoadStart(controller);
         }
+      },
+      onPageCommitVisible: (controller, url) {
+        LogService.instance.log(
+          'WebViewLifecycle',
+          'onPageCommitVisible siteId=${config.siteId} url=$url',
+          sensitivity: LogSensitivity.sensitive,
+        );
+        config.onPageCommitVisible?.call();
       },
       onLoadStop: (controller, url) async {
         LogService.instance.log(

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -876,6 +876,12 @@ class WebViewModel {
   /// closest Dart-side signal to the reloaded document committing onto
   /// the surface, which is the moment the repaint has to land (PAUSE-021).
   VoidCallback? onLoadSettled;
+  /// Host hook fired when the WebView commits its first visible frame for a
+  /// navigation (Android `onPageCommitVisible`). Unlike [onLoadSettled] this
+  /// reports that pixels exist rather than that a load finished, so it is the
+  /// one repaint trigger that cannot fire before there is something to paint
+  /// (BUG-001 gap #18).
+  VoidCallback? onPageCommitVisible;
   /// Host hook fired once per committed navigation (deduped across the
   /// `onLoadStop` / `onUpdateVisitedHistory` double-fire). The host
   /// debounces `controller.saveState()` captures off this so the
@@ -1626,6 +1632,7 @@ class WebViewModel {
           shouldFetchHtml: shouldFetchHtml,
           initialHtml: initialHtml,
           onRendererGone: (didCrash) => handleRendererGone(didCrash: didCrash),
+          onPageCommitVisible: () => onPageCommitVisible?.call(),
           onConsoleMessage: (message, level) {
             consoleLogs.add(ConsoleLogEntry(
               timestamp: DateTime.now(),

--- a/openspec/specs/webview-pause-lifecycle/spec.md
+++ b/openspec/specs/webview-pause-lifecycle/spec.md
@@ -1137,6 +1137,55 @@ unawaited at the call site and failures are logged, never surfaced.
 
 ---
 
+---
+
+### Requirement: PAUSE-031 — A Repaint Is Owed When The Renderer Reports Pixels
+
+Every repaint trigger before this one is a lifecycle event *hoped* to imply a
+surface with content: a resume, a metrics change, a route pop, a load settling.
+None of them is reported by the renderer, and a load settling is not a frame —
+`onLoadStop` fires when the main-frame navigation finishes, which on a slow
+device can precede the first composited frame by many seconds.
+
+Android's `onPageCommitVisible` is the one signal that fires *because* the
+WebView has committed a frame that is visible. Every webview the app creates
+SHALL route it to a surface repaint:
+
+- `WebViewConfig.onPageCommitVisible` is wired in `WebViewFactory.createWebView`,
+  so the site webview and the nested `InAppWebViewScreen` both carry it.
+- The site webview reaches the page through `WebViewModel.onPageCommitVisible`,
+  the same shape as `onLoadSettled` (PAUSE-021); the nested screen nudges its
+  own surface directly.
+- Both nudge under the trigger label `page-commit-visible`, so the `SurfaceDiag`
+  trace names it like every other path (PAUSE-029).
+
+The trigger SHALL NOT be gated on the commit window (`noteLoadSettled`,
+PAUSE-027). That window is 15 seconds from the issue, and BUG-001 gap #18
+recorded a load whose six nudges had all drained and whose window had closed
+before the renderer produced any content at all. Gating this trigger on the
+window would reproduce precisely the failure it exists to cover. Structural
+gate: `test/js/surface_repaint_funnel.test.js`.
+
+Off Android the nudge is a no-op, so no platform gate is needed at the call
+site; `_nudgeSurfaceRepaint` already returns early.
+
+#### Scenario: A slow first paint lands after every other trigger has drained
+
+**Given** the visible site's webview is created and its navigation settles
+**And** the nudges for activate, controller-attach, reload and commit-settled have all drained
+**And** the 15-second commit window has closed
+**When** the renderer commits its first visible frame
+**Then** `onPageCommitVisible` fires
+**And** the surface is nudged under the trigger `page-commit-visible`
+**And** the trace carries that trigger, so the repaint can be attributed to it
+
+#### Scenario: The commit-visible trigger reaches the nested webview
+
+**Given** a cross-domain link opened an `InAppWebViewScreen`
+**When** its renderer commits its first visible frame
+**Then** that screen nudges its own surface under the same trigger label
+
+
 ## Implementation
 
 ### API Surface

--- a/scripts/classify_window_pixels.py
+++ b/scripts/classify_window_pixels.py
@@ -21,6 +21,10 @@ expectation not met, 2 = unreadable frame. Expectations:
       webview composited).
   --expect-blank-white
       verdict must be the white blank (detector sensitivity control).
+  --expect-blank
+      verdict must be either blank. Which shade the uncomposited hole
+      samples as is not the app's to decide, so a scenario asserting the
+      surface went blank must not depend on it.
 """
 
 import argparse
@@ -95,6 +99,7 @@ def main():
     ap.add_argument('--tolerance', type=int, default=28)
     ap.add_argument('--min-uniform', type=float, default=0.5)
     ap.add_argument('--expect-blank-white', action='store_true')
+    ap.add_argument('--expect-blank', action='store_true')
     args = ap.parse_args()
 
     crop = DEFAULT_CROP
@@ -135,6 +140,8 @@ def main():
         return 0 if near and uniform >= args.min_uniform else 3
     if args.expect_blank_white:
         return 0 if verdict == 'blank-white' else 3
+    if args.expect_blank:
+        return 0 if verdict in ('blank-white', 'blank-black') else 3
     return 0
 
 

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -473,7 +473,12 @@ if [ "${WS_RUN_NATIVE_REPAINT_PROBE:-0}" != "1" ]; then
 else
   echo "== Scenario B2: warm start with the Dart resume nudges suppressed"
   echo "   (BUG-001 gap #5: does the native layer repaint on its own?)"
-  adb shell am force-stop "$pkg"
+  # Wipe first, not just force-stop. This runs last, after Scenario H has
+  # deliberately left the dark site's session navigated to the magenta page,
+  # and a cold start restores that session: the seed replaces the site list
+  # but not the per-siteId nav state, so the cold start below came up magenta
+  # and the scenario failed in setup without ever testing a repaint.
+  adb shell pm clear "$pkg" >/dev/null
   adb shell am start -W -n "$component" \
     --es ws_diag_seed "$(seed_b64 dark.html "$dark_site_id")" \
     --es ws_diag_suppress_repaint "resume,metrics-resume" \

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -261,6 +261,15 @@ wait_for_pixels() { # $1 = slug, $2 = deadline secs, rest = classifier expectati
       echo "  last SurfaceDiag lines:" >&2
       adb logcat -d 2>/dev/null | grep -F 'SurfaceDiag' | tail -8 \
         | sed 's/^/    /' >&2 || true
+      # SurfaceDiag only speaks once a repaint is traced, so an empty list above
+      # says nothing about whether the app got that far. These two do: the Dart
+      # side's own output, and anything that killed or refused the activity.
+      echo "  last app log lines:" >&2
+      adb logcat -d -s flutter:V 2>/dev/null | tail -25 | sed 's/^/    /' >&2 || true
+      echo "  crashes / activity errors:" >&2
+      adb logcat -d 2>/dev/null \
+        | grep -E "AndroidRuntime|FATAL|ANR in|Force finishing|$pkg.*(died|killed)" \
+        | tail -10 | sed 's/^/    /' >&2 || true
       exit 1
     fi
     sleep 1

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -305,6 +305,26 @@ dump_composition_mode() {
       | grep -iE 'platformview|hybrid composition|FlutterImageView|virtual display' \
       | tail -40
   } > "$out" 2>&1 || true
+  # The host facts that decide whether a green here means anything. Every one
+  # of these differs between this emulator and a phone, and each is a candidate
+  # explanation for why the emulator repaints a surface nothing asked it to.
+  # Recorded, not asserted: the tier must not go red because a runner image
+  # changed, but a bug report that cites a green run should be able to say what
+  # it ran on. See docs/bugs/001-white-screen.md gap #13.
+  echo "  host: rendering backend: $(adb logcat -d 2>/dev/null | tr -d '\r' \
+    | grep -oiE 'impeller[^,)]*(vulkan|opengles|gl)|using the [a-z]+ rendering backend' \
+    | tail -1 || true)"
+  echo "  host: isolation engine: $(adb logcat -d 2>/dev/null | tr -d '\r' \
+    | grep -F '[Container' | tail -1 | sed 's/.*\[Container[^]]*\] *//' || true)"
+  echo "  host: system webview: $(adb shell dumpsys webviewupdate 2>/dev/null \
+    | tr -d '\r' | grep -m1 -i 'current webview package (name, version)' || true)"
+  echo "  host: animation scales (window/transition/animator): \
+$(adb shell settings get global window_animation_scale 2>/dev/null | tr -d '\r') \
+$(adb shell settings get global transition_animation_scale 2>/dev/null | tr -d '\r') \
+$(adb shell settings get global animator_duration_scale 2>/dev/null | tr -d '\r')"
+  echo "  host: build: $(adb shell getprop ro.build.version.release 2>/dev/null | tr -d '\r') \
+api $(adb shell getprop ro.build.version.sdk 2>/dev/null | tr -d '\r') \
+$(adb shell getprop ro.product.model 2>/dev/null | tr -d '\r')"
   echo "  composition: SurfaceFlinger layers naming $pkg"
   printf '%s\n' "$layers" | grep -F "$pkg" | head -12 | sed 's/^/    /' \
     || echo "    (none)"

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -75,6 +75,7 @@ cleanup() {
   adb shell settings put global hide_error_dialogs 0 >/dev/null 2>&1 || true
   adb shell svc power stayon false >/dev/null 2>&1 || true
   adb shell service call SurfaceFlinger 1008 i32 0 >/dev/null 2>&1 || true
+  adb unroot >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
@@ -656,14 +657,29 @@ else
   # nothing asked it to repaint is the whole reason no arrangement of this
   # tier goes red, and hardware overlays are the part of the composition path
   # most likely to be doing it: an overlay-composed layer is re-scanned out
-  # every frame from whatever the buffer last held. `1008` is what the
-  # "Disable HW overlays" developer option calls. It is not asserted, because
-  # the call is silent on failure -- the dumpsys line below is the evidence,
-  # and a run where composition never changed reads as one where it did not.
+  # every frame from whatever the buffer last held. `1008` is the raw binder
+  # code the "Disable HW overlays" developer option used before SurfaceFlinger
+  # moved to AIDL; shell also lacks ACCESS_SURFACE_FLINGER, so try as root.
+  adb root >/dev/null 2>&1 || true
+  adb wait-for-device
   adb shell service call SurfaceFlinger 1008 i32 1 >/dev/null 2>&1 || true
-  echo "   composition after disabling HW overlays:"
-  adb shell dumpsys SurfaceFlinger 2>/dev/null \
-    | grep -iE 'hwc|client|device' | head -8 | sed 's/^/     /' || true
+  # The call is silent on failure and the first attempt was accepted and
+  # discarded, so the arm ran with overlays fully on and its red meant nothing.
+  # Verify the precondition instead of assuming it: a layer still reported as
+  # DEVICE is composed by the hardware composer, and the experiment did not
+  # happen. Skip rather than fail -- a red here would claim a result we do not
+  # have, which is the mistake this scenario exists to avoid.
+  device_layers="$(adb shell dumpsys SurfaceFlinger 2>/dev/null \
+    | grep -c 'composition type=DEVICE' | tr -d '[:space:]' || true)"
+  echo "   layers still on hardware overlays: ${device_layers:-unknown}"
+  if [ "${device_layers:-1}" != "0" ]; then
+    echo "   SKIPPED: forcing GPU composition did not take. The 1008 binder code"
+    echo "   does not reach SurfaceFlinger on this API level, so the overlay"
+    echo "   hypothesis is untested, not disproved."
+    adb unroot >/dev/null 2>&1 || true
+    adb wait-for-device
+    exit 0
+  fi
   adb shell input keyevent 3
   sleep 3
   adb logcat -c 2>/dev/null || true

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -281,20 +281,20 @@ wait_for_logcat() { # $1 = slug, $2 = deadline secs, $3 = literal pattern
 }
 
 # Which composition mode the engine picked for the platform view decides
-# whether this tier can observe BUG-001 at all. Flutter's own rule is that a
-# SurfaceView-backed platform view does not invalidate itself when its
-# content changes, so the embedder has to; a texture-composited one is
-# redrawn by Flutter's frame loop and cannot go blank that way. Every
-# negative result this tier has produced is conditional on the emulator
-# running the same mode as the devices that report the symptom, and nothing
-# in the suite recorded which one it ran. Dump the evidence on every run.
-# Never fail on it: the layer list is the fact, the reading below is a
-# heuristic, and a wrong heuristic must not turn a real pass red.
+# whether this tier can observe BUG-001 at all: if Flutter composites the
+# webview into its own frames, its frame loop redraws it and the gap cannot
+# occur here by construction, which would make every negative result this
+# tier produced a statement about the emulator rather than about the bug.
+# The mode itself is settled in Dart (the fork defaults useHybridComposition
+# to true, and `initExpensiveAndroidView` "always creates a Hybrid
+# Composition (HC) view"), so this dump is the runtime witness for it, not
+# the decision. Never fail on it: the layer list is the fact.
 dump_composition_mode() {
-  local out="$artifacts/composition-mode.txt"
+  local out="$artifacts/composition-mode.txt" layers
+  layers="$(adb shell dumpsys SurfaceFlinger --list 2>/dev/null | tr -d '\r' || true)"
   {
     echo "# dumpsys SurfaceFlinger --list"
-    adb shell dumpsys SurfaceFlinger --list 2>/dev/null | tr -d '\r'
+    printf '%s\n' "$layers"
     echo
     echo "# SurfaceFlinger layer records mentioning $pkg, with composition types"
     adb shell dumpsys SurfaceFlinger 2>/dev/null | tr -d '\r' \
@@ -305,20 +305,12 @@ dump_composition_mode() {
       | grep -iE 'platformview|hybrid composition|FlutterImageView|virtual display' \
       | tail -40
   } > "$out" 2>&1 || true
-  local sv
-  sv="$(grep -cE "SurfaceView\[$pkg" "$out" 2>/dev/null || true)"
-  sv="$(printf '%s' "${sv:-0}" | tr -d '[:space:]')"
-  echo "  composition: SurfaceView layers owned by $pkg: ${sv:-0}"
-  if [ "${sv:-0}" = "0" ]; then
-    echo "    reading (heuristic): no FlutterSurfaceView layer while the webview is"
-    echo "    on screen, which is what the engine leaves behind after it converts"
-    echo "    to FlutterImageView for hybrid composition. The affected mode."
-  else
-    echo "    reading (heuristic): Flutter is still rendering through its own"
-    echo "    SurfaceView, so the platform view is composited into Flutter's frames"
-    echo "    (texture path). BUG-001's invalidate gap cannot occur in this mode,"
-    echo "    and this tier's negative results say nothing about the reported one."
-  fi
+  echo "  composition: SurfaceFlinger layers naming $pkg"
+  printf '%s\n' "$layers" | grep -F "$pkg" | head -12 | sed 's/^/    /' \
+    || echo "    (none)"
+  # An android.webkit.WebView draws through a functor into whatever surface
+  # contains it and never owns a layer here, in either mode. So these names
+  # say which surfaces the app has, not which one the page renders into.
   echo "    full dump: $out"
 }
 

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -149,6 +149,7 @@ white_site_id="ws-$run_tag-white"
 notif_site_id="ws-$run_tag-notif"
 blue_site_id="ws-$run_tag-blue"
 b2_site_id="ws-$run_tag-b2"
+b3_site_id="ws-$run_tag-b3"
 
 site_json() { # $1 = page basename, $2 = siteId, $3 = extra site fields (optional)
   printf '{"name":"Diag","url":"%s/%s","siteId":"%s"%s}' \
@@ -202,6 +203,14 @@ wait_for_pixels() { # $1 = slug, $2 = deadline secs, rest = classifier expectati
     fi
     sleep 1
   done
+}
+
+# `am start -W` blocks until the launch reports complete; a start that never
+# reports would burn the whole emulator step. Cap it and let the pixel check
+# decide -- it produces the screenshot and logcat a bare hang does not.
+capped_start() {
+  timeout 120 adb shell am start -W "$@" \
+    || echo "  (am start -W did not return in 120s; continuing to pixels)"
 }
 
 wait_for_logcat() { # $1 = slug, $2 = deadline secs, $3 = literal pattern
@@ -504,14 +513,7 @@ else
   # to restore. (`pm clear` would also work, but mid-suite it left `am start
   # -W` blocked past the step budget.)
   adb shell am force-stop "$pkg"
-  # `am start -W` blocks until the launch reports complete; a start that never
-  # reports would burn the whole emulator step. Cap it and let the pixel check
-  # decide -- it produces the screenshot and logcat a bare hang does not.
-  b2_start() {
-    timeout 120 adb shell am start -W "$@" \
-      || echo "  (am start -W did not return in 120s; continuing to pixels)"
-  }
-  b2_start -n "$component" \
+  capped_start -n "$component" \
     --es ws_diag_seed "$(seed_b64 dark.html "$b2_site_id")" \
     --es ws_diag_suppress_repaint "resume,metrics-resume" \
     --es siteId "$b2_site_id"
@@ -524,7 +526,7 @@ else
   # start's. Without this assertion a green B2 is unreadable: "the native layer
   # repainted" and "the suppression never armed" produce the same dark frame.
   adb logcat -c 2>/dev/null || true
-  b2_start -n "$component"
+  capped_start -n "$component"
   wait_for_logcat b2-resume-nudge-suppressed 60 "trigger=resume suppressed"
   # Two independent Dart paths repaint on resume, both under the trigger name
   # `resume`: the nudge funnel, and the renderer probe, whose offsetHeight read
@@ -541,5 +543,66 @@ else
   echo "   SurfaceDiag trace across the warm start:"
   sed 's/^/     /' "$artifacts/b2-surfacediag.txt" || true
 fi
+
+# Scenario B3 goes after the path BUG-001 was actually reported on: refresh.
+# B2 found that the emulator repaints a warm-started surface on its own, but a
+# warm start carries a window visibility change and a reload does not, so
+# nothing below Dart has a reason to repaint what a reload blanks. That makes
+# this the path where suppressing the Dart repaint should be visible, and it is
+# the one no scenario could reach before (refresh lives in the overflow menu,
+# which adb cannot drive; `ws_diag_reload` calls the same `reloadAndRepaint`
+# funnel the menu item does).
+#
+# Two arms, and the first is the point:
+#
+#   A. POSITIVE CONTROL. Suppress every repaint on the reload path and issue one
+#      reload. The surface MUST go blank. If it does, three things are settled
+#      at once: the reload really does blank the surface (BUG-001's mechanism,
+#      observed rather than argued), this harness can see a white screen through
+#      this route at all, and the Dart nudge is what prevents it -- gap #11, the
+#      largest untested premise in the whole lineage. If it comes back painted,
+#      something below Dart repaints reloads too and the nudge is unnecessary
+#      here, which is equally worth knowing.
+#
+#   B. THE LIVE TEST. Same page, no suppression, several rapid reloads. Asserts
+#      the surface stays painted. Red here is the user-reported bug reproduced
+#      on current code, after the bounded commit window (PAUSE-027) that was
+#      supposed to fix exactly this.
+#
+# Arm A is why B2's shape is not repeated: a scenario that asserts a green
+# without a control that can go red proves nothing, which is how B2 passed for
+# two runs while measuring nothing.
+echo "== Scenario B3-A: a reload with its repaint suppressed must blank (control)"
+adb shell am force-stop "$pkg"
+capped_start -n "$component" \
+  --es ws_diag_seed "$(seed_b64 dark.html "$b3_site_id")" \
+  --es ws_diag_suppress_repaint "reload,commit-settled,controller-attach" \
+  --es siteId "$b3_site_id"
+wait_for_pixels b3-cold-start-dark 180 --expect-dominant "$dark"
+adb shell input keyevent 3
+sleep 3
+adb logcat -c 2>/dev/null || true
+capped_start -n "$component" --es ws_diag_reload "1"
+wait_for_logcat b3-reload-nudge-suppressed 90 "trigger=reload suppressed"
+wait_for_pixels b3-blank-after-suppressed-reload 60 --expect-blank
+
+echo "== Scenario B3-B: rapid reloads keep the surface painted (BUG-001/PAUSE-027)"
+adb shell am force-stop "$pkg"
+capped_start -n "$component" \
+  --es ws_diag_seed "$(seed_b64 dark.html "$b3_site_id")" \
+  --es siteId "$b3_site_id"
+wait_for_pixels b3b-cold-start-dark 180 --expect-dominant "$dark"
+adb shell input keyevent 3
+sleep 3
+adb logcat -c 2>/dev/null || true
+# Five reloads 120ms apart: each lands while the previous is still in flight,
+# which is the shape that spent the old one-shot latch on an aborted load.
+capped_start -n "$component" --es ws_diag_reload "5"
+sleep 12
+wait_for_pixels b3b-rapid-reload-stays-painted 60 --expect-dominant "$dark"
+adb logcat -d 2>/dev/null | grep -F 'SurfaceDiag' \
+  > "$artifacts/b3b-surfacediag.txt" || true
+echo "   SurfaceDiag trace across the rapid reloads:"
+sed 's/^/     /' "$artifacts/b3b-surfacediag.txt" || true
 
 echo "White-screen lifecycle + shortcut tier passed."

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -85,6 +85,7 @@ page '#123524' 'magenta.html' > "$www/dark.html"
 page '#8c1d5a' > "$www/magenta.html"
 page '#ffffff' > "$www/white.html"
 page '#1d3f8c' > "$www/blue.html"
+page '#123524' > "$www/slow.html"
 
 # Same dark fill, plus a JS Notification on every load: a forced
 # background refresh reloads the page, so a new OS notification is the
@@ -115,10 +116,23 @@ cat > "$www/notif.html" <<'EOF'
 EOF
 
 python3 - "$www" > "$server_log" 2>&1 <<'EOF' &
-import http.server, os, sys
-os.chdir(sys.argv[1])
-srv = http.server.ThreadingHTTPServer(('0.0.0.0', 0),
-                                      http.server.SimpleHTTPRequestHandler)
+import http.server, os, sys, time
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        # `slow.html` stalls before the first byte. BUG-001's blank is the gap
+        # between a reload discarding the painted frame and the replacement
+        # committing, and a 200-byte page off localhost closes that gap faster
+        # than a 1 Hz screencap sampler can see -- which is the regime the app
+        # is never wrong in. A slow commit is the regime the bug was reported
+        # in, and the one Attempts 9/10/11 are all about.
+        if self.path.startswith('/slow'):
+            time.sleep(5)
+        return super().do_GET()
+
+
+srv = http.server.ThreadingHTTPServer(('0.0.0.0', 0), Handler)
 print(srv.server_address[1], flush=True)
 srv.serve_forever()
 EOF
@@ -545,37 +559,50 @@ else
 fi
 
 # Scenario B3 goes after the path BUG-001 was actually reported on: refresh.
-# B2 found that the emulator repaints a warm-started surface on its own, but a
-# warm start carries a window visibility change and a reload does not, so
-# nothing below Dart has a reason to repaint what a reload blanks. That makes
-# this the path where suppressing the Dart repaint should be visible, and it is
-# the one no scenario could reach before (refresh lives in the overflow menu,
-# which adb cannot drive; `ws_diag_reload` calls the same `reloadAndRepaint`
-# funnel the menu item does).
+# B2 found the emulator repaints a warm-started surface on its own, but a warm
+# start carries a window visibility change and a reload does not, so nothing
+# below Dart has a reason to repaint what a reload blanks. Refresh is also the
+# one path no scenario could reach (it lives in the overflow menu, which adb
+# cannot drive); `ws_diag_reload` calls the same `reloadAndRepaint` funnel.
 #
-# Two arms, and the first is the point:
+# Both arms load `slow.html`, which stalls 5s before its first byte. The first
+# attempt used the instant localhost page and proved nothing: the replacement
+# committed inside a single sampler tick, so the blank window the bug is about
+# never existed to be photographed. A slow commit is the regime the bug was
+# reported in and the one Attempts 9/10/11 all address.
 #
-#   A. POSITIVE CONTROL. Suppress every repaint on the reload path and issue one
-#      reload. The surface MUST go blank. If it does, three things are settled
-#      at once: the reload really does blank the surface (BUG-001's mechanism,
-#      observed rather than argued), this harness can see a white screen through
-#      this route at all, and the Dart nudge is what prevents it -- gap #11, the
-#      largest untested premise in the whole lineage. If it comes back painted,
-#      something below Dart repaints reloads too and the nudge is unnecessary
-#      here, which is equally worth knowing.
-#
-#   B. THE LIVE TEST. Same page, no suppression, several rapid reloads. Asserts
-#      the surface stays painted. Red here is the user-reported bug reproduced
-#      on current code, after the bounded commit window (PAUSE-027) that was
-#      supposed to fix exactly this.
-#
-# Arm A is why B2's shape is not repeated: a scenario that asserts a green
-# without a control that can go red proves nothing, which is how B2 passed for
-# two runs while measuring nothing.
-echo "== Scenario B3-A: a reload with its repaint suppressed must blank (control)"
+# The live test runs FIRST so a failing control cannot abort it -- it is the arm
+# that can find a real bug, and it is the user's reported symptom.
+echo "== Scenario B3-B: rapid reloads of a slow page stay painted (PAUSE-027)"
 adb shell am force-stop "$pkg"
 capped_start -n "$component" \
-  --es ws_diag_seed "$(seed_b64 dark.html "$b3_site_id")" \
+  --es ws_diag_seed "$(seed_b64 slow.html "$b3_site_id")" \
+  --es siteId "$b3_site_id"
+wait_for_pixels b3b-cold-start-dark 180 --expect-dominant "$dark"
+adb shell input keyevent 3
+sleep 3
+adb logcat -c 2>/dev/null || true
+# Five reloads 120ms apart against a 5s page: each lands while the previous is
+# still in flight, so four commits are aborted before the fifth lands. That is
+# the shape that spent the old one-shot latch on an aborted load and left the
+# surface blank (BUG-001 / PAUSE-027).
+capped_start -n "$component" --es ws_diag_reload "5"
+sleep 20
+wait_for_pixels b3b-rapid-reload-stays-painted 60 --expect-dominant "$dark"
+adb logcat -d 2>/dev/null | grep -F 'SurfaceDiag' \
+  > "$artifacts/b3b-surfacediag.txt" || true
+echo "   SurfaceDiag trace across the rapid reloads:"
+sed 's/^/     /' "$artifacts/b3b-surfacediag.txt" || true
+
+# POSITIVE CONTROL, and it runs last because it is expected to be the arm that
+# breaks first. Suppress every repaint on the reload path, issue one reload,
+# and wait past the commit before sampling: a blank BEFORE the commit is just a
+# slow page, a blank AFTER it is the bug. If this cannot go red then no B3
+# result means anything, which is exactly the trap B2 fell into.
+echo "== Scenario B3-A: a committed reload with its repaint suppressed must blank"
+adb shell am force-stop "$pkg"
+capped_start -n "$component" \
+  --es ws_diag_seed "$(seed_b64 slow.html "$b3_site_id")" \
   --es ws_diag_suppress_repaint "reload,commit-settled,controller-attach" \
   --es siteId "$b3_site_id"
 wait_for_pixels b3-cold-start-dark 180 --expect-dominant "$dark"
@@ -584,25 +611,10 @@ sleep 3
 adb logcat -c 2>/dev/null || true
 capped_start -n "$component" --es ws_diag_reload "1"
 wait_for_logcat b3-reload-nudge-suppressed 90 "trigger=reload suppressed"
-wait_for_pixels b3-blank-after-suppressed-reload 60 --expect-blank
-
-echo "== Scenario B3-B: rapid reloads keep the surface painted (BUG-001/PAUSE-027)"
-adb shell am force-stop "$pkg"
-capped_start -n "$component" \
-  --es ws_diag_seed "$(seed_b64 dark.html "$b3_site_id")" \
-  --es siteId "$b3_site_id"
-wait_for_pixels b3b-cold-start-dark 180 --expect-dominant "$dark"
-adb shell input keyevent 3
-sleep 3
-adb logcat -c 2>/dev/null || true
-# Five reloads 120ms apart: each lands while the previous is still in flight,
-# which is the shape that spent the old one-shot latch on an aborted load.
-capped_start -n "$component" --es ws_diag_reload "5"
-sleep 12
-wait_for_pixels b3b-rapid-reload-stays-painted 60 --expect-dominant "$dark"
-adb logcat -d 2>/dev/null | grep -F 'SurfaceDiag' \
-  > "$artifacts/b3b-surfacediag.txt" || true
-echo "   SurfaceDiag trace across the rapid reloads:"
-sed 's/^/     /' "$artifacts/b3b-surfacediag.txt" || true
+# Reload fires 1s after resume, the page commits ~5s later. Sample past that:
+# the question is whether the committed document reached the surface without
+# the Dart nudge, not whether a loading page is briefly blank.
+sleep 15
+wait_for_pixels b3-blank-after-suppressed-reload 25 --expect-blank
 
 echo "White-screen lifecycle + shortcut tier passed."

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -649,7 +649,7 @@ echo "== Scenario F2: a refresh tick in the foreground must not touch the visibl
 # leg that was always correct, so nothing drove the leg that broke.
 fg_beacons_before="$(beacon_hits)"
 fg_triggers_before="$(bg_log_hits 'debug trigger: enqueueing')"
-adb shell am broadcast -n "$pkg/.NotificationRefreshDebugReceiver" >/dev/null
+adb shell am broadcast -n "$pkg/$ns.NotificationRefreshDebugReceiver" >/dev/null
 deadline=$(( $(date +%s) + 20 ))
 while [ "$(bg_log_hits 'debug trigger: enqueueing')" -le "$fg_triggers_before" ]; do
   if [ "$(date +%s)" -ge "$deadline" ]; then

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -626,27 +626,41 @@ adb logcat -d 2>/dev/null | grep -F 'SurfaceDiag' \
 echo "   SurfaceDiag trace across the rapid reloads:"
 sed 's/^/     /' "$artifacts/b3b-surfacediag.txt" || true
 
-# POSITIVE CONTROL, and it runs last because it is expected to be the arm that
-# breaks first. Suppress every repaint on the reload path, issue one reload,
-# and wait past the commit before sampling: a blank BEFORE the commit is just a
-# slow page, a blank AFTER it is the bug. If this cannot go red then no B3
-# result means anything, which is exactly the trap B2 fell into.
-echo "== Scenario B3-A: a committed reload with its repaint suppressed must blank"
-adb shell am force-stop "$pkg"
-capped_start -n "$component" \
-  --es ws_diag_seed "$(seed_b64 slow.html "$b3_site_id")" \
-  --es ws_diag_suppress_repaint "$all_repaint_triggers" \
-  --es siteId "$b3_site_id"
-wait_for_pixels b3-cold-start-dark 180 --expect-dominant "$dark"
-adb shell input keyevent 3
-sleep 3
-adb logcat -c 2>/dev/null || true
-capped_start -n "$component" --es ws_diag_reload "1"
-wait_for_logcat b3-reload-nudge-suppressed 90 "trigger=reload suppressed"
-# Reload fires 1s after resume, the page commits ~5s later. Sample past that:
-# the question is whether the committed document reached the surface without
-# the Dart nudge, not whether a loading page is briefly blank.
-sleep 15
-wait_for_pixels b3-blank-after-suppressed-reload 25 --expect-blank
+# The blank control, OPT-IN and not run in CI. With all fourteen repaint
+# triggers suppressed and the trace showing nothing else fired, the surface
+# still came back painted after a commit that landed 5s behind the reload
+# (2026-09-04). That is the second path, after B2's warm start, where this
+# emulator repaints the platform view with no Dart help at all -- so the arm
+# cannot go red here and a green from it would mean nothing.
+#
+# It is kept because it is still the right experiment, just not for this
+# device: run it against hardware that actually goes white and it answers
+# BUG-001 gap #11, whether the nudge is what prevents the blank. Nothing in
+# the app is needed beyond a debug build:
+#
+#   WS_RUN_BLANK_CONTROL=1 bash scripts/run_android_lifecycle_tests.sh <serial>
+#
+# See docs/bugs/001-white-screen.md, gap #11.
+if [ "${WS_RUN_BLANK_CONTROL:-0}" != "1" ]; then
+  echo "== Scenario B3-A: SKIPPED (set WS_RUN_BLANK_CONTROL=1 on a device that reproduces)"
+else
+  echo "== Scenario B3-A: a committed reload with its repaint suppressed must blank"
+  adb shell am force-stop "$pkg"
+  capped_start -n "$component" \
+    --es ws_diag_seed "$(seed_b64 slow.html "$b3_site_id")" \
+    --es ws_diag_suppress_repaint "$all_repaint_triggers" \
+    --es siteId "$b3_site_id"
+  wait_for_pixels b3-cold-start-dark 180 --expect-dominant "$dark"
+  adb shell input keyevent 3
+  sleep 3
+  adb logcat -c 2>/dev/null || true
+  capped_start -n "$component" --es ws_diag_reload "1"
+  wait_for_logcat b3-reload-nudge-suppressed 90 "trigger=reload suppressed"
+  # Reload fires 1s after resume, the page commits ~5s later. Sample past that:
+  # the question is whether the committed document reached the surface without
+  # the Dart nudge, not whether a loading page is briefly blank.
+  sleep 15
+  wait_for_pixels b3-blank-after-suppressed-reload 25 --expect-blank
+fi
 
 echo "White-screen lifecycle + shortcut tier passed."

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -118,6 +118,8 @@ EOF
 python3 - "$www" > "$server_log" 2>&1 <<'EOF' &
 import http.server, os, sys, time
 
+os.chdir(sys.argv[1])
+
 
 class Handler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -858,9 +858,10 @@ else
   wait_for_pixels b3-blank-after-suppressed-reload 25 --expect-blank
 fi
 
-# Repeated here on purpose: in a passing run the original sits ~370 lines up,
-# past the tail a reader (or a log-fetch API) actually gets. A green is only
-# worth anything alongside what it was green on.
+echo "White-screen lifecycle + shortcut tier passed."
+# Last, on purpose. The original sits ~370 lines up in a passing run, past the
+# tail a reader (or a log-fetch API) gets; printed second-to-last it still fell
+# outside a 148-line tail. A green is only worth anything alongside what it was
+# green on, so this is the final thing the tier says.
 echo "== What this run was green on"
 sed 's/^/  /' "$artifacts/host-summary.txt" 2>/dev/null || true
-echo "White-screen lifecycle + shortcut tier passed."

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -35,11 +35,24 @@ if [ -z "$device_id" ]; then
 fi
 export ANDROID_SERIAL="$device_id"
 
+# `initWith(debug)` -- so the diag seed, the reload extra and the repaint
+# suppression all still work. Default stays debug; set the mode to profile to
+# run the tier against the closer artifact. See docs/bugs/001-white-screen.md
+# gap #13.
+build_mode="${WS_LIFECYCLE_BUILD_MODE:-debug}"
+case "$build_mode" in
+  debug|profile) ;;
+  *) echo "ERROR: WS_LIFECYCLE_BUILD_MODE must be debug or profile" >&2; exit 1 ;;
+esac
+
 # The debug build type suffixes the applicationId (android/app/build.gradle)
 # but not the namespace, so `pkg/.Class` shorthand would resolve to a class
-# that does not exist -- components are spelled out in full.
-pkg="org.codeberg.theoden8.webspace.debug"
+# that does not exist -- components are spelled out in full. Only debug carries
+# the suffix: Flutter creates profile with `initWith(debug)` while applying its
+# plugin, which is before the `debug {}` block below sets the suffix, so a
+# profile build keeps the unsuffixed id.
 ns="org.codeberg.theoden8.webspace"
+if [ "$build_mode" = "debug" ]; then pkg="$ns.debug"; else pkg="$ns"; fi
 component="$pkg/$ns.MainActivity"
 artifacts="$root/build/white_screen_adb"
 classify="$root/scripts/classify_window_pixels.py"
@@ -212,15 +225,6 @@ seed_pair_b64() { # $1/$2 = first page + siteId, $3/$4 = second page + siteId
 # only build-mode-dependent WebView setting in the app). A debug build has
 # neither property, so no scenario here has ever driven the webview users get.
 # `profile` flips both and stays debuggable -- Flutter's profile build type is
-# `initWith(debug)` -- so the diag seed, the reload extra and the repaint
-# suppression all still work. Default stays debug; set the mode to profile to
-# run the tier against the closer artifact. See docs/bugs/001-white-screen.md
-# gap #13.
-build_mode="${WS_LIFECYCLE_BUILD_MODE:-debug}"
-case "$build_mode" in
-  debug|profile) ;;
-  *) echo "ERROR: WS_LIFECYCLE_BUILD_MODE must be debug or profile" >&2; exit 1 ;;
-esac
 echo "== Building default-entrypoint fdebug APK ($build_mode)"
 fvm flutter build apk "--$build_mode" --flavor fdebug -t lib/main.dart
 apk="build/app/outputs/flutter-apk/app-fdebug-$build_mode.apk"

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -213,6 +213,16 @@ wait_for_pixels() { # $1 = slug, $2 = deadline secs, rest = classifier expectati
       adb exec-out screencap -p > "$artifacts/fail-$slug.png" 2>/dev/null || true
       adb logcat -d -t 500 > "$artifacts/fail-$slug.logcat.txt" 2>/dev/null || true
       printf '%s\n' "$out" > "$artifacts/fail-$slug.classify.json" || true
+      # A blank frame alone does not say which bug it is: an app that is alive
+      # and unpainted is BUG-001, a dead one or a system dialog over the window
+      # is infrastructure, and the two are indistinguishable in a screenshot
+      # nobody downloads. Say which, in the log, where it is already being read.
+      echo "  app pid: $(adb shell pidof "$pkg" 2>/dev/null | tr -d '\r' || true)" >&2
+      echo "  focus: $(adb shell dumpsys window 2>/dev/null \
+        | grep -m1 -i 'mCurrentFocus' | tr -d '\r' || true)" >&2
+      echo "  last SurfaceDiag lines:" >&2
+      adb logcat -d 2>/dev/null | grep -F 'SurfaceDiag' | tail -8 \
+        | sed 's/^/    /' >&2 || true
       exit 1
     fi
     sleep 1

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -475,9 +475,12 @@ wait_for_pixels shortcut-warm-preserves-session 90 --expect-dominant "$magenta"
 # does not fire, Attempt 8 is a no-op — and Scenario B above cannot tell that
 # device from a healthy one, because on the emulator the proxy always fires.
 #
-# Suppressing both triggers by name simulates that device exactly. What repaints
-# the surface afterwards, if anything, is whatever the native layer does on its
-# own. Modeled as `Fix="proxy"` vs `Fix="attach"` in formal/warmstart.tla.
+# Suppressing the Dart triggers by name simulates that device exactly. Both
+# resume-time paths go, the nudge funnel and the renderer probe (its
+# offsetHeight read forces the layout that schedules the missing paint, so it
+# repaints whether or not the funnel ran). What is left is whatever the native
+# layer does on its own. Modeled as `Fix="proxy"` vs `Fix="attach"` in
+# formal/warmstart.tla.
 #
 # EXPECTED RED against a fork with no native attach/visibility repaint hook.
 # That red IS the reproduction: evidence that the surface depends on a Dart
@@ -523,11 +526,16 @@ else
   adb logcat -c 2>/dev/null || true
   b2_start -n "$component"
   wait_for_logcat b2-resume-nudge-suppressed 60 "trigger=resume suppressed"
+  # Two independent Dart paths repaint on resume, both under the trigger name
+  # `resume`: the nudge funnel, and the renderer probe, whose offsetHeight read
+  # forces the layout that schedules the missing paint. Asserting only the
+  # first is how this scenario passed while the second quietly did the work.
+  wait_for_logcat b2-resume-probe-suppressed 60 "trigger=resume probe suppressed"
   wait_for_pixels b2-warm-start-native-repaint 90 --expect-dominant "$dark"
-  # The seed turns developer mode on, so every nudge that was NOT suppressed
-  # also traced. Print the slice: a dark frame with resume dropped only proves
-  # the native layer repainted if nothing else nudged in its place, and the
-  # trace is the only thing that can say which of the other 12 triggers fired.
+  # The seed turns developer mode on, so every repaint path that was NOT
+  # suppressed also traced. Print the slice: a dark frame only proves the
+  # native layer repainted if nothing Dart-side did it instead, and the trace
+  # is the only thing that can say which path ran.
   adb logcat -d 2>/dev/null | grep -F 'SurfaceDiag' \
     > "$artifacts/b2-surfacediag.txt" || true
   echo "   SurfaceDiag trace across the warm start:"

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -524,6 +524,14 @@ else
   b2_start -n "$component"
   wait_for_logcat b2-resume-nudge-suppressed 60 "trigger=resume suppressed"
   wait_for_pixels b2-warm-start-native-repaint 90 --expect-dominant "$dark"
+  # The seed turns developer mode on, so every nudge that was NOT suppressed
+  # also traced. Print the slice: a dark frame with resume dropped only proves
+  # the native layer repainted if nothing else nudged in its place, and the
+  # trace is the only thing that can say which of the other 12 triggers fired.
+  adb logcat -d 2>/dev/null | grep -F 'SurfaceDiag' \
+    > "$artifacts/b2-surfacediag.txt" || true
+  echo "   SurfaceDiag trace across the warm start:"
+  sed 's/^/     /' "$artifacts/b2-surfacediag.txt" || true
 fi
 
 echo "White-screen lifecycle + shortcut tier passed."

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -558,6 +558,46 @@ done
 adb shell am start -W -n "$component"
 wait_for_pixels notif-foreground-dark 90 --expect-dominant "$dark"
 
+echo "== Scenario F2: a refresh tick in the foreground must not touch the visible site"
+# v0.3.1 shipped this reloading the page the user was reading. Android's
+# WorkManager tick (NOTIF-005-A) fires whenever the Flutter engine is
+# reachable, the foreground included, and the handler had no active-site
+# exclusion: it was written when only iOS's BGAppRefreshTask reached it, where
+# the app is suspended by definition. A spontaneous reload of the visible page
+# discards its painted frame, which is BUG-001's reload path (PAUSE-021/027)
+# arriving with no user action behind it -- and therefore at no reproducible
+# moment, which is what "it happens on many things" looks like from outside.
+# Fixed on master by f02d4af. Scenario F fires this same receiver while the
+# app is BACKGROUNDED, so no scenario has ever driven the leg that broke.
+fg_beacons_before="$(beacon_hits)"
+fg_triggers_before="$(bg_log_hits 'debug trigger: enqueueing')"
+adb shell am broadcast -n "$pkg/.NotificationRefreshDebugReceiver" >/dev/null
+deadline=$(( $(date +%s) + 20 ))
+while [ "$(bg_log_hits 'debug trigger: enqueueing')" -le "$fg_triggers_before" ]; do
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "FAIL: the debug refresh receiver never fired with the app foregrounded" >&2
+    dump_bg_diagnostics no-debug-receiver-foreground
+    exit 1
+  fi
+  sleep 1
+done
+# The worker dispatches asynchronously; a reload would beacon well inside this.
+sleep 20
+fg_beacons_after="$(beacon_hits)"
+if [ "$fg_beacons_after" -gt "$fg_beacons_before" ]; then
+  echo "FAIL: the refresh tick reloaded the site the user is looking at"        "(page loads $fg_beacons_before -> $fg_beacons_after)" >&2
+  echo "  This is the v0.3.1 behaviour: _refreshNotificationSites must pass"        "excludeActive when the app is resumed." >&2
+  echo "  WebspaceBgRefresh logcat:" >&2
+  bg_log | tail -10 | sed 's/^/    /' >&2
+  dump_bg_diagnostics foreground-refresh-reloaded-active
+  exit 1
+fi
+echo "  visible site not reloaded (page loads unchanged at $fg_beacons_after)"
+# Even with the reload correctly skipped, the surface must still be painted:
+# a green above with a blank screen here would mean the tick blanked it by
+# some other route.
+wait_for_pixels notif-foreground-tick-stays-painted 30 --expect-dominant "$dark"
+
 # ---- Warm home-shortcut taps (HS-002 / HS-006 / INTEG-013) ----
 #
 # A tap on a pinned tile while the app is running is delivered as

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -867,3 +867,15 @@ echo "White-screen lifecycle + shortcut tier passed."
 # green on, so this is the final thing the tier says.
 echo "== What this run was green on"
 sed 's/^/  /' "$artifacts/host-summary.txt" 2>/dev/null || true
+# Also on the run's summary page. The job log is not a reliable place to read
+# one line from: the runner appends 135-240 lines of post-job cleanup after the
+# last thing this script prints, and how many depends on whether the caches
+# happened to save, so no fixed tail reaches it.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ] && [ -s "$artifacts/host-summary.txt" ]; then
+  {
+    echo "### White-screen tier: what this run was green on"
+    echo '```'
+    cat "$artifacts/host-summary.txt"
+    echo '```'
+  } >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+fi

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -150,6 +150,14 @@ if ! [[ "$port" =~ ^[0-9]+$ ]]; then
 fi
 base="http://10.0.2.2:$port"
 echo "Serving diag pages from $base (host pid $server_pid)"
+# Prove the server serves before blaming the app for a blank screen: a page the
+# emulator never received renders as a white error document, which is
+# indistinguishable from an unpainted surface in a screenshot.
+if ! curl -sf -o /dev/null "http://127.0.0.1:$port/dark.html"; then
+  echo "ERROR: page server did not serve dark.html to the host" >&2
+  cat "$server_log" >&2
+  exit 1
+fi
 
 # Per-run unique siteIds: no keyed state (cookies, containers, nav-state)
 # can bleed across runs, and the harness knows the id to activate. A plain
@@ -220,6 +228,8 @@ wait_for_pixels() { # $1 = slug, $2 = deadline secs, rest = classifier expectati
       echo "  app pid: $(adb shell pidof "$pkg" 2>/dev/null | tr -d '\r' || true)" >&2
       echo "  focus: $(adb shell dumpsys window 2>/dev/null \
         | grep -m1 -i 'mCurrentFocus' | tr -d '\r' || true)" >&2
+      echo "  page server access log (did the emulator fetch the page?):" >&2
+      tail -15 "$server_log" | sed 's/^/    /' >&2 || true
       echo "  last SurfaceDiag lines:" >&2
       adb logcat -d 2>/dev/null | grep -F 'SurfaceDiag' | tail -8 \
         | sed 's/^/    /' >&2 || true

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -201,9 +201,23 @@ seed_pair_b64() { # $1/$2 = first page + siteId, $3/$4 = second page + siteId
     "$(site_json "$1" "$2")" "$(site_json "$3" "$4")" | base64 | tr -d '\n'
 }
 
-echo "== Building default-entrypoint fdebug APK"
-fvm flutter build apk --debug --flavor fdebug -t lib/main.dart
-apk="build/app/outputs/flutter-apk/app-fdebug-debug.apk"
+# The shipped artifact is AOT-compiled and its webviews are created with
+# `isInspectable: false` (webview.dart gates that on kDebugMode, and it is the
+# only build-mode-dependent WebView setting in the app). A debug build has
+# neither property, so no scenario here has ever driven the webview users get.
+# `profile` flips both and stays debuggable -- Flutter's profile build type is
+# `initWith(debug)` -- so the diag seed, the reload extra and the repaint
+# suppression all still work. Default stays debug; set the mode to profile to
+# run the tier against the closer artifact. See docs/bugs/001-white-screen.md
+# gap #13.
+build_mode="${WS_LIFECYCLE_BUILD_MODE:-debug}"
+case "$build_mode" in
+  debug|profile) ;;
+  *) echo "ERROR: WS_LIFECYCLE_BUILD_MODE must be debug or profile" >&2; exit 1 ;;
+esac
+echo "== Building default-entrypoint fdebug APK ($build_mode)"
+fvm flutter build apk "--$build_mode" --flavor fdebug -t lib/main.dart
+apk="build/app/outputs/flutter-apk/app-fdebug-$build_mode.apk"
 if [ ! -f "$apk" ]; then
   echo "ERROR: $apk not produced" >&2
   exit 1
@@ -322,6 +336,7 @@ dump_composition_mode() {
 $(adb shell settings get global window_animation_scale 2>/dev/null | tr -d '\r') \
 $(adb shell settings get global transition_animation_scale 2>/dev/null | tr -d '\r') \
 $(adb shell settings get global animator_duration_scale 2>/dev/null | tr -d '\r')"
+  echo "  host: app build mode: $build_mode"
   echo "  host: build: $(adb shell getprop ro.build.version.release 2>/dev/null | tr -d '\r') \
 api $(adb shell getprop ro.build.version.sdk 2>/dev/null | tr -d '\r') \
 $(adb shell getprop ro.product.model 2>/dev/null | tr -d '\r')"

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -700,8 +700,8 @@ else
 fi
 
 # Scenario B3 adds refresh to the entry paths this tier drives. Refresh is one
-# of many -- BUG-001 is reported across warm start, tab switch, fullscreen exit
-# and back navigation too -- but it is the one no scenario could reach, because
+# of many -- the report says "many things" without naming them -- but it is the
+# one no scenario could reach, because
 # it lives in the overflow menu and adb cannot drive it; `ws_diag_reload` calls
 # the same `reloadAndRepaint` funnel. B2 found the emulator repaints a
 # warm-started surface on its own, and a warm start carries a window visibility

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -559,16 +559,13 @@ adb shell am start -W -n "$component"
 wait_for_pixels notif-foreground-dark 90 --expect-dominant "$dark"
 
 echo "== Scenario F2: a refresh tick in the foreground must not touch the visible site"
-# v0.3.1 shipped this reloading the page the user was reading. Android's
-# WorkManager tick (NOTIF-005-A) fires whenever the Flutter engine is
-# reachable, the foreground included, and the handler had no active-site
-# exclusion: it was written when only iOS's BGAppRefreshTask reached it, where
-# the app is suspended by definition. A spontaneous reload of the visible page
-# discards its painted frame, which is BUG-001's reload path (PAUSE-021/027)
-# arriving with no user action behind it -- and therefore at no reproducible
-# moment, which is what "it happens on many things" looks like from outside.
-# Fixed on master by f02d4af. Scenario F fires this same receiver while the
-# app is BACKGROUNDED, so no scenario has ever driven the leg that broke.
+# Android's WorkManager tick (NOTIF-005-A) fires whenever the Flutter engine
+# is reachable, the foreground included, and the handler took no active-site
+# exclusion until f02d4af: it was written when only iOS's BGAppRefreshTask
+# reached it, where the app is suspended by definition. So the page the user
+# was reading was reloaded on the worker's schedule, with no user action behind
+# it. Scenario F fires this same receiver while the app is BACKGROUNDED, the
+# leg that was always correct, so nothing drove the leg that broke.
 fg_beacons_before="$(beacon_hits)"
 fg_triggers_before="$(bg_log_hits 'debug trigger: enqueueing')"
 adb shell am broadcast -n "$pkg/.NotificationRefreshDebugReceiver" >/dev/null

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -280,6 +280,48 @@ wait_for_logcat() { # $1 = slug, $2 = deadline secs, $3 = literal pattern
   done
 }
 
+# Which composition mode the engine picked for the platform view decides
+# whether this tier can observe BUG-001 at all. Flutter's own rule is that a
+# SurfaceView-backed platform view does not invalidate itself when its
+# content changes, so the embedder has to; a texture-composited one is
+# redrawn by Flutter's frame loop and cannot go blank that way. Every
+# negative result this tier has produced is conditional on the emulator
+# running the same mode as the devices that report the symptom, and nothing
+# in the suite recorded which one it ran. Dump the evidence on every run.
+# Never fail on it: the layer list is the fact, the reading below is a
+# heuristic, and a wrong heuristic must not turn a real pass red.
+dump_composition_mode() {
+  local out="$artifacts/composition-mode.txt"
+  {
+    echo "# dumpsys SurfaceFlinger --list"
+    adb shell dumpsys SurfaceFlinger --list 2>/dev/null | tr -d '\r'
+    echo
+    echo "# SurfaceFlinger layer records mentioning $pkg, with composition types"
+    adb shell dumpsys SurfaceFlinger 2>/dev/null | tr -d '\r' \
+      | grep -E "$pkg|composition type" | tail -80
+    echo
+    echo "# platform-view chatter in logcat"
+    adb logcat -d 2>/dev/null | tr -d '\r' \
+      | grep -iE 'platformview|hybrid composition|FlutterImageView|virtual display' \
+      | tail -40
+  } > "$out" 2>&1 || true
+  local sv
+  sv="$(grep -cE "SurfaceView\[$pkg" "$out" 2>/dev/null || true)"
+  sv="$(printf '%s' "${sv:-0}" | tr -d '[:space:]')"
+  echo "  composition: SurfaceView layers owned by $pkg: ${sv:-0}"
+  if [ "${sv:-0}" = "0" ]; then
+    echo "    reading (heuristic): no FlutterSurfaceView layer while the webview is"
+    echo "    on screen, which is what the engine leaves behind after it converts"
+    echo "    to FlutterImageView for hybrid composition. The affected mode."
+  else
+    echo "    reading (heuristic): Flutter is still rendering through its own"
+    echo "    SurfaceView, so the platform view is composited into Flutter's frames"
+    echo "    (texture path). BUG-001's invalidate gap cannot occur in this mode,"
+    echo "    and this tier's negative results say nothing about the reported one."
+  fi
+  echo "    full dump: $out"
+}
+
 adb shell input keyevent KEYCODE_WAKEUP
 adb shell input keyevent 82
 adb shell svc power stayon true
@@ -291,6 +333,7 @@ adb shell am start -W -n "$component" \
   --es ws_diag_seed "$(seed_b64 dark.html "$dark_site_id")" \
   --es siteId "$dark_site_id"
 wait_for_pixels cold-start-dark 180 --expect-dominant "$dark"
+dump_composition_mode
 
 echo "== Scenario B: warm start repaints the re-attached surface (PAUSE-020)"
 adb shell input keyevent 3
@@ -592,12 +635,14 @@ else
   sed 's/^/     /' "$artifacts/b2-surfacediag.txt" || true
 fi
 
-# Scenario B3 goes after the path BUG-001 was actually reported on: refresh.
-# B2 found the emulator repaints a warm-started surface on its own, but a warm
-# start carries a window visibility change and a reload does not, so nothing
-# below Dart has a reason to repaint what a reload blanks. Refresh is also the
-# one path no scenario could reach (it lives in the overflow menu, which adb
-# cannot drive); `ws_diag_reload` calls the same `reloadAndRepaint` funnel.
+# Scenario B3 adds refresh to the entry paths this tier drives. Refresh is one
+# of many -- BUG-001 is reported across warm start, tab switch, fullscreen exit
+# and back navigation too -- but it is the one no scenario could reach, because
+# it lives in the overflow menu and adb cannot drive it; `ws_diag_reload` calls
+# the same `reloadAndRepaint` funnel. B2 found the emulator repaints a
+# warm-started surface on its own, and a warm start carries a window visibility
+# change that a reload does not, so a reload is the entry path where nothing
+# below Dart has an obvious reason to repaint.
 #
 # Both arms load `slow.html`, which stalls 5s before its first byte. The first
 # attempt used the instant localhost page and proved nothing: the replacement

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -349,6 +349,43 @@ $(adb shell getprop ro.product.model 2>/dev/null | tr -d '\r')"
   echo "    full dump: $out"
 }
 
+# The pixel assertions below are close to vacuous on this host. Scenario B3-A
+# suppressed all fourteen `_nudgeSurfaceRepaint` triggers *and* the second
+# repaint path in `_probeRendererAndRecover`, and every surface still came back
+# painted -- so this tier would stay green with the repaint machinery deleted.
+# What it can still check, host-independently, is the wiring: that the app
+# ASKED for a repaint on the path just driven. That is the thing that actually
+# keeps recurring (a new entry path reaches a surface without passing a
+# chokepoint), and it is read from the app's own trace rather than from the
+# compositor. `_traceRepaint` is developer-mode gated and the diag seed turns
+# developer mode on, so the lines are there in every seeded run.
+nudge_hits() { # $1 = trigger label
+  adb logcat -d 2>/dev/null | grep -cF "trigger=$1" || true
+}
+
+assert_nudged() { # $1 = slug, $2 = trigger label, $3 = count before the action
+  local slug="$1" trigger="$2" before="$3" deadline
+  # RepaintLogThrottle.burstWindow is 2s; the first line of a burst is emitted
+  # immediately, so this only has to outlast a loaded runner.
+  deadline=$(( $(date +%s) + 20 ))
+  while [ "$(nudge_hits "$trigger")" -le "$before" ]; do
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "FAIL: $slug painted, but the app never asked it to" >&2
+      echo "  No new 'trigger=$trigger' line within 20s. The pixels above prove" >&2
+      echo "  nothing on this emulator -- it repaints an unnudged surface on its" >&2
+      echo "  own (B2/B3-A) -- so a path that stopped nudging shows up here and" >&2
+      echo "  nowhere else. See docs/bugs/001-white-screen.md gap #16." >&2
+      echo "  SurfaceDiag tail:" >&2
+      adb logcat -d 2>/dev/null | grep -F 'SurfaceDiag' | tail -15 \
+        | sed 's/^/    /' >&2
+      adb logcat -d -t 2000 > "$artifacts/fail-$slug.logcat.txt" 2>/dev/null || true
+      exit 1
+    fi
+    sleep 1
+  done
+  echo "  $slug: repaint requested (trigger=$trigger)"
+}
+
 adb shell input keyevent KEYCODE_WAKEUP
 adb shell input keyevent 82
 adb shell svc power stayon true
@@ -365,8 +402,10 @@ dump_composition_mode
 echo "== Scenario B: warm start repaints the re-attached surface (PAUSE-020)"
 adb shell input keyevent 3
 sleep 5
+resume_nudges_before="$(nudge_hits resume)"
 adb shell am start -W -n "$component"
 wait_for_pixels warm-start-dark 90 --expect-dominant "$dark"
+assert_nudged warm-start-nudged resume "$resume_nudges_before"
 
 echo "== Scenario C: back into a bfcached entry repaints (PAUSE-018)"
 size="$(adb shell wm size | sed -n 's/.*: *\([0-9]*\)x\([0-9]*\).*/\1 \2/p' | head -1)"
@@ -374,8 +413,10 @@ w="${size% *}"
 h="${size#* }"
 adb shell input tap "$((w / 2))" "$((h / 2))"
 wait_for_pixels forward-nav-magenta 90 --expect-dominant "$magenta"
+back_nudges_before="$(nudge_hits back)"
 adb shell input keyevent 4
 wait_for_pixels back-nav-dark 90 --expect-dominant "$dark"
+assert_nudged back-nav-nudged back "$back_nudges_before"
 
 echo "== Scenario D: activity recreation ends painted"
 adb shell settings put global always_finish_activities 1
@@ -612,8 +653,10 @@ adb shell am start -W -n "$component" \
   --es siteId "$dark_site_id"
 wait_for_pixels shortcut-cold-dark 180 --expect-dominant "$dark"
 
+activate_nudges_before="$(nudge_hits activate)"
 adb shell am start -W -n "$component" --es siteId "$blue_site_id"
 wait_for_pixels shortcut-warm-switch-blue 90 --expect-dominant "$blue"
+assert_nudged shortcut-warm-switch-nudged activate "$activate_nudges_before"
 
 echo "== Scenario H: warm tap leaves the running session intact (HS-006)"
 # Back to the dark site, drive it off its initUrl (the full-page link),

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -353,14 +353,16 @@ $(adb shell settings get global animator_duration_scale 2>/dev/null | tr -d '\r'
     echo "  host: build: $(adb shell getprop ro.build.version.release 2>/dev/null | tr -d '\r') \
 api $(adb shell getprop ro.build.version.sdk 2>/dev/null | tr -d '\r') \
 $(adb shell getprop ro.product.model 2>/dev/null | tr -d '\r')"
-    echo "  composition: SurfaceFlinger layers naming $pkg"
-    printf '%s\n' "$layers" | grep -F "$pkg" | head -12 | sed 's/^/    /' \
-      || echo "    (none)"
-    # An android.webkit.WebView draws through a functor into whatever surface
-    # contains it and never owns a layer here, in either mode. So these names
-    # say which surfaces the app has, not which one the page renders into.
-    echo "    full dump: $out"
   } | tee "$artifacts/host-summary.txt"
+  # Outside the summary: nine lines of layer names would swamp the six facts
+  # the replay exists to carry, and they are already in $out. An
+  # android.webkit.WebView draws through a functor into whatever surface
+  # contains it and never owns a layer here, in either mode, so these names say
+  # which surfaces the app has, not which one the page renders into.
+  echo "  composition: SurfaceFlinger layers naming $pkg"
+  printf '%s\n' "$layers" | grep -F "$pkg" | head -12 | sed 's/^/    /' \
+    || echo "    (none)"
+  echo "    full dump: $out"
 }
 
 # The pixel assertions below are close to vacuous on this host. Scenario B3-A

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -337,28 +337,30 @@ dump_composition_mode() {
   # Matched nothing on the first run: the engine's banner is not the phrase this
   # guessed at, or it never reaches logcat here. Dump the candidate lines rather
   # than pattern-match a message whose wording is unverified.
-  echo "  host: renderer lines: $(adb logcat -d 2>/dev/null | tr -d '\r' \
-    | grep -iE 'impeller|vulkan|opengl|angle|swiftshader' | tail -3 \
-    | tr '\n' '|' || true)"
-  echo "  host: isolation engine: $(adb logcat -d 2>/dev/null | tr -d '\r' \
-    | grep -F '[Container' | tail -1 | sed 's/.*\[Container[^]]*\] *//' || true)"
-  echo "  host: system webview: $(adb shell dumpsys webviewupdate 2>/dev/null \
-    | tr -d '\r' | grep -m1 -i 'current webview package (name, version)' || true)"
-  echo "  host: animation scales (window/transition/animator): \
+  {
+    echo "  host: renderer lines: $(adb logcat -d 2>/dev/null | tr -d '\r' \
+      | grep -iE 'impeller|vulkan|opengl|angle|swiftshader' | tail -3 \
+      | tr '\n' '|' || true)"
+    echo "  host: isolation engine: $(adb logcat -d 2>/dev/null | tr -d '\r' \
+      | grep -F '[Container' | tail -1 | sed 's/.*\[Container[^]]*\] *//' || true)"
+    echo "  host: system webview: $(adb shell dumpsys webviewupdate 2>/dev/null \
+      | tr -d '\r' | grep -m1 -i 'current webview package (name, version)' || true)"
+    echo "  host: animation scales (window/transition/animator): \
 $(adb shell settings get global window_animation_scale 2>/dev/null | tr -d '\r') \
 $(adb shell settings get global transition_animation_scale 2>/dev/null | tr -d '\r') \
 $(adb shell settings get global animator_duration_scale 2>/dev/null | tr -d '\r')"
-  echo "  host: app build mode: $build_mode"
-  echo "  host: build: $(adb shell getprop ro.build.version.release 2>/dev/null | tr -d '\r') \
+    echo "  host: app build mode: $build_mode"
+    echo "  host: build: $(adb shell getprop ro.build.version.release 2>/dev/null | tr -d '\r') \
 api $(adb shell getprop ro.build.version.sdk 2>/dev/null | tr -d '\r') \
 $(adb shell getprop ro.product.model 2>/dev/null | tr -d '\r')"
-  echo "  composition: SurfaceFlinger layers naming $pkg"
-  printf '%s\n' "$layers" | grep -F "$pkg" | head -12 | sed 's/^/    /' \
-    || echo "    (none)"
-  # An android.webkit.WebView draws through a functor into whatever surface
-  # contains it and never owns a layer here, in either mode. So these names
-  # say which surfaces the app has, not which one the page renders into.
-  echo "    full dump: $out"
+    echo "  composition: SurfaceFlinger layers naming $pkg"
+    printf '%s\n' "$layers" | grep -F "$pkg" | head -12 | sed 's/^/    /' \
+      || echo "    (none)"
+    # An android.webkit.WebView draws through a functor into whatever surface
+    # contains it and never owns a layer here, in either mode. So these names
+    # say which surfaces the app has, not which one the page renders into.
+    echo "    full dump: $out"
+  } | tee "$artifacts/host-summary.txt"
 }
 
 # The pixel assertions below are close to vacuous on this host. Scenario B3-A
@@ -856,4 +858,9 @@ else
   wait_for_pixels b3-blank-after-suppressed-reload 25 --expect-blank
 fi
 
+# Repeated here on purpose: in a passing run the original sits ~370 lines up,
+# past the tail a reader (or a log-fetch API) actually gets. A green is only
+# worth anything alongside what it was green on.
+echo "== What this run was green on"
+sed 's/^/  /' "$artifacts/host-summary.txt" 2>/dev/null || true
 echo "White-screen lifecycle + shortcut tier passed."

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -71,6 +71,12 @@ server_pid=""
 
 cleanup() {
   if [ -n "$server_pid" ]; then kill "$server_pid" 2>/dev/null || true; fi
+  for scale in window_animation_scale transition_animation_scale \
+               animator_duration_scale; do
+    eval "restore=\${saved_$scale:-}"
+    [ -n "$restore" ] && adb shell settings put global "$scale" "$restore" \
+      >/dev/null 2>&1 || true
+  done
   adb shell settings put global always_finish_activities 0 >/dev/null 2>&1 || true
   adb shell settings put global hide_error_dialogs 0 >/dev/null 2>&1 || true
   adb shell svc power stayon false >/dev/null 2>&1 || true
@@ -401,6 +407,20 @@ assert_nudged() { # $1 = slug, $2 = trigger label, $3 = count before the action
   done
   echo "  $slug: repaint requested (trigger=$trigger)"
 }
+
+# Animations, on, for this tier only. The emulator step runs with
+# `disable-animations: true`, which zeroes all three scales, and BUG-001 lives
+# in activity and route transitions: an unanimated transition has a different
+# surface-transaction ordering than the one a phone performs. Every other tier
+# in this emulator session has already run by now, and cleanup restores what
+# was there. `wait_for_pixels` polls to a deadline, so a frame sampled mid
+# transition costs a retry, not a failure.
+for scale in window_animation_scale transition_animation_scale \
+             animator_duration_scale; do
+  value="$(adb shell settings get global "$scale" 2>/dev/null | tr -d '\r')"
+  eval "saved_$scale=\$value"
+  adb shell settings put global "$scale" 1.0 >/dev/null 2>&1 || true
+done
 
 adb shell input keyevent KEYCODE_WAKEUP
 adb shell input keyevent 82

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -334,9 +334,12 @@ dump_composition_mode() {
   # Recorded, not asserted: the tier must not go red because a runner image
   # changed, but a bug report that cites a green run should be able to say what
   # it ran on. See docs/bugs/001-white-screen.md gap #13.
-  echo "  host: rendering backend: $(adb logcat -d 2>/dev/null | tr -d '\r' \
-    | grep -oiE 'impeller[^,)]*(vulkan|opengles|gl)|using the [a-z]+ rendering backend' \
-    | tail -1 || true)"
+  # Matched nothing on the first run: the engine's banner is not the phrase this
+  # guessed at, or it never reaches logcat here. Dump the candidate lines rather
+  # than pattern-match a message whose wording is unverified.
+  echo "  host: renderer lines: $(adb logcat -d 2>/dev/null | tr -d '\r' \
+    | grep -iE 'impeller|vulkan|opengl|angle|swiftshader' | tail -3 \
+    | tr '\n' '|' || true)"
   echo "  host: isolation engine: $(adb logcat -d 2>/dev/null | tr -d '\r' \
     | grep -F '[Container' | tail -1 | sed 's/.*\[Container[^]]*\] *//' || true)"
   echo "  host: system webview: $(adb shell dumpsys webviewupdate 2>/dev/null \

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -175,6 +175,16 @@ blue_site_id="ws-$run_tag-blue"
 b2_site_id="ws-$run_tag-b2"
 b3_site_id="ws-$run_tag-b3"
 
+# Every trigger _nudgeSurfaceRepaint takes, for the control that has to see a
+# blank. Naming only the reload-path ones left `metrics-resume` live, and
+# didChangeMetrics fires throughout a reload: it nudged 17 times and the
+# control measured nothing. A control is only a control if nothing Dart-side
+# can repaint behind it.
+all_repaint_triggers="route-return,metrics-resume,memory-pressure,resume,manual"
+all_repaint_triggers="$all_repaint_triggers,activate,fullscreen-toggle,fullscreen-exit"
+all_repaint_triggers="$all_repaint_triggers,back,tab-overlay-hide,tab-overlay-show"
+all_repaint_triggers="$all_repaint_triggers,controller-attach,reload,commit-settled"
+
 site_json() { # $1 = page basename, $2 = siteId, $3 = extra site fields (optional)
   printf '{"name":"Diag","url":"%s/%s","siteId":"%s"%s}' \
     "$base" "$1" "$2" "${3:-}"
@@ -625,7 +635,7 @@ echo "== Scenario B3-A: a committed reload with its repaint suppressed must blan
 adb shell am force-stop "$pkg"
 capped_start -n "$component" \
   --es ws_diag_seed "$(seed_b64 slow.html "$b3_site_id")" \
-  --es ws_diag_suppress_repaint "reload,commit-settled,controller-attach" \
+  --es ws_diag_suppress_repaint "$all_repaint_triggers" \
   --es siteId "$b3_site_id"
 wait_for_pixels b3-cold-start-dark 180 --expect-dominant "$dark"
 adb shell input keyevent 3

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -221,49 +221,6 @@ sleep 5
 adb shell am start -W -n "$component"
 wait_for_pixels warm-start-dark 90 --expect-dominant "$dark"
 
-# Scenario B2 asks a question the rest of the suite structurally cannot: does
-# ANYTHING below Dart repaint the surface when the window comes back?
-#
-# Every warm-start repaint the app has keys on a Dart-side signal — the
-# `_onResumed` tail nudge (PAUSE-015) and the `didChangeMetrics` re-nudge
-# (PAUSE-020). BUG-001 gap #5 is that `didChangeMetrics` is a *proxy* for the
-# SurfaceView reattach, not the reattach: Flutter can dedupe identical window
-# metrics and the callback tracks the main FlutterView. On a device where it
-# does not fire, Attempt 8 is a no-op — and Scenario B above cannot tell that
-# device from a healthy one, because on the emulator the proxy always fires.
-#
-# Suppressing both triggers by name simulates that device exactly. What repaints
-# the surface afterwards, if anything, is whatever the native layer does on its
-# own. Modeled as `Fix="proxy"` vs `Fix="attach"` in formal/warmstart.tla.
-#
-# EXPECTED RED against a fork with no native attach/visibility repaint hook.
-# That red IS the reproduction: evidence that the surface depends on a Dart
-# proxy nobody has confirmed fires. It turns green when the fork gains the hook
-# (upstream starship-s 643cf23 + 1a8ed58 add exactly that), at which point this
-# becomes its regression guard.
-#
-# OPT-IN, because a scenario that is red by design would drown the signal from
-# every other scenario in this tier. Set WS_RUN_NATIVE_REPAINT_PROBE=1 to run
-# it — the PR that bumps the fork pin turns it on for good.
-if [ "${WS_RUN_NATIVE_REPAINT_PROBE:-0}" != "1" ]; then
-  echo "== Scenario B2: SKIPPED (set WS_RUN_NATIVE_REPAINT_PROBE=1 to run)"
-else
-  echo "== Scenario B2: warm start with the Dart resume nudges suppressed"
-  echo "   (BUG-001 gap #5: does the native layer repaint on its own?)"
-  adb shell am force-stop "$pkg"
-  adb shell am start -W -n "$component" \
-    --es ws_diag_seed "$(seed_b64 dark.html "$dark_site_id")" \
-    --es ws_diag_suppress_repaint "resume,metrics-resume" \
-    --es siteId "$dark_site_id"
-  wait_for_pixels b2-cold-start-dark 180 --expect-dominant "$dark"
-  adb shell input keyevent 3
-  sleep 5
-  # No seed extra on the return: the suppression is already armed in-process,
-  # and reseeding would restart the app rather than warm-start it.
-  adb shell am start -W -n "$component"
-  wait_for_pixels b2-warm-start-native-repaint 90 --expect-dominant "$dark"
-fi
-
 echo "== Scenario C: back into a bfcached entry repaints (PAUSE-018)"
 size="$(adb shell wm size | sed -n 's/.*: *\([0-9]*\)x\([0-9]*\).*/\1 \2/p' | head -1)"
 w="${size% *}"
@@ -486,5 +443,48 @@ adb shell input keyevent 3
 sleep 5
 adb shell am start -W -n "$component" --es siteId "$dark_site_id"
 wait_for_pixels shortcut-warm-preserves-session 90 --expect-dominant "$magenta"
+
+# Scenario B2 asks a question the rest of the suite structurally cannot: does
+# ANYTHING below Dart repaint the surface when the window comes back?
+#
+# Every warm-start repaint the app has keys on a Dart-side signal — the
+# `_onResumed` tail nudge (PAUSE-015) and the `didChangeMetrics` re-nudge
+# (PAUSE-020). BUG-001 gap #5 is that `didChangeMetrics` is a *proxy* for the
+# SurfaceView reattach, not the reattach: Flutter can dedupe identical window
+# metrics and the callback tracks the main FlutterView. On a device where it
+# does not fire, Attempt 8 is a no-op — and Scenario B above cannot tell that
+# device from a healthy one, because on the emulator the proxy always fires.
+#
+# Suppressing both triggers by name simulates that device exactly. What repaints
+# the surface afterwards, if anything, is whatever the native layer does on its
+# own. Modeled as `Fix="proxy"` vs `Fix="attach"` in formal/warmstart.tla.
+#
+# EXPECTED RED against a fork with no native attach/visibility repaint hook.
+# That red IS the reproduction: evidence that the surface depends on a Dart
+# proxy nobody has confirmed fires. It turns green when the fork gains the hook
+# (upstream starship-s 643cf23 + 1a8ed58 add exactly that), at which point this
+# becomes its regression guard.
+#
+# OPT-IN, because a scenario that is red by design would drown the signal from
+# every other scenario in this tier. Set WS_RUN_NATIVE_REPAINT_PROBE=1 to run
+# it — the PR that bumps the fork pin turns it on for good.
+if [ "${WS_RUN_NATIVE_REPAINT_PROBE:-0}" != "1" ]; then
+  echo "== Scenario B2: SKIPPED (set WS_RUN_NATIVE_REPAINT_PROBE=1 to run)"
+else
+  echo "== Scenario B2: warm start with the Dart resume nudges suppressed"
+  echo "   (BUG-001 gap #5: does the native layer repaint on its own?)"
+  adb shell am force-stop "$pkg"
+  adb shell am start -W -n "$component" \
+    --es ws_diag_seed "$(seed_b64 dark.html "$dark_site_id")" \
+    --es ws_diag_suppress_repaint "resume,metrics-resume" \
+    --es siteId "$dark_site_id"
+  wait_for_pixels b2-cold-start-dark 180 --expect-dominant "$dark"
+  adb shell input keyevent 3
+  sleep 5
+  # No seed extra on the return: the suppression is already armed in-process,
+  # and reseeding would restart the app rather than warm-start it.
+  adb shell am start -W -n "$component"
+  wait_for_pixels b2-warm-start-native-repaint 90 --expect-dominant "$dark"
+fi
 
 echo "White-screen lifecycle + shortcut tier passed."

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -204,6 +204,25 @@ wait_for_pixels() { # $1 = slug, $2 = deadline secs, rest = classifier expectati
   done
 }
 
+wait_for_logcat() { # $1 = slug, $2 = deadline secs, $3 = literal pattern
+  local slug="$1" deadline="$2" pattern="$3" start now
+  start=$(date +%s)
+  while :; do
+    if adb logcat -d 2>/dev/null | grep -qF -- "$pattern"; then
+      echo "  $slug: logged '$pattern'"
+      return 0
+    fi
+    now=$(date +%s)
+    if [ $((now - start)) -ge "$deadline" ]; then
+      echo "FAIL: $slug never logged '$pattern' within ${deadline}s" >&2
+      adb logcat -d -t 2000 > "$artifacts/fail-$slug.logcat.txt" 2>/dev/null || true
+      adb exec-out screencap -p > "$artifacts/fail-$slug.png" 2>/dev/null || true
+      exit 1
+    fi
+    sleep 1
+  done
+}
+
 adb shell input keyevent KEYCODE_WAKEUP
 adb shell input keyevent 82
 adb shell svc power stayon true
@@ -498,7 +517,12 @@ else
   sleep 5
   # No seed extra on the return: the suppression is already armed in-process,
   # and reseeding would restart the app rather than warm-start it.
+  # Clear first so the only drop we can match is this resume's, not the cold
+  # start's. Without this assertion a green B2 is unreadable: "the native layer
+  # repainted" and "the suppression never armed" produce the same dark frame.
+  adb logcat -c 2>/dev/null || true
   b2_start -n "$component"
+  wait_for_logcat b2-resume-nudge-suppressed 60 "trigger=resume suppressed"
   wait_for_pixels b2-warm-start-native-repaint 90 --expect-dominant "$dark"
 fi
 

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -148,6 +148,7 @@ dark_site_id="ws-$run_tag-dark"
 white_site_id="ws-$run_tag-white"
 notif_site_id="ws-$run_tag-notif"
 blue_site_id="ws-$run_tag-blue"
+b2_site_id="ws-$run_tag-b2"
 
 site_json() { # $1 = page basename, $2 = siteId, $3 = extra site fields (optional)
   printf '{"name":"Diag","url":"%s/%s","siteId":"%s"%s}' \
@@ -473,22 +474,31 @@ if [ "${WS_RUN_NATIVE_REPAINT_PROBE:-0}" != "1" ]; then
 else
   echo "== Scenario B2: warm start with the Dart resume nudges suppressed"
   echo "   (BUG-001 gap #5: does the native layer repaint on its own?)"
-  # Wipe first, not just force-stop. This runs last, after Scenario H has
-  # deliberately left the dark site's session navigated to the magenta page,
-  # and a cold start restores that session: the seed replaces the site list
-  # but not the per-siteId nav state, so the cold start below came up magenta
-  # and the scenario failed in setup without ever testing a repaint.
-  adb shell pm clear "$pkg" >/dev/null
-  adb shell am start -W -n "$component" \
-    --es ws_diag_seed "$(seed_b64 dark.html "$dark_site_id")" \
+  # Its own siteId, not the dark site's. This runs last, after Scenario H has
+  # deliberately left the dark site's session navigated to the magenta page:
+  # the seed replaces the site list but not the per-siteId nav state, so
+  # reusing $dark_site_id restored magenta and the scenario failed in setup
+  # without ever testing a repaint. A siteId nothing has touched has no state
+  # to restore. (`pm clear` would also work, but mid-suite it left `am start
+  # -W` blocked past the step budget.)
+  adb shell am force-stop "$pkg"
+  # `am start -W` blocks until the launch reports complete; a start that never
+  # reports would burn the whole emulator step. Cap it and let the pixel check
+  # decide -- it produces the screenshot and logcat a bare hang does not.
+  b2_start() {
+    timeout 120 adb shell am start -W "$@" \
+      || echo "  (am start -W did not return in 120s; continuing to pixels)"
+  }
+  b2_start -n "$component" \
+    --es ws_diag_seed "$(seed_b64 dark.html "$b2_site_id")" \
     --es ws_diag_suppress_repaint "resume,metrics-resume" \
-    --es siteId "$dark_site_id"
+    --es siteId "$b2_site_id"
   wait_for_pixels b2-cold-start-dark 180 --expect-dominant "$dark"
   adb shell input keyevent 3
   sleep 5
   # No seed extra on the return: the suppression is already armed in-process,
   # and reseeding would restart the app rather than warm-start it.
-  adb shell am start -W -n "$component"
+  b2_start -n "$component"
   wait_for_pixels b2-warm-start-native-repaint 90 --expect-dominant "$dark"
 fi
 

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -74,6 +74,7 @@ cleanup() {
   adb shell settings put global always_finish_activities 0 >/dev/null 2>&1 || true
   adb shell settings put global hide_error_dialogs 0 >/dev/null 2>&1 || true
   adb shell svc power stayon false >/dev/null 2>&1 || true
+  adb shell service call SurfaceFlinger 1008 i32 0 >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
@@ -651,6 +652,18 @@ else
     --es ws_diag_suppress_repaint "$all_repaint_triggers" \
     --es siteId "$b3_site_id"
   wait_for_pixels b3-cold-start-dark 180 --expect-dominant "$dark"
+  # Force GPU composition for this arm. The emulator repainting a surface
+  # nothing asked it to repaint is the whole reason no arrangement of this
+  # tier goes red, and hardware overlays are the part of the composition path
+  # most likely to be doing it: an overlay-composed layer is re-scanned out
+  # every frame from whatever the buffer last held. `1008` is what the
+  # "Disable HW overlays" developer option calls. It is not asserted, because
+  # the call is silent on failure -- the dumpsys line below is the evidence,
+  # and a run where composition never changed reads as one where it did not.
+  adb shell service call SurfaceFlinger 1008 i32 1 >/dev/null 2>&1 || true
+  echo "   composition after disabling HW overlays:"
+  adb shell dumpsys SurfaceFlinger 2>/dev/null \
+    | grep -iE 'hwc|client|device' | head -8 | sed 's/^/     /' || true
   adb shell input keyevent 3
   sleep 3
   adb logcat -c 2>/dev/null || true

--- a/test/browser/camera_stream_real_engine.test.js
+++ b/test/browser/camera_stream_real_engine.test.js
@@ -194,8 +194,14 @@ test('the committed clip alternates colour on every frame', async (t) => {
     const flipped = (p, q) => Math.abs(p[0] - q[0]) + Math.abs(p[1] - q[1]) +
       Math.abs(p[2] - q[2]) > 40;
     assert.ok(r.length >= 8, `clip presented only ${r.length} frames`);
-    assert.ok(flipped(r[0], r[1]),
-      `the clip must flip on its second frame, got ${JSON.stringify(r.slice(0, 3))}`);
+    // Not `flipped(r[0], r[1])`: presentation can repeat a frame under a
+    // software decoder running slower than real time, which the transitions
+    // budget below already allows for. Demanding the flip at a fixed index
+    // contradicted that tolerance and failed a clip that was playing fine.
+    const firstFlip = r.findIndex((_, i) => i > 0 && flipped(r[i - 1], r[i]));
+    assert.ok(firstFlip > 0 && firstFlip <= 3,
+      `the clip must start alternating within its first frames, got ${
+        JSON.stringify(r.slice(0, 4))}`);
     let transitions = 0;
     for (let i = 1; i < r.length; i++) if (flipped(r[i - 1], r[i])) transitions++;
     // Presentation can duplicate a frame under load; half the boundaries is

--- a/test/browser/media_session_real_engine.test.js
+++ b/test/browser/media_session_real_engine.test.js
@@ -57,11 +57,17 @@ test('reports playing:true with page metadata once audio actually plays', async 
     });
     assert.equal(played, true, 'autoplay must be allowed in this tier');
 
-    const got = await waitForReports(page, (r) => r.length >= 1);
-    assert.ok(got.length >= 1, 'shim reported nothing while audio was playing');
-    assert.equal(got[0].name, 'wsMediaSession');
+    // Not `got[0]`: the shim's liveness predicate is `currentTime > 0`, and
+    // the 300ms debounce after `play` can elapse before the media clock has
+    // moved on a loaded runner. That first report says playing:false and the
+    // 3s reconcile follows with the real state, so wait for the one that
+    // says playing rather than assuming it is the first.
+    const got = await waitForReports(page, (r) => r.some((x) => x.payload.playing));
+    const said = got.find((x) => x.payload.playing) || got[0];
+    assert.ok(said, 'shim reported nothing while audio was playing');
+    assert.equal(said.name, 'wsMediaSession');
     // Opaque per-frame token; media_session_frames.test.js owns its semantics.
-    const { frame, ...payload } = got[0].payload;
+    const { frame, ...payload } = said.payload;
     assert.match(frame, /^f[a-z0-9]+$/);
     // Every remaining key MediaSessionService.report destructures.
     assert.deepEqual(payload, {
@@ -89,12 +95,13 @@ test('falls back to document.title when the page declares no metadata', async (t
       document.body.appendChild(a);
       await a.play();
     });
-    const got = await waitForReports(page, (r) => r.length >= 1);
-    assert.ok(got.length >= 1, 'shim reported nothing');
-    assert.equal(got[0].payload.playing, true);
-    assert.equal(got[0].payload.title, 'Radio Station');
-    assert.equal(got[0].payload.artist, '');
-    assert.equal(got[0].payload.artwork, '');
+    const got = await waitForReports(page, (r) => r.some((x) => x.payload.playing));
+    const said = got.find((x) => x.payload.playing) || got[0];
+    assert.ok(said, 'shim reported nothing');
+    assert.equal(said.payload.playing, true);
+    assert.equal(said.payload.title, 'Radio Station');
+    assert.equal(said.payload.artist, '');
+    assert.equal(said.payload.artwork, '');
   } finally {
     await page.close();
   }

--- a/test/js/nested_webview_posture_parity.test.js
+++ b/test/js/nested_webview_posture_parity.test.js
@@ -159,6 +159,9 @@ const PLUMBING = new Set([
   // on both surfaces; not a posture value to copy.
   'pullToRefreshGate',
   'onRendererGone', 'onProtectedMediaRequest', 'onCameraDecision',
+  // Repaint wiring, not a posture value: both surfaces set their own handler
+  // to nudge their own surface (PAUSE-031), gated by surface_repaint_funnel.
+  'onPageCommitVisible',
   // Accessor for the host's live camera mode (backs the non-prompting
   // webCameraMode handler), not a posture value to copy: the nested screen
   // supplies its own in-memory mode.

--- a/test/js/surface_repaint_funnel.test.js
+++ b/test/js/surface_repaint_funnel.test.js
@@ -349,10 +349,60 @@ for (const rel of GUARDED) {
         /void\s+_repaintCurrentSurface\s*\(\)/.test(l),
       );
       assert.ok(defIdx >= 0, '_repaintCurrentSurface must be defined');
-      const body = lines.slice(defIdx, defIdx + 12).join('\n');
+      // An expression body is the whole method; a block body runs to its
+      // closing brace rather than a fixed window, because the main-page one
+      // cycles through repaint mechanisms (BUG-001 gap #18) and a line count
+      // would fail on the next mechanism added.
+      const isExpr = /=>/.test(lines[defIdx]);
+      let body;
+      if (isExpr) {
+        body = lines[defIdx];
+      } else {
+        const endIdx = lines.findIndex((l, i) => i > defIdx && /^ {2}}$/.test(l));
+        assert.ok(endIdx > defIdx, '_repaintCurrentSurface must be closed');
+        body = lines.slice(defIdx, endIdx).join('\n');
+        // A mechanism that does not route through the nudge funnel emits no
+        // trigger= line, so a tap must name itself or a user report cannot be
+        // matched to what it actually did.
+        assert.match(body, /LogService\.instance\.log\(\s*'SurfaceDiag'/,
+          'a branching manual repaint must log which mechanism it ran');
+      }
       assert.match(body, /_nudgeSurfaceRepaint\('manual'\)/,
         "the manual action must nudge under the 'manual' trigger, so a user " +
           'report can be matched to the log line the tap produced');
+    });
+  }
+}
+
+// Commit-visible trigger (BUG-001 Attempt 12 / PAUSE-031). `onPageCommitVisible`
+// is the only signal that fires because the renderer produced pixels; every
+// other trigger is a lifecycle event hoped to imply one. Gap #18 caught a load
+// whose nudges had all drained, and whose 15s commit window had closed, before
+// the renderer produced anything. So this trigger must NOT be gated on that
+// window -- a later tidy-up that routes it through noteLoadSettled() would
+// reproduce exactly the failure it was added for.
+{
+  const GUARDED = ['lib/main.dart', 'lib/screens/inappbrowser.dart'];
+  for (const rel of GUARDED) {
+    const lines = linesOf(rel);
+    const src = lines.join('\n');
+
+    test(`${rel}: the commit-visible trigger nudges (PAUSE-031)`, () => {
+      assert.match(src, /_nudgeSurfaceRepaint\('page-commit-visible'\)/,
+        'onPageCommitVisible must route through the nudge funnel');
+    });
+
+    test(`${rel}: the commit-visible trigger is not window-gated (PAUSE-031)`, () => {
+      const i = lines.findIndex((l) =>
+        /_nudgeSurfaceRepaint\('page-commit-visible'\)/.test(l),
+      );
+      assert.ok(i >= 0, 'the commit-visible nudge must exist');
+      // The five lines above the nudge: enough to hold an index guard, not
+      // enough to reach the neighbouring commit-settled handler's own gate.
+      const before = lines.slice(Math.max(0, i - 5), i).join('\n');
+      assert.doesNotMatch(before, /noteLoadSettled\(\)/,
+        'the commit-visible nudge must not be gated on the commit window: ' +
+          'the window can close before a slow renderer produces a frame');
     });
   }
 }


### PR DESCRIPTION
Started as an audit of what the adb white-screen tier can observe, then two
captures off a real device turned it into a fix. `docs/bugs/001-white-screen.md`
gaps #12 to #18 carry the reasoning; this is the summary.

## The tier cannot go red on BUG-001, on this host

Scenario B2 (warm start) and B3-A (committed reload) each suppress every
`_nudgeSurfaceRepaint` trigger *and* the second repaint path in
`_probeRendererAndRecover`, show the drops in the trace, and the surface comes
back painted anyway. So the pixel assertions would hold with the repaint
machinery deleted, and adding scenarios does not change that.

Two instrument bugs made the first greens unreadable and are fixed here:
`RepaintSuppression` gated only the nudge funnel while the renderer probe
repainted under the same trigger name, and a passing run dumped no logcat.

Since the pixels cannot fail, the tier now also asserts from the app's own
`SurfaceDiag` trace that a repaint was *requested* on the path just driven:
`trigger=resume` after a warm start, `trigger=back` after a back gesture,
`trigger=activate` after a warm site switch. Host-independent, and it fails on
the mode that actually recurs, a path reaching a surface without passing a
chokepoint.

## What the device said (gaps #17, #18)

Two `SurfaceDiag` captures off an affected phone, the first anyone has taken.

The second one is the finding. A cold start, one site opened for the first
time, screen white:

    22:32:19  trigger=activate          -> nudge
    22:32:20  trigger=controller-attach -> nudge (coalesced)
    22:32:21  trigger=reload            -> nudge (coalesced)
    22:32:24  trigger=commit-settled    -> nudge
    22:32:29  trigger=commit-settled    -> nudge
    22:32:41..48  HtmlCache saved 376028 bytes  (x5)

Six nudges, the two `commit-settled` ones each running their own six-tick loop
right after `onLoadStop`. The renderer answered `getHtml` five times over the
next seven seconds with a 376 KB document, after the screen was already blank.
Every enumerated trigger fired and the surface stayed blank.

The last nudge drained by ~22:32:29.6 and the 15-second commit window closed
~22:32:36, while the renderer was still producing content at 22:32:48. So the
triggers were not missing, they were spent.

The first capture is separate and still open: a probe returning `-1`
(`document.body` missing) classifies as renderer-alive, because
`rendererProbeIndicatesGone` is `probeResult == null`. A surface nudge cannot
repaint a document with no body. That trace could not say which site it read,
so the probe line now carries `site=<siteId>` and a `-1` emits a second line
with `readyState`, whether `documentElement` exists, and `protocol//host`.

## PAUSE-031: repaint on the commit-visible signal

Android's `onPageCommitVisible` was already plumbed to Dart in the fork and
unused. It is the only signal that fires *because* the WebView committed a
visible frame; every other trigger is a lifecycle event hoped to imply one, and
`onLoadStop` reports that a navigation finished, not that a frame exists.

Wired through `WebViewConfig` to a nudge under `page-commit-visible`, on the
site webview (via `WebViewModel.onPageCommitVisible`, the same shape as
`onLoadSettled`) and on the nested `InAppWebViewScreen`. **Not** gated on the
commit window — that window closing early is the failure above, and
`test/js/surface_repaint_funnel.test.js` fails if someone routes it through
`noteLoadSettled()`.

## The half still open

Whether the mechanism works at all on that device is unanswered: PAUSE-031 only
helps if the nudge repaints when it lands in time. The developer-mode "Repaint
Screen" entry now cycles mechanisms on successive taps and logs which it ran —
`inset-1` (today's), `inset-16`, `unpaint` (held unpainted a few frames, so the
Android view leaves and re-enters the hierarchy without the WebView being
destroyed), `native-invalidate`, `native-visibility`, `recreate`. The last two
call the View API directly on every WebView in the window; `SurfaceDiagPlugin`
already holds the Activity on the main looper, so neither needs a fork change.

Whichever tap restores a blank screen names the layer the fix belongs in.

## Host configuration

The first measurement found CI was never running the container engine:

    isolation engine: Container API not supported, using CookieIsolationEngine
    system webview:   com.google.android.webview, 113.0.5672.136
    animation scales: 0.0 0.0 0.0
    build:            Android 14, api 34, sdk_gphone64_x86_64

`androidx.webkit` resolves to 1.14.0 so the library supports `MULTI_PROFILE`;
the runtime WebView did not. Every emulator image pins its WebView at image
build time with no Play Store to update it, so API 34 sat on Chromium 113 from
May 2023, and the API level is the only thing that moves it.

Four of the five differences from a real device were our own configuration:

- **Image**: API 34 `google_apis` to API 35 `default` (AOSP). The app ships
  GMS-free and CI asserts that about the APK, so the test host should not carry
  Google's stack either; its WebView is `com.android.webview`.
- **Animations**: the lifecycle tier sets all three scales to 1.0 for its own
  run and restores what it found. This bug lives in transitions.
- **Build mode**: `WS_LIFECYCLE_BUILD_MODE=profile` (also a `workflow_dispatch`
  input) drives an AOT, non-inspectable build. Default stays `debug` until the
  profile arm's Scenario A failure is understood. Only `debug` carries the
  `applicationIdSuffix` from #579 — Flutter creates the profile build type with
  `initWith(debug)` before that block runs — so the tier derives its package
  name from the mode.

The fifth, software rasterisation, is a property of a GPU-less runner and is not
fixable in cloud CI by any emulator, Cuttlefish included.

## Scenario F2

Scenario F fires the notification refresh receiver while the app is
backgrounded, the leg that was always correct. F2 fires it foregrounded, which
is the leg that broke before `f02d4af`, and asserts the visible site neither
re-fetches nor blanks.

## Not claimed

B3-B guards the `PAUSE-027` latch's ordering, read from the trace. It does not
show the repaint prevented a blank: on this host the surface stays painted with
every trigger suppressed, so "stayed painted" distinguishes nothing.

PAUSE-031 is still a trigger. It does not address the `-1` no-body case, it is
Android-only by construction, and a page whose first commit-visible frame is
itself blank gets one nudge at the wrong moment and nothing after.

Whether the AOSP WebView at API 35 advertises `MULTI_PROFILE`, and so puts CI on
the container path, is read from `host: isolation engine:` on the run summary
rather than asserted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRj4fM3TEVaSLwoB1fyJFD