### PR TITLE
Drop the iOS edge swipe fallback for back at history start

### DIFF
--- a/docs/bugs/011-back-at-history-start-apple.md
+++ b/docs/bugs/011-back-at-history-start-apple.md
@@ -1,0 +1,103 @@
+# BUG-011 — Back-at-history-start misreads history on Apple
+
+Status: open
+
+## Symptom
+
+With the opt-in "back gesture opens the menu" setting (NAV-009) on, the
+left-edge swipe on iOS resolves against the wrong history state. Faces
+seen so far:
+
+- The drawer slides in mid-article, on a page the swipe should have
+  navigated back from.
+- At the actual start of a site's history the swipe does nothing, which
+  is what the setting was turned on to change.
+- Before either: the setting shipped and had no effect at all on
+  iOS/macOS, so the row read as broken.
+
+## Root mechanism / invariant
+
+At the moment an edge swipe arrives, nothing on Apple tells the app
+whether the visible webview has a previous history entry.
+
+- `canGoBack()` under-reports `history.pushState` entries on WKWebView
+  (NAV-002) and reports true for entries the page has since replaced, so
+  an affordance gated on it opens the drawer where history exists and
+  stays shut where it does not.
+- The substitute signal — call `goBack()`, wait a fixed settle, compare
+  the URL — is wrong in both directions too. A same-URL history entry
+  (pushState to the same address, a fragment, a replaceState-heavy SPA)
+  reads as "no history"; a navigation that commits after the settle
+  window reads as "no history"; a redirect or a late async URL update
+  reads as "history".
+- The app only gets to evaluate either signal if it takes the left edge
+  away from WKWebView, which owns it
+  (`allowsBackForwardNavigationGestures`, NAV-001) and resolves the swipe
+  silently inside itself. The root site webview sits at the `MaterialApp`
+  root route, so there is no Flutter pop for `PopScope` to intercept
+  either.
+
+The invariant: **on iOS and macOS the app has no reliable "is there a
+previous history entry" signal at gesture time, so no affordance may
+branch on one.** WKWebView is the only component that knows, and it does
+not say. The normative rule lives in
+[openspec/specs/navigation/spec.md](../../openspec/specs/navigation/spec.md)
+(NAV-001, NAV-002, NAV-009).
+
+## Fix attempts
+
+1. **Pre-#371 (date not in this repo's history).** `drawerEdgeDragWidth`
+   was left enabled on iOS exactly while a tracked `_canGoBack` was
+   false, so the Scaffold's own edge drag opened the drawer at what it
+   believed was the start of history. *Why partial*: gated on
+   `canGoBack()`, which is unreliable in both directions on WKWebView —
+   the drawer opened where history existed and stayed shut where it did
+   not.
+
+2. **#371, then #512.** #371 removed both the edge drag and the
+   `_canGoBack` tracking; #512 later enabled
+   `allowsBackForwardNavigationGestures` on the root site webview, handing
+   the edge to WKWebView outright. *Why partial*: removed the symptom by
+   removing the behaviour. Issue #431 asked for it back, so the class was
+   dormant, not closed.
+
+3. **2026-08-22 — PR #549, `a8951c0`.** Reintroduced it as an opt-in
+   global setting (NAV-009) decided by a pure engine and driven from the
+   `PopScope` handler. *Why partial*: covered Android, where the system
+   back button reaches `PopScope`. On Apple the root route has no pop and
+   WKWebView consumes the swipe, so the setting was inert — visible in
+   App Settings and doing nothing.
+
+4. **2026-09-03 — PR #565, `8b13e7f`.** Claimed a 24px strip of the left
+   edge on iOS with a horizontal drag recognizer and routed it through
+   the same policy, deciding history from `goBack()` plus a 150ms URL
+   diff. *Why partial*: swapped one unreliable history signal for
+   another. The gesture now reached the app, but the drawer still opened
+   over pages that had history, and the strip cost WKWebView's
+   interactive swipe animation for every session that opted in.
+
+5. **2026-09-09 — this change.** Removed the edge strip and scoped the
+   NAV-009 setting to non-Apple platforms: the row is absent from App
+   Settings on iOS/macOS and a restored backup carrying `backOpensMenu`
+   does not turn the behaviour on there. The Apple left edge is
+   WKWebView's again (NAV-001). *Why partial*: it removes the misread by
+   removing the affordance — the same move as attempt 2, so the request
+   behind #431 is again unserved on Apple (see gaps).
+
+## Known open gaps
+
+- **iOS/macOS have no back-at-history-start option.** Issue #431's
+  request stands unmet there. Attempt 2 shows that leaving it unmet is
+  how the class recurs: someone will ask again.
+- **A third attempt needs a history signal, not a third heuristic.** The
+  only candidate is in-page: a `DOCUMENT_START` script counting real
+  history depth by wrapping `pushState`/`replaceState` and listening for
+  `popstate`. It is itself partial — the counter resets on every
+  cross-origin document, and `history.length` includes forward entries —
+  so it must be treated as a signal to validate before an affordance is
+  built on it, not after.
+- **Nothing gates the recurrence in code.** The engine test asserts the
+  setting is not offered on Apple
+  ([test/back_gesture_engine_test.dart](../../test/back_gesture_engine_test.dart)),
+  which fails if the platform predicate is widened, but nothing stops a
+  new call site reading `canGoBack()` on iOS to drive UI.

--- a/integration_test/settings_backup_roundtrip_test.dart
+++ b/integration_test/settings_backup_roundtrip_test.dart
@@ -168,6 +168,11 @@ void main() {
         300.0,
         scrollable: find.byType(Scrollable).first,
       );
+      // The drag loop stops as soon as the tile is built, which the ListView
+      // does up to a cacheExtent below the fold, and the ensureVisible jump
+      // that closes it is not laid out until the next frame. Settle so the
+      // tap reads where the tile ended up rather than where it was.
+      await tester.pumpAndSettle();
     }
 
     // Tap the Export Settings tile. The tile's onTap pops the

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1024,11 +1024,6 @@ class _WebSpacePageState extends State<WebSpacePage>
   /// webview surface below doesn't shift by a few pixels every time a
   /// navigation starts or ends.
   static const double _loadingBarHeight = 3.0;
-  // Width of the iOS left-edge strip the app claims back from WKWebView's
-  // own swipe when NAV-009 is on. Matches the system edge-gesture region.
-  static const double _backEdgeSwipeWidth = 24.0;
-  // Horizontal travel accumulated by that strip's drag, in logical pixels.
-  double _edgeSwipeDx = 0;
 
   bool _isBackHandling = false;
   bool _isFindVisible = false;
@@ -1087,7 +1082,12 @@ class _WebSpacePageState extends State<WebSpacePage>
   // NAV-009: what the back gesture does at the start of a site's history.
   // Off by default — the gesture only walks webview history (issue #369);
   // turning it on opens the drawer there, and again to leave the app (#431).
+  // Pinned off where the setting is not offered.
   BackAtHistoryStart _backAtHistoryStart = BackAtHistoryStart.ignore;
+  bool get _backAtHistoryStartOffered => backAtHistoryStartConfigurable(
+        isIOS: hostIsIOS,
+        isMacOS: hostIsMacOS,
+      );
   // True while the drawer showing is the one the back gesture itself opened.
   // Only that drawer escalates to leaving the app on the next gesture.
   bool _drawerOpenedByBackGesture = false;
@@ -4771,9 +4771,10 @@ class _WebSpacePageState extends State<WebSpacePage>
           prefs.getBool('tabBarButton') ?? prefs.getBool('tabBarButtonInFullscreen') ?? false;
       _tabBarButtonOnRight = prefs.getBool('tabBarButtonOnRight') ?? true;
       _fullscreenOnShortcut = prefs.getBool('fullscreenOnShortcut') ?? true;
-      _backAtHistoryStart = (prefs.getBool(kBackOpensMenuKey) ?? false)
-          ? BackAtHistoryStart.openMenu
-          : BackAtHistoryStart.ignore;
+      _backAtHistoryStart =
+          _backAtHistoryStartOffered && (prefs.getBool(kBackOpensMenuKey) ?? false)
+              ? BackAtHistoryStart.openMenu
+              : BackAtHistoryStart.ignore;
       _tabMaxWidth = prefs.getInt('tabMaxWidth') ?? 140;
       _showStatsBanner = prefs.getBool('showStatsBanner') ?? true;
       WebViewFactory.backForwardCacheEnabled =
@@ -6419,7 +6420,7 @@ class _WebSpacePageState extends State<WebSpacePage>
           backup.globalPrefs['fullscreenOnShortcut'] as bool? ?? _fullscreenOnShortcut;
       final backOpensMenu = backup.globalPrefs[kBackOpensMenuKey] as bool?;
       if (backOpensMenu != null) {
-        _backAtHistoryStart = backOpensMenu
+        _backAtHistoryStart = backOpensMenu && _backAtHistoryStartOffered
             ? BackAtHistoryStart.openMenu
             : BackAtHistoryStart.ignore;
       }
@@ -6636,9 +6637,8 @@ class _WebSpacePageState extends State<WebSpacePage>
     scaffoldState.openDrawer();
   }
 
-  /// Resolve one back gesture, whatever raised it: the Android system back,
-  /// a pushable route's pop, or the iOS left-edge swipe the app takes over
-  /// under NAV-009 (see [needsEdgeSwipeFallback]).
+  /// Resolve one back gesture: the Android system back button, or a pushable
+  /// route's pop.
   Future<void> _handleBackGesture() async {
     if (_isBackHandling) return;
     _isBackHandling = true;
@@ -9273,37 +9273,6 @@ class _WebSpacePageState extends State<WebSpacePage>
                       ),
                     ),
                     ),
-                    ),
-                  ),
-                // NAV-009 on iOS: WKWebView owns the left-edge swipe on the
-                // root site webview, so the gesture never reaches PopScope and
-                // the setting would do nothing. Claim a strip of that edge back
-                // and run the same policy. A horizontal drag recognizer competes
-                // in the gesture arena, so a vertical scroll started at the edge
-                // still reaches the page.
-                if (needsEdgeSwipeFallback(
-                  isIOS: hostIsIOS,
-                  webViewVisible: _currentIndex != null &&
-                      _currentIndex! < _webViewModels.length,
-                  drawerAvailable: !_kioskLocked,
-                  atHistoryStart: _backAtHistoryStart,
-                ))
-                  Positioned(
-                    left: 0,
-                    top: 0,
-                    bottom: 0,
-                    width: _backEdgeSwipeWidth,
-                    child: GestureDetector(
-                      behavior: HitTestBehavior.translucent,
-                      onHorizontalDragStart: (_) => _edgeSwipeDx = 0,
-                      onHorizontalDragUpdate: (details) =>
-                          _edgeSwipeDx += details.delta.dx,
-                      onHorizontalDragEnd: (details) {
-                        final flungRight = (details.primaryVelocity ?? 0) > 300;
-                        if (_edgeSwipeDx > 48 || (flungRight && _edgeSwipeDx > 0)) {
-                          unawaited(_handleBackGesture());
-                        }
-                      },
                     ),
                   ),
                 // Fullscreen sessions (including kiosk-locked, where

--- a/lib/screens/app_settings.dart
+++ b/lib/screens/app_settings.dart
@@ -10,6 +10,7 @@ import 'package:webspace/main.dart' show AppThemeSettings, AccentColor;
 import 'package:webspace/screens/block_stats.dart';
 import 'package:webspace/screens/dev_tools.dart';
 import 'package:webspace/screens/trusted_certificates.dart';
+import 'package:webspace/services/back_gesture_engine.dart';
 import 'package:webspace/services/clearurl_service.dart';
 import 'package:webspace/services/content_blocker_service.dart';
 import 'package:webspace/services/developer_mode_service.dart';
@@ -918,6 +919,10 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
     final backOpensMenuHint = hostIsAndroid
         ? '${loc.appSettingsBackOpensMenuHint} ${loc.appSettingsBackOpensMenuHintExit}'
         : loc.appSettingsBackOpensMenuHint;
+    final backOpensMenuOffered = backAtHistoryStartConfigurable(
+      isIOS: hostIsIOS,
+      isMacOS: hostIsMacOS,
+    );
     return PopScope(
       canPop: !_isOutboundProxyDirty(),
       onPopInvokedWithResult: (didPop, _) async {
@@ -1124,27 +1129,30 @@ class _AppSettingsScreenState extends State<AppSettingsScreen>
               );
             },
           ),
-          SwitchListTile(
-            title: Row(
-              children: [
-                Flexible(child: Text(loc.appSettingsBackOpensMenu)),
-                HintButton(
-                  title: loc.appSettingsBackOpensMenu,
-                  // The escalation to leaving the app is Android's alone
-                  // (NAV-009), so the sentence describing it stays off every
-                  // other platform.
-                  description: backOpensMenuHint,
-                ),
-              ],
+          // Apple has no back gesture the app can act on (NAV-009), so the
+          // setting is absent there rather than present and inert.
+          if (backOpensMenuOffered)
+            SwitchListTile(
+              title: Row(
+                children: [
+                  Flexible(child: Text(loc.appSettingsBackOpensMenu)),
+                  HintButton(
+                    title: loc.appSettingsBackOpensMenu,
+                    // The escalation to leaving the app is Android's alone
+                    // (NAV-009), so the sentence describing it stays off every
+                    // other platform.
+                    description: backOpensMenuHint,
+                  ),
+                ],
+              ),
+              value: _backOpensMenu,
+              onChanged: (value) {
+                setState(() {
+                  _backOpensMenu = value;
+                });
+                widget.onBackOpensMenuChanged(value);
+              },
             ),
-            value: _backOpensMenu,
-            onChanged: (value) {
-              setState(() {
-                _backOpensMenu = value;
-              });
-              widget.onBackOpensMenuChanged(value);
-            },
-          ),
           SwitchListTile(
             title: Text(loc.appSettingsStatsBar),
             subtitle: Text(loc.appSettingsStatsBarSubtitle),

--- a/lib/services/back_gesture_engine.dart
+++ b/lib/services/back_gesture_engine.dart
@@ -34,7 +34,8 @@ enum BackGestureAction {
 /// [BackAtHistoryStart.ignore] is the default (issue #369): the gesture only
 /// ever walks webview history. [BackAtHistoryStart.openMenu] restores the
 /// pre-#371 behaviour (issue #431): the drawer opens, and a second gesture on
-/// that drawer leaves the app.
+/// that drawer leaves the app. Only offered where the app sees the gesture at
+/// all — see [backAtHistoryStartConfigurable].
 enum BackAtHistoryStart { ignore, openMenu }
 
 /// Decides what a back gesture means before any webview navigation is
@@ -84,24 +85,17 @@ BackGestureAction decideAfterAttemptedGoBack({
       : BackGestureAction.ignore;
 }
 
-/// Whether the main page has to install its own left-edge back-swipe over the
-/// visible webview.
+/// Whether the NAV-009 setting is offered on this platform.
 ///
-/// On iOS the root site webview owns the edge swipe natively
-/// (`allowsBackForwardNavigationGestures`, NAV-001): WKWebView consumes the
-/// gesture and, at the start of history, silently does nothing. The root route
-/// has no Flutter pop for `PopScope` to intercept either, so [decideBackGesture]
-/// is never reached and NAV-009 would have no effect on iOS at all. When the
-/// setting is on, a Flutter drag recognizer over the left edge takes the gesture
-/// back and routes it through the same policy — trading WKWebView's interactive
-/// swipe animation for a decision the app can act on.
-bool needsEdgeSwipeFallback({
+/// Apple is out. WKWebView owns the root site webview's left edge natively
+/// (`allowsBackForwardNavigationGestures`, NAV-001) and resolves the swipe
+/// inside itself, and the root route has no Flutter pop for `PopScope` to
+/// intercept, so the app never learns a start-of-history swipe happened. An
+/// app-side edge recognizer put the gesture back in reach but had to infer
+/// history from `goBack()` plus a URL diff, which misreads the start of
+/// history often enough that the drawer appears mid-history.
+bool backAtHistoryStartConfigurable({
   required bool isIOS,
-  required bool webViewVisible,
-  required bool drawerAvailable,
-  required BackAtHistoryStart atHistoryStart,
+  required bool isMacOS,
 }) =>
-    isIOS &&
-    webViewVisible &&
-    drawerAvailable &&
-    atHistoryStart == BackAtHistoryStart.openMenu;
+    !isIOS && !isMacOS;

--- a/openspec/specs/navigation/spec.md
+++ b/openspec/specs/navigation/spec.md
@@ -30,7 +30,7 @@ WebSpace embeds webviews in a Scaffold with a drawer. Navigation gestures compet
 | iOS | `target="_blank"` links may only trigger `onCreateWindow`, not `shouldOverrideUrlLoading` | Links load in current webview instead of nested browser without explicit delegation (fixed in PR #175) |
 | iOS/macOS | `allowsBackForwardNavigationGestures` is enabled for the **root site webview** only | The root webview lives at the `MaterialApp` root route, which has no Flutter route-pop edge-swipe — so without the native gesture the main view has no reliable back-swipe (PopScope only fires for pushable routes). Nested `InAppWebViewScreen`s leave it off so their route-pop-at-history-start (NAV-008) isn't hijacked. |
 | Android | `hasGesture` on `NavigationAction` is a reliable boolean | Used directly for gesture detection |
-| iOS | WKWebView's native swipe is silent at the start of history, and consumes the gesture | The app never learns the swipe happened, so NAV-009 cannot act on it through PopScope; the opt-in installs its own left-edge recognizer instead (NAV-011) |
+| iOS/macOS | WKWebView's native swipe is silent at the start of history, and consumes the gesture | The app never learns the swipe happened, so NAV-009 cannot act on it and the setting is not offered there |
 | iOS/macOS | No `hasGesture`; must infer from `navigationType` (`LINK_ACTIVATED`, `FORM_SUBMITTED`) | Less reliable than Android's boolean flag |
 
 ---
@@ -39,7 +39,7 @@ WebSpace embeds webviews in a Scaffold with a drawer. Navigation gestures compet
 
 ### Requirement: NAV-001 - System Back Gesture
 
-The system back gesture (Android back button, iOS/macOS left-edge swipe) SHALL navigate back in webview history when possible. On the root site webview, iOS/macOS use WKWebView's native back/forward swipe (`allowsBackForwardNavigationGestures`); Android, and all nested routes, use the PopScope handler. It SHALL NOT open the drawer and SHALL NOT exit the app; when there is no back history it is a no-op. What happens at that history start is the one thing the user can change, via the opt-in setting in NAV-009 — off by default, which is this requirement.
+The system back gesture (Android back button, iOS/macOS left-edge swipe) SHALL navigate back in webview history when possible. On the root site webview, iOS/macOS use WKWebView's native back/forward swipe (`allowsBackForwardNavigationGestures`); Android, and all nested routes, use the PopScope handler. It SHALL NOT open the drawer and SHALL NOT exit the app; when there is no back history it is a no-op. What happens at that history start is the one thing the user can change, via the opt-in setting in NAV-009 — off by default and absent on Apple, which is this requirement.
 
 **Rationale:** Users navigating content-heavy sites (especially SPA news sites) expect the back gesture to mean "go back in the page," not "open the menu" or "leave the app." Folding drawer-opening and app-exit into the back gesture made the gesture ambiguous and, combined with the iOS `canGoBack()` heuristic (NAV-002), occasionally misfired mid-navigation. The drawer is reached via the AppBar menu button; the app is left via the OS home/recents gesture.
 
@@ -55,7 +55,7 @@ The system back gesture (Android back button, iOS/macOS left-edge swipe) SHALL n
 **When** the user performs a left-edge back swipe
 **Then** WKWebView navigates back in its own history, including `history.pushState` entries
 **And** at the start of history the swipe is a no-op: the app does not exit and the drawer does not open
-**And** the setting in NAV-009 is off (on, iOS takes the edge back per NAV-011)
+**And** NAV-009 does not apply: the setting is not offered on Apple
 
 #### Scenario: Webview has no back history
 
@@ -284,15 +284,17 @@ The **AppBar back button** on a nested `InAppWebViewScreen` SHALL always close t
 
 ### Requirement: NAV-009 - Back At Start Of History (opt-in)
 
-The app SHALL expose exactly one global setting for what the system back gesture does once the webview has no page left to go back to. It SHALL default to off, which is NAV-001's no-op.
+The app SHALL expose exactly one global setting for what the system back gesture does once the webview has no page left to go back to. It SHALL default to off, which is NAV-001's no-op. It SHALL be offered on Android, Linux and Windows only: on iOS and macOS the setting SHALL be absent from App Settings and the behaviour SHALL stay pinned to NAV-001, whatever the persisted `backOpensMenu` value says.
 
 When the setting is on, the back gesture at the start of a site's history SHALL open the drawer, and a further back gesture on a drawer *that gesture opened* SHALL close it and leave the app. A drawer the user opened any other way (AppBar menu button, webspace tap) SHALL only close, never leave the app — and leaving the app SHALL happen on Android only, where finishing the activity is the platform's own back-at-root behaviour.
 
-The setting SHALL be persisted as the `backOpensMenu` app pref and ride settings export/import. It SHALL have no effect while the kiosk shell is locked (KIOSK-002), which owns the drawer's absence.
+The setting SHALL be persisted as the `backOpensMenu` app pref and ride settings export/import; a backup carrying it on SHALL restore on Apple without turning the behaviour on. It SHALL have no effect while the kiosk shell is locked (KIOSK-002), which owns the drawer's absence. Its hint SHALL describe the app-exit escalation only on the platform where it happens.
 
 **Rationale:** Issue #369 and issue #431 ask for opposite gestures from the same swipe: one user's news-site navigation is broken by the drawer appearing mid-article, the other lost the "menu, then exit" sequence they navigated by. Neither is wrong, and no heuristic separates them, so the choice belongs to the user. Off stays the default because it is the gesture that cannot misfire: it never takes the user somewhere they did not ask to go.
 
 The escalation to leaving the app is bound to the drawer the gesture itself opened, because otherwise back-to-dismiss on a deliberately opened menu would quit the app — the exact ambiguity NAV-001 removed.
+
+Apple is excluded because the app cannot see the gesture: the root site webview owns the left edge natively (NAV-001) and the root route has no Flutter pop for `PopScope` to intercept, so a start-of-history swipe is resolved silently inside WKWebView. #565 claimed a strip of that edge with an app-side recognizer, which had to infer history from `goBack()` plus a URL diff and misread it often enough to open the drawer mid-history; it was reverted. Presenting a setting that does nothing is worse than not offering it. Lineage: [docs/bugs/011-back-at-history-start-apple.md](../../../docs/bugs/011-back-at-history-start-apple.md).
 
 #### Scenario: Setting off — start of history stays a no-op
 
@@ -339,13 +341,18 @@ The escalation to leaving the app is bound to the drawer the gesture itself open
 **When** the user triggers the system back gesture
 **Then** the app is left (the drawer would only repeat the list already on screen)
 
-#### Scenario: Setting on — iOS/macOS URL-comparison path
+#### Scenario: The setting does not exist on Apple
 
-**Given** the setting is on on iOS or macOS
-**And** `goBack()` was attempted and the URL did not change (NAV-002)
-**When** the handler resolves the gesture
-**Then** the drawer opens
-**And** the app is NOT left
+**Given** the app is running on iOS or macOS
+**When** the user opens App Settings
+**Then** no back-gesture setting is shown
+**And** the back gesture behaves as in NAV-001, even if a restored backup has `backOpensMenu` set
+
+#### Scenario: Hint copy names app-exit only where it applies
+
+**Given** the app settings screen is open on Linux or Windows
+**When** the user opens the setting's hint
+**Then** the hint does not mention leaving the app
 
 #### Scenario: Locked kiosk shell ignores the setting
 
@@ -353,58 +360,6 @@ The escalation to leaving the app is bound to the drawer the gesture itself open
 **And** the kiosk shell is locked (KIOSK-002, no drawer)
 **When** the user triggers the system back gesture at the start of history
 **Then** nothing happens (no drawer, no exit)
-
----
-
-### Requirement: NAV-011 - iOS Edge Swipe Reaches The NAV-009 Policy
-
-While the NAV-009 setting is on and a site is visible on iOS, the app SHALL claim a narrow strip of the webview's left edge with its own horizontal drag recognizer and route a rightward drag there through the same back-gesture policy as the system back gesture. The strip SHALL exist only while the setting is on, a webview is visible, and the drawer is available (KIOSK-002); with the setting off, the edge belongs to WKWebView and NAV-001 stands unchanged.
-
-A drag that resolves as horizontal SHALL be handled by the app, and one that resolves as vertical SHALL reach the page, so scrolling at the left edge still works. Leaving the app stays Android-only (NAV-009), so on iOS the strip only ever navigates back or opens the drawer.
-
-The setting's hint SHALL describe the app-exit escalation only on the platform where it happens.
-
-**Rationale:** the root site webview owns the left edge natively (`allowsBackForwardNavigationGestures`, NAV-001) and the root route has no Flutter pop for `PopScope` to intercept, so on iOS the swipe was resolved entirely inside WKWebView — which does nothing, silently, at the start of history. NAV-009 could therefore never fire on iOS, and the toggle read as broken. Taking the edge back costs WKWebView's interactive swipe animation, which is why it is scoped to the sessions that opted in.
-
-Before #371 this worked by a different route: `drawerEdgeDragWidth` was left enabled on iOS exactly while a tracked `_canGoBack` was false, so the Scaffold's own edge drag opened the drawer at history start. #371 removed both the drag and the tracking, and #512 later handed the edge to WKWebView. That mechanism is not restored here: it gated on `canGoBack()`, which is unreliable on iOS in both directions (NAV-002), so it opened the drawer where history existed and stayed shut where it did not. The recognizer decides from the same `goBack()` + URL diff NAV-002 makes authoritative instead.
-
-The hint said "On Android, pressing back again leaves the app" on every platform, describing a behaviour iOS does not have.
-
-#### Scenario: Setting on — iOS edge swipe at the start of history
-
-**Given** the setting is on on iOS
-**And** a webview is visible with no back history
-**When** the user swipes right from the left edge
-**Then** the drawer opens
-**And** the app is NOT left
-
-#### Scenario: Setting on — iOS edge swipe with history
-
-**Given** the setting is on on iOS
-**And** a webview is visible with back history
-**When** the user swipes right from the left edge
-**Then** the webview navigates back (the NAV-002 URL-comparison path)
-**And** the drawer does not open
-
-#### Scenario: Setting off — the edge stays WKWebView's
-
-**Given** the setting is off on iOS
-**When** a site is visible
-**Then** the app installs no recognizer over the left edge
-**And** the native back/forward swipe behaves as in NAV-001
-
-#### Scenario: Vertical scrolling at the left edge still reaches the page
-
-**Given** the setting is on on iOS
-**When** the user drags vertically starting at the left edge
-**Then** the page scrolls
-**And** no back gesture is resolved
-
-#### Scenario: Hint copy names app-exit only where it applies
-
-**Given** the app settings screen is open
-**When** the user opens the setting's hint on a platform other than Android
-**Then** the hint does not mention leaving the app
 
 ---
 
@@ -494,7 +449,7 @@ The call site gathers state (drawer, controller, `canGoBack()` where it is
 trusted) and `decideBackGesture` in
 [lib/services/back_gesture_engine.dart](../../../lib/services/back_gesture_engine.dart)
 returns the action; `openMenu` below is the NAV-009 setting, and is forced off
-while the kiosk shell is locked.
+on iOS/macOS and while the kiosk shell is locked.
 
 ```
 System back gesture received
@@ -554,11 +509,14 @@ Home button pressed
 #### `lib/services/back_gesture_engine.dart`
 - `decideBackGesture` / `decideAfterAttemptedGoBack` — the whole policy above as
   pure functions returning a `BackGestureAction`; `BackAtHistoryStart` is the
-  NAV-009 setting. Tests: [test/back_gesture_engine_test.dart](../../../test/back_gesture_engine_test.dart)
+  NAV-009 setting. `backAtHistoryStartConfigurable` says where that setting is
+  offered at all. Tests: [test/back_gesture_engine_test.dart](../../../test/back_gesture_engine_test.dart)
 
 #### `lib/main.dart`
 - `_isBackHandling` — boolean guard for PopScope handler
 - `_backAtHistoryStart` — NAV-009 setting, mirrored from the `backOpensMenu` pref
+  on load and import, and pinned to `ignore` where `_backAtHistoryStartOffered`
+  is false (iOS/macOS)
 - `_drawerOpenedByBackGesture` — set when the handler opens the drawer, cleared by
   `Scaffold.onDrawerChanged` on every close, so only a gesture-opened drawer escalates
 - `_openDrawerFromBackGesture()` — the one place that opens the drawer for NAV-009
@@ -606,11 +564,13 @@ Home button pressed
 
 ### Manual Test: Back At Start Of History (NAV-009)
 
-1. App settings → turn on "Back gesture opens the menu"
+1. (Android/Linux/Windows) App settings → turn on "Back gesture opens the menu"
 2. Open a site, press system back at its initial URL — the drawer opens
 3. Press system back again — the drawer closes and the app is left (Android)
 4. Open the drawer with the AppBar menu button, press system back — it only closes
 5. Turn the setting off again and repeat step 2 — back does nothing
+6. (iOS/macOS) App settings shows no such row, and the left-edge swipe is
+   WKWebView's own: back through history, nothing at its start
 
 ### Manual Test: Android Back Never Exits (Webview)
 

--- a/test/back_gesture_engine_test.dart
+++ b/test/back_gesture_engine_test.dart
@@ -164,38 +164,17 @@ void main() {
     });
   });
 
-  group('iOS edge-swipe fallback (NAV-009)', () {
-    bool needs({
-      bool isIOS = true,
-      bool webViewVisible = true,
-      bool drawerAvailable = true,
-      BackAtHistoryStart atHistoryStart = BackAtHistoryStart.openMenu,
-    }) =>
-        needsEdgeSwipeFallback(
-          isIOS: isIOS,
-          webViewVisible: webViewVisible,
-          drawerAvailable: drawerAvailable,
-          atHistoryStart: atHistoryStart,
-        );
-
-    test('iOS claims the edge back from WKWebView when the setting is on', () {
-      expect(needs(), isTrue);
+  group('platform availability (NAV-009)', () {
+    test('the setting is offered where the app sees the gesture', () {
+      expect(
+        backAtHistoryStartConfigurable(isIOS: false, isMacOS: false),
+        isTrue,
+      );
     });
 
-    test('the setting off leaves the native swipe alone (NAV-001)', () {
-      expect(needs(atHistoryStart: BackAtHistoryStart.ignore), isFalse);
-    });
-
-    test('other platforms reach the policy through PopScope', () {
-      expect(needs(isIOS: false), isFalse);
-    });
-
-    test('no strip over the site list, where there is no webview to go back in', () {
-      expect(needs(webViewVisible: false), isFalse);
-    });
-
-    test('a locked kiosk shell has no drawer to open (KIOSK-002)', () {
-      expect(needs(drawerAvailable: false), isFalse);
+    test('Apple never sees the start-of-history swipe, so no setting', () {
+      expect(backAtHistoryStartConfigurable(isIOS: true, isMacOS: false), isFalse);
+      expect(backAtHistoryStartConfigurable(isIOS: false, isMacOS: true), isFalse);
     });
   });
 }


### PR DESCRIPTION
The recognizer had to infer history from goBack() plus a URL diff and got
it wrong often enough to open the drawer mid-history. Offer the setting on
non-Apple platforms only, where the app actually sees the gesture.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011Wf7jBpnNv1qzypaof4S78