### PR TITLE
Replace per-site DNS level picker with shared slider widget

### DIFF
--- a/lib/l10n/app_af.arb
+++ b/lib/l10n/app_af.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Nie beskikbaar nie. ’n Skermopname dek die hele skerm en sou dus ook jou ander werwe wys.",
   "siteSettingsDnsBlocklistLevel": "Bloklysvlak",
   "siteSettingsDnsBlocklistLevelHint": "Elke vlak blokkeer meer domeine as die een daaronder. Verlaag dit vir 'n werf wat die bloklys breek, sodat dit steeds 'n mate van beskerming behou in plaas van niks nie. 'n Vlak wat die program nog nie afgelaai het nie, word gehaal wanneer jy dit kies.",
-  "siteSettingsDnsLevelFollowApp": "Dieselfde as programinstellings",
+  "siteSettingsDnsLevelFollowAppShort": "Program",
   "siteSettingsDnsLevelFollowsApp": "Dieselfde as programinstellings ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Nog nie afgelaai nie, gebruik tans {level}",
   "siteSettingsDnsLevelDownloading": "Bloklys word afgelaai...",

--- a/lib/l10n/app_am.arb
+++ b/lib/l10n/app_am.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "አይገኝም። የማያ ገጽ ቀረጻ ሙሉውን ማያ ገጽ ስለሚይዝ ሌሎች ጣቢያዎችዎንም ያሳያል።",
   "siteSettingsDnsBlocklistLevel": "የማገጃ ዝርዝር ደረጃ",
   "siteSettingsDnsBlocklistLevelHint": "እያንዳንዱ ደረጃ ከታችኛው ደረጃ የበለጠ ጎራዎችን ያግዳል። የማገጃ ዝርዝሩ የሚያበላሸውን ጣቢያ ሙሉ በሙሉ ጥበቃ ከማጣት ይልቅ የተወሰነ ጥበቃ እንዲይዝ ደረጃውን ዝቅ ያድርጉ። መተግበሪያው ገና ያላወረደው ደረጃ ሲመርጡት ይወርዳል።",
-  "siteSettingsDnsLevelFollowApp": "እንደ የመተግበሪያ ቅንብሮች",
+  "siteSettingsDnsLevelFollowAppShort": "መተግበሪያ",
   "siteSettingsDnsLevelFollowsApp": "እንደ የመተግበሪያ ቅንብሮች ({level})",
   "siteSettingsDnsLevelNeedsDownload": "ገና አልወረደም፣ {level} በመጠቀም ላይ",
   "siteSettingsDnsLevelDownloading": "የማገጃ ዝርዝር በመውረድ ላይ...",

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "غير متاح. تسجيل الشاشة يغطي الشاشة بأكملها، وبذلك يعرض أيضًا مواقعك الأخرى.",
   "siteSettingsDnsBlocklistLevel": "مستوى قائمة الحظر",
   "siteSettingsDnsBlocklistLevelHint": "يحظر كل مستوى نطاقات أكثر من المستوى الذي تحته. اخفض المستوى لموقع تعطّله قائمة الحظر، لكي يحتفظ ببعض الحماية بدلاً من فقدانها كلها. أي مستوى لم ينزّله التطبيق بعد يُنزَّل عند اختياره.",
-  "siteSettingsDnsLevelFollowApp": "مثل إعدادات التطبيق",
+  "siteSettingsDnsLevelFollowAppShort": "التطبيق",
   "siteSettingsDnsLevelFollowsApp": "مثل إعدادات التطبيق ({level})",
   "siteSettingsDnsLevelNeedsDownload": "لم يُنزَّل بعد، يُستخدم {level}",
   "siteSettingsDnsLevelDownloading": "جارٍ تنزيل قائمة الحظر...",

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Не е налично. Записът на екрана обхваща целия екран и затова би показал и другите ви сайтове.",
   "siteSettingsDnsBlocklistLevel": "Ниво на списъка за блокиране",
   "siteSettingsDnsBlocklistLevelHint": "Всяко ниво блокира повече домейни от предходното. Понижете го за сайт, който списъкът разваля, за да запази някаква защита вместо никаква. Ниво, което приложението още не е изтеглило, се изтегля при избирането му.",
-  "siteSettingsDnsLevelFollowApp": "Като настройките на приложението",
+  "siteSettingsDnsLevelFollowAppShort": "Приложение",
   "siteSettingsDnsLevelFollowsApp": "Като настройките на приложението ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Още не е изтеглено, използва се {level}",
   "siteSettingsDnsLevelDownloading": "Изтегляне на списъка за блокиране...",

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "উপলব্ধ নয়। স্ক্রিন ক্যাপচার পুরো স্ক্রিন ধারণ করে, তাই এটি আপনার অন্যান্য সাইটও দেখাত।",
   "siteSettingsDnsBlocklistLevel": "ব্লকতালিকার স্তর",
   "siteSettingsDnsBlocklistLevelHint": "প্রতিটি স্তর তার নিচের স্তরের চেয়ে বেশি ডোমেইন ব্লক করে। যে সাইট ব্লকতালিকার কারণে ভেঙে যায় তার জন্য স্তর কমিয়ে দিন, যাতে পুরো সুরক্ষা হারানোর বদলে কিছুটা সুরক্ষা থাকে। অ্যাপ যে স্তর এখনও নামায়নি, সেটি বেছে নিলে নামানো হয়।",
-  "siteSettingsDnsLevelFollowApp": "অ্যাপ সেটিংসের মতোই",
+  "siteSettingsDnsLevelFollowAppShort": "অ্যাপ",
   "siteSettingsDnsLevelFollowsApp": "অ্যাপ সেটিংসের মতোই ({level})",
   "siteSettingsDnsLevelNeedsDownload": "এখনও নামানো হয়নি, {level} ব্যবহার করা হচ্ছে",
   "siteSettingsDnsLevelDownloading": "ব্লকতালিকা নামানো হচ্ছে...",

--- a/lib/l10n/app_bs.arb
+++ b/lib/l10n/app_bs.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Nije dostupno. Snimanje ekrana obuhvata cijeli ekran, pa bi prikazalo i vaše druge stranice.",
   "siteSettingsDnsBlocklistLevel": "Nivo liste blokiranja",
   "siteSettingsDnsBlocklistLevelHint": "Svaki nivo blokira više domena od onog ispod njega. Snizite ga za stranicu koju lista blokiranja kvari, kako bi zadržala nešto zaštite umjesto nijedne. Nivo koji aplikacija još nije preuzela preuzima se kada ga odaberete.",
-  "siteSettingsDnsLevelFollowApp": "Isto kao postavke aplikacije",
+  "siteSettingsDnsLevelFollowAppShort": "Aplikacija",
   "siteSettingsDnsLevelFollowsApp": "Isto kao postavke aplikacije ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Još nije preuzeto, koristi se {level}",
   "siteSettingsDnsLevelDownloading": "Preuzimanje liste blokiranja...",

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "No disponible. Una captura de pantalla abasta tota la pantalla, de manera que també mostraria els vostres altres llocs.",
   "siteSettingsDnsBlocklistLevel": "Nivell de la llista de bloqueig",
   "siteSettingsDnsBlocklistLevelHint": "Cada nivell bloqueja més dominis que el de sota. Baixa'l per a un lloc que la llista de bloqueig espatlla, així conserva una mica de protecció en lloc de cap. Un nivell que l'aplicació encara no ha baixat es descarrega quan el tries.",
-  "siteSettingsDnsLevelFollowApp": "Igual que la configuració de l'aplicació",
+  "siteSettingsDnsLevelFollowAppShort": "Aplicació",
   "siteSettingsDnsLevelFollowsApp": "Igual que la configuració de l'aplicació ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Encara no s'ha baixat; s'utilitza {level}",
   "siteSettingsDnsLevelDownloading": "S'està baixant la llista de bloqueig...",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Není k dispozici. Záznam obrazovky pokrývá celou obrazovku, takže by ukázal i vaše ostatní weby.",
   "siteSettingsDnsBlocklistLevel": "Úroveň seznamu blokování",
   "siteSettingsDnsBlocklistLevelHint": "Každá úroveň blokuje více domén než ta pod ní. Pro web, který seznam blokování rozbíjí, ji snižte, aby si zachoval alespoň nějakou ochranu místo žádné. Úroveň, kterou aplikace zatím nestáhla, se stáhne, jakmile ji zvolíte.",
-  "siteSettingsDnsLevelFollowApp": "Stejně jako nastavení aplikace",
+  "siteSettingsDnsLevelFollowAppShort": "Aplikace",
   "siteSettingsDnsLevelFollowsApp": "Stejně jako nastavení aplikace ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Zatím nestaženo, používá se {level}",
   "siteSettingsDnsLevelDownloading": "Stahování seznamu blokování...",

--- a/lib/l10n/app_cy.arb
+++ b/lib/l10n/app_cy.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Ddim ar gael. Mae recordiad sgrin yn cwmpasu'r sgrin gyfan, felly byddai hefyd yn dangos eich gwefannau eraill.",
   "siteSettingsDnsBlocklistLevel": "Lefel y rhestr rwystro",
   "siteSettingsDnsBlocklistLevelHint": "Mae pob lefel yn rhwystro mwy o barthau na'r un oddi tani. Gostyngwch hi ar gyfer safle y mae'r rhestr rwystro yn ei dorri, fel ei fod yn cadw rhywfaint o amddiffyniad yn hytrach na dim. Caiff lefel nad yw'r ap wedi ei lawrlwytho eto ei nôl pan fyddwch yn ei dewis.",
-  "siteSettingsDnsLevelFollowApp": "Yr un fath â gosodiadau'r ap",
+  "siteSettingsDnsLevelFollowAppShort": "Ap",
   "siteSettingsDnsLevelFollowsApp": "Yr un fath â gosodiadau'r ap ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Heb ei lawrlwytho eto, yn defnyddio {level}",
   "siteSettingsDnsLevelDownloading": "Wrthi'n lawrlwytho'r rhestr rwystro...",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Ikke tilgængelig. En skærmoptagelse dækker hele skærmen og ville derfor også vise dine andre websteder.",
   "siteSettingsDnsBlocklistLevel": "Blokeringslisteniveau",
   "siteSettingsDnsBlocklistLevelHint": "Hvert niveau blokerer flere domæner end niveauet under. Sænk det for et websted, som blokeringslisten ødelægger, så det beholder en vis beskyttelse i stedet for ingen. Et niveau, appen endnu ikke har hentet, hentes, når du vælger det.",
-  "siteSettingsDnsLevelFollowApp": "Samme som appindstillinger",
+  "siteSettingsDnsLevelFollowAppShort": "App",
   "siteSettingsDnsLevelFollowsApp": "Samme som appindstillinger ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Endnu ikke hentet, bruger {level}",
   "siteSettingsDnsLevelDownloading": "Henter blokeringsliste...",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Nicht verfügbar. Eine Bildschirmaufnahme erfasst den gesamten Bildschirm und würde damit auch Ihre anderen Websites zeigen.",
   "siteSettingsDnsBlocklistLevel": "Sperrlisten-Stufe",
   "siteSettingsDnsBlocklistLevelHint": "Jede Stufe blockiert mehr Domains als die darunter. Senken Sie sie für eine Website, die durch die Sperrliste kaputtgeht, damit ein Rest an Schutz bleibt statt gar keiner. Eine Stufe, die die App noch nicht heruntergeladen hat, wird beim Auswählen geholt.",
-  "siteSettingsDnsLevelFollowApp": "Wie in den App-Einstellungen",
+  "siteSettingsDnsLevelFollowAppShort": "App",
   "siteSettingsDnsLevelFollowsApp": "Wie in den App-Einstellungen ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Noch nicht heruntergeladen, verwendet {level}",
   "siteSettingsDnsLevelDownloading": "Sperrliste wird heruntergeladen...",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Μη διαθέσιμο. Μια καταγραφή οθόνης καλύπτει ολόκληρη την οθόνη, οπότε θα εμφάνιζε και τους άλλους ιστότοπούς σας.",
   "siteSettingsDnsBlocklistLevel": "Επίπεδο λίστας αποκλεισμού",
   "siteSettingsDnsBlocklistLevelHint": "Κάθε επίπεδο αποκλείει περισσότερους τομείς από το προηγούμενο. Χαμηλώστε το για έναν ιστότοπο που χαλάει από τη λίστα αποκλεισμού, ώστε να κρατήσει κάποια προστασία αντί για καμία. Ένα επίπεδο που η εφαρμογή δεν έχει κατεβάσει ακόμη λαμβάνεται μόλις το επιλέξετε.",
-  "siteSettingsDnsLevelFollowApp": "Όπως στις ρυθμίσεις της εφαρμογής",
+  "siteSettingsDnsLevelFollowAppShort": "Εφαρμογή",
   "siteSettingsDnsLevelFollowsApp": "Όπως στις ρυθμίσεις της εφαρμογής ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Δεν έχει ληφθεί ακόμη, χρησιμοποιείται το {level}",
   "siteSettingsDnsLevelDownloading": "Λήψη λίστας αποκλεισμού...",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3806,9 +3806,9 @@
   "@siteSettingsDnsBlocklistLevelHint": {
     "description": "Explanation shown in the hint dialog next to the per-site blocklist level row."
   },
-  "siteSettingsDnsLevelFollowApp": "Same as app settings",
-  "@siteSettingsDnsLevelFollowApp": {
-    "description": "Option in the per-site blocklist level picker meaning the site tracks the app-wide level."
+  "siteSettingsDnsLevelFollowAppShort": "App",
+  "@siteSettingsDnsLevelFollowAppShort": {
+    "description": "Label under the leftmost stop of the per-site blocklist level slider, meaning the site tracks the app-wide level. It sits in a row of six tick labels, so keep it to one short word; the row's subtitle spells the setting out in full."
   },
   "siteSettingsDnsLevelFollowsApp": "Same as app settings ({level})",
   "@siteSettingsDnsLevelFollowsApp": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "No disponible. Una captura de pantalla abarca toda la pantalla, así que también mostraría tus otros sitios.",
   "siteSettingsDnsBlocklistLevel": "Nivel de la lista de bloqueo",
   "siteSettingsDnsBlocklistLevelHint": "Cada nivel bloquea más dominios que el anterior. Bájalo para un sitio que la lista de bloqueo rompe, así conserva algo de protección en vez de ninguna. Un nivel que la aplicación aún no ha descargado se descarga al elegirlo.",
-  "siteSettingsDnsLevelFollowApp": "Igual que los ajustes de la aplicación",
+  "siteSettingsDnsLevelFollowAppShort": "Aplicación",
   "siteSettingsDnsLevelFollowsApp": "Igual que los ajustes de la aplicación ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Aún no descargado; se usa {level}",
   "siteSettingsDnsLevelDownloading": "Descargando la lista de bloqueo...",

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Pole saadaval. Ekraanisalvestus katab kogu ekraani ja näitaks seega ka sinu teisi saite.",
   "siteSettingsDnsBlocklistLevel": "Blokeerimisloendi tase",
   "siteSettingsDnsBlocklistLevelHint": "Iga tase blokeerib rohkem domeene kui sellest allpool olev. Langeta seda saidi puhul, mille blokeerimisloend katki teeb, et jääks siiski mingi kaitse, mitte üldse mitte midagi. Taseme, mida rakendus pole veel alla laadinud, laadib ta alla, kui selle valid.",
-  "siteSettingsDnsLevelFollowApp": "Sama mis rakenduse seaded",
+  "siteSettingsDnsLevelFollowAppShort": "Rakendus",
   "siteSettingsDnsLevelFollowsApp": "Sama mis rakenduse seaded ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Pole veel alla laaditud, kasutusel on {level}",
   "siteSettingsDnsLevelDownloading": "Blokeerimisloendi allalaadimine...",

--- a/lib/l10n/app_eu.arb
+++ b/lib/l10n/app_eu.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Ez dago erabilgarri. Pantaila-kapturak pantaila osoa hartzen du, eta beraz zure beste guneak ere erakutsiko lituzke.",
   "siteSettingsDnsBlocklistLevel": "Blokeo-zerrendaren maila",
   "siteSettingsDnsBlocklistLevelHint": "Maila bakoitzak azpikoak baino domeinu gehiago blokeatzen ditu. Jaitsi ezazu blokeo-zerrendak hausten duen gune baterako, babes apur bat gorde dezan bat ere ez izan beharrean. Aplikazioak oraindik deskargatu ez duen maila bat aukeratzean deskargatzen da.",
-  "siteSettingsDnsLevelFollowApp": "Aplikazioaren ezarpenen berdina",
+  "siteSettingsDnsLevelFollowAppShort": "Aplikazioa",
   "siteSettingsDnsLevelFollowsApp": "Aplikazioaren ezarpenen berdina ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Oraindik ez da deskargatu, {level} erabiltzen",
   "siteSettingsDnsLevelDownloading": "Blokeo-zerrenda deskargatzen...",

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "در دسترس نیست. ضبط صفحه کل صفحه را دربر می‌گیرد و بنابراین سایت‌های دیگر شما را هم نشان می‌دهد.",
   "siteSettingsDnsBlocklistLevel": "سطح فهرست مسدودسازی",
   "siteSettingsDnsBlocklistLevelHint": "هر سطح دامنه‌های بیشتری از سطح پایین‌تر مسدود می‌کند. برای سایتی که فهرست مسدودسازی خرابش می‌کند آن را پایین بیاورید تا به‌جای هیچ محافظتی، اندکی محافظت باقی بماند. سطحی که برنامه هنوز دریافت نکرده، هنگام انتخاب دریافت می‌شود.",
-  "siteSettingsDnsLevelFollowApp": "مانند تنظیمات برنامه",
+  "siteSettingsDnsLevelFollowAppShort": "برنامه",
   "siteSettingsDnsLevelFollowsApp": "مانند تنظیمات برنامه ({level})",
   "siteSettingsDnsLevelNeedsDownload": "هنوز دریافت نشده؛ {level} در حال استفاده است",
   "siteSettingsDnsLevelDownloading": "در حال دریافت فهرست مسدودسازی...",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Ei käytettävissä. Näytön tallennus kattaa koko näytön, joten se näyttäisi myös muut sivustosi.",
   "siteSettingsDnsBlocklistLevel": "Estolistan taso",
   "siteSettingsDnsBlocklistLevelHint": "Jokainen taso estää enemmän verkkotunnuksia kuin sitä alempi. Laske sitä sivustolle, jonka estolista rikkoo, jotta se säilyttää edes jonkin verran suojaa eikä menetä kaikkea. Tason, jota sovellus ei ole vielä ladannut, se hakee kun valitset sen.",
-  "siteSettingsDnsLevelFollowApp": "Sama kuin sovelluksen asetuksissa",
+  "siteSettingsDnsLevelFollowAppShort": "Sovellus",
   "siteSettingsDnsLevelFollowsApp": "Sama kuin sovelluksen asetuksissa ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Ei vielä ladattu, käytössä {level}",
   "siteSettingsDnsLevelDownloading": "Ladataan estolistaa...",

--- a/lib/l10n/app_fil.arb
+++ b/lib/l10n/app_fil.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Hindi available. Sinasakop ng screen capture ang buong screen, kaya ipapakita rin nito ang iba mong site.",
   "siteSettingsDnsBlocklistLevel": "Antas ng blocklist",
   "siteSettingsDnsBlocklistLevelHint": "Mas maraming domain ang hinaharangan ng bawat antas kaysa sa nasa ilalim nito. Ibaba ito para sa site na nasisira ng blocklist, para may natitira pa ring proteksyon sa halip na wala. Ang antas na hindi pa na-download ng app ay kukunin kapag pinili mo ito.",
-  "siteSettingsDnsLevelFollowApp": "Kapareho ng mga setting ng app",
+  "siteSettingsDnsLevelFollowAppShort": "App",
   "siteSettingsDnsLevelFollowsApp": "Kapareho ng mga setting ng app ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Hindi pa na-download, ginagamit ang {level}",
   "siteSettingsDnsLevelDownloading": "Dina-download ang blocklist...",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Indisponible. Une capture d'écran couvre tout l'écran et montrerait donc aussi vos autres sites.",
   "siteSettingsDnsBlocklistLevel": "Niveau de la liste de blocage",
   "siteSettingsDnsBlocklistLevelHint": "Chaque niveau bloque plus de domaines que celui du dessous. Abaissez-le pour un site que la liste de blocage casse, afin qu'il garde une protection partielle plutôt qu'aucune. Un niveau que l'application n'a pas encore téléchargé est récupéré au moment où vous le choisissez.",
-  "siteSettingsDnsLevelFollowApp": "Comme les réglages de l'application",
+  "siteSettingsDnsLevelFollowAppShort": "Appli",
   "siteSettingsDnsLevelFollowsApp": "Comme les réglages de l'application ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Pas encore téléchargé, utilisation de {level}",
   "siteSettingsDnsLevelDownloading": "Téléchargement de la liste de blocage...",

--- a/lib/l10n/app_ga.arb
+++ b/lib/l10n/app_ga.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Níl sé ar fáil. Clúdaíonn taifeadadh scáileáin an scáileán ar fad, agus mar sin thaispeánfadh sé do shuímh eile freisin.",
   "siteSettingsDnsBlocklistLevel": "Leibhéal an liosta bactha",
   "siteSettingsDnsBlocklistLevelHint": "Cuireann gach leibhéal cosc ar níos mó fearann ná an ceann faoi. Ísligh é do shuíomh a bhriseann an liosta bactha, ionas go gcoinneoidh sé roinnt cosanta seachas a dhath. Íoslódáiltear leibhéal nach bhfuil ag an aip fós nuair a roghnaíonn tú é.",
-  "siteSettingsDnsLevelFollowApp": "Mar an gcéanna le socruithe na haipe",
+  "siteSettingsDnsLevelFollowAppShort": "Aip",
   "siteSettingsDnsLevelFollowsApp": "Mar an gcéanna le socruithe na haipe ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Gan íoslódáil fós, {level} in úsáid",
   "siteSettingsDnsLevelDownloading": "An liosta bactha á íoslódáil...",

--- a/lib/l10n/app_gl.arb
+++ b/lib/l10n/app_gl.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Non dispoñible. Unha captura de pantalla abrangue toda a pantalla, polo que tamén amosaría os teus outros sitios.",
   "siteSettingsDnsBlocklistLevel": "Nivel da lista de bloqueo",
   "siteSettingsDnsBlocklistLevelHint": "Cada nivel bloquea máis dominios que o anterior. Báixao para un sitio que a lista de bloqueo estraga, así conserva algo de protección en lugar de ningunha. Un nivel que a aplicación aínda non descargou obtense ao escollelo.",
-  "siteSettingsDnsLevelFollowApp": "Igual que os axustes da aplicación",
+  "siteSettingsDnsLevelFollowAppShort": "Aplicación",
   "siteSettingsDnsLevelFollowsApp": "Igual que os axustes da aplicación ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Aínda non descargado; úsase {level}",
   "siteSettingsDnsLevelDownloading": "Descargando a lista de bloqueo...",

--- a/lib/l10n/app_gu.arb
+++ b/lib/l10n/app_gu.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "ઉપલબ્ધ નથી. સ્ક્રીન કૅપ્ચર આખી સ્ક્રીનને આવરી લે છે, તેથી તે તમારી બીજી સાઇટ્સ પણ બતાવત.",
   "siteSettingsDnsBlocklistLevel": "બ્લોકસૂચિનું સ્તર",
   "siteSettingsDnsBlocklistLevelHint": "દરેક સ્તર તેની નીચેના સ્તર કરતાં વધુ ડોમેન બ્લોક કરે છે. જે સાઇટ બ્લોકસૂચિથી બગડે તેના માટે સ્તર ઘટાડો, જેથી કોઈ સુરક્ષા ન રહેવાને બદલે થોડી સુરક્ષા જળવાઈ રહે. એપે હજી ડાઉનલોડ ન કરેલું સ્તર તમે પસંદ કરો ત્યારે મેળવવામાં આવે છે.",
-  "siteSettingsDnsLevelFollowApp": "એપ સેટિંગ્સ પ્રમાણે જ",
+  "siteSettingsDnsLevelFollowAppShort": "ઍપ",
   "siteSettingsDnsLevelFollowsApp": "એપ સેટિંગ્સ પ્રમાણે જ ({level})",
   "siteSettingsDnsLevelNeedsDownload": "હજી ડાઉનલોડ થયું નથી, {level} વપરાય છે",
   "siteSettingsDnsLevelDownloading": "બ્લોકસૂચિ ડાઉનલોડ થઈ રહી છે...",

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "לא זמין. הקלטת מסך מכסה את כל המסך, ולכן היא הייתה מציגה גם את האתרים האחרים שלך.",
   "siteSettingsDnsBlocklistLevel": "רמת רשימת החסימה",
   "siteSettingsDnsBlocklistLevelHint": "כל רמה חוסמת יותר דומיינים מזו שמתחתיה. הורידו אותה עבור אתר שרשימת החסימה שוברת, כדי שתישאר לו הגנה חלקית במקום כלום. רמה שהיישום עדיין לא הוריד תימשך ברגע שתבחרו בה.",
-  "siteSettingsDnsLevelFollowApp": "כמו בהגדרות היישום",
+  "siteSettingsDnsLevelFollowAppShort": "אפליקציה",
   "siteSettingsDnsLevelFollowsApp": "כמו בהגדרות היישום ({level})",
   "siteSettingsDnsLevelNeedsDownload": "עדיין לא הורדה, בשימוש {level}",
   "siteSettingsDnsLevelDownloading": "מוריד את רשימת החסימה...",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "उपलब्ध नहीं। स्क्रीन कैप्चर पूरी स्क्रीन को ढक लेता है, इसलिए वह आपकी दूसरी साइटें भी दिखाता।",
   "siteSettingsDnsBlocklistLevel": "ब्लॉकसूची स्तर",
   "siteSettingsDnsBlocklistLevelHint": "हर स्तर अपने नीचे वाले स्तर से ज़्यादा डोमेन रोकता है। जिस साइट को ब्लॉकसूची तोड़ देती है, उसके लिए स्तर घटा दें, ताकि पूरी सुरक्षा खोने के बजाय कुछ सुरक्षा बनी रहे। जो स्तर ऐप ने अभी डाउनलोड नहीं किया है, वह चुनते ही डाउनलोड हो जाता है।",
-  "siteSettingsDnsLevelFollowApp": "ऐप सेटिंग्स जैसा ही",
+  "siteSettingsDnsLevelFollowAppShort": "ऐप",
   "siteSettingsDnsLevelFollowsApp": "ऐप सेटिंग्स जैसा ही ({level})",
   "siteSettingsDnsLevelNeedsDownload": "अभी डाउनलोड नहीं हुआ, {level} इस्तेमाल हो रहा है",
   "siteSettingsDnsLevelDownloading": "ब्लॉकसूची डाउनलोड हो रही है...",

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Nije dostupno. Snimanje zaslona obuhvaća cijeli zaslon pa bi prikazalo i vaše druge stranice.",
   "siteSettingsDnsBlocklistLevel": "Razina popisa blokiranja",
   "siteSettingsDnsBlocklistLevelHint": "Svaka razina blokira više domena od one ispod nje. Snizite je za stranicu koju popis blokiranja kvari, kako bi zadržala nešto zaštite umjesto nikakve. Razinu koju aplikacija još nije preuzela preuzet će kad je odaberete.",
-  "siteSettingsDnsLevelFollowApp": "Isto kao postavke aplikacije",
+  "siteSettingsDnsLevelFollowAppShort": "Aplikacija",
   "siteSettingsDnsLevelFollowsApp": "Isto kao postavke aplikacije ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Još nije preuzeto, koristi se {level}",
   "siteSettingsDnsLevelDownloading": "Preuzimanje popisa blokiranja...",

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Nem érhető el. A képernyőfelvétel a teljes képernyőt lefedi, így a többi webhelyét is megmutatná.",
   "siteSettingsDnsBlocklistLevel": "Tiltólista szintje",
   "siteSettingsDnsBlocklistLevelHint": "Minden szint több tartományt tilt, mint az alatta lévő. Csökkentse egy olyan oldalnál, amelyet a tiltólista elront, hogy maradjon valamennyi védelem a semmi helyett. Az alkalmazás által még le nem töltött szintet a kiválasztáskor tölti le.",
-  "siteSettingsDnsLevelFollowApp": "Ugyanaz, mint az alkalmazás beállításaiban",
+  "siteSettingsDnsLevelFollowAppShort": "Alkalmazás",
   "siteSettingsDnsLevelFollowsApp": "Ugyanaz, mint az alkalmazás beállításaiban ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Még nincs letöltve, a(z) {level} van használatban",
   "siteSettingsDnsLevelDownloading": "Tiltólista letöltése...",

--- a/lib/l10n/app_hy.arb
+++ b/lib/l10n/app_hy.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Հասանելի չէ։ Էկրանի գրանցումը ընդգրկում է ամբողջ էկրանը, ուստի ցույց կտար նաև ձեր մյուս կայքերը։",
   "siteSettingsDnsBlocklistLevel": "Արգելացանկի մակարդակ",
   "siteSettingsDnsBlocklistLevelHint": "Յուրաքանչյուր մակարդակ արգելափակում է ավելի շատ դոմեններ, քան իրենից ցածրը։ Իջեցրեք այն այն կայքի համար, որը արգելացանկը փչացնում է, որպեսզի պաշտպանության մի մասը մնա՝ ամբողջը կորցնելու փոխարեն։ Այն մակարդակը, որը հավելվածը դեռ չի ներբեռնել, ներբեռնվում է ընտրելու պահին։",
-  "siteSettingsDnsLevelFollowApp": "Նույնը, ինչ հավելվածի կարգավորումներում",
+  "siteSettingsDnsLevelFollowAppShort": "Հավելված",
   "siteSettingsDnsLevelFollowsApp": "Նույնը, ինչ հավելվածի կարգավորումներում ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Դեռ ներբեռնված չէ, օգտագործվում է {level}",
   "siteSettingsDnsLevelDownloading": "Արգելացանկը ներբեռնվում է...",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Tidak tersedia. Perekaman layar mencakup seluruh layar, sehingga juga akan menampilkan situs Anda yang lain.",
   "siteSettingsDnsBlocklistLevel": "Tingkat daftar blokir",
   "siteSettingsDnsBlocklistLevelHint": "Setiap tingkat memblokir lebih banyak domain daripada tingkat di bawahnya. Turunkan untuk situs yang rusak karena daftar blokir, agar tetap ada sebagian perlindungan alih-alih tidak ada sama sekali. Tingkat yang belum diunduh aplikasi akan diambil saat Anda memilihnya.",
-  "siteSettingsDnsLevelFollowApp": "Sama seperti pengaturan aplikasi",
+  "siteSettingsDnsLevelFollowAppShort": "Aplikasi",
   "siteSettingsDnsLevelFollowsApp": "Sama seperti pengaturan aplikasi ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Belum diunduh, memakai {level}",
   "siteSettingsDnsLevelDownloading": "Mengunduh daftar blokir...",

--- a/lib/l10n/app_is.arb
+++ b/lib/l10n/app_is.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Ekki í boði. Skjáupptaka nær yfir allan skjáinn og myndi því einnig sýna hin vefsvæðin þín.",
   "siteSettingsDnsBlocklistLevel": "Stig útilokunarlista",
   "siteSettingsDnsBlocklistLevelHint": "Hvert stig útilokar fleiri lén en stigið fyrir neðan. Lækkaðu það fyrir vef sem útilokunarlistinn skemmir, svo hann haldi einhverri vörn í stað engrar. Stig sem forritið hefur ekki sótt enn er sótt þegar þú velur það.",
-  "siteSettingsDnsLevelFollowApp": "Sama og stillingar forritsins",
+  "siteSettingsDnsLevelFollowAppShort": "Forrit",
   "siteSettingsDnsLevelFollowsApp": "Sama og stillingar forritsins ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Ekki sótt enn, notar {level}",
   "siteSettingsDnsLevelDownloading": "Sæki útilokunarlista...",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Non disponibile. Una registrazione dello schermo copre l'intero schermo e mostrerebbe quindi anche gli altri tuoi siti.",
   "siteSettingsDnsBlocklistLevel": "Livello della lista di blocco",
   "siteSettingsDnsBlocklistLevelHint": "Ogni livello blocca più domini di quello sotto. Abbassalo per un sito che la lista di blocco rompe, così conserva una parte di protezione invece di nessuna. Un livello che l'app non ha ancora scaricato viene recuperato quando lo scegli.",
-  "siteSettingsDnsLevelFollowApp": "Come le impostazioni dell'app",
+  "siteSettingsDnsLevelFollowAppShort": "App",
   "siteSettingsDnsLevelFollowsApp": "Come le impostazioni dell'app ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Non ancora scaricato, in uso {level}",
   "siteSettingsDnsLevelDownloading": "Download della lista di blocco...",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "利用できません。画面キャプチャは画面全体を対象とするため、他のサイトも映してしまいます。",
   "siteSettingsDnsBlocklistLevel": "ブロックリストの強度",
   "siteSettingsDnsBlocklistLevelHint": "強度が上がるほど、より多くのドメインをブロックします。ブロックリストが原因で壊れるサイトでは強度を下げれば、保護をすべて失う代わりに一部を残せます。まだダウンロードしていない強度は、選んだ時点で取得されます。",
-  "siteSettingsDnsLevelFollowApp": "アプリ設定と同じ",
+  "siteSettingsDnsLevelFollowAppShort": "アプリ",
   "siteSettingsDnsLevelFollowsApp": "アプリ設定と同じ（{level}）",
   "siteSettingsDnsLevelNeedsDownload": "未ダウンロードのため {level} を使用中",
   "siteSettingsDnsLevelDownloading": "ブロックリストをダウンロード中...",

--- a/lib/l10n/app_ka.arb
+++ b/lib/l10n/app_ka.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "მიუწვდომელია. ეკრანის ჩაწერა მოიცავს მთელ ეკრანს, ამიტომ ის აჩვენებდა თქვენს სხვა საიტებსაც.",
   "siteSettingsDnsBlocklistLevel": "ბლოკსიის დონე",
   "siteSettingsDnsBlocklistLevelHint": "ყოველი დონე მის ქვემოთ მდებარეზე მეტ დომენს ბლოკავს. დაუწიეთ იმ საიტისთვის, რომელსაც ბლოკსია აფუჭებს, რომ დაცვის ნაწილი მაინც შენარჩუნდეს და არა არაფერი. დონე, რომელიც აპს ჯერ არ ჩამოუტვირთავს, არჩევისთანავე ჩამოიტვირთება.",
-  "siteSettingsDnsLevelFollowApp": "იგივე, რაც აპის პარამეტრებში",
+  "siteSettingsDnsLevelFollowAppShort": "აპი",
   "siteSettingsDnsLevelFollowsApp": "იგივე, რაც აპის პარამეტრებში ({level})",
   "siteSettingsDnsLevelNeedsDownload": "ჯერ არ ჩამოტვირთულა, გამოიყენება {level}",
   "siteSettingsDnsLevelDownloading": "ბლოკსიის ჩამოტვირთვა...",

--- a/lib/l10n/app_km.arb
+++ b/lib/l10n/app_km.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "មិនមាន។ ការថតអេក្រង់គ្របដណ្តប់លើអេក្រង់ទាំងមូល ដូច្នេះវានឹងបង្ហាញគេហទំព័រផ្សេងទៀតរបស់អ្នកផងដែរ។",
   "siteSettingsDnsBlocklistLevel": "កម្រិតបញ្ជីទប់ស្កាត់",
   "siteSettingsDnsBlocklistLevelHint": "កម្រិតនីមួយៗទប់ស្កាត់ដែនច្រើនជាងកម្រិតខាងក្រោមវា។ សូមបន្ថយវាសម្រាប់គេហទំព័រដែលបញ្ជីទប់ស្កាត់ធ្វើឱ្យខូច ដើម្បីឱ្យវានៅមានការការពារខ្លះ ជាជាងគ្មានសោះ។ កម្រិតដែលកម្មវិធីមិនទាន់ទាញយក នឹងត្រូវទាញយកនៅពេលអ្នកជ្រើសរើសវា។",
-  "siteSettingsDnsLevelFollowApp": "ដូចការកំណត់កម្មវិធី",
+  "siteSettingsDnsLevelFollowAppShort": "កម្មវិធី",
   "siteSettingsDnsLevelFollowsApp": "ដូចការកំណត់កម្មវិធី ({level})",
   "siteSettingsDnsLevelNeedsDownload": "មិនទាន់ទាញយកទេ កំពុងប្រើ {level}",
   "siteSettingsDnsLevelDownloading": "កំពុងទាញយកបញ្ជីទប់ស្កាត់...",

--- a/lib/l10n/app_kn.arb
+++ b/lib/l10n/app_kn.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "ಲಭ್ಯವಿಲ್ಲ. ಸ್ಕ್ರೀನ್ ಸೆರೆಹಿಡಿಯುವಿಕೆ ಇಡೀ ಸ್ಕ್ರೀನ್ ಆವರಿಸುತ್ತದೆ, ಆದ್ದರಿಂದ ಅದು ನಿಮ್ಮ ಇತರ ಸೈಟ್‌ಗಳನ್ನೂ ತೋರಿಸುತ್ತಿತ್ತು.",
   "siteSettingsDnsBlocklistLevel": "ನಿರ್ಬಂಧ ಪಟ್ಟಿಯ ಮಟ್ಟ",
   "siteSettingsDnsBlocklistLevelHint": "ಪ್ರತಿ ಮಟ್ಟವು ತನ್ನ ಕೆಳಗಿನ ಮಟ್ಟಕ್ಕಿಂತ ಹೆಚ್ಚು ಡೊಮೇನ್‌ಗಳನ್ನು ನಿರ್ಬಂಧಿಸುತ್ತದೆ. ನಿರ್ಬಂಧ ಪಟ್ಟಿಯಿಂದ ಹಾಳಾಗುವ ಸೈಟ್‌ಗೆ ಮಟ್ಟವನ್ನು ಇಳಿಸಿ, ಆಗ ಎಲ್ಲ ರಕ್ಷಣೆ ಕಳೆದುಕೊಳ್ಳುವ ಬದಲು ಸ್ವಲ್ಪ ರಕ್ಷಣೆ ಉಳಿಯುತ್ತದೆ. ಅಪ್ಲಿಕೇಶನ್ ಇನ್ನೂ ಡೌನ್‌ಲೋಡ್ ಮಾಡದ ಮಟ್ಟವನ್ನು ನೀವು ಆಯ್ಕೆ ಮಾಡಿದಾಗ ತರಲಾಗುತ್ತದೆ.",
-  "siteSettingsDnsLevelFollowApp": "ಅಪ್ಲಿಕೇಶನ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳಂತೆಯೇ",
+  "siteSettingsDnsLevelFollowAppShort": "ಅಪ್ಲಿಕೇಶನ್",
   "siteSettingsDnsLevelFollowsApp": "ಅಪ್ಲಿಕೇಶನ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳಂತೆಯೇ ({level})",
   "siteSettingsDnsLevelNeedsDownload": "ಇನ್ನೂ ಡೌನ್‌ಲೋಡ್ ಆಗಿಲ್ಲ, {level} ಬಳಕೆಯಲ್ಲಿದೆ",
   "siteSettingsDnsLevelDownloading": "ನಿರ್ಬಂಧ ಪಟ್ಟಿ ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ...",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "사용할 수 없습니다. 화면 캡처는 화면 전체를 담기 때문에 다른 사이트도 함께 보이게 됩니다.",
   "siteSettingsDnsBlocklistLevel": "차단 목록 수준",
   "siteSettingsDnsBlocklistLevelHint": "수준이 높을수록 더 많은 도메인을 차단합니다. 차단 목록 때문에 깨지는 사이트는 수준을 낮추면 보호를 전부 포기하지 않고 일부를 남길 수 있습니다. 앱이 아직 내려받지 않은 수준은 선택하는 순간 내려받습니다.",
-  "siteSettingsDnsLevelFollowApp": "앱 설정과 동일",
+  "siteSettingsDnsLevelFollowAppShort": "앱",
   "siteSettingsDnsLevelFollowsApp": "앱 설정과 동일({level})",
   "siteSettingsDnsLevelNeedsDownload": "아직 내려받지 않아 {level} 사용 중",
   "siteSettingsDnsLevelDownloading": "차단 목록을 내려받는 중...",

--- a/lib/l10n/app_la.arb
+++ b/lib/l10n/app_la.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Non praesto. Captura scrinii totum scrinium comprehendit, itaque etiam alia loca tua monstraret.",
   "siteSettingsDnsBlocklistLevel": "Gradus indicis interclusionis",
   "siteSettingsDnsBlocklistLevelHint": "Quisque gradus plura dominia intercludit quam is qui infra est. Eum deprime pro loco quem index interclusionis corrumpit, ut aliquam tutelam servet potius quam nullam. Gradus quem applicatio nondum deposuit, cum eum eligis, deponitur.",
-  "siteSettingsDnsLevelFollowApp": "Idem ac optiones applicationis",
+  "siteSettingsDnsLevelFollowAppShort": "Applicatio",
   "siteSettingsDnsLevelFollowsApp": "Idem ac optiones applicationis ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Nondum depositus; {level} adhibetur",
   "siteSettingsDnsLevelDownloading": "Index interclusionis deponitur...",

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Nepasiekiama. Ekrano įrašas apima visą ekraną, tad parodytų ir kitas jūsų svetaines.",
   "siteSettingsDnsBlocklistLevel": "Blokavimo sąrašo lygis",
   "siteSettingsDnsBlocklistLevelHint": "Kiekvienas lygis blokuoja daugiau domenų nei žemesnysis. Sumažinkite jį svetainei, kurią blokavimo sąrašas gadina, kad liktų bent dalis apsaugos, o ne jokios. Lygį, kurio programa dar neatsisiuntė, ji parsiunčia jį pasirinkus.",
-  "siteSettingsDnsLevelFollowApp": "Kaip programos nustatymuose",
+  "siteSettingsDnsLevelFollowAppShort": "Programėlė",
   "siteSettingsDnsLevelFollowsApp": "Kaip programos nustatymuose ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Dar neatsisiųsta, naudojama {level}",
   "siteSettingsDnsLevelDownloading": "Atsiunčiamas blokavimo sąrašas...",

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Nav pieejams. Ekrāna tveršana aptver visu ekrānu, tāpēc tā rādītu arī jūsu pārējās vietnes.",
   "siteSettingsDnsBlocklistLevel": "Bloķēšanas saraksta līmenis",
   "siteSettingsDnsBlocklistLevelHint": "Katrs līmenis bloķē vairāk domēnu nekā zemākais. Pazeminiet to vietnei, ko bloķēšanas saraksts sabojā, lai saglabātu kaut daļu aizsardzības, nevis nekādu. Līmeni, ko lietotne vēl nav lejupielādējusi, tā iegūst brīdī, kad to izvēlaties.",
-  "siteSettingsDnsLevelFollowApp": "Tāpat kā lietotnes iestatījumos",
+  "siteSettingsDnsLevelFollowAppShort": "Lietotne",
   "siteSettingsDnsLevelFollowsApp": "Tāpat kā lietotnes iestatījumos ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Vēl nav lejupielādēts, tiek lietots {level}",
   "siteSettingsDnsLevelDownloading": "Notiek bloķēšanas saraksta lejupielāde...",

--- a/lib/l10n/app_mk.arb
+++ b/lib/l10n/app_mk.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Недостапно. Снимањето на екранот го зафаќа целиот екран, па би ги прикажало и вашите други сајтови.",
   "siteSettingsDnsBlocklistLevel": "Ниво на списокот за блокирање",
   "siteSettingsDnsBlocklistLevelHint": "Секое ниво блокира повеќе домени од претходното. Намалете го за страница што списокот за блокирање ја расипува, за да задржи дел од заштитата наместо ниту една. Ниво што апликацијата сè уште не го презела се презема кога ќе го изберете.",
-  "siteSettingsDnsLevelFollowApp": "Исто како поставките на апликацијата",
+  "siteSettingsDnsLevelFollowAppShort": "Апликација",
   "siteSettingsDnsLevelFollowsApp": "Исто како поставките на апликацијата ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Сè уште не е преземено, се користи {level}",
   "siteSettingsDnsLevelDownloading": "Се презема списокот за блокирање...",

--- a/lib/l10n/app_ml.arb
+++ b/lib/l10n/app_ml.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "ലഭ്യമല്ല. സ്ക്രീൻ ക്യാപ്ചർ സ്ക്രീൻ മുഴുവൻ ഉൾക്കൊള്ളുന്നു, അതിനാൽ അത് നിങ്ങളുടെ മറ്റ് സൈറ്റുകളും കാണിക്കുമായിരുന്നു.",
   "siteSettingsDnsBlocklistLevel": "തടയൽപ്പട്ടികയുടെ നില",
   "siteSettingsDnsBlocklistLevelHint": "ഓരോ നിലയും അതിനു താഴെയുള്ളതിനെക്കാൾ കൂടുതൽ ഡൊമെയ്‌നുകൾ തടയുന്നു. തടയൽപ്പട്ടിക തകർക്കുന്ന സൈറ്റിനായി നില കുറയ്ക്കുക, അപ്പോൾ സംരക്ഷണം മുഴുവൻ നഷ്ടപ്പെടുന്നതിനു പകരം കുറച്ചെങ്കിലും നിലനിൽക്കും. ആപ്പ് ഇതുവരെ ഡൗൺലോഡ് ചെയ്യാത്ത നില നിങ്ങൾ തിരഞ്ഞെടുക്കുമ്പോൾ എടുക്കും.",
-  "siteSettingsDnsLevelFollowApp": "ആപ്പ് ക്രമീകരണങ്ങൾ പോലെ തന്നെ",
+  "siteSettingsDnsLevelFollowAppShort": "ആപ്പ്",
   "siteSettingsDnsLevelFollowsApp": "ആപ്പ് ക്രമീകരണങ്ങൾ പോലെ തന്നെ ({level})",
   "siteSettingsDnsLevelNeedsDownload": "ഇതുവരെ ഡൗൺലോഡ് ചെയ്തിട്ടില്ല, {level} ഉപയോഗിക്കുന്നു",
   "siteSettingsDnsLevelDownloading": "തടയൽപ്പട്ടിക ഡൗൺലോഡ് ചെയ്യുന്നു...",

--- a/lib/l10n/app_mn.arb
+++ b/lib/l10n/app_mn.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Боломжгүй. Дэлгэцийн бичлэг бүх дэлгэцийг хамардаг тул таны бусад сайтуудыг ч харуулах болно.",
   "siteSettingsDnsBlocklistLevel": "Хориглох жагсаалтын түвшин",
   "siteSettingsDnsBlocklistLevelHint": "Түвшин бүр өөрөөсөө доогуур түвшнээс илүү олон домэйныг хориглоно. Хориглох жагсаалт эвдэж буй сайтын хувьд түвшинг бууруулбал бүх хамгаалалтаа алдахын оронд зарим нь үлдэнэ. Аппын хараахан татаагүй түвшинг та сонгох үед татна.",
-  "siteSettingsDnsLevelFollowApp": "Аппын тохиргоотой ижил",
+  "siteSettingsDnsLevelFollowAppShort": "Апп",
   "siteSettingsDnsLevelFollowsApp": "Аппын тохиргоотой ижил ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Хараахан татаагүй, {level} ашиглаж байна",
   "siteSettingsDnsLevelDownloading": "Хориглох жагсаалтыг татаж байна...",

--- a/lib/l10n/app_mr.arb
+++ b/lib/l10n/app_mr.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "उपलब्ध नाही. स्क्रीन कॅप्चर संपूर्ण स्क्रीन व्यापते, त्यामुळे ते तुमच्या इतर साइटदेखील दाखवेल.",
   "siteSettingsDnsBlocklistLevel": "अवरोधसूचीची पातळी",
   "siteSettingsDnsBlocklistLevelHint": "प्रत्येक पातळी तिच्या खालच्या पातळीपेक्षा अधिक डोमेन अडवते. अवरोधसूचीमुळे बिघडणाऱ्या साइटसाठी पातळी कमी करा, म्हणजे संपूर्ण संरक्षण गमावण्याऐवजी थोडे तरी टिकून राहील. अ‍ॅपने अद्याप न उतरवलेली पातळी तुम्ही निवडताच उतरवली जाते.",
-  "siteSettingsDnsLevelFollowApp": "अ‍ॅप सेटिंग्जप्रमाणेच",
+  "siteSettingsDnsLevelFollowAppShort": "ॲप",
   "siteSettingsDnsLevelFollowsApp": "अ‍ॅप सेटिंग्जप्रमाणेच ({level})",
   "siteSettingsDnsLevelNeedsDownload": "अद्याप उतरवलेली नाही, {level} वापरात आहे",
   "siteSettingsDnsLevelDownloading": "अवरोधसूची उतरवली जात आहे...",

--- a/lib/l10n/app_ms.arb
+++ b/lib/l10n/app_ms.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Tidak tersedia. Rakaman skrin meliputi seluruh skrin, jadi ia juga akan menunjukkan tapak anda yang lain.",
   "siteSettingsDnsBlocklistLevel": "Tahap senarai sekatan",
   "siteSettingsDnsBlocklistLevelHint": "Setiap tahap menyekat lebih banyak domain daripada tahap di bawahnya. Turunkan tahap bagi tapak yang rosak akibat senarai sekatan, supaya sebahagian perlindungan kekal dan bukannya hilang sama sekali. Tahap yang belum dimuat turun oleh apl akan diambil apabila anda memilihnya.",
-  "siteSettingsDnsLevelFollowApp": "Sama seperti tetapan apl",
+  "siteSettingsDnsLevelFollowAppShort": "Apl",
   "siteSettingsDnsLevelFollowsApp": "Sama seperti tetapan apl ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Belum dimuat turun, menggunakan {level}",
   "siteSettingsDnsLevelDownloading": "Memuat turun senarai sekatan...",

--- a/lib/l10n/app_mt.arb
+++ b/lib/l10n/app_mt.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Mhux disponibbli. Reġistrazzjoni tal-iskrin tkopri l-iskrin kollu, u għalhekk kienet turi wkoll is-siti l-oħra tiegħek.",
   "siteSettingsDnsBlocklistLevel": "Livell tal-lista tal-imblukkar",
   "siteSettingsDnsBlocklistLevelHint": "Kull livell jimblokka aktar dominji minn dak ta' taħtu. Niżżlu għal sit li l-lista tal-imblukkar tħassar, biex iżomm xi ftit protezzjoni minflok xejn. Livell li l-applikazzjoni għadha ma niżżlitx jinġieb meta tagħżlu.",
-  "siteSettingsDnsLevelFollowApp": "L-istess bħall-issettjar tal-applikazzjoni",
+  "siteSettingsDnsLevelFollowAppShort": "App",
   "siteSettingsDnsLevelFollowsApp": "L-istess bħall-issettjar tal-applikazzjoni ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Għadu ma tniżżilx, qed jintuża {level}",
   "siteSettingsDnsLevelDownloading": "Qed titniżżel il-lista tal-imblukkar...",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Ikke tilgjengelig. Et skjermopptak dekker hele skjermen og ville derfor også vise de andre nettstedene dine.",
   "siteSettingsDnsBlocklistLevel": "Blokkeringslistenivå",
   "siteSettingsDnsBlocklistLevelHint": "Hvert nivå blokkerer flere domener enn nivået under. Senk det for et nettsted som blokkeringslisten ødelegger, slik at det beholder noe beskyttelse i stedet for ingen. Et nivå appen ikke har lastet ned ennå, hentes når du velger det.",
-  "siteSettingsDnsLevelFollowApp": "Samme som appinnstillingene",
+  "siteSettingsDnsLevelFollowAppShort": "App",
   "siteSettingsDnsLevelFollowsApp": "Samme som appinnstillingene ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Ikke lastet ned ennå, bruker {level}",
   "siteSettingsDnsLevelDownloading": "Laster ned blokkeringsliste...",

--- a/lib/l10n/app_ne.arb
+++ b/lib/l10n/app_ne.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "उपलब्ध छैन। स्क्रिन क्याप्चरले सम्पूर्ण स्क्रिन ओगट्छ, त्यसैले यसले तपाईंका अन्य साइटहरू पनि देखाउँथ्यो।",
   "siteSettingsDnsBlocklistLevel": "अवरोधसूचीको स्तर",
   "siteSettingsDnsBlocklistLevelHint": "हरेक स्तरले आफूभन्दा तलको स्तरभन्दा बढी डोमेन रोक्छ। अवरोधसूचीले बिगार्ने साइटका लागि स्तर घटाउनुहोस्, ताकि सम्पूर्ण सुरक्षा गुमाउनुको साटो केही सुरक्षा रहोस्। एपले अझै डाउनलोड नगरेको स्तर तपाईंले छान्नेबित्तिकै ल्याइन्छ।",
-  "siteSettingsDnsLevelFollowApp": "एप सेटिङजस्तै",
+  "siteSettingsDnsLevelFollowAppShort": "एप",
   "siteSettingsDnsLevelFollowsApp": "एप सेटिङजस्तै ({level})",
   "siteSettingsDnsLevelNeedsDownload": "अझै डाउनलोड भएको छैन, {level} प्रयोगमा छ",
   "siteSettingsDnsLevelDownloading": "अवरोधसूची डाउनलोड हुँदै...",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Niet beschikbaar. Een schermopname bestrijkt het hele scherm en zou dus ook je andere sites tonen.",
   "siteSettingsDnsBlocklistLevel": "Niveau van de blokkeerlijst",
   "siteSettingsDnsBlocklistLevelHint": "Elk niveau blokkeert meer domeinen dan het niveau eronder. Verlaag het voor een site die de blokkeerlijst stukmaakt, zodat er wat bescherming overblijft in plaats van geen. Een niveau dat de app nog niet heeft gedownload, wordt opgehaald zodra je het kiest.",
-  "siteSettingsDnsLevelFollowApp": "Hetzelfde als de app-instellingen",
+  "siteSettingsDnsLevelFollowAppShort": "App",
   "siteSettingsDnsLevelFollowsApp": "Hetzelfde als de app-instellingen ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Nog niet gedownload, gebruikt {level}",
   "siteSettingsDnsLevelDownloading": "Blokkeerlijst downloaden...",

--- a/lib/l10n/app_pa.arb
+++ b/lib/l10n/app_pa.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "ਉਪਲਬਧ ਨਹੀਂ। ਸਕ੍ਰੀਨ ਕੈਪਚਰ ਪੂਰੀ ਸਕ੍ਰੀਨ ਨੂੰ ਢੱਕਦਾ ਹੈ, ਇਸ ਲਈ ਇਹ ਤੁਹਾਡੀਆਂ ਹੋਰ ਸਾਈਟਾਂ ਵੀ ਵਿਖਾਉਂਦਾ।",
   "siteSettingsDnsBlocklistLevel": "ਰੋਕ-ਸੂਚੀ ਦਾ ਪੱਧਰ",
   "siteSettingsDnsBlocklistLevelHint": "ਹਰ ਪੱਧਰ ਆਪਣੇ ਹੇਠਲੇ ਪੱਧਰ ਨਾਲੋਂ ਵੱਧ ਡੋਮੇਨ ਰੋਕਦਾ ਹੈ। ਜਿਸ ਸਾਈਟ ਨੂੰ ਰੋਕ-ਸੂਚੀ ਵਿਗਾੜਦੀ ਹੈ, ਉਸ ਲਈ ਪੱਧਰ ਘਟਾਓ, ਤਾਂ ਜੋ ਸਾਰੀ ਸੁਰੱਖਿਆ ਗੁਆਉਣ ਦੀ ਥਾਂ ਕੁਝ ਸੁਰੱਖਿਆ ਬਚੀ ਰਹੇ। ਜਿਹੜਾ ਪੱਧਰ ਐਪ ਨੇ ਹਾਲੇ ਡਾਊਨਲੋਡ ਨਹੀਂ ਕੀਤਾ, ਉਹ ਚੁਣਨ ਵੇਲੇ ਲਿਆਂਦਾ ਜਾਂਦਾ ਹੈ।",
-  "siteSettingsDnsLevelFollowApp": "ਐਪ ਸੈਟਿੰਗਾਂ ਵਾਂਗ ਹੀ",
+  "siteSettingsDnsLevelFollowAppShort": "ਐਪ",
   "siteSettingsDnsLevelFollowsApp": "ਐਪ ਸੈਟਿੰਗਾਂ ਵਾਂਗ ਹੀ ({level})",
   "siteSettingsDnsLevelNeedsDownload": "ਹਾਲੇ ਡਾਊਨਲੋਡ ਨਹੀਂ ਹੋਇਆ, {level} ਵਰਤਿਆ ਜਾ ਰਿਹਾ ਹੈ",
   "siteSettingsDnsLevelDownloading": "ਰੋਕ-ਸੂਚੀ ਡਾਊਨਲੋਡ ਹੋ ਰਹੀ ਹੈ...",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Niedostępne. Nagranie ekranu obejmuje cały ekran, więc pokazałoby też Twoje pozostałe witryny.",
   "siteSettingsDnsBlocklistLevel": "Poziom listy blokowania",
   "siteSettingsDnsBlocklistLevelHint": "Każdy poziom blokuje więcej domen niż poziom poniżej. Obniż go dla witryny, którą lista blokowania psuje, żeby zachowała część ochrony zamiast żadnej. Poziom, którego aplikacja jeszcze nie pobrała, zostaje pobrany w chwili wyboru.",
-  "siteSettingsDnsLevelFollowApp": "Tak jak w ustawieniach aplikacji",
+  "siteSettingsDnsLevelFollowAppShort": "Aplikacja",
   "siteSettingsDnsLevelFollowsApp": "Tak jak w ustawieniach aplikacji ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Jeszcze nie pobrano, używany jest {level}",
   "siteSettingsDnsLevelDownloading": "Pobieranie listy blokowania...",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Indisponível. Uma captura de ecrã abrange todo o ecrã, pelo que mostraria também os seus outros sites.",
   "siteSettingsDnsBlocklistLevel": "Nível da lista de bloqueio",
   "siteSettingsDnsBlocklistLevelHint": "Cada nível bloqueia mais domínios do que o anterior. Baixe-o para um site que a lista de bloqueio estraga, para que fique com alguma proteção em vez de nenhuma. Um nível que a aplicação ainda não transferiu é obtido quando o escolhe.",
-  "siteSettingsDnsLevelFollowApp": "Igual às definições da aplicação",
+  "siteSettingsDnsLevelFollowAppShort": "Aplicação",
   "siteSettingsDnsLevelFollowsApp": "Igual às definições da aplicação ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Ainda não transferido; a usar {level}",
   "siteSettingsDnsLevelDownloading": "A transferir a lista de bloqueio...",

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Indisponível. Uma captura de tela abrange a tela inteira, então também mostraria seus outros sites.",
   "siteSettingsDnsBlocklistLevel": "Nível da lista de bloqueio",
   "siteSettingsDnsBlocklistLevelHint": "Cada nível bloqueia mais domínios do que o anterior. Diminua-o para um site que a lista de bloqueio quebra, assim ele mantém alguma proteção em vez de nenhuma. Um nível que o aplicativo ainda não baixou é obtido quando você o escolhe.",
-  "siteSettingsDnsLevelFollowApp": "Igual às configurações do aplicativo",
+  "siteSettingsDnsLevelFollowAppShort": "Aplicativo",
   "siteSettingsDnsLevelFollowsApp": "Igual às configurações do aplicativo ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Ainda não baixado; usando {level}",
   "siteSettingsDnsLevelDownloading": "Baixando a lista de bloqueio...",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Indisponibil. O captură de ecran acoperă întregul ecran, deci ar arăta și celelalte site-uri ale tale.",
   "siteSettingsDnsBlocklistLevel": "Nivelul listei de blocare",
   "siteSettingsDnsBlocklistLevelHint": "Fiecare nivel blochează mai multe domenii decât cel de sub el. Coboară-l pentru un site pe care lista de blocare îl strică, astfel încât să păstreze o parte din protecție în loc de niciuna. Un nivel pe care aplicația nu l-a descărcat încă este adus în momentul în care îl alegi.",
-  "siteSettingsDnsLevelFollowApp": "La fel ca setările aplicației",
+  "siteSettingsDnsLevelFollowAppShort": "Aplicație",
   "siteSettingsDnsLevelFollowsApp": "La fel ca setările aplicației ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Încă nedescărcat; se folosește {level}",
   "siteSettingsDnsLevelDownloading": "Se descarcă lista de blocare...",

--- a/lib/l10n/app_si.arb
+++ b/lib/l10n/app_si.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "ලබා ගත නොහැක. තිර ග්‍රහණය මුළු තිරයම ආවරණය කරන බැවින්, එය ඔබේ අනෙක් අඩවිද පෙන්වනු ඇත.",
   "siteSettingsDnsBlocklistLevel": "අවහිර ලැයිස්තුවේ මට්ටම",
   "siteSettingsDnsBlocklistLevelHint": "සෑම මට්ටමක්ම එයට පහළ මට්ටමට වඩා වැඩි වසම් අවහිර කරයි. අවහිර ලැයිස්තුව නිසා කැඩෙන අඩවියක් සඳහා මට්ටම අඩු කරන්න, එවිට මුළු ආරක්ෂාවම නැති කර ගැනීම වෙනුවට යම් ආරක්ෂාවක් ඉතිරි වේ. යෙදුම තවම බාගත නොකළ මට්ටමක් ඔබ තෝරන විට බාගත වේ.",
-  "siteSettingsDnsLevelFollowApp": "යෙදුම් සැකසුම් හා සමානයි",
+  "siteSettingsDnsLevelFollowAppShort": "යෙදුම",
   "siteSettingsDnsLevelFollowsApp": "යෙදුම් සැකසුම් හා සමානයි ({level})",
   "siteSettingsDnsLevelNeedsDownload": "තවම බාගත කර නැත, {level} භාවිතා වේ",
   "siteSettingsDnsLevelDownloading": "අවහිර ලැයිස්තුව බාගත වෙමින්...",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Nie je k dispozícii. Záznam obrazovky pokrýva celú obrazovku, takže by ukázal aj vaše ostatné stránky.",
   "siteSettingsDnsBlocklistLevel": "Úroveň zoznamu blokovania",
   "siteSettingsDnsBlocklistLevelHint": "Každá úroveň blokuje viac domén než tá pod ňou. Znížte ju pre stránku, ktorú zoznam blokovania pokazí, aby si zachovala aspoň časť ochrany namiesto žiadnej. Úroveň, ktorú aplikácia zatiaľ nestiahla, sa stiahne pri jej výbere.",
-  "siteSettingsDnsLevelFollowApp": "Rovnako ako nastavenia aplikácie",
+  "siteSettingsDnsLevelFollowAppShort": "Aplikácia",
   "siteSettingsDnsLevelFollowsApp": "Rovnako ako nastavenia aplikácie ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Zatiaľ nestiahnuté, používa sa {level}",
   "siteSettingsDnsLevelDownloading": "Sťahuje sa zoznam blokovania...",

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Ni na voljo. Posnetek zaslona pokriva celoten zaslon, zato bi pokazal tudi vaša druga mesta.",
   "siteSettingsDnsBlocklistLevel": "Raven seznama blokiranja",
   "siteSettingsDnsBlocklistLevelHint": "Vsaka raven blokira več domen kot tista pod njo. Znižajte jo za spletišče, ki ga seznam blokiranja pokvari, da ohrani nekaj zaščite namesto nobene. Raven, ki je aplikacija še ni prenesla, se prenese, ko jo izberete.",
-  "siteSettingsDnsLevelFollowApp": "Enako kot nastavitve aplikacije",
+  "siteSettingsDnsLevelFollowAppShort": "Aplikacija",
   "siteSettingsDnsLevelFollowsApp": "Enako kot nastavitve aplikacije ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Še ni preneseno, uporablja se {level}",
   "siteSettingsDnsLevelDownloading": "Prenašanje seznama blokiranja...",

--- a/lib/l10n/app_sq.arb
+++ b/lib/l10n/app_sq.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Nuk ofrohet. Një regjistrim i ekranit mbulon të gjithë ekranin, prandaj do të tregonte edhe sajtet tuaja të tjera.",
   "siteSettingsDnsBlocklistLevel": "Niveli i listës së bllokimit",
   "siteSettingsDnsBlocklistLevelHint": "Çdo nivel bllokon më shumë domene se ai poshtë tij. Ulni nivelin për një sajt që lista e bllokimit e prish, që të mbetet një pjesë e mbrojtjes në vend që të humbasë e gjitha. Një nivel që aplikacioni nuk e ka shkarkuar ende merret kur ta zgjidhni.",
-  "siteSettingsDnsLevelFollowApp": "Njësoj si cilësimet e aplikacionit",
+  "siteSettingsDnsLevelFollowAppShort": "Aplikacioni",
   "siteSettingsDnsLevelFollowsApp": "Njësoj si cilësimet e aplikacionit ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Ende i pashkarkuar; po përdoret {level}",
   "siteSettingsDnsLevelDownloading": "Po shkarkohet lista e bllokimit...",

--- a/lib/l10n/app_sr.arb
+++ b/lib/l10n/app_sr.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Није доступно. Снимак екрана обухвата цео екран, па би приказао и ваше друге сајтове.",
   "siteSettingsDnsBlocklistLevel": "Ниво листе блокирања",
   "siteSettingsDnsBlocklistLevelHint": "Сваки ниво блокира више домена од оног испод њега. Спустите га за сајт који листа блокирања квари, како би задржао део заштите уместо ниједне. Ниво који апликација још није преузела преузима се када га изаберете.",
-  "siteSettingsDnsLevelFollowApp": "Исто као подешавања апликације",
+  "siteSettingsDnsLevelFollowAppShort": "Апликација",
   "siteSettingsDnsLevelFollowsApp": "Исто као подешавања апликације ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Још није преузето, користи се {level}",
   "siteSettingsDnsLevelDownloading": "Преузимање листе блокирања...",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Inte tillgänglig. En skärminspelning täcker hela skärmen och skulle därför också visa dina andra webbplatser.",
   "siteSettingsDnsBlocklistLevel": "Blockeringslistans nivå",
   "siteSettingsDnsBlocklistLevelHint": "Varje nivå blockerar fler domäner än nivån under. Sänk den för en webbplats som blockeringslistan förstör, så att den behåller något skydd i stället för inget alls. En nivå som appen inte har hämtat ännu hämtas när du väljer den.",
-  "siteSettingsDnsLevelFollowApp": "Samma som appinställningarna",
+  "siteSettingsDnsLevelFollowAppShort": "App",
   "siteSettingsDnsLevelFollowsApp": "Samma som appinställningarna ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Inte hämtad ännu, använder {level}",
   "siteSettingsDnsLevelDownloading": "Hämtar blockeringslistan...",

--- a/lib/l10n/app_sw.arb
+++ b/lib/l10n/app_sw.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Haipatikani. Kunasa skrini hufunika skrini nzima, hivyo kungeonyesha pia tovuti zako nyingine.",
   "siteSettingsDnsBlocklistLevel": "Kiwango cha orodha ya kuzuia",
   "siteSettingsDnsBlocklistLevelHint": "Kila kiwango huzuia vikoa vingi zaidi kuliko kiwango kilicho chini yake. Kishushe kwa tovuti ambayo orodha ya kuzuia inaiharibu, ili ibaki na ulinzi kiasi badala ya kukosa kabisa. Kiwango ambacho programu bado haijapakua hupakuliwa unapokichagua.",
-  "siteSettingsDnsLevelFollowApp": "Sawa na mipangilio ya programu",
+  "siteSettingsDnsLevelFollowAppShort": "Programu",
   "siteSettingsDnsLevelFollowsApp": "Sawa na mipangilio ya programu ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Bado haijapakuliwa, inatumia {level}",
   "siteSettingsDnsLevelDownloading": "Inapakua orodha ya kuzuia...",

--- a/lib/l10n/app_ta.arb
+++ b/lib/l10n/app_ta.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "கிடைக்கவில்லை. திரைப் பிடிப்பு முழுத் திரையையும் உள்ளடக்குவதால், உங்கள் மற்ற தளங்களையும் காட்டியிருக்கும்.",
   "siteSettingsDnsBlocklistLevel": "தடுப்புப்பட்டியல் நிலை",
   "siteSettingsDnsBlocklistLevelHint": "ஒவ்வொரு நிலையும் அதற்குக் கீழுள்ள நிலையை விட அதிக டொமைன்களைத் தடுக்கும். தடுப்புப்பட்டியலால் பழுதாகும் தளத்திற்கு நிலையைக் குறையுங்கள், அப்போது முழு பாதுகாப்பையும் இழப்பதற்குப் பதிலாக ஓரளவு பாதுகாப்பு இருக்கும். செயலி இன்னும் பதிவிறக்காத நிலையை நீங்கள் தேர்ந்தெடுக்கும்போது பெறப்படும்.",
-  "siteSettingsDnsLevelFollowApp": "செயலி அமைப்புகளைப் போலவே",
+  "siteSettingsDnsLevelFollowAppShort": "செயலி",
   "siteSettingsDnsLevelFollowsApp": "செயலி அமைப்புகளைப் போலவே ({level})",
   "siteSettingsDnsLevelNeedsDownload": "இன்னும் பதிவிறக்கப்படவில்லை, {level} பயன்படுத்தப்படுகிறது",
   "siteSettingsDnsLevelDownloading": "தடுப்புப்பட்டியல் பதிவிறக்கப்படுகிறது...",

--- a/lib/l10n/app_te.arb
+++ b/lib/l10n/app_te.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "అందుబాటులో లేదు. స్క్రీన్ క్యాప్చర్ మొత్తం స్క్రీన్‌ను కప్పుతుంది, కాబట్టి ఇది మీ ఇతర సైట్లను కూడా చూపేది.",
   "siteSettingsDnsBlocklistLevel": "నిరోధక జాబితా స్థాయి",
   "siteSettingsDnsBlocklistLevelHint": "ప్రతి స్థాయి తన కింది స్థాయి కంటే ఎక్కువ డొమైన్‌లను నిరోధిస్తుంది. నిరోధక జాబితా వల్ల పాడయ్యే సైట్‌కు స్థాయిని తగ్గించండి, అప్పుడు మొత్తం రక్షణ కోల్పోయే బదులు కొంత రక్షణ మిగులుతుంది. యాప్ ఇంకా దించని స్థాయిని మీరు ఎంచుకున్నప్పుడు తెచ్చుకుంటుంది.",
-  "siteSettingsDnsLevelFollowApp": "యాప్ సెట్టింగ్‌ల మాదిరిగానే",
+  "siteSettingsDnsLevelFollowAppShort": "యాప్",
   "siteSettingsDnsLevelFollowsApp": "యాప్ సెట్టింగ్‌ల మాదిరిగానే ({level})",
   "siteSettingsDnsLevelNeedsDownload": "ఇంకా దించలేదు, {level} వాడుతోంది",
   "siteSettingsDnsLevelDownloading": "నిరోధక జాబితా దించబడుతోంది...",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "ไม่พร้อมใช้งาน การบันทึกหน้าจอครอบคลุมทั้งหน้าจอ จึงจะแสดงเว็บไซต์อื่น ๆ ของคุณด้วย",
   "siteSettingsDnsBlocklistLevel": "ระดับรายการบล็อก",
   "siteSettingsDnsBlocklistLevelHint": "แต่ละระดับจะบล็อกโดเมนมากกว่าระดับที่ต่ำกว่า ลดระดับลงสำหรับเว็บไซต์ที่รายการบล็อกทำให้พัง เพื่อให้ยังเหลือการป้องกันบางส่วนแทนที่จะไม่มีเลย ระดับที่แอปยังไม่ได้ดาวน์โหลดจะถูกดึงมาเมื่อคุณเลือก",
-  "siteSettingsDnsLevelFollowApp": "เหมือนกับการตั้งค่าแอป",
+  "siteSettingsDnsLevelFollowAppShort": "แอป",
   "siteSettingsDnsLevelFollowsApp": "เหมือนกับการตั้งค่าแอป ({level})",
   "siteSettingsDnsLevelNeedsDownload": "ยังไม่ได้ดาวน์โหลด กำลังใช้ {level}",
   "siteSettingsDnsLevelDownloading": "กำลังดาวน์โหลดรายการบล็อก...",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Kullanılamıyor. Ekran kaydı tüm ekranı kapsar, dolayısıyla diğer sitelerinizi de gösterirdi.",
   "siteSettingsDnsBlocklistLevel": "Engelleme listesi düzeyi",
   "siteSettingsDnsBlocklistLevelHint": "Her düzey, altındakinden daha çok alan adını engeller. Engelleme listesinin bozduğu bir site için düzeyi düşürün; böylece korumanın tamamını yitirmek yerine bir kısmı kalır. Uygulamanın henüz indirmediği bir düzey, siz seçtiğinizde indirilir.",
-  "siteSettingsDnsLevelFollowApp": "Uygulama ayarlarıyla aynı",
+  "siteSettingsDnsLevelFollowAppShort": "Uygulama",
   "siteSettingsDnsLevelFollowsApp": "Uygulama ayarlarıyla aynı ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Henüz indirilmedi, {level} kullanılıyor",
   "siteSettingsDnsLevelDownloading": "Engelleme listesi indiriliyor...",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "Недоступно. Запис екрана охоплює весь екран, тож показав би й інші ваші сайти.",
   "siteSettingsDnsBlocklistLevel": "Рівень списку блокування",
   "siteSettingsDnsBlocklistLevelHint": "Кожен рівень блокує більше доменів, ніж той, що нижче. Знизьте його для сайту, який список блокування ламає, щоб залишився хоч якийсь захист замість жодного. Рівень, який застосунок ще не завантажив, отримується в момент вибору.",
-  "siteSettingsDnsLevelFollowApp": "Так само, як у налаштуваннях застосунку",
+  "siteSettingsDnsLevelFollowAppShort": "Застосунок",
   "siteSettingsDnsLevelFollowsApp": "Так само, як у налаштуваннях застосунку ({level})",
   "siteSettingsDnsLevelNeedsDownload": "Ще не завантажено, використовується {level}",
   "siteSettingsDnsLevelDownloading": "Завантаження списку блокування...",

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "دستیاب نہیں۔ اسکرین کیپچر پوری اسکرین کا احاطہ کرتا ہے، اس لیے یہ آپ کی دوسری سائٹس بھی دکھاتا۔",
   "siteSettingsDnsBlocklistLevel": "بلاک فہرست کی سطح",
   "siteSettingsDnsBlocklistLevelHint": "ہر سطح اپنے سے نیچے والی سطح کی نسبت زیادہ ڈومین روکتی ہے۔ جس سائٹ کو بلاک فہرست خراب کرتی ہو اس کے لیے سطح کم کر دیں، تاکہ ساری حفاظت گنوانے کے بجائے کچھ حفاظت باقی رہے۔ جو سطح ایپ نے ابھی ڈاؤن لوڈ نہیں کی، وہ منتخب کرتے ہی حاصل کر لی جاتی ہے۔",
-  "siteSettingsDnsLevelFollowApp": "ایپ کی ترتیبات جیسی ہی",
+  "siteSettingsDnsLevelFollowAppShort": "ایپ",
   "siteSettingsDnsLevelFollowsApp": "ایپ کی ترتیبات جیسی ہی ({level})",
   "siteSettingsDnsLevelNeedsDownload": "ابھی ڈاؤن لوڈ نہیں ہوئی، {level} استعمال ہو رہی ہے",
   "siteSettingsDnsLevelDownloading": "بلاک فہرست ڈاؤن لوڈ ہو رہی ہے...",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -789,7 +789,7 @@
   "permissionScreenShareNeverReal": "無法使用。畫面擷取會涵蓋整個畫面，因此也會顯示您的其他網站。",
   "siteSettingsDnsBlocklistLevel": "封鎖清單層級",
   "siteSettingsDnsBlocklistLevelHint": "層級越高，封鎖的網域越多。若某個網站因封鎖清單而故障，可為它調低層級，這樣仍保有部分防護，而不是完全放棄。應用程式尚未下載的層級，會在你選取時取得。",
-  "siteSettingsDnsLevelFollowApp": "與應用程式設定相同",
+  "siteSettingsDnsLevelFollowAppShort": "應用程式",
   "siteSettingsDnsLevelFollowsApp": "與應用程式設定相同（{level}）",
   "siteSettingsDnsLevelNeedsDownload": "尚未下載，目前使用 {level}",
   "siteSettingsDnsLevelDownloading": "正在下載封鎖清單...",

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -30,6 +30,7 @@ import 'package:webspace/settings/user_script.dart';
 import 'package:webspace/screens/user_scripts.dart';
 import 'package:webspace/widgets/firefox_version_tile.dart';
 import 'package:webspace/widgets/hint_button.dart';
+import 'package:webspace/widgets/level_slider.dart';
 
 // Accent color definitions for display
 const Map<AccentColor, Color> _accentColors = {
@@ -189,7 +190,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
   bool _isDownloadingBlocklist = false;
   DateTime? _blocklistLastUpdated;
   int _dnsBlockLevel = 0; // Downloaded level
-  double _dnsBlockSliderValue = 0; // Ephemeral slider value
+  int _dnsBlockSliderValue = 0; // Ephemeral slider value
   late AnimationController _spinController;
 
   // Content Blocker state
@@ -442,14 +443,14 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
     if (mounted) {
       setState(() {
         _dnsBlockLevel = DnsBlockService.instance.level;
-        _dnsBlockSliderValue = _dnsBlockLevel.toDouble();
+        _dnsBlockSliderValue = _dnsBlockLevel;
         _blocklistLastUpdated = lastUpdated;
       });
     }
   }
 
   Future<void> _downloadBlocklist() async {
-    final level = _dnsBlockSliderValue.round();
+    final level = _dnsBlockSliderValue;
 
     setState(() {
       _isDownloadingBlocklist = true;
@@ -1620,54 +1621,22 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
                   )
                 : IconButton(
                     icon: Icon(
-                      _dnsBlockSliderValue.round() != _dnsBlockLevel
+                      _dnsBlockSliderValue != _dnsBlockLevel
                           ? Icons.download
                           : Icons.sync,
                     ),
-                    tooltip: _dnsBlockSliderValue.round() != _dnsBlockLevel
+                    tooltip: _dnsBlockSliderValue != _dnsBlockLevel
                         ? loc.appSettingsDownloadBlocklist
                         : loc.appSettingsRefreshBlocklist,
                     onPressed: _downloadBlocklist,
                   ),
           ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16.0),
-            child: Column(
-              children: [
-                Slider(
-                  value: _dnsBlockSliderValue,
-                  min: 0,
-                  max: 5,
-                  divisions: 5,
-                  label: dnsBlockLevelNames[_dnsBlockSliderValue.round()],
-                  onChanged: _isDownloadingBlocklist
-                      ? null
-                      : (value) {
-                          setState(() {
-                            _dnsBlockSliderValue = value;
-                          });
-                        },
-                ),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    for (int i = 0; i < dnsBlockLevelNames.length; i++)
-                      Text(
-                        dnsBlockLevelNames[i],
-                        style: TextStyle(
-                          fontSize: 9,
-                          fontWeight: _dnsBlockSliderValue.round() == i
-                              ? FontWeight.bold
-                              : FontWeight.normal,
-                          color: _dnsBlockSliderValue.round() == i
-                              ? Theme.of(context).colorScheme.secondary
-                              : null,
-                        ),
-                      ),
-                  ],
-                ),
-              ],
-            ),
+          LevelSlider(
+            labels: dnsBlockLevelNames,
+            value: _dnsBlockSliderValue,
+            onChanged: _isDownloadingBlocklist
+                ? null
+                : (value) => setState(() => _dnsBlockSliderValue = value),
           ),
 
           // LocalCDN (Android only)

--- a/lib/screens/site_privacy.dart
+++ b/lib/screens/site_privacy.dart
@@ -8,6 +8,7 @@ import 'package:webspace/services/dns_block_service.dart';
 import 'package:webspace/services/dns_level_mask_engine.dart';
 import 'package:webspace/services/localcdn_service.dart';
 import 'package:webspace/widgets/hint_button.dart';
+import 'package:webspace/widgets/level_slider.dart';
 
 /// Everything the privacy screen may change, in one value so the caller can
 /// apply a whole edit in a single `setState`.
@@ -316,6 +317,11 @@ class _SitePrivacyScreenState extends State<SitePrivacyScreen> {
         downloadedLevels: DnsBlockService.instance.downloadedLevels,
       );
 
+  /// Slider stop standing for "same as app settings". The stops above it are
+  /// the levels themselves; level 0 (Off) is not one of them, because the
+  /// row's own switch is what turns DNS blocking off.
+  static const int _followsAppStop = 0;
+
   Widget _dnsBlocklistLevel(AppLocalizations loc) {
     final needsDownload = _dnsLevelNeedsDownload;
     final chosen = _values.dnsBlockLevel;
@@ -327,66 +333,51 @@ class _SitePrivacyScreenState extends State<SitePrivacyScreen> {
             ? loc.siteSettingsDnsLevelFollowsApp(
                 dnsBlockLevelNames[DnsBlockService.instance.level])
             : dnsBlockLevelNames[chosen]);
-    return ListTile(
-      contentPadding: const EdgeInsets.only(left: 32, right: 16),
-      title: Row(
-        children: [
-          Flexible(child: Text(title)),
-          HintButton(
-              title: title, description: loc.siteSettingsDnsBlocklistLevelHint),
-          if (needsDownload) _warnIcon(),
-        ],
-      ),
-      subtitle: Text(subtitle,
-          style: TextStyle(color: needsDownload ? Colors.orange : null)),
-      trailing: _downloadingLevel != null
-          ? const SizedBox(
-              width: 18, height: 18,
-              child: CircularProgressIndicator(strokeWidth: 2))
-          : const Icon(Icons.chevron_right, size: 18),
-      onTap: _downloadingLevel != null ? null : _pickDnsLevel,
-    );
-  }
-
-  /// Picker value standing for "follow the app setting". The picker never
-  /// offers level 0 — the row's own switch is what turns DNS blocking off.
-  static const int _followsAppSetting = -1;
-
-  Future<void> _pickDnsLevel() async {
-    final loc = AppLocalizations.of(context);
-    final picked = await showDialog<int>(
-      context: context,
-      builder: (context) => SimpleDialog(
-        title: Text(loc.siteSettingsDnsBlocklistLevel),
-        children: [
-          RadioGroup<int>(
-            groupValue: _values.dnsBlockLevel ?? _followsAppSetting,
-            onChanged: (value) => Navigator.pop(context, value),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                RadioListTile<int>(
-                  value: _followsAppSetting,
-                  title: Text(loc.siteSettingsDnsLevelFollowApp),
-                ),
-                for (var level = 1; level <= kDnsMaxLevel; level++)
-                  RadioListTile<int>(
-                    value: level,
-                    title: Text(dnsBlockLevelNames[level]),
-                  ),
-              ],
-            ),
+    return Column(
+      children: [
+        ListTile(
+          contentPadding: const EdgeInsets.only(left: 32, right: 16),
+          title: Row(
+            children: [
+              Flexible(child: Text(title)),
+              HintButton(
+                  title: title, description: loc.siteSettingsDnsBlocklistLevelHint),
+              if (needsDownload) _warnIcon(),
+            ],
           ),
-        ],
-      ),
+          subtitle: Text(subtitle,
+              style: TextStyle(color: needsDownload ? Colors.orange : null)),
+          trailing: _downloadingLevel != null
+              ? const SizedBox(
+                  width: 18, height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2))
+              : null,
+        ),
+        LevelSlider(
+          padding: const EdgeInsets.only(left: 32, right: 16),
+          labels: [
+            loc.siteSettingsDnsLevelFollowAppShort,
+            for (var level = 1; level <= kDnsMaxLevel; level++)
+              dnsBlockLevelNames[level],
+          ],
+          value: chosen ?? _followsAppStop,
+          onChanged: _downloadingLevel != null
+              ? null
+              : (stop) => _update(_values.copyWith(
+                    dnsBlockLevel: stop == _followsAppStop ? null : stop,
+                  )),
+          // Fetching waits for the drag to settle: every stop the thumb
+          // crosses is a level, and downloading each one would pull four
+          // lists nobody asked for.
+          onChangeEnd: (stop) {
+            if (stop != _followsAppStop &&
+                !DnsBlockService.instance.downloadedLevels.contains(stop)) {
+              _downloadLevel(stop);
+            }
+          },
+        ),
+      ],
     );
-    if (picked == null || !mounted) return;
-    final level = picked == _followsAppSetting ? null : picked;
-    _update(_values.copyWith(dnsBlockLevel: level));
-    if (level != null &&
-        !DnsBlockService.instance.downloadedLevels.contains(level)) {
-      await _downloadLevel(level);
-    }
   }
 
   /// Fetch a level's list on demand. Until it lands the site keeps running at

--- a/lib/widgets/level_slider.dart
+++ b/lib/widgets/level_slider.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+/// Discrete slider over a small set of named steps, with every step's name
+/// printed under the track and the current one highlighted.
+///
+/// Shared by the two DNS blocklist level controls (app-wide in App Settings,
+/// per-site in Site Privacy) so the same choice is not made two different
+/// ways in two screens.
+class LevelSlider extends StatelessWidget {
+  const LevelSlider({
+    super.key,
+    required this.labels,
+    required this.value,
+    required this.onChanged,
+    this.onChangeEnd,
+    this.padding = const EdgeInsets.symmetric(horizontal: 16),
+  });
+
+  /// Step names in order; a step's index is its value.
+  final List<String> labels;
+
+  final int value;
+
+  /// Null disables the slider.
+  final ValueChanged<int>? onChanged;
+
+  /// Fired once the drag settles, for work too expensive to run on every
+  /// step the thumb passes over (a download, a write).
+  final ValueChanged<int>? onChangeEnd;
+
+  final EdgeInsetsGeometry padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final selected = Theme.of(context).colorScheme.secondary;
+    final max = labels.length - 1;
+    final current = value.clamp(0, max);
+    return Padding(
+      padding: padding,
+      child: Column(
+        children: [
+          Slider(
+            value: current.toDouble(),
+            min: 0,
+            max: max.toDouble(),
+            divisions: max,
+            label: labels[current],
+            onChanged:
+                onChanged == null ? null : (v) => onChanged!(v.round()),
+            onChangeEnd:
+                onChangeEnd == null ? null : (v) => onChangeEnd!(v.round()),
+          ),
+          // Six labels at their natural width overrun a narrow phone once the
+          // control is indented, and one of them is translated, so each is
+          // capped at its share of the row and scaled down to fit rather than
+          // allowed to overflow.
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              for (var i = 0; i <= max; i++)
+                Flexible(
+                  child: FittedBox(
+                    fit: BoxFit.scaleDown,
+                    child: Text(
+                      labels[i],
+                      maxLines: 1,
+                      style: TextStyle(
+                        fontSize: 9,
+                        fontWeight:
+                            i == current ? FontWeight.bold : FontWeight.normal,
+                        color: i == current ? selected : null,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/openspec/changes/per-site-blocker-masks/specs/dns-blocklist/spec.md
+++ b/openspec/changes/per-site-blocker-masks/specs/dns-blocklist/spec.md
@@ -151,6 +151,13 @@ use
 **And** the site blocks at Pro until the Light list arrives
 **And** the Light list is fetched
 
+#### Scenario: Dragging across levels fetches only where the drag settles
+
+**Given** a site on the app-wide level and no other level downloaded
+**When** the user drags the level slider from the app-wide stop to Ultimate
+**Then** the site's level follows the thumb across every stop it crosses
+**And** only Ultimate's list is fetched
+
 #### Scenario: A failed fetch leaves the site protected
 
 **Given** every mirror fails for the requested level
@@ -247,6 +254,9 @@ inherits them.
 **Then** a "Blocklist level" row sits under the toggle
 **And** its subtitle names the level in use, or that the site follows the app
 setting
+**And** the level is picked on a stepped slider labelled with every level,
+whose leftmost stop is the app-wide setting, the same control App Settings
+uses for the app-wide level
 
 ---
 

--- a/openspec/changes/per-site-blocker-masks/tasks.md
+++ b/openspec/changes/per-site-blocker-masks/tasks.md
@@ -58,8 +58,10 @@
 
 ## 5. Settings UI
 
-- [x] 5.1 "Blocklist level" row under the DNS toggle: level picker, the
-  app-setting default, the not-downloaded state, and the on-demand fetch.
+- [x] 5.1 "Blocklist level" row under the DNS toggle: the stepped slider App
+  Settings uses for the app-wide level (`lib/widgets/level_slider.dart`), whose
+  leftmost stop is the app-setting default, plus the not-downloaded state and
+  the on-demand fetch once the drag settles.
 - [x] 5.2 "Filter lists" row under the content-blocker toggle: a checklist of
   the app's enabled lists.
 - [x] 5.3 Ten new ARB keys, translated across every shipped locale.
@@ -114,3 +116,8 @@
   Dart writers and the Kotlin reader agree on the `#`-plus-hex marker, the
   level-bit formula, the level range, and the unmarked-blob-is-level-1
   fallback. Nothing else links the two sides of the platform channel.
+- [x] 6.11 `test/level_slider_test.dart` and the slider group in
+  `test/site_privacy_screen_test.dart`: every stop labelled and the current one
+  highlighted, an out-of-range level clamped onto the track, the tick row
+  fitting a narrow phone in all 67 locales, and the leftmost stop reading and
+  writing "follow the app setting".

--- a/test/js/design_tokens_no_literals.test.js
+++ b/test/js/design_tokens_no_literals.test.js
@@ -23,6 +23,7 @@ const MIGRATED = [
   'lib/screens/favicon_image_web.dart',
   'lib/widgets/url_bar.dart',
   'lib/widgets/hint_button.dart',
+  'lib/widgets/level_slider.dart',
   'lib/widgets/tab_bar_corner_button.dart',
 ];
 

--- a/test/js/l10n_no_hardcoded_text.test.js
+++ b/test/js/l10n_no_hardcoded_text.test.js
@@ -43,6 +43,7 @@ const migrated = new Set([
   'lib/widgets/find_toolbar.dart',
   'lib/widgets/firefox_version_tile.dart',
   'lib/widgets/hint_button.dart',
+  'lib/widgets/level_slider.dart',
   'lib/widgets/root_messenger.dart',
   'lib/widgets/site_permission_badges.dart',
   'lib/widgets/stats_banner.dart',

--- a/test/level_slider_test.dart
+++ b/test/level_slider_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webspace/l10n/gen/app_localizations.dart';
+import 'package:webspace/services/dns_block_service.dart';
+import 'package:webspace/services/dns_level_mask_engine.dart';
+import 'package:webspace/widgets/level_slider.dart';
+
+/// Narrowest phone the app targets, at the per-site row's own indentation:
+/// the tick row is the widest thing on the control and the only part of it
+/// that carries a translated string.
+Future<void> _pump(
+  WidgetTester tester,
+  List<String> labels,
+  int value,
+) async {
+  tester.view.physicalSize = const Size(320, 640);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  await tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: LevelSlider(
+        padding: const EdgeInsets.only(left: 32, right: 16),
+        labels: labels,
+        value: value,
+        onChanged: (_) {},
+      ),
+    ),
+  ));
+}
+
+void main() {
+  testWidgets('every stop is labelled and the current one stands out',
+      (tester) async {
+    await _pump(tester, dnsBlockLevelNames, 2);
+    for (final name in dnsBlockLevelNames) {
+      expect(find.text(name), findsOneWidget, reason: name);
+    }
+    expect(
+      tester.widget<Text>(find.text(dnsBlockLevelNames[2])).style?.fontWeight,
+      FontWeight.bold,
+    );
+    expect(
+      tester.widget<Text>(find.text(dnsBlockLevelNames[3])).style?.fontWeight,
+      FontWeight.normal,
+    );
+  });
+
+  testWidgets('an out-of-range value lands on a real stop', (tester) async {
+    // A site can carry a level this build no longer offers; the slider must
+    // still render rather than assert its value out of the track.
+    await _pump(tester, dnsBlockLevelNames, 99);
+    expect(tester.takeException(), isNull);
+    expect(tester.widget<Slider>(find.byType(Slider)).value, 5.0);
+  });
+
+  testWidgets('the tick row fits a narrow phone in every locale',
+      (tester) async {
+    // Only the leftmost stop is translated (the level names are Hagezi's own),
+    // so a long word for "app" is the one thing that can push the row over.
+    for (final locale in AppLocalizations.supportedLocales) {
+      final loc = await AppLocalizations.delegate.load(locale);
+      await _pump(tester, [
+        loc.siteSettingsDnsLevelFollowAppShort,
+        for (var level = 1; level <= kDnsMaxLevel; level++)
+          dnsBlockLevelNames[level],
+      ], 0);
+      expect(tester.takeException(), isNull, reason: '$locale');
+    }
+  });
+}

--- a/test/site_privacy_screen_test.dart
+++ b/test/site_privacy_screen_test.dart
@@ -2,11 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:webspace/l10n/gen/app_localizations.dart';
 import 'package:webspace/screens/site_privacy.dart';
+import 'package:webspace/services/dns_block_service.dart';
+import 'package:webspace/widgets/level_slider.dart';
 
 SitePrivacyValues _values({
   bool trackingProtection = false,
   bool clearUrl = false,
   bool dnsBlock = false,
+  int? dnsBlockLevel,
   bool contentBlock = false,
   bool localCdn = false,
   bool thirdPartyCookies = false,
@@ -17,6 +20,7 @@ SitePrivacyValues _values({
       trackingProtectionEnabled: trackingProtection,
       clearUrlEnabled: clearUrl,
       dnsBlockEnabled: dnsBlock,
+      dnsBlockLevel: dnsBlockLevel,
       contentBlockEnabled: contentBlock,
       localCdnEnabled: localCdn,
       thirdPartyCookiesEnabled: thirdPartyCookies,
@@ -165,6 +169,53 @@ void main() {
     expect(find.textContaining('Forced on by'), findsNothing);
     expect(find.text('Forced off by Tracking Protection'), findsOneWidget);
     expect(find.text('Strip tracking parameters from URLs'), findsOneWidget);
+  });
+
+  group('the per-site level uses the same slider as App Settings', () {
+    // The level row only renders with a blocklist in memory, and the slider's
+    // stops are the levels the app knows about, so the service has to be
+    // seeded rather than stubbed at the call site.
+    setUp(() {
+      DnsBlockService.instance.loadLevelsFromStrings(
+        {2: 'normal.example', 3: 'pro.example'},
+        globalLevel: 3,
+      );
+    });
+    tearDown(DnsBlockService.instance.resetForTest);
+
+    LevelSlider slider(WidgetTester tester) {
+      final found = find.byType(LevelSlider);
+      expect(found, findsOneWidget);
+      return tester.widget<LevelSlider>(found);
+    }
+
+    testWidgets('the leftmost stop is the app-wide setting', (tester) async {
+      await _pump(tester, values: _values(dnsBlock: true));
+      final s = slider(tester);
+      expect(s.value, 0);
+      expect(s.labels, ['App', 'Light', 'Normal', 'Pro', 'Pro++', 'Ultimate']);
+      expect(find.text('Same as app settings (Pro)'), findsOneWidget);
+    });
+
+    testWidgets('a site level puts the thumb on that level', (tester) async {
+      await _pump(tester, values: _values(dnsBlock: true, dnsBlockLevel: 2));
+      expect(slider(tester).value, 2);
+    });
+
+    testWidgets('moving the thumb reports the level, stop 0 reports null',
+        (tester) async {
+      SitePrivacyValues? seen;
+      await _pump(
+        tester,
+        values: _values(dnsBlock: true, dnsBlockLevel: 2),
+        onChanged: (v) => seen = v,
+      );
+      slider(tester).onChanged!(3);
+      expect(seen!.dnsBlockLevel, 3);
+      await tester.pumpAndSettle();
+      slider(tester).onChanged!(0);
+      expect(seen!.dnsBlockLevel, isNull);
+    });
   });
 
   testWidgets('toggling a row reports the whole value back', (tester) async {


### PR DESCRIPTION
Extract the DNS blocklist level slider from App Settings into a reusable `LevelSlider` widget and use it in Site Privacy to replace the radio button picker. Both screens now present the same control for consistency.

**Changes:**
- New `LevelSlider` widget (`lib/widgets/level_slider.dart`) — discrete slider with labeled stops, current stop highlighted, disabled state support. Handles narrow phones by scaling down labels to fit.
- Site Privacy: replace `_pickDnsLevel()` dialog with `LevelSlider` embedded below the DNS blocklist level row. Fetch on drag settle rather than on every stop crossed, reducing unnecessary downloads.
- App Settings: refactor slider state from `double` to `int` and use the new `LevelSlider` widget.
- New test file `test/level_slider_test.dart` verifies label rendering, out-of-range clamping, and layout on narrow phones across all locales.
- Updated Site Privacy tests to verify slider integration and value reporting.
- Localization: rename `siteSettingsDnsLevelFollowApp` to `siteSettingsDnsLevelFollowAppShort` (shorter for slider label space); update all 67 locale files.

The slider's leftmost stop represents "follow app settings" (null level); stops 1–5 are the DNS blocklist levels. Dragging updates the site's level in real time; only the final settled stop triggers a download if needed.

https://claude.ai/code/session_01ESzRH7b8ZwZJCp4unz9YdM