### PR TITLE
Stop TOR sites loading direct when bootstrap races the render

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1208,6 +1208,8 @@ class _WebSpacePageState extends State<WebSpacePage>
   bool _kioskLocked = false;
 
   StreamSubscription<TrustedHostEntry>? _untrustSub;
+  StreamSubscription<TorStatus>? _torStatusSub;
+  bool _lastTorUp = false;
 
   @override
   void initState() {
@@ -1226,6 +1228,35 @@ class _WebSpacePageState extends State<WebSpacePage>
     // the trust callback finds no pin, and the prompt fires again.
     _untrustSub =
         TrustedHostsService.instance.untrustChanges.listen(_onPinRevoked);
+    // Every TOR-bound webview computes its proxy binding once at
+    // construction time (webview.dart _bindingFor is synchronous). Without
+    // this listener a webview built during bootstrap stays bound to a null
+    // SOCKS endpoint for its whole lifetime, so a later Up transition
+    // silently loads the site direct (the fail-open flavour of TOR-008).
+    // Dispose any TOR-bound webview when the runtime crosses Up in either
+    // direction; the next build fetches a fresh binding from
+    // TorService.socksFor, or falls back to the interstitial when Up gave
+    // way to error / stopped.
+    _lastTorUp = TorService.instance.status.isUp;
+    _torStatusSub =
+        TorService.instance.statusStream.listen(_onTorStatusChanged);
+  }
+
+  void _onTorStatusChanged(TorStatus s) {
+    if (!mounted) return;
+    final nowUp = s.isUp;
+    if (nowUp == _lastTorUp) return;
+    _lastTorUp = nowUp;
+    var anyTorSite = false;
+    for (final m in _webViewModels) {
+      if (m.proxySettings.type != ProxyType.TOR) continue;
+      anyTorSite = true;
+      // A site whose webview is null is showing the placeholder — no
+      // dispose needed there, but the setState below still swaps in the
+      // real webview once getWebView is called again.
+      if (m.webview != null) m.disposeWebView();
+    }
+    if (anyTorSite) setState(() {});
   }
 
   Future<void> _onPinRevoked(TrustedHostEntry entry) async {
@@ -1515,6 +1546,7 @@ class _WebSpacePageState extends State<WebSpacePage>
     _repaintLogFlushTimer?.cancel();
     _navStateDebouncer.dispose();
     _untrustSub?.cancel();
+    _torStatusSub?.cancel();
     surfaceRouteObserver.unsubscribe(this);
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();

--- a/lib/screens/inappbrowser.dart
+++ b/lib/screens/inappbrowser.dart
@@ -21,6 +21,7 @@ import 'package:webspace/services/pull_to_refresh_gate.dart';
 import 'package:webspace/services/resume_reload_engine.dart';
 import 'package:webspace/services/surface_repaint_engine.dart';
 import 'package:webspace/services/surface_route_observer.dart';
+import 'package:webspace/services/tor_service.dart';
 import 'package:webspace/services/webview.dart';
 import 'package:webspace/settings/camera.dart';
 import 'package:webspace/settings/microphone.dart';
@@ -37,6 +38,7 @@ import 'package:webspace/web_view_model.dart'
 import 'package:webspace/widgets/download_button.dart';
 import 'package:webspace/widgets/external_url_prompt.dart';
 import 'package:webspace/widgets/find_toolbar.dart';
+import 'package:webspace/widgets/tor_bootstrap.dart';
 import 'package:webspace/widgets/untrusted_cert_prompt.dart';
 import 'package:webspace/widgets/url_bar.dart';
 
@@ -274,7 +276,13 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
   /// `partition_alloc_support.cc:770 dangling raw_ptr` SIGTRAPs on
   /// Chrome_IOThread. Stabilizing the Widget reference removes the
   /// source of churn.
-  late final Widget _webView;
+  /// Null while the site's proxy is `ProxyType.TOR` and the runtime has not
+  /// yet reached [TorUp]. Constructing the InAppWebView here against a null
+  /// proxy binding would leave its WKWebsiteDataStore with no proxy for the
+  /// life of the widget (TOR-008), so we defer construction until the SOCKS
+  /// endpoint is real. The subscription in [_torStatusSub] flips this in.
+  Widget? _webView;
+  StreamSubscription<TorStatus>? _torStatusSub;
 
   bool _isFindVisible = false;
   late bool _showUrlBar;
@@ -353,7 +361,28 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
     final bool isMobile = hostIsIOS || hostIsAndroid;
     _pullToRefreshGate =
         isMobile ? PullToRefreshGate.create(onRefresh: _reloadAndRepaint) : null;
-    _webView = WebViewFactory.createWebView(
+    // Defer InAppWebView construction while Tor is not up (TOR-008). Building
+    // it here binds its WKWebsiteDataStore to a null proxy for the widget's
+    // lifetime, so a later Up transition would leak — the nested twin of the
+    // gate in WebViewModel.getWebView.
+    if (widget.proxySettings.type == ProxyType.TOR &&
+        !TorService.instance.status.isUp) {
+      _torStatusSub = TorService.instance.statusStream.listen((s) {
+        if (s is TorUp && _webView == null && mounted) {
+          setState(() => _webView = _createNestedInappWebView());
+        }
+      });
+      TorService.instance.maybeStart('nested:${widget.siteId}');
+    } else {
+      _webView = _createNestedInappWebView();
+    }
+  }
+
+  /// Extracted so [initState] can defer the call under Tor. All state it
+  /// closes over is either on [widget] or on `this`; no locals from
+  /// `initState`.
+  Widget _createNestedInappWebView() {
+    return WebViewFactory.createWebView(
       config: WebViewConfig(
         siteId: widget.siteId,
         initialUrl: widget.url,
@@ -680,6 +709,10 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
     _resumeRepaintWindowTimer?.cancel();
     _commitWindowTimer?.cancel();
     _repaintLogFlushTimer?.cancel();
+    _torStatusSub?.cancel();
+    if (widget.proxySettings.type == ProxyType.TOR) {
+      TorService.instance.release('nested:${widget.siteId}');
+    }
     surfaceRouteObserver.unsubscribe(this);
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
@@ -1215,7 +1248,10 @@ class _InAppWebViewScreenState extends State<InAppWebViewScreen>
               padding: EdgeInsets.only(bottom: _repaintNudge ? 1.0 : 0.0),
               // KeyedSubtree key bumped by _handleRendererGone remounts a fresh
               // InAppWebView after a renderer death (BUG-002 gap #1).
-              child: KeyedSubtree(key: ValueKey(_rendererGen), child: _webView),
+              child: KeyedSubtree(
+                key: ValueKey(_rendererGen),
+                child: _webView ?? const TorBootstrapPlaceholder(),
+              ),
             ),
           ),
           if (_showUrlBar)

--- a/lib/web_view_model.dart
+++ b/lib/web_view_model.dart
@@ -36,7 +36,9 @@ import 'package:webspace/settings/location.dart';
 import 'package:webspace/settings/proxy.dart';
 import 'package:webspace/settings/user_script.dart';
 import 'package:webspace/utils/url_utils.dart';
+import 'package:webspace/services/tor_service.dart';
 import 'package:webspace/widgets/external_url_prompt.dart' show launchUrlInSystemBrowser;
+import 'package:webspace/widgets/tor_bootstrap.dart';
 
 export 'package:webspace/settings/location.dart'
     show LocationMode, LocationGranularity, WebRtcPolicy;
@@ -1192,6 +1194,21 @@ class WebViewModel {
         onScreenShareDecision,
     List<UserScriptConfig> globalUserScripts = const [],
   }) {
+    // Fail closed while Tor is still bootstrapping (TOR-008). The stored
+    // `proxySettings.type` is the source of truth — resolving through the
+    // global-inherit path would keep DEFAULT sites off Tor, which is the
+    // documented decision for globally-inherited traffic (PROXY-011 last
+    // scenario). Constructing an InAppWebView here with a null proxy binds
+    // its WKWebsiteDataStore to no proxy for the life of the widget, so a
+    // later `Up` transition would silently leak — hence the widget-level
+    // gate rather than a proxy substitution.
+    final needsTor = proxySettings.type == ProxyType.TOR;
+    if (needsTor && !TorService.instance.status.isUp) {
+      // Do not cache the placeholder in `webview` — the next getWebView call
+      // after WebSpacePage's Tor listener disposes + setStates must fall
+      // through to real construction.
+      return const TorBootstrapPlaceholder();
+    }
     if (webview == null) {
       // Use this.language directly to ensure we get the current value from WebViewModel
       final effectiveLanguage = this.language;

--- a/lib/widgets/tor_bootstrap.dart
+++ b/lib/widgets/tor_bootstrap.dart
@@ -1,0 +1,108 @@
+// Interstitial shown in place of a Tor-bound webview while the runtime is
+// starting, bootstrapping or errored. Sits at the widget level so no
+// InAppWebView is constructed against a dead SOCKS endpoint (which is what
+// makes a fresh site whose bootstrap raced the render come up direct — the
+// fail-open flavour of TOR-008).
+//
+// Deliberately text-free. Localization for the descriptive strings and the
+// status card land in a follow-up commit; this file must stay under
+// lib/widgets/ (a scanned root) with no `Text(...)` sinks so
+// `l10n_no_hardcoded_text` accepts it as migrated without new ARB keys.
+//
+// Spec: openspec/changes/add-ios-tor-proxy/specs/tor-proxy/spec.md
+// (TOR-008 fail-closed before bootstrap, TOR-013 bootstrap surface).
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'package:webspace/services/tor_service.dart';
+
+/// Renders a placeholder for a TOR-bound webview whose runtime is not yet
+/// [TorUp]. Subscribes to [TorService.statusStream] so its own progress
+/// display updates; the parent (WebSpacePage's status listener, or the
+/// nested screen's) is responsible for swapping us out for the real
+/// webview once Tor reaches [TorUp].
+class TorBootstrapPlaceholder extends StatefulWidget {
+  const TorBootstrapPlaceholder({super.key});
+
+  @override
+  State<TorBootstrapPlaceholder> createState() =>
+      _TorBootstrapPlaceholderState();
+}
+
+class _TorBootstrapPlaceholderState extends State<TorBootstrapPlaceholder> {
+  StreamSubscription<TorStatus>? _sub;
+  TorStatus _status = const TorStopped();
+
+  @override
+  void initState() {
+    super.initState();
+    _status = TorService.instance.status;
+    _sub = TorService.instance.statusStream.listen((s) {
+      if (!mounted) return;
+      setState(() => _status = s);
+    });
+    // Kick a start attempt if nothing else has. Idempotent under refcount.
+    TorService.instance.maybeStart('interstitial:${identityHashCode(this)}');
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    // The refcount holder is per-placeholder-instance; releasing it here is
+    // symmetric with the acquire above. The site itself still holds its own
+    // refcount via _syncTorHolders, so the runtime does not shut down just
+    // because the placeholder went away.
+    TorService.instance
+        .release('interstitial:${identityHashCode(this)}');
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final s = _status;
+
+    Widget centered(Widget child) => Container(
+          color: scheme.surface,
+          alignment: Alignment.center,
+          padding: const EdgeInsets.all(24),
+          child: child,
+        );
+
+    if (s is TorErrored) {
+      // No retry button: the current TorEngine has no restart-from-error
+      // path (acquire is a no-op when the holder set is non-empty, which it
+      // is for a site pinned to TOR). The user recovers by switching the
+      // site's proxy off Tor and back on, which cycles the refcount and
+      // triggers a fresh acquire. A dedicated restart API belongs in the
+      // status card follow-on (TOR-013).
+      return centered(
+        Icon(Icons.cloud_off_outlined, size: 56, color: scheme.error),
+      );
+    }
+
+    final double? progress = s is TorBootstrapping
+        ? (s.percent.clamp(0, 100) / 100.0).toDouble()
+        : null;
+
+    return centered(Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Icons.privacy_tip_outlined,
+            size: 56, color: scheme.primary.withOpacity(0.7)),
+        const SizedBox(height: 20),
+        SizedBox(
+          width: 220,
+          child: LinearProgressIndicator(
+            value: progress,
+            minHeight: 4,
+          ),
+        ),
+      ],
+    ));
+  }
+}
+

--- a/lib/widgets/tor_bootstrap.dart
+++ b/lib/widgets/tor_bootstrap.dart
@@ -17,6 +17,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import 'package:webspace/services/tor_service.dart';
+import 'package:webspace/theme/design_tokens.dart';
 
 /// Renders a placeholder for a TOR-bound webview whose runtime is not yet
 /// [TorUp]. Subscribes to [TorService.statusStream] so its own progress
@@ -30,6 +31,14 @@ class TorBootstrapPlaceholder extends StatefulWidget {
   State<TorBootstrapPlaceholder> createState() =>
       _TorBootstrapPlaceholderState();
 }
+
+/// Empty-state glyph, larger than anything in [IconSizes] — those name
+/// in-row and in-button icons, and this one is the only thing on screen.
+const double _glyphSize = 56;
+
+/// Width of the bootstrap progress bar. A layout measure rather than a
+/// spacing step, so it is not a [Spacing] value.
+const double _progressWidth = 220;
 
 class _TorBootstrapPlaceholderState extends State<TorBootstrapPlaceholder> {
   StreamSubscription<TorStatus>? _sub;
@@ -68,7 +77,7 @@ class _TorBootstrapPlaceholderState extends State<TorBootstrapPlaceholder> {
     Widget centered(Widget child) => Container(
           color: scheme.surface,
           alignment: Alignment.center,
-          padding: const EdgeInsets.all(24),
+          padding: const EdgeInsets.all(Spacing.xl),
           child: child,
         );
 
@@ -80,7 +89,7 @@ class _TorBootstrapPlaceholderState extends State<TorBootstrapPlaceholder> {
       // triggers a fresh acquire. A dedicated restart API belongs in the
       // status card follow-on (TOR-013).
       return centered(
-        Icon(Icons.cloud_off_outlined, size: 56, color: scheme.error),
+        Icon(Icons.cloud_off_outlined, size: _glyphSize, color: scheme.error),
       );
     }
 
@@ -92,13 +101,13 @@ class _TorBootstrapPlaceholderState extends State<TorBootstrapPlaceholder> {
       mainAxisSize: MainAxisSize.min,
       children: [
         Icon(Icons.privacy_tip_outlined,
-            size: 56, color: scheme.primary.withOpacity(0.7)),
-        const SizedBox(height: 20),
+            size: _glyphSize, color: scheme.primary.withOpacity(0.7)),
+        const SizedBox(height: Spacing.xl),
         SizedBox(
-          width: 220,
+          width: _progressWidth,
           child: LinearProgressIndicator(
             value: progress,
-            minHeight: 4,
+            minHeight: Spacing.xs,
           ),
         ),
       ],

--- a/scripts/run_android_lifecycle_tests.sh
+++ b/scripts/run_android_lifecycle_tests.sh
@@ -549,14 +549,43 @@ echo "  app pid while backgrounded: ${baseline_pid:-none}"
 # NOTIF-005-A schedules unique periodic work (webspace-notification-refresh)
 # whenever a notification site exists; WorkManager backs it with a
 # JobScheduler job. No job = the scheduling contract itself broke.
-job_ids="$(adb shell dumpsys jobscheduler 2>/dev/null \
-  | grep "$pkg/androidx.work" \
-  | sed -n 's/.*#u[0-9a]*\/\([0-9]\{1,\}\):.*/\1/p' | sort -u)"
-if [ -z "$job_ids" ]; then
-  echo "FAIL: no WorkManager job scheduled for $pkg (NOTIF-005-A)" >&2
-  dump_bg_diagnostics no-workmanager-job
-  exit 1
-fi
+#
+# Polled rather than read once after the fixed sleep above: the enqueue is
+# two hops from the keyevent (lifecycle -> platform channel ->
+# enqueueUniquePeriodicWork), and WorkManager writes its own DB and
+# registers with JobScheduler on a background executor, so how long the job
+# takes to become visible to dumpsys is a property of runner load, not of
+# the contract. Three seconds is usually enough and occasionally is not,
+# which is the coin flip #577 set out to remove. The deadline keeps the
+# assertion honest: a job that never appears still fails the scenario, just
+# 60s later than it used to.
+deadline=$(( $(date +%s) + 60 ))
+while :; do
+  # `|| true` on both stages: grep exits 1 when the app has no androidx.work
+  # entry yet, and under `set -o pipefail` that non-zero would propagate out
+  # of the command substitution and kill the script at the assignment
+  # instead of letting the poll (and the diagnostics below) run.
+  job_lines="$(adb shell dumpsys jobscheduler 2>/dev/null \
+    | grep "$pkg/androidx.work" || true)"
+  job_ids="$(printf '%s\n' "$job_lines" \
+    | sed -n 's/.*#u[0-9a]*\/\([0-9]\{1,\}\):.*/\1/p' | sort -u || true)"
+  [ -n "$job_ids" ] && break
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "FAIL: no WorkManager job scheduled for $pkg within 60s (NOTIF-005-A)" >&2
+    # "no job at all" and "a job dumpsys words differently than the id
+    # pattern expects" both reach here with job_ids empty, and only the raw
+    # lines separate them.
+    if [ -n "$job_lines" ]; then
+      echo "  androidx.work lines present but no id parsed from:" >&2
+      printf '    %s\n' "$job_lines" >&2
+    else
+      echo "  no $pkg/androidx.work line in dumpsys jobscheduler at all" >&2
+    fi
+    dump_bg_diagnostics no-workmanager-job
+    exit 1
+  fi
+  sleep 2
+done
 echo "  WorkManager job(s) scheduled: $(echo "$job_ids" | tr '\n' ' ')"
 
 # The job exists, but it cannot be driven with `cmd jobscheduler run -f`:

--- a/test/js/design_tokens_no_literals.test.js
+++ b/test/js/design_tokens_no_literals.test.js
@@ -25,6 +25,7 @@ const MIGRATED = [
   'lib/widgets/hint_button.dart',
   'lib/widgets/level_slider.dart',
   'lib/widgets/tab_bar_corner_button.dart',
+  'lib/widgets/tor_bootstrap.dart',
 ];
 
 const PENDING = [

--- a/test/js/l10n_no_hardcoded_text.test.js
+++ b/test/js/l10n_no_hardcoded_text.test.js
@@ -48,6 +48,7 @@ const migrated = new Set([
   'lib/widgets/site_permission_badges.dart',
   'lib/widgets/stats_banner.dart',
   'lib/widgets/tab_bar_corner_button.dart',
+  'lib/widgets/tor_bootstrap.dart',
   'lib/widgets/untrusted_cert_prompt.dart',
   'lib/widgets/url_bar.dart',
   'lib/widgets/virtual_source_preview.dart',

--- a/test/tor_bootstrap_placeholder_test.dart
+++ b/test/tor_bootstrap_placeholder_test.dart
@@ -49,7 +49,7 @@ void main() {
     TorService.overrideEngine(
       TorEngine(runtime: runtime, sessionSecret: 'secret'),
     );
-    // The widget uses TorService.maybeStart, whose refcount-take is gated
+    // The widget calls TorService.maybeStart, whose refcount-take is gated
     // on isAvailable. Turn dev mode on so the acquire actually reaches the
     // fake runtime — otherwise startCalls stays 0 and the widget looks
     // broken for the wrong reason.
@@ -62,31 +62,47 @@ void main() {
     DeveloperModeService.instance.debugSet(false);
   });
 
-  Future<void> pumpAndSettleMicrotasks(WidgetTester t) async {
+  Future<void> settle(WidgetTester t) async {
     await t.pump();
     await t.pump(const Duration(milliseconds: 10));
   }
 
+  /// Unmount, then tear the engine down, both inside the test body.
+  ///
+  /// `acquire` arms a 90s bootstrap timeout and `release` arms a 60s idle
+  /// debounce; flutter_test fails any test that ends with a pending Timer.
+  /// The group tearDown cannot clear them — it runs after the binding's
+  /// invariant check. Unmount first so the placeholder's own release lands
+  /// before dispose cancels both timers.
+  Future<void> teardownTor(WidgetTester t) async {
+    await t.pumpWidget(const SizedBox.shrink());
+    await settle(t);
+    await TorService.reset();
+    await settle(t);
+  }
+
   testWidgets('renders a progress bar while bootstrapping', (t) async {
     await t.pumpWidget(const MaterialApp(home: TorBootstrapPlaceholder()));
-    await pumpAndSettleMicrotasks(t);
+    await settle(t);
 
     runtime.emit(const TorBootstrapping(45));
-    await pumpAndSettleMicrotasks(t);
+    await settle(t);
 
     final progressFinder = find.byType(LinearProgressIndicator);
     expect(progressFinder, findsOneWidget);
     final progress = t.widget<LinearProgressIndicator>(progressFinder);
     expect(progress.value, closeTo(0.45, 1e-6));
+
+    await teardownTor(t);
   });
 
   testWidgets('renders an error icon on TorErrored, no retry button',
       (t) async {
     await t.pumpWidget(const MaterialApp(home: TorBootstrapPlaceholder()));
-    await pumpAndSettleMicrotasks(t);
+    await settle(t);
 
     runtime.emit(const TorErrored('directory authority unreachable'));
-    await pumpAndSettleMicrotasks(t);
+    await settle(t);
 
     expect(find.byIcon(Icons.cloud_off_outlined), findsOneWidget);
     // No retry: the current engine has no restart-from-error path
@@ -94,26 +110,24 @@ void main() {
     // the button would be inert. Guard against it accidentally coming back
     // and lying to the user.
     expect(find.byType(TextButton), findsNothing);
+
+    await teardownTor(t);
   });
 
-  testWidgets('kicks TorService.maybeStart on mount and releases on unmount',
-      (t) async {
+  testWidgets('kicks TorService.maybeStart on mount', (t) async {
     expect(runtime.startCalls, 0);
 
     await t.pumpWidget(const MaterialApp(home: TorBootstrapPlaceholder()));
-    await pumpAndSettleMicrotasks(t);
+    await settle(t);
 
     expect(runtime.startCalls, 1,
         reason: 'the placeholder acquires a refcount so bootstrap actually '
             'begins even if no site is holding one yet');
 
-    await t.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
-    await pumpAndSettleMicrotasks(t);
+    await teardownTor(t);
 
-    // The idle-stop debounce means stop is not immediate; the important
-    // property is that the holder is released, which the next test path
-    // (letting the debounce elapse) would show — here we just assert the
-    // mount side stays quiet, i.e. no repeat start after unmount.
+    // No second start after unmount: the placeholder released rather than
+    // re-acquired on the way out.
     expect(runtime.startCalls, 1);
   });
 }

--- a/test/tor_bootstrap_placeholder_test.dart
+++ b/test/tor_bootstrap_placeholder_test.dart
@@ -1,0 +1,119 @@
+// Widget contract for the interstitial that stands in for a TOR-bound
+// webview while the runtime is not [TorUp]. The point of the widget is
+// twofold: block a null-proxy InAppWebView from ever being constructed
+// (TOR-008 fail-closed), and give the user something visible while
+// bootstrap runs (TOR-013).
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webspace/services/developer_mode_service.dart';
+import 'package:webspace/services/tor_engine.dart';
+import 'package:webspace/services/tor_service.dart';
+import 'package:webspace/widgets/tor_bootstrap.dart';
+
+class _Runtime implements TorRuntime {
+  final _events = StreamController<TorStatus>.broadcast();
+  int startCalls = 0;
+  int stopCalls = 0;
+
+  @override
+  bool get isAvailable => true;
+
+  @override
+  Stream<TorStatus> get events => _events.stream;
+
+  @override
+  Future<void> start() async => startCalls++;
+
+  @override
+  Future<void> stop() async => stopCalls++;
+
+  @override
+  Future<void> rebuildCircuits() async {}
+
+  @override
+  Future<void> applyExitCountry(String? exitNodes) async {}
+
+  void emit(TorStatus s) => _events.add(s);
+  Future<void> dispose() => _events.close();
+}
+
+void main() {
+  late _Runtime runtime;
+
+  setUp(() {
+    runtime = _Runtime();
+    TorService.overrideEngine(
+      TorEngine(runtime: runtime, sessionSecret: 'secret'),
+    );
+    // The widget uses TorService.maybeStart, whose refcount-take is gated
+    // on isAvailable. Turn dev mode on so the acquire actually reaches the
+    // fake runtime — otherwise startCalls stays 0 and the widget looks
+    // broken for the wrong reason.
+    DeveloperModeService.instance.debugSet(true);
+  });
+
+  tearDown(() async {
+    await TorService.reset();
+    await runtime.dispose();
+    DeveloperModeService.instance.debugSet(false);
+  });
+
+  Future<void> pumpAndSettleMicrotasks(WidgetTester t) async {
+    await t.pump();
+    await t.pump(const Duration(milliseconds: 10));
+  }
+
+  testWidgets('renders a progress bar while bootstrapping', (t) async {
+    await t.pumpWidget(const MaterialApp(home: TorBootstrapPlaceholder()));
+    await pumpAndSettleMicrotasks(t);
+
+    runtime.emit(const TorBootstrapping(45));
+    await pumpAndSettleMicrotasks(t);
+
+    final progressFinder = find.byType(LinearProgressIndicator);
+    expect(progressFinder, findsOneWidget);
+    final progress = t.widget<LinearProgressIndicator>(progressFinder);
+    expect(progress.value, closeTo(0.45, 1e-6));
+  });
+
+  testWidgets('renders an error icon on TorErrored, no retry button',
+      (t) async {
+    await t.pumpWidget(const MaterialApp(home: TorBootstrapPlaceholder()));
+    await pumpAndSettleMicrotasks(t);
+
+    runtime.emit(const TorErrored('directory authority unreachable'));
+    await pumpAndSettleMicrotasks(t);
+
+    expect(find.byIcon(Icons.cloud_off_outlined), findsOneWidget);
+    // No retry: the current engine has no restart-from-error path
+    // (TorEngine.acquire returns early with a non-empty holder set), so
+    // the button would be inert. Guard against it accidentally coming back
+    // and lying to the user.
+    expect(find.byType(TextButton), findsNothing);
+  });
+
+  testWidgets('kicks TorService.maybeStart on mount and releases on unmount',
+      (t) async {
+    expect(runtime.startCalls, 0);
+
+    await t.pumpWidget(const MaterialApp(home: TorBootstrapPlaceholder()));
+    await pumpAndSettleMicrotasks(t);
+
+    expect(runtime.startCalls, 1,
+        reason: 'the placeholder acquires a refcount so bootstrap actually '
+            'begins even if no site is holding one yet');
+
+    await t.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+    await pumpAndSettleMicrotasks(t);
+
+    // The idle-stop debounce means stop is not immediate; the important
+    // property is that the holder is released, which the next test path
+    // (letting the debounce elapse) would show — here we just assert the
+    // mount side stays quiet, i.e. no repeat start after unmount.
+    expect(runtime.startCalls, 1);
+  });
+}

--- a/test/tor_bootstrap_placeholder_test.dart
+++ b/test/tor_bootstrap_placeholder_test.dart
@@ -38,14 +38,22 @@ class _Runtime implements TorRuntime {
   Future<void> applyExitCountry(String? exitNodes) async {}
 
   void emit(TorStatus s) => _events.add(s);
-  Future<void> dispose() => _events.close();
 }
 
 void main() {
-  late _Runtime runtime;
-
-  setUp(() {
-    runtime = _Runtime();
+  /// Install a fake-backed engine **from inside the test body**.
+  ///
+  /// Not from `setUp`: that runs in the real async zone, while a
+  /// `testWidgets` body runs inside `fakeAsync`. `TorEngine`'s constructor
+  /// subscribes to `runtime.events`, and a stream delivers to its listener
+  /// in the zone that called `listen`. Built in `setUp`, the engine's
+  /// `_onRuntimeStatus` deliveries are scheduled on the real microtask
+  /// queue, which `tester.pump` never drains — so `runtime.emit(...)`
+  /// silently never reaches the engine, and the widget sits on the
+  /// `TorStarting` that `acquire` emitted synchronously. Constructing here
+  /// puts that subscription in the same zone as the pumps.
+  _Runtime installEngine() {
+    final runtime = _Runtime();
     TorService.overrideEngine(
       TorEngine(runtime: runtime, sessionSecret: 'secret'),
     );
@@ -54,11 +62,11 @@ void main() {
     // fake runtime — otherwise startCalls stays 0 and the widget looks
     // broken for the wrong reason.
     DeveloperModeService.instance.debugSet(true);
-  });
+    return runtime;
+  }
 
   tearDown(() async {
     await TorService.reset();
-    await runtime.dispose();
     DeveloperModeService.instance.debugSet(false);
   });
 
@@ -67,21 +75,26 @@ void main() {
     await t.pump(const Duration(milliseconds: 10));
   }
 
-  /// Unmount, then tear the engine down, both inside the test body.
+  /// Unmount, then run both of the engine's one-shot timers out on the fake
+  /// clock.
   ///
-  /// `acquire` arms a 90s bootstrap timeout and `release` arms a 60s idle
-  /// debounce; flutter_test fails any test that ends with a pending Timer.
-  /// The group tearDown cannot clear them — it runs after the binding's
-  /// invariant check. Unmount first so the placeholder's own release lands
-  /// before dispose cancels both timers.
+  /// `acquire` arms a 90s bootstrap timeout and `release` a 60s idle
+  /// debounce. flutter_test fails any test that ends with a pending Timer,
+  /// and the group tearDown cannot clear them — it runs after the binding's
+  /// invariant check. Awaiting `TorService.reset()` here instead deadlocks:
+  /// the await stops the body from advancing the fake clock that the
+  /// disposal is waiting on, and the test hangs rather than fails. Pumping
+  /// past both is the one move that works from inside the body. Firing them
+  /// is harmless once the widget is gone — each is one-shot, and the
+  /// TorStopped / TorErrored they emit arm nothing new.
   Future<void> teardownTor(WidgetTester t) async {
     await t.pumpWidget(const SizedBox.shrink());
     await settle(t);
-    await TorService.reset();
-    await settle(t);
+    await t.pump(const Duration(seconds: 91));
   }
 
   testWidgets('renders a progress bar while bootstrapping', (t) async {
+    final runtime = installEngine();
     await t.pumpWidget(const MaterialApp(home: TorBootstrapPlaceholder()));
     await settle(t);
 
@@ -98,6 +111,7 @@ void main() {
 
   testWidgets('renders an error icon on TorErrored, no retry button',
       (t) async {
+    final runtime = installEngine();
     await t.pumpWidget(const MaterialApp(home: TorBootstrapPlaceholder()));
     await settle(t);
 
@@ -115,6 +129,7 @@ void main() {
   });
 
   testWidgets('kicks TorService.maybeStart on mount', (t) async {
+    final runtime = installEngine();
     expect(runtime.startCalls, 0);
 
     await t.pumpWidget(const MaterialApp(home: TorBootstrapPlaceholder()));


### PR DESCRIPTION
_bindingFor runs synchronously at InAppWebView construction, so a webview built while TorService is still bootstrapping is bound to `proxySettings: null` for its whole lifetime — and a later Up transition then loads the site over the device IP (TOR-008 fail-open). Two fixes:

- WebViewModel.getWebView and InAppWebViewScreen defer InAppWebView construction until TorUp; while waiting they show a text-free progress placeholder (TorBootstrapPlaceholder) so the user has something visible instead of a black tab.
- WebSpacePage subscribes to TorService.statusStream and, on Up in either direction, disposes every TOR-bound webview and setStates. The next getWebView fetches a fresh binding, or the placeholder — never the stale null.

Widget test covers progress and error rendering. Follow-up will add the App Settings status card + descriptive strings (needs l10n across 66 locales).


Claude-Session: https://claude.ai/code/session_01VE3viuaxsh4f9Gm3pmrS3Q