### PR TITLE
Read persisted bridge config at engine start, not on push

### DIFF
--- a/lib/services/tor_engine.dart
+++ b/lib/services/tor_engine.dart
@@ -154,10 +154,12 @@ class TorEngine {
     required String sessionSecret,
     Duration idleDebounce = kTorIdleDebounce,
     Duration bootstrapTimeout = kTorBootstrapTimeout,
+    Future<TorBridgeConfig> Function()? bridgeLoader,
   })  : _runtime = runtime,
         _sessionSecret = sessionSecret,
         _idleDebounce = idleDebounce,
-        _bootstrapTimeout = bootstrapTimeout {
+        _bootstrapTimeout = bootstrapTimeout,
+        _bridgeLoader = bridgeLoader {
     // Second gate, belt to the runtime's braces: a runtime with no plugin
     // behind it has nothing to say, and subscribing to find that out is
     // what threw MissingPluginException on Android.
@@ -191,6 +193,25 @@ class TorEngine {
   /// than applied immediately: bridges only take effect at bootstrap, so
   /// changing them while tor is up needs a [restart] to mean anything.
   TorBridgeConfig _bridges = const TorBridgeConfig();
+
+  /// Reads the persisted bridge configuration, or null where nothing
+  /// persists it (tests, and platforms with no runtime).
+  ///
+  /// The engine pulls rather than waiting to be pushed. Bridges live in the
+  /// keystore precisely so they survive a relaunch, and an in-memory field
+  /// seeded only by the settings screen does not: nothing on a cold start
+  /// visits that screen, so a user with obfs4 configured got a bridgeless
+  /// bootstrap straight to the public directory authorities — from their
+  /// real IP, while the screen still showed the toggle on and the card said
+  /// "connected". Hydrating here rather than at a startup call site makes
+  /// that unmissable, since every start already funnels through
+  /// [_applyBridgeConfig].
+  final Future<TorBridgeConfig> Function()? _bridgeLoader;
+
+  /// Whether [_bridges] reflects storage yet. Set by the first load and by
+  /// any [setBridges]: an explicit set is the user acting now, so it wins
+  /// over a re-read and is not overwritten by one.
+  bool _bridgesHydrated = false;
 
   bool get isAvailable => _runtime.isAvailable;
   TorStatus get status => _status;
@@ -270,7 +291,30 @@ class TorEngine {
   /// editing a text field.
   bool setBridges(TorBridgeConfig config) {
     _bridges = config;
+    _bridgesHydrated = true;
     return _status is TorUp || _status is TorBootstrapping;
+  }
+
+  /// Pull the persisted configuration in, once, before the first start that
+  /// needs it.
+  ///
+  /// A loader that throws leaves the default (bridges off) rather than
+  /// propagating: the alternative is refusing to start Tor at all because
+  /// the keystore was unreadable. It stays un-hydrated so a later start can
+  /// try again rather than caching the failure for the process lifetime.
+  Future<void> _hydrateBridges() async {
+    if (_bridgesHydrated) return;
+    final loader = _bridgeLoader;
+    if (loader == null) {
+      _bridgesHydrated = true;
+      return;
+    }
+    try {
+      _bridges = await loader();
+      _bridgesHydrated = true;
+    } catch (_) {
+      // Left un-hydrated deliberately; see above.
+    }
   }
 
   /// Put [_bridges] into force for the start that is about to happen.
@@ -281,6 +325,7 @@ class TorEngine {
   /// configuration pointing at a dead port — tor would otherwise hang the
   /// whole bootstrap dialling it.
   Future<void> _applyBridgeConfig() async {
+    await _hydrateBridges();
     final config = _bridges;
     if (!config.enabled || !config.isUsable) {
       await _runtime.setTorrcOptions(const []);

--- a/lib/services/tor_service.dart
+++ b/lib/services/tor_service.dart
@@ -15,6 +15,7 @@ import 'package:flutter/services.dart';
 
 import 'package:webspace/services/developer_mode_service.dart';
 import 'package:webspace/services/log_service.dart';
+import 'package:webspace/services/tor_bridge_secure_storage.dart';
 import 'package:webspace/services/tor_engine.dart';
 import 'package:webspace/settings/proxy.dart';
 
@@ -155,6 +156,11 @@ class TorService {
       _instance ??= TorService._(TorEngine(
         runtime: MethodChannelTorRuntime(),
         sessionSecret: newSessionSecret(),
+        // The engine reads bridges itself rather than waiting for a startup
+        // call to push them: nothing on a cold start opens the bridge
+        // screen, so a pushed-only configuration was simply absent on every
+        // relaunch (TOR-016).
+        bridgeLoader: () => TorBridgeSecureStorage().load(),
       ));
 
   /// Swap in an engine backed by a fake runtime. Tests only.

--- a/openspec/changes/add-ios-tor-proxy/specs/tor-proxy/spec.md
+++ b/openspec/changes/add-ios-tor-proxy/specs/tor-proxy/spec.md
@@ -613,6 +613,16 @@ Where Tor itself is blocked, a bridge is the only route in, so the app
 SHALL let the user configure pluggable transports: obfs4, snowflake,
 meek_lite and webtunnel, run by IPtProxy.
 
+The configuration applied at start SHALL be the persisted one, read by
+the engine itself rather than pushed in by a caller. Bridges are kept in
+the keystore precisely so they survive a relaunch, and nothing on a cold
+start visits the settings screen: a value seeded only by that screen is
+simply absent on every launch after the first, which is a bridgeless
+bootstrap to the public directory authorities from the user's real IP
+while the screen still shows the toggle on. A keystore that cannot be
+read SHALL leave Tor startable rather than refusing to start, and SHALL
+be retried on a later start rather than cached as a failure.
+
 Bridge configuration SHALL be applied at runtime start, never by SETCONF
 afterwards: bridges have to be in force before bootstrap begins, and
 configuring them later means a bootstrap attempt over the direct guards
@@ -652,6 +662,22 @@ is covered by LEAK-010.
 - **THEN** the transport is started and its port read back
 - **AND** tor receives `UseBridges 1`, one `ClientTransportPlugin` naming
   that port, and both `Bridge` lines
+
+#### Scenario: A persisted configuration survives a relaunch
+
+- **GIVEN** bridges are enabled in the keystore from an earlier session
+- **AND** nothing this launch has opened the bridge settings screen
+- **WHEN** a site pinned to Tor starts the runtime
+- **THEN** tor receives `UseBridges 1` and the stored `Bridge` lines
+- **AND** the transport is started, without any caller having pushed the
+  configuration in
+
+#### Scenario: An unreadable keystore does not strand the user
+
+- **GIVEN** the keystore throws when the bridge configuration is read
+- **WHEN** the runtime starts
+- **THEN** tor still starts, without bridge options
+- **AND** a later start re-reads rather than reusing the failure
 
 #### Scenario: Bridges off clear the options rather than leaving them stale
 

--- a/test/tor_bridges_test.dart
+++ b/test/tor_bridges_test.dart
@@ -265,6 +265,91 @@ void main() {
       await engine.dispose();
     });
 
+    test('a persisted configuration reaches tor with no one pushing it',
+        () async {
+      // The cold-start case, and the one that was broken: nothing on a
+      // fresh launch opens the bridge screen, so an engine seeded only by
+      // that screen started tor bridgeless — straight to the public
+      // directory authorities from the user's real IP, while the screen
+      // still showed the toggle on.
+      final runtime = FakeTorRuntime()..transportPort = 47000;
+      var loads = 0;
+      final engine = TorEngine(
+        runtime: runtime,
+        sessionSecret: 's',
+        bridgeLoader: () async {
+          loads++;
+          return TorBridgeConfig(
+            enabled: true,
+            transport: TorTransport.obfs4,
+            lines: [line(_obfs4)],
+          );
+        },
+      );
+
+      // No setBridges anywhere: this is a launch, not an edit.
+      await engine.acquire('site-a');
+
+      expect(loads, 1);
+      expect(runtime.startedTransports, ['obfs4']);
+      expect(runtime.torrcOptions, contains(('UseBridges', '1')));
+      expect(runtime.torrcOptions, contains(('Bridge', _obfs4)));
+      await engine.dispose();
+    });
+
+    test('an explicit set wins over the persisted value', () async {
+      // The user acting now beats a re-read: setBridges is called after the
+      // save, so re-loading would at best duplicate it and at worst undo it
+      // if the keystore write had failed.
+      final runtime = FakeTorRuntime()..transportPort = 47000;
+      final engine = TorEngine(
+        runtime: runtime,
+        sessionSecret: 's',
+        bridgeLoader: () async => const TorBridgeConfig(),
+      );
+      engine.setBridges(TorBridgeConfig(
+        enabled: true,
+        transport: TorTransport.obfs4,
+        lines: [line(_obfs4)],
+      ));
+
+      await engine.acquire('site-a');
+
+      expect(runtime.torrcOptions, contains(('Bridge', _obfs4)));
+      await engine.dispose();
+    });
+
+    test('a keystore that throws leaves tor startable, and retries later',
+        () async {
+      // Refusing to start Tor because the keychain was unreadable would be
+      // worse than starting without bridges, but caching the failure would
+      // strand the user bridgeless for the whole process.
+      final runtime = FakeTorRuntime()..transportPort = 47000;
+      var attempts = 0;
+      final engine = TorEngine(
+        runtime: runtime,
+        sessionSecret: 's',
+        bridgeLoader: () async {
+          attempts++;
+          if (attempts == 1) throw StateError('keystore unavailable');
+          return TorBridgeConfig(
+            enabled: true,
+            transport: TorTransport.obfs4,
+            lines: [line(_obfs4)],
+          );
+        },
+      );
+
+      await engine.acquire('site-a');
+      expect(runtime.startCalls, 1, reason: 'tor still starts');
+      expect(runtime.torrcOptions, isEmpty);
+
+      await engine.restart();
+      expect(attempts, 2, reason: 'the failure is retried, not cached');
+      expect(runtime.torrcOptions, contains(('Bridge', _obfs4)));
+      await engine.dispose();
+    });
+
     test('bridges off clears the options rather than leaving them stale',
         () async {
       final runtime = FakeTorRuntime();


### PR DESCRIPTION
Bridges configured in the keystore were not applied on cold start because the in-memory `_bridges` field was seeded only by the settings screen. Nothing visits that screen on launch, so the persisted configuration was invisible until the user manually opened settings.

The engine now pulls the bridge configuration itself via a `bridgeLoader` callback at the first start that needs it, rather than waiting for a caller to push it in. This happens in `_applyBridgeConfig`, which already runs before every bootstrap, making the hydration unmissable.

Key changes:
- Add optional `bridgeLoader` parameter to `TorEngine` constructor
- Add `_hydrateBridges()` method that loads persisted config once, before the first start
- Track hydration state with `_bridgesHydrated` flag; explicit `setBridges()` calls set it to true, winning over a re-read
- If the loader throws, leave the engine startable with bridges off and retry on the next start rather than caching the failure
- Wire `TorBridgeSecureStorage().load()` as the loader in `TorService`
- Add test coverage for cold-start hydration, explicit set precedence, and keystore failure handling
- Update spec with the new behavior and guarantees

The keystore failure case is handled defensively: refusing to start Tor because the keystore is unreadable would be worse than starting without bridges, but caching the failure would strand the user bridgeless for the process lifetime.

https://claude.ai/code/session_01VE3viuaxsh4f9Gm3pmrS3Q