### PR TITLE
Gate the iOS export compliance code before upload

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,24 +2,29 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- The app implements encryption rather than only consuming the OS's:
-	     AES at rest in archive_crypto.dart / html_cache_service.dart, and
-	     tor's own TLS and onion-routing crypto once Tor.framework links.
-	     Apple's exemption covers OS-provided encryption (HTTPS via
-	     URLSession) and authentication-only use; neither describes this.
-	     See openspec/changes/add-ios-tor-proxy/specs/tor-proxy/spec.md
-	     TOR-010.
+	<!-- Exempt, which is not the same as "no encryption". The app
+	     implements AES-GCM-256, Argon2id, HKDF-SHA-256 and HMAC-SHA-256
+	     (archive_crypto.dart, html_cache_service.dart) and links tor's
+	     TLS and OpenSSL, so Apple's OS-provided and authentication-only
+	     exemptions genuinely do not apply.
 
-	     `true` is half the declaration. Apple issues a compliance code once
-	     it approves the encryption documentation in App Store Connect, and
-	     that code belongs here as ITSEncryptionExportComplianceCode; until
-	     it does, every upload is rejected with ITMS-90592 ("the export
-	     compliance key value [] ... doesn't match"). The documentation is
-	     not filed yet, so the key is absent rather than guessed.
-	     scripts/check_ios_export_compliance.sh gates the pair on the
-	     fastlane deploy lanes. -->
+	     The basis is publicly available source: MIT, free, built from a
+	     public repo, so the object code is not subject to the EAR (note
+	     to 15 CFR 734.3(b)(3), 742.15(b)(1)).
+
+	     The detail that decides it: 742.15(b)(2) requires an email
+	     notification to BIS and the ENC Coordinator only for
+	     "non-standard cryptography". Every primitive here is published
+	     (FIPS 197, SP 800-38D, RFC 9106, RFC 5869, RFC 2104, RFC 8446),
+	     so nothing is owed. A proprietary or unpublished algorithm, or
+	     the source ceasing to be public, ends that. See EXPORT-001.
+
+	     `true` is not the safe fallback: it obliges an
+	     ITSEncryptionExportComplianceCode that only exists after Apple
+	     approves uploaded documentation, and every upload without one is
+	     rejected (ITMS-90592). -->
 	<key>ITSAppUsesNonExemptEncryption</key>
-	<true/>
+	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -8,8 +8,16 @@
 	     Apple's exemption covers OS-provided encryption (HTTPS via
 	     URLSession) and authentication-only use; neither describes this.
 	     See openspec/changes/add-ios-tor-proxy/specs/tor-proxy/spec.md
-	     TOR-010. Export documentation is filed in App Store Connect, and
-	     the annual BIS self-classification report is a release step. -->
+	     TOR-010.
+
+	     `true` is half the declaration. Apple issues a compliance code once
+	     it approves the encryption documentation in App Store Connect, and
+	     that code belongs here as ITSEncryptionExportComplianceCode; until
+	     it does, every upload is rejected with ITMS-90592 ("the export
+	     compliance key value [] ... doesn't match"). The documentation is
+	     not filed yet, so the key is absent rather than guessed.
+	     scripts/check_ios_export_compliance.sh gates the pair on the
+	     fastlane deploy lanes. -->
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<true/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -16,6 +16,14 @@ platform :ios do
     File.expand_path("../..", __dir__)
   end
 
+  # ITSAppUsesNonExemptEncryption without its matching
+  # ITSEncryptionExportComplianceCode archives and exports cleanly and is
+  # rejected only by App Store Connect at upload (ITMS-90592). Fail before the
+  # binary is sent rather than after. See TOR-010.
+  def check_export_compliance
+    sh("cd '#{project_root}' && ./scripts/check_ios_export_compliance.sh")
+  end
+
   desc "Run tests"
   lane :test do
     run_tests(
@@ -54,6 +62,7 @@ platform :ios do
 
   desc "Deploy to TestFlight"
   lane :deploy_beta do
+    check_export_compliance
     build_release
     upload_to_testflight(
       skip_waiting_for_build_processing: true
@@ -62,6 +71,7 @@ platform :ios do
 
   desc "Deploy to App Store"
   lane :deploy_production do
+    check_export_compliance
     build_release
     upload_to_app_store(
       submit_for_review: false,

--- a/openspec/changes/add-ios-tor-proxy/design.md
+++ b/openspec/changes/add-ios-tor-proxy/design.md
@@ -30,8 +30,8 @@ CocoaPods-distributed static framework that wraps upstream `tor`,
 Stakeholders: privacy-focused iOS users (primary), the F-Droid /
 Play-only Android tier (no impact — Android stays generic SOCKS5,
 Orbot users keep their existing config), and the iOS App Store review
-process (`ITSAppUsesNonExemptEncryption` flips to `true` — see D8, which
-corrects the draft's reasoning-from-Onion-Browser here).
+process (`ITSAppUsesNonExemptEncryption` stays `false` — see D8, which
+corrects an earlier revision that flipped it).
 
 Constraints from the existing codebase:
 
@@ -350,28 +350,25 @@ responsible for its own manifest inside its own bundle; if the pinned
 pod ships none, that is an upstream gap to raise, not something the
 app can declare on the pod's behalf. See TOR-011.
 
-**Export compliance.** The app currently declares
-`ITSAppUsesNonExemptEncryption = false`. That declaration does not
-survive this change. Apple's exemption covers encryption provided by
-the operating system (HTTPS via `URLSession`) and encryption used
-purely for authentication; Tor.framework ships tor's own TLS and
-onion-routing cryptography plus a full OpenSSL build *inside our
-binary*, which is encryption the app implements. The key flips to
-`true`, export-compliance documentation is filed in App Store Connect
-before the first Tor build is submitted, and the annual
-self-classification report to BIS joins the release checklist.
+**Export compliance.** `ITSAppUsesNonExemptEncryption` stays
+`false`. Tor.framework ships tor's own TLS and onion-routing
+cryptography plus a full OpenSSL build *inside our binary*, so
+Apple's OS-provided (`URLSession` HTTPS) and authentication-only
+exemptions do not cover it. They never did: the app already
+implements AES at rest in `archive_crypto.dart` and
+`html_cache_service.dart`. EXPORT-001's basis is a different one
+entirely, publicly available source, and Tor does not touch it.
 
-Two honest notes on this. First, the flip is arguably owed already:
-the app implements AES at rest in `archive_crypto.dart` and
-`html_cache_service.dart`, so the current `false` is questionable on
-its own terms and Tor only makes it unambiguous. Second, the earlier
-draft of this design asserted the opposite — that the exemption
-"remains valid" and "no plist change is needed" — by reasoning from
-Onion Browser's posture rather than from Apple's stated exemption
-categories. That was wrong, and it is the single highest-cost error
-in the change: a false submission-form declaration is a
-misrepresentation to Apple and a U.S. export-control exposure, not a
-guideline nit that review would simply bounce back. See TOR-010.
+This design shipped with the opposite conclusion and it cost
+releases. It argued the key must flip to `true` because the app
+implements rather than borrows its cryptography, which rebuts the
+OS-provided exemption that EXPORT-001 never claimed. `true` then
+obliges an `ITSEncryptionExportComplianceCode` that Apple issues only
+after approving uploaded documentation, and for standard algorithms
+that documentation is the French ANSSI declaration, one to two months
+out. Every upload in between was rejected as ITMS-90592. The lesson
+is narrow and worth keeping: check which exemption a `false` actually
+rests on before arguing it away. See TOR-010 and EXPORT-001.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/add-ios-tor-proxy/proposal.md
+++ b/openspec/changes/add-ios-tor-proxy/proposal.md
@@ -52,7 +52,7 @@ stream isolation, with no entitlement extensions needed.
   cleanly to free the loopback port.
 - `Info.plist`: no new entitlements (`NSAppTransportSecurity` already
   permits loopback HTTP for the fork's debugger bridge), but
-  `ITSAppUsesNonExemptEncryption` flips to `true` (TOR-010). A new
+  `ITSAppUsesNonExemptEncryption` stays `false` (TOR-010). A new
   `PrivacyInfo.xcprivacy` resource carries the required-reason API
   rows — those do not belong in `Info.plist` (TOR-011).
 - Linker: `Tor.framework` + `OpenSSL.framework` + `libevent.framework`
@@ -109,7 +109,7 @@ stream isolation, with no entitlement extensions needed.
     `stop`, `status`, `rebuildCircuits`, `socksEndpoint`, plus a
     bootstrap-progress event channel.
   - `Info.plist`: no new entitlements;
-    `ITSAppUsesNonExemptEncryption` becomes `true`.
+    `ITSAppUsesNonExemptEncryption` is unchanged at `false`.
   - `ios/Runner/PrivacyInfo.xcprivacy`: new privacy-manifest resource
     (the repo has none today) declaring the app's own required-reason
     API usage.
@@ -160,11 +160,11 @@ stream isolation, with no entitlement extensions needed.
   the release changelog.
 - **Export compliance**: embedding Tor ships tor's own TLS/onion
   cryptography and OpenSSL inside the binary, which is *not* the
-  OS-provided encryption Apple's exemption covers.
-  `ITSAppUsesNonExemptEncryption` flips from `false` to `true`,
-  export documentation is filed in App Store Connect before the first
-  Tor build is submitted, and the annual BIS self-classification
-  report joins the release checklist (TOR-010).
+  OS-provided encryption Apple's exemption covers. That exemption is
+  not the one EXPORT-001 relies on, so
+  `ITSAppUsesNonExemptEncryption` stays `false` on the
+  publicly-available-source basis, and no 742.15(b)(2) notification is
+  owed because every primitive is a published standard (TOR-010).
 - **App Store review**: no current App Store Review Guideline
   prohibits this design. Guideline 5.4 (VPN Apps) does not apply — no
   `NEVPNManager`, no NetworkExtension entitlement, and the loopback

--- a/openspec/changes/add-ios-tor-proxy/specs/tor-proxy/spec.md
+++ b/openspec/changes/add-ios-tor-proxy/specs/tor-proxy/spec.md
@@ -342,6 +342,34 @@ of Tor, not a new cost introduced by this change.
 - **THEN** `ITSAppUsesNonExemptEncryption` is `true`
 - **AND** no build declaring `false` is submitted to App Store Connect
 
+`true` is half the declaration. Apple issues a compliance code once it
+approves the uploaded encryption documentation, and the binary SHALL
+carry that code as `ITSEncryptionExportComplianceCode` in the same
+plist. A build declaring `true` with the code absent compiles,
+archives and exports cleanly, and is rejected only at upload
+(ITMS-90592, "the export compliance key value [] in the app's
+Info.plist doesn't match the key value of the app's export compliance
+documentation"). Nothing between the edit and the upload observes it,
+so the pair SHALL be checked before submission by
+[scripts/check_ios_export_compliance.sh](../../../../scripts/check_ios_export_compliance.sh),
+wired into the fastlane deploy lanes. The code SHALL be the value
+Apple issued; a placeholder is a false statement on a submission form,
+not a rejected upload.
+
+#### Scenario: A build is submitted with the declaration set
+
+- **GIVEN** `ITSAppUsesNonExemptEncryption` is `true`
+- **WHEN** an IPA is uploaded to App Store Connect
+- **THEN** `ITSEncryptionExportComplianceCode` is present and non-empty
+- **AND** `scripts/check_ios_export_compliance.sh` exits non-zero when it
+  is not, before the upload rather than after
+
+#### Scenario: The declaration is reverted to exempt
+
+- **GIVEN** `ITSAppUsesNonExemptEncryption` is `false`
+- **THEN** `ITSEncryptionExportComplianceCode` is absent, since an exempt
+  declaration carries no code
+
 #### Scenario: Year-end self-classification is tracked
 
 - **GIVEN** a build containing Tor.framework was distributed in a

--- a/openspec/changes/add-ios-tor-proxy/specs/tor-proxy/spec.md
+++ b/openspec/changes/add-ios-tor-proxy/specs/tor-proxy/spec.md
@@ -320,65 +320,55 @@ termination.
 
 Embedding Tor ships `tor`'s own TLS and onion-routing cryptography
 plus a full OpenSSL build inside the app binary. That is encryption
-the app *implements*, not encryption provided by the operating
-system, so it does not fall under the OS-provided/HTTPS exemption.
-`ITSAppUsesNonExemptEncryption` in
-[ios/Runner/Info.plist](../../../../ios/Runner/Info.plist) SHALL be
-`true` from the first build that links Tor.framework, and the App
-Store Connect export-compliance documentation SHALL be filed before
-that build is submitted.
+the app *implements*, so Apple's OS-provided/HTTPS and
+authentication-only exemptions do not cover it.
 
-This supersedes the pre-existing `false` declaration, which is
-already questionable on its own terms: the app implements AES at
-rest in [archive_crypto.dart](../../../../lib/services/archive_crypto.dart)
-and [html_cache_service.dart](../../../../lib/services/html_cache_service.dart).
-Flipping the key is therefore a correction the app owes regardless
-of Tor, not a new cost introduced by this change.
+They are not what covers it. `ITSAppUsesNonExemptEncryption` in
+[ios/Runner/Info.plist](../../../../ios/Runner/Info.plist) SHALL
+remain `false` under EXPORT-001's basis: the source is publicly
+available under MIT and the object code is therefore not subject to
+the EAR (note to 15 CFR 734.3(b)(3), 742.15(b)(1)). Tor changes what
+cryptography ships; it does not change whether the source is public.
 
-#### Scenario: Info.plist declares non-exempt encryption
+An earlier revision of this requirement mandated `true`, on the
+reasoning that the app implements rather than borrows its
+cryptography. That is true and beside the point: it rebuts the
+OS-provided exemption, which EXPORT-001 never invoked. The
+consequence was concrete, not academic. `true` obliges an
+`ITSEncryptionExportComplianceCode` that Apple issues only after
+approving uploaded documentation, so every upload was rejected with
+ITMS-90592 ("the export compliance key value [] ... doesn't match")
+until the key was reverted.
+
+No 15 CFR 742.15(b)(2) notification is owed either: it reaches only
+source code performing "non-standard cryptography", and everything
+the app and the Tor pod use is a published standard. See EXPORT-001
+for the full argument and EXPORT-002 for the primitive list that
+keeps it true.
+
+#### Scenario: Info.plist declares exempt encryption
 
 - **GIVEN** the iOS target links Tor.framework
 - **WHEN** `ios/Runner/Info.plist` is read
-- **THEN** `ITSAppUsesNonExemptEncryption` is `true`
-- **AND** no build declaring `false` is submitted to App Store Connect
+- **THEN** `ITSAppUsesNonExemptEncryption` is `false`
+- **AND** no `ITSEncryptionExportComplianceCode` is present, since an
+  exempt declaration carries no code
 
-`true` is half the declaration. Apple issues a compliance code once it
-approves the uploaded encryption documentation, and the binary SHALL
-carry that code as `ITSEncryptionExportComplianceCode` in the same
-plist. A build declaring `true` with the code absent compiles,
-archives and exports cleanly, and is rejected only at upload
-(ITMS-90592, "the export compliance key value [] in the app's
-Info.plist doesn't match the key value of the app's export compliance
-documentation"). Nothing between the edit and the upload observes it,
-so the pair SHALL be checked before submission by
-[scripts/check_ios_export_compliance.sh](../../../../scripts/check_ios_export_compliance.sh),
-wired into the fastlane deploy lanes. The code SHALL be the value
-Apple issued; a placeholder is a false statement on a submission form,
-not a rejected upload.
+#### Scenario: A build is submitted
 
-#### Scenario: A build is submitted with the declaration set
+- **GIVEN** an IPA built from this source
+- **WHEN** it is uploaded to App Store Connect
+- **THEN** it is not rejected for export compliance
+- **AND** [scripts/check_ios_export_compliance.sh](../../../../scripts/check_ios_export_compliance.sh)
+  exits non-zero before the upload if the two keys ever disagree
 
-- **GIVEN** `ITSAppUsesNonExemptEncryption` is `true`
-- **WHEN** an IPA is uploaded to App Store Connect
-- **THEN** `ITSEncryptionExportComplianceCode` is present and non-empty
-- **AND** `scripts/check_ios_export_compliance.sh` exits non-zero when it
-  is not, before the upload rather than after
+#### Scenario: The declaration is set to true
 
-#### Scenario: The declaration is reverted to exempt
-
-- **GIVEN** `ITSAppUsesNonExemptEncryption` is `false`
-- **THEN** `ITSEncryptionExportComplianceCode` is absent, since an exempt
-  declaration carries no code
-
-#### Scenario: Year-end self-classification is tracked
-
-- **GIVEN** a build containing Tor.framework was distributed in a
-  calendar year
-- **WHEN** the following 1 February approaches
-- **THEN** the annual self-classification report to the U.S. Bureau
-  of Industry and Security is filed for that build
-- **AND** the obligation is recorded in the release checklist, not
-  left to memory
+- **GIVEN** a change sets `ITSAppUsesNonExemptEncryption` to `true`
+- **THEN** `ITSEncryptionExportComplianceCode` carries the code Apple
+  issued after approving export documentation, never a placeholder
+- **AND** the documentation is filed and approved before the build is
+  submitted, since the code does not exist beforehand
 
 ---
 

--- a/openspec/changes/add-ios-tor-proxy/tasks.md
+++ b/openspec/changes/add-ios-tor-proxy/tasks.md
@@ -86,7 +86,7 @@ the nested-webview propagation chain. See PROXY-010 for the reasoning.
 
 - [x] 11.0 Structural CI gates in `test/js/ios_compliance_declarations.test.js`: the encryption declaration, the privacy manifest's existence, its absence from `Info.plist`, its presence in Copy Bundle Resources, and no hardcoded 9050. Each verified to fail on its own regression.
 
-- [x] 11.1 Set `ITSAppUsesNonExemptEncryption` to `true` in `ios/Runner/Info.plist` and file export-compliance documentation in App Store Connect before the first Tor build is submitted (TOR-010). The current `false` does not survive embedding tor's own TLS/onion crypto and OpenSSL. Do not ship a build that still declares `false`.
+- [x] 11.1 Leave `ITSAppUsesNonExemptEncryption` at `false` in `ios/Runner/Info.plist` (TOR-010). Tor changes what cryptography ships, not whether the source is public, and EXPORT-001's exemption is the publicly-available-source one. An earlier revision of this task mandated `true`; that obliges a compliance code Apple issues only after approving documentation, and it blocked every upload with ITMS-90592 until reverted.
 - [ ] 11.1a Add the annual BIS self-classification report (due 1 February for the prior calendar year's distributed builds) to the release checklist.
 - [ ] 11.1b Draft the App Review notes: what the toggle does, that bootstrap takes 10-30s on first use, and that a restricted network surfaces an explicit error by design (TOR-013).
 - [ ] 11.1c Audit UI strings and assets for trademark discipline before submission — descriptive use of "Tor" only, no onion logo, no "Tor" in app name/subtitle/bundle id, no implied Tor Project endorsement (TOR-012).

--- a/openspec/specs/legal/spec.md
+++ b/openspec/specs/legal/spec.md
@@ -16,31 +16,69 @@ encryption declaration, and MIT as the licence of the shipped work.
 
 ### EXPORT-001 - Encryption declaration
 
-The iOS bundle SHALL declare `ITSAppUsesNonExemptEncryption` as `true`, and
-SHALL carry the App Store Connect compliance code as
-`ITSEncryptionExportComplianceCode` once Apple issues it. Normative detail,
-including the pre-submission gate, is TOR-010 in
-[the tor-proxy change](../../changes/add-ios-tor-proxy/specs/tor-proxy/spec.md)
-until that change is archived.
+The iOS bundle SHALL declare `ITSAppUsesNonExemptEncryption` as `false` and
+SHALL NOT carry an `ITSEncryptionExportComplianceCode`.
 
-This requirement previously read `false`, on the basis that the source is
-published under a licence permitting further dissemination, so the object
-code is not subject to the EAR (note to 15 CFR 734.3(b)(3), criteria in
-15 CFR 742.15(b)). TOR-010 superseded it in #344, when `pod 'Tor'` began
-linking tor's TLS and OpenSSL into the binary; the app also implements AES
-at rest (EXPORT-002), so `false` was already doubtful on the OS-provided
-exemption alone.
+Basis: the source is published under a licence permitting further
+dissemination, so the object code is not subject to the EAR (note to
+15 CFR 734.3(b)(3), criteria in 15 CFR 742.15(b)(1)). This rests on
+EXPORT-002 and EXPORT-003; revisit it if either stops holding.
 
-Two things that argument did not settle, recorded so the next reader does
-not assume they were: it answered only the OS-provided and
-authentication-only exemptions, never the publicly-available-source basis
-above, and no 15 CFR 742.15(b) notification is recorded anywhere in this
-repo. Reopening `false` means resolving both, not just citing the licence.
+**Exempt is not "no encryption".** The app implements AES-GCM-256, Argon2id,
+HKDF-SHA-256 and HMAC-SHA-256 in
+[archive_crypto.dart](../../../lib/services/archive_crypto.dart), AES over the
+page cache in
+[html_cache_service.dart](../../../lib/services/html_cache_service.dart), and
+links tor's TLS and OpenSSL. Apple's OS-provided and authentication-only
+exemptions describe none of that. Reasoning from *those* exemptions is what
+led #344 to flip the key to `true`; they were never the basis here.
+
+**No notification is owed, and it turns on one term.** 15 CFR 742.15(b)(2)
+requires emailing the source location to BIS and the ENC Encryption Request
+Coordinator, but only for source code that "provides or performs
+*non-standard cryptography*" — an EAR term of art for proprietary or
+unpublished algorithms. EXPORT-002 confines the app to published standards
+(FIPS 197, NIST SP 800-38D, RFC 9106, RFC 5869, RFC 2104, RFC 8446,
+RFC 7748/8032), so 742.15(b)(2) does not reach it and there is nothing to
+file. This is the whole reason the app owes no paperwork despite shipping a
+lot of cryptography, and it is the first thing to re-check when EXPORT-002
+is amended.
+
+**Tor is the near miss, and it clears.** 15 CFR 772.1 defines non-standard
+cryptography as functionality "that ha[s] not been adopted or approved by a
+duly recognized international standards body (e.g., IEEE, IETF, ISO, ITU,
+ETSI, 3GPP, TIA, and GSMA) **and** ha[s] not otherwise been published". Tor's
+circuit protocol and ntor handshake are not IETF standards, so the first limb
+is met. The second is not: the protocol is published in full at
+spec.torproject.org, the implementation is open source, and the primitives
+under it are AES, SHA-2, Curve25519 (RFC 7748), Ed25519 (RFC 8032) and TLS
+(RFC 8446). The test is conjunctive, so an unratified but published protocol
+is not non-standard cryptography. A future component that is *unpublished*
+fails on the second limb no matter how standard its primitives are, and that
+is the case to watch for.
+
+**`true` is not the cautious alternative.** It obliges an
+`ITSEncryptionExportComplianceCode`, which Apple issues only after approving
+uploaded documentation; for standard algorithms that documentation is the
+French ANSSI declaration, required when distributing in France and reported
+to take one to two months. Until the code exists every upload is rejected as
+ITMS-90592, which is how #344 blocked releases.
+[scripts/check_ios_export_compliance.sh](../../../scripts/check_ios_export_compliance.sh)
+gates the two keys against each other on the fastlane deploy lanes.
 
 #### Scenario: Key present
 
 - **GIVEN** `ios/Runner/Info.plist`
-- **THEN** `ITSAppUsesNonExemptEncryption` is `true`
+- **THEN** `ITSAppUsesNonExemptEncryption` is `false`
+- **AND** no `ITSEncryptionExportComplianceCode` is present
+
+#### Scenario: A change introduces a non-standard algorithm
+
+- **GIVEN** a proprietary or unpublished cryptographic algorithm is added,
+  contrary to EXPORT-002
+- **THEN** the 15 CFR 742.15(b)(2) notification naming the source location is
+  sent to BIS and the ENC Encryption Request Coordinator before release
+- **AND** the date it was sent is recorded in this requirement
 
 ---
 

--- a/openspec/specs/legal/spec.md
+++ b/openspec/specs/legal/spec.md
@@ -16,17 +16,31 @@ encryption declaration, and MIT as the licence of the shipped work.
 
 ### EXPORT-001 - Encryption declaration
 
-The iOS bundle SHALL declare `ITSAppUsesNonExemptEncryption` as `false`.
+The iOS bundle SHALL declare `ITSAppUsesNonExemptEncryption` as `true`, and
+SHALL carry the App Store Connect compliance code as
+`ITSEncryptionExportComplianceCode` once Apple issues it. Normative detail,
+including the pre-submission gate, is TOR-010 in
+[the tor-proxy change](../../changes/add-ios-tor-proxy/specs/tor-proxy/spec.md)
+until that change is archived.
 
-Basis: the source is published under a licence permitting further
-dissemination, so the object code is not subject to the EAR (note to
-15 CFR 734.3(b)(3), criteria in 15 CFR 742.15(b)). This rests on EXPORT-002
-and EXPORT-003; revisit it if either stops holding.
+This requirement previously read `false`, on the basis that the source is
+published under a licence permitting further dissemination, so the object
+code is not subject to the EAR (note to 15 CFR 734.3(b)(3), criteria in
+15 CFR 742.15(b)). TOR-010 superseded it in #344, when `pod 'Tor'` began
+linking tor's TLS and OpenSSL into the binary; the app also implements AES
+at rest (EXPORT-002), so `false` was already doubtful on the OS-provided
+exemption alone.
+
+Two things that argument did not settle, recorded so the next reader does
+not assume they were: it answered only the OS-provided and
+authentication-only exemptions, never the publicly-available-source basis
+above, and no 15 CFR 742.15(b) notification is recorded anywhere in this
+repo. Reopening `false` means resolving both, not just citing the licence.
 
 #### Scenario: Key present
 
 - **GIVEN** `ios/Runner/Info.plist`
-- **THEN** `ITSAppUsesNonExemptEncryption` is `false`
+- **THEN** `ITSAppUsesNonExemptEncryption` is `true`
 
 ---
 

--- a/scripts/check_ios_export_compliance.sh
+++ b/scripts/check_ios_export_compliance.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Verify the two export-compliance keys in ios/Runner/Info.plist agree before
+# a build is handed to App Store Connect.
+#
+# ITSAppUsesNonExemptEncryption is only half the declaration. Once Apple
+# approves the uploaded encryption documentation it issues a compliance code,
+# and the binary must carry it as ITSEncryptionExportComplianceCode. A build
+# declaring `true` with the code absent compiles, archives and exports
+# cleanly, produces a valid-looking IPA, and is rejected only by App Store
+# Connect at upload:
+#
+#   Invalid Export Compliance Code. The export compliance key value [] in the
+#   app's Info.plist doesn't match the key value of the app's export
+#   compliance documentation. (ITMS-90592)
+#
+# Nothing between the edit and the upload notices, which is why this exists.
+# See TOR-010 in openspec/changes/add-ios-tor-proxy/specs/tor-proxy/spec.md.
+#
+# Deliberately NOT wired into CI or `flutter build ipa`: the code does not
+# exist until Apple finishes reviewing the documentation, so a commit-time
+# gate would be red for the whole turnaround. This is a property of a
+# submission, not of the source tree, so it runs on the fastlane deploy lanes.
+#
+# Usage: scripts/check_ios_export_compliance.sh [path-to-Info.plist]
+
+set -euo pipefail
+
+PLIST="${1:-$(dirname "$0")/../ios/Runner/Info.plist}"
+
+if [[ ! -f "$PLIST" ]]; then
+  echo "ERROR: Info.plist not found: $PLIST" >&2
+  exit 2
+fi
+
+# Print the first element following <key>$1</key>, whitespace trimmed. Empty
+# when the key is absent.
+plist_value_after_key() {
+  awk -v key="$1" '
+    index($0, "<key>" key "</key>") { found = 1; next }
+    found {
+      gsub(/^[ \t]+|[ \t\r]+$/, "")
+      if ($0 == "") next
+      print
+      exit
+    }
+  ' "$PLIST"
+}
+
+declared=$(plist_value_after_key ITSAppUsesNonExemptEncryption)
+code=$(plist_value_after_key ITSEncryptionExportComplianceCode |
+  sed -e 's|^<string>||' -e 's|</string>$||')
+
+case "$declared" in
+  "")
+    cat >&2 <<'MSG'
+ERROR: ios/Runner/Info.plist declares no ITSAppUsesNonExemptEncryption.
+
+Omitting it does not skip the question; it stalls every submission on the
+export-compliance prompt in App Store Connect instead.
+MSG
+    exit 1
+    ;;
+  "<true/>")
+    if [[ -z "$code" ]]; then
+      cat >&2 <<'MSG'
+ERROR: ITSAppUsesNonExemptEncryption is <true/> but
+ITSEncryptionExportComplianceCode is missing or empty.
+
+App Store Connect will reject the upload with ITMS-90592:
+
+  Invalid Export Compliance Code. The export compliance key value [] in the
+  app's Info.plist doesn't match the key value of the app's export compliance
+  documentation.
+
+The code is issued after Apple approves the encryption documentation:
+App Store Connect > My Apps > Webspace > App Information > App Encryption
+Documentation. Add it to ios/Runner/Info.plist as
+
+  <key>ITSEncryptionExportComplianceCode</key>
+  <string>the-code-apple-gave-you</string>
+
+Do not invent a value. A wrong code is a false statement on a submission
+form, not a rejected upload.
+MSG
+      exit 1
+    fi
+    ;;
+  "<false/>")
+    if [[ -n "$code" ]]; then
+      cat >&2 <<MSG
+ERROR: ITSAppUsesNonExemptEncryption is <false/> but
+ITSEncryptionExportComplianceCode is set to "$code".
+
+An exempt declaration carries no compliance code. This is the same mismatch
+ITMS-90592 reports, in the other direction: drop the code key, or set the
+declaration back to <true/>.
+MSG
+      exit 1
+    fi
+    ;;
+  *)
+    echo "ERROR: ITSAppUsesNonExemptEncryption has a non-boolean value: $declared" >&2
+    exit 1
+    ;;
+esac
+
+echo "OK: export compliance keys agree (ITSAppUsesNonExemptEncryption=$declared)."

--- a/test/js/ios_compliance_declarations.test.js
+++ b/test/js/ios_compliance_declarations.test.js
@@ -19,6 +19,8 @@ const exists = (p) => fs.existsSync(path.join(repo, p));
 const INFO_PLIST = 'ios/Runner/Info.plist';
 const PRIVACY_MANIFEST = 'ios/Runner/PrivacyInfo.xcprivacy';
 const PBXPROJ = 'ios/Runner.xcodeproj/project.pbxproj';
+const FASTFILE = 'ios/fastlane/Fastfile';
+const COMPLIANCE_CHECK = 'scripts/check_ios_export_compliance.sh';
 
 /** Value of a <key>…</key> followed by <true/> or <false/>. */
 function boolForKey(plist, key) {
@@ -26,6 +28,22 @@ function boolForKey(plist, key) {
     new RegExp(`<key>${key}</key>\\s*<(true|false)\\s*/>`),
   );
   return m ? m[1] === 'true' : null;
+}
+
+/** Value of a <key>…</key> followed by <string>…</string>. */
+function stringForKey(plist, key) {
+  const m = plist.match(
+    new RegExp(`<key>${key}</key>\\s*<string>([^<]*)</string>`),
+  );
+  return m ? m[1] : null;
+}
+
+/** Fastlane lane bodies keyed by lane name. */
+function lanes(fastfile) {
+  return Object.fromEntries(
+    fastfile.split(/^  lane :/m).slice(1)
+      .map((part) => [part.match(/^(\w+)/)[1], part]),
+  );
 }
 
 test('TOR-010: the app declares non-exempt encryption', () => {
@@ -43,6 +61,67 @@ test('TOR-010: the app declares non-exempt encryption', () => {
     'authentication-only use, so `false` here is a false declaration to ' +
     'Apple, not a guideline nit a review would bounce back. See TOR-010.',
   );
+});
+
+// `true` is only half the declaration: once App Store Connect approves the
+// encryption documentation Apple issues a code, and a build declaring `true`
+// without it is rejected at upload with ITMS-90592 ("the export compliance
+// key value [] ... doesn't match"). It archives and exports cleanly first, so
+// the source tree cannot tell the two states apart — which is why the real
+// gate is a pre-submission script and this only fixes the shape.
+test('TOR-010: the compliance code, if declared, is not empty', () => {
+  const plist = read(INFO_PLIST);
+  const code = stringForKey(plist, 'ITSEncryptionExportComplianceCode');
+  if (code !== null) {
+    assert.notStrictEqual(
+      code.trim(), '',
+      `${INFO_PLIST} declares an empty ITSEncryptionExportComplianceCode. ` +
+      'That is the exact value App Store Connect reports as [] when it ' +
+      'rejects the upload. Use the code Apple issued, or drop the key.',
+    );
+  }
+  if (boolForKey(plist, 'ITSAppUsesNonExemptEncryption') === false) {
+    assert.strictEqual(
+      code, null,
+      `${INFO_PLIST} declares encryption exempt but still carries an ` +
+      'ITSEncryptionExportComplianceCode. An exempt declaration has no code.',
+    );
+  }
+});
+
+// The value of a gate here is that it fails for a *third* deploy lane too,
+// which is how this recurs: the check is one line that a new lane forgets,
+// and forgetting it costs a full upload round-trip to find out.
+test('TOR-010: every lane that uploads a binary checks export compliance', () => {
+  assert.ok(
+    exists(COMPLIANCE_CHECK),
+    `${COMPLIANCE_CHECK} is missing; the deploy lanes call it before upload.`,
+  );
+  const fastfile = read(FASTFILE);
+  assert.match(
+    fastfile, new RegExp(COMPLIANCE_CHECK.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+    `${FASTFILE} defines check_export_compliance but never runs ` +
+    `${COMPLIANCE_CHECK}.`,
+  );
+
+  const uploading = Object.entries(lanes(fastfile)).filter(
+    ([, body]) =>
+      /upload_to_testflight|upload_to_app_store/.test(body) &&
+      !/skip_binary_upload:\s*true/.test(body),
+  );
+  assert.ok(
+    uploading.length > 0,
+    `${FASTFILE} has no binary-uploading lane; did the parser break?`,
+  );
+  for (const [name, body] of uploading) {
+    assert.match(
+      body, /check_export_compliance/,
+      `Lane :${name} uploads a binary to App Store Connect without calling ` +
+      'check_export_compliance first. A mismatched export-compliance key is ' +
+      'only diagnosed by Apple at upload (ITMS-90592), so the check has to ' +
+      'run before the binary is sent. See TOR-010.',
+    );
+  }
 });
 
 test('TOR-011: required-reason APIs are declared in a privacy manifest', () => {

--- a/test/js/ios_compliance_declarations.test.js
+++ b/test/js/ios_compliance_declarations.test.js
@@ -1,7 +1,7 @@
 // Structural gates for the two iOS submission declarations that are easy to
 // get wrong and impossible to notice: they are not code, nothing imports
 // them, no test exercises them, and both fail silently — a wrong
-// ITSAppUsesNonExemptEncryption is a false statement on a submission form
+// a wrong ITSAppUsesNonExemptEncryption is a false statement on a submission
 // that ships, and a privacy manifest in the wrong file is simply not read.
 //
 // Spec: openspec/changes/add-ios-tor-proxy/specs/tor-proxy/spec.md
@@ -46,7 +46,7 @@ function lanes(fastfile) {
   );
 }
 
-test('TOR-010: the app declares non-exempt encryption', () => {
+test('TOR-010: the app declares its encryption exempt', () => {
   const declared = boolForKey(read(INFO_PLIST), 'ITSAppUsesNonExemptEncryption');
   assert.notStrictEqual(
     declared, null,
@@ -54,12 +54,14 @@ test('TOR-010: the app declares non-exempt encryption', () => {
     'stalls every submission on the export-compliance prompt.',
   );
   assert.strictEqual(
-    declared, true,
-    'The app ships its own cryptography (AES at rest in archive_crypto.dart ' +
-    'and html_cache_service.dart; tor\'s TLS and onion routing via ' +
-    'Tor.framework). Apple\'s exemption covers OS-provided encryption and ' +
-    'authentication-only use, so `false` here is a false declaration to ' +
-    'Apple, not a guideline nit a review would bounce back. See TOR-010.',
+    declared, false,
+    'EXPORT-001 rests on publicly available source (MIT, 15 CFR ' +
+    '734.3(b)(3) note, 742.15(b)(1)), not on Apple\'s OS-provided ' +
+    'exemption. The app does ship its own cryptography, and that is not ' +
+    'what decides this key. `true` obliges an ' +
+    'ITSEncryptionExportComplianceCode that Apple issues only after ' +
+    'approving uploaded documentation, so flipping it here rejects every ' +
+    'upload with ITMS-90592 until the code exists. See EXPORT-001.',
   );
 });
 


### PR DESCRIPTION
ITSAppUsesNonExemptEncryption=true without its matching
ITSEncryptionExportComplianceCode archives and exports cleanly, so the
mismatch is only diagnosed by App Store Connect at upload (ITMS-90592).
Check the pair on the fastlane deploy lanes instead.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N4T8ozxK7vyfPz9e9qW6HM