### PR TITLE
Stop the repaint nudge flipping the letterbox bars

### DIFF
--- a/docs/bugs/001-white-screen.md
+++ b/docs/bugs/001-white-screen.md
@@ -892,6 +892,14 @@ nothing after, because there is no second commit for a same-document update.
 
 ## Guardrails now in place
 
+- **Nudge-inset publication** ([test/js/surface_repaint_funnel.test.js](../../test/js/surface_repaint_funnel.test.js)):
+  the nudge's body inset is visible to layout below it, and anything that quantises
+  its own size amplifies the pixel. The letterbox box (`ETP-020`) is a step function
+  of the available height, so the raw inset dropped it a whole grid step and the bars
+  flashed in and out on every toggle (reported on a slow debug build). The inset is now
+  published through `SurfaceNudgeScope` and backed out of the snap; the gate asserts one
+  shared `nudgeInset` value feeds both the `Padding` and the scope, and that
+  `_applyLetterbox` reads it. A second, unpublished inset fails CI.
 - **Formal model** ([formal/kernel.tla](../../formal/kernel.tla)): `RepaintLiveness`
   (every blank-surface attach is eventually repainted); the `bypass` demonstrator *is*
   this bug and TLC rejects it. Liveness backbone proved for unbounded N in

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -123,6 +123,7 @@ import 'package:webspace/widgets/download_button.dart';
 import 'package:webspace/widgets/external_url_prompt.dart';
 import 'package:webspace/widgets/root_messenger.dart';
 import 'package:webspace/widgets/site_permission_badges.dart';
+import 'package:webspace/widgets/surface_nudge_scope.dart';
 import 'package:webspace/widgets/untrusted_cert_prompt.dart';
 
 // Accent color enum
@@ -9024,6 +9025,7 @@ class _WebSpacePageState extends State<WebSpacePage>
   /// The tab strip stays in bottomNavigationBar separately.
   Widget _buildBodyWithBottomBar() {
     final inputBar = _buildInputBar();
+    final nudgeInset = _repaintNudge ? _repaintInsetPx : 0.0;
     // Tab strip in bottomNavigationBar handles bottom safe area when visible.
     // Input bar has its own SafeArea. Only apply body safe area when neither
     // is present (e.g. webspace list screen). The tab strip is also rendered
@@ -9084,9 +9086,10 @@ class _WebSpacePageState extends State<WebSpacePage>
                       maintainState: true,
                       maintainSize: true,
                       maintainAnimation: true,
+                      child: SurfaceNudgeScope(
+                      bottomInset: nudgeInset,
                       child: Padding(
-                      padding: EdgeInsets.only(
-                          bottom: _repaintNudge ? _repaintInsetPx : 0.0),
+                      padding: EdgeInsets.only(bottom: nudgeInset),
                       child: IndexedStack(
                       index: _currentIndex ?? 0,
                       children: _webViewModels.asMap().entries.map<Widget>((entry) {
@@ -9268,6 +9271,7 @@ class _WebSpacePageState extends State<WebSpacePage>
                         );
                       }).toList(),
                       ),
+                    ),
                     ),
                     ),
                   ),

--- a/lib/services/letterbox.dart
+++ b/lib/services/letterbox.dart
@@ -86,6 +86,16 @@ double _snapAxis(double available, double grid) {
 /// When [fixedWidth] and [fixedHeight] are both set and positive the box is
 /// that exact size, capped to the available area so it never overflows the
 /// screen; no grid snap is applied.
+///
+/// [transientInsetHeight] is a shrink the caller has already applied to
+/// [availableHeight] and that must not move the bars. Android's blank-surface
+/// repaint nudge (BUG-001 / PAUSE-015) toggles a one-pixel body inset several
+/// times a second to force the hybrid-composition platform view to
+/// recomposite; fed straight into the snap that pixel is amplified, because
+/// [_snapAxis] is a step function and one pixel below a grid multiple drops the
+/// box a whole step (300 -> 287.5), so the bars flash in and out on every
+/// toggle. Snapping the un-inset extent and handing the inset back to the box
+/// keeps the margin constant while the webview still resizes.
 LetterboxTarget computeLetterboxTarget({
   required double availableWidth,
   required double availableHeight,
@@ -93,20 +103,30 @@ LetterboxTarget computeLetterboxTarget({
   int? fixedHeight,
   double gridWidth = 200,
   double gridHeight = 100,
+  double transientInsetHeight = 0,
 }) {
   final aw = availableWidth.isFinite ? math.max(0.0, availableWidth) : 0.0;
   final ah = availableHeight.isFinite ? math.max(0.0, availableHeight) : 0.0;
+  final inset = (transientInsetHeight.isFinite && transientInsetHeight > 0)
+      ? transientInsetHeight
+      : 0.0;
   if (aw <= 0 || ah <= 0) return LetterboxTarget(aw, ah);
 
+  // Size against the extent the body has when nothing is nudging it, then hand
+  // the inset back to the box. The bars are the difference between the two, so
+  // they stay put while the webview still changes size by the inset.
+  final settledHeight = ah + inset;
+  final double width;
+  final double height;
   if (fixedWidth != null &&
       fixedWidth > 0 &&
       fixedHeight != null &&
       fixedHeight > 0) {
-    return LetterboxTarget(
-      math.min(fixedWidth.toDouble(), aw),
-      math.min(fixedHeight.toDouble(), ah),
-    );
+    width = math.min(fixedWidth.toDouble(), aw);
+    height = math.min(fixedHeight.toDouble(), settledHeight);
+  } else {
+    width = _snapAxis(aw, gridWidth);
+    height = _snapAxis(settledHeight, gridHeight);
   }
-
-  return LetterboxTarget(_snapAxis(aw, gridWidth), _snapAxis(ah, gridHeight));
+  return LetterboxTarget(width, math.max(0.0, math.min(ah, height - inset)));
 }

--- a/lib/services/webview.dart
+++ b/lib/services/webview.dart
@@ -62,6 +62,7 @@ import 'package:webspace/settings/microphone.dart';
 import 'package:webspace/settings/location.dart';
 import 'package:webspace/settings/user_script.dart';
 import 'package:webspace/widgets/root_messenger.dart';
+import 'package:webspace/widgets/surface_nudge_scope.dart';
 
 // Re-export inapp.Cookie as Cookie for convenience
 typedef Cookie = inapp.Cookie;
@@ -4669,6 +4670,11 @@ class WebViewFactory {
   /// layout changes (rotation re-snaps the box without rebuilding the view),
   /// so the page is not reloaded. When letterboxing is off or the parent is
   /// unbounded, the WebView is returned unwrapped.
+  ///
+  /// The box is snapped against the extent the body has with the repaint nudge
+  /// backed out ([SurfaceNudgeScope]); the nudge's pixel is then taken off the
+  /// box rather than the bars, so the platform view still resizes and the bars
+  /// hold still.
   static Widget _applyLetterbox(WebViewConfig config, Widget webView) {
     if (!config.letterboxEnabled) return webView;
     return LayoutBuilder(
@@ -4681,6 +4687,7 @@ class WebViewFactory {
           availableHeight: constraints.maxHeight,
           fixedWidth: config.spoofWindowWidth,
           fixedHeight: config.spoofWindowHeight,
+          transientInsetHeight: SurfaceNudgeScope.bottomInsetOf(context),
         );
         return Container(
           color: const Color(0xFF202124),

--- a/lib/widgets/surface_nudge_scope.dart
+++ b/lib/widgets/surface_nudge_scope.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/widgets.dart';
+
+/// The body inset the Android blank-surface repaint nudge is applying right
+/// now (`_nudgeSurfaceRepaint`, BUG-001 / PAUSE-015). Zero in steady state.
+///
+/// The nudge shrinks the body by a pixel a few times a second so the
+/// hybrid-composition platform view recomposites. Anything below it that
+/// quantises its own size has to snap against the settled extent and re-apply
+/// the pixel itself, or the toggle moves a whole quantum: the letterbox box
+/// (ETP-020) drops a full grid step and its bars flash in and out. Descendants
+/// read the inset here rather than through [WebViewConfig] because it is host
+/// layout state, not per-site configuration; a nested webview pushed on its own
+/// route has no scope above it and correctly reads zero.
+class SurfaceNudgeScope extends InheritedWidget {
+  const SurfaceNudgeScope({
+    super.key,
+    required this.bottomInset,
+    required super.child,
+  });
+
+  final double bottomInset;
+
+  static double bottomInsetOf(BuildContext context) =>
+      context
+          .dependOnInheritedWidgetOfExactType<SurfaceNudgeScope>()
+          ?.bottomInset ??
+      0.0;
+
+  @override
+  bool updateShouldNotify(SurfaceNudgeScope oldWidget) =>
+      oldWidget.bottomInset != bottomInset;
+}

--- a/openspec/specs/tracking-protection/spec.md
+++ b/openspec/specs/tracking-protection/spec.md
@@ -423,6 +423,18 @@ live `window.inner*` so screen and window agree (rather than the fixed
 1920x1080 of ETP-010). Letterboxing is gated on `trackingProtectionEnabled`
 (the shim is) and propagates to nested webviews via `launchUrl`.
 
+The snap is a step function, so a transient sub-grid change in the available
+area moves the box a whole grid step. Android's blank-surface repaint nudge
+(`PAUSE-015`, BUG-001) is exactly such a change: it toggles a one-pixel body
+inset several times a second, and fed into the snap raw it makes the bars
+appear and disappear on every toggle. The host SHALL therefore publish the
+inset it is applying (`SurfaceNudgeScope`) and `computeLetterboxTarget` SHALL
+snap against the extent with that inset backed out, then take the inset off the
+resulting box. The margin is then invariant under the nudge while the webview
+still changes size, so the platform view recomposites. The same holds for a
+`spoofWindowWidth`/`spoofWindowHeight` box (ETP-021), which would otherwise
+absorb the inset whole and leave the nudge with nothing to resize.
+
 #### Scenario: Available area snaps down to the grid
 
 **Given** an available area of 1366 x 768
@@ -439,6 +451,18 @@ live `window.inner*` so screen and window agree (rather than the fixed
 **Then** the box never exceeds the available area
 **And** the trimmed margin on each axis is at most 1/8 of that axis (a
 390-wide phone yields a ~350px box, not 200)
+
+#### Scenario: The repaint nudge moves the box, not the bars
+
+**Given** a letterboxed site on Android with an available height of 800
+**When** the surface-repaint nudge applies its one-pixel body inset
+**Then** `computeLetterboxTarget` is called with `availableHeight: 799` and
+`transientInsetHeight: 1` and returns a box one pixel shorter than the
+un-nudged box
+**And** the margin on that axis is unchanged, so the bars do not move (raw, the
+799 would snap to 750 and flash a 49px bar in and out)
+**And** a fixed box (ETP-021) shrinks by the same pixel, so the platform view
+still resizes
 
 #### Scenario: screen.* mirrors the letterboxed viewport
 

--- a/test/js/design_tokens_no_literals.test.js
+++ b/test/js/design_tokens_no_literals.test.js
@@ -26,6 +26,8 @@ const MIGRATED = [
   'lib/widgets/level_slider.dart',
   'lib/widgets/tab_bar_corner_button.dart',
   'lib/widgets/tor_bootstrap.dart',
+  // Ambient layout state, no painting: nothing to tokenise.
+  'lib/widgets/surface_nudge_scope.dart',
 ];
 
 const PENDING = [

--- a/test/js/l10n_no_hardcoded_text.test.js
+++ b/test/js/l10n_no_hardcoded_text.test.js
@@ -47,6 +47,8 @@ const migrated = new Set([
   'lib/widgets/root_messenger.dart',
   'lib/widgets/site_permission_badges.dart',
   'lib/widgets/stats_banner.dart',
+  // Ambient layout state for the repaint nudge: no user-facing strings.
+  'lib/widgets/surface_nudge_scope.dart',
   'lib/widgets/tab_bar_corner_button.dart',
   'lib/widgets/tor_bootstrap.dart',
   'lib/widgets/untrusted_cert_prompt.dart',

--- a/test/js/surface_repaint_funnel.test.js
+++ b/test/js/surface_repaint_funnel.test.js
@@ -181,6 +181,46 @@ for (const rel of GUARDED) {
   });
 }
 
+// Nudge-inset publication gate (ETP-020 x BUG-001). The nudge's body inset is
+// not private to the repaint machinery: anything below it that quantises its
+// own size amplifies the pixel. The letterbox box is a step function of the
+// available height, so a raw inset drops it a whole grid step and the bars
+// flash in and out on every toggle. The inset must therefore reach the box, and
+// both the Padding and the scope must read the same value — a second, unpublished
+// inset would reproduce the jitter.
+{
+  const lines = linesOf('lib/main.dart');
+  const src = lines.join('\n');
+
+  test('lib/main.dart: the nudge inset is published to SurfaceNudgeScope', () => {
+    assert.match(src, /SurfaceNudgeScope\(\s*\n?\s*bottomInset:\s*nudgeInset,/,
+      'the body must publish the nudge inset for descendants that quantise size');
+    assert.match(src, /final\s+nudgeInset\s*=\s*_repaintNudge\s*\?\s*_repaintInsetPx\s*:\s*0\.0;/,
+      'the inset must be computed once so the Padding and the scope cannot drift');
+  });
+
+  test('lib/main.dart: no unpublished nudge inset', () => {
+    const offenders = [];
+    lines.forEach((l, i) => {
+      if (/_repaintNudge\s*\?/.test(l) && !/final\s+nudgeInset/.test(l)) {
+        offenders.push(i + 1);
+      }
+    });
+    assert.deepEqual(offenders, [],
+      `raw _repaintNudge inset at line(s) ${offenders.join(', ')}; route it through ` +
+        'nudgeInset so SurfaceNudgeScope carries it to the letterbox.');
+  });
+
+  test('lib/services/webview.dart: the letterbox backs the nudge out of its snap', () => {
+    const wv = linesOf('lib/services/webview.dart');
+    const defIdx = wv.findIndex((l) => /Widget\s+_applyLetterbox\s*\(/.test(l));
+    assert.ok(defIdx >= 0, '_applyLetterbox must exist');
+    const body = wv.slice(defIdx, defIdx + 30).join('\n');
+    assert.match(body, /transientInsetHeight:\s*SurfaceNudgeScope\.bottomInsetOf\(context\)/,
+      'the box must snap against the settled extent, not the nudged one');
+  });
+}
+
 // Route-return repaint gate (PAUSE-024 / BUG-001 Attempt 10). An opaque route
 // pushed over a webview screen stops its platform view from being composited,
 // so Android detaches the SurfaceView and re-attaches it blank on the pop.

--- a/test/letterbox_test.dart
+++ b/test/letterbox_test.dart
@@ -116,6 +116,61 @@ void main() {
       expect(t.height, 750);
     });
 
+    test('the repaint nudge shrinks the box, never the bars', () {
+      // BUG-001's Android nudge toggles a 1px body inset a few times a second.
+      // The snap is a step function, so feeding the inset in raw drops the box
+      // a whole grid step (300 -> 287.5) and the bars flash in and out.
+      const nudge = 1.0;
+      for (final settled in const <double>[
+        300, 400, 600, 700, 730.9, 800, 844, 866.3, 873, 915, 926, 1080,
+      ]) {
+        final at = computeLetterboxTarget(
+            availableWidth: 393, availableHeight: settled);
+        final nudged = computeLetterboxTarget(
+          availableWidth: 393,
+          availableHeight: settled - nudge,
+          transientInsetHeight: nudge,
+        );
+        expect(nudged.height, at.height - nudge,
+            reason: 'box must absorb the nudge at $settled');
+        expect(settled - nudge - nudged.height, settled - at.height,
+            reason: 'bars must hold still at $settled');
+      }
+    });
+
+    test('a nudged fixed box still resizes so the surface recomposites', () {
+      // A fixed box smaller than the screen would otherwise swallow the inset
+      // whole: the platform view keeps its size and the nudge does nothing.
+      final t = computeLetterboxTarget(
+        availableWidth: 400,
+        availableHeight: 799,
+        fixedWidth: 360,
+        fixedHeight: 640,
+        transientInsetHeight: 1,
+      );
+      expect(t.width, 360);
+      expect(t.height, 639);
+    });
+
+    test('a zero inset leaves the target untouched', () {
+      final plain =
+          computeLetterboxTarget(availableWidth: 393, availableHeight: 873);
+      final zero = computeLetterboxTarget(
+          availableWidth: 393, availableHeight: 873, transientInsetHeight: 0);
+      expect(zero, plain);
+    });
+
+    test('a full-frame height stays full-frame under the nudge', () {
+      // The reported symptom: 800 has no bars, and one pixel under it the raw
+      // snap falls to 750. Both toggle states must stay bar-free.
+      final t = computeLetterboxTarget(
+        availableWidth: 400,
+        availableHeight: 799,
+        transientInsetHeight: 1,
+      );
+      expect(t.height, 799);
+    });
+
     test('infinite or non-positive constraints degrade gracefully', () {
       final inf = computeLetterboxTarget(
           availableWidth: double.infinity, availableHeight: 800);


### PR DESCRIPTION
The Android blank-surface nudge toggles a 1px body inset several times a
second; the letterbox snap is a step function, so a pixel under a grid
multiple dropped the box a whole step and the bars flashed in and out.
Snap against the un-inset extent and take the pixel off the box instead.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TEkQwudrAPZ8eguqYJFZZF