### PR TITLE
Install debug builds under their own applicationId

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,10 @@ fvm flutter build linux  --release
 fvm dart run flutter_launcher_icons
 ```
 
-Android flavors: `fdroid` (CI), `fmain` (Play), `fdebug`.
+Android flavors: `fdroid` (CI), `fmain` (Play), `fdebug`. The `debug` build type
+suffixes the applicationId (`org.codeberg.theoden8.webspace.debug`, label "Webspace
+Debug") so a dev build installs beside a store one; the namespace is unchanged, so
+`adb` component names in `scripts/` must be fully qualified, not `pkg/.Class`.
 
 ## Architecture
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -65,6 +65,7 @@ android {
         targetSdkVersion 36
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+        resValue "string", "app_name", "Webspace"
     }
 
     signingConfigs {
@@ -103,6 +104,18 @@ android {
     }
 
     buildTypes {
+        debug {
+            // Distinct applicationId so a debug build installs alongside a
+            // release/store install instead of colliding with it (a collision
+            // also fails outright, since the signing keys differ). The
+            // namespace is untouched, so every class name, MethodChannel and
+            // JNI symbol stays as-is; only the package identity moves.
+            // adb-driven scripts under scripts/ must follow this suffix.
+            applicationIdSuffix ".debug"
+            versionNameSuffix "-debug"
+            resValue "string", "app_name", "Webspace Debug"
+        }
+
         release {
             // Only use release signing if keystore exists
             def keystorePropertiesFile = rootProject.file('key.properties')

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <application
-        android:label="Webspace"
+        android:label="@string/app_name"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:usesCleartextTraffic="true">

--- a/scripts/run_android_background_audio_tests.sh
+++ b/scripts/run_android_background_audio_tests.sh
@@ -17,7 +17,8 @@
 # device id in scope across the `flutter test` calls.
 set -euo pipefail
 
-PKG="org.codeberg.theoden8.webspace"
+# Debug build type suffixes the applicationId; see android/app/build.gradle.
+PKG="org.codeberg.theoden8.webspace.debug"
 
 device_id="${1:-$(adb devices | grep -w 'device' | head -1 | awk '{print $1}' || true)}"
 if [ -z "$device_id" ]; then

--- a/scripts/run_android_camera_tests.sh
+++ b/scripts/run_android_camera_tests.sh
@@ -13,7 +13,8 @@
 # camera scenario reports NotAllowedError and skips.
 set -euo pipefail
 
-PKG="org.codeberg.theoden8.webspace"
+# Debug build type suffixes the applicationId; see android/app/build.gradle.
+PKG="org.codeberg.theoden8.webspace.debug"
 
 device_id="${1:-$(adb devices | grep -w 'device' | head -1 | awk '{print $1}' || true)}"
 if [ -z "$device_id" ]; then

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -35,8 +35,12 @@ if [ -z "$device_id" ]; then
 fi
 export ANDROID_SERIAL="$device_id"
 
-pkg="org.codeberg.theoden8.webspace"
-component="$pkg/.MainActivity"
+# The debug build type suffixes the applicationId (android/app/build.gradle)
+# but not the namespace, so `pkg/.Class` shorthand would resolve to a class
+# that does not exist -- components are spelled out in full.
+pkg="org.codeberg.theoden8.webspace.debug"
+ns="org.codeberg.theoden8.webspace"
+component="$pkg/$ns.MainActivity"
 artifacts="$root/build/white_screen_adb"
 classify="$root/scripts/classify_window_pixels.py"
 dark=123524
@@ -389,7 +393,7 @@ bg_log_hits() { bg_log | grep -c "$1" || true; }
 triggers_before="$(bg_log_hits 'debug trigger: enqueueing')"
 worker_runs_before="$(bg_log_hits 'NotificationRefreshWorker fired')"
 echo "  triggering a one-shot refresh via the debug receiver"
-adb shell am broadcast -n "$pkg/.NotificationRefreshDebugReceiver" >/dev/null
+adb shell am broadcast -n "$pkg/$ns.NotificationRefreshDebugReceiver" >/dev/null
 
 # `am broadcast` reports the same result whether or not a receiver matched,
 # so confirm delivery instead of spending the 90s notification deadline on a

--- a/test/js/notification_refresh_trigger.test.js
+++ b/test/js/notification_refresh_trigger.test.js
@@ -65,7 +65,7 @@ test('the debug refresh receiver lives only in the debug source set', () => {
 });
 
 test('the harness triggers the refresh through the receiver', () => {
-  assert.match(harness, /am broadcast -n "\$pkg\/\.NotificationRefreshDebugReceiver"/,
+  assert.match(harness, /am broadcast -n "[^"]*NotificationRefreshDebugReceiver"/,
     `${harnessRel} must drive the refresh through the debug receiver`);
 });
 


### PR DESCRIPTION
Debug and release shared one applicationId, so a dev build could not sit
beside a store install and installing over one failed on the signing-key
mismatch. The debug build type now suffixes the id and the launcher label;
the namespace is unchanged, so adb component names have to be spelled out
in full rather than as pkg/.Class.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EQekfhRgwBKuBMedKX3tQM