### PR TITLE
Trim README licence section to a pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,30 +117,11 @@ WebSpace's own source code is licensed under the [MIT License](LICENSE) - Copyri
 
 **Assets**: Icons and images in the `assets/` directory are licensed under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) - Copyright (c) Polina Levchenko. See [assets/LICENSE](assets/LICENSE) for details.
 
-### Third-party components
-
-The MIT license covers WebSpace's original code. Third-party material falls into two distinct categories, neither of which conflicts with MIT:
-
-**1. Linked/compiled dependencies** (part of the shipped binary) are all under permissive, MIT-compatible licenses:
-
-| Component | License | Linkage |
-|-----------|---------|---------|
-| flutter_inappwebview ([fork](https://github.com/theoden8/flutter_inappwebview)) | Apache-2.0 | Dart/native plugin |
-| WPE WebKit (Linux only) | LGPL-2.1 | Dynamically linked system library (LGPL permits this from non-LGPL code) |
-| [adblock-rust](https://github.com/brave/adblock-rust) + `rust/webspace_adblock` wrapper | MPL-2.0 | Optional native `.so` (file-level copyleft; source is in-repo and public) |
-| uBlock Origin web-accessible resources (`$redirect` bodies) | MPL-2.0 | Embedded into the MPL-2.0 `.so` at build time |
-| `lib/third_party/favicon`, cdnjs helpers | MIT | Vendored source |
-| Other pub.dev packages (flutter_map, flutter_zxing/zxing-cpp, encrypt, …) | BSD-3 / MIT / Apache-2.0 | Standard pub dependencies |
-
-MPL-2.0 and Apache-2.0 are file-/component-level copyleft and combine cleanly into an MIT-licensed larger work; the covered files keep their own license and their source stays available (it is all in this repo or upstream). LGPL applies only to the Linux WebKit system library, which is dynamically linked.
-
-**2. Filter-list and blocklist data** is **not** compiled or bundled into the app. The (L)GPL / CC BY-SA lists below are downloaded at runtime from upstream by the user, cached on-device, and never committed to this repo or shipped in the APK/IPA:
-
-| Data source | License | How it is used |
-|-------------|---------|----------------|
-| [ClearURLs Rules](https://github.com/ClearURLs/Rules) | LGPL-3.0 | Tracking-param rules fetched at runtime |
-| [Hagezi DNS blocklists](https://github.com/hagezi/dns-blocklists) | GPL-3.0 | Domain lists fetched at runtime |
-| [EasyList / EasyPrivacy / Fanboy](https://easylist.to/) | GPL-3.0 or CC BY-SA 3.0 (used under CC BY-SA 3.0) | Filter lists fetched at runtime |
-| [OpenStreetMap](https://www.openstreetmap.org/copyright) tiles/data | ODbL / CC BY-SA 2.0 | Map tiles fetched at runtime |
-
-A program reading GPL-licensed *data* at runtime does not become a derivative work of that data, just as a browser loading a GPL filter list, or `grep` processing a GPL text file, is not itself GPL. These lists are listed here and in the in-app license page (Settings → Licenses, labelled "rules data" / "domain data" / "filter data") purely for attribution. Per-source license texts are bundled under [assets/licenses/](assets/licenses/).
+Third-party code in the shipped binary is permissive or file-level copyleft
+(Apache-2.0, MPL-2.0, BSD, MIT), plus WPE WebKit as a dynamically linked LGPL
+system library on Linux. Filter lists, blocklists and map tiles under GPL, LGPL,
+CC BY-SA or ODbL are downloaded at runtime and never bundled. Full attribution
+is in the app under Settings → Licenses; the licence texts for runtime-fetched
+data live under [assets/licenses/](assets/licenses/); the rules that keep the
+composition this way, and the App Store encryption declaration, are in the
+[legal spec](openspec/specs/legal/spec.md).

--- a/openspec/specs/content-blocker/spec.md
+++ b/openspec/specs/content-blocker/spec.md
@@ -378,7 +378,7 @@ Each site SHALL have a `contentBlockEnabled` setting (default: `true`) that cont
 
 ### Requirement: CB-007 - License Attribution
 
-The EasyList filter lists SHALL be credited under CC BY-SA 3.0, and `adblock-rust` plus its transitive dependencies SHALL be credited in the app's license page and README.
+The EasyList filter lists SHALL be credited under CC BY-SA 3.0, and `adblock-rust` plus its transitive dependencies SHALL be credited in the app's license page; the README names EasyList and `adblock-rust` in its feature list.
 
 #### Scenario: EasyList license visible
 
@@ -395,8 +395,8 @@ The EasyList filter lists SHALL be credited under CC BY-SA 3.0, and `adblock-rus
 #### Scenario: README attribution
 
 **Given** a user reads the README
-**Then** EasyList is listed in the Tech Stack section with license info
-**And** `adblock-rust` (Brave Software) is credited there too
+**Then** EasyList and `adblock-rust` are named in the Features list
+**And** the License section points at the in-app license page and the legal spec for the license details
 
 ---
 

--- a/openspec/specs/legal/spec.md
+++ b/openspec/specs/legal/spec.md
@@ -155,4 +155,3 @@ graph.
 
 - **THEN** its licence text is bundled under `assets/licenses/` and registered
   in the custom-licence list in `lib/main.dart`
-- **AND** the README License section names it


### PR DESCRIPTION
The two component tables and the derivative-work argument repeated
what the in-app licence page, assets/licenses/ and the legal spec
already hold; the README now names the licences and points there.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017gQvmpdVKwutWFST69DVLt