### PR TITLE
Record upstream flutter_inappwebview issue audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,7 @@ Specs live under `openspec/specs/<slug>/spec.md` (Given/When/Then). **Read the r
 | site-permission-badges | drawer badges for location/camera/mic/background-audio grants; real device access vs simulated |
 | tracking-protection | umbrella per-site ETP: forces ClearURLs/DNS/content blocker/LocalCDN + injects anti-fingerprinting shim (Canvas/WebGL/audio/fonts/screen/hardware/timing/clientrects) seeded by siteId |
 | user-agent-identity | engine-consistent navigator identity for the per-site UA (vendor/productSub/oscpu/buildID/platform/userAgentData); complements desktop-mode |
+| upstream-webview-defects *(change)* | defects found auditing the pinned flutter_inappwebview fork's upstream tracker: a declined `onCreateWindow` still navigating on iOS/macOS, UA client hints that half-spoof, the plugin's unmasked console wrappers, the real Linux WPE build floor |
 | user-scripts | per-site JS injection w/ timing control |
 | web-camera-access | per-site camera for camera-only getUserMedia (banking QR flows); `cameraMode` ask/real/virtual/block. Virtual serves a user-picked image/looped video via a canvas `captureStream` shim (no real camera, no OS prompt); real grant ensures Android CAMERA perm |
 | web-microphone-access | per-site audio capture with **no real-mic mode**; `microphoneMode` ask/virtual/block. Virtual loops a user-picked clip through WebAudio into a `MediaStreamAudioDestinationNode`. No OS recording permission on any platform (native layer DENYs MICROPHONE outright); audio+video requests are split, video re-issued to the camera shim |

--- a/docs/bugs/007-native-shared-state-races.md
+++ b/docs/bugs/007-native-shared-state-races.md
@@ -177,3 +177,27 @@ unguarded and is the obvious next file to point this technique at.
 4. **CONT-005 silent degrade-to-shared.** If the native `containerId` bind ever fails, the
    site falls back to the default store; the engine tolerates a zero-bind result but can't
    detect the degraded (isolation-lost) state. Wants a native post-bind assertion.
+5. **Adblock engine: correct locking, unbounded latency.** Found 2026-09-06 while triaging
+   upstream [#2888](https://github.com/pichillilorenzo/flutter_inappwebview/issues/2888)
+   (a fork latch with no timeout) and [#2718](https://github.com/pichillilorenzo/flutter_inappwebview/issues/2718)
+   (an ANR in `MyCookieManager.deleteAllCookies`); see
+   [docs/upstream/flutter-inappwebview-audit.md](../upstream/flutter-inappwebview-audit.md).
+   Neither upstream issue reaches us, but reading them exposed the same geometry in our own
+   code. `AdblockEngineNative.setRules` (`AdblockEngineNative.kt:90-111`) holds the **write**
+   lock across `nativeEngineFree` plus `nativeEngineNew(rulesText)`, a full adblock-rust parse
+   of the concatenated filter lists, and it runs synchronously on the Android platform thread
+   from the method-channel handler (`WebInterceptPlugin.kt:105-115`). `checkUrl`
+   (`AdblockEngineNative.kt:118-128`) takes an **unbounded** `readLock.lock()` on chromium's
+   concurrent sub-resource IO threads. So flipping the content-blocker toggle blocks the main
+   thread in a JNI parse and every IO thread queued behind it, with no timeout on either side.
+   Separately `DNS_READY_TIMEOUT_MS` is `15_000L` (`WebInterceptPlugin.kt:846`), three times
+   the ANR window, deliberately fail-closed but reachable from those same IO threads.
+   This is attempt 1's RW-lock doing exactly what it was asked to do: it closed the UAF and
+   was never asked to bound latency. It is a **gap, not a regression** (no crash, no
+   incorrect block decision), and it is recorded here rather than as a fix attempt because
+   nothing has been attempted yet. The shape of the fix is the one #2888 proposes for the
+   fork: move `setRules` onto the build-worker pattern `setDnsBlockedDomains` already uses
+   (`WebInterceptPlugin.kt:88-95`), and give `checkUrl` a `tryLock(timeout)` that falls
+   through to allow. `AdblockEngineNativeTest.kt` asserts readers and writers don't deadlock
+   or throw; it does not assert either of them finishes in bounded time, which is why this
+   sat unnoticed.

--- a/docs/upstream/flutter-inappwebview-audit.md
+++ b/docs/upstream/flutter-inappwebview-audit.md
@@ -325,9 +325,23 @@ for a different signal on the same handler (`hasGesture`, not `isForMainFrame`),
 it has been conflicted since August, and NESTED-013 touches the same spec
 section, so land one before writing the other.
 
-Note for whoever revisits the Linux CI comment: the claim at
-`.github/workflows/build-and-test.yml:562-566` that the plugin calls
-`webkit_navigation_action_is_for_main_frame` describes the *intended* end state,
-not the present one. The symbol does not exist in shipped WebKit yet, which is
-what PR 65415 is for, and nothing in the fork calls it. Only
-`webkit_web_view_get_theme_color` actually forces the 2.50 floor today.
+### Verified against WebKit sources, 2026-09-07
+
+`webkit_navigation_action_is_for_main_frame` **has never been added to WebKit.**
+`Source/WebKit/UIProcess/API/glib/WebKitNavigationAction.h.in` declares the same
+six accessors (`get_navigation_type`, `get_mouse_button`, `get_modifiers`,
+`get_request`, `is_user_gesture`, `get_frame_name`) and nothing else on every ref
+checked: `main`, `webkitglib/2.50`, `webkitglib/2.52` and `webkitglib/2.54`, all
+HTTP 200. PR 65415 is open and merging-blocked, so there is no release to wait
+for and no version to gate on yet.
+
+The claim at `.github/workflows/build-and-test.yml:562-566` that the plugin
+"calls `webkit_navigation_action_is_for_main_frame` (added in 2.50)" is wrong on
+both halves: nothing in the fork calls it, and it was not added in 2.50 or in
+any release since.
+
+`webkit_web_view_get_theme_color` is real and the boundary is as stated: absent
+from `WebKitWebView.h.in` on `webkitglib/2.48`, present on `webkitglib/2.50`. It
+is the only symbol actually forcing our 2.50 floor, so PR #2781's guard should
+free the `debian:sid-slim` pin on its own. The full Linux job is still the proof,
+but the second symbol in that comment was never a reason.

--- a/docs/upstream/flutter-inappwebview-audit.md
+++ b/docs/upstream/flutter-inappwebview-audit.md
@@ -1,0 +1,140 @@
+# Upstream audit: flutter_inappwebview
+
+We ship a fork of `flutter_inappwebview` pinned by `dependency_overrides` in
+[pubspec.yaml](../../pubspec.yaml), so upstream releases never reach us on their
+own and upstream's issue tracker is not a feed we can ignore: a defect filed
+there is a defect in code we compile, and a fix landed there is a fix we do not
+have until someone rebases the fork.
+
+This file is the record of reading that tracker. One section per audit, dated,
+appended, never rewritten. Each entry says what the fork ref was at the time, so
+a later reader can tell whether a verdict still holds.
+
+**What belongs here:** the per-issue verdict and the evidence for it, including
+the verdicts of NO. "We checked #2555 and we do not take that path" is the
+expensive half of the work and the half that gets redone if nobody writes it
+down.
+
+**What does not:** the behaviour we decided to require as a result. That goes in
+the owning OpenSpec capability, and a bug whose symptom recurs across code paths
+goes in [docs/bugs/](../bugs/). This file links out to both.
+
+## Method
+
+1. Resolve the baseline: `git merge-base` between the pinned fork ref and
+   `upstream/master`. Everything upstream has that we do not is backlog we
+   carry; everything we have on top is fork surface only we can break.
+2. Harvest the open issues. The GitHub HTML listing truncates each page, so
+   sort both ascending and descending by created and by updated, and take the
+   union rather than trusting a single pass.
+3. Batch by category and triage each issue against **both** trees: the app, and
+   the fork at the pinned ref. A verdict without a `path:line` in at least one
+   of them is a guess.
+4. Verdicts are AFFECTS / MAYBE / NO. NO needs a reason of the form "we never
+   call it", "it is guarded at our ref", or "that platform is not shipped", not
+   "it looks unrelated".
+
+Platforms shipped: Android, iOS, macOS, Linux. Windows and web are not shipped
+(`web/` exists only for the design gallery, where no WebView runs), so issues
+confined to them are NO by construction.
+
+## Audit 2026-09-06
+
+**Fork ref:** `v6.2.0-beta.3-privacy-v6`
+**Baseline:** `merge-base(fork, upstream/master)` = `17527cae`, which *is*
+upstream master HEAD. The fork is upstream master plus 19 commits, all additive
+(containers, `proxySettings`, three Android settings, cookie flush/memo fixes).
+
+That baseline is the single most useful fact in this audit: **we carry no
+upstream backlog.** Every issue of the form "fixed on master but never
+released" is already fixed for us, which disposes of #2886 and #2709 outright.
+
+**Coverage:** 131 of 144 open issues read. The 13 unread are most likely
+Windows/web given how the remainder distributed, but they are unread, not
+cleared.
+
+### Affects us
+
+| # | Title | Verdict | Evidence | Disposition |
+|---|---|---|---|---|
+| 2763 | iOS `onCreateWindow` return value ignored | AFFECTS, high | fork iOS `InAppWebView.swift:2762-2766` calls `self?.loadUrl(navigationAction.request)` in `defaultBehaviour`; Android `InAppWebViewChromeClient.java:675-679` only drops the pending message; our handler returns `false` on every path but the captcha popup (`lib/services/webview.dart:4054-4141`) | NESTED-011, EXT-009 |
+| 2834 | Suppress/customize `Sec-CH-UA` | AFFECTS, medium (residual) | `lib/services/user_agent_metadata_builder.dart:49-62` ships `platform`/`mobile` with a null `brandVersionList`; fork `InAppWebView.java:2370-2372` then skips `setBrandVersionList`, leaving the real brands | UAID-005 |
+| 2878 | Soft keyboard dead app-wide after HTML5 fullscreen | AFFECTS, high | fork `InAppWebViewChromeClient.java:151-179` `onHideCustomView` restores system UI and orientation, never the IME; zero `InputMethodManager` references in the file | fork patch, no spec |
+| 2859 | iOS 17.2+ scroll stuck after keyboard dismiss | AFFECTS, medium | fork iOS `InAppWebView.swift:189-193` applies a negative `contentInset`; `:201-203` `keyboardWillHide` only clears `_scrollViewContentInsetAdjusted` | cherry-pick reporter's PR |
+| 2718 | ANR in `MyCookieManager.deleteAllCookies` | AFFECTS, medium | fork `MyCookieManager.java:445-460` flushes on the platform thread, and our own `flushContainerCookieManagers()` (`:535-556`) fans that out across every profile; callers `lib/main.dart:6315`, `:9548`, `lib/services/cookie_isolation.dart:155` | BUG-007 gap 5 |
+| 2703 | 16 KB page size | AFFECTS, medium (release) | no `max-page-size` flag anywhere in the repo; alignment is incidental, from `CARGO_NDK_VERSION: "4.1.2"` (`.github/workflows/build-and-test.yml:25`) against NDK r26d, and CI builds only `--flavor fdroid` (`:367-369`) | tasks 5.x |
+| 2863 | Android native WebView background color | AFFECTS, low-medium | fork `InAppWebView.java:397-398` sets `Color.TRANSPARENT` only when `transparentBackground` is set, which we never set outside `lib/widgets/virtual_source_preview.dart:97` | [BUG-001](../bugs/001-white-screen.md) |
+| 2850 | iOS `console.log` coerces objects | AFFECTS, low-medium | fork's `ConsoleLogJS` concatenation is identical on iOS, macOS and Linux; consumed raw at `lib/services/webview.dart:4405-4406` | ETP-025 (the fingerprinting half) |
+| 2873 | Restrict FileProvider paths | AFFECTS, low-medium | our `android/app/src/main/res/xml/flutter_inappwebview_android_provider_paths.xml` carries five roots against upstream's one | tasks 6.x |
+| 2791 | `shouldOverrideUrlLoading` always returns true | AFFECTS, medium | `lib/services/webview.dart:3531` sets `useShouldOverrideUrlLoading` unconditionally; fork `InAppWebViewClient.java:105` returns `request.isForMainFrame()` even on ALLOW, reissuing at `:145` | NESTED-012, documentation only |
+| 2780 | `webkit_web_view_get_theme_color` on WebKit < 2.50 | AFFECTS, build | one unguarded call at fork `flutter_inappwebview_linux/linux/in_app_webview/in_app_webview.cc:6268`; no `WEBKIT_CHECK_VERSION` anywhere in the Linux plugin | CONT-009 |
+| 2861 | Linux white screen under `DISABLE_GL=1` | AFFECTS, users only | env var read at `custom_platform_view.cc:18`, never consulted by the buffer path; CI uses llvmpipe instead (`.github/workflows/build-and-test.yml:811`) | [BUG-001](../bugs/001-white-screen.md) |
+| 2862 | Cannot build on Ubuntu | AFFECTS, docs | fork `flutter_inappwebview_linux/linux/CMakeLists.txt:47-63` probes 2.0/1.1/1.0 and never version-checks | CONT-009 |
+| 2883 | Flutter 3.47 UI separation | AFFECTS on next upgrade | `.fvmrc` pins 3.38.6 | fork rebase, blocks the bump |
+| 2880, 2882 | iOS 27 SDK deprecations | AFFECTS on next upgrade, low | fork `InAppBrowserNavigationController.swift:14`, `InAppBrowserManager.swift:131`, both in native `InAppBrowser` we never instantiate | compile-time only |
+| 2728 | Android 15 nav/status bar color APIs | AFFECTS now, cosmetic | fork `InAppBrowserActivity.java:122`; `targetSdk 36` makes the setter a no-op but Play's static scan reads the artifact | fork patch to silence |
+
+### Watch list
+
+Reachable in principle, no evidence we hit it, no action taken.
+
+- **#2867 + #2600**, the `windowId` KVO crash. One mechanism, two reporters:
+  `observeValue` to `initializeWindowIdJS` to a JS eval on a window webview
+  whose `plugin`/`channelDelegate` are swapped in mid-flight, against an
+  unsynchronised `windowWebViews` dictionary. We are unusually exposed because
+  every captcha opens a `windowId` popup (`lib/services/webview.dart:1852`) and
+  the iOS universal-link bypass reissues every gesture navigation. Same shape as
+  [BUG-007](../bugs/007-native-shared-state-races.md) on the Swift side.
+- **#2727, #2713**, iOS 26 dead touch after a dialog or drawer closes. Our whole
+  settings UX is dialogs over a live webview and the drawer is primary
+  navigation, so if these are real we would see them everywhere on iOS 26.
+  Needs a device.
+- **#2491**, renderer crash navigating back. Worst case for us is a rebuild,
+  which [BUG-002](../bugs/002-black-screen.md) already absorbs.
+- **#2695**, `ERR_NAME_NOT_RESOLVED` after a long background. Our
+  `onReceivedError` suppression branch loads `about:blank`
+  (`lib/services/webview.dart:4471-4478`), which is the reporter's symptom.
+- **#2697, #2721**, multi-window and display-size changes. We suppress activity
+  recreate via `configChanges` (`android/app/src/main/AndroidManifest.xml:32`),
+  so we sit on the non-adapting path by construction.
+- **#2493, #2135**, bottom-of-page inputs not scrolled into view. One item, not
+  two. Likely the same root as #2859 on iOS; retest after that lands.
+- **#2826**, macOS fractional-width frame drift. Would read as
+  [BUG-008](../bugs/008-viewport-scale.md) if a user hit it. None has.
+
+### Cleared, with the reason
+
+Recording these is the point of the file: each one cost a read of both trees.
+
+| # | Reason |
+|---|---|
+| 2888 | The unbounded latch is real (fork `Util.java:99-109`) but all four arm sites are disarmed for us: `useShouldInterceptRequest = false` (`lib/services/webview.dart:3537`), no `resourceCustomSchemes`, no `WebViewAssetLoader`, `setServiceWorkerClient(null)` (`lib/main.dart:646`). Gated by task 4.1 so it stays that way. |
+| 2580 | Same gate. Our subresource interception is native (`WebInterceptPlugin.kt`) and never crosses to Dart, so the reported deadlock cannot occur. |
+| 2886, 2709 | Fixed at our ref (`webview_asset_loader.dart:242` already spreads `super.toMap()`), and we use `HtmlCacheService`, not `WebViewAssetLoader`. |
+| 2848 | Both file-URL flags default `false` (fork `InAppWebViewSettings.java:74-75`) and we never set them. Latent, not live: we do run untrusted HTML at a `file://` origin with `allowFileAccess = true` (`lib/services/webview.dart:3547`), so an upstream default flip would be immediately exploitable. Task 6.2 pins them. |
+| 2745 | The `eval()` is in `flutter_inappwebview_web` (not shipped) and in an Android path reached only when `contentWorld != PAGE`, which we never pass. |
+| 2712 | We already built it: `FastSubresourceInterceptor` blocks by hostname before the fetch. |
+| 2673, 2594 | Guarded by try/catch at our ref, and we never set `forceDark`. |
+| 2555 | The IME proxy hack is gated on `!useHybridComposition`; we leave hybrid composition on. |
+| 2868 | Needs a custom `contextMenu`, which we never pass. |
+| 2819 | We subscribe to neither `onEnterFullscreen` nor `onExitFullscreen`. |
+| 2753 | We discard subframe errors anyway (`lib/services/webview.dart:4432`). |
+| 2707, 2855, 2730, 2619, 2570 | Native `InAppBrowser`, `ContextMenu`, `targetFrame`, `callAsyncJavaScript`, autofill: none referenced in `lib/`. Our `lib/screens/inappbrowser.dart` is a Flutter route, not the plugin's native browser. |
+| 2723, 2795, 2598, 2340, 2821 | Require a scroll ancestor, a `Slider`, a `Draggable` or a `BackdropFilter` over a live webview. We have none. |
+| 2415, 2762 | Fixed in Flutter 3.38.6, which `.fvmrc` already pins. |
+| 2654 | Reported against 5.8/6.0; `dispose()` at our ref removes every observer symmetrically. |
+| 2887, 2830 | Our AGP (8.13.1) and iOS deployment target (15.0) are past the reporters' boundaries. |
+| 2687, 2685, 2641, 1627, 2178, 2796, 2757 | Warnings with no `-Werror`, a `compileSdk` we already exceed, a package we do not depend on, or `pana`, which we never run (`publish_to: 'none'`). |
+| 2807, 2615, 460, 2798 | System WPE, Windows, a 2020 meta-issue, and `keepAlive`, which we never use. |
+| ~40 Windows/web issues | Not shipped. |
+
+### Findings that are ours, not upstream's
+
+Two of the threading findings came out of reading upstream's reports and then
+looking at our own code. They are recorded where they belong rather than here:
+
+- The adblock engine's write lock spans a full filter-list parse on the platform
+  thread, and `checkUrl`'s read lock is unbounded:
+  [BUG-007 gap 5](../bugs/007-native-shared-state-races.md).
+- `DNS_READY_TIMEOUT_MS` is 15s (`WebInterceptPlugin.kt:846`), three times the
+  ANR window: same gap.

--- a/docs/upstream/flutter-inappwebview-audit.md
+++ b/docs/upstream/flutter-inappwebview-audit.md
@@ -260,3 +260,65 @@ WebKit 2.50 symbols, but `webkit_navigation_action_is_for_main_frame` does not
 appear anywhere in the fork. `webkit_web_view_get_theme_color` is the only one,
 which is why #2781 alone should free the pin. The Linux build is the proof, not
 the comment.
+
+## Upstream beyond the plugin: WebKit
+
+The plugin is not the only upstream we depend on. On Linux the fork binds to WPE
+WebKit's GLib API, so a missing WebKit API is our problem too.
+
+### WebKit PR 65415, main-frame status on `WebKitNavigationAction`
+
+<https://github.com/WebKit/WebKit/pull/65415> (ours, open, currently
+merging-blocked) adds `webkit_navigation_action_is_for_main_frame()` to the
+WPE/GTK GLib bindings, mirroring `WKNavigationAction.targetFrame.isMainFrame` on
+Cocoa. Without it the `decide-policy` signal cannot distinguish a main-frame
+navigation from a subframe one: `webkit_navigation_action_get_frame_name()`
+returns NULL for an ordinary unnamed iframe, which is indistinguishable from the
+main frame.
+
+The fork implements exactly the heuristic the PR describes as forced
+(`flutter_inappwebview_linux/linux/in_app_webview/in_app_webview.cc:3966-3972`):
+
+```c
+// Best-effort main frame detection: frame name is usually null/empty for main frame.
+bool is_for_main_frame = true;
+const gchar* frame_name = webkit_navigation_action_get_frame_name(nav_action);
+if (frame_name != nullptr && frame_name[0] != '\0') is_for_main_frame = false;
+```
+
+It defaults to `true`, which is the unsafe direction, and an unnamed cross-origin
+iframe hits that default.
+
+**This reaches us, and we already noticed the symptom without naming the cause.**
+`lib/services/webview.dart:3918` reads
+`navigationAction.isForMainFrame ?? true`, and the comment three lines below it
+says WebKit on Linux "has been observed to return true for navigations that
+originate from inside an iframe". Everything below that gate assumes the
+navigation is the top document, and the comment at `:3930-3933` states the
+intent plainly: "a cross-origin subframe navigation must never be able to steer
+the top document."
+
+On Linux it can. Past the gate sit the ClearURLs rewrite and the ABP
+`$removeparam` rewrite, both of which respond to a match by calling
+`controller.loadUrl(cleanedUrl)` on the **top** frame and cancelling the original
+load. So an iframe whose URL merely carries a stripped tracking parameter
+navigates the whole page to that iframe's URL. Below those sits the cross-domain
+nested-webview routing, which would open embedded iframes (SSO, captcha
+challenges, one-tap sign-in) as separate top-level screens. There is no
+`Platform.isLinux` guard anywhere in `webview.dart`.
+
+Two tracks, and they are independent:
+
+- **Root fix:** land PR 65415, then replace the heuristic in the fork's
+  `OnDecidePolicy` with the real API. That also retires the guessing in
+  `create_window_action.cc:41`, which hardcodes `isForMainFrame(true)`.
+- **Until then:** the app must not steer the top document on a main-frame signal
+  it cannot trust. NESTED-013 states that; it is a WebSpace-side fix that needs
+  no WebKit change and should not wait for one.
+
+Note for whoever revisits the Linux CI comment: the claim at
+`.github/workflows/build-and-test.yml:562-566` that the plugin calls
+`webkit_navigation_action_is_for_main_frame` describes the *intended* end state,
+not the present one. The symbol does not exist in shipped WebKit yet, which is
+what PR 65415 is for, and nothing in the fork calls it. Only
+`webkit_web_view_get_theme_color` actually forces the 2.50 floor today.

--- a/docs/upstream/flutter-inappwebview-audit.md
+++ b/docs/upstream/flutter-inappwebview-audit.md
@@ -17,7 +17,9 @@ down.
 
 **What does not:** the behaviour we decided to require as a result. That goes in
 the owning OpenSpec capability, and a bug whose symptom recurs across code paths
-goes in [docs/bugs/](../bugs/). This file links out to both.
+goes in [docs/bugs/](../bugs/). This file links out to both. Work that lands in
+the fork rather than here has its own standalone brief:
+[fork-work-brief.md](fork-work-brief.md).
 
 ## Method
 

--- a/docs/upstream/flutter-inappwebview-audit.md
+++ b/docs/upstream/flutter-inappwebview-audit.md
@@ -289,23 +289,25 @@ if (frame_name != nullptr && frame_name[0] != '\0') is_for_main_frame = false;
 It defaults to `true`, which is the unsafe direction, and an unnamed cross-origin
 iframe hits that default.
 
-**This reaches us, and we already noticed the symptom without naming the cause.**
-`lib/services/webview.dart:3918` reads
-`navigationAction.isForMainFrame ?? true`, and the comment three lines below it
-says WebKit on Linux "has been observed to return true for navigations that
-originate from inside an iframe". Everything below that gate assumes the
-navigation is the top document, and the comment at `:3930-3933` states the
-intent plainly: "a cross-origin subframe navigation must never be able to steer
-the top document."
+**None of that is a new discovery.** [PR #356](https://github.com/theoden8/webspace_app/pull/356)
+(open since 2026-05-17, currently conflicted) already documents it in the
+`nested-url-blocking` spec: "the Linux plugin can't reliably mark iframe
+navigations as non-main-frame (`webkit_navigation_action_get_frame_name()` is
+the *target* frame name, not the source, so iframes whose own URL navigates show
+up with `isForMainFrame=true`). The result is that those iframes can open a
+nested webview. Per-site `blockAutoRedirects = false` is the escape hatch."
+`lib/services/webview.dart:3920-3923` carries the same observation as a comment.
 
-On Linux it can. Past the gate sit the ClearURLs rewrite and the ABP
-`$removeparam` rewrite, both of which respond to a match by calling
-`controller.loadUrl(cleanedUrl)` on the **top** frame and cancelling the original
-load. So an iframe whose URL merely carries a stripped tracking parameter
-navigates the whole page to that iframe's URL. Below those sits the cross-domain
-nested-webview routing, which would open embedded iframes (SSO, captcha
-challenges, one-tap sign-in) as separate top-level screens. There is no
-`Platform.isLinux` guard anywhere in `webview.dart`.
+What that write-up does not name is the **second** consequence, which is worse
+than the nested webview and has no escape hatch. Past the main-frame gate sit the
+ClearURLs rewrite and the ABP `$removeparam` rewrite, and both respond to a match
+by calling `controller.loadUrl(cleanedUrl)` on the **top** frame and cancelling
+the original load. So an iframe whose URL merely carries a stripped tracking
+parameter navigates the whole page to that iframe's URL. The comment at
+`:3930-3933` states the intent this violates: "a cross-origin subframe navigation
+must never be able to steer the top document." There is no `Platform.isLinux`
+guard anywhere in `webview.dart`, and `blockAutoRedirects = false` does not
+disable the rewrites.
 
 Two tracks, and they are independent:
 
@@ -314,7 +316,14 @@ Two tracks, and they are independent:
   `create_window_action.cc:41`, which hardcodes `isForMainFrame(true)`.
 - **Until then:** the app must not steer the top document on a main-frame signal
   it cannot trust. NESTED-013 states that; it is a WebSpace-side fix that needs
-  no WebKit change and should not wait for one.
+  no WebKit change and should not wait for one. It supersedes PR #356's
+  "disable the feature per site" escape hatch for the rewrite half, which that
+  hatch never covered.
+
+PR #356 itself is worth rescuing separately: it is a two-line fix plus spec text
+for a different signal on the same handler (`hasGesture`, not `isForMainFrame`),
+it has been conflicted since August, and NESTED-013 touches the same spec
+section, so land one before writing the other.
 
 Note for whoever revisits the Linux CI comment: the claim at
 `.github/workflows/build-and-test.yml:562-566` that the plugin calls

--- a/docs/upstream/flutter-inappwebview-audit.md
+++ b/docs/upstream/flutter-inappwebview-audit.md
@@ -60,14 +60,13 @@ cleared.
 | 2763 | iOS `onCreateWindow` return value ignored | AFFECTS, high | fork iOS `InAppWebView.swift:2762-2766` calls `self?.loadUrl(navigationAction.request)` in `defaultBehaviour`; Android `InAppWebViewChromeClient.java:675-679` only drops the pending message; our handler returns `false` on every path but the captcha popup (`lib/services/webview.dart:4054-4141`) | NESTED-011, EXT-009 |
 | 2834 | Suppress/customize `Sec-CH-UA` | AFFECTS, medium (residual) | `lib/services/user_agent_metadata_builder.dart:49-62` ships `platform`/`mobile` with a null `brandVersionList`; fork `InAppWebView.java:2370-2372` then skips `setBrandVersionList`, leaving the real brands | UAID-005 |
 | 2878 | Soft keyboard dead app-wide after HTML5 fullscreen | AFFECTS, high | fork `InAppWebViewChromeClient.java:151-179` `onHideCustomView` restores system UI and orientation, never the IME; zero `InputMethodManager` references in the file | fork patch, no spec |
-| 2859 | iOS 17.2+ scroll stuck after keyboard dismiss | AFFECTS, medium | fork iOS `InAppWebView.swift:189-193` applies a negative `contentInset`; `:201-203` `keyboardWillHide` only clears `_scrollViewContentInsetAdjusted` | cherry-pick reporter's PR |
 | 2718 | ANR in `MyCookieManager.deleteAllCookies` | AFFECTS, medium | fork `MyCookieManager.java:445-460` flushes on the platform thread, and our own `flushContainerCookieManagers()` (`:535-556`) fans that out across every profile; callers `lib/main.dart:6315`, `:9548`, `lib/services/cookie_isolation.dart:155` | BUG-007 gap 5 |
 | 2703 | 16 KB page size | AFFECTS, medium (release) | no `max-page-size` flag anywhere in the repo; alignment is incidental, from `CARGO_NDK_VERSION: "4.1.2"` (`.github/workflows/build-and-test.yml:25`) against NDK r26d, and CI builds only `--flavor fdroid` (`:367-369`) | tasks 5.x |
 | 2863 | Android native WebView background color | AFFECTS, low-medium | fork `InAppWebView.java:397-398` sets `Color.TRANSPARENT` only when `transparentBackground` is set, which we never set outside `lib/widgets/virtual_source_preview.dart:97` | [BUG-001](../bugs/001-white-screen.md) |
 | 2850 | iOS `console.log` coerces objects | AFFECTS, low-medium | fork's `ConsoleLogJS` concatenation is identical on iOS, macOS and Linux; consumed raw at `lib/services/webview.dart:4405-4406` | ETP-025 (the fingerprinting half) |
 | 2873 | Restrict FileProvider paths | AFFECTS, low-medium | our `android/app/src/main/res/xml/flutter_inappwebview_android_provider_paths.xml` carries five roots against upstream's one | tasks 6.x |
 | 2791 | `shouldOverrideUrlLoading` always returns true | AFFECTS, medium | `lib/services/webview.dart:3531` sets `useShouldOverrideUrlLoading` unconditionally; fork `InAppWebViewClient.java:105` returns `request.isForMainFrame()` even on ALLOW, reissuing at `:145` | NESTED-012, documentation only |
-| 2780 | `webkit_web_view_get_theme_color` on WebKit < 2.50 | AFFECTS, build | one unguarded call at fork `flutter_inappwebview_linux/linux/in_app_webview/in_app_webview.cc:6268`; no `WEBKIT_CHECK_VERSION` anywhere in the Linux plugin | CONT-009 |
+| 2780 | `webkit_web_view_get_theme_color` on WebKit < 2.50 | AFFECTS, build | one unguarded call at fork `flutter_inappwebview_linux/linux/in_app_webview/in_app_webview.cc:6268`; no `WEBKIT_CHECK_VERSION` anywhere in the Linux plugin | CONT-009; fixed by PR #2781 |
 | 2861 | Linux white screen under `DISABLE_GL=1` | AFFECTS, users only | env var read at `custom_platform_view.cc:18`, never consulted by the buffer path; CI uses llvmpipe instead (`.github/workflows/build-and-test.yml:811`) | [BUG-001](../bugs/001-white-screen.md) |
 | 2862 | Cannot build on Ubuntu | AFFECTS, docs | fork `flutter_inappwebview_linux/linux/CMakeLists.txt:47-63` probes 2.0/1.1/1.0 and never version-checks | CONT-009 |
 | 2883 | Flutter 3.47 UI separation | AFFECTS on next upgrade | `.fvmrc` pins 3.38.6 | fork rebase, blocks the bump |
@@ -121,6 +120,7 @@ Recording these is the point of the file: each one cost a read of both trees.
 | 2753 | We discard subframe errors anyway (`lib/services/webview.dart:4432`). |
 | 2707, 2855, 2730, 2619, 2570 | Native `InAppBrowser`, `ContextMenu`, `targetFrame`, `callAsyncJavaScript`, autofill: none referenced in `lib/`. Our `lib/screens/inappbrowser.dart` is a Flutter route, not the plugin's native browser. |
 | 2723, 2795, 2598, 2340, 2821 | Require a scroll ancestor, a `Slider`, a `Draggable` or a `BackdropFilter` over a live webview. We have none. |
+| 2859 | **Corrected 2026-09-07.** Listed as AFFECTS in the first pass; it is not. `keyboardWillShow` only takes the negative-inset branch when `scrollView.adjustedContentInset != .zero`, and `contentInsetAdjustmentBehavior` defaults to `NEVER` (`in_app_webview_settings.dart:3561-3562`) with no override in `lib/`, so adjusted equals `contentInset`, which starts `.zero`. The branch is never entered and `keyboardWillHide` clears a flag that was never set. Becomes live the moment we set `contentInsetAdjustmentBehavior` or `resizeToAvoidBottomInset: false`. |
 | 2415, 2762 | Fixed in Flutter 3.38.6, which `.fvmrc` already pins. |
 | 2654 | Reported against 5.8/6.0; `dispose()` at our ref removes every observer symmetrically. |
 | 2887, 2830 | Our AGP (8.13.1) and iOS deployment target (15.0) are past the reporters' boundaries. |
@@ -138,3 +138,123 @@ looking at our own code. They are recorded where they belong rather than here:
   [BUG-007 gap 5](../bugs/007-native-shared-state-races.md).
 - `DNS_READY_TIMEOUT_MS` is 15s (`WebInterceptPlugin.kt:846`), three times the
   ANR window: same gap.
+
+## Audit 2026-09-07: open pull requests
+
+Same baseline. The issue sweep found defects; this pass asks whether anyone has
+already fixed them, and whether an unmerged PR would help or hurt us on the next
+fork rebase. All **72** open PRs read, diffs fetched rather than rendered pages.
+
+Two facts shape every verdict. Our fork sits on upstream master, so an open PR is
+genuinely unmerged, not something we already carry. And **no maintainer has
+reviewed any of these**, so "wait for upstream" is not a plan: anything we want,
+we carry as a fork patch.
+
+### Take
+
+| # | What | Why it is worth carrying |
+|---|---|---|
+| 2781 | Linux: `#if WEBKIT_CHECK_VERSION(2,50,0)` around `webkit_web_view_get_theme_color` | The single thing pinning our Linux CI to `debian:sid-slim`. We never call `getMetaThemeColor` from Dart, so returning nothing below 2.50 costs us nothing, and it makes trixie and ParrotOS buildable. Guards the 2.50-only `WebKitColor` type as well as the call, so it is complete. |
+| 2767 | macOS: `responds(to: "setUpgradeKnownHostsToHTTPS:")` instead of `#available(macOS 11.3)` | We advertise Big Sur (`macos/Podfile:1` targets 10.15), the setting defaults to `true`, and the assignment is on the path every macOS webview creation takes. An affected user crashes on first site load. The selector check is strictly stronger than the availability check, which is what fails here. |
+| 2851 | iOS: serialize console arguments instead of string-concatenating them | Fixes #2850 on one of the three platforms where we are degraded. Port the same `_stringify` into the macOS and Linux copies in the same commit; they carry the byte-identical bug. |
+| 2243 | Android: reject picker results that canonicalize under the app data dir | CVE-2020-6563's mitigation for the plugin's own file picker. We never set `useOnShowFileChooser`, so we take the unfiltered default path. Does **not** close our variant: it covers `file://` only, and our FileProvider maps five roots over the whole data dir with `grantUriPermissions="true"`, so a `content://` result still reaches `HtmlCacheService` blobs. Pick it and narrow the provider paths. |
+| 2881 | Linux: re-import DMA-BUF per frame on Flutter's EGLDisplay | Two of its five commits matter. One is #2861's actual cause: `OnWpePlatformBufferRendered` sets `buffer_handled = true` on any DMA-BUF import even in software mode, so the pixel buffer is never filled and the texture stays blank. The other fixes a raster-thread use-after-free on recycled textures, which is BUG-007's shape on Linux. |
+| 2870 | macOS: availability-annotated `ASWebAuthenticationPresentationContextProviding` helper | We never use `WebAuthenticationSession`, but it compiles into the macOS plugin and CI builds macOS on `macos-latest`. This is a build break waiting for the next Xcode. |
+
+### Take, but verify on a device first
+
+- **#2776**, `windowId` EXC_BAD_ACCESS. Routes around the faulting
+  `evaluateJavaScript(_:frame:contentWorld:)` overload. Behaviour-neutral for us
+  because our content world is always `.page`. Needs mirroring into the macOS
+  twin, and its `callAsyncJavaScript` half dropped. It fixes the crash, not the
+  cause: see "still owed" below.
+- **#2866**, `NavigationActionPolicy.ALLOW_WITHOUT_TRYING_APP_LINK`. The right
+  shape for `ios-universal-link-bypass`: it suppresses app-link matching on the
+  original `WKNavigationAction` instead of cancelling and reissuing it, so
+  `Referer`, `window.opener` and `Sec-Fetch-Site: cross-site` all survive. It
+  would delete `lib/services/ios_universal_link_bypass.dart` outright and
+  recover the iOS half of NESTED-012. Three caveats: iOS and macOS only, so the
+  Android half of NESTED-012 stays open; our fork decodes unknown policy ints to
+  `.cancel`, so the Dart enum alone is not enough; and the failure mode is
+  silent, since a rejected raw value degrades to a plain allow and universal
+  links resume with nothing in the logs. Keep the old path behind a flag for one
+  release and prove the new policy on a device before deleting it.
+
+### Never take
+
+- **#2671**, WKWebView proxy for iOS 17+. Assigns
+  `WKWebsiteDataStore.nonPersistent()` unconditionally at the end of the same
+  `preWKWebViewConfiguration` block our container binding and per-site proxy live
+  in (`flutter_inappwebview_ios/.../InAppWebView.swift:745-772`). If it landed
+  and we rebased naively, its assignment would run after ours and silently drop
+  both: every iOS site sharing one ephemeral jar on the global proxy. That is a
+  per-site-containers failure and an `ip-leakage` failure at once, and neither
+  shows up as a build break. Treat `preWKWebViewConfiguration` as a permanent
+  hand-resolved conflict site.
+- **#2832**, WebKitGTK backend for Linux. It would make us build on Ubuntu, and
+  it would cost us Linux isolation silently. It targets `webkit2gtk-4.1`, a
+  generation with no `WebKitNetworkSession` at all, which is the type our whole
+  Linux container layer is built on. Worse, `ContainerController.isClassSupported`
+  is a static platform-name list with no runtime probe, so `_useContainers` would
+  stay `true`, `containerId` would be accepted and ignored, and every site would
+  share one cookie jar while the UI reported containers active.
+- **#2771** (disables all content-world JS: `frame: nil` is how the plugin says
+  "main frame"), **#1952** (shadows a loop binding, returns empty credentials),
+  **#2694** (comments out the iOS Apple Pay guard). All three are regressions
+  presented as fixes.
+
+### Wrong remedy for a real problem
+
+- **#2864** adds a runtime `setBackgroundColor` controller method for #2863. A
+  runtime call cannot fire before the platform view's first paint, and the first
+  paint *is* the flash. The fix belongs in `prepare()` beside
+  `transparentBackground`, as a setting.
+- **#2729** adds `Build.VERSION.SDK_INT` to `TrustedWebActivity.java` without
+  adding `import android.os.Build`, which is absent at our ref. It does not
+  compile. Pick it only with the import added.
+
+### Watch
+
+- **#2844** defers Android JS bridge registrations off platform-view attach,
+  fixing a real cold-start race. Not as-is: it defers plugin scripts but not
+  user-only scripts, inverting DOCUMENT_START order so our shims would run
+  before the bridge, and both its catch blocks log and continue, which is
+  fail-open injection. If we take it, defer both and make the catch fail closed.
+- **#2829** (system nlohmann) would break our Linux job until
+  `nlohmann-json3-dev` joins the apt set. **#2817** (Java deprecations) collides
+  with our two cookie flush/memo commits in `MyCookieManager.java`.
+
+### Still owed after all of the above
+
+#2776 fixes the eval call, not the state behind it. The fork keeps
+`contentWorlds`, `userOnlyScripts` and `pluginScripts` in process-global static
+dictionaries keyed by the object's pointer formatted as a string
+(`Types/WKUserContentController.swift:18-53`, and the macOS twin), unsynchronised.
+`getContentWorlds` already carries a scar comment about `EXC_BREAKPOINT` when the
+set mutates mid-loop, mitigated with a copy rather than a lock: BUG-007 exactly.
+The quiet consequence is worse than the crash. A controller freed without
+`dispose()` leaves its entry behind, and the next controller at that address
+inherits it, so `containsPluginScript` reports scripts that were never added and
+`sync()` skips them. That is a site whose per-site shims silently never inject.
+
+Separately, ours to fix: `windowWebViews` entries are removed in only three
+places (`InAppWebView.swift:2764` on decline, `:3656` on a windowId webview's own
+dispose, `:128` on manager teardown). Our captcha handler returns `true`, so the
+first never runs, and `createPopupWebView` can still bail to `SizedBox.shrink()`
+(`lib/services/webview.dart:1858-1865`) without building an
+`InAppWebView(windowId:)`, so the second never runs either. The native popup
+WKWebView stays pinned for the process lifetime on the parent's configuration and
+cookie jar.
+
+### Correction to the 2026-09-06 audit
+
+**#2859 does not affect us** and its row has moved to the cleared table. The
+negative-inset branch is guarded by `adjustedContentInset != .zero`, and
+`contentInsetAdjustmentBehavior` defaults to `NEVER` with no override in `lib/`.
+
+Also stale, and worth fixing while we are here: the comment at
+`.github/workflows/build-and-test.yml:562-566` justifies the sid pin with two
+WebKit 2.50 symbols, but `webkit_navigation_action_is_for_main_frame` does not
+appear anywhere in the fork. `webkit_web_view_get_theme_color` is the only one,
+which is why #2781 alone should free the pin. The Linux build is the proof, not
+the comment.

--- a/docs/upstream/fork-work-brief.md
+++ b/docs/upstream/fork-work-brief.md
@@ -1,0 +1,237 @@
+# Fork work brief: what to change in `theoden8/flutter_inappwebview`
+
+Everything here happens in the **fork**, not in this repo. It is written to be
+pasted into a session opened on the fork with no other context, so it repeats
+what that session needs to know. The evidence behind each item is in
+[flutter-inappwebview-audit.md](flutter-inappwebview-audit.md); the WebSpace-side
+follow-ups are in
+[openspec/changes/upstream-webview-defects/tasks.md](../../openspec/changes/upstream-webview-defects/tasks.md).
+
+Keep the two halves in step. Landing a fork patch means re-tagging the fork and
+bumping all six `dependency_overrides` refs in this repo's `pubspec.yaml`
+together; they must always name one ref.
+
+---
+
+## Ground rules for that session
+
+**Baseline.** `merge-base(v6.2.0-beta.3-privacy-v6, upstream/master)` is
+`17527cae`, which is upstream master HEAD. The fork is upstream master plus 19
+commits, all additive: containers, `proxySettings`, three Android settings, and
+two cookie flush/memo fixes. There is no upstream backlog to catch up on, so
+every open upstream PR is genuinely unmerged and no maintainer has reviewed any
+of them. Nothing here can be obtained by waiting.
+
+**Attribution.** Taking someone else's commit keeps their `--author` verbatim.
+Write your own message for what the change does here, and cite the origin with
+one `Cherry-picked-from: <sha> (pichillilorenzo/flutter_inappwebview)`. Never
+`--reset-author`, never `git commit -s`, never `--signoff`, never re-pick
+without `-x`. One `Co-Authored-By:` per identity at most, no `Signed-off-by:`
+at all. Non-ASCII author names stay verbatim. Where a PR spans two author
+emails plus a merge commit, pick the individual commits, each keeping its own
+author.
+
+**Marking.** Anything we originate, or any upstream patch we modify, carries a
+`[WebSpace fork patch]` comment at the change site. That marker is how this
+repo finds the fork's surface area later.
+
+---
+
+## A. Original patches (nobody upstream is fixing these)
+
+### A1. A declined `onCreateWindow` must not navigate the parent
+
+The highest-severity item in the whole audit, and the reason this brief exists.
+
+On iOS (`flutter_inappwebview_ios/.../InAppWebView/InAppWebView.swift:2762-2766`)
+and macOS (the twin around `:1947-1951`), `callback.defaultBehaviour` removes the
+pending transport and then calls
+`self?.loadUrl(urlRequest: navigationAction.request, allowingReadAccessTo: nil)`
+on the **parent** webview. Android's equivalent
+(`InAppWebViewChromeClient.java:675-679`) only drops the pending message. Since
+`nonNullSuccess = { !handledByClient }`, returning `false` from Dart is exactly
+what triggers it.
+
+WebSpace returns `false` on every `onCreateWindow` path except the captcha
+popup, so on iOS and macOS a blocked cross-domain `window.open()` loads anyway,
+a declined `intent://` is handed to the parent raw, and an allowed one is loaded
+twice, the second time unrewritten.
+
+Bring iOS and macOS to Android parity: `defaultBehaviour` drops the transport
+and does nothing else. Then offer it upstream on issue #2763 as a
+cross-platform contract violation, not a WebSpace need.
+
+### A2. Android soft keyboard dies app-wide after HTML5 fullscreen
+
+`InAppWebViewChromeClient.onHideCustomView` (`:151-179`) restores system UI and
+orientation but never touches the IME; the file has zero `InputMethodManager`
+references. After exiting a fullscreen video the keyboard is dead for the whole
+app, including the host app's own text fields. Upstream issue #2878, whose
+predecessor #1176 is unresolved, so this will not arrive on its own.
+
+### A3. Android native WebView background color
+
+`InAppWebView.java:397-398` sets `Color.TRANSPARENT` only when
+`transparentBackground` is set, so the native view otherwise keeps its default
+white beneath the compositor. Add a `backgroundColor` **setting** applied in
+`prepare()` beside `transparentBackground`.
+
+Do **not** take upstream PR #2864 for this: it adds a runtime controller method,
+and a runtime call cannot fire before the platform view's first paint, which is
+the flash being complained about.
+
+### A4. Address-keyed statics in `WKUserContentController`
+
+`Types/WKUserContentController.swift:18-53` (and the macOS twin) keep
+`contentWorlds`, `userOnlyScripts` and `pluginScripts` in process-global static
+dictionaries keyed by `String(format: "%p", unsafeBitCast(self, to: Int.self))`,
+with no synchronization. `getContentWorlds` already carries a comment about
+`EXC_BREAKPOINT` when the collection mutates mid-loop, mitigated with a copy
+rather than a lock.
+
+Two failure modes. The crash, and the quieter one: a controller freed without
+`dispose()` leaves its entry behind, and the next controller allocated at that
+address inherits it, so `containsPluginScript` reports scripts that were never
+added and `sync()` skips them. For WebSpace that is a site whose per-site
+privacy shims silently never inject.
+
+Replace the address keying with object-identity storage
+(`objc_setAssociatedObject`, or an `NSMapTable` with weak keys) behind one
+serial queue or lock, on both iOS and macOS. Take A5 first, then do this.
+
+---
+
+## B. Cherry-picks, in the order they pay off
+
+### B1. PR #2781, Linux WebKit version guard
+
+`#if WEBKIT_CHECK_VERSION(2,50,0)` around `webkit_web_view_get_theme_color`
+(`flutter_inappwebview_linux/linux/in_app_webview/in_app_webview.cc:6268`), the
+only unguarded 2.50 symbol in the plugin. Guards the 2.50-only `WebKitColor`
+type as well as the call, so it is complete. Applies clean.
+
+This is the single thing pinning WebSpace's Linux CI to `debian:sid-slim`.
+Nothing calls `getMetaThemeColor` from Dart there, so returning nothing below
+2.50 costs that app nothing, and it makes Debian trixie and ParrotOS buildable.
+
+### B2. PR #2767, macOS `upgradeKnownHostsToHTTPS` selector guard
+
+`responds(to: "setUpgradeKnownHostsToHTTPS:")` instead of
+`#available(macOS 11.3, *)`, which is what actually fails: Apple's header
+back-annotates a selector Big Sur lacks. The setting defaults to `true` and the
+assignment is on the path every macOS webview creation takes, so an affected
+user crashes on first load. Stale and written against the pre-SPM layout, but
+git rename-detects onto the current path; confirm the hunk lands in
+`flutter_inappwebview_macos/macos/.../InAppWebView.swift` and that no stale
+`macos/Classes/` file is created.
+
+### B3. PR #2851, console argument serialization
+
+Fixes objects arriving as `[object Object]` and `Error` losing message and
+stack. **Port it to all three copies in the same commit**: the PR is iOS-only,
+and `flutter_inappwebview_macos/.../ConsoleLogJS.swift` plus
+`flutter_inappwebview_linux/linux/plugin_scripts_js/console_log_js.h` carry the
+byte-identical bug. Its 2000-char cap is worth raising for HTML export, but
+that is a deliberate deviation: say so in the message.
+
+### B4. PR #2243, Android picker sandbox filter (CVE-2020-6563)
+
+Rejects picker results canonicalizing under the app data dir. Two known gaps to
+note in the commit message rather than fix here: `content://` is out of scope,
+and the blanket `/data/` prefix could false-positive on ROMs where `/sdcard`
+canonicalizes into `/data/media/0`.
+
+### B5. PR #2881, Linux, two of five commits
+
+Take `fc1bd5756` (the `skip_pixel_readback_` gate: `OnWpePlatformBufferRendered`
+currently sets `buffer_handled = true` on any DMA-BUF import even in software
+mode, so the pixel buffer is never filled and the texture stays blank, which is
+issue #2861) and `0c9963cc1` (raster-thread use-after-free on recycled textures
+reaching destroyed webviews). `in_app_webview.h` needs a trivial merge against
+the fork's member block. Leave the other three for now.
+
+### B6. PR #2870, macOS availability helper
+
+Constrains `ASWebAuthenticationPresentationContextProviding` to
+`@available(macOS 10.15)`. WebSpace never uses `WebAuthenticationSession`, but
+it compiles into the macOS plugin and CI builds macOS, so this is a build break
+waiting for the next Xcode.
+
+### B7. PR #2776, `windowId` evaluateJavaScript crash
+
+Routes around the faulting `evaluateJavaScript(_:frame:contentWorld:)` overload
+on `windowId` webviews. Three changes needed: mirror it into the macOS twin,
+which the PR does not touch; drop its `callAsyncJavaScript` half, which silently
+collapses custom-world isolation; and normalise the `result as Any` box, which
+turns a nil result into `Optional<Any>.none` rather than a plain nil.
+
+It fixes the crash and not the cause. A4 is the cause.
+
+### B8. PR #2866, `ALLOW_WITHOUT_TRYING_APP_LINK`
+
+Adds `NavigationActionPolicy.ALLOW_WITHOUT_TRYING_APP_LINK` (= 3), decoded on
+iOS and macOS as `WKNavigationActionPolicy(rawValue: .allow.rawValue + 2)`.
+
+Take it **with the fork's decode fixed**: our `WebViewChannelDelegate.swift`
+currently maps unknown policy ints to `.cancel`, so the Dart enum alone changes
+nothing. Regenerate the hand-edited `.g.dart`.
+
+Then flag the risk clearly for the app side: if Swift's `init?(rawValue:)`
+rejects 3 on an imported NS_ENUM, the PR's `?? .allow` fallback degrades to a
+plain allow and universal links resume firing **with nothing in the logs**. It
+needs a device check before anything is deleted on the app side.
+
+---
+
+## C. Never take these, including silently in a rebase
+
+Write these into the fork's own notes, because the danger is a future rebase
+swallowing them without a build break.
+
+- **PR #2671**, WKWebView proxy for iOS 17+. Assigns
+  `WKWebsiteDataStore.nonPersistent()` unconditionally at the end of the same
+  `preWKWebViewConfiguration` block the container binding and per-site proxy
+  live in (`flutter_inappwebview_ios/.../InAppWebView.swift:745-772`). Landing
+  after ours, it drops both: every iOS site on one ephemeral jar with the global
+  proxy. Treat `preWKWebViewConfiguration` as a permanent hand-resolved conflict
+  site; if #2671 ever merges, keep our block and drop theirs.
+- **PR #2832**, WebKitGTK backend. Targets `webkit2gtk-4.1`, a generation with
+  no `WebKitNetworkSession`, which the entire Linux container layer is built on,
+  and its CMake `return()` stops the WPE sources compiling at all. It would buy
+  Ubuntu support by deleting the feature the app exists for.
+- **PR #2771**, "iPad crash when frame is nil". `frame: nil` is how the plugin's
+  own callers say "main frame"; the patch disables all content-world JS on iOS.
+- **PR #1952** (shadows a loop binding, returns empty credentials) and
+  **PR #2694** (comments out the iOS Apple Pay guard). Regressions presented as
+  fixes.
+- **PR #2729** as-is: adds `Build.VERSION.SDK_INT` to `TrustedWebActivity.java`
+  without `import android.os.Build`, which is absent. It does not compile. Take
+  it only with the import added.
+- **PR #2844** as-is: defers Android plugin-script registration but not
+  user-only scripts, inverting DOCUMENT_START order so app shims would run
+  before the bridge, and both its catch blocks log and continue, which is
+  fail-open injection. If adopted, defer both and make the catch fail closed.
+
+---
+
+## D. Verification, honestly
+
+Most of this is not reachable from any automated tier.
+
+- **B1** is proved by the build: run `fvm flutter build linux --release` in
+  `debian:trixie-slim` (WPE 2.48) with the CI apt set. Before the patch it fails
+  at `in_app_webview.cc:6268`; after, it builds. Then flip WebSpace's Linux CI
+  container and confirm the whole job stays green including the Xvfb loop. That
+  full run is the only proof no other 2.50 symbol lurks, because the comment
+  claiming a second one names `webkit_navigation_action_is_for_main_frame`,
+  which does not appear anywhere in the fork.
+- **B5** needs the Linux integration tier run a second time with
+  `FLUTTER_INAPPWEBVIEW_LINUX_DISABLE_GL=1`, asserting a non-blank surface.
+- **A1** is gateable from the app side: a structural test asserting no
+  platform's decline path calls `loadUrl`. Add it there, not here.
+- **B2, B7, B8, A2** are device-only. B2 needs a Big Sur VM; if that is not
+  worth keeping, the honest alternative is raising the macOS deployment target
+  to 12.0 and skipping B2 entirely.
+- **A4**'s quiet half is observable: open and close a `windowId` popup
+  repeatedly and assert the popup still reports the parent's per-site shim
+  values. That belongs in the app's macOS integration tier.

--- a/docs/upstream/fork-work-brief.md
+++ b/docs/upstream/fork-work-brief.md
@@ -235,3 +235,22 @@ Most of this is not reachable from any automated tier.
 - **A4**'s quiet half is observable: open and close a `windowId` popup
   repeatedly and assert the popup still reports the parent's per-site shim
   values. That belongs in the app's macOS integration tier.
+
+---
+
+## E. Blocked on WebKit, not on us
+
+`OnDecidePolicy` (`flutter_inappwebview_linux/linux/in_app_webview/in_app_webview.cc:3966-3972`)
+infers main-frame status from `webkit_navigation_action_get_frame_name()` being
+empty, which is also true of every unnamed iframe, and defaults to `true`.
+`create_window_action.cc:41` simply hardcodes `isForMainFrame(true)`.
+
+The real API is coming from us:
+[WebKit PR 65415](https://github.com/WebKit/WebKit/pull/65415) adds
+`webkit_navigation_action_is_for_main_frame()` for WPE and GTK. It is open and
+merging-blocked on test failures.
+
+When it lands and a WPE release carries it, replace both sites with the real
+call behind a `WEBKIT_CHECK_VERSION` guard, the same shape as B1, so the fork
+still builds against older WPE. Until then the app compensates (NESTED-013), so
+this is not urgent for the fork; do not paper over it with a second heuristic.

--- a/docs/upstream/fork-work-brief.md
+++ b/docs/upstream/fork-work-brief.md
@@ -248,7 +248,9 @@ empty, which is also true of every unnamed iframe, and defaults to `true`.
 The real API is coming from us:
 [WebKit PR 65415](https://github.com/WebKit/WebKit/pull/65415) adds
 `webkit_navigation_action_is_for_main_frame()` for WPE and GTK. It is open and
-merging-blocked on test failures.
+merging-blocked on test failures, and the symbol exists in **no** WebKit release:
+verified absent from `WebKitNavigationAction.h.in` on `main` and on the
+`webkitglib/2.50`, `2.52` and `2.54` branches. There is nothing to gate on yet.
 
 When it lands and a WPE release carries it, replace both sites with the real
 call behind a `WEBKIT_CHECK_VERSION` guard, the same shape as B1, so the fork

--- a/openspec/changes/upstream-webview-defects/.openspec.yaml
+++ b/openspec/changes/upstream-webview-defects/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-06

--- a/openspec/changes/upstream-webview-defects/proposal.md
+++ b/openspec/changes/upstream-webview-defects/proposal.md
@@ -1,0 +1,75 @@
+## Why
+
+We pin `flutter_inappwebview` to a fork ref, so upstream's issue tracker
+describes code we compile. Nobody had read it end to end. A sweep of the 144
+open issues at ref `v6.2.0-beta.3-privacy-v6`
+([docs/upstream/flutter-inappwebview-audit.md](../../../docs/upstream/flutter-inappwebview-audit.md))
+turned up four defects that defeat a privacy control we already claim to
+enforce, plus one factual error in our own compatibility matrix.
+
+The one that matters most is #2763. On iOS and macOS the plugin treats a `false`
+return from `onCreateWindow` as "the host declined, so I will load it myself":
+`defaultBehaviour` calls `loadUrl(navigationAction.request)` on the *parent*
+webview (`InAppWebView.swift:2762-2766`). Android's equivalent only drops the
+pending window message. Our handler returns `false` on every path except the
+captcha popup, so on two of four shipped platforms:
+
+- a cross-domain or gesture-less `window.open()` that NESTED-004 exists to block
+  gets loaded anyway,
+- an `intent://` we deliberately declined or suppressed under EXT-003/EXT-007
+  gets handed to the parent raw, and
+- on the allow path we load the rewritten URL and the platform loads the
+  original on top, so a ClearURLs-stripped navigation is followed by an
+  unstripped one.
+
+None of this is visible from Dart. The handler returns, the block is logged, and
+the navigation happens regardless.
+
+The second is quieter. `buildUserAgentMetadata` returns metadata carrying
+`platform` and `mobile` while leaving `brandVersionList` null whenever the UA
+matches neither `Firefox/` nor `Chrome/`, and the fork's converter then skips
+`setBrandVersionList` entirely. A Firefox-for-iOS preset (a `FxiOS/` UA, so
+neither token matches) therefore ships `Sec-CH-UA-Platform: "iOS"` and
+`Sec-CH-UA-Mobile: ?1` alongside the device's *real* `Sec-CH-UA`, naming
+Chromium's true version and the literal string "Android WebView", while the
+shimmed `navigator.userAgentData` says WebKit. That is worse than not spoofing:
+it discloses the real engine version and manufactures exactly the header-vs-JS
+contradiction [BUG-009](../../../docs/bugs/009-shim-realm-escape.md) is about.
+Every custom UA a user types hits the same path, as does every device whose
+WebView lacks `WebViewFeature.USER_AGENT_METADATA`.
+
+## What Changes
+
+- **The platform may not override a declined window request** (NESTED-011). A
+  `false` from `onCreateWindow` means "do not open it", on every platform. Fork
+  patch bringing iOS and macOS `defaultBehaviour` to Android parity, plus the
+  regression scenarios that say so. EXT-009 states the external-scheme half:
+  declining an `intent://` must not leave the parent to load it.
+- **UA Client Hints fail closed** (UAID-005). If we cannot build a brand list
+  consistent with the UA we are presenting, we do not ship a half-spoof: either
+  synthesize a brand list matching the engine the UA claims, or suppress the
+  metadata override entirely. Never leave the real brand list standing under a
+  spoofed platform.
+- **The console shim is masked like every other wrapper** (ETP-025). The
+  plugin's `ConsoleLogJS` installs five non-native `console` methods at document
+  start. We mask every other injected wrapper as `[native code]`; these were
+  missed, so `console.log.toString()` is a free "this is flutter_inappwebview"
+  tell that survives Tracking Protection.
+- **The Linux build floor is stated where the wrong number lives** (CONT-009).
+  The container primitive needs WPE 2.40, but the plugin as a whole does not
+  compile below 2.50 because of one unguarded `webkit_web_view_get_theme_color`.
+  The Platform Support Matrix currently claims 2.40 and names Debian trixie and
+  Ubuntu, neither of which can build us.
+- **Documented, not changed:** NESTED-012 records the provenance loss that
+  `useShouldOverrideUrlLoading` already causes on Android (cancel-and-reissue
+  drops `Referer` and `window.opener` and downgrades `Sec-Fetch-Site` to
+  `none`). We accept this on iOS under IOS-UL-001; Android inherits it silently.
+  Writing it down makes it a stated property instead of an accident.
+
+## What this change does not do
+
+Fix the iOS `windowId` KVO crash (#2867/#2600), chase the iOS 26 touch reports
+(#2727/#2713), or rebase the fork for Flutter 3.47 (#2883). Those are on the
+audit's watch list with the evidence gathered so far. The two threading findings
+that turned out to be ours rather than upstream's are recorded as
+[BUG-007](../../../docs/bugs/007-native-shared-state-races.md) gap 5.

--- a/openspec/changes/upstream-webview-defects/specs/external-scheme-handling/spec.md
+++ b/openspec/changes/upstream-webview-defects/specs/external-scheme-handling/spec.md
@@ -1,0 +1,41 @@
+# External Scheme Handling
+
+## ADDED Requirements
+
+### Requirement: EXT-009 - Declining An External-Scheme Window Does Not Hand It To The Parent
+
+EXT-001 through EXT-004 route `intent://` and other external schemes through
+parsing, resolution and (where unresolvable) a confirmation prompt. EXT-007 adds
+a suppression guard so a silent route cannot loop. All of them are reached from
+`onCreateWindow` as well as from `shouldOverrideUrlLoading`, because a
+`target="_blank"` link can carry an external scheme.
+
+Every one of those paths ends by returning `false`. Under NESTED-011's defect
+that return value causes iOS and macOS to load the raw external-scheme request
+into the parent webview, which defeats the whole sequence:
+
+- a resolved intent is loaded as its web equivalent by us, then the raw
+  `intent://` is loaded on top by the platform,
+- a suppressed silent route (EXT-007) navigates anyway, so the loop guard guards
+  nothing,
+- an unresolvable intent that should have produced a prompt navigates instead.
+
+The external-scheme paths MUST therefore be able to decline a window without the
+platform completing the navigation on their behalf. This is the same fix as
+NESTED-011, stated here because the failure mode is different: NESTED-004 loses
+a block, EXT loses a user confirmation.
+
+#### Scenario: Resolved intent loads once, as its web equivalent
+
+- **GIVEN** a `target="_blank"` link to `intent://...#Intent;...;end` that
+  EXT-002 resolves to an `https://` URL
+- **WHEN** the handler loads the resolved URL and returns `false`
+- **THEN** the webview navigates to the resolved `https://` URL only
+- **AND** the raw `intent://` request is not loaded after it
+
+#### Scenario: Suppressed silent route stays suppressed
+
+- **GIVEN** an external scheme already marked by `ExternalUrlSuppressor` under
+  EXT-007
+- **WHEN** a gesture-less `onCreateWindow` for the same scheme returns `false`
+- **THEN** no navigation occurs on any platform

--- a/openspec/changes/upstream-webview-defects/specs/nested-url-blocking/spec.md
+++ b/openspec/changes/upstream-webview-defects/specs/nested-url-blocking/spec.md
@@ -81,3 +81,59 @@ fork.
 - **THEN** the destination receives `Sec-Fetch-Site: none` and no `Referer`
 - **AND** this spec says so, so the destination's trust decision is a known
   property of the app rather than a surprise
+
+### Requirement: NESTED-013 - Top-Document Steering Requires A Trustworthy Main-Frame Signal
+
+`shouldOverrideUrlLoading` fires for subframe navigations as well as main-frame
+ones, and several actions below the main-frame gate steer the **top** document:
+the ClearURLs rewrite and the ABP `$removeparam` rewrite both respond to a match
+by calling `loadUrl` on the top frame and cancelling the original navigation, and
+the cross-domain path routes the navigation into a nested `InAppWebViewScreen`.
+
+Those actions are correct for a main-frame navigation and are a redress attack
+for a subframe one: an embedded cross-origin iframe gets to decide where the
+whole page goes. The existing gate says so already, requiring that "a
+cross-origin subframe navigation must never be able to steer the top document".
+
+The gate is only as good as its input, and its input is not uniform. Android
+reports `isForMainFrame` correctly. Linux cannot: WPE WebKit exposes no
+main-frame flag on `WebKitNavigationAction`, so the plugin infers it from
+`webkit_navigation_action_get_frame_name()` being empty, which is also true of
+every unnamed iframe. The inference defaults to main frame, and the app then
+reads `isForMainFrame ?? true`, so an unreliable signal and a missing signal both
+resolve to the permissive answer.
+
+Therefore: an action that navigates or replaces the top document MUST NOT run on
+a main-frame signal the platform cannot vouch for. Where the signal is absent or
+known-unreliable, the navigation is allowed to proceed unmodified rather than
+rewritten or rerouted. Losing a stripped tracking parameter is the acceptable
+cost; letting a subframe steer the top document is not.
+
+This requirement is satisfied either by the platform supplying a real signal
+(WebKit PR 65415 adds `webkit_navigation_action_is_for_main_frame()` for
+WPE/GTK, after which the fork can drop the inference) or by the app treating the
+inferred signal as untrustworthy. The app-side half MUST NOT wait for the
+platform half.
+
+#### Scenario: A tracking parameter inside an iframe URL
+
+- **GIVEN** a page on Linux embedding a cross-origin iframe whose URL carries a
+  parameter ClearURLs strips
+- **WHEN** the iframe navigates and `shouldOverrideUrlLoading` fires
+- **THEN** the top document does not navigate to the iframe's URL
+- **AND** the iframe is allowed to load, stripped or not
+
+#### Scenario: An embedded sign-in iframe
+
+- **GIVEN** a cross-domain SSO or captcha iframe on a platform with no reliable
+  main-frame signal
+- **WHEN** the navigation is evaluated
+- **THEN** it loads in place
+- **AND** it is not routed into a nested `InAppWebViewScreen`
+
+#### Scenario: The signal becomes trustworthy
+
+- **GIVEN** a platform that reports main-frame status from the engine rather than
+  by inference
+- **WHEN** a genuine main-frame navigation carries a tracking parameter
+- **THEN** the rewrite runs as it does on Android, with no capability lost

--- a/openspec/changes/upstream-webview-defects/specs/nested-url-blocking/spec.md
+++ b/openspec/changes/upstream-webview-defects/specs/nested-url-blocking/spec.md
@@ -98,10 +98,17 @@ cross-origin subframe navigation must never be able to steer the top document".
 The gate is only as good as its input, and its input is not uniform. Android
 reports `isForMainFrame` correctly. Linux cannot: WPE WebKit exposes no
 main-frame flag on `WebKitNavigationAction`, so the plugin infers it from
-`webkit_navigation_action_get_frame_name()` being empty, which is also true of
-every unnamed iframe. The inference defaults to main frame, and the app then
-reads `isForMainFrame ?? true`, so an unreliable signal and a missing signal both
-resolve to the permissive answer.
+`webkit_navigation_action_get_frame_name()` being empty, which is the *target*
+frame name and so is also empty for every unnamed iframe. The inference defaults
+to main frame, and the app then reads `isForMainFrame ?? true`, so an unreliable
+signal and a missing signal both resolve to the permissive answer.
+
+That much is already recorded, in this spec's platform-gesture section and in
+[PR #356](https://github.com/theoden8/webspace_app/pull/356), which names the
+nested-webview consequence and offers per-site `blockAutoRedirects = false` as
+the escape hatch. This requirement exists because that hatch covers only the
+routing half. It does not disable the rewrites, and the rewrites are the half
+that lets a subframe navigate the top document.
 
 Therefore: an action that navigates or replaces the top document MUST NOT run on
 a main-frame signal the platform cannot vouch for. Where the signal is absent or

--- a/openspec/changes/upstream-webview-defects/specs/nested-url-blocking/spec.md
+++ b/openspec/changes/upstream-webview-defects/specs/nested-url-blocking/spec.md
@@ -1,0 +1,83 @@
+# Nested URL Blocking
+
+## ADDED Requirements
+
+### Requirement: NESTED-011 - A Declined Window Request Is Not Reissued By The Platform
+
+When `onCreateWindow` returns `false`, the navigation MUST NOT happen. This is
+the contract NESTED-004 (script-initiated cross-domain blocking), NESTED-005
+(captcha allowance) and NESTED-008 (`target="_blank"` routing) all rest on:
+each of them expresses its decision solely through that return value.
+
+The plugin does not honour it uniformly. On iOS and macOS the `false` branch
+runs `defaultBehaviour`, which loads `navigationAction.request` into the
+**parent** webview
+(`InAppWebView.swift:2762-2766` in the pinned fork); on Android the
+same branch only discards the pending window message. The host cannot observe
+the difference: the handler returns, the block is logged, and iOS navigates
+anyway.
+
+The fork MUST bring iOS and macOS to Android's behaviour, so that declining a
+window request is a decision rather than a suggestion on every shipped
+platform.
+
+Where the host wants the URL loaded in the current webview after declining a
+window (NESTED-008's same-domain path, EXT-003's resolved intent), it MUST do
+that itself with an explicit `loadUrl`. A platform that also loads the original
+request produces two navigations, the second of which skips every rewrite the
+first one applied.
+
+#### Scenario: Script-initiated cross-domain popup on iOS
+
+- **GIVEN** a site whose script calls `window.open('https://other.example')`
+  with no user gesture
+- **AND** the per-site auto-redirect block is on (NESTED-004)
+- **WHEN** `onCreateWindow` returns `false`
+- **THEN** no navigation occurs in the parent webview
+- **AND** the site stays on its current page, as it does on Android
+
+#### Scenario: A declined window is not loaded twice
+
+- **GIVEN** a `target="_blank"` link that NESTED-008 routes by calling
+  `loadUrl` with a ClearURLs-stripped URL and then returning `false`
+- **WHEN** the platform processes the return value
+- **THEN** exactly one navigation occurs, to the stripped URL
+- **AND** the original, unstripped request is not loaded on top of it
+
+#### Scenario: Parity is asserted, not assumed
+
+- **GIVEN** the fork's `onCreateWindow` decline path on Android, iOS and macOS
+- **WHEN** the fork is rebased or retagged
+- **THEN** a test asserts that none of the three platforms navigates the parent
+  on a `false` return, so a reintroduction fails the build rather than
+  reappearing in the field
+
+### Requirement: NESTED-012 - Cancel-And-Reissue Loses Navigation Provenance
+
+`useShouldOverrideUrlLoading` is set unconditionally
+([lib/services/webview.dart:3531](../../../../../lib/services/webview.dart)),
+and the Android client returns `true` for every main-frame navigation even when
+the Dart side answered ALLOW, reissuing it as a fresh programmatic
+`webView.loadUrl(url, headers)`.
+
+A reissued navigation is not the navigation the user made. It arrives at the
+destination with no `Referer`, no `window.opener`, and `Sec-Fetch-Site: none`
+instead of `cross-site`. Two of those three are privacy wins we keep. The third
+is not: a destination that treats `Sec-Fetch-Site: none` as "the user typed this
+in the address bar" will extend trust to what was actually a cross-site link,
+and container isolation attaches that site's cookies because it keys on
+`siteId`, not on how the navigation arrived.
+
+This is accepted behaviour, not a defect to fix here. iOS already takes the same
+shape deliberately under IOS-UL-001. The requirement is that it be **stated**:
+anyone reasoning about what a WebSpace site sees on an inbound navigation MUST
+be able to find out that provenance headers are stripped without reading the
+fork.
+
+#### Scenario: A cross-site link arrives looking direct
+
+- **GIVEN** a link from a hostile page to a site the user has in WebSpace
+- **WHEN** the navigation is allowed and reissued by the Android client
+- **THEN** the destination receives `Sec-Fetch-Site: none` and no `Referer`
+- **AND** this spec says so, so the destination's trust decision is a known
+  property of the app rather than a surprise

--- a/openspec/changes/upstream-webview-defects/specs/per-site-containers/spec.md
+++ b/openspec/changes/upstream-webview-defects/specs/per-site-containers/spec.md
@@ -1,0 +1,50 @@
+# Per-Site Containers
+
+## ADDED Requirements
+
+### Requirement: CONT-009 - The Linux Build Floor Is WPE WebKit 2.50, Not 2.40
+
+The Platform Support Matrix records the version each container primitive landed
+in, which for Linux is WPE WebKit 2.40 (`webkit_network_session_new`, the
+per-container `WebKitNetworkSession` the engine binds to). That number is
+correct for the feature and wrong for the app, and the matrix presents it as
+the requirement.
+
+The fork's `flutter_inappwebview_linux` calls
+`webkit_web_view_get_theme_color` once, unguarded, with no
+`WEBKIT_CHECK_VERSION` anywhere in the plugin. That symbol arrived in WPE 2.50.
+Below it the plugin does not compile at all, so no part of WebSpace runs,
+containers included. `linux/CMakeLists.txt` compounds it by probing
+`wpe-webkit-2.0` with fallbacks to 1.1 and 1.0 and never version-checking: a
+2.48 system configures cleanly and then fails at compile with an undeclared
+identifier rather than a readable message.
+
+The matrix therefore MUST state the floor that governs, and distinguish it from
+the primitive's own floor. Concretely, Debian trixie (2.48) and ParrotOS (2.48)
+cannot build us, and no supported Ubuntu release ships a `libwpewebkit-*-dev`
+package at all, so naming Ubuntu 23.10+ and Debian trixie as supported is wrong
+in both directions. CI already reflects the real floor: `build-linux` pins
+`debian:sid-slim` for exactly this reason.
+
+Two follow-ons, either of which relaxes the constraint but neither of which
+changes what the matrix must say today:
+
+- If the fork guards the call with `WEBKIT_CHECK_VERSION(2,50,0)`, the floor
+  returns to what the container primitive needs and CI can move off the sid pin.
+- Until then `CMakeLists.txt` SHOULD fail at configure time with the version it
+  found and the version it needs, rather than at compile time with a symbol
+  name.
+
+#### Scenario: Building on a 2.48 distribution
+
+- **GIVEN** a machine with WPE WebKit 2.48
+- **WHEN** a contributor runs `fvm flutter build linux`
+- **THEN** the failure names the WebKit version requirement
+- **AND** the documented compatibility matrix already told them 2.50, not 2.40
+
+#### Scenario: The matrix separates the two floors
+
+- **GIVEN** a reader deciding whether a Linux target can run per-site containers
+- **WHEN** they read the Platform Support Matrix
+- **THEN** they can tell that the container primitive needs 2.40 while the
+  plugin needs 2.50, and that the higher of the two is what governs

--- a/openspec/changes/upstream-webview-defects/specs/tracking-protection/spec.md
+++ b/openspec/changes/upstream-webview-defects/specs/tracking-protection/spec.md
@@ -1,0 +1,42 @@
+# Tracking Protection
+
+## ADDED Requirements
+
+### Requirement: ETP-025 - The Plugin's Console Wrappers Are Masked Like Ours
+
+The anti-fingerprinting shim masks every function it installs so
+`Function.prototype.toString` reports `[native code]`, because an overridden
+built-in that admits to being a JS wrapper is a stronger signal than the value
+it was hiding.
+
+The plugin installs five of its own at document start, in every content world:
+`console.log`, `console.debug`, `console.error`, `console.info` and
+`console.warn`, replaced by `ConsoleLogJS` so page output can be bridged to the
+developer-tools console. These are not ours, so the masking funnel never saw
+them, and `console.log.toString()` returns readable JS naming the plugin.
+
+That is a browser-identifying tell that survives Tracking Protection being on,
+and it is available to any script without permission or user interaction. The
+five console methods MUST be registered into the same masking funnel as every
+other injected wrapper.
+
+This is orthogonal to the console shim's other defect (arguments are
+string-concatenated, so objects arrive as `[object Object]` and `Error` message
+and stack are dropped on iOS, macOS and Linux). That one costs us fidelity in
+our own developer tools, not privacy, and is tracked in the upstream audit
+rather than here.
+
+#### Scenario: A page probes the console
+
+- **GIVEN** a site with Tracking Protection on
+- **WHEN** it evaluates `console.log.toString()`
+- **THEN** it receives the `[native code]` form, as it does for every other
+  function the shim replaces
+
+#### Scenario: The funnel covers new wrappers
+
+- **GIVEN** the set of functions injected into the page at document start,
+  including those the plugin injects rather than the app
+- **WHEN** the masking funnel is built
+- **THEN** every one of them is registered, and a wrapper that is not is caught
+  by the structural gate rather than by a site

--- a/openspec/changes/upstream-webview-defects/specs/user-agent-identity/spec.md
+++ b/openspec/changes/upstream-webview-defects/specs/user-agent-identity/spec.md
@@ -1,0 +1,63 @@
+# User Agent Identity
+
+## ADDED Requirements
+
+### Requirement: UAID-005 - UA Client Hints Fail Closed
+
+UAID-002 requires the JS navigator identity to stay consistent with the
+per-site UA string. The same consistency MUST hold on the wire. Android sends
+`Sec-CH-UA`, `Sec-CH-UA-Platform`, `Sec-CH-UA-Mobile` and friends from
+`WebSettingsCompat.setUserAgentMetadata`, and those headers are a second,
+independent statement of identity that a site can compare against both the UA
+string and `navigator.userAgentData`.
+
+`buildUserAgentMetadata` currently derives the brand list by matching `Firefox/`
+or `Chrome/` in the UA and returns `null` for anything else, while still
+returning a metadata object carrying `platform` and `mobile`. The native side
+applies a brand list only when it is non-empty, so a null list leaves the
+device's **real** brands in place.
+
+The result for any UA carrying neither token, including the shipped
+Firefox-for-iOS preset (`FxiOS/`), every WebKit-shaped preset, and every custom
+UA a user types, is headers that read `Sec-CH-UA-Platform: "iOS"` beside a
+`Sec-CH-UA` naming the true Chromium version and the string "Android WebView".
+The site learns the real engine *and* sees a contradiction the unspoofed
+configuration would not have produced.
+
+Partial application is therefore forbidden. When a UA is presented for which a
+consistent brand list cannot be derived, the implementation MUST do one of:
+
+1. **Synthesize** a brand list matching the engine the UA claims (a
+   WebKit/Safari list for a WebKit-shaped UA), with the GREASE entry UAID-004
+   already requires; or
+2. **Suppress** the metadata override entirely, so platform, mobile and brands
+   are all the device's real values and no contradiction is introduced.
+
+What it MUST NOT do is ship some fields spoofed and others real. The same rule
+applies when `WebViewFeature.USER_AGENT_METADATA` is unsupported: the override
+silently no-ops there, so the JS shim MUST NOT assume the headers agree with it.
+
+#### Scenario: WebKit-shaped UA on Android
+
+- **GIVEN** a site set to the Firefox-for-iOS preset, whose UA carries `FxiOS/`
+  and `Safari/` but neither `Firefox/` nor `Chrome/`
+- **WHEN** the per-site UA is applied on Android
+- **THEN** either the emitted `Sec-CH-UA` names a WebKit/Safari brand set
+  consistent with that UA, or no client-hint override is applied at all
+- **AND** in no case does the site receive a spoofed `Sec-CH-UA-Platform`
+  alongside the device's real `Sec-CH-UA`
+
+#### Scenario: User-typed custom UA
+
+- **GIVEN** a custom UA string the user typed that matches no known brand token
+- **WHEN** metadata is built for it
+- **THEN** the outcome is one of the two fail-closed options, chosen the same
+  way for every unrecognized UA
+
+#### Scenario: Feature unsupported
+
+- **GIVEN** a device whose System WebView lacks
+  `WebViewFeature.USER_AGENT_METADATA`
+- **WHEN** a per-site UA is applied
+- **THEN** the headers stay at their real values
+- **AND** the app does not report or assume that client hints were spoofed

--- a/openspec/changes/upstream-webview-defects/tasks.md
+++ b/openspec/changes/upstream-webview-defects/tasks.md
@@ -132,3 +132,24 @@ something to wait for. Keep each contributor's `--author` and cite
   probe rather than a static platform-name list, so a backend without
   `WebKitNetworkSession` (PR #2832's WebKitGTK, say) reports false and we fall
   back deliberately instead of reporting containers active over one shared jar.
+
+## 11. The popup transport leak (ours)
+
+`windowWebViews` entries are removed in exactly three places: `defaultBehaviour`
+on decline, a windowId webview's own `dispose()`, and manager teardown. Our
+captcha handler returns `true`, which skips the first, and
+`createPopupWebView` can then bail to `SizedBox.shrink()` without ever building
+an `InAppWebView(windowId:)`, which skips the second. The native popup WKWebView
+stays pinned for the process lifetime on the parent's configuration and jar.
+
+- [ ] 11.1 Decide the contract: either `onCreateWindow` must not return `true`
+  on a path where `createPopupWebView` can bail, or the bail must tell the
+  native side to drop the transport. Prefer the first, it needs no fork change.
+- [ ] 11.2 Move both bail conditions (no recorded parent config,
+  `proxyUnavailable`) ahead of the return value in
+  `lib/services/webview.dart:4063-4077`, so the decision is made once.
+- [ ] 11.3 Structural gate under `test/js/`: `onCreateWindow` must not return
+  `true` on any path that reaches a `createPopupWebView` early return.
+- [ ] 11.4 Note the ordering hazard in the fix: `_popupParentConfigs[windowId]`
+  is cleared in a `finally` when `onWindowRequested` resolves, so a late
+  `createPopupWebView` finds no parent and takes bail one.

--- a/openspec/changes/upstream-webview-defects/tasks.md
+++ b/openspec/changes/upstream-webview-defects/tasks.md
@@ -1,0 +1,82 @@
+## 1. Record the audit
+
+- [x] 1.1 Write `docs/upstream/flutter-inappwebview-audit.md`: the method, the
+  baseline (`merge-base` against upstream master), and a verdict per issue with
+  `path:line` evidence in the app tree, the fork tree, or both.
+- [x] 1.2 Record the cleared issues with their reasons, not just the ones that
+  affect us. The reads that ended in NO are the expensive half and the half
+  that gets redone.
+- [x] 1.3 Add the `upstream-webview-defects` row to the OpenSpec table in
+  `CLAUDE.md`, marked *(change)* until archived.
+
+## 2. Declined window requests (NESTED-011, EXT-009)
+
+- [ ] 2.1 Patch the fork's iOS and macOS `onCreateWindow` `defaultBehaviour` to
+  Android parity: drop the pending window transport, do not load the request
+  into the parent. Mark it `[WebSpace fork patch]`.
+- [ ] 2.2 Re-tag the fork and bump the six `dependency_overrides` refs in
+  `pubspec.yaml` together.
+- [ ] 2.3 Verify each of our four `onCreateWindow` return-`false` paths on iOS:
+  blocked cross-domain, resolved intent, suppressed intent, unresolvable
+  intent. Each must produce exactly the navigations the handler asked for and
+  no others.
+- [ ] 2.4 Add a structural gate asserting no platform's decline path calls
+  `loadUrl`, so a fork rebase that reintroduces it fails at test time.
+
+## 3. UA Client Hints fail closed (UAID-005)
+
+- [ ] 3.1 Decide between synthesizing a WebKit/Safari brand list and suppressing
+  the override, and apply the same rule to every UA that matches no known brand
+  token.
+- [ ] 3.2 Implement it in `lib/services/user_agent_metadata_builder.dart` so a
+  null brand list can never coexist with a spoofed `platform`/`mobile`.
+- [ ] 3.3 Extend the builder's tests with the shipped WebKit-shaped presets and
+  a user-typed UA, asserting the two fields move together.
+- [ ] 3.4 Check the `WebViewFeature.USER_AGENT_METADATA` unsupported path: the
+  JS shim must not claim agreement with headers that were never overridden.
+
+## 4. Keep the latch disarmed (#2888, #2580)
+
+- [ ] 4.1 Add a structural gate asserting `useShouldInterceptRequest` stays
+  false, `resourceCustomSchemes` stays unset, and no `WebViewAssetLoader` is
+  configured. Each of those arms an unbounded native latch on chromium IO
+  threads; today all four arm sites are disarmed by accident of configuration,
+  not by anything that would notice a change.
+
+## 5. 16 KB alignment (#2703)
+
+- [ ] 5.1 Add an ELF alignment check for `libwebspace_adblock.so` beside
+  `scripts/check_no_gms.sh` and `scripts/check_jni_intact.sh`, run on the built
+  APK rather than on the source tree.
+- [ ] 5.2 Pass `-Wl,-z,max-page-size=16384` explicitly in `scripts/build_rust.sh`
+  instead of inheriting it from whichever `cargo ndk` is on `$PATH`. CI pins
+  4.1.2; the signed Play build does not.
+- [ ] 5.3 Update the stale NDK hint in `android/app/build.gradle` that still
+  recommends r26.
+
+## 6. Smaller hardening
+
+- [ ] 6.1 Narrow `flutter_inappwebview_android_provider_paths.xml` from five
+  roots to the external-files subdirectories the camera-capture path actually
+  uses.
+- [ ] 6.2 Pin `allowUniversalAccessFromFileURLs` and
+  `allowFileAccessFromFileURLs` to false explicitly rather than inheriting the
+  plugin defaults. We run untrusted imported HTML at a `file://` origin, so an
+  upstream default flip would be immediately exploitable.
+- [ ] 6.3 Register the five `console` methods into the masking funnel (ETP-025).
+- [ ] 6.4 Correct the Linux row of the Platform Support Matrix in
+  `openspec/specs/per-site-containers/spec.md` per CONT-009, and give
+  `linux/CMakeLists.txt` a configure-time version check.
+
+## 7. Upstream
+
+- [ ] 7.1 File or comment on #2763 with the Android-parity patch: it is a
+  cross-platform contract violation, not a WebSpace-specific need.
+- [ ] 7.2 Cherry-pick the reporter's #2859 `contentInset` fix into the fork,
+  keeping their `--author` and citing `Cherry-picked-from:`.
+- [ ] 7.3 Patch #2878 (IME dead after HTML5 fullscreen) in the fork and offer it
+  upstream. Its predecessor #1176 is unresolved, so upstream will not fix it
+  for us.
+- [ ] 7.4 Add a `backgroundColor` setting for the Android native WebView
+  (#2863), which is the white half of BUG-001 that the repaint funnel cannot
+  reach.

--- a/openspec/changes/upstream-webview-defects/tasks.md
+++ b/openspec/changes/upstream-webview-defects/tasks.md
@@ -159,6 +159,14 @@ stays pinned for the process lifetime on the parent's configuration and jar.
 Independent of WebKit PR 65415. Do the app half now; the platform half retires
 the inference later.
 
+The signal's unreliability is already documented in PR #356, which covers the
+nested-webview consequence and offers a per-site escape hatch. This section is
+about the half that hatch does not reach: the top-frame rewrites.
+
+- [ ] 12.0 Land or close PR #356 first. It has been conflicted since August, it
+  edits the same spec section, and it fixes a different signal (`hasGesture`) on
+  the same handler. Two open edits to one section is how one of them gets lost.
+
 - [ ] 12.1 Stop resolving a missing or inferred main-frame signal to the
   permissive answer at `lib/services/webview.dart:3918`
   (`isForMainFrame ?? true`). Distinguish "reported false", "reported true" and

--- a/openspec/changes/upstream-webview-defects/tasks.md
+++ b/openspec/changes/upstream-webview-defects/tasks.md
@@ -89,8 +89,11 @@ something to wait for. Keep each contributor's `--author` and cite
 - [ ] 8.1 #2781, the `WEBKIT_CHECK_VERSION(2,50,0)` guard. Then flip the Linux
   CI container off `debian:sid-slim` and confirm the whole job stays green,
   including the Xvfb integration loop. The build is the only proof no other 2.50
-  symbol lurks. Fix the stale comment at `build-and-test.yml:562-566` while
-  there: `webkit_navigation_action_is_for_main_frame` is not in the fork.
+  symbol lurks. Fix the wrong comment at `build-and-test.yml:562-566` while
+  there: `webkit_navigation_action_is_for_main_frame` is not called by the fork
+  and was never added to WebKit (verified absent on `main` and on the 2.50,
+  2.52 and 2.54 branches). `webkit_web_view_get_theme_color` is the only real
+  2.50 symbol, verified absent on 2.48 and present on 2.50.
 - [ ] 8.2 #2767, the `responds(to:)` guard for `upgradeKnownHostsToHTTPS`. If we
   would rather not keep a Big Sur VM to verify it, the honest alternative is to
   raise `macos/Podfile` and `MACOSX_DEPLOYMENT_TARGET` to 12.0 and skip it.

--- a/openspec/changes/upstream-webview-defects/tasks.md
+++ b/openspec/changes/upstream-webview-defects/tasks.md
@@ -153,3 +153,24 @@ stays pinned for the process lifetime on the parent's configuration and jar.
 - [ ] 11.4 Note the ordering hazard in the fix: `_popupParentConfigs[windowId]`
   is cleared in a `finally` when `onWindowRequested` resolves, so a late
   `createPopupWebView` finds no parent and takes bail one.
+
+## 12. Untrustworthy main-frame signal on Linux (NESTED-013)
+
+Independent of WebKit PR 65415. Do the app half now; the platform half retires
+the inference later.
+
+- [ ] 12.1 Stop resolving a missing or inferred main-frame signal to the
+  permissive answer at `lib/services/webview.dart:3918`
+  (`isForMainFrame ?? true`). Distinguish "reported false", "reported true" and
+  "not trustworthy on this platform".
+- [ ] 12.2 On the untrustworthy branch, allow the navigation unmodified: skip
+  the ClearURLs and `$removeparam` top-frame `loadUrl` rewrites and the
+  cross-domain nested route. Losing a stripped parameter beats letting a
+  subframe steer the top document.
+- [ ] 12.3 Keep the existing diagnostic log at `:3925`; it is what surfaced this.
+- [ ] 12.4 Regression test for the two NESTED-013 scenarios against a fake
+  navigation action reporting the inferred signal.
+- [ ] 12.5 Once WebKit PR 65415 lands and WPE ships it, replace the fork's
+  heuristic (`in_app_webview.cc:3966-3972`) and the hardcoded
+  `isForMainFrame(true)` in `create_window_action.cc:41` with the real API, then
+  drop the untrustworthy branch. Fork-side, see the brief.

--- a/openspec/changes/upstream-webview-defects/tasks.md
+++ b/openspec/changes/upstream-webview-defects/tasks.md
@@ -72,11 +72,63 @@
 
 - [ ] 7.1 File or comment on #2763 with the Android-parity patch: it is a
   cross-platform contract violation, not a WebSpace-specific need.
-- [ ] 7.2 Cherry-pick the reporter's #2859 `contentInset` fix into the fork,
-  keeping their `--author` and citing `Cherry-picked-from:`.
-- [ ] 7.3 Patch #2878 (IME dead after HTML5 fullscreen) in the fork and offer it
+- [ ] 7.2 Patch #2878 (IME dead after HTML5 fullscreen) in the fork and offer it
   upstream. Its predecessor #1176 is unresolved, so upstream will not fix it
   for us.
-- [ ] 7.4 Add a `backgroundColor` setting for the Android native WebView
-  (#2863), which is the white half of BUG-001 that the repaint funnel cannot
-  reach.
+- [ ] 7.3 Add a `backgroundColor` **setting** for the Android native WebView
+  (#2863), applied in `prepare()` beside `transparentBackground`. Not upstream
+  PR #2864, which adds a runtime controller method that cannot fire before the
+  first paint, and the first paint is the flash.
+
+## 8. Cherry-picks from open upstream PRs
+
+No maintainer has reviewed any of these, so each is a fork patch we carry, not
+something to wait for. Keep each contributor's `--author` and cite
+`Cherry-picked-from: <sha> (pichillilorenzo/flutter_inappwebview)`.
+
+- [ ] 8.1 #2781, the `WEBKIT_CHECK_VERSION(2,50,0)` guard. Then flip the Linux
+  CI container off `debian:sid-slim` and confirm the whole job stays green,
+  including the Xvfb integration loop. The build is the only proof no other 2.50
+  symbol lurks. Fix the stale comment at `build-and-test.yml:562-566` while
+  there: `webkit_navigation_action_is_for_main_frame` is not in the fork.
+- [ ] 8.2 #2767, the `responds(to:)` guard for `upgradeKnownHostsToHTTPS`. If we
+  would rather not keep a Big Sur VM to verify it, the honest alternative is to
+  raise `macos/Podfile` and `MACOSX_DEPLOYMENT_TARGET` to 12.0 and skip it.
+- [ ] 8.3 #2851, console argument serialization, ported in the same commit to
+  the macOS and Linux copies. Add a structural gate asserting all three
+  `ConsoleLogJS` copies carry `_stringify`, so a rebase cannot silently drop two.
+- [ ] 8.4 #2243, the picker sandbox filter (CVE-2020-6563). Land it with task
+  6.1: it covers `file://` only, and our `content://` provider surface is the
+  half that reaches `HtmlCacheService`.
+- [ ] 8.5 #2881, the two Linux commits that matter: the `skip_pixel_readback_`
+  gate (issue #2861) and the raster-thread use-after-free on recycled textures.
+  Record the second in BUG-007, it is the same class on a new platform.
+- [ ] 8.6 #2870, the macOS availability helper, before the next Xcode bump
+  breaks the macOS build.
+- [ ] 8.7 #2776, the `windowId` eval crash, mirrored into macOS and with its
+  `callAsyncJavaScript` half dropped. It fixes the crash and not the cause, so
+  file the remaining work (address-keyed statics in
+  `Types/WKUserContentController.swift`) as a BUG-007 gap in the same change.
+
+## 9. Retire the universal-link hack (#2866)
+
+- [ ] 9.1 Cherry-pick `ALLOW_WITHOUT_TRYING_APP_LINK` and patch the fork's
+  policy decode, which currently maps unknown ints to `.cancel`.
+- [ ] 9.2 Verify on a device with an AASA app installed that the app is not
+  backgrounded and that `Referer` and `Sec-Fetch-Site: cross-site` survive.
+  The failure mode is silent: a rejected raw value degrades to a plain allow.
+- [ ] 9.3 Keep `IosUniversalLinkBypass` behind a flag for one release, then
+  delete it along with its eligibility predicate, 2s memo and GET/HEAD carve-out.
+- [ ] 9.4 Update IOS-UL-001 and NESTED-012: the iOS half of the provenance loss
+  is recovered, the Android half is not.
+
+## 10. Guard against a harmful rebase
+
+- [ ] 10.1 Record `preWKWebViewConfiguration` as a permanent hand-resolved
+  conflict site. If #2671 ever merges, keep our block and drop theirs: its
+  unconditional `nonPersistent()` assignment would silently drop both the
+  container binding and the per-site proxy, with no build break.
+- [ ] 10.2 Give Linux `ContainerController.isClassSupported` a real runtime
+  probe rather than a static platform-name list, so a backend without
+  `WebKitNetworkSession` (PR #2832's WebKitGTK, say) reports false and we fall
+  back deliberately instead of reporting containers active over one shared jar.


### PR DESCRIPTION
Read the 144 open issues against the pinned fork ref and the app tree.
Four defects defeat privacy controls we already claim to enforce; the
verdicts for the rest are recorded so the reads that ended in NO are
not redone.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VF3eVwSCmHwmQP8DkR4uLV